### PR TITLE
Czech localisation

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">Meshtastic</string>
+    <string name="action_settings">Nastavení</string>
+    <string name="channel_name">Název kanálu</string>
+    <string name="channel_options">Nastavení kanálu</string>
+    <string name="share_button">Tlačítko pro sdílení</string>
+    <string name="qr_code">QR kód</string>
+    <string name="unset">Zrušit nastavení</string>
+    <string name="connection_status">Stav připojení</string>
+    <string name="application_icon">Ikona aplikace</string>
+    <string name="unknown_username">Neznámé uživatelské jméno</string>
+    <string name="user_avatar">Uživatelský avatar</string>
+    <string name="sample_distance" translatable="false">2,13 km</string>
+    <string name="sample_message">Dobrý den, celý den! I cesta může být cíl, následuj mě!</string>
+    <string name="some_username" translatable="false">Honza</string>
+    <string name="send_text">Odeslat text</string>
+    <string name="warning_not_paired">You haven\'t yet paired a Meshtastic compatible radio with this phone. Please pair a device and set your username.\n\nThis open-source application is in alpha-testing, if you find problems please post on our forum: meshtastic.discourse.group.\n\nFor more information see our web page - www.meshtastic.org.</string>
+    <string name="username_unset">Uživatelské jméno smazané</string>
+    <string name="your_name">Vaše jméno</string>
+    <string name="analytics_okay">Anonymní hlášení o používání aplikace a jejích chybách.</string>
+    <string name="looking_for_meshtastic_devices">Hledám zařízení Meshtastic…</string>
+    <string name="test__devname1" translatable="false">Meshtastic_ac23</string>
+    <string name="test_devname2" translatable="false">Meshtastic_1267</string>
+    <string name="requires_bluetooth">Tato aplikace vyžaduje přístup k Bluetooth. Prosím povolte ji přístup v nastavení telefonu.</string>
+    <string name="error_bluetooth">Chyba - tato aplikace potřebuje bluetooth.</string>
+    <string name="starting_pairing">Spouštím párování</string>
+    <string name="pairing_failed">Párování selhalo</string>
+    <string name="url_for_join">URL pro připojení do Meshtastic MESH sítě.</string>
+    <string name="accept">Přijmout</string>
+    <string name="cancel">Odmítnout</string>
+    <string name="change_channel">Změnit kanál</string>
+    <string name="are_you_sure_channel">Jste si jistý, že chcete změnit kanál? Veškerá komunikace s ostatními vysílači přestane fungovat až do momentu distribuce stejného nastavení na ostatní vysílače.</string>
+    <string name="new_channel_rcvd">Nová URL kanálu přijata.</string>
+    <string name="do_you_want_switch">Chcete se připojit ke kanálu \'%s\' ?</string>
+    <string name="map_not_allowed">You have analytics disabled. Unfortunately our map provider (mapbox) requires analytics to be allowed for their \'free\' plan. So we have turned off the map view.\n\n
+        If you would like to see the map, you\'ll need to turn on analytics in the Settings pane (also, for the time being you might need to force restart the application).\n\n
+        If you are interested in us paying for mapbox (or switching to a different map provider), please post in meshtastic.discourse.group</string>
+    <string name="permission_missing">Chybí požadovaná oprávnění, Meshtastic nebude fungovat správně. Prosím změntě oprávnění pro aplikaci.</string>
+    <string name="radio_sleeping">Vysílač je uspaný, nepodařilo se změnit kanál.</string>
+    <string name="report_bug">Nahlášení chyby</string>
+    <string name="report_a_bug">Nahlásit chybu</string>
+    <string name="report_bug_text">Jste si jistý, že chcete nahlásit chybu? Po odoslaní prosím přidejte zprávu do meshtastic.discourse.group abychom mohli přiřadit Vaši nahlášenou chybu k příspěvku.</string>
+    <string name="report">Odeslat chybové hlášení</string>
+    <string name="select_radio">Vyberte vysílač</string>
+    <string name="current_pair">Momenteálně je připojen vysílač %s</string>
+    <string name="not_paired_yet">Žádný vysílač zatím nebyl spárovaný</string>
+    <string name="change_radio">Změnit vysílač</string>
+    <string name="please_pair">Prosím připojte zařízení v nastavení systému Android.</string>
+    <string name="pairing_completed">Párování bylo úspěšné, spouštím službu</string>
+    <string name="pairing_failed_try_again">Párování selhalo, prosím zkuste to znovu.</string>
+    <string name="location_disabled">Přístup k poloze zařízení nebyl povole, není možné poskytnout polohu zařízení do MESH sítě.</string>
+    <string name="share">Sdílet</string>
+    <string name="disconnected">Odpojeno</string>
+    <string name="device_sleeping">Zařízení spí</string>
+    <string name="connected_count">Pripojeno: %s z %s je online</string>
+    <string name="list_of_nodes">Seznam vysílačů v síti</string>
+    <string name="update_firmware">Aktualizace softwaru</string>
+    <string name="connected_to">Připojeno k vysílači (%s)</string>
+    <string name="not_connected">Nepřipojeno, zvolte si vysílač</string>
+    <string name="connected_sleeping">Připojené k uspanému vysílači.</string>
+    <string name="update_to">Aktualizovat na %s</string>
+    <string name="app_too_old">Aplikace je příliš stará</string>
+    <string name="must_update">Musíte aktualizovat aplikci na Google Play store (nebo z Github). Je příliš stará pro komunikaci s touto verzí firmware vysílače.</string>
+    <string name="none">Žádný (zakázat)</string>
+    <string name="rate_dialog_no_en">Ne, děkuju</string>
+    <string name="rate_dialog_cancel_en">Připomenout později</string>
+    <string name="rate_dialog_ok_en">Ohodnotit teď</string>
+    <string name="rate_dialog_title_en">Ohodnoťte Meshtastic</string>
+</resources>


### PR DESCRIPTION
This one is based on slovak version (Jo, bylo to jednodušší ;)) and some tags are missing: modem_config_short, modem_config_medium, modem_config_long, modem_config_very_long, modem_config_unrecognized. What is recent source of these tags? I will update it later.