### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -13,19 +13,19 @@
     <string name="sample_message">Hey, ich habe den Cache gefunden, er ist hier neben dem großen Tiger. Ich bin ein bisschen besorgt.</string>
     <string name="send_text">Text senden</string>
     <string name="warning_not_paired">Sie haben noch kein Meshtastic-kompatibles Funkgerät mit diesem Telefon gekoppelt. Bitte koppeln Sie ein Gerät und legen Sie Ihren Benutzernamen fest.\n\nDiese Open-Source-Anwendung befindet sich im Alpha-Test. Wenn Sie Probleme finden, veröffentlichen Sie diese bitte auf unserer Website im Chat.\n\nWeitere Informationen finden Sie auf unserer Webseite - www.meshtastic.org.</string>
-    <string name="username_unset">Benutzername ungesetzt</string>
+    <string name="username_unset">Benutzername nicht gesetzt</string>
     <string name="your_name">Dein Name</string>
     <string name="analytics_okay">Anonyme Nutzungsstatistiken und Absturzberichte.</string>
-    <string name="looking_for_meshtastic_devices">Suche nach Meshtastic Geräte...</string>
+    <string name="looking_for_meshtastic_devices">Suche nach Meshtastic Geräten...</string>
     <string name="requires_bluetooth">Diese Anwendung erfordert Bluetooth-Zugang. Bitte gewähren Sie Zugriff in den Android-Einstellungen.</string>
     <string name="error_bluetooth">Fehler - dieses Programm erfordert Bluetooth!</string>
     <string name="starting_pairing">Pairing beginnen</string>
     <string name="pairing_failed">Pairing fehlgeschlagen</string>
     <string name="url_for_join">Ein Link zum Beitritt zu einem meshtastischen Netzwerk</string>
     <string name="accept">Akzeptieren</string>
-    <string name="cancel">Rückgänig</string>
+    <string name="cancel">Abbrechen</string>
     <string name="change_channel">Kanal wechseln</string>
     <string name="are_you_sure_channel">Möchten Sie wirklich den Kanal wechseln? Die gesamte Kommunikation mit anderen Knoten wird unterbrochen, bis Sie die neuen Kanaleinstellungen freigeben.</string>
-    <string name="new_channel_rcvd">Neue Kanal-Link empfangen</string>
+    <string name="new_channel_rcvd">Neuen Kanal-Link empfangen</string>
     <string name="do_you_want_switch">Möchten Sie zum Kanal wechseln? \'%s\' </string>
 </resources>


### PR DESCRIPTION
username_unset - look to "unset", normally not translated to "ungesetzt" instead use "nicht gesetzt"

Translated "cancel" to "Abbrechen".  Expected standard for most users. If you want to use "Rückgängig" please fix the typo ("Rückgänig")

looking_for_meshtastic_devices - corrected wrong case

new_channel_rcvd - corrected wrong case