### PR TITLE
add CH9102F USB serial (used on some tlora-v2-1-1.6 variants)

### DIFF
--- a/app/src/main/res/xml/device_filter.xml
+++ b/app/src/main/res/xml/device_filter.xml
@@ -56,4 +56,7 @@
         vendor-id="3368"
         product-id="516" /> <!-- 0x0d28 / 0x0204: ARM mbed -->
     <usb-device vendor-id="9114" /> <!-- 0x239A RAK Wireless -->
+    <usb-device
+        vendor-id="6790"
+        product-id="21972" /> <!-- 0x1a86 / 0x55d4: Qinheng CH9102F -->
 </resources>


### PR DESCRIPTION
The LILYGO LoRa32 modules that I recently purchased off Amazon use the CH9102F instead of a CP2102.  (The PCB markings are T3_V1.6.1 20210104, the same as one of the images on meshtastic.org)

felHR95/UsbSerial already supports devices using the CDC protocol (which the Qinheng CH9102F adopts), so adding support is as straightforward as adding the VID:PID to device_filter.xml.