### PR TITLE
Put channel options into URL fragments

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Channel.kt
@@ -32,7 +32,7 @@ data class Channel(
                 .setModemConfig(MeshProtos.ChannelSettings.ModemConfig.Bw125Cr45Sf128).build()
         )
 
-        const val prefix = "https://www.meshtastic.org/c/"
+        const val prefix = "https://www.meshtastic.org/c/#"
 
         private const val base64Flags = Base64.URL_SAFE + Base64.NO_WRAP
 


### PR DESCRIPTION
Put the channel options into the URL fragment instead of the URL path.
This ensures that the channel options (including the channel key) is
never accidentally leaked to a remote party. This URL format appears to
be backwards compatible, URLs generated in the new form are properly
parsed by the old version. URLs generated by the old version are _not_
parsed by the new version.

Closes #126.