### PR TITLE
fix: replace duplicate packet IDs before sending queue

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/PacketRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/PacketRepository.kt
@@ -34,6 +34,10 @@ class PacketRepository @Inject constructor(private val packetDaoLazy: dagger.Laz
         packetDao.updateMessageStatus(d, m)
     }
 
+    suspend fun updateMessageId(d: DataPacket, id: Int) = withContext(Dispatchers.IO) {
+        packetDao.updateMessageId(d, id)
+    }
+
     suspend fun getDataPacketById(requestId: Int) = withContext(Dispatchers.IO) {
         packetDao.getDataPacketById(requestId)
     }

--- a/app/src/main/java/com/geeksville/mesh/database/dao/PacketDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/PacketDao.kt
@@ -48,6 +48,12 @@ interface PacketDao {
         findDataPacket(data)?.let { update(it.copy(data = new)) }
     }
 
+    @Transaction
+    fun updateMessageId(data: DataPacket, id: Int) {
+        val new = data.copy(id = id)
+        findDataPacket(data)?.let { update(it.copy(data = new)) }
+    }
+
     @Query("Select data from packet order by received_time asc")
     fun getDataPackets(): List<DataPacket>
 


### PR DESCRIPTION
check for duplicate packet IDs before sending queued messages (so ACK/NAK updates can work).