### PR TITLE
add companion device pairing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,9 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <!-- For android >=26 we can use the new BLE scanning API, which allows auto launching our service when our device is seen -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+                     android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.REQUEST_COMPANION_RUN_IN_BACKGROUND" />
     <uses-permission android:name="android.permission.REQUEST_COMPANION_USE_DATA_IN_BACKGROUND" />
 

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -290,9 +290,6 @@ class MainActivity : AppCompatActivity(), Logging,
     }
 
     /** Ask the user to grant camera permission */
-    fun requestBTScanPermission() = requestPermission(getCameraPermissions(), false)
-
-    /** Ask the user to grant camera permission */
     fun requestCameraPermission() = requestPermission(getCameraPermissions(), false)
 
     /** Ask the user to grant foreground location permission */

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -290,6 +290,9 @@ class MainActivity : AppCompatActivity(), Logging,
     }
 
     /** Ask the user to grant camera permission */
+    fun requestBTScanPermission() = requestPermission(getCameraPermissions(), false)
+
+    /** Ask the user to grant camera permission */
     fun requestCameraPermission() = requestPermission(getCameraPermissions(), false)
 
     /** Ask the user to grant foreground location permission */
@@ -331,7 +334,7 @@ class MainActivity : AppCompatActivity(), Logging,
      *
      * @return true if we already have the needed permissions
      */
