### PR TITLE
Fix: Mapbox API token for CI test

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,9 +14,6 @@ jobs:
         with:
           submodules: true
       - name: Loading secrets
-        env:
-          gservices: ${{ secrets.gservices }}
-          mapboxtoken: ${{ secrets.mapboxtoken }}
         run: |
           # not yet needed echo $gservices > ./app/google-services.json
           rm ./app/google-services.json          
@@ -25,10 +22,13 @@ jobs:
           rm ./app/src/main/res/values/mapbox-token.xml
           cp ./app/special/mapbox-token.xml ./app/src/main/res/values/
           # The following would not be valid XML, don't use yet
-          # echo $mapboxtoken > ./app/src/main/res/values/mapbox-token.xml
+          # echo $MAPBOXTOKEN > ./app/src/main/res/values/mapbox-token.xml
 
           mkdir -p ~/.gradle
-          echo "MAPBOX_DOWNLOADS_TOKEN=$mapboxtoken" >>~/.gradle/gradle.properties
+          echo "MAPBOX_DOWNLOADS_TOKEN=$MAPBOXTOKEN" >>~/.gradle/gradle.properties
+        env:
+          gservices: ${{ secrets.gservices }}
+          mapboxtoken: ${{ secrets.mapboxtoken }}
       - name: Mock curfirmware version for CI
         run: |
           rm ./app/src/main/res/values/curfirmwareversion.xml

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,7 +28,7 @@ jobs:
           echo "MAPBOX_DOWNLOADS_TOKEN=$MAPBOXTOKEN" >>~/.gradle/gradle.properties
         env:
           gservices: ${{ secrets.gservices }}
-          mapboxtoken: ${{ secrets.mapboxtoken }}
+          MAPBOXTOKEN: ${{ secrets.MAPBOXTOKEN }}
       - name: Mock curfirmware version for CI
         run: |
           rm ./app/src/main/res/values/curfirmwareversion.xml


### PR DESCRIPTION
fix Mapbox gradle error:

"Could not GET 'https://api.mapbox.com/downloads/v2/releases/maven/com/mapbox/mapboxsdk/mapbox-android-sdk/9.6.0/mapbox-android-sdk-9.6.0.pom'. Received status code 401 from server: Unauthorized"

changes:
- uppercase "$MAPBOXTOKEN";
- "env" below "run".