### PR TITLE
Introduce Hilt dependency injection

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlinx-serialization'
+apply plugin: 'dagger.hilt.android.plugin'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.github.triplet.play'
 apply plugin: 'de.mobilej.unmock'
@@ -135,7 +136,9 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.4.0'
     implementation "androidx.room:room-runtime:$room_version"
+    implementation "com.google.dagger:hilt-android:$hilt_version"
     kapt "androidx.room:room-compiler:$room_version"
+    kapt "com.google.dagger:hilt-compiler:$hilt_version"
 
 
     // optional - Kotlin Extensions and Coroutines support for Room
@@ -199,4 +202,8 @@ dependencies {
     implementation "androidx.core:core-splashscreen:1.0.0-beta01"
 
     implementation project(':geeksville-androidlib')
+}
+
+kapt {
+    correctErrorTypes true
 }

--- a/app/src/main/java/com/geeksville/mesh/ApplicationModule.kt
+++ b/app/src/main/java/com/geeksville/mesh/ApplicationModule.kt
@@ -1,0 +1,18 @@
+package com.geeksville.mesh
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@InstallIn(SingletonComponent::class)
+@Module
+object ApplicationModule {
+    @Provides
+    fun provideSharedPreferences(application: Application): SharedPreferences {
+        return application.getSharedPreferences("ui-prefs", Context.MODE_PRIVATE)
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -62,6 +62,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayoutMediator
 import com.vorlonsoft.android.rate.AppRate
 import com.vorlonsoft.android.rate.StoreType
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -123,6 +124,7 @@ eventually:
 
 val utf8 = Charset.forName("UTF-8")
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity(), Logging,
     ActivityCompat.OnRequestPermissionsResultCallback {
 

--- a/app/src/main/java/com/geeksville/mesh/MeshUtilApplication.kt
+++ b/app/src/main/java/com/geeksville/mesh/MeshUtilApplication.kt
@@ -7,8 +7,13 @@ import com.geeksville.android.GeeksvilleApplication
 import com.geeksville.android.Logging
 import com.geeksville.util.Exceptions
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import dagger.hilt.android.HiltAndroidApp
 
-class MeshUtilApplication : GeeksvilleApplication() {
+// NOTE: This is a workaround since the Hilt Gradle plugin doesn't support constructors with default parameters
+open class GeeksvilleApplicationWrapper : GeeksvilleApplication()
+
+@HiltAndroidApp
+class MeshUtilApplication : GeeksvilleApplicationWrapper() {
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/geeksville/mesh/database/DatabaseModule.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/DatabaseModule.kt
@@ -1,0 +1,29 @@
+package com.geeksville.mesh.database
+
+import android.app.Application
+import androidx.room.Room
+import com.geeksville.mesh.database.dao.PacketDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@InstallIn(SingletonComponent::class)
+@Module
+class DatabaseModule {
+    @Provides
+    fun provideDatabase(application: Application): MeshtasticDatabase {
+        return Room.databaseBuilder(
+            application.applicationContext,
+            MeshtasticDatabase::class.java,
+            "meshtastic_database"
+        )
+            .fallbackToDestructiveMigration()
+            .build()
+    }
+
+    @Provides
+    fun providePacketDao(database: MeshtasticDatabase): PacketDao {
+        return database.packetDao()
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
@@ -1,8 +1,6 @@
 package com.geeksville.mesh.database
 
-import android.content.Context
 import androidx.room.Database
-import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.geeksville.mesh.database.dao.PacketDao
 import com.geeksville.mesh.database.entity.Packet
@@ -10,27 +8,4 @@ import com.geeksville.mesh.database.entity.Packet
 @Database(entities = [Packet::class], version = 1, exportSchema = false)
 abstract class MeshtasticDatabase : RoomDatabase() {
     abstract fun packetDao(): PacketDao
-
-    companion object {
-        @Volatile
-        private var INSTANCE: MeshtasticDatabase? = null
-
-        fun getDatabase(
-            context: Context
-        ): MeshtasticDatabase {
-            return INSTANCE ?: synchronized(this) {
-                val instance = Room.databaseBuilder(
-                    context.applicationContext,
-                    MeshtasticDatabase::class.java,
-                    "meshtastic_database"
-                )
-                    .fallbackToDestructiveMigration()
-                    .build()
-                INSTANCE = instance
-
-                instance
-            }
-        }
-    }
-
 }

--- a/app/src/main/java/com/geeksville/mesh/database/PacketRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/PacketRepository.kt
@@ -1,24 +1,34 @@
 package com.geeksville.mesh.database
 
-import androidx.lifecycle.LiveData
 import com.geeksville.mesh.database.dao.PacketDao
 import com.geeksville.mesh.database.entity.Packet
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class PacketRepository(private val packetDao : PacketDao) {
-    val allPackets : LiveData<List<Packet>> = packetDao.getAllPacket(MAX_ITEMS)
-    val allPacketsInReceiveOrder : Flow<List<Packet>> = packetDao.getAllPacketsInReceiveOrder(MAX_ITEMS)
+class PacketRepository @Inject constructor(private val packetDaoLazy: dagger.Lazy<PacketDao>) {
+    private val packetDao by lazy {
+        packetDaoLazy.get()
+    }
 
-    suspend fun insert(packet: Packet) {
+    suspend fun getAllPackets(): Flow<List<Packet>> = withContext(Dispatchers.IO) {
+        packetDao.getAllPacket(MAX_ITEMS)
+    }
+
+    suspend fun getAllPacketsInReceiveOrder(): Flow<List<Packet>> = withContext(Dispatchers.IO) {
+        packetDao.getAllPacketsInReceiveOrder(MAX_ITEMS)
+    }
+
+    suspend fun insert(packet: Packet) = withContext(Dispatchers.IO) {
         packetDao.insert(packet)
     }
 
-    suspend fun deleteAll() {
+    suspend fun deleteAll() = withContext(Dispatchers.IO) {
         packetDao.deleteAll()
     }
 
     companion object {
         private const val MAX_ITEMS = 500
     }
-
 }

--- a/app/src/main/java/com/geeksville/mesh/database/dao/PacketDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/PacketDao.kt
@@ -1,6 +1,5 @@
 package com.geeksville.mesh.database.dao
 
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
@@ -11,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface PacketDao {
 
     @Query("Select * from packet order by received_date desc limit 0,:maxItem")
-    fun getAllPacket(maxItem: Int): LiveData<List<Packet>>
+    fun getAllPacket(maxItem: Int): Flow<List<Packet>>
 
     @Query("Select * from packet order by received_date asc limit 0,:maxItem")
     fun getAllPacketsInReceiveOrder(maxItem: Int): Flow<List<Packet>>

--- a/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettingsFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Observer
 import com.geeksville.android.Logging
 import com.geeksville.android.hideKeyboard
 import com.geeksville.mesh.R
@@ -16,7 +15,9 @@ import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.service.MeshService
 import com.geeksville.util.exceptionToSnackbar
 import com.google.android.material.snackbar.Snackbar
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class AdvancedSettingsFragment : ScreenFragment("Advanced Settings"), Logging {
     private val MAX_INT_DEVICE = 0xFFFFFFFF
     private var _binding: AdvancedSettingsBinding? = null

--- a/app/src/main/java/com/geeksville/mesh/ui/ChannelFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ChannelFragment.kt
@@ -33,6 +33,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.protobuf.ByteString
 import com.google.zxing.integration.android.IntentIntegrator
+import dagger.hilt.android.AndroidEntryPoint
 import java.security.SecureRandom
 
 
@@ -51,6 +52,7 @@ fun ImageView.setOpaque() {
     imageAlpha = 255
 }
 
+@AndroidEntryPoint
 class ChannelFragment : ScreenFragment("Channel"), Logging {
 
     private var _binding: ChannelFragmentBinding? = null

--- a/app/src/main/java/com/geeksville/mesh/ui/DebugFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/DebugFragment.kt
@@ -6,13 +6,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
+import androidx.lifecycle.asLiveData
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.geeksville.mesh.R
 import com.geeksville.mesh.databinding.DebugFragmentBinding
 import com.geeksville.mesh.model.UIViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class DebugFragment : Fragment() {
 
     private var _binding: DebugFragmentBinding? = null
@@ -48,8 +50,8 @@ class DebugFragment : Fragment() {
         binding.closeButton.setOnClickListener {
             parentFragmentManager.popBackStack()
         }
-        model.allPackets.observe(viewLifecycleOwner, Observer { packets ->
+        model.allPackets.asLiveData().observe(viewLifecycleOwner) { packets ->
             packets?.let { adapter.setPackets(it) }
-        })
+        }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MapFragment.kt
@@ -32,8 +32,10 @@ import com.mapbox.maps.extension.style.sources.generated.GeoJsonSource
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.flyTo
 import com.mapbox.maps.plugin.gestures.gestures
+import dagger.hilt.android.AndroidEntryPoint
 
 
+@AndroidEntryPoint
 class MapFragment : ScreenFragment("Map"), Logging {
 
     private val model: UIViewModel by activityViewModels()

--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -26,6 +26,7 @@ import com.geeksville.mesh.databinding.MessagesFragmentBinding
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.service.MeshService
 import com.google.android.material.chip.Chip
+import dagger.hilt.android.AndroidEntryPoint
 import java.text.DateFormat
 import java.util.*
 
@@ -41,6 +42,7 @@ fun EditText.on(actionId: Int, func: () -> Unit) {
     }
 }
 
+@AndroidEntryPoint
 class MessagesFragment : ScreenFragment("Messages"), Logging {
 
     private var _binding: MessagesFragmentBinding? = null

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -49,6 +49,7 @@ import com.google.android.gms.location.LocationSettingsRequest
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.hoho.android.usbserial.driver.UsbSerialDriver
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -439,6 +440,7 @@ class BTScanModel(app: Application) : AndroidViewModel(app), Logging {
 }
 
 @SuppressLint("NewApi")
+@AndroidEntryPoint
 class SettingsFragment : ScreenFragment("Settings"), Logging {
     private var _binding: SettingsFragmentBinding? = null
 

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -9,7 +9,6 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.geeksville.android.Logging
@@ -19,9 +18,11 @@ import com.geeksville.mesh.databinding.AdapterNodeLayoutBinding
 import com.geeksville.mesh.databinding.NodelistFragmentBinding
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.util.formatAgo
+import dagger.hilt.android.AndroidEntryPoint
 import java.net.URLEncoder
 import kotlin.math.roundToInt
 
+@AndroidEntryPoint
 class UsersFragment : ScreenFragment("Users"), Logging {
 
     private var _binding: NodelistFragmentBinding? = null

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.6.10'
     ext.coroutines_version = "1.5.2"
+    ext.hilt_version = '2.40.5'
 
     repositories {
         google()
@@ -30,6 +31,8 @@ buildscript {
 
         // for unit testing https://github.com/bjoernQ/unmock-plugin
         classpath 'com.github.bjoernq:unmockplugin:0.7.9'
+
+        classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
     }
 }
 


### PR DESCRIPTION
Uses [Hilt](https://dagger.dev/hilt/) to get the database initialization off of the main thread.

The initial introduction always has a disproportionate fan-out of boilerplate.  In this case, all entry points which
were using `UIViewModel` needed to be annotated in order to let the code gen know that they needed to support
it.

The `PacketRepository` is injected into things via the main thread (e.g., the `MeshService`) but due to the
lazy declaration, the database isn't hydrated until the DAO is access while on an IO thread.
