### PR TITLE
update permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,8 +35,9 @@
      -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <!-- Only for debug log writing, disable for production -->
+    <!-- Only for debug log writing, disable for production
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    -->
 
     <!-- We run our mesh code as a foreground service - FIXME, find a way to stop doing this -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -315,10 +315,10 @@ class MainActivity : AppCompatActivity(), Logging,
                 MaterialAlertDialogBuilder(this)
                     .setTitle(getString(R.string.required_permissions))
                     .setMessage(getMissingMessage())
-                    .setNeutralButton(R.string.cancel_no_radio) { _, _ ->
+                    .setNeutralButton(R.string.cancel) { _, _ ->
                         warn("User bailed due to permissions")
                     }
-                    .setPositiveButton(R.string.allow_will_show) { _, _ ->
+                    .setPositiveButton(R.string.accept) { _, _ ->
                         doRequest()
                     }
                     .show()

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -316,7 +316,7 @@ class MainActivity : AppCompatActivity(), Logging,
                     .setTitle(getString(R.string.required_permissions))
                     .setMessage(getMissingMessage())
                     .setNeutralButton(R.string.cancel_no_radio) { _, _ ->
-                        error("User bailed due to permissions")
+                        warn("User bailed due to permissions")
                     }
                     .setPositiveButton(R.string.allow_will_show) { _, _ ->
                         doRequest()

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -41,6 +41,7 @@ import com.geeksville.android.GeeksvilleApplication
 import com.geeksville.android.Logging
 import com.geeksville.android.ServiceClient
 import com.geeksville.concurrent.handledLaunch
+import com.geeksville.mesh.android.getLocationPermissions
 import com.geeksville.mesh.android.getBackgroundPermissions
 import com.geeksville.mesh.android.getCameraPermissions
 import com.geeksville.mesh.android.getMissingPermissions
@@ -250,6 +251,9 @@ class MainActivity : AppCompatActivity(), Logging,
 
     /** Ask the user to grant camera permission */
     fun requestCameraPermission() = requestPermission(getCameraPermissions(), false)
+
+    /** Ask the user to grant foreground location permission */
+    fun requestLocationPermission() = requestPermission(getLocationPermissions(), false)
 
     /** Ask the user to grant background location permission */
     fun requestBackgroundPermission() = requestPermission(getBackgroundPermissions(), false)

--- a/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
@@ -41,6 +41,18 @@ fun Context.getCameraPermissions(): List<String> {
 fun Context.hasCameraPermission() = getCameraPermissions().isEmpty()
 
 /**
+ * Camera permission (or empty if we already have what we need)
+ */
+fun Context.getLocationPermissions(): List<String> {
+    val perms = mutableListOf(Manifest.permission.ACCESS_FINE_LOCATION)
+
+    return getMissingPermissions(perms)
+}
+
+/** @return true if the user already has camera permission */
+fun Context.hasLocationPermission() = getLocationPermissions().isEmpty()
+
+/**
  * A list of missing background location permissions (or empty if we already have what we need)
  */
 fun Context.getBackgroundPermissions(): List<String> {

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -35,6 +35,7 @@ import com.geeksville.mesh.MainActivity
 import com.geeksville.mesh.R
 import com.geeksville.mesh.RadioConfigProtos
 import com.geeksville.mesh.android.bluetoothManager
+import com.geeksville.mesh.android.hasLocationPermission
 import com.geeksville.mesh.android.hasBackgroundPermission
 import com.geeksville.mesh.android.usbManager
 import com.geeksville.mesh.databinding.SettingsFragmentBinding
@@ -656,14 +657,20 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
 
             if (view.isPressed && isChecked) { // We want to ignore changes caused by code (as opposed to the user)
                 debug("User changed location tracking to $isChecked")
-                view.isChecked =
-                    myActivity.hasBackgroundPermission() // Don't check the box until the system setting changes
-                if (!view.isChecked)
+                val hasLocationPermission = myActivity.hasLocationPermission()
+                val hasBackgroundPermission = myActivity.hasBackgroundPermission()
+
+                // Don't check the box until the system setting changes
+                view.isChecked = hasLocationPermission && hasBackgroundPermission
+
+                if (!hasLocationPermission) // Make sure we have location permission (prerequisite)
+                    myActivity.requestLocationPermission()
+                if (hasLocationPermission && !hasBackgroundPermission)
                     MaterialAlertDialogBuilder(requireContext())
                         .setTitle(R.string.background_required)
                         .setMessage(R.string.why_background_required)
                         .setNeutralButton(R.string.cancel) { _, _ ->
-                            debug("Decided not to report a bug")
+                            debug("User denied background permission")
                         }
                         .setPositiveButton(getString(R.string.accept)) { _, _ ->
                             myActivity.requestBackgroundPermission()

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -11,6 +11,7 @@ import android.companion.AssociationRequest
 import android.companion.BluetoothDeviceFilter
 import android.companion.CompanionDeviceManager
 import android.content.*
+import android.content.pm.PackageManager
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import android.os.Bundle
@@ -908,8 +909,12 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
      * If the user has not turned on location access throw up a toast warning
      */
     private fun checkLocationEnabled() {
+
+        fun hasGpsSensor(): Boolean =
+            myActivity.packageManager.hasSystemFeature(PackageManager.FEATURE_LOCATION_GPS)
+
         // If they don't have google play FIXME for now we don't check for location access
-        if (isGooglePlayAvailable(requireContext())) {
+        if (hasGpsSensor() && isGooglePlayAvailable(requireContext())) {
             // We do this painful process because LocationManager.isEnabled is only SDK28 or latet
             val builder = LocationSettingsRequest.Builder()
             builder.setNeedBle(true)

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -665,7 +665,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
                         .setNeutralButton(R.string.cancel) { _, _ ->
                             debug("Decided not to report a bug")
                         }
-                        .setPositiveButton(getString(R.string.show_system_settings)) { _, _ ->
+                        .setPositiveButton(getString(R.string.accept)) { _, _ ->
                             myActivity.requestBackgroundPermission()
                         }
                         .show()

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -31,7 +31,7 @@
     <string name="map_not_allowed">O Google Analytics está desativado. Infelizmente a plataforma de mapas utilizada (Mapbox) requer este recurso ativado para uso do plano \’gratuito\’ . Tivemos que desativar a visualização do mapa.\n\n
         Para poder visualizar o mapa será necessário ativar o Google Analytics na configuração do Android (pode ser necessário forçar o reinício do aplicativo).\n\n
         Se tiver interesse em que o Meshtastic use um plano pago do Mapbox (ou mude para uma plataforma de mapas diferente), por favor envie uma mensagem em meshtastic.discourse.group</string>
-    <string name="permission_missing">Meshtastic precisa permissão de %s. Sem isso o Android não permite conexão com um rádio LoRa via bluetooth.</string>
+    <string name="permission_missing">Meshtastic precisa da permissão de %s e da localização ativada para encontrar novos dispositivos via bluetooth. Você pode desativar novamente depois.</string>
     <string name="radio_sleeping">Rádio estava em suspensão (sleep), não foi possível mudar de canal</string>
     <string name="report_bug">Informar Bug</string>
     <string name="report_a_bug">Informar um bug</string>
@@ -104,9 +104,9 @@
     <string name="theme_dark">Escuro</string>
     <string name="theme_system">Padrão do sistema</string>
     <string name="choose_theme_title">Escolher tema</string>
-    <string name="background_required">Localização em segundo plano necessária</string>
+    <string name="background_required">Localização em segundo plano</string>
     <string name="show_system_settings">Exibir configurações do sistema</string>
-    <string name="why_background_required">Para usar esta função, você deve permitir acesso ao Local com a opção "localização em segundo plano".\n\nIsso permite acesso à localização enquanto o Meshtastic roda em segundo plano, possibilitando o envio da sua localização aos outros membros da mesh.</string>
+    <string name="why_background_required">Para este recurso, você deve conceder permissão para acessar Local com a opção \"Permitir o tempo todo\".\nIsto permite ao Meshtastic ler a localização do seu smartphone e enviar aos membros da sua mesh, mesmo quando o aplicativo está fechado ou não em uso.</string>
     <string name="required_permissions">Permissões necessárias</string>
     <string name="location">localização</string>
     <string name="cancel_no_radio">Cancelar (sem acesso ao rádio)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -30,7 +30,7 @@
     <string name="map_not_allowed">Tem os dados analícos desativados. Infelizmente o fornecedor do mapa (mapbox) requer dos dados analíticos estejam activados para o seu plano \'gratuito\' . Por isso a visualização do mapa esta desativado.\n\n
         Se pretender visualizar o mapa, vai necessitar de ativar os dados anaíticos no painel Configurações (também pode ser necessário forçar o reinício do aplicativo). \n\n
         Se estiver interessado em pagarmos pelo mapbox (ou mudar para um provedor de mapas diferente), contacte através de meshtastic.discourse.group</string>
-    <string name="permission_missing">Uma permissão necessária está a faltar, o Meshtastic não será capaz de funcionar corretamente. Ative nas configurações do aplicativo Android.</string>
+    <string name="permission_missing">Meshtastic precisa da permissão de %s e da localização ativada para encontrar novos dispositivos via bluetooth. Você pode desativar novamente depois.</string>
     <string name="radio_sleeping">O rádio estava a dormir, não conseguia mudar de canal</string>
     <string name="report_bug">Reportar Bug</string>
     <string name="report_a_bug">Reportar a bug</string>
@@ -104,9 +104,9 @@
     <string name="theme_dark">Escuro</string>
     <string name="theme_system">Padrão do sistema</string>
     <string name="choose_theme_title">Escolher tema</string>
-    <string name="background_required">Localização em segundo plano necessária</string>
+    <string name="background_required">Localização em segundo plano</string>
     <string name="show_system_settings">Exibir configurações do sistema</string>
-    <string name="why_background_required">Para usar esta função, você deve permitir acesso ao Local com a opção "localização em segundo plano".\n\nIsso permite acesso à localização enquanto o Meshtastic roda em segundo plano, possibilitando o envio da sua localização aos outros membros da mesh.</string>
+    <string name="why_background_required">Para este recurso, você deve conceder permissão para acessar Local com a opção \"Permitir o tempo todo\".\nIsto permite ao Meshtastic ler a localização do seu smartphone e enviar aos membros da sua mesh, mesmo quando o aplicativo está fechado ou não em uso.</string>
     <string name="required_permissions">Permissões necessárias</string>
     <string name="location">localização</string>
     <string name="cancel_no_radio">Cancelar (sem acesso ao rádio)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="map_not_allowed">You have analytics disabled. Unfortunately our map provider (mapbox) requires analytics to be allowed for their \'free\' plan. So we have turned off the map view.\n\n
         If you would like to see the map, you\'ll need to turn on analytics in the Settings pane (also, for the time being you might need to force restart the application).\n\n
         If you are interested in us paying for mapbox (or switching to a different map provider), please post in meshtastic.discourse.group</string>
-    <string name="permission_missing">Meshtastic needs %s permission granted. Without this Android will not allow connecting to the LoRa bluetooth radios.</string>
+    <string name="permission_missing">Meshtastic needs %s permission and location must be turned on to find new devices via bluetooth. You can turn it off again afterwards.</string>
     <string name="radio_sleeping">Radio was sleeping, could not change channel</string>
     <string name="report_bug">Report Bug</string>
     <string name="report_a_bug">Report a bug</string>
@@ -108,9 +108,9 @@
     <string name="theme_dark">Dark</string>
     <string name="theme_system">System default</string>
     <string name="choose_theme_title">Choose theme</string>
-    <string name="background_required">Background location access required</string>
+    <string name="background_required">Background location</string>
     <string name="show_system_settings">Show system settings</string>
-    <string name="why_background_required">In order to enable this feature, you must grant "allow location access all the time" permission.\n\nThis allows meshtastic to read your location while the application is in the background, so that it can send your location to other members of your mesh.</string>
+    <string name="why_background_required">For this feature, you must grant Location permission option \"Allow all the time\".\nThis allows Meshtastic to read your smartphone location and send it to other members of your mesh, even when the app is closed or not in use.</string>
     <string name="required_permissions">Required permissions</string>
     <string name="location">location</string>
     <string name="cancel_no_radio">Cancel (no radio access)</string>


### PR DESCRIPTION

- allow user to deny permissions (`warn` instead of `error`);
- improve and better explain permission dialogs;
- comply with Google's requirements for background location access.

references:
https://developer.android.com/training/location/permissions#request-background-location
https://support.google.com/googleplay/android-developer/answer/9799150