### PR TITLE
Extract `RadioInterfaceService` companion object functions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
-        freeCompilerArgs += [ '-Xopt-in=kotlin.RequiresOptIn' ]
+        freeCompilerArgs += [ '-opt-in=kotlin.RequiresOptIn' ]
     }
     lint {
         abortOnError false

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -42,7 +42,6 @@ import com.geeksville.mesh.model.DeviceVersion
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.repository.radio.SerialInterface
-import com.geeksville.mesh.repository.usb.UsbRepository
 import com.geeksville.mesh.service.*
 import com.geeksville.mesh.ui.*
 import com.geeksville.util.Exceptions
@@ -140,7 +139,7 @@ class MainActivity : BaseActivity(), Logging,
     val model: UIViewModel by viewModels()
 
     @Inject
-    internal lateinit var usbRepository: UsbRepository
+    internal lateinit var radioInterfaceService: RadioInterfaceService
 
     data class TabInfo(val text: String, val icon: Int, val content: Fragment)
 
@@ -982,7 +981,7 @@ class MainActivity : BaseActivity(), Logging,
             errormsg("Bind of MeshService failed")
         }
 
-        val bonded = RadioInterfaceService.getBondedDeviceAddress(this, usbRepository) != null
+        val bonded = radioInterfaceService.getBondedDeviceAddress() != null
         if (!bonded && usbDevice == null) // we will handle USB later
             showSettingsPage()
     }

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioRepositoryModule.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioRepositoryModule.kt
@@ -1,0 +1,19 @@
+package com.geeksville.mesh.repository.radio
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RadioRepositoryModule {
+    @Provides
+    @RadioRepositoryQualifier
+    fun provideSharedPreferences(application: Application): SharedPreferences {
+        return application.getSharedPreferences("radio-prefs", Context.MODE_PRIVATE)
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioRepositoryQualifier.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioRepositoryQualifier.kt
@@ -1,0 +1,9 @@
+package com.geeksville.mesh.repository.radio
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifier to distinguish radio repository- specific object instances.
+ */
+@Qualifier
+annotation class RadioRepositoryQualifier

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -22,7 +22,6 @@ import com.geeksville.mesh.repository.location.LocationRepository
 import com.geeksville.mesh.repository.radio.BluetoothInterface
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.repository.radio.RadioServiceConnectionState
-import com.geeksville.mesh.repository.usb.UsbRepository
 import com.geeksville.util.*
 import com.google.protobuf.ByteString
 import com.google.protobuf.InvalidProtocolBufferException
@@ -54,9 +53,6 @@ class MeshService : Service(), Logging {
 
     @Inject
     lateinit var radioInterfaceService: RadioInterfaceService
-
-    @Inject
-    lateinit var usbRepository: Lazy<UsbRepository>
 
     @Inject
     lateinit var locationRepository: LocationRepository
@@ -211,7 +207,7 @@ class MeshService : Service(), Logging {
      * tell android not to kill us
      */
     private fun startForeground() {
-        val a = RadioInterfaceService.getBondedDeviceAddress(this, usbRepository.get())
+        val a = radioInterfaceService.getBondedDeviceAddress()
         val wantForeground = a != null && a != "n"
 
         info("Requesting foreground service=$wantForeground")
@@ -1180,7 +1176,7 @@ class MeshService : Service(), Logging {
     private fun regenMyNodeInfo() {
         val myInfo = rawMyNodeInfo
         if (myInfo != null) {
-            val a = RadioInterfaceService.getBondedDeviceAddress(this, usbRepository.get())
+            val a = radioInterfaceService.getBondedDeviceAddress()
             val isBluetoothInterface = a != null && a.startsWith("x")
 
             val nodeNum =

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -4,11 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Application
 import android.app.PendingIntent
 import android.bluetooth.BluetoothDevice
-import android.bluetooth.le.BluetoothLeScanner
-import android.bluetooth.le.ScanCallback
-import android.bluetooth.le.ScanSettings
-import android.bluetooth.le.ScanFilter
-import android.bluetooth.le.ScanResult
+import android.bluetooth.le.*
 import android.companion.AssociationRequest
 import android.companion.BluetoothDeviceFilter
 import android.companion.CompanionDeviceManager
@@ -127,6 +123,7 @@ class BTScanModel @Inject constructor(
     private val bluetoothRepository: BluetoothRepository,
     private val usbRepository: UsbRepository,
     private val nsdRepository: NsdRepository,
+    private val radioInterfaceService: RadioInterfaceService,
 ) : ViewModel(), Logging {
 
     private val context: Context get() = application.applicationContext
@@ -258,7 +255,7 @@ class BTScanModel @Inject constructor(
      * returns true if we could start scanning, false otherwise
      */
     fun setupScan(): Boolean {
-        selectedAddress = RadioInterfaceService.getDeviceAddress(context, usbRepository)
+        selectedAddress = radioInterfaceService.getDeviceAddress()
 
         return if (bluetoothAdapter == null || MockInterface.addressValid(context, usbRepository, "")) {
             warn("No bluetooth adapter.  Running under emulation?")


### PR DESCRIPTION
Slowly continuing work on #369:

In preparation for replacing the `InterfaceFactory` with an
injectable form we need to convert static methods that call
`InterfaceFactory` into non-static, injected forms.

Also:
- Updated kotlin `-Xopt-in` to `-opt-in` to remove build
  time warnings.
- Removed some unused `RadioInterfaceService` code.
