### PR TITLE
1.2.60

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,11 +19,12 @@ jobs:
     - name: Load secrets
       run: |
         rm ./app/src/main/res/values/mapbox-token.xml
-        echo -e "<resources>\n    <string name=\"mapbox_access_token\">$MAPBOXTOKEN</string>\n</resources>" > ./app/src/main/res/values/mapbox-token.xml
+        echo -e "<resources>\n    <string name=\"mapbox_access_token\">$MAPBOX_ACCESS_TOKEN</string>\n</resources>" > ./app/src/main/res/values/mapbox-token.xml
         mkdir -p ~/.gradle
-        echo "MAPBOX_DOWNLOADS_TOKEN=$MAPBOXTOKEN" >>~/.gradle/gradle.properties
+        echo "MAPBOX_DOWNLOADS_TOKEN=$MAPBOX_DOWNLOADS_TOKEN" >>~/.gradle/gradle.properties
       env:
-        MAPBOXTOKEN: ${{ secrets.MAPBOXTOKEN }}
+        MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+        MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
 
     - name: Mock files for CI
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,15 @@ jobs:
         rm ./app/google-services.json
         echo $GSERVICES > ./app/google-services.json
         rm ./app/src/main/res/values/mapbox-token.xml
-        echo -e "<resources>\n    <string name=\"mapbox_access_token\">$MAPBOXTOKEN</string>\n</resources>" > ./app/src/main/res/values/mapbox-token.xml
+        echo -e "<resources>\n    <string name=\"mapbox_access_token\">$MAPBOX_ACCESS_TOKEN</string>\n</resources>" > ./app/src/main/res/values/mapbox-token.xml
         mkdir -p ~/.gradle
-        echo "MAPBOX_DOWNLOADS_TOKEN=$MAPBOXTOKEN" >> ~/.gradle/gradle.properties
+        echo "MAPBOX_DOWNLOADS_TOKEN=$MAPBOX_DOWNLOADS_TOKEN" >> ~/.gradle/gradle.properties
         echo $KEYSTORE | base64 -di > ./app/$KEYSTORE_FILENAME
         echo "$KEYSTORE_PROPERTIES" > ./keystore.properties
       env:
           GSERVICES: ${{ secrets.GSERVICES }}
-          MAPBOXTOKEN: ${{ secrets.MAPBOXTOKEN }}
+          MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          MAPBOX_DOWNLOADS_TOKEN: ${{ secrets.MAPBOX_DOWNLOADS_TOKEN }}
           KEYSTORE: ${{ secrets.KEYSTORE }}
           KEYSTORE_FILENAME: ${{ secrets.KEYSTORE_FILENAME }}
           KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,8 +43,8 @@ android {
         applicationId "com.geeksville.mesh"
         minSdkVersion 21 // The oldest emulator image I have tried is 22 (though 21 probably works)
         targetSdkVersion 30 // 30 can't work until an explicit location permissions dialog is added
-        versionCode 20259 // format is Mmmss (where M is 1+the numeric major number
-        versionName "1.2.59"
+        versionCode 20260 // format is Mmmss (where M is 1+the numeric major number
+        versionName "1.2.60"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // per https://developer.android.com/studio/write/vector-asset-studio

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1309,13 +1309,14 @@ class MeshService : Service(), Logging {
                 if (asStr != null)
                     hwModelStr = asStr
             }
+            setFirmwareUpdateFilename(hwModelStr)
             val mi = with(myInfo) {
                 MyNodeInfo(
                     myNodeNum,
                     hasGps,
                     hwModelStr,
                     firmwareVersion,
-                    firmwareUpdateFilename != null,
+                    firmwareUpdateFilename?.appLoad != null && firmwareUpdateFilename?.spiffs != null,
                     isBluetoothInterface && SoftwareUpdateService.shouldUpdate(
                         this@MeshService,
                         DeviceVersion(firmwareVersion)
@@ -1328,9 +1329,7 @@ class MeshService : Service(), Logging {
                     airUtilTx
                 )
             }
-
             newMyNodeInfo = mi
-            setFirmwareUpdateFilename(mi)
         }
     }
 
@@ -1670,12 +1669,12 @@ class MeshService : Service(), Logging {
     /***
      * Return the filename we will install on the device
      */
-    private fun setFirmwareUpdateFilename(info: MyNodeInfo) {
+    private fun setFirmwareUpdateFilename(model: String?) {
         firmwareUpdateFilename = try {
-            if (info.firmwareVersion != null && info.model != null)
+            if (model != null)
                 SoftwareUpdateService.getUpdateFilename(
                     this,
-                    info.model
+                    model
                 )
             else
                 null

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -24,6 +24,7 @@ import android.widget.*
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import com.geeksville.analytics.DataPair
 import com.geeksville.android.GeeksvilleApplication
 import com.geeksville.android.Logging
 import com.geeksville.android.hideKeyboard
@@ -474,6 +475,10 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         model.meshService?.let { service ->
 
             debug("User started firmware update")
+            GeeksvilleApplication.analytics.track(
+                "firmware_update",
+                DataPair("content_type", "start")
+            )
             binding.updateFirmwareButton.isEnabled = false // Disable until things complete
             binding.updateProgressBar.visibility = View.VISIBLE
             binding.updateProgressBar.progress = 0 // start from scratch
@@ -515,6 +520,10 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
             } else
                 when (progress) {
                     ProgressSuccess -> {
+                        GeeksvilleApplication.analytics.track(
+                            "firmware_update",
+                            DataPair("content_type", "success")
+                        )
                         binding.scanStatusText.setText(R.string.update_successful)
                         binding.updateProgressBar.visibility = View.GONE
                     }
@@ -523,6 +532,10 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
                         binding.updateProgressBar.visibility = View.GONE
                     }
                     else -> {
+                        GeeksvilleApplication.analytics.track(
+                            "firmware_update",
+                            DataPair("content_type", "failure")
+                        )
                         binding.scanStatusText.setText(R.string.update_failed)
                         binding.updateProgressBar.visibility = View.VISIBLE
                     }


### PR DESCRIPTION
improve firmware update
- call setFirmwareUpdateFilename before generating MyNodeInfo (makes couldUpdate more reliable)
- add analytics events for firmware_update: start/success/failure
- better firmware update progress bar feedback (better transition between spiffs/appLoad 0% --> 100%)

& include firmware 1.2.59
