### PR TITLE
Support A13 Themed Icons (close #573)

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher2.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher2.xml
@@ -2,5 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher2_background"/>
     <foreground android:drawable="@drawable/ic_launcher2_foreground"/>
-    <monochrome android:drawable="@drawable/ic_launcher2_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher2_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher2.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher2.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher2_background"/>
     <foreground android:drawable="@drawable/ic_launcher2_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher2_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher2_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher2_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher2_background"/>
     <foreground android:drawable="@drawable/ic_launcher2_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher2_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Taking a stab at #573 

Added `<monochrome android:drawable="@drawable/ic_launcher2_foreground"/>` in `ic_launcher2.xml` and `ic_launcher2_round.xml` to add support for A13's themed icons per here [Adaptive icons | Android Developers](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive#add_your_adaptive_icon_to_your_app).

I built the apk in Android Studio and tested it with my Pixel 7 Pro running Android 13 and it installed without issue and support for the themed icons were added allowing color to be changed based on wallpaper or as selected. 