### PR TITLE
Set crash report text background

### DIFF
--- a/app/src/main/res/layout/settings_fragment.xml
+++ b/app/src/main/res/layout/settings_fragment.xml
@@ -89,6 +89,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginBottom="8dp"
+        android:background="@color/cardview_light_background"
         android:checked="true"
         android:text="@string/analytics_okay"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
(Disclaimer: still very new to Android dev)
On Pixel 3XL when resizing to do split window the text for the crash report checkbox overlaps the text behind it. This just adds a background to that text box
## Before 
<img src="https://user-images.githubusercontent.com/4623792/87733450-d7a61480-c79d-11ea-9fa2-2f006731f77e.png" width="50%">

## And After: 
<img src="https://user-images.githubusercontent.com/4623792/87733429-d1b03380-c79d-11ea-9f41-1ab85aacfb0a.png" width="50%">

