### PR TITLE
Issue #392 - fix connected but sleeping text to reflect actual device state

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1225,8 +1225,10 @@ class MeshService : Service(), Logging {
             when (intent.action) {
                 RadioInterfaceService.RADIO_CONNECTED_ACTION -> {
                     try {
+                        // sleep now disabled by default on ESP32, permanent is true unless isPowerSaving enabled
+                        val lsEnabled = radioConfig?.preferences?.isPowerSaving ?: false
                         val connected = intent.getBooleanExtra(EXTRA_CONNECTED, false)
-                        val permanent = intent.getBooleanExtra(EXTRA_PERMANENT, false)
+                        val permanent = intent.getBooleanExtra(EXTRA_PERMANENT, false) || !lsEnabled
                         onConnectionChanged(
                             when {
                                 connected -> ConnectionState.CONNECTED

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -52,7 +52,7 @@
     <string name="list_of_nodes">Seznam vysílačů v síti</string>
     <string name="update_firmware">Aktualizace softwaru</string>
     <string name="connected_to">Připojeno k vysílači (%s)</string>
-    <string name="not_connected">Nepřipojeno, zvolte si vysílač</string>
+    <string name="not_connected">Nepřipojeno</string>
     <string name="connected_sleeping">Připojené k uspanému vysílači.</string>
     <string name="update_to">Aktualizovat na %s</string>
     <string name="app_too_old">Aplikace je příliš stará</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -53,7 +53,7 @@
     <string name="update_firmware">Αναβάθμιση Firmware</string>
     <string name="connected">Συνδεδεμένο στο radio</string>
     <string name="connected_to">Συνδεδεμένο στο radio (%s)</string>
-    <string name="not_connected">Αποσυνδεδεμένο, επιλέξτε radio </string>
+    <string name="not_connected">Αποσυνδεδεμένο</string>
     <string name="connected_sleeping">Συνδεδεμένο στο radio, αλλά βρίσκεται σε ύπνωση</string>
     <string name="update_to">Αναβάθμιση σε %s</string>
     <string name="app_too_old">Εφαρμογή πολύ παλαιά</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -50,7 +50,7 @@
     <string name="update_firmware">Actualizar el firmware</string>
     <string name="connected">Conectado a la radio</string>
     <string name="connected_to">Conectado a la radio (%s)</string>
-    <string name="not_connected">No está conectado seleccione la radio de abajo</string>
+    <string name="not_connected">No está conectado</string>
     <string name="connected_sleeping">Conectado a la radio pero está en reposo</string>
     <string name="update_to">Actualizar a %s</string>
     <string name="app_too_old">Es necesario actualizar la aplicación</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -54,7 +54,7 @@
     <string name="update_firmware">Mise à jour du Firmware</string>
     <string name="connected">Connecté à une radio</string>
     <string name="connected_to">Connecté à la radio (%s)</string>
-    <string name="not_connected">Non connecté, veuillez sélectionner une radio ci-dessous</string>
+    <string name="not_connected">Non connecté</string>
     <string name="connected_sleeping">Connecté à la radio, mais en mode veille</string>
     <string name="none">Aucun (désactivé)</string>
     <string name="must_update">Vous devez mettre à jour l\'application sur le Google Play Store (ou Github). Cette version n\'est plus compatible avec la radio.</string>

--- a/app/src/main/res/values-ht/strings.xml
+++ b/app/src/main/res/values-ht/strings.xml
@@ -51,7 +51,7 @@
     <string name="update_firmware">Mete ajou mikrolojisyèl</string>
     <string name="connected">Konekte ak radyo</string>
     <string name="connected_to">Konekte ak radyo (%s)</string>
-    <string name="not_connected">Pa konekte, chwazi radyo anba a</string>
+    <string name="not_connected">Pa konekte</string>
     <string name="connected_sleeping">Konekte ak radyo, men li ap dòmi</string>
     <string name="update_to">Mizajou %s</string>
     <string name="app_too_old">Aplikasyon twò ansyen</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -52,7 +52,7 @@
     <string name="update_firmware">Firmware frissítés</string>
     <string name="connected">Kapcsolódva a rádióhoz</string>
     <string name="connected_to">Kapcsolódva a(z) %s rádióhoz</string>
-    <string name="not_connected">Nincs kapcsolat, válasszon egy rádiót alább</string>
+    <string name="not_connected">Nincs kapcsolat</string>
     <string name="connected_sleeping">Kapcsolódva a rádióhoz, de az alvó üzemmódban van</string>
     <string name="update_to">Frissítés %s verzióra</string>
     <string name="app_too_old">Az alkalmazás frissítése szükséges</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -52,7 +52,7 @@ mapboxの有償プラン（または代替地図プロバイダ）を検討さ�
     <string name="list_of_nodes">ネットワーク内のノードリスト</string>
     <string name="update_firmware">ファームウェアアップデート</string>
     <string name="connected_to">Meshtasticデバイスに接続しました。(%s)</string>
-    <string name="not_connected">接続されていません。下記のMeshtasticデバイスを選択してください。</string>
+    <string name="not_connected">接続されていません</string>
     <string name="connected_sleeping">接続しましたが、Meshtasticデバイスはスリープ状態です。</string>
     <string name="update_to">%s更新</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -51,7 +51,7 @@
     <string name="update_firmware">펌웨어 업데이트</string>
     <string name="connected">라디오로 연결됨</string>
     <string name="connected_to">라디오로 연결됨 (%s)</string>
-    <string name="not_connected">연결되지 않음, 아래에서 라이오를 선택하세요.</string>
+    <string name="not_connected">연결되지 않음</string>
     <string name="connected_sleeping">라디오에 연결됨, 해당 라이도는 잠자기중.</string>
     <string name="update_to">%s로 업데이트</string>
     <string name="app_too_old">너무 오래된 앱</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -53,7 +53,7 @@
     <string name="update_firmware">Programma Updaten</string>
     <string name="connected">Verbonden met een radio</string>
     <string name="connected_to">Verbonden met radio (%s)</string>
-    <string name="not_connected">Niet verbonden, selecteer radio hieronder</string>
+    <string name="not_connected">Niet verbonden</string>
     <string name="connected_sleeping">Verbonden met radio in slaapstand</string>
     <string name="update_to">Updaten naar %s</string>
     <string name="app_too_old">Applicatie te oud</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -53,7 +53,7 @@
     <string name="update_firmware">Oppdater Firmware</string>
     <string name="connected">Tilkoblet radio</string>
     <string name="connected_to">Tilkoblet til radio (%s)</string>
-    <string name="not_connected">Ikke tilkoblet. velg radio nedenfor</string>
+    <string name="not_connected">Ikke tilkoblet</string>
     <string name="connected_sleeping">Tilkoblet radio, men den sover</string>
     <string name="update_to">Oppdater til %s</string>
     <string name="app_too_old">Applikasjon for gammel</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -53,7 +53,7 @@
     <string name="update_firmware">Atualizar Firmware</string>
     <string name="connected">Conectado ao rádio</string>
     <string name="connected_to">Conectado ao rádio (%s)</string>
-    <string name="not_connected">Não conectado, selecione um rádio abaixo</string>
+    <string name="not_connected">Não conectado</string>
     <string name="connected_sleeping">Conectado ao rádio, mas ele está em suspensão (sleep)</string>
     <string name="update_to">Atualização para %s</string>
     <string name="app_too_old">Atualização do aplicativo necessária</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -52,7 +52,7 @@
     <string name="update_firmware">Atualizar Firmware</string>
     <string name="connected">Conectado ao rádio</string>
     <string name="connected_to">Conectado ao rádio (%s)</string>
-    <string name="not_connected">Não conectado, escolha um rádio em baixo</string>
+    <string name="not_connected">Não conectado</string>
     <string name="connected_sleeping">Conectado ao rádio, mas está a dormir</string>
     <string name="update_to">Atualização para %s</string>
     <string name="app_too_old">A aplicação é muito antiga</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -53,7 +53,7 @@
     <string name="update_firmware">Updateaza firmware-ul</string>
     <string name="connected">Connectat la dispozitiv</string>
     <string name="connected_to">Conectat la dispozitivul (%s)</string>
-    <string name="not_connected">Neconectat, selectează dispozitivul din lista de jos</string>
+    <string name="not_connected">Neconectat</string>
     <string name="connected_sleeping">Connectat la dispozitivi, dar e în modul de sleep</string>
     <string name="update_to">Updateaza către %s</string>
     <string name="app_too_old">Aplicație prea veche</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -53,7 +53,7 @@
     <string name="update_firmware">Aktualizácia firmvéru</string>
     <string name="connected">Pripojené k vysielaču</string>
     <string name="connected_to">Pripojené k vysielaču (%s)</string>
-    <string name="not_connected">Nepripojené, zvoľte si vysielač.</string>
+    <string name="not_connected">Nepripojené</string>
     <string name="connected_sleeping">Pripojené k uspatému vysielaču.</string>
     <string name="update_to">Aktualizovať na %s</string>
     <string name="app_too_old">Aplikácia je príliš stará</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -51,7 +51,7 @@
     <string name="update_firmware">Posodobite vdelano programsko opremo</string>
     <string name="connected">Povezana z radiem</string>
     <string name="connected_to">Povezana z radiem (%s)</string>
-    <string name="not_connected">Ni povezano. Izberite radio spodaj</string>
+    <string name="not_connected">Ni povezano</string>
     <string name="connected_sleeping">Povezan z radiem, vendar radio "spi"</string>
     <string name="update_to">Posodobi v %s</string>
     <string name="app_too_old">Aplikacija je prestara</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -53,7 +53,7 @@
     <string name="update_firmware">Yazılım güncelle</string>
     <string name="connected">Radyoya bağlandı</string>
     <string name="connected_to">(%s) telsizine bağlandı </string>
-    <string name="not_connected">Bağlı değil, aşağıdan bir radyo seçiniz</string>
+    <string name="not_connected">Bağlı değil</string>
     <string name="connected_sleeping">Telsize bağlandı, ancak uyku durumunda</string>
     <string name="update_to">%s\'e güncelle</string>
     <string name="app_too_old">Uygulama çok eski</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -53,7 +53,7 @@
     <string name="update_firmware">更新固件</string>
     <string name="connected">连接设备</string>
     <string name="connected_to">连接到设备(%s)</string>
-    <string name="not_connected">未连接，请选择下方的设备</string>
+    <string name="not_connected">未连接</string>
     <string name="connected_sleeping">已连接到设备，正在休眠中</string>
     <string name="update_to">更新到%s</string>
     <string name="app_too_old">需要应用程序更新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     <string name="update_firmware">Update Firmware</string>
     <string name="connected">Connected to radio</string>
     <string name="connected_to">Connected to radio (%s)</string>
-    <string name="not_connected">Not connected, select radio below</string>
+    <string name="not_connected">Not connected</string>
     <string name="connected_sleeping">Connected to radio, but it is sleeping</string>
     <string name="update_to">Update to %s</string>
     <string name="app_too_old">Application update required</string>


### PR DESCRIPTION
- only consider sleep connection state when isPowerSaving is enabled (sleep is now disabled by default)
- update `not_connected` string