-    private fun requestPermission(
+    fun requestPermission(
         missingPerms: List<String> = getMinimumPermissions(),
         shouldShowDialog: Boolean = true
     ): Boolean =
@@ -534,9 +537,6 @@ class MainActivity : AppCompatActivity(), Logging,
         handleIntent(intent)
 
         askToRate()
-
-        // if (!isInTestLab) - very important - even in test lab we must request permissions because we need location perms for some of our tests to pass
-        requestPermission()
     }
 
     private fun initToolbar() {

--- a/app/src/main/java/com/geeksville/mesh/service/BluetoothInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/BluetoothInterface.kt
@@ -5,6 +5,8 @@ import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattService
 import android.bluetooth.BluetoothManager
 import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import com.geeksville.android.Logging
 import com.geeksville.concurrent.handledLaunch
 import com.geeksville.util.anonymize
@@ -148,7 +150,7 @@ class BluetoothInterface(val service: RadioInterfaceService, val address: String
 */
 
         /// Can we use the modern BLE scan API?
-        fun hasCompanionDeviceApi(context: Context): Boolean = false /* ALAS - not ready for production yet
+        fun hasCompanionDeviceApi(context: Context): Boolean =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val res =
                     context.packageManager.hasSystemFeature(PackageManager.FEATURE_COMPANION_DEVICE_SETUP)
@@ -157,7 +159,7 @@ class BluetoothInterface(val service: RadioInterfaceService, val address: String
             } else {
                 warn("CompanionDevice API not available, falling back to classic scan")
                 false
-            } */
+            }
 
         /** FIXME - when adding companion device support back in, use this code to set companion device from setBondedDevice
          *         if (BluetoothInterface.hasCompanionDeviceApi(this)) {

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -12,6 +12,8 @@ import android.content.pm.PackageManager
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.RemoteException
 import android.view.LayoutInflater
 import android.view.View
@@ -811,12 +813,32 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
 
     private fun initClassicScan() {
 
-        model.bluetoothEnabled.observe(viewLifecycleOwner, Observer { enabled ->
-            if (enabled)
-                scanModel.startScan()
-            else
+        binding.changeRadioButton.setOnClickListener {
+            if (myActivity.warnMissingPermissions()) {
+                myActivity.requestPermission()
+            } else scanLeDevice()
+        }
+    }
+
+    // per https://developer.android.com/guide/topics/connectivity/bluetooth/find-ble-devices
+    private fun scanLeDevice() {
+        var scanning = false
+        val SCAN_PERIOD: Long = 5000 // Stops scanning after 5 seconds
+
+        if (!scanning) { // Stops scanning after a pre-defined scan period.
+            Handler(Looper.getMainLooper()).postDelayed({
+                scanning = false
+                binding.scanProgressBar.visibility = View.GONE
                 scanModel.stopScan()
-        })
+            }, SCAN_PERIOD)
+            scanning = true
+            binding.scanProgressBar.visibility = View.VISIBLE
+            scanModel.startScan()
+        } else {
+            scanning = false
+            binding.scanProgressBar.visibility = View.GONE
+            scanModel.stopScan()
+        }
     }
 
     private fun initModernScan() {

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -831,10 +831,8 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
 
         if (curRadio != null) {
             binding.scanStatusText.text = getString(R.string.current_pair).format(curRadio)
-            binding.changeRadioButton.text = getString(R.string.change_radio)
         } else {
             binding.scanStatusText.text = getString(R.string.not_paired_yet)
-            binding.changeRadioButton.setText(R.string.select_radio)
         }
         binding.changeRadioButton.setOnClickListener {
             myActivity.startCompanionScan()

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -559,7 +559,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         val statusText = binding.scanStatusText
         val permissionsWarning = myActivity.getMissingMessage()
         when {
-            permissionsWarning != null ->
+            (!hasCompanionDeviceApi && permissionsWarning != null) ->
                 statusText.text = permissionsWarning
 
             region == RadioConfigProtos.RegionCode.Unset ->
@@ -927,17 +927,18 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         // Keep reminding user BLE is still off
         val hasUSB = SerialInterface.findDrivers(myActivity).isNotEmpty()
         if (!hasUSB) {
-            // First warn about permissions, and then if needed warn about settings
-            if (!myActivity.warnMissingPermissions()) {
-                // Warn user if BLE is disabled
-                if (scanModel.bluetoothAdapter?.isEnabled != true) {
-                    Toast.makeText(
-                        requireContext(),
-                        R.string.error_bluetooth,
-                        Toast.LENGTH_SHORT
-                    ).show()
-                } else {
-                    checkLocationEnabled()
+            // Warn user if BLE is disabled
+            if (scanModel.bluetoothAdapter?.isEnabled != true) {
+                Toast.makeText(
+                    requireContext(),
+                    R.string.error_bluetooth,
+                    Toast.LENGTH_SHORT
+                ).show()
+            } else {
+                if (!hasCompanionDeviceApi) {
+                    if (!myActivity.warnMissingPermissions()) {
+                        checkLocationEnabled()
+                    }
                 }
             }
         }

--- a/app/src/main/res/drawable/ic_twotone_add_24.xml
+++ b/app/src/main/res/drawable/ic_twotone_add_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/layout/settings_fragment.xml
+++ b/app/src/main/res/layout/settings_fragment.xml
@@ -96,7 +96,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/changeRadioButton">
+            app:layout_constraintTop_toBottomOf="@+id/scanStatusText">
 
             <RadioButton
                 android:id="@+id/radioButton2"
@@ -111,15 +111,15 @@
                 android:text="@string/test_devname2" />
         </RadioGroup>
 
-        <com.google.android.material.button.MaterialButton
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/changeRadioButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@string/select_radio"
+            android:layout_margin="16dp"
+            android:contentDescription="@string/change_radio"
+            app:srcCompat="@drawable/ic_twotone_add_24"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/scanStatusText" />
+            app:layout_constraintBottom_toTopOf="@+id/reportBugButton" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/updateFirmwareButton"

--- a/app/src/main/res/layout/settings_fragment.xml
+++ b/app/src/main/res/layout/settings_fragment.xml
@@ -85,6 +85,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
+            android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/deviceRadioGroup" />


### PR DESCRIPTION
https://developer.android.com/guide/topics/connectivity/companion-device-pairing 
- no location requirements for device pairing on Android 8+ (API level 26+)

Classic device scan/discovery
- added button press & 5 sec timer for legacy scan

various UI & user notification changes to handle both methods
- common "add" button to search and select devices

![Screenshot_20220109-121449](https://user-images.githubusercontent.com/48680741/148688651-421ae2ea-f36d-42b7-8641-4c35b774d480.jpg) ![Screenshot_20220109-121438](https://user-images.githubusercontent.com/48680741/148688654-ff532640-0b97-451b-8577-40afe4c72ec2.jpg)

