### PR TITLE
add lastHeard to installNodeInfo

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1282,6 +1282,8 @@ class MeshService : Service(), Logging {
                 // so if the info is for _our_ node we always assume time is current
                 it.position = Position(info.position)
             }
+
+            it.lastHeard = info.lastHeard
         }
     }
 


### PR DESCRIPTION
when NodeInfo is recreated by `installNodeInfo`, only `user` and `position` are updated.

this change adds `lastHeard` and prevents a `?` showing for every node until a new packet is received.