### PR TITLE
Fix expired link

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,7 +90,7 @@
     <string name="protocol_stress_test">Protocol stress test</string>
     <string name="advanced_settings">Advanced settings</string>
     <string name="firmware_too_old">Firmware update required</string>
-    <string name="firmware_old">The radio firmware is too old to talk to this application, please go to the settings pane and choose "Update Firmware".  For more information on this see <a href="https://www.meshtastic.org/software/firmware-too-old.html">our wiki</a>.</string>
+    <string name="firmware_old">The radio firmware is too old to talk to this application, please go to the settings pane and choose "Update Firmware".  For more information on this see <a href="https://github.com/meshtastic/Meshtastic-device#firmware-installation">our Firmware Installation guide</a> on Github.</string>
     <string name="okay">Okay</string>
     <string name="must_set_region">You must set a region!</string>
     <string name="region">Region</string>


### PR DESCRIPTION
The 'Firmware update required' modal contains an expired link to the
Wiki. This commit points the user towards the Firmware Installation
section on Github instead.

* app/src/main/res/values/strings.xml