### PR TITLE
Prep work for radio service repository

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -117,7 +117,7 @@
 
         <!-- This is a private service which just does direct communication to the radio -->
         <service
-            android:name="com.geeksville.mesh.service.RadioInterfaceService"
+            android:name="com.geeksville.mesh.repository.radio.RadioInterfaceService"
             android:enabled="true"
             android:exported="false" />
 

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -39,6 +39,8 @@ import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.ChannelSet
 import com.geeksville.mesh.model.DeviceVersion
 import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.repository.radio.RadioInterfaceService
+import com.geeksville.mesh.repository.radio.SerialInterface
 import com.geeksville.mesh.repository.usb.UsbRepository
 import com.geeksville.mesh.service.*
 import com.geeksville.mesh.ui.*

--- a/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
@@ -8,7 +8,7 @@ import android.content.pm.PackageManager
 import android.hardware.usb.UsbManager
 import android.os.Build
 import androidx.core.content.ContextCompat
-import com.geeksville.mesh.service.BluetoothInterface
+import com.geeksville.mesh.repository.radio.BluetoothInterface
 
 /**
  * @return null on platforms without a BlueTooth driver (i.e. the emulator)

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
@@ -1,4 +1,4 @@
-package com.geeksville.mesh.service
+package com.geeksville.mesh.repository.radio
 
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
@@ -11,6 +11,7 @@ import android.os.Build
 import com.geeksville.android.Logging
 import com.geeksville.concurrent.handledLaunch
 import com.geeksville.mesh.repository.usb.UsbRepository
+import com.geeksville.mesh.service.*
 import com.geeksville.util.anonymize
 import com.geeksville.util.exceptionReporter
 import com.geeksville.util.ignoreException

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/IRadioInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/IRadioInterface.kt
@@ -1,4 +1,4 @@
-package com.geeksville.mesh.service
+package com.geeksville.mesh.repository.radio
 
 import java.io.Closeable
 

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/InterfaceFactory.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/InterfaceFactory.kt
@@ -1,4 +1,4 @@
-package com.geeksville.mesh.service
+package com.geeksville.mesh.repository.radio
 
 import android.content.Context
 import com.geeksville.mesh.repository.usb.UsbRepository

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/MockInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/MockInterface.kt
@@ -1,4 +1,4 @@
-package com.geeksville.mesh.service
+package com.geeksville.mesh.repository.radio
 
 import android.content.Context
 import com.geeksville.android.BuildUtils

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/NopInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/NopInterface.kt
@@ -1,4 +1,4 @@
-package com.geeksville.mesh.service
+package com.geeksville.mesh.repository.radio
 
 import com.geeksville.android.Logging
 import com.geeksville.mesh.repository.usb.UsbRepository

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -1,4 +1,4 @@
-package com.geeksville.mesh.service
+package com.geeksville.mesh.repository.radio
 
 import android.annotation.SuppressLint
 import android.app.Service
@@ -17,6 +17,10 @@ import com.geeksville.concurrent.handledLaunch
 import com.geeksville.mesh.IRadioInterfaceService
 import com.geeksville.mesh.repository.bluetooth.BluetoothRepository
 import com.geeksville.mesh.repository.usb.UsbRepository
+import com.geeksville.mesh.service.EXTRA_CONNECTED
+import com.geeksville.mesh.service.EXTRA_PAYLOAD
+import com.geeksville.mesh.service.EXTRA_PERMANENT
+import com.geeksville.mesh.service.prefix
 import com.geeksville.util.anonymize
 import com.geeksville.util.ignoreException
 import com.geeksville.util.toRemoteExceptions
@@ -122,7 +126,8 @@ class RadioInterfaceService : Service(), Logging {
             if (address != null) {
                 val c = address[0]
                 val rest = address.substring(1)
-                val isValid = InterfaceFactory.getFactory(c)?.addressValid(context, usbRepository, rest) ?: false
+                val isValid = InterfaceFactory.getFactory(c)
+                    ?.addressValid(context, usbRepository, rest) ?: false
                 if (!isValid)
                     return null
             }

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/SerialInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/SerialInterface.kt
@@ -1,4 +1,4 @@
-package com.geeksville.mesh.service
+package com.geeksville.mesh.repository.radio
 
 import android.content.Context
 import com.geeksville.android.Logging

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/StreamInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/StreamInterface.kt
@@ -1,4 +1,4 @@
-package com.geeksville.mesh.service
+package com.geeksville.mesh.repository.radio
 
 import com.geeksville.android.Logging
 

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/TCPInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/TCPInterface.kt
@@ -1,4 +1,4 @@
-package com.geeksville.mesh.service
+package com.geeksville.mesh.repository.radio
 
 import com.geeksville.android.Logging
 import com.geeksville.mesh.repository.usb.UsbRepository

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -25,6 +25,8 @@ import com.geeksville.mesh.android.hasBackgroundPermission
 import com.geeksville.mesh.database.PacketRepository
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.model.DeviceVersion
+import com.geeksville.mesh.repository.radio.BluetoothInterface
+import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.repository.usb.UsbRepository
 import com.geeksville.mesh.service.SoftwareUpdateService.Companion.ProgressNotStarted
 import com.geeksville.util.*

--- a/app/src/main/java/com/geeksville/mesh/service/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/RadioInterfaceService.kt
@@ -25,10 +25,6 @@ import kotlinx.coroutines.*
 import javax.inject.Inject
 
 
-open class RadioNotConnectedException(message: String = "Not connected to radio") :
-    BLEException(message)
-
-
 /**
  * Handles the bluetooth link with a mesh radio device.  Does not cache any device state,
  * just does bluetooth comms etc...

--- a/app/src/main/java/com/geeksville/mesh/service/RadioNotConnectedException.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/RadioNotConnectedException.kt
@@ -1,0 +1,4 @@
+package com.geeksville.mesh.service
+
+open class RadioNotConnectedException(message: String = "Not connected to radio") :
+    BLEException(message)

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -36,6 +36,10 @@ import com.geeksville.mesh.android.*
 import com.geeksville.mesh.databinding.SettingsFragmentBinding
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.repository.radio.BluetoothInterface
+import com.geeksville.mesh.repository.radio.MockInterface
+import com.geeksville.mesh.repository.radio.RadioInterfaceService
+import com.geeksville.mesh.repository.radio.SerialInterface
 import com.geeksville.mesh.repository.usb.UsbRepository
 import com.geeksville.mesh.service.*
 import com.geeksville.mesh.service.SoftwareUpdateService.Companion.ACTION_UPDATE_PROGRESS


### PR DESCRIPTION
Continuing work on #369 

This pair of commits simply creates the `repository/radio` dir and moves the radio service code into that new location.

Doing this in a dedicated PR to make the next steps more clear/transparent.

Future/next steps:
- Converting the AIDL `IRadioInterfaceService` / `RadioInterfaceService` from a `Service` into a vanilla object instance.  Using services implies RPC calls - an expensive choice for something not exported outside of the application.
- Native dependency injection of the `InterfaceFactory` instances and `RadioInterfaceService` itself.
- Conversion of `RadioInterfaceService` into a proper repository form.