### PR TITLE
add shutdown & reboot buttons

### DIFF
--- a/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
+++ b/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
@@ -95,6 +95,12 @@ interface IMeshService {
     /// It sets a ChannelSet protobuf
     void setChannels(in byte []payload);
 
+    /// Send Shutdown admin packet to nodeNum
+    void requestShutdown(in String nodeId);
+
+    /// Send Reboot admin packet to nodeNum
+    void requestReboot(in String nodeId);
+
     /**
     Is the packet radio currently connected to the phone?  Returns a ConnectionState string.
     */

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -279,6 +279,14 @@ class UIViewModel @Inject constructor(
             }
     }
 
+    fun requestShutdown() {
+        meshService?.requestShutdown(DataPacket.ID_LOCAL)
+    }
+
+    fun requestReboot() {
+        meshService?.requestReboot(DataPacket.ID_LOCAL)
+    }
+
     /**
      * Write the persisted packet data out to a CSV file in the specified location.
      */

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1406,6 +1406,18 @@ class MeshService : Service(), Logging {
         })
     }
 
+    private fun requestShutdown(nodeId: String) {
+        sendToRadio(newMeshPacketTo(toNodeNum(nodeId)).buildAdminPacket {
+            shutdownSeconds = 5
+        })
+    }
+
+    private fun requestReboot(nodeId: String) {
+        sendToRadio(newMeshPacketTo(toNodeNum(nodeId)).buildAdminPacket {
+            rebootSeconds = 5
+        })
+    }
+
     /**
      * Start the modern (REV2) API configuration flow
      */
@@ -1762,6 +1774,14 @@ class MeshService : Service(), Logging {
 
         override fun stopProvideLocation() = toRemoteExceptions {
             stopLocationRequests()
+        }
+
+        override fun requestShutdown(nodeId: String) = toRemoteExceptions {
+            this@MeshService.requestShutdown(nodeId)
+        }
+
+        override fun requestReboot(nodeId: String) = toRemoteExceptions {
+            this@MeshService.requestReboot(nodeId)
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettingsFragment.kt
@@ -14,6 +14,7 @@ import com.geeksville.mesh.model.ChannelOption
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.service.MeshService
 import com.geeksville.util.exceptionToSnackbar
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -52,6 +53,8 @@ class AdvancedSettingsFragment : ScreenFragment("Advanced Settings"), Logging {
             binding.lsSleepView.isEnabled = connected && model.isPowerSaving ?: false
             binding.positionBroadcastSwitch.isEnabled = connected
             binding.lsSleepSwitch.isEnabled = connected
+            binding.shutdownButton.isEnabled = connected
+            binding.rebootButton.isEnabled = connected
         }
 
         binding.positionBroadcastPeriodEditText.on(EditorInfo.IME_ACTION_DONE) {
@@ -105,6 +108,28 @@ class AdvancedSettingsFragment : ScreenFragment("Advanced Settings"), Logging {
                 model.isPowerSaving = isChecked
                 debug("User changed isPowerSaving to $isChecked")
             }
+        }
+
+        binding.shutdownButton.setOnClickListener {
+            MaterialAlertDialogBuilder(requireContext())
+                .setMessage("${getString(R.string.update_firmware)}?")
+                .setNeutralButton(R.string.cancel) { _, _ ->
+                }
+                .setPositiveButton(getString(R.string.okay)) { _, _ ->
+                    model.requestShutdown()
+                }
+                .show()
+        }
+
+        binding.rebootButton.setOnClickListener {
+            MaterialAlertDialogBuilder(requireContext())
+                .setMessage("${getString(R.string.update_firmware)}?")
+                .setNeutralButton(R.string.cancel) { _, _ ->
+                }
+                .setPositiveButton(getString(R.string.okay)) { _, _ ->
+                    model.requestReboot()
+                }
+                .show()
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettingsFragment.kt
@@ -112,7 +112,7 @@ class AdvancedSettingsFragment : ScreenFragment("Advanced Settings"), Logging {
 
         binding.shutdownButton.setOnClickListener {
             MaterialAlertDialogBuilder(requireContext())
-                .setMessage("${getString(R.string.update_firmware)}?")
+                .setMessage("${getString(R.string.shutdown)}?")
                 .setNeutralButton(R.string.cancel) { _, _ ->
                 }
                 .setPositiveButton(getString(R.string.okay)) { _, _ ->
@@ -123,7 +123,7 @@ class AdvancedSettingsFragment : ScreenFragment("Advanced Settings"), Logging {
 
         binding.rebootButton.setOnClickListener {
             MaterialAlertDialogBuilder(requireContext())
-                .setMessage("${getString(R.string.update_firmware)}?")
+                .setMessage("${getString(R.string.reboot)}?")
                 .setNeutralButton(R.string.cancel) { _, _ ->
                 }
                 .setPositiveButton(getString(R.string.okay)) { _, _ ->

--- a/app/src/main/res/layout/advanced_settings.xml
+++ b/app/src/main/res/layout/advanced_settings.xml
@@ -65,4 +65,27 @@
         app:layout_constraintBottom_toBottomOf="@id/lsSleepView"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/lsSleepView" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/shutdownButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="4dp"
+        android:text="shutdown"
+        app:layout_constraintEnd_toStartOf="@id/rebootButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/lsSleepView" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/rebootButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="16dp"
+        android:text="reboot"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/shutdownButton"
+        app:layout_constraintTop_toTopOf="@id/shutdownButton" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/advanced_settings.xml
+++ b/app/src/main/res/layout/advanced_settings.xml
@@ -73,7 +73,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="4dp"
-        android:text="shutdown"
+        android:text="@string/shutdown"
         app:layout_constraintEnd_toStartOf="@id/rebootButton"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/lsSleepView" />
@@ -84,7 +84,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="4dp"
         android:layout_marginEnd="16dp"
-        android:text="reboot"
+        android:text="@string/reboot"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/shutdownButton"
         app:layout_constraintTop_toTopOf="@id/shutdownButton" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,4 +142,6 @@
     <string name="preferences_system_default">System default</string>
     <string name="preferences_map_style">Map style</string>
     <string name="resend">Resend</string>
+    <string name="shutdown">Shutdown</string>
+    <string name="reboot">Reboot</string>
 </resources>


### PR DESCRIPTION
add `Shutdown` & `Reboot` buttons to advanced settings
- send admin packets `shutdown_seconds` and `reboot_seconds` with value of 5 seconds

Note: only sent to the local node but can be expanded to remote nodes.