### PR TITLE
Initial step in refactoring RadioInterfaceService for dependency injection

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,6 +88,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += [ '-Xopt-in=kotlin.RequiresOptIn' ]
     }
     lint {
         abortOnError false

--- a/app/src/main/java/com/geeksville/mesh/repository/usb/ProbeTableProvider.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/usb/ProbeTableProvider.kt
@@ -1,0 +1,25 @@
+package com.geeksville.mesh.repository.usb
+
+import com.hoho.android.usbserial.driver.CdcAcmSerialDriver
+import com.hoho.android.usbserial.driver.ProbeTable
+import com.hoho.android.usbserial.driver.UsbSerialProber
+import dagger.Reusable
+import javax.inject.Inject
+import javax.inject.Provider
+
+/**
+ * Creates a probe table for the USB driver.  This augments the default device-to-driver
+ * mappings with additional known working configurations.  See this package's README for
+ * more info.
+ */
+@Reusable
+class ProbeTableProvider @Inject constructor() : Provider<ProbeTable> {
+    override fun get(): ProbeTable {
+        return UsbSerialProber.getDefaultProbeTable().apply {
+            // RAK 4631:
+            addProduct(9114, 32809, CdcAcmSerialDriver::class.java)
+            // LilyGo TBeam v1.1:
+            addProduct(6790, 21972, CdcAcmSerialDriver::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/repository/usb/README.md
+++ b/app/src/main/java/com/geeksville/mesh/repository/usb/README.md
@@ -1,0 +1,23 @@
+# USB Module
+
+This module provides a repository for acessing USB devices.
+
+## Device Support
+
+In order to be picked up, devices need to be supported by two different mechanisms:
+- Android needs to be supplied with a device filter so that it knows what devices to inform
+  the app about.  These are expressed as vendor and device IDs in `src/res/xml/device_filter.xml`.
+- The USB driver library also needs to have a mapping between the vendor + device IDs and the
+  driver to use for communications.  Many mappings are already natively supported by the driver
+  but unknown devices can have manual mappings added via `ProbeTableProvider`.
+  
+The [Serial USB Terminal](https://play.google.com/store/apps/details?id=de.kai_morich.serial_usb_terminal)
+app in the Google Play Store seems to be a good app for determining both the vendor and
+device IDs as well as testing different underlying drivers.
+
+
+## Testing
+
+When granting permissions to a USB device, the Android platform remembers the user's decision.
+In order to test the permission granting logic, re-install the app.  This will cause Android
+to forget previously granted permissions and will re-trigger the permission acquisition logic.

--- a/app/src/main/java/com/geeksville/mesh/repository/usb/UsbBroadcastReceiver.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/usb/UsbBroadcastReceiver.kt
@@ -1,0 +1,43 @@
+package com.geeksville.mesh.repository.usb
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbManager
+import com.geeksville.android.Logging
+import com.geeksville.util.exceptionReporter
+import javax.inject.Inject
+
+/**
+ * A helper class to call onChanged when bluetooth is enabled or disabled or when permissions are
+ * changed.
+ */
+class UsbBroadcastReceiver @Inject constructor(
+    private val usbRepository: UsbRepository
+) : BroadcastReceiver(), Logging {
+    // Can be used for registering
+    internal val intentFilter get() = IntentFilter().apply {
+        addAction(UsbManager.ACTION_USB_DEVICE_DETACHED)
+        addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) = exceptionReporter {
+        val deviceName: String = intent.getParcelableExtra<UsbDevice?>(UsbManager.EXTRA_DEVICE)?.deviceName ?: "unknown"
+        when (intent.action) {
+            UsbManager.ACTION_USB_DEVICE_DETACHED -> {
+                debug("USB device '$deviceName' was detached")
+                usbRepository.refreshState()
+            }
+            UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
+                debug("USB device '$deviceName' was attached")
+                usbRepository.refreshState()
+            }
+            UsbManager.EXTRA_PERMISSION_GRANTED -> {
+                debug("USB device '$deviceName' was granted permission")
+                usbRepository.refreshState()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/repository/usb/UsbRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/usb/UsbRepository.kt
@@ -1,0 +1,77 @@
+package com.geeksville.mesh.repository.usb
+
+import android.app.Application
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbManager
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.coroutineScope
+import com.geeksville.android.Logging
+import com.geeksville.mesh.CoroutineDispatchers
+import com.hoho.android.usbserial.driver.UsbSerialProber
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repository responsible for maintaining and updating the state of USB connectivity.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@Singleton
+class UsbRepository @Inject constructor(
+    private val application: Application,
+    private val dispatchers: CoroutineDispatchers,
+    private val processLifecycle: Lifecycle,
+    private val usbBroadcastReceiverLazy: dagger.Lazy<UsbBroadcastReceiver>,
+    private val usbManagerLazy: dagger.Lazy<UsbManager?>,
+    private val usbSerialProberLazy: dagger.Lazy<UsbSerialProber>
+) : Logging {
+    private val _serialDevices = MutableStateFlow(emptyMap<String, UsbDevice>())
+
+    @Suppress("unused") // Retained as public API
+    val serialDevices = _serialDevices
+        .asStateFlow()
+
+    val serialDevicesWithDrivers = _serialDevices
+        .mapLatest {  serialDevices ->
+            val serialProber = usbSerialProberLazy.get()
+            buildMap {
+                serialDevices.forEach { (k, v) ->
+                    serialProber.probeDevice(v)?.let { driver ->
+                        put(k, driver)
+                    }
+                }
+            }
+        }.stateIn(processLifecycle.coroutineScope, SharingStarted.Eagerly, emptyMap())
+
+    @Suppress("unused") // Retained as public API
+    val serialDevicesWithPermission = _serialDevices
+        .mapLatest { serialDevices ->
+            usbManagerLazy.get()?.let { usbManager ->
+                serialDevices.filterValues { device ->
+                    usbManager.hasPermission(device)
+                }
+            } ?: emptyMap()
+        }.stateIn(processLifecycle.coroutineScope, SharingStarted.Eagerly, emptyMap())
+
+    init {
+        processLifecycle.coroutineScope.launch(dispatchers.default) {
+            refreshStateInternal()
+            usbBroadcastReceiverLazy.get().let { receiver ->
+                application.registerReceiver(receiver, receiver.intentFilter)
+            }
+        }
+    }
+
+    fun refreshState() {
+        processLifecycle.coroutineScope.launch(dispatchers.default) {
+            refreshStateInternal()
+        }
+    }
+
+    private suspend fun refreshStateInternal() = withContext(dispatchers.default) {
+        _serialDevices.emit(usbManagerLazy.get()?.deviceList ?: emptyMap())
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/repository/usb/UsbRepositoryModule.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/usb/UsbRepositoryModule.kt
@@ -1,0 +1,27 @@
+package com.geeksville.mesh.repository.usb
+
+import android.app.Application
+import android.content.Context
+import android.hardware.usb.UsbManager
+import com.hoho.android.usbserial.driver.ProbeTable
+import com.hoho.android.usbserial.driver.UsbSerialProber
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface UsbRepositoryModule {
+    companion object {
+        @Provides
+        fun provideUsbManager(application: Application): UsbManager? =
+            application.getSystemService(Context.USB_SERVICE) as UsbManager?
+
+        @Provides
+        fun provideProbeTable(provider: ProbeTableProvider): ProbeTable = provider.get()
+
+        @Provides
+        fun provideUsbSerialProber(probeTable: ProbeTable): UsbSerialProber = UsbSerialProber(probeTable)
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/service/BluetoothInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/BluetoothInterface.kt
@@ -5,12 +5,12 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattService
 import android.bluetooth.BluetoothManager
-import android.companion.CompanionDeviceManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import com.geeksville.android.Logging
 import com.geeksville.concurrent.handledLaunch
+import com.geeksville.mesh.repository.usb.UsbRepository
 import com.geeksville.util.anonymize
 import com.geeksville.util.exceptionReporter
 import com.geeksville.util.ignoreException
@@ -85,6 +85,7 @@ class BluetoothInterface(val service: RadioInterfaceService, val address: String
     companion object : Logging, InterfaceFactory('x') {
         override fun createInterface(
             service: RadioInterfaceService,
+            usbRepository: UsbRepository, // Temporary until dependency injection transition is completed
             rest: String
         ): IRadioInterface = BluetoothInterface(service, rest)
 
@@ -111,7 +112,11 @@ class BluetoothInterface(val service: RadioInterfaceService, val address: String
 
         /** Return true if this address is still acceptable. For BLE that means, still bonded */
         @SuppressLint("NewApi", "MissingPermission")
-        override fun addressValid(context: Context, rest: String): Boolean {
+        override fun addressValid(
+            context: Context,
+            usbRepository: UsbRepository, // Temporary until dependency injection transition is completed
+            rest: String
+        ): Boolean {
             /* val allPaired = if (hasCompanionDeviceApi(context)) {
                 val deviceManager: CompanionDeviceManager by lazy {
                     context.getSystemService(Context.COMPANION_DEVICE_SERVICE) as CompanionDeviceManager

--- a/app/src/main/java/com/geeksville/mesh/service/InterfaceFactory.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/InterfaceFactory.kt
@@ -1,6 +1,7 @@
 package com.geeksville.mesh.service
 
 import android.content.Context
+import com.geeksville.mesh.repository.usb.UsbRepository
 
 /**
  * A base class for the singleton factories that make interfaces.  One instance per interface type
@@ -16,8 +17,8 @@ abstract class InterfaceFactory(val prefix: Char) {
         factories[prefix] = this
     }
 
-    abstract fun createInterface(service: RadioInterfaceService, rest: String): IRadioInterface
+    abstract fun createInterface(service: RadioInterfaceService, usbRepository: UsbRepository, rest: String): IRadioInterface
 
     /** Return true if this address is still acceptable. For BLE that means, still bonded */
-    open fun addressValid(context: Context, rest: String): Boolean = true
+    open fun addressValid(context: Context, usbRepository: UsbRepository, rest: String): Boolean = true
 }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -25,6 +25,7 @@ import com.geeksville.mesh.android.hasBackgroundPermission
 import com.geeksville.mesh.database.PacketRepository
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.model.DeviceVersion
+import com.geeksville.mesh.repository.usb.UsbRepository
 import com.geeksville.mesh.service.SoftwareUpdateService.Companion.ProgressNotStarted
 import com.geeksville.util.*
 import com.google.android.gms.common.api.ApiException
@@ -55,6 +56,9 @@ import kotlin.math.max
 class MeshService : Service(), Logging {
     @Inject
     lateinit var packetRepository: Lazy<PacketRepository>
+
+    @Inject
+    lateinit var usbRepository: Lazy<UsbRepository>
 
     companion object : Logging {
 
@@ -306,7 +310,7 @@ class MeshService : Service(), Logging {
      * tell android not to kill us
      */
     private fun startForeground() {
-        val a = RadioInterfaceService.getBondedDeviceAddress(this)
+        val a = RadioInterfaceService.getBondedDeviceAddress(this, usbRepository.get())
         val wantForeground = a != null && a != "n"
 
         info("Requesting foreground service=$wantForeground")
@@ -1337,7 +1341,7 @@ class MeshService : Service(), Logging {
     private fun regenMyNodeInfo() {
         val myInfo = rawMyNodeInfo
         if (myInfo != null) {
-            val a = RadioInterfaceService.getBondedDeviceAddress(this)
+            val a = RadioInterfaceService.getBondedDeviceAddress(this, usbRepository.get())
             val isBluetoothInterface = a != null && a.startsWith("x")
 
             val nodeNum =

--- a/app/src/main/java/com/geeksville/mesh/service/MockInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MockInterface.kt
@@ -6,6 +6,7 @@ import com.geeksville.android.GeeksvilleApplication
 import com.geeksville.android.Logging
 import com.geeksville.mesh.*
 import com.geeksville.mesh.model.getInitials
+import com.geeksville.mesh.repository.usb.UsbRepository
 import com.google.protobuf.ByteString
 import okhttp3.internal.toHexString
 
@@ -14,10 +15,15 @@ class MockInterface(private val service: RadioInterfaceService) : Logging, IRadi
     companion object : Logging, InterfaceFactory('m') {
         override fun createInterface(
             service: RadioInterfaceService,
+            usbRepository: UsbRepository, // Temporary until dependency injection transition is completed
             rest: String
         ): IRadioInterface = MockInterface(service)
 
-        override fun addressValid(context: Context, rest: String): Boolean =
+        override fun addressValid(
+            context: Context,
+            usbRepository: UsbRepository, // Temporary until dependency injection transition is completed
+            rest: String
+        ): Boolean =
             BuildUtils.isEmulator || ((context.applicationContext as GeeksvilleApplication).isInTestLab)
 
         init {

--- a/app/src/main/java/com/geeksville/mesh/service/NopInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/NopInterface.kt
@@ -1,11 +1,13 @@
 package com.geeksville.mesh.service
 
 import com.geeksville.android.Logging
+import com.geeksville.mesh.repository.usb.UsbRepository
 
 class NopInterface : IRadioInterface {
     companion object : Logging, InterfaceFactory('n') {
         override fun createInterface(
             service: RadioInterfaceService,
+            usbRepository: UsbRepository, // Temporary until dependency injection transition is completed
             rest: String
         ): IRadioInterface = NopInterface()
 

--- a/app/src/main/java/com/geeksville/mesh/service/TCPInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/TCPInterface.kt
@@ -1,6 +1,7 @@
 package com.geeksville.mesh.service
 
 import com.geeksville.android.Logging
+import com.geeksville.mesh.repository.usb.UsbRepository
 import com.geeksville.util.Exceptions
 import java.io.BufferedOutputStream
 import java.io.IOException
@@ -18,6 +19,7 @@ class TCPInterface(service: RadioInterfaceService, private val address: String) 
     companion object : Logging, InterfaceFactory('t') {
         override fun createInterface(
             service: RadioInterfaceService,
+            usbRepository: UsbRepository, // Temporary until dependency injection transition is completed
             rest: String
         ): IRadioInterface = TCPInterface(service, rest)
 

--- a/app/src/main/res/xml/device_filter.xml
+++ b/app/src/main/res/xml/device_filter.xml
@@ -55,4 +55,5 @@
     <usb-device
         vendor-id="3368"
         product-id="516" /> <!-- 0x0d28 / 0x0204: ARM mbed -->
+    <usb-device vendor-id="9114" /> <!-- 0x239A RAK Wireless -->
 </resources>


### PR DESCRIPTION
Extracts USB device management into a `UsbRepository`.

In order for `SerialInterface to gain access to this prior to
the `RadioInterfaceService` being fully natively dependency
injected, all `InterfaceFactory` implementations needed
to be modified to accept the `UsbRepository` via argument.  This
will go away in a future PR.

Changed `assumePermission` constant to `false` as it was preventing
the request for permission from occurring, breaking serial connectivity.

Minor improvement: `SerialInterface` re-bonding by device name is
now supported.

Another minor improvement:  Adds USB serial connectivity support for TBeam and RAK 4631 devices. 😁 