### PR TITLE
Simplified calls to system services

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
@@ -9,4 +9,4 @@ import android.hardware.usb.UsbManager
  */
 val Context.bluetoothManager: BluetoothManager? get() = getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager?
 
-val Context.usbManager: UsbManager get() = requireNotNull(getSystemService(Context.USB_SERVICE) as? UsbManager) { "USB_SERVICE is not available"}
+val Context.usbManager: UsbManager get() = requireNotNull(getSystemService(Context.USB_SERVICE) as? UsbManager?) { "USB_SERVICE is not available"}

--- a/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
@@ -1,0 +1,12 @@
+package com.geeksville.mesh.android
+
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import android.hardware.usb.UsbManager
+
+/**
+ * @return null on platforms without a BlueTooth driver (i.e. the emulator)
+ */
+val Context.bluetoothManager: BluetoothManager? get() = getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager?
+
+val Context.usbManager: UsbManager get() = requireNotNull(getSystemService(Context.USB_SERVICE) as? UsbManager) { "USB_SERVICE is not available"}

--- a/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
@@ -10,6 +10,7 @@ import com.geeksville.android.Logging
 import com.geeksville.concurrent.CallbackContinuation
 import com.geeksville.concurrent.Continuation
 import com.geeksville.concurrent.SyncContinuation
+import com.geeksville.mesh.android.bluetoothManager
 import com.geeksville.util.exceptionReporter
 import kotlinx.coroutines.*
 import java.io.Closeable
@@ -101,10 +102,7 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
     fun restartBle() {
         GeeksvilleApplication.analytics.track("ble_restart") // record # of times we needed to use this nasty hack
         errormsg("Doing emergency BLE restart")
-        val mgr =
-            context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-        val adp = mgr.adapter
-        if (null != adp) {
+        context.bluetoothManager?.adapter?.let { adp ->
             if (adp.isEnabled) {
                 adp.disable()
                 // TODO: display some kind of UI about restarting BLE

--- a/app/src/main/java/com/geeksville/mesh/service/SerialInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/SerialInterface.kt
@@ -7,6 +7,7 @@ import android.content.IntentFilter
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import com.geeksville.android.Logging
+import com.geeksville.mesh.android.usbManager
 import com.geeksville.util.exceptionReporter
 import com.geeksville.util.ignoreException
 import com.hoho.android.usbserial.driver.UsbSerialDriver
@@ -32,8 +33,7 @@ class SerialInterface(private val service: RadioInterfaceService, val address: S
         fun toInterfaceName(deviceName: String) = "s$deviceName"
 
         fun findDrivers(context: Context): List<UsbSerialDriver> {
-            val manager = context.getSystemService(Context.USB_SERVICE) as UsbManager
-            val drivers = UsbSerialProber.getDefaultProber().findAllDrivers(manager)
+            val drivers = UsbSerialProber.getDefaultProber().findAllDrivers(context.usbManager)
             val devices = drivers.map { it.device }
             devices.forEach { d ->
                 debug("Found serial port ${d.deviceName}")
@@ -43,8 +43,7 @@ class SerialInterface(private val service: RadioInterfaceService, val address: S
 
         fun addressValid(context: Context, rest: String): Boolean {
             findSerial(context, rest)?.let { d ->
-                val manager = context.getSystemService(Context.USB_SERVICE) as UsbManager
-                return assumePermission || manager.hasPermission(d.device)
+                return assumePermission || context.usbManager.hasPermission(d.device)
             }
             return false
         }
@@ -75,8 +74,7 @@ class SerialInterface(private val service: RadioInterfaceService, val address: S
             if (UsbManager.ACTION_USB_DEVICE_ATTACHED == intent.action) {
                 debug("attaching USB")
                 val device: UsbDevice = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)!!
-                val manager = context.getSystemService(Context.USB_SERVICE) as UsbManager
-                if (assumePermission || manager.hasPermission(device)) {
+                if (assumePermission || context.usbManager.hasPermission(device)) {
                     // reinit the port from scratch and reopen
                     onDeviceDisconnect(true)
                     connect()

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -33,6 +33,8 @@ import com.geeksville.android.isGooglePlayAvailable
 import com.geeksville.concurrent.handledLaunch
 import com.geeksville.mesh.MainActivity
 import com.geeksville.mesh.R
+import com.geeksville.mesh.android.bluetoothManager
+import com.geeksville.mesh.android.usbManager
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.service.BluetoothInterface
 import com.geeksville.mesh.service.MeshService
@@ -137,11 +139,8 @@ class BTScanModel(app: Application) : AndroidViewModel(app), Logging {
         debug("BTScanModel cleared")
     }
 
-    /// Note: may be null on platforms without a bluetooth driver (ie. the emulator)
-    val bluetoothAdapter =
-        (context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager?)?.adapter
-
-    private val usbManager = context.getSystemService(Context.USB_SERVICE) as UsbManager
+    val bluetoothAdapter = context.bluetoothManager?.adapter
+    private val usbManager get() = context.usbManager
 
     var selectedAddress: String? = null
     val errorText = object : MutableLiveData<String?>(null) {}


### PR DESCRIPTION
Rather than calling the Android interfaces, I made some read-only extension properties to easily (and consistently) call the system services.
I also fixed some code that assumed BluetoothManager to never be NULL.

The consuming code of the `UsbManager` assumes that the `UsbManager` is always there, so I enforced that too.