### PR TITLE
chore(deps): update osmdroid_version to v6.1.16

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ android {
     compileSdkVersion 33
     defaultConfig {
         applicationId "com.geeksville.mesh"
-        minSdkVersion 21 // The oldest emulator image I have tried is 22 (though 21 probably works)
+        minSdkVersion 23 // The oldest emulator image I have tried is 22 (though 21 probably works)
         targetSdkVersion 31
         versionCode 30109 // format is Mmmss (where M is 1+the numeric major number
         versionName "2.1.9"
@@ -187,10 +187,13 @@ dependencies {
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
 
     // Osmdroid & Maps
-    def osmdroid_version = '6.1.14'
+    def osmdroid_version = '6.1.16'
     implementation "org.osmdroid:osmdroid-android:$osmdroid_version"
     implementation "org.osmdroid:osmdroid-wms:$osmdroid_version"
-    implementation "org.osmdroid:osmdroid-geopackage:$osmdroid_version"
+    implementation ("org.osmdroid:osmdroid-geopackage:$osmdroid_version") {
+        exclude module: 'ormlite-core'
+        exclude group: 'com.j256.ormlite'
+    }
     implementation 'com.github.MKergall:osmbonuspack:6.9.0'
     implementation('mil.nga.mgrs:mgrs-android:2.2.2') { exclude group: 'com.google.android.gms' }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,8 +34,8 @@ android {
         applicationId "com.geeksville.mesh"
         minSdkVersion 21 // The oldest emulator image I have tried is 22 (though 21 probably works)
         targetSdkVersion 31
-        versionCode 30108 // format is Mmmss (where M is 1+the numeric major number
-        versionName "2.1.8"
+        versionCode 30109 // format is Mmmss (where M is 1+the numeric major number
+        versionName "2.1.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // per https://developer.android.com/studio/write/vector-asset-studio

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -192,7 +192,6 @@ dependencies {
     implementation "org.osmdroid:osmdroid-wms:$osmdroid_version"
     implementation ("org.osmdroid:osmdroid-geopackage:$osmdroid_version") {
         exclude module: 'ormlite-core'
-        exclude group: 'com.j256.ormlite'
     }
     implementation 'com.github.MKergall:osmbonuspack:6.9.0'
     implementation('mil.nga.mgrs:mgrs-android:2.2.2') { exclude group: 'com.google.android.gms' }


### PR DESCRIPTION
Bumped OSMDroid from 6.1.14 to 6.1.16

Min SDK was bumped in this update since OSMDroid requires minSDK 23.

[OSMDroid AndroidX PR](https://github.com/osmdroid/osmdroid/pull/1856)
[OSMDroid GEOPackage PR](https://github.com/osmdroid/osmdroid/pull/1853)

These 2 PR's addressed the underlying library OSMDroid and NGA Geopackage. We can potentially update the map to allow uploading of custom map tiles/files from storage. There is a long thread addressing this issue in the OSMDroid repo/issue thread.
