### PR TITLE
move ChannelSet out of MeshService

### DIFF
--- a/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
+++ b/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
@@ -72,20 +72,12 @@ interface IMeshService {
     List<NodeInfo> getNodes();
 
     /// This method is only intended for use in our GUI, so the user can set radio options
-    /// It returns a DeviceConfig protobuf.
-    byte []getDeviceConfig();
+    /// It sets a Config protobuf via admin packet
+    void setConfig(in byte []payload);
 
     /// This method is only intended for use in our GUI, so the user can set radio options
-    /// It sets a DeviceConfig protobuf
-    void setDeviceConfig(in byte []payload);
-
-    /// This method is only intended for use in our GUI, so the user can set radio options
-    /// It returns a ChannelSet protobuf.
-    byte []getChannels();
-
-    /// This method is only intended for use in our GUI, so the user can set radio options
-    /// It sets a ChannelSet protobuf
-    void setChannels(in byte []payload);
+    /// It sets a Channel protobuf via admin packet
+    void setChannel(in byte []payload);
 
     /// Send Shutdown admin packet to nodeNum
     void requestShutdown(in int idNum);

--- a/app/src/main/java/com/geeksville/mesh/ui/ChannelFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ChannelFragment.kt
@@ -314,10 +314,11 @@ class ChannelFragment : ScreenFragment("Channel"), Logging {
 
                     // No matter what apply the speed selection from the user
                     val newLoRaConfig = loRaConfig {
-                        region = model.region
-                        txEnabled = model.txEnabled
                         usePreset = true
                         modemPreset = newModemPreset
+                        region = model.region
+                        txEnabled = model.txEnabled
+                        txPower = model.config.lora.txPower
                     }
 
                     val humanName = Channel(newSettings, newLoRaConfig).humanName


### PR DESCRIPTION
- remove channelSet fom service;
- interface service only with `setConfig` / `setChannel` (getters use the datastore equivalents).