### PR TITLE
improve firmware update

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1304,13 +1304,14 @@ class MeshService : Service(), Logging {
                 myInfo.myNodeNum // Note: can't use the normal property because myNodeInfo not yet setup
             val ni = nodeDBbyNodeNum[nodeNum] // can't use toNodeInfo because too early
             val hwModelStr = ni?.user?.hwModelString
+            setFirmwareUpdateFilename(hwModelStr)
             val mi = with(myInfo) {
                 MyNodeInfo(
                     myNodeNum,
                     hasGps,
                     hwModelStr,
                     firmwareVersion,
-                    firmwareUpdateFilename != null,
+                    firmwareUpdateFilename?.appLoad != null && firmwareUpdateFilename?.littlefs != null,
                     isBluetoothInterface && SoftwareUpdateService.shouldUpdate(
                         this@MeshService,
                         DeviceVersion(firmwareVersion)
@@ -1323,9 +1324,7 @@ class MeshService : Service(), Logging {
                     airUtilTx
                 )
             }
-
             newMyNodeInfo = mi
-            setFirmwareUpdateFilename(mi)
         }
     }
 
@@ -1641,12 +1640,12 @@ class MeshService : Service(), Logging {
     /***
      * Return the filename we will install on the device
      */
-    private fun setFirmwareUpdateFilename(info: MyNodeInfo) {
+    private fun setFirmwareUpdateFilename(model: String?) {
         firmwareUpdateFilename = try {
-            if (info.firmwareVersion != null && info.model != null)
+            if (model != null)
                 SoftwareUpdateService.getUpdateFilename(
                     this,
-                    info.model
+                    model
                 )
             else
                 null

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -24,6 +24,7 @@ import android.widget.*
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import com.geeksville.analytics.DataPair
 import com.geeksville.android.GeeksvilleApplication
 import com.geeksville.android.Logging
 import com.geeksville.android.hideKeyboard
@@ -474,6 +475,10 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         model.meshService?.let { service ->
 
             debug("User started firmware update")
+            GeeksvilleApplication.analytics.track(
+                "firmware_update",
+                DataPair("content_type", "start")
+            )
             binding.updateFirmwareButton.isEnabled = false // Disable until things complete
             binding.updateProgressBar.visibility = View.VISIBLE
             binding.updateProgressBar.progress = 0 // start from scratch
@@ -515,6 +520,10 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
             } else
                 when (progress) {
                     ProgressSuccess -> {
+                        GeeksvilleApplication.analytics.track(
+                            "firmware_update",
+                            DataPair("content_type", "success")
+                        )
                         binding.scanStatusText.setText(R.string.update_successful)
                         binding.updateProgressBar.visibility = View.GONE
                     }
@@ -523,6 +532,10 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
                         binding.updateProgressBar.visibility = View.GONE
                     }
                     else -> {
+                        GeeksvilleApplication.analytics.track(
+                            "firmware_update",
+                            DataPair("content_type", "failure")
+                        )
                         binding.scanStatusText.setText(R.string.update_failed)
                         binding.updateProgressBar.visibility = View.VISIBLE
                     }


### PR DESCRIPTION
- update spiffs to littlefs
- call `setFirmwareUpdateFilename` before generating `MyNodeInfo` (makes `couldUpdate` more reliable)
- add analytics events for `firmware_update`: start/success/failure
- better firmware update progress bar feedback (smooth transition between littlefs/appLoad from 0% to 100%)