### PR TITLE
Map UI update fixes

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -21,6 +21,7 @@ import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.service.MeshService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlin.math.max
 
 /// Given a human name, strip out the first letter of the first three words and return that as the initials for
 /// that user. If the original name is only one word, strip vowels from the original name and if the result is
@@ -119,12 +120,15 @@ class UIViewModel(app: Application) : AndroidViewModel(app), Logging {
                 val builder = config.toBuilder()
                 if (value > 0) {
                     builder.preferencesBuilder.positionBroadcastSecs = value
+                    builder.preferencesBuilder.gpsUpdateInterval = value
+                    builder.preferencesBuilder.sendOwnerInterval = max(1, 3600 / value).toInt()
                     builder.preferencesBuilder.locationShare =
                         MeshProtos.LocationSharing.LocEnabled
-                } else
+                } else {
+                    builder.preferencesBuilder.positionBroadcastSecs = Int.MAX_VALUE
                     builder.preferencesBuilder.locationShare =
                         MeshProtos.LocationSharing.LocDisabled
-
+                }
                 setRadioConfig(builder.build())
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -623,9 +623,14 @@ class MeshService : Service(), Logging {
 
             if (dataPacket != null) {
 
-                if (myInfo.myNodeNum == packet.from)
-                    debug("Ignoring packet sent from our node")
-                else {
+                if (myInfo.myNodeNum == packet.from) {
+                    // Handle position updates from the device
+                    if (data.portnumValue == Portnums.PortNum.POSITION_APP_VALUE) {
+                        val rxTime = if (packet.rxTime != 0) packet.rxTime else currentSecond()
+                        handleReceivedPosition(packet.from, MeshProtos.Position.parseFrom(data.payload), rxTime)
+                    } else
+                        debug("Ignoring packet sent from our node, portnum=${data.portnumValue} ${bytes.size} bytes")
+                } else {
                     debug("Received data from $fromId, portnum=${data.portnumValue} ${bytes.size} bytes")
 
                     dataPacket.status = MessageStatus.RECEIVED

--- a/app/src/main/java/com/geeksville/mesh/ui/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MapFragment.kt
@@ -86,32 +86,34 @@ class MapFragment : ScreenFragment("Map"), Logging {
             return FeatureCollection.fromFeatures(locations)
         }
 
-        fun zoomToNodes(map: MapboxMap) {
-            if (nodesWithPosition.isNotEmpty()) {
-                val update = if (nodesWithPosition.size >= 2) {
-                    // Multiple nodes, make them all fit on the map view
-                    val bounds = LatLngBounds.Builder()
 
-                    // Add all positions
-                    bounds.includes(nodesWithPosition.map { it.position!! }
-                        .map { LatLng(it.latitude, it.longitude) })
-
-                    CameraUpdateFactory.newLatLngBounds(bounds.build(), 150)
-                } else {
-                    // Only one node, just zoom in on it
-                    val it = nodesWithPosition[0].position!!
-
-                    val cameraPos = CameraPosition.Builder().target(
-                        LatLng(it.latitude, it.longitude)
-                    ).zoom(9.0).build()
-                    CameraUpdateFactory.newCameraPosition(cameraPos)
-                }
-                map.animateCamera(update, 1000)
-            }
-        }
 
         nodePositions.setGeoJson(getCurrentNodes()) // Update node positions
-        zoomToNodes(map)
+    }
+
+    fun zoomToNodes(map: MapboxMap) {
+        val nodesWithPosition = model.nodeDB.nodes.value?.values?.filter { it.validPosition != null }
+        if (nodesWithPosition != null && nodesWithPosition.isNotEmpty()) {
+            val update = if (nodesWithPosition.size >= 2) {
+                // Multiple nodes, make them all fit on the map view
+                val bounds = LatLngBounds.Builder()
+
+                // Add all positions
+                bounds.includes(nodesWithPosition.map { it.position!! }
+                    .map { LatLng(it.latitude, it.longitude) })
+
+                CameraUpdateFactory.newLatLngBounds(bounds.build(), 150)
+            } else {
+                // Only one node, just zoom in on it
+                val it = nodesWithPosition[0].position!!
+
+                val cameraPos = CameraPosition.Builder().target(
+                    LatLng(it.latitude, it.longitude)
+                ).zoom(9.0).build()
+                CameraUpdateFactory.newCameraPosition(cameraPos)
+            }
+            map.animateCamera(update, 1000)
+        }
     }
 
     override fun onCreateView(
@@ -135,8 +137,11 @@ class MapFragment : ScreenFragment("Map"), Logging {
     /**
      * Mapbox native code can crash painfully if you ever call a mapbox view function while the view is not actively being show
      */
+    /**
+     * Mapbox native code can crash painfully if you ever call a mapbox view function while the view is not actively being show
+     */
     private val isViewVisible: Boolean
-        get() = view != null && isResumed && (mapView?.isDestroyed != false)
+        get() = view != null && isResumed && mapView != null && !(mapView!!.isDestroyed)
 
     override fun onViewCreated(viewIn: View, savedInstanceState: Bundle?) {
         super.onViewCreated(viewIn, savedInstanceState)
@@ -164,9 +169,7 @@ class MapFragment : ScreenFragment("Map"), Logging {
                             style.addLayer(labelLayer)
                         }
 
-                        //map.uiSettings.isScrollGesturesEnabled = true
-                        //map.uiSettings.isZoomGesturesEnabled = true
-
+                        map.uiSettings.isRotateGesturesEnabled = false
                         // Provide initial positions
                         model.nodeDB.nodes.value?.let { nodes ->
                             onNodesChanged(map, nodes.values)
@@ -175,10 +178,11 @@ class MapFragment : ScreenFragment("Map"), Logging {
 
                     // Any times nodes change update our map
                     model.nodeDB.nodes.observe(viewLifecycleOwner, Observer { nodes ->
-                        debug("Nodes updated! map visible = $isViewVisible")
-                        if (isViewVisible)
+                        debug("Nodes updated! map visible = $isViewVisible view!= null: ${view != null}  isResumed: $isResumed mapview destroyed: ${mapView?.isDestroyed}")
+                       // if (isViewVisible)
                             onNodesChanged(map, nodes.values)
                     })
+                    zoomToNodes(map)
                 }
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MapFragment.kt
@@ -134,15 +134,6 @@ class MapFragment : ScreenFragment("Map"), Logging {
 
     var mapView: MapView? = null
 
-    /**
-     * Mapbox native code can crash painfully if you ever call a mapbox view function while the view is not actively being show
-     */
-    /**
-     * Mapbox native code can crash painfully if you ever call a mapbox view function while the view is not actively being show
-     */
-    private val isViewVisible: Boolean
-        get() = view != null && isResumed && mapView != null && !(mapView!!.isDestroyed)
-
     override fun onViewCreated(viewIn: View, savedInstanceState: Bundle?) {
         super.onViewCreated(viewIn, savedInstanceState)
 
@@ -178,9 +169,7 @@ class MapFragment : ScreenFragment("Map"), Logging {
 
                     // Any times nodes change update our map
                     model.nodeDB.nodes.observe(viewLifecycleOwner, Observer { nodes ->
-                        debug("Nodes updated! map visible = $isViewVisible view!= null: ${view != null}  isResumed: $isResumed mapview destroyed: ${mapView?.isDestroyed}")
-                       // if (isViewVisible)
-                            onNodesChanged(map, nodes.values)
+                        onNodesChanged(map, nodes.values)
                     })
                     zoomToNodes(map)
                 }


### PR DESCRIPTION
Fixes for issues discovered during testing map updates
* The isViewVisible workaround for mapbox crashes was not working as expected, as isViewVisible was false all the time (and not updating the map). Rather than fixing the expression for it, I tested on my devices without the workaround and the crash does not happen. I suggest we try to release without the workaround (this PR)
* Follow up to recent change to allow increasing frequency of position broadcast:  
** update gps wakeup frequency, otherwise we were sending the same position all the time.
** shorten period of owner updates according to broadcast frequency (I wish we had an independent period for owner updates..)
* Do not ignore position updates for our device
* Zoom map camera to user location only once, afterwards if user scrolls elsewhere, it becomes annoying.
