### PR TITLE
Bump protobuf-gradle-plugin to 0.8.18 and protoc to 3.21.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,7 +106,7 @@ play {
 // per protobuf-gradle-plugin docs, this is recommended for android
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.15.3'
+        artifact = 'com.google.protobuf:protoc:3.21.1'
     }
     generateProtoTasks {
         all().each { task ->
@@ -160,7 +160,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
     // For now I'm not using javalite, because I want JSON printing
-    implementation 'com.google.protobuf:protobuf-java:3.15.8'
+    implementation 'com.google.protobuf:protobuf-java:3.21.1'
 
     // For UART access
     // implementation 'com.google.android.things:androidthings:1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'
 
         // protobuf plugin - docs here https://github.com/google/protobuf-gradle-plugin
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.17'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.18'
 
         //classpath "app.brant:amazonappstorepublisher:0.1.0"
         classpath 'com.github.triplet.gradle:play-publisher:2.8.0'


### PR DESCRIPTION
This pulls in a new protoc version that has a workaround allowing M1 MacBooks to resolve an intel arch binary (since the arm64 binary for mac is not yet being built).  Without this, M1's cannot build the project.

Bumped the protobuf plugin version as well but it is unrelated.