### PR TITLE
usb-serial-for-android to v3.4.6; adopt more comprehensive device_fil…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -164,7 +164,7 @@ dependencies {
 
     // For UART access
     // implementation 'com.google.android.things:androidthings:1.0'
-    implementation 'com.github.mik3y:usb-serial-for-android:3.4.3'
+    implementation 'com.github.mik3y:usb-serial-for-android:3.4.6'
 
     // mapbox
     implementation 'com.mapbox.maps:android:10.2.0'

--- a/app/src/main/res/xml/device_filter.xml
+++ b/app/src/main/res/xml/device_filter.xml
@@ -31,10 +31,28 @@
         vendor-id="4292"
         product-id="60032" /> <!-- 0xea80: CP2110 -->
 
-    <!-- 0x067B / 0x2303: Prolific PL2303 -->
+    <!-- 0x067B / 0x23x3: Prolific PL2303 -->
     <usb-device
         vendor-id="1659"
-        product-id="8963" />
+        product-id="8963" /> <!-- 0x067B / 0x2303: PL2303Hx -->
+    <usb-device
+        vendor-id="1659"
+        product-id="9123" /> <!-- 0x067B / 0x23a3: PL2303GC -->
+    <usb-device
+        vendor-id="1659"
+        product-id="9139" /> <!-- 0x067B / 0x23b3: PL2303GB -->
+    <usb-device
+        vendor-id="1659"
+        product-id="9155" /> <!-- 0x067B / 0x23c3: PL2303GT -->
+    <usb-device
+        vendor-id="1659"
+        product-id="9171" /> <!-- 0x23d3: PL2303GL -->
+    <usb-device
+        vendor-id="1659"
+        product-id="9187" /> <!-- 0x23e3: PL2303GE -->
+    <usb-device
+        vendor-id="1659"
+        product-id="9203" /> <!-- 0x23f3: PL2303GS -->
 
     <!-- 0x1a86 / 0x7523: Qinheng CH340 -->
     <usb-device


### PR DESCRIPTION
The PR updates the version of usb-serial-for-android to v3.4.6 to get additional device support, and expands the VID:PID list in device_filter to reflect some of those added options.

My personal motivation for doing is that I'm using a USB null modem cable to run Meshtastic-Android on an Android device that connects via USB to a PC running the portduino variant of Meshtastic-device.  I'm assuming that this capability might benefit others.

It may be obvious to those heavily involved in the project, but to get Meshtastic-device to talk to a serial port, I found that PlatformIO was hiding the relevant library file here:

~/.platformio/packages/framework-portduino/cores/portduino/linux/LinuxSerial.cpp

and below is my modified version of the file.  It has the serial port hard-coded to "/dev/ttyUSB0", but that is easily changed by the user as needed.  speed equals B115200 to reflect the latest bleeding edge Meshtastic source code, but the earlier v1.2 used B921600.

```
#include "LinuxSerial.h"

#include <stdio.h>
#include <sys/types.h>
#include <fcntl.h>
#include <termios.h>
#include <unistd.h>
#include <sys/ioctl.h>
#include <sys/select.h>

namespace arduino {
    LinuxSerial Serial;

    int fd;

    void LinuxSerial::begin(unsigned long baudrate, uint16_t config) {
        // Ignore baudrate and config on linux (for now)

        fd = open("/dev/ttyUSB0", O_RDWR | O_NOCTTY | O_NDELAY | O_EXCL);

        struct flock fl;
        memset(&fl, 0, sizeof(fl));
        fl.l_type = F_WRLCK;
        fcntl(fd, F_SETLK, &fl);

        struct termios options;
        tcgetattr(fd, &options);

        speed_t speed = B115200;
        cfsetispeed(&options, speed);
        cfsetospeed(&options, speed);

        // mandatory
        options.c_cflag |= (CLOCAL | CREAD);

        // 8N1
        options.c_cflag &= ~PARENB;
        options.c_cflag &= ~CSTOPB;
        options.c_cflag &= ~CSIZE;
        options.c_cflag |= CS8;

        // don't use XON/XOFF
        options.c_iflag &= ~(IXON | IXOFF | IXANY);
        // don't use RTS/CTS hardware flow control
        options.c_cflag &= ~CRTSCTS;

        // choose non-canonical input and no echo
        options.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);

        // don't remap CR and LF
        options.c_iflag &= ~(INLCR | ICRNL);

        // choose raw output mode
        options.c_oflag &= ~OPOST;

        tcsetattr(fd, TCSANOW, &options);
    }

    void LinuxSerial::end() {
        close(fd);
    }

    int LinuxSerial::available(void) {
        struct timeval timeout;
        fd_set input;

        memset(&timeout, 0, sizeof(timeout));

        FD_ZERO(&input);
        FD_SET(fd, &input);

        int rc = select(fd + 1, &input, NULL, NULL, &timeout);

        return ( (rc > 0) && FD_ISSET(fd, &input) );
    }

    int LinuxSerial::peek(void) {
        return -1;
    }

    int LinuxSerial::read(void) {
        uint8_t c;
        int rc = ::read(fd, &c, 1);
        return (rc > 0) ? c : -1;
    }

    void LinuxSerial::flush(void) {
    }

    size_t LinuxSerial::write(uint8_t c) {
        return ::write(fd, &c, 1);
    }

    LinuxSerial::operator bool() {
        // Returns true if the port is ready for use
        return true;
    }
}
```
