### PR TITLE
refactor permissions

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
@@ -55,48 +55,22 @@ fun Context.getMissingPermissions(perms: List<String>): Array<String> = perms.fi
 }.toTypedArray()
 
 /**
- * Bluetooth connect permissions (or empty if we already have what we need)
+ * Bluetooth permissions (or empty if we already have what we need)
  */
-fun Context.getConnectPermissions(): Array<String> {
+fun Context.getBluetoothPermissions(): Array<String> {
     val perms = mutableListOf<String>()
 
 /*  TODO - wait for targetSdkVersion 31
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        perms.add(Manifest.permission.BLUETOOTH_SCAN)
         perms.add(Manifest.permission.BLUETOOTH_CONNECT)
-    } else {
-        perms.add(Manifest.permission.BLUETOOTH)
     }
 */
     return getMissingPermissions(perms)
 }
 
 /** @return true if the user already has Bluetooth connect permission */
-fun Context.hasConnectPermission() = getConnectPermissions().isEmpty()
-
-/**
- * Bluetooth scan/discovery permissions (or empty if we already have what we need)
- */
-fun Context.getScanPermissions(): Array<String> {
-    val perms = mutableListOf<String>()
-
-/*  TODO - wait for targetSdkVersion 31
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        perms.add(Manifest.permission.BLUETOOTH_SCAN)
-    } else if (!BluetoothInterface.hasCompanionDeviceApi(this)) {
-        perms.add(Manifest.permission.ACCESS_FINE_LOCATION)
-        perms.add(Manifest.permission.BLUETOOTH_ADMIN)
-    }
-*/
-    if (!hasCompanionDeviceApi()) {
-        perms.add(Manifest.permission.ACCESS_FINE_LOCATION)
-        perms.add(Manifest.permission.BLUETOOTH_ADMIN)
-    }
-
-    return getMissingPermissions(perms)
-}
-
-/** @return true if the user already has Bluetooth scan/discovery permission */
-fun Context.hasScanPermission() = getScanPermissions().isEmpty()
+fun Context.hasBluetoothPermission() = getBluetoothPermissions().isEmpty()
 
 /**
  * Camera permission (or empty if we already have what we need)

--- a/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
@@ -131,7 +131,7 @@ class BTScanModel @Inject constructor(
     private val bluetoothAdapter = context.bluetoothManager?.adapter
     private val deviceManager get() = context.deviceManager
     val hasCompanionDeviceApi get() = context.hasCompanionDeviceApi()
-    private val hasConnectPermission get() = application.hasConnectPermission()
+    private val hasBluetoothPermission get() = application.hasBluetoothPermission()
     private val usbManager get() = context.usbManager
 
     var selectedAddress: String? = null

--- a/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
 import com.geeksville.android.Logging
 import com.geeksville.mesh.CoroutineDispatchers
-import com.geeksville.mesh.android.hasConnectPermission
+import com.geeksville.mesh.android.hasBluetoothPermission
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -66,7 +66,7 @@ class BluetoothRepository @Inject constructor(
     @SuppressLint("MissingPermission")
     internal suspend fun updateBluetoothState() {
         val newState: BluetoothState = bluetoothAdapterLazy.get()?.takeIf {
-            application.hasConnectPermission().also { hasPerms ->
+            application.hasBluetoothPermission().also { hasPerms ->
                 if (!hasPerms) errormsg("Still missing needed bluetooth permissions")
             }
         }?.let { adapter ->

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -113,7 +113,6 @@
     <string name="show_system_settings">시스템 설정 보기</string>
     <string name="why_background_required">기능을위해서, 옵션에서 위치권한을 \"항상 허용\" 으로 설정해야합니다.앱이 닫혀있거나 사용중이지 않을때에도 메쉬태스틱이 당신의 스마트폰의 위치를 읽어 당신의 메쉬의 다른 사용자에게 위치를 전송할수있게합니다.</string>
     <string name="required_permissions">권한부여 필요</string>
-    <string name="location">장소</string>
     <string name="cancel_no_radio">취소 (no radio access)</string>
     <string name="allow_will_show">허용 (대화에 보일것입니다)</string>
     <string name="provide_location_to_mesh">메쉬에 현재 위치 공유</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -26,7 +26,7 @@
     <string name="are_you_sure_channel">Are you sure you want to change the channel? All communication with other nodes will stop until you share the new channel settings.</string>
     <string name="new_channel_rcvd">Odebrano nowy URL kanału</string>
     <string name="do_you_want_switch">Chcesz przełączyć na \'%s\' kanał?</string>
-    <string name="permission_missing">Meshtastic potrzebuje %s zezwolenie i lokalizacja muszą być włączone, aby można było znaleźć nowe urządzenia przez Bluetooth. Możesz go później wyłączyć.</string>
+    <string name="permission_missing">Meshtastic potrzebuje lokalizacja zezwolenie i lokalizacja muszą być włączone, aby można było znaleźć nowe urządzenia przez Bluetooth. Możesz go później wyłączyć.</string>
     <string name="radio_sleeping">Radio było w trybie uśpienia, nie mogło zmienić kanału</string>
     <string name="report_bug">Zgłoś bug</string>
     <string name="report_a_bug">Zgłoś bug</string>
@@ -105,7 +105,6 @@
     <string name="background_required">Lokalizacja w tle</string>
     <string name="show_system_settings">Pokaż ustawienia systemowe</string>
     <string name="required_permissions">Wymagane uprawnienia</string>
-    <string name="location">Lokalizacja</string>
     <string name="provide_location_to_mesh">Podaj lokalizację do sieci</string>
     <plurals name="delete_messages">
         <item quantity="one">Usunąć wiadomość?</item>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -26,7 +26,7 @@
     <string name="are_you_sure_channel">Tem certeza que deseja mudar de canal? Toda comunicação com os outros dispositivos será interrompida até serem compartilhadas as novas configurações do canal.</string>
     <string name="new_channel_rcvd">Novo link de canal recebido</string>
     <string name="do_you_want_switch">Deseja mudar para o canal \'%s\'?</string>
-    <string name="permission_missing">Meshtastic precisa da permissão de %s e da localização ativada para encontrar novos dispositivos via bluetooth. Você pode desativar novamente depois.</string>
+    <string name="permission_missing">Meshtastic precisa da permissão de localização e localização ativada para encontrar novos dispositivos via bluetooth. Você pode desativar novamente depois.</string>
     <string name="radio_sleeping">Rádio estava em suspensão (sleep), não foi possível mudar de canal</string>
     <string name="report_bug">Informar Bug</string>
     <string name="report_a_bug">Informar um bug</string>
@@ -102,7 +102,6 @@
     <string name="show_system_settings">Exibir configurações do sistema</string>
     <string name="why_background_required">Para este recurso, você deve conceder permissão para acessar Local com a opção \"Permitir o tempo todo\".\nIsto permite ao Meshtastic ler a localização do seu smartphone e enviar aos membros da sua mesh, mesmo quando o aplicativo está fechado ou não em uso.</string>
     <string name="required_permissions">Permissões necessárias</string>
-    <string name="location">localização</string>
     <string name="cancel_no_radio">Cancelar (sem acesso ao rádio)</string>
     <string name="allow_will_show">Permitir (exibe diálogo)</string>
     <string name="provide_location_to_mesh">Fornecer localização para mesh</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -25,7 +25,7 @@
     <string name="are_you_sure_channel">Tem certeza que deseja mudar de canal? Todas as comunicações com outros nós serão interrompidas até que partilhe as novas configurações do canal.</string>
     <string name="new_channel_rcvd">Novo Link Recebido do Canal</string>
     <string name="do_you_want_switch">Pretende mudar para o canal \'%s\' ?</string>
-    <string name="permission_missing">Meshtastic precisa da permissão de %s e da localização ativada para encontrar novos dispositivos via bluetooth. Você pode desativar novamente depois.</string>
+    <string name="permission_missing">Meshtastic precisa da permissão de localização e localização ativada para encontrar novos dispositivos via bluetooth. Você pode desativar novamente depois.</string>
     <string name="radio_sleeping">O rádio estava a dormir, não conseguia mudar de canal</string>
     <string name="report_bug">Reportar Bug</string>
     <string name="report_a_bug">Reportar a bug</string>
@@ -102,7 +102,6 @@
     <string name="show_system_settings">Exibir configurações do sistema</string>
     <string name="why_background_required">Para este recurso, você deve conceder permissão para acessar Local com a opção \"Permitir o tempo todo\".\nIsto permite ao Meshtastic ler a localização do seu smartphone e enviar aos membros da sua mesh, mesmo quando o aplicativo está fechado ou não em uso.</string>
     <string name="required_permissions">Permissões necessárias</string>
-    <string name="location">localização</string>
     <string name="cancel_no_radio">Cancelar (sem acesso ao rádio)</string>
     <string name="allow_will_show">Permitir (exibe diálogo)</string>
     <string name="provide_location_to_mesh">Fornecer localização para mesh</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -107,7 +107,6 @@
     <string name="show_system_settings">Zobraziť nastavenia systému</string>
     <string name="why_background_required">Pre túto možnosť musíte povoliť prístup ku polohe zariadenia v režime \"Vždy povolené\".\nTáto možnosť povolí aplikácii Meshtastic zistiť polohu Vášho zariadenia a odoslať ju členom Vašej siete aj keď je aplikácia Meshtastic vypnutá alebo sa nepoužíva.</string>
     <string name="required_permissions">Požadované oprávnenia</string>
-    <string name="location">poloha</string>
     <string name="cancel_no_radio">Zrušiť (žiaden dosah na vysielač)</string>
     <string name="allow_will_show">Povoliť (zobrazí potvrdzovací dialóg)</string>
     <string name="provide_location_to_mesh">Odoslať polohu do siete</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="are_you_sure_channel">Are you sure you want to change the channel? All communication with other nodes will stop until you share the new channel settings.</string>
     <string name="new_channel_rcvd">New Channel URL received</string>
     <string name="do_you_want_switch">Do you want to switch to the \'%s\' channel?</string>
-    <string name="permission_missing">Meshtastic needs %s permission and location must be turned on to find new devices via bluetooth. You can turn it off again afterwards.</string>
+    <string name="permission_missing">Meshtastic needs location permission and location must be turned on to find new devices via Bluetooth. You can turn it off again afterwards.</string>
     <string name="radio_sleeping">Radio was sleeping, could not change channel</string>
     <string name="report_bug">Report Bug</string>
     <string name="report_a_bug">Report a bug</string>
@@ -108,7 +108,6 @@
     <string name="show_system_settings">Show system settings</string>
     <string name="why_background_required">For this feature, you must grant Location permission option \"Allow all the time\".\nThis allows Meshtastic to read your smartphone location and send it to other members of your mesh, even when the app is closed or not in use.</string>
     <string name="required_permissions">Required permissions</string>
-    <string name="location">location</string>
     <string name="cancel_no_radio">Cancel (no radio access)</string>
     <string name="allow_will_show">Allow (will show dialog)</string>
     <string name="provide_location_to_mesh">Provide location to mesh</string>
@@ -155,4 +154,5 @@
     <string name="are_you_sure_factory_reset">Are you sure you want to factory reset?</string>
     <string name="factory_reset_description">This will clear all device configuration you have done.</string>
     <string name="bluetooth_disabled">Bluetooth disabled.</string>
+    <string name="permission_missing_31">Meshtastic needs Nearby devices permission to find and connect to devices via Bluetooth. You can turn it off when not in use.</string>
 </resources>


### PR DESCRIPTION
- cleanup and update MainActivity permissions to ActivityResult
- replace `ScanPermissions` with `LocationPermissions` for classic scan (only loc is a runtime perm)
- refactor Scan/ConnectPermissions to BluetoothPermissions (both Nearby devices in API 31+)
- keep Nearby devices at app start for now
