### PR TITLE
Issue #369 - Expand bluetooth repository use cases

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -134,7 +134,7 @@ class MainActivity : AppCompatActivity(), Logging,
     // Used to schedule a coroutine in the GUI thread
     private val mainScope = CoroutineScope(Dispatchers.Main + Job())
 
-    val bluetoothViewModel: BluetoothViewModel by viewModels()
+    private val bluetoothViewModel: BluetoothViewModel by viewModels()
     val model: UIViewModel by viewModels()
 
     data class TabInfo(val text: String, val icon: Int, val content: Fragment)
@@ -355,7 +355,7 @@ class MainActivity : AppCompatActivity(), Logging,
             }
         }
 
-        bluetoothViewModel.refreshState()
+        bluetoothViewModel.permissionsUpdated()
     }
 
 

--- a/app/src/main/java/com/geeksville/mesh/model/BluetoothViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/BluetoothViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import com.geeksville.mesh.repository.bluetooth.BluetoothRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 /**
@@ -13,7 +14,11 @@ import javax.inject.Inject
 class BluetoothViewModel @Inject constructor(
     private val bluetoothRepository: BluetoothRepository,
 ) : ViewModel() {
-    fun refreshState() = bluetoothRepository.refreshState()
+    /**
+     * Called when permissions have been updated.  This causes an explicit refresh of the
+     * bluetooth state.
+     */
+    fun permissionsUpdated() = bluetoothRepository.refreshState()
 
-    val enabled = bluetoothRepository.enabled.asLiveData()
+    val enabled = bluetoothRepository.state.map { it.enabled }.asLiveData()
 }

--- a/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothBroadcastReceiver.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothBroadcastReceiver.kt
@@ -5,20 +5,14 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.coroutineScope
-import com.geeksville.mesh.CoroutineDispatchers
 import com.geeksville.util.exceptionReporter
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
  * A helper class to call onChanged when bluetooth is enabled or disabled
  */
-class BluetoothStateReceiver @Inject constructor(
-    private val dispatchers: CoroutineDispatchers,
-    private val bluetoothRepository: BluetoothRepository,
-    private val processLifecycle: Lifecycle,
+class BluetoothBroadcastReceiver @Inject constructor(
+    private val bluetoothRepository: BluetoothRepository
 ) : BroadcastReceiver() {
     internal val intentFilter get() = IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED) // Can be used for registering
 
@@ -26,15 +20,9 @@ class BluetoothStateReceiver @Inject constructor(
         if (intent.action == BluetoothAdapter.ACTION_STATE_CHANGED) {
             when (intent.bluetoothAdapterState) {
                 // Simulate a disconnection if the user disables bluetooth entirely
-                BluetoothAdapter.STATE_OFF -> emitState(false)
-                BluetoothAdapter.STATE_ON -> emitState(true)
+                BluetoothAdapter.STATE_OFF -> bluetoothRepository.refreshState()
+                BluetoothAdapter.STATE_ON -> bluetoothRepository.refreshState()
             }
-        }
-    }
-
-    private fun emitState(newState: Boolean) {
-        processLifecycle.coroutineScope.launch(dispatchers.default) {
-            bluetoothRepository.enabledInternal.emit(newState)
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepositoryModule.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepositoryModule.kt
@@ -14,13 +14,13 @@ import dagger.hilt.components.SingletonComponent
 interface BluetoothRepositoryModule {
     companion object {
         @Provides
-        fun provideBluetoothManager(application: Application): BluetoothManager {
-            return application.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+        fun provideBluetoothManager(application: Application): BluetoothManager? {
+            return application.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager?
         }
 
         @Provides
-        fun provideBluetoothAdapter(service: BluetoothManager): BluetoothAdapter {
-            return service.adapter
+        fun provideBluetoothAdapter(service: BluetoothManager?): BluetoothAdapter? {
+            return service?.adapter
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothState.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothState.kt
@@ -1,0 +1,16 @@
+package com.geeksville.mesh.repository.bluetooth
+
+import android.bluetooth.BluetoothDevice
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A snapshot in time of the state of the bluetooth subsystem.
+ */
+data class BluetoothState(
+    /** Whether we have adequate permissions to query bluetooth state */
+    val hasPermissions: Boolean = false,
+    /** If we have adequate permissions and bluetooth is enabled */
+    val enabled: Boolean = false,
+    /** If enabled, a cold flow of the currently bonded devices */
+    val bondedDevices: Flow<Set<BluetoothDevice>>? = null
+)

--- a/app/src/main/java/com/geeksville/mesh/service/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/RadioInterfaceService.kt
@@ -204,8 +204,8 @@ class RadioInterfaceService : Service(), Logging {
         super.onCreate()
 
         lifecycleOwner.lifecycle.coroutineScope.launch {
-            bluetoothRepository.enabled.collect { enabled ->
-                if (enabled) {
+            bluetoothRepository.state.collect { state ->
+                if (state.enabled) {
                     startInterface()
                 } else {
                     stopInterface()


### PR DESCRIPTION
Changes:
- Adds support for obtaining bonded devices
- Adds support for obtaining BLE scanner
- Consolidates state into a single, immutable data class instance
- Simplified and renamed broadcast receiver
- Renamed view model permissionsUpdated fun to identify the intended use
