### PR TITLE
Material design for Message UI

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -813,7 +813,8 @@ class MainActivity : AppCompatActivity(), Logging,
                 // Init our messages table with the service's record of past text messages (ignore all other message types)
                 val msgs =
                     service.oldMessages.filter { p -> p.dataType == Portnums.PortNum.TEXT_MESSAGE_APP_VALUE }
-                debug("Service provided ${msgs.size} messages")
+                debug("Service provided ${msgs.size} messages and myNodeNum ${service.myNodeInfo?.myNodeNum}")
+                model.myNodeInfo.value = service.myNodeInfo
                 model.messagesState.setMessages(msgs)
                 val connectionState =
                     MeshService.ConnectionState.valueOf(service.connectionState())

--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -231,11 +231,6 @@ class MessagesFragment : ScreenFragment("Messages"), Logging {
         layoutManager.stackFromEnd = true // We want the last rows to always be shown
         binding.messageListView.layoutManager = layoutManager
 
-
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
         model.messagesState.messages.observe(viewLifecycleOwner, Observer {
             debug("New messages received: ${it.size}")
             messagesAdapter.onMessagesChanged(it)
@@ -252,12 +247,6 @@ class MessagesFragment : ScreenFragment("Messages"), Logging {
             // If we don't know our node ID and we are offline don't let user try to send
             binding.textInputLayout.isEnabled =
                 model.isConnected.value != MeshService.ConnectionState.DISCONNECTED && myId != null
-        })
-
-        model.myNodeInfo.observe(viewLifecycleOwner, Observer { myNodeInfo ->
-            // If our Id changed, the UI may need to be updated
-            messagesAdapter.notifyDataSetChanged()
-            debug("New id received ${myNodeInfo?.myNodeNum}")
         })
     }
 

--- a/app/src/main/res/layout/adapter_message_layout.xml
+++ b/app/src/main/res/layout/adapter_message_layout.xml
@@ -1,61 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="4dp"
-    android:clipToPadding="false"
-    android:contentDescription="Message delivery status"
-    android:elevation="2dp">
+    android:contentDescription="Message delivery status">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.cardview.widget.CardView
+        android:id="@+id/Card"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent"
+        android:layout_marginEnd="@dimen/message_offset"
+        app:cardBackgroundColor="@color/colorMsg"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="2dp"
+        app:cardUseCompatPadding="true">
 
-        <com.google.android.material.chip.Chip
-            android:id="@+id/username"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:text="@string/some_username"
-            app:chipIcon="@drawable/ic_twotone_person_24"
-            app:layout_constraintEnd_toEndOf="@+id/messageTime"
-            app:layout_constraintStart_toStartOf="@+id/messageTime"
-            app:layout_constraintTop_toTopOf="parent" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/messageText"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginEnd="8dp"
-            android:autoLink="all"
-            android:text="@string/sample_message"
-            android:textIsSelectable="true"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/username"
-            app:layout_constraintTop_toTopOf="parent" />
+            <com.google.android.material.chip.Chip
+                android:id="@+id/username"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/some_username"
+                android:visibility="visible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
 
-        <TextView
-            android:id="@+id/messageTime"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:text="3 min"
-            app:layout_constraintStart_toStartOf="@+id/username"
-            app:layout_constraintTop_toBottomOf="@+id/username" />
+            <TextView
+                android:id="@+id/messageText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:autoLink="all"
+                android:text="@string/sample_message"
+                android:textIsSelectable="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/username"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/messageStatusIcon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            app:layout_constraintBottom_toBottomOf="@+id/messageText"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:srcCompat="@drawable/cloud_on" />
+            <ImageView
+                android:id="@+id/messageStatusIcon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/messageText"
+                app:srcCompat="@drawable/cloud_on" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/messageTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:text="3 minutes ago"
+                app:layout_constraintEnd_toStartOf="@id/messageStatusIcon"
+                app:layout_constraintTop_toBottomOf="@id/messageText" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,6 @@
     <color name="colorPrimary">#3700B3</color>
     <color name="colorPrimaryDark">#3700B3</color>
     <color name="colorAccent">#D81B60</color>
+    <color name="colorMsg">#07000000</color>
+    <color name="colorMyMsg">#403700B3</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,3 +1,4 @@
 <resources>
     <dimen name="fab_margin">16dp</dimen>
+    <dimen name="message_offset">64dp</dimen>
 </resources>


### PR DESCRIPTION
This is how it looks: 
![Screenshot_20210125-173539](https://user-images.githubusercontent.com/77995643/105787845-22b29880-5f34-11eb-9416-ff36d746e7e6.jpg)

Mostly UI changes to the layout, but there are also code changes:
* Update myNode LiveData when messages are loaded from the storage, otherwise the UI will not classify messages correctly until BT connection is established
* Manually set colors/margins in the code