### PR TITLE
POC: Show nodes in Locus Maps. 

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -31,5 +31,10 @@
       <option name="name" value="maven" />
       <option name="url" value="https://api.mapbox.com/downloads/v2/releases/maven" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -190,4 +190,7 @@ dependencies {
     implementation "androidx.work:work-runtime-ktx:$work_version"
 
     implementation project(':geeksville-androidlib')
+
+    // Locus Maps: displaying stations as POIs in the map
+    implementation 'com.asamm:locus-api-android:0.9.39'
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -496,7 +496,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         if (model.isConnected.value == MeshService.ConnectionState.CONNECTED && info != null && info.shouldUpdate && info.couldUpdate && service != null) {
             binding.updateFirmwareButton.visibility = View.VISIBLE
             binding.updateFirmwareButton.text =
-                getString(R.string.update_to).format(getString(R.string.short_firmware_version))
+                getString(R.string.update_to).format(getString(R.string.cur_firmware_version))
 
             val progress = service.updateStatus
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ allprojects {
             }
         }
         google()
-        jcenter()
         maven { url 'https://jitpack.io' }
+        mavenCentral()
         //maven { url "https://plugins.gradle.org/m2/" }
     }
 }


### PR DESCRIPTION
On each update of the nodeDb Broadcast the first 1k nodes so that a running LocusMaps instance can display them as Map Points. The current state is neither in the perfect place nor perfect but might be a good start.

Things to take into consideration
- Should we litter the MeshService with that or is there a better place where optional code should be located and still called?
- We call the method quite often, any idea of intelligent filtering? To keep this from becoming a battery hog.
- Cleanup on exit? We could send an empty points list
- Configuration? If Locus isn't installed it doesn't hurt anybody but is hust useless
- Alternative import methods (starting locus etc.)

Extra changes:  jcenter replaced with maven central since jcenter is deprecated