### PR TITLE
Fix: MessagesFragment layout

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -1,5 +1,6 @@
 package com.geeksville.mesh.ui
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -54,7 +55,7 @@ class MessagesFragment : ScreenFragment("Messages"), Logging {
 
     private fun getShortDateTime(time: Date): String {
         // return time if within 24 hours, otherwise date/time
-        val one_day = 60 * 60 * 24 * 100L
+        val one_day = 60 * 60 * 24 * 1000
         if (System.currentTimeMillis() - time.time > one_day) {
             return dateTimeFormat.format(time)
         } else return timeFormat.format(time)
@@ -142,7 +143,8 @@ class MessagesFragment : ScreenFragment("Messages"), Logging {
             val nodes = model.nodeDB.nodes.value!!
             val node = nodes.get(msg.from)
             // Determine if this is my message (originated on this device).
-            val isMe = model.myNodeInfo.value?.myNodeNum == node?.num
+            // val isMe = model.myNodeInfo.value?.myNodeNum == node?.num
+            val isMe = msg.from == "^local"
 
             // Set cardview offset and color.
             val marginParams = holder.card.layoutParams as ViewGroup.MarginLayoutParams
@@ -180,7 +182,7 @@ class MessagesFragment : ScreenFragment("Messages"), Logging {
                 holder.username.text = user?.shortName ?: msg.from
             }
             if (msg.errorMessage != null) {
-                // FIXME, set the style to show a red error message
+                context?.let { holder.card.setCardBackgroundColor(Color.RED) }
                 holder.messageText.text = msg.errorMessage
             } else {
                 holder.messageText.text = msg.text

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -4,7 +4,7 @@
     <color name="colorPrimary">#141414</color>
     <color name="colorPrimaryDark">#141414</color>
     <color name="colorMsg">#212121</color>
-    <color name="colorMyMsg">#212121</color>
+    <color name="colorMyMsg">#28463C</color>
     <color name="colorDebugBackground">#141414</color>
     <color name="colorAdvancedBackground">#141414</color>
     <color name="colorIconTint">#FFFFFF</color>


### PR DESCRIPTION
Fixed different styles for sent and received messages (like [this](https://user-images.githubusercontent.com/48680741/132432075-4ab0bfcb-2ec6-409c-8dc0-2f9cdbcfa97f.jpg)):
- fix "one_day" typo (= 86400000 ms/day);
- fix isMe logic (applies different margin & background color to sent messages);
- fix message card background color for Dark theme (colorMsg & colorMyMsg were the same on Dark theme);
- added setCardBackgroundColor(Color.RED) to errorMessage.

