### PR TITLE
Shows a prompt when Bluetooth is off and trying to add a device

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -506,10 +506,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
     private fun checkBTEnabled(
         warningReason: String = getString(R.string.requires_bluetooth)
     ) {
-
-        var btAdapter = BluetoothAdapter.getDefaultAdapter();
-
-        if (!(btAdapter.isEnabled())) {
+        if (bluetoothViewModel.enabled.value == false) {
             warn("We need bluetooth")
             showSnackbar(warningReason)
         }


### PR DESCRIPTION
When trying to add a Meshtastic device, the app will check if Bluetooth is turned on, if it isn't then it will display a message.