### PR TITLE
Fix: sendButton / EditText

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -1,6 +1,7 @@
 package com.geeksville.mesh.ui
 
 import android.os.Bundle
+import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -28,6 +29,8 @@ import java.util.*
 
 // Allows usage like email.on(EditorInfo.IME_ACTION_NEXT, { confirm() })
 fun EditText.on(actionId: Int, func: () -> Unit) {
+    setImeOptions(EditorInfo.IME_ACTION_SEND) // Force "SEND" IME Action
+    setRawInputType(InputType.TYPE_CLASS_TEXT) // Suppress ENTER but allow textMultiLine
     setOnEditorActionListener { _, receivedActionId, _ ->
 
         if (actionId == receivedActionId) {
@@ -239,7 +242,7 @@ class MessagesFragment : ScreenFragment("Messages"), Logging {
             // requireActivity().hideKeyboard()
         }
 
-        binding.messageInputText.on(EditorInfo.IME_ACTION_DONE) {
+        binding.messageInputText.on(EditorInfo.IME_ACTION_SEND) {
             debug("did IME action")
 
             val str = binding.messageInputText.text.toString().trim()

--- a/app/src/main/res/layout/messages_fragment.xml
+++ b/app/src/main/res/layout/messages_fragment.xml
@@ -33,7 +33,7 @@
             android:id="@+id/messageInputText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:imeOptions="actionDone"
+            android:inputType="textMultiLine"
             android:maxLength="200"
             android:text="" />
 

--- a/app/src/main/res/layout/messages_fragment.xml
+++ b/app/src/main/res/layout/messages_fragment.xml
@@ -33,8 +33,8 @@
             android:id="@+id/messageInputText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:maxLength="200"
             android:imeOptions="actionDone"
+            android:maxLength="200"
             android:text="" />
 
     </com.google.android.material.textfield.TextInputLayout>
@@ -42,15 +42,12 @@
     <ImageButton
         android:id="@+id/sendButton"
         android:layout_width="64dp"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_height="64dp"
+        android:layout_marginBottom="4dp"
+        android:contentDescription="@string/send_text"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/textInputLayout"
-        app:layout_constraintTop_toBottomOf="@+id/messageListView"
         app:srcCompat="@drawable/ic_send_24" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
ENTER/ characters could be sent with textMutiLine & IME_ACTION_DONE.

Fix:

- EditText: Define "SEND" IME Action & InputType "Text" to disable ENTER/ input in message text;
- messageInputText: declare textMultiLine to keep multi-line layout;
- sendButton: minor cosmetic layout changes.