### PR TITLE
add is_power_saving to advanced settings

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettingsFragment.kt
@@ -36,17 +36,22 @@ class AdvancedSettingsFragment : ScreenFragment("Advanced Settings"), Logging {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        model.radioConfig.observe(viewLifecycleOwner, { _ ->
+        model.radioConfig.observe(viewLifecycleOwner, {
             binding.positionBroadcastPeriodEditText.setText(model.positionBroadcastSecs.toString())
             binding.lsSleepEditText.setText(model.lsSleepSecs.toString())
-            binding.isAlwaysPoweredCheckbox.isChecked = model.isAlwaysPowered?: false
+            binding.positionBroadcastSwitch.isChecked = model.locationShare ?: true
+            binding.lsSleepView.isEnabled = model.isPowerSaving ?: false
+            binding.lsSleepSwitch.isChecked = model.isPowerSaving ?: false
+            binding.isAlwaysPoweredSwitch.isChecked = model.isAlwaysPowered ?: false
         })
 
-        model.isConnected.observe(viewLifecycleOwner, Observer { connectionState ->
+        model.isConnected.observe(viewLifecycleOwner, { connectionState ->
             val connected = connectionState == MeshService.ConnectionState.CONNECTED
             binding.positionBroadcastPeriodView.isEnabled = connected
-            binding.lsSleepView.isEnabled = connected
-            binding.isAlwaysPoweredCheckbox.isEnabled = connected
+            binding.lsSleepView.isEnabled = connected && model.isPowerSaving ?: false
+            binding.positionBroadcastSwitch.isEnabled = connected
+            binding.lsSleepSwitch.isEnabled = connected
+            binding.isAlwaysPoweredSwitch.isEnabled = connected
         })
 
         binding.positionBroadcastPeriodEditText.on(EditorInfo.IME_ACTION_DONE) {
@@ -74,6 +79,14 @@ class AdvancedSettingsFragment : ScreenFragment("Advanced Settings"), Logging {
             requireActivity().hideKeyboard()
         }
 
+        binding.positionBroadcastSwitch.setOnCheckedChangeListener { view, isChecked ->
+            if (view.isPressed) {
+                model.locationShare = isChecked
+                debug("User changed locationShare to $isChecked")
+            }
+        }
+
+        // TODO - disable all sleep settings for non-ESP32 devices
         binding.lsSleepEditText.on(EditorInfo.IME_ACTION_DONE) {
             val str = binding.lsSleepEditText.text.toString()
             val n = str.toIntOrNull()
@@ -87,7 +100,14 @@ class AdvancedSettingsFragment : ScreenFragment("Advanced Settings"), Logging {
             requireActivity().hideKeyboard()
         }
 
-        binding.isAlwaysPoweredCheckbox.setOnCheckedChangeListener { view, isChecked ->
+        binding.lsSleepSwitch.setOnCheckedChangeListener { view, isChecked ->
+            if (view.isPressed) {
+                model.isPowerSaving = isChecked
+                debug("User changed isPowerSaving to $isChecked")
+            }
+        }
+
+        binding.isAlwaysPoweredSwitch.setOnCheckedChangeListener { view, isChecked ->
             if (view.isPressed) {
                 model.isAlwaysPowered = isChecked
                 debug("User changed isAlwaysPowered to $isChecked")

--- a/app/src/main/res/layout/advanced_settings.xml
+++ b/app/src/main/res/layout/advanced_settings.xml
@@ -27,6 +27,15 @@
             android:singleLine="true" />
     </com.google.android.material.textfield.TextInputLayout>
 
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/positionBroadcastSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintBottom_toBottomOf="@id/positionBroadcastPeriodView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/positionBroadcastPeriodView" />
+
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/lsSleepView"
         android:layout_width="0dp"
@@ -48,15 +57,24 @@
             android:singleLine="true" />
     </com.google.android.material.textfield.TextInputLayout>
 
-    <CheckBox
-        android:id="@+id/isAlwaysPoweredCheckbox"
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/lsSleepSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintBottom_toBottomOf="@id/lsSleepView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/lsSleepView" />
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/isAlwaysPoweredSwitch"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:text="isAlwaysPowered"
+        android:text="is_always_powered"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/lsSleepView"
         app:layout_constraintTop_toBottomOf="@+id/lsSleepView" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -75,7 +75,7 @@
     <string name="message_reception_time">tiempo de recepción del mensaje</string>
     <string name="message_reception_state">estado de recepción de mensajes</string>
     <string name="message_delivery_status">Estado de entrega del mensaje</string>
-    <string name="broadcast_position_secs">Periodo de emisión de la posición (en segundos) 0 - deshabilitar</string>
+    <string name="broadcast_position_secs">Periodo de emisión de la posición (en segundos)</string>
     <string name="ls_sleep_secs">Período de reposo del dispositivo (en segundos)</string>
     <string name="meshtastic_messages_notifications">Notificaciones de mensajes</string>
     <string name="broadcast_period_too_small">El periodo mínimo de emisión de este canal es %d</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -78,7 +78,7 @@
     <string name="message_reception_time">üzenet fogadásának ideje</string>
     <string name="message_reception_state">üzenet fogadásának állapota</string>
     <string name="message_delivery_status">Üzenet kézbesítésének állapota</string>
-    <string name="broadcast_position_secs">Pozíció hírdetésének gyakorisága (másodpercben), 0 - letiltva</string>
+    <string name="broadcast_position_secs">Pozíció hírdetésének gyakorisága (másodpercben)</string>
     <string name="ls_sleep_secs">Eszköz alvásának gyakorisága (másodpercben)</string>
     <string name="meshtastic_messages_notifications">Értesítések az üzenetekről</string>
     <string name="broadcast_period_too_small">Minimum üzenet küldési gyakoriság ezen a csatornán %d</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -84,7 +84,7 @@
     <string name="message_reception_time">Czas odbioru wiadomości</string>
     <string name="message_reception_state">Status odbioru wiadomości</string>
     <string name="message_delivery_status">Status dostarczenia wiadomości</string>
-    <string name="broadcast_position_secs">Rozgłaszanie pozycji co: (w sekundach), 0 - wyłączone</string>
+    <string name="broadcast_position_secs">Rozgłaszanie pozycji co: (w sekundach)</string>
     <string name="ls_sleep_secs">Uśpienie urządzenia (w sekundach)</string>
     <string name="meshtastic_messages_notifications">Powiadomienie o wiadomościach</string>
     <string name="broadcast_period_too_small">Minimalny okres rozgłaszania dla tego kanału wynosi %d</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -79,8 +79,8 @@
     <string name="message_reception_time">tempo de recebimento de mensagem</string>
     <string name="message_reception_state">estado de recebimento de mensagem</string>
     <string name="message_delivery_status">Status de entrega de mensagem</string>
-    <string name="broadcast_position_secs">Intervalo de localização (segundos), 0 - desabilitar</string>
-    <string name="ls_sleep_secs">Intervalo de suspensão (sleep) (segundos)</string>
+    <string name="broadcast_position_secs">Intervalo de localização (em segundos)</string>
+    <string name="ls_sleep_secs">Intervalo de suspensão (sleep) (em segundos)</string>
     <string name="meshtastic_messages_notifications">Notificações sobre mensagens</string>
     <string name="broadcast_period_too_small">Período mínimo de transmissão para este canal é %d</string>
     <string name="protocol_stress_test">Stress test do protocolo</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -79,7 +79,7 @@
     <string name="message_reception_time">tempo de recebimento de mensagem</string>
     <string name="message_reception_state">estado de recebimento de mensagem</string>
     <string name="message_delivery_status">Status de entrega de mensagem</string>
-    <string name="broadcast_position_secs">Intervalo de localização (segundos), 0 - desabilitar</string>
+    <string name="broadcast_position_secs">Intervalo de localização (segundos)</string>
     <string name="ls_sleep_secs">Intervalo de suspensão (sleep) (segundos)</string>
     <string name="meshtastic_messages_notifications">Notificações sobre mensagens</string>
     <string name="broadcast_period_too_small">Período mínimo de transmissão para este canal é %d</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -79,7 +79,7 @@
     <string name="message_reception_time">消息接收时间</string>
     <string name="message_reception_state">消息接收状态</string>
     <string name="message_delivery_status">消息传递状态</string>
-    <string name="broadcast_position_secs">广播周期（以秒为单位），0为禁用</string>
+    <string name="broadcast_position_secs">广播周期（以秒为单位）</string>
     <string name="ls_sleep_secs">设备休眠时间（以秒为单位）</string>
     <string name="meshtastic_messages_notifications">关于消息的通知</string>
     <string name="broadcast_period_too_small">此频道的最短广播时间为 %d</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,7 +83,7 @@
     <string name="message_reception_time">message reception time</string>
     <string name="message_reception_state">message reception state</string>
     <string name="message_delivery_status">Message delivery status</string>
-    <string name="broadcast_position_secs">Broadcast position period (in seconds), 0 - disable</string>
+    <string name="broadcast_position_secs">Broadcast position period (in seconds)</string>
     <string name="ls_sleep_secs">Device sleep period (in seconds)</string>
     <string name="meshtastic_messages_notifications">Notifications about messages</string>
     <string name="broadcast_period_too_small">Minimum broadcast period for this channel is %d</string>


### PR DESCRIPTION
added switches to all settings
- Broadcast position period: location_share LocEnabled/LocDisabled
- Device sleep period: is_power_saving
- is_always_powered (changed from checkbox to switch)
- removed "0 to disable" logic and text strings

TODO: disable sleep settings from non-ESP32 devices