### PR TITLE
removed hints from channel inputs

### DIFF
--- a/app/src/main/res/layout/channel_fragment.xml
+++ b/app/src/main/res/layout/channel_fragment.xml
@@ -22,7 +22,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:digits="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890- "
-            android:hint="@string/channel_name"
             android:imeOptions="actionDone"
             android:maxLength="15"
             android:singleLine="true"
@@ -92,8 +91,7 @@
         <AutoCompleteTextView
             android:id="@+id/filled_exposed_dropdown"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/set_channel_options" />
+            android:layout_height="wrap_content" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <Button


### PR DESCRIPTION
Related to Issue [#326](https://github.com/meshtastic/Meshtastic-device/issues/326) in Meshtastic-device.

+ Removed the hint for the Channel Name text field.
+ Removed the hint for the filled_exposed_dropdown text view.

This removes the ghosting as seen [here](https://meshtastic.org/assets/files/android-change-channel-92c9ab05f305ce0d36c8aa208afbc2ba.png) in the docs for the Android app usage.