### PR TITLE
feat: calculate default values for LoRa channel_num and frequency

### DIFF
--- a/app/src/androidTest/java/com/geeksville/mesh/ChannelTest.kt
+++ b/app/src/androidTest/java/com/geeksville/mesh/ChannelTest.kt
@@ -1,6 +1,7 @@
 package com.geeksville.mesh
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.geeksville.mesh.model.Channel
 import com.geeksville.mesh.model.ChannelSet
 import org.junit.Assert
 import org.junit.Test
@@ -14,5 +15,19 @@ class ChannelTest {
 
         Assert.assertTrue(ch.getChannelUrl().toString().startsWith(ChannelSet.prefix))
         Assert.assertEquals(ChannelSet(ch.getChannelUrl()), ch)
+    }
+
+    @Test
+    fun channelNumGood() {
+        val ch = Channel.default
+
+        Assert.assertEquals(20, ch.channelNum)
+    }
+
+    @Test
+    fun radioFreqGood() {
+        val ch = Channel.default
+
+        Assert.assertEquals(906.875f, ch.radioFreq)
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/model/ChannelOption.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/ChannelOption.kt
@@ -1,27 +1,85 @@
 package com.geeksville.mesh.model
 
+import com.geeksville.mesh.ConfigProtos.Config.LoRaConfig
 import com.geeksville.mesh.ConfigProtos.Config.LoRaConfig.ModemPreset
+import com.geeksville.mesh.ConfigProtos.Config.LoRaConfig.RegionCode
 import com.geeksville.mesh.R
+
+fun LoRaConfig.bandwidth() = if (usePreset) {
+    val wideLora = region == RegionCode.LORA_24
+    ChannelOption.bandwidth(modemPreset) * if (wideLora) 3.25f else 1f
+} else when (bandwidth) {
+    31 -> .03125f
+    62 -> .0625f
+    200 -> .203125f
+    400 -> .40625f
+    800 -> .8125f
+    1600 -> 1.6250f
+    else -> bandwidth / 1000f
+}
+
+enum class RegionInfo(
+    val regionCode: RegionCode,
+    val freqStart: Float,
+    val freqEnd: Float,
+) {
+    US(RegionCode.US, 902.0f, 928.0f),
+    EU_433(RegionCode.EU_433, 433.0f, 434.0f),
+    EU_868(RegionCode.EU_868, 869.4f, 869.65f),
+    CN(RegionCode.CN, 470.0f, 510.0f),
+    JP(RegionCode.JP, 920.8f, 927.8f),
+    ANZ(RegionCode.ANZ, 915.0f, 928.0f),
+    RU(RegionCode.RU, 868.7f, 869.2f),
+    KR(RegionCode.KR, 920.0f, 923.0f),
+    TW(RegionCode.TW, 920.0f, 925.0f),
+    IN(RegionCode.IN, 865.0f, 867.0f),
+    NZ_865(RegionCode.NZ_865, 864.0f, 868.0f),
+    TH(RegionCode.TH, 920.0f, 925.0f),
+    UA_433(RegionCode.UA_433, 433.0f, 434.7f),
+    UA_868(RegionCode.UA_868, 868.0f, 868.6f),
+    LORA_24(RegionCode.LORA_24, 2400.0f, 2483.5f),
+    UNSET(RegionCode.UNSET, 902.0f, 928.0f);
+
+    companion object {
+        fun numChannels(loraConfig: LoRaConfig): Int {
+            for (option in values()) {
+                if (option.regionCode == loraConfig.region)
+                    return ((option.freqEnd - option.freqStart) / loraConfig.bandwidth()).toInt()
+            }
+            return 0
+        }
+
+        fun radioFreq(loraConfig: LoRaConfig, channelNum: Int): Float = with(loraConfig) {
+            if (overrideFrequency != 0f) return overrideFrequency + frequencyOffset
+            for (option in values()) {
+                if (option.regionCode == region)
+                    return (option.freqStart + bandwidth() / 2) + (channelNum - 1) * bandwidth()
+            }
+            return 0f
+        }
+    }
+}
 
 enum class ChannelOption(
     val modemPreset: ModemPreset,
     val configRes: Int,
+    val bandwidth: Float,
 ) {
-    SHORT_FAST(ModemPreset.SHORT_FAST, R.string.modem_config_short),
-    SHORT_SLOW(ModemPreset.SHORT_SLOW, R.string.modem_config_slow_short),
-    MEDIUM_FAST(ModemPreset.MEDIUM_FAST, R.string.modem_config_medium),
-    MEDIUM_SLOW(ModemPreset.MEDIUM_SLOW, R.string.modem_config_slow_medium),
-    LONG_FAST(ModemPreset.LONG_FAST, R.string.modem_config_long),
-    LONG_MODERATE(ModemPreset.LONG_MODERATE, R.string.modem_config_mod_long),
-    LONG_SLOW(ModemPreset.LONG_SLOW, R.string.modem_config_slow_long),
-    VERY_LONG_SLOW(ModemPreset.VERY_LONG_SLOW, R.string.modem_config_very_long);
+    LONG_SLOW(ModemPreset.LONG_SLOW, R.string.modem_config_slow_long, .125f),
+    VERY_LONG_SLOW(ModemPreset.VERY_LONG_SLOW, R.string.modem_config_very_long, .0625f),
+    MEDIUM_SLOW(ModemPreset.MEDIUM_SLOW, R.string.modem_config_slow_medium, .250f),
+    MEDIUM_FAST(ModemPreset.MEDIUM_FAST, R.string.modem_config_medium, .250f),
+    SHORT_SLOW(ModemPreset.SHORT_SLOW, R.string.modem_config_slow_short, .250f),
+    SHORT_FAST(ModemPreset.SHORT_FAST, R.string.modem_config_short, .250f),
+    LONG_MODERATE(ModemPreset.LONG_MODERATE, R.string.modem_config_mod_long, .125f),
+    LONG_FAST(ModemPreset.LONG_FAST, R.string.modem_config_long, .250f);
 
     companion object {
-        fun fromConfig(modemPreset: ModemPreset?): ChannelOption? {
+        fun bandwidth(modemPreset: ModemPreset?): Float {
             for (option in values()) {
-                if (option.modemPreset == modemPreset) return option
+                if (option.modemPreset == modemPreset) return option.bandwidth
             }
-            return null
+            return 0f
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EditTextPreference.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EditTextPreference.kt
@@ -34,6 +34,7 @@ fun EditTextPreference(
     keyboardActions: KeyboardActions,
     onValueChanged: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    onFocusChanged: (FocusState) -> Unit = {},
     trailingIcon: (@Composable () -> Unit)? = null,
 ) {
     var valueState by remember(value) { mutableStateOf(value.toUInt().toString()) }
@@ -54,7 +55,7 @@ fun EditTextPreference(
                 onValueChanged(int)
             }
         },
-        onFocusChanged = {},
+        onFocusChanged = onFocusChanged,
         modifier = modifier,
         trailingIcon = trailingIcon
     )
@@ -68,7 +69,8 @@ fun EditTextPreference(
     keyboardActions: KeyboardActions,
     onValueChanged: (Float) -> Unit,
     modifier: Modifier = Modifier,
-) {
+    onFocusChanged: (FocusState) -> Unit = {},
+    ) {
     var valueState by remember(value) { mutableStateOf(value.toString()) }
 
     EditTextPreference(
@@ -87,7 +89,7 @@ fun EditTextPreference(
                 onValueChanged(float)
             }
         },
-        onFocusChanged = {},
+        onFocusChanged = onFocusChanged,
         modifier = modifier
     )
 }

--- a/app/src/test/java/com/geeksville/mesh/model/ChannelSetTest.kt
+++ b/app/src/test/java/com/geeksville/mesh/model/ChannelSetTest.kt
@@ -8,7 +8,7 @@ class ChannelSetTest {
     /** make sure we match the python and device code behavior */
     @Test
     fun matchPython() {
-        val url = Uri.parse("https://meshtastic.org/e/#CgMSAQESAA")
+        val url = Uri.parse("https://meshtastic.org/e/#CgMSAQESBggBQANIAQ")
         val cs = ChannelSet(url)
         Assert.assertEquals("LongFast", cs.primaryChannel!!.name)
         Assert.assertEquals("#LongFast-I", cs.primaryChannel!!.humanName)


### PR DESCRIPTION
Radio Configuration > LoRa config:
- displays calculated values for `channel_num` and LoRa `frequency` when set to zero (defaults).