### PR TITLE
Always keep first character of long name when making short name

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -28,7 +28,7 @@ fun getInitials(nameIn: String): String {
 
     val initials = when (words.size) {
         in 0..minchars - 1 -> {
-            val nm = name.filterNot { c -> c.toLowerCase() in "aeiou" }
+            val nm = name.first() + name.drop(1).filterNot { c -> c.toLowerCase() in "aeiou" }
             if (nm.length >= nchars) nm else name
         }
         else -> words.map { it.first() }.joinToString("")


### PR DESCRIPTION
This should ensure that the first character of the long name is retained when forming short names even if it is a vowel.