### PR TITLE
add device association list

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
@@ -1,8 +1,10 @@
 package com.geeksville.mesh.android
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.app.NotificationManager
 import android.bluetooth.BluetoothManager
+import android.companion.CompanionDeviceManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.hardware.usb.UsbManager
@@ -13,6 +15,11 @@ import androidx.core.content.ContextCompat
  * @return null on platforms without a BlueTooth driver (i.e. the emulator)
  */
 val Context.bluetoothManager: BluetoothManager? get() = getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager?
+
+val Context.deviceManager: CompanionDeviceManager?
+    @SuppressLint("InlinedApi")
+    get() = if (hasCompanionDeviceApi()) getSystemService(Context.COMPANION_DEVICE_SERVICE) as? CompanionDeviceManager?
+    else null
 
 val Context.usbManager: UsbManager get() = requireNotNull(getSystemService(Context.USB_SERVICE) as? UsbManager?) { "USB_SERVICE is not available"}
 

--- a/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
@@ -8,7 +8,6 @@ import android.content.pm.PackageManager
 import android.hardware.usb.UsbManager
 import android.os.Build
 import androidx.core.content.ContextCompat
-import com.geeksville.mesh.repository.radio.BluetoothInterface
 
 /**
  * @return null on platforms without a BlueTooth driver (i.e. the emulator)
@@ -18,6 +17,14 @@ val Context.bluetoothManager: BluetoothManager? get() = getSystemService(Context
 val Context.usbManager: UsbManager get() = requireNotNull(getSystemService(Context.USB_SERVICE) as? UsbManager?) { "USB_SERVICE is not available"}
 
 val Context.notificationManager: NotificationManager get() = requireNotNull(getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager?)
+
+/**
+ * @return true if CompanionDeviceManager API is present
+ */
+fun Context.hasCompanionDeviceApi(): Boolean =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+        packageManager.hasSystemFeature(PackageManager.FEATURE_COMPANION_DEVICE_SETUP)
+    else false
 
 /**
  * return a list of the permissions we don't have
@@ -62,7 +69,7 @@ fun Context.getScanPermissions(): List<String> {
         perms.add(Manifest.permission.BLUETOOTH_ADMIN)
     }
 */
-    if (!BluetoothInterface.hasCompanionDeviceApi(this)) {
+    if (!hasCompanionDeviceApi()) {
         perms.add(Manifest.permission.ACCESS_FINE_LOCATION)
         perms.add(Manifest.permission.BLUETOOTH_ADMIN)
     }

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
@@ -118,12 +118,6 @@ class BluetoothInterface(val service: RadioInterfaceService, val address: String
             usbRepository: UsbRepository, // Temporary until dependency injection transition is completed
             rest: String
         ): Boolean {
-            /* val allPaired = if (hasCompanionDeviceApi(context)) {
-                val deviceManager: CompanionDeviceManager by lazy {
-                    context.getSystemService(Context.COMPANION_DEVICE_SERVICE) as CompanionDeviceManager
-                }
-                deviceManager.associations.map { it }.toSet()
-            } else { */
             val allPaired = getBluetoothAdapter(context)?.bondedDevices.orEmpty()
                     .map { it.address }.toSet()
             return if (!allPaired.contains(rest)) {
@@ -132,63 +126,6 @@ class BluetoothInterface(val service: RadioInterfaceService, val address: String
             } else
                 true
         }
-
-
-        /// Return the device we are configured to use, or null for none
-        /*
-        @SuppressLint("NewApi")
-        fun getBondedDeviceAddress(context: Context): String? =
-            if (hasCompanionDeviceApi(context)) {
-                // Use new companion API
-
-                val deviceManager = context.getSystemService(CompanionDeviceManager::class.java)
-                val associations = deviceManager.associations
-                val result = associations.firstOrNull()
-                debug("reading bonded devices: $result")
-                result
-            } else {
-                // Use classic API and a preferences string
-
-                val allPaired =
-                    getBluetoothAdapter(context)?.bondedDevices.orEmpty().map { it.address }.toSet()
-
-                // If the user has unpaired our device, treat things as if we don't have one
-                val address = InterfaceService.getPrefs(context).getString(DEVADDR_KEY, null)
-
-                if (address != null && !allPaired.contains(address)) {
-                    warn("Ignoring stale bond to ${address.anonymize}")
-                    null
-                } else
-                    address
-            }
-*/
-
-        /// Can we use the modern BLE scan API?
-        fun hasCompanionDeviceApi(context: Context): Boolean =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val res =
-                    context.packageManager.hasSystemFeature(PackageManager.FEATURE_COMPANION_DEVICE_SETUP)
-                debug("CompanionDevice API available=$res")
-                res
-            } else {
-                warn("CompanionDevice API not available, falling back to classic scan")
-                false
-            }
-
-        /** FIXME - when adding companion device support back in, use this code to set companion device from setBondedDevice
-         *         if (BluetoothInterface.hasCompanionDeviceApi(this)) {
-        // We only keep an association to one device at a time...
-        if (addr != null) {
-        val deviceManager = getSystemService(CompanionDeviceManager::class.java)
-
-        deviceManager.associations.forEach { old ->
-        if (addr != old) {
-        BluetoothInterface.debug("Forgetting old BLE association $old")
-        deviceManager.disassociate(old)
-        }
-        }
-        }
-         */
 
         /**
          * this is created in onCreate()

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -681,9 +681,12 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         regionAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinner.adapter = regionAdapter
 
-        bluetoothViewModel.enabled.observe(viewLifecycleOwner) {
-            if (it) binding.changeRadioButton.show()
-            else binding.changeRadioButton.hide()
+        bluetoothViewModel.enabled.observe(viewLifecycleOwner) { enabled ->
+            if (enabled) {
+                binding.changeRadioButton.show()
+                if (scanModel.devices.value.isNullOrEmpty()) scanModel.setupScan()
+                if (binding.scanStatusText.text == getString(R.string.requires_bluetooth)) updateNodeInfo()
+            } else binding.changeRadioButton.hide()
         }
 
         model.ownerName.observe(viewLifecycleOwner) { name ->

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -37,7 +37,6 @@ import com.geeksville.mesh.android.*
 import com.geeksville.mesh.databinding.SettingsFragmentBinding
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
-import com.geeksville.mesh.repository.radio.BluetoothInterface
 import com.geeksville.mesh.repository.radio.MockInterface
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.repository.radio.SerialInterface
@@ -154,6 +153,7 @@ class BTScanModel @Inject constructor(
     }
 
     val bluetoothAdapter = context.bluetoothManager?.adapter
+    val hasCompanionDeviceApi get() = context.hasCompanionDeviceApi()
     private val usbManager get() = context.usbManager
 
     var selectedAddress: String? = null
@@ -465,10 +465,6 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
 
     @Inject
     internal lateinit var usbRepository: UsbRepository
-
-    private val hasCompanionDeviceApi: Boolean by lazy {
-        BluetoothInterface.hasCompanionDeviceApi(requireContext())
-    }
 
     private val deviceManager: CompanionDeviceManager by lazy {
         requireContext().getSystemService(Context.COMPANION_DEVICE_SERVICE) as CompanionDeviceManager
@@ -958,7 +954,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         super.onViewCreated(view, savedInstanceState)
 
         initCommonUI()
-        if (hasCompanionDeviceApi)
+        if (scanModel.hasCompanionDeviceApi)
             initModernScan()
         else
             initClassicScan()


### PR DESCRIPTION
`Settings tab`: add a persistent device list from previous associations ("device history"):
+ adds another option to connect to devices from the list;
+ to remove devices from the list, `forget pairing` in Android Settings.
