### PR TITLE
increase message max length to 228 chars

### DIFF
--- a/app/src/main/res/layout/messages_fragment.xml
+++ b/app/src/main/res/layout/messages_fragment.xml
@@ -34,7 +34,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="textMultiLine"
-            android:maxLength="200"
+            android:maxLength="228"
             android:text="" />
 
     </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
increase message maxLength to 228 characters (from 200).

in theory 237 should be max, but 234 appears to be the max for Android App and 228 for iOS App.
using 228 to match iOS.