### PR TITLE
Add Exit button in dropdown menu

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import java.nio.charset.Charset
+import kotlin.system.exitProcess
 
 /*
 UI design
@@ -926,6 +927,11 @@ class MainActivity : AppCompatActivity(), Logging,
                 fragmentTransaction.add(R.id.mainActivityLayout, nameFragment)
                 fragmentTransaction.addToBackStack(null)
                 fragmentTransaction.commit()
+                return true
+            }
+            R.id.exit -> {
+                moveTaskToBack(true);
+                exitProcess(0)
                 return true
             }
             else -> super.onOptionsItemSelected(item)

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -15,4 +15,8 @@
         android:id="@+id/about"
         android:title="@string/about"
         app:showAsAction="withText" />
+    <item
+        android:id="@+id/exit"
+        android:title="@string/exit_app"
+        app:showAsAction="withText" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
         If you are interested in us paying for mapbox (or switching to a different map provider), please post in meshtastic.discourse.group</string>
     <string name="permission_missing">A required permission is missing, Meshtastic won\'t be able to work properly.  Please enable in Android application settings.</string>
     <string name="radio_sleeping">Radio was sleeping, could not change channel</string>
+    <string name="exit_app">Exit App</string>
     <string name="report_bug">Report Bug</string>
     <string name="report_a_bug">Report a bug</string>
     <string name="report_bug_text">Are you sure you want to report a bug? After reporting, please post in meshtastic.discourse.group so we can match up the report with what you found.</string>


### PR DESCRIPTION
This mostly fixes #186 .
After the app "closes", a few seconds later the bluetooth notification goes away.
User still needs to close app from open apps but no longer needs to force close
the app from the system settings in order to get rid of the bluetooth
notification.