### PR TITLE
Add a separate notification channel for messages

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -98,6 +98,8 @@ class MeshService : Service(), Logging {
         DEVICE_SLEEP // device is in LS sleep state, it will reconnected to us over bluetooth once it has data
     }
 
+    private var previousSummary: String? = null
+
     /// A mapping of receiver class name to package name - used for explicit broadcasts
     private val clientPackages = mutableMapOf<String, String>()
     private val serviceNotifications = MeshServiceNotifications(this)
@@ -124,18 +126,10 @@ class MeshService : Service(), Logging {
         getNodeNum = { myNodeNum }
     )
 
-    private fun getSenderName(): String {
-        val recentFrom = recentReceivedTextPacket?.from // safe, immutable copy
-        return if (recentFrom != null) {
-            nodeDBbyID[recentFrom]?.user?.longName
-                ?: recentFrom
-        } else {
-            getString(R.string.unknown_username)
-        }
+    private fun getSenderName(packet : DataPacket?): String {
+        val name = nodeDBbyID[packet?.from]?.user?.longName
+        return name ?: "Unknown username"
     }
-
-    /// A text message that has a arrived since the last notification update
-    private var recentReceivedTextPacket: DataPacket? = null
 
     private val notificationSummary
         get() = when (connectionState) {
@@ -259,11 +253,9 @@ class MeshService : Service(), Logging {
         })
     }
 
-    private fun updateNotification() = serviceNotifications.updateNotification(
-        recentReceivedTextPacket,
-        notificationSummary,
-        getSenderName()
-    )
+    private fun updateMessageNotification(message: DataPacket) =
+        serviceNotifications.updateMessageNotification(
+                getSenderName(message), message.bytes!!.toString(utf8))
 
     /**
      * tell android not to kill us
@@ -276,11 +268,9 @@ class MeshService : Service(), Logging {
 
         // We always start foreground because that's how our service is always started (if we didn't then android would kill us)
         // but if we don't really need foreground we immediately stop it.
-        val notification = serviceNotifications.createNotification(
-            recentReceivedTextPacket,
-            notificationSummary,
-            getSenderName()
-        )
+        val notification = serviceNotifications.createServiceStateNotification(
+            notificationSummary)
+
         startForeground(serviceNotifications.notifyId, notification)
         if (!wantForeground) {
             stopForeground(true)
@@ -634,9 +624,7 @@ class MeshService : Service(), Logging {
                     when (data.portnumValue) {
                         Portnums.PortNum.TEXT_MESSAGE_APP_VALUE -> {
                             debug("Received CLEAR_TEXT from $fromId")
-
-                            recentReceivedTextPacket = dataPacket
-                            updateNotification()
+                            updateMessageNotification(dataPacket)
                         }
 
                         // Handle new style position info
@@ -814,7 +802,7 @@ class MeshService : Service(), Logging {
 
     /// If we just changed our nodedb, we might want to do somethings
     private fun onNodeDBChanged() {
-        updateNotification()
+        maybeUpdateServiceStatusNotification()
 
         // we don't ask for GPS locations from android if our device has a built in GPS
         // Note: myNodeInfo can go away if we lose connections, so it might be null
@@ -956,7 +944,15 @@ class MeshService : Service(), Logging {
         }
 
         // Update the android notification in the status bar
-        updateNotification()
+        maybeUpdateServiceStatusNotification()
+    }
+
+    private fun maybeUpdateServiceStatusNotification() {
+        val currentSummary = notificationSummary
+        if (previousSummary == null || !previousSummary.equals(currentSummary)) {
+            serviceNotifications.updateServiceStateNotification(currentSummary)
+            previousSummary = currentSummary
+        }
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,4 +85,5 @@
     <string name="message_delivery_status">Message delivery status</string>
     <string name="broadcast_position_secs">Broadcast position period (in seconds), 0 - disable</string>
     <string name="ls_sleep_secs">Device sleep period (in seconds)</string>
+    <string name="meshtastic_messages_notifications">Notifications about messages</string>
 </resources>


### PR DESCRIPTION
* Split notification channel into 'service' and 'messages' notifications. With a separate channel, we can reasonably enable sounds for incoming messages, otherwise it will be too annoying, as service notifications are very frequent.
* Added deduping for service notifications to reduce their frequency, but in the end it proved not sufficient, so went for the split channel option.
* Provided separate "notification" methods for messages and service, to make things look cleaner.
* Removed recentReceivedTextPacket member, seemed a bit hacky.