### PR TITLE
add provideLocation service start/stop

### DIFF
--- a/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
+++ b/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
@@ -109,11 +109,15 @@ interface IMeshService {
     /// Start updating the radios firmware
     void startFirmwareUpdate();
 
-    /**
-    Return a number 0-100 for progress. -1 for completed and success, -2 for failure
-    */
+    /// Return a number 0-100 for firmware update progress. -1 for completed and success, -2 for failure
     int getUpdateStatus();
 
     int getRegion();
     void setRegion(int regionCode);
+
+    /// Start providing location (from phone GPS) to mesh
+    void setupProvideLocation();
+
+    /// Stop providing location (from phone GPS) to mesh
+    void stopProvideLocation();
 }

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -179,8 +179,7 @@ class MainActivity : AppCompatActivity(), Logging,
         )
     )
 
-    private
-    val tabsAdapter = object : FragmentStateAdapter(this) {
+    private val tabsAdapter = object : FragmentStateAdapter(this) {
 
         override fun getItemCount(): Int = tabInfos.size
 
@@ -200,7 +199,6 @@ class MainActivity : AppCompatActivity(), Logging,
         updateBluetoothEnabled()
     }
 
-
     /**
      * Don't tell our app we have bluetooth until we have bluetooth _and_ location access
      */
@@ -212,7 +210,6 @@ class MainActivity : AppCompatActivity(), Logging,
             Manifest.permission.BLUETOOTH,
             Manifest.permission.BLUETOOTH_ADMIN
         )
-
 
         if (getMissingPermissions(requiredPerms).isEmpty()) {
             /// ask the adapter if we have access
@@ -532,7 +529,6 @@ class MainActivity : AppCompatActivity(), Logging,
         }
     }
 
-
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleIntent(intent)
@@ -659,8 +655,7 @@ class MainActivity : AppCompatActivity(), Logging,
         } */
     }
 
-    private
-    var receiverRegistered = false
+    private var receiverRegistered = false
 
     private fun registerMeshReceiver() {
         unregisterMeshReceiver()
@@ -679,7 +674,6 @@ class MainActivity : AppCompatActivity(), Logging,
             unregisterReceiver(meshServiceReceiver)
         }
     }
-
 
     /// Pull our latest node db from the device
     private fun updateNodesFromDevice() {
@@ -723,7 +717,6 @@ class MainActivity : AppCompatActivity(), Logging,
 
         showSettingsPage() // Default to the settings page in this case
     }
-
 
     /// Called when we gain/lose a connection to our mesh radio
     private fun onMeshConnectionChanged(connected: MeshService.ConnectionState) {
@@ -773,6 +766,9 @@ class MainActivity : AppCompatActivity(), Logging,
                     warn("Abandoning connect $ex, because we probably just lost device connection")
                     model.isConnected.value = oldConnection
                 }
+                // if provideLocation enabled: Start providing location (from phone GPS) to mesh
+                if (model.provideLocation.value == true && (oldConnection != connected))
+                    service.setupProvideLocation()
             }
         } else {
             // For other connection states, just slam them in
@@ -842,8 +838,7 @@ class MainActivity : AppCompatActivity(), Logging,
         }
     }
 
-    private
-    val meshServiceReceiver = object : BroadcastReceiver() {
+    private val meshServiceReceiver = object : BroadcastReceiver() {
 
         override fun onReceive(context: Context, intent: Intent) =
             exceptionReporter {
@@ -891,8 +886,7 @@ class MainActivity : AppCompatActivity(), Logging,
 
     private var connectionJob: Job? = null
 
-    private
-    val mesh = object :
+    private val mesh = object :
         ServiceClient<com.geeksville.mesh.IMeshService>({
             com.geeksville.mesh.IMeshService.Stub.asInterface(it)
         }) {
@@ -1269,4 +1263,3 @@ class MainActivity : AppCompatActivity(), Logging,
     }
 
 }
-

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1015,12 +1015,12 @@ class MeshService : Service(), Logging {
         maybeUpdateServiceStatusNotification()
     }
 
-    private fun setupLocationRequest() {
+    private fun setupLocationRequests() {
         stopLocationRequests()
         val mi = myNodeInfo
         val prefs = radioConfig?.preferences
         if (mi != null && prefs != null) {
-            var broadcastSecs = prefs.positionBroadcastSecs
+            val broadcastSecs = prefs.positionBroadcastSecs
 
             var desiredInterval = if (broadcastSecs == 0) // unset by device, use default
                 15 * 60 * 1000L
@@ -1046,7 +1046,6 @@ class MeshService : Service(), Logging {
             }
         }
     }
-
 
     /**
      * Send in analytics about mesh connection
@@ -1326,7 +1325,7 @@ class MeshService : Service(), Logging {
                     hwModelStr,
                     firmwareVersion,
                     firmwareUpdateFilename != null,
-                    isBluetoothInterface && com.geeksville.mesh.service.SoftwareUpdateService.shouldUpdate(
+                    isBluetoothInterface && SoftwareUpdateService.shouldUpdate(
                         this@MeshService,
                         DeviceVersion(firmwareVersion)
                     ),
@@ -1481,8 +1480,6 @@ class MeshService : Service(), Logging {
         reportConnection()
 
         updateRegion()
-
-        setupLocationRequest() // start sending location packets if needed
     }
 
     private fun handleConfigComplete(configCompleteId: Int) {
@@ -1879,6 +1876,15 @@ class MeshService : Service(), Logging {
             info("in connectionState=$r")
             r.toString()
         }
+
+        override fun setupProvideLocation() = toRemoteExceptions {
+            setupLocationRequests()
+        }
+
+        override fun stopProvideLocation() = toRemoteExceptions {
+            stopLocationRequests()
+        }
+
     }
 }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -650,9 +650,9 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
 
         binding.provideLocationCheckbox.isEnabled = isGooglePlayAvailable(requireContext())
         binding.provideLocationCheckbox.setOnCheckedChangeListener { view, isChecked ->
-            if (view.isPressed) { // We want to ignore changes caused by code (as opposed to the user)
+            if (view.isChecked) {
                 debug("User changed location tracking to $isChecked")
-                if (view.isChecked) {
+                if (view.isPressed) { // We want to ignore changes caused by code (as opposed to the user)
                     val hasLocationPermission = myActivity.hasLocationPermission()
                     val hasBackgroundPermission = myActivity.hasBackgroundPermission()
 
@@ -677,9 +677,10 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
                         model.provideLocation.value = isChecked
                         model.meshService?.setupProvideLocation()
                 }
-                else {
-                    model.meshService?.stopProvideLocation()
-                }
+            }
+            else {
+                model.provideLocation.value = isChecked
+                model.meshService?.stopProvideLocation()
             }
         }
 
@@ -993,7 +994,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
             scanModel.startScan()
 
         // system permissions might have changed while we were away
-        binding.provideLocationCheckbox.isChecked = myActivity.hasBackgroundPermission() && (model.provideLocation.value ?: false) && isGooglePlayAvailable(requireContext())
+        binding.provideLocationCheckbox.isChecked = myActivity.hasLocationPermission() && myActivity.hasBackgroundPermission() && (model.provideLocation.value ?: false) && isGooglePlayAvailable(requireContext())
 
         myActivity.registerReceiver(updateProgressReceiver, updateProgressFilter)
 


### PR DESCRIPTION

- start MeshService `setupLocationRequests` (to use phone GPS) when preference is enabled;
- attach Settings tab `provideLocationCheckbox` to call MeshService `setup/stopLocationRequests`;
- disable "Provide location to mesh" checkbox if Google Play Services is not available (prerequisite).