### PR TITLE
Fix: Localization for pt-BR

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,7 +58,7 @@ android {
     defaultConfig {
         // We have to list all translated languages here, because some of our libs have bogus languages that google play
         // doesn't like and we need to strip them (gr)
-        resConfigs "cs", "de", "el", "en", "es", "fi", "fr", "ga", "ht", "it", "ja", "ko", "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sq", "sv", "tr", "zh"
+        resConfigs "cs", "de", "el", "en", "es", "fi", "fr", "ga", "ht", "it", "ja", "ko", "nl", "no", "pl", "pt", "pt-rBR", "ro", "ru", "sk", "sl", "sq", "sv", "tr", "zh"
 
         // Needed to make mapbox work inside the firebase testlab - FIXME, alas, still doesn't work
         ndk {

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -12,11 +12,11 @@
     <string name="user_avatar">Avatar do usuário</string>
     <string name="sample_message">ei, encontrei o esconderijo, está aqui ao lado do tigre grande. estou um pouco assustado.</string>
     <string name="send_text">Enviar Texto</string>
-    <string name="warning_not_paired">Você ainda não pareou um rádio compatível ao Meshtastic com este smartphone. Por favor pareie um dispositivo e configure seu nome de usuário.\n\nEste aplicativo opensource está em desenvolvimento, caso encontrar algum problema por favor publique em nosso fórum: meshtastic.discourse.group.\n\nPara mais informações acesse nossa página - www.meshtastic.org.</string>
+    <string name="warning_not_paired">Você ainda não pareou um rádio compatível ao Meshtastic com este smartphone. Por favor pareie um dispositivo e configure seu nome de usuário.\n\nEste aplicativo open source está em desenvolvimento, caso encontre algum problema por favor publique em nosso fórum: meshtastic.discourse.group.\n\nPara mais informações acesse nossa página: www.meshtastic.org.</string>
     <string name="username_unset">Nome de usuário não configurado</string>
     <string name="your_name">Seu Nome</string>
-    <string name="analytics_okay">Estatísticas anônimas de uso e relatórios de falhas.</string>
-    <string name="looking_for_meshtastic_devices">Procurando por dispositivos Meshtastic...</string>
+    <string name="analytics_okay">Estatísticas anônimas de uso e relatórios de erros.</string>
+    <string name="looking_for_meshtastic_devices">Procurando por dispositivos Meshtastic…</string>
     <string name="requires_bluetooth">Este aplicativo requer acesso ao bluetooth. Por favor permita o acesso nas configurações do Android.</string>
     <string name="error_bluetooth">Erro - este app requer bluetooth</string>
     <string name="starting_pairing">Iniciando pareamento</string>
@@ -73,14 +73,14 @@
     <string name="debug_panel">Painel de depuração</string>
     <string name="debug_last_messages">500 últimas mensagens</string>
     <string name="clear_last_messages">Limpar</string>
-    <string name="updating_firmware">Atualizando firmware, aguarde até 8 minutos...</string>
+    <string name="updating_firmware">Atualizando firmware, aguarde até 8 minutos…</string>
     <string name="update_successful">Atualização bem sucedida</string>
     <string name="update_failed">Atualização falhou</string>
     <string name="message_reception_time">tempo de recebimento de mensagem</string>
     <string name="message_reception_state">estado de recebimento de mensagem</string>
     <string name="message_delivery_status">Status de entrega de mensagem</string>
-    <string name="broadcast_position_secs">Intervalo de transmissão da posição (em segundos), 0 - desabilitar</string>
-    <string name="ls_sleep_secs">Período de suspensão (sleep) do dispositivo (em segundos)</string>
+    <string name="broadcast_position_secs">Intervalo de localização (segundos), 0 - desabilitar</string>
+    <string name="ls_sleep_secs">Intervalo de suspensão (sleep) (segundos)</string>
     <string name="meshtastic_messages_notifications">Notificações sobre mensagens</string>
     <string name="broadcast_period_too_small">Período mínimo de transmissão para este canal é %d</string>
     <string name="protocol_stress_test">Stress test do protocolo</string>
@@ -88,11 +88,11 @@
     <string name="firmware_too_old">Atualização do firmware necessária</string>
     <string name="firmware_old">Versão de firmware do rádio muito antiga para comunicar com este aplicativo, favor acessar opção "Atualizar firmware" nas Configurações.  Para mais informações consultar <a href="https://github.com/meshtastic/Meshtastic-device#firmware-installation">Nosso guia de instalação de firmware</a> no Github.</string>
     <string name="okay">Okay</string>
-    <string name="must_set_region">Você deve informar a região!</string>
+    <string name="must_set_region">Você deve informar uma região!</string>
     <string name="region">Região</string>
     <string name="cant_change_no_radio">Não foi possível mudar de canal, rádio não conectado. Tente novamente.</string>
     <string name="sample_coords">55.332244 34.442211</string>
-    <string name="save_messages">Salvar mensagens como .CSV...</string>
+    <string name="save_messages">Salvar mensagens como .CSV…</string>
     <string name="set_channel_options">Configurar opções do canal</string>
     <string name="reset">Redefinir</string>
     <string name="are_you_shure_change_default">Tem certeza que quer mudar para o canal padrão?</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -43,7 +43,7 @@
     <string name="please_pair">Emparelhe o dispositivo nas configurações do Android.</string>
     <string name="pairing_completed">Emparelhamento concluído, a iniciar serviço</string>
     <string name="pairing_failed_try_again">Emparelhamento falhou, por favor escolha novamente</string>
-    <string name="location_disabled">Acesso à localização desativado, não é possivel fornecer a localização na mesh.</string>
+    <string name="location_disabled">Acesso à localização desativado, não é possível fornecer a localização na mesh.</string>
     <string name="share">Partilha</string>
     <string name="disconnected">Desconectado</string>
     <string name="device_sleeping">Dispositivo a dormir</string>
@@ -56,7 +56,7 @@
     <string name="connected_sleeping">Conectado ao rádio, mas está a dormir</string>
     <string name="update_to">Atualização para %s</string>
     <string name="app_too_old">A aplicação é muito antiga</string>
-    <string name="must_update">Tem de atualizar esta aplicação no Google Play (ou Github). A versão é muito antiga para ser possivel falar com este rádio.</string>
+    <string name="must_update">Tem de atualizar esta aplicação no Google Play (ou Github). A versão é muito antiga para ser possível falar com este rádio.</string>
     <string name="none">Nenhum (desabilitado)</string>
     <string name="modem_config_short">Curto alcance (mas rápido)</string>
     <string name="modem_config_medium">Médio alcance (mas rápido)</string>
@@ -69,4 +69,47 @@
     <string name="a_list_of_nodes_in_the_mesh">Lista de nós na mesh</string>
     <string name="text_messages">Mensagem de Texto</string>
     <string name="channel_invalid">O Link Deste Canal é inválido e não pode ser usado</string>
+    <!--Bellow copied from Brazillian Portuguese (values-pt-rBR)-->
+    <string name="debug_panel">Painel de depuração</string>
+    <string name="debug_last_messages">500 últimas mensagens</string>
+    <string name="clear_last_messages">Limpar</string>
+    <string name="updating_firmware">Atualizando firmware, aguarde até 8 minutos…</string>
+    <string name="update_successful">Atualização bem sucedida</string>
+    <string name="update_failed">Atualização falhou</string>
+    <string name="message_reception_time">tempo de recebimento de mensagem</string>
+    <string name="message_reception_state">estado de recebimento de mensagem</string>
+    <string name="message_delivery_status">Status de entrega de mensagem</string>
+    <string name="broadcast_position_secs">Intervalo de localização (segundos), 0 - desabilitar</string>
+    <string name="ls_sleep_secs">Intervalo de suspensão (sleep) (segundos)</string>
+    <string name="meshtastic_messages_notifications">Notificações sobre mensagens</string>
+    <string name="broadcast_period_too_small">Período mínimo de transmissão para este canal é %d</string>
+    <string name="protocol_stress_test">Stress test do protocolo</string>
+    <string name="advanced_settings">Configurações avançadas</string>
+    <string name="firmware_too_old">Atualização do firmware necessária</string>
+    <string name="firmware_old">Versão de firmware do rádio muito antiga para comunicar com este aplicativo, favor acessar opção "Atualizar firmware" nas Configurações.  Para mais informações consultar <a href="https://github.com/meshtastic/Meshtastic-device#firmware-installation">Nosso guia de instalação de firmware</a> no Github.</string>
+    <string name="okay">Okay</string>
+    <string name="must_set_region">Você deve informar uma região!</string>
+    <string name="region">Região</string>
+    <string name="cant_change_no_radio">Não foi possível mudar de canal, rádio não conectado. Tente novamente.</string>
+    <string name="sample_coords">55.332244 34.442211</string>
+    <string name="save_messages">Salvar mensagens como .CSV…</string>
+    <string name="set_channel_options">Configurar opções do canal</string>
+    <string name="reset">Redefinir</string>
+    <string name="are_you_shure_change_default">Tem certeza que quer mudar para o canal padrão?</string>
+    <string name="reset_to_defaults">Redefinir para configurações originais</string>
+    <string name="apply">Aplicar</string>
+    <string name="no_app_found">Aplicativo não encontrado para enviar link</string>
+    <string name="theme">Tema</string>
+    <string name="theme_light">Claro</string>
+    <string name="theme_dark">Escuro</string>
+    <string name="theme_system">Padrão do sistema</string>
+    <string name="choose_theme_title">Escolher tema</string>
+    <string name="background_required">Localização em segundo plano necessária</string>
+    <string name="show_system_settings">Exibir configurações do sistema</string>
+    <string name="why_background_required">Para usar esta função, você deve permitir acesso ao Local com a opção "localização em segundo plano".\n\nIsso permite acesso à localização enquanto o Meshtastic roda em segundo plano, possibilitando o envio da sua localização aos outros membros da mesh.</string>
+    <string name="required_permissions">Permissões necessárias</string>
+    <string name="location">localização</string>
+    <string name="cancel_no_radio">Cancelar (sem acesso ao rádio)</string>
+    <string name="allow_will_show">Permitir (exibe diálogo)</string>
+    <string name="provide_location_to_mesh">Fornecer localização para mesh</string>
 </resources>


### PR DESCRIPTION
Issue: "Brazilian Portuguese (pt-BR)" language loading "Portuguese (pt)" localization files.

Fix: 

- app/build.gradle: Added "pt-rBR" to "resConfigs" line;

Other changes to localization:

- app/src/main/res/values-pt-rBR/strings.xml: various minor changes;
- app/src/main/res/values-pt/strings.xml: copied missing lines 72-114 from updated "pt-rBR" localization.