### PR TITLE
Treat Detection Sensor messages like text messages

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/DataPacket.kt
+++ b/app/src/main/java/com/geeksville/mesh/DataPacket.kt
@@ -48,10 +48,10 @@ data class DataPacket(
     )
 
     /**
-     * If this is a text message, return the string, otherwise null
+     * If this is a text or detection sensor message, return the string, otherwise null
      */
     val text: String?
-        get() = if (dataType == Portnums.PortNum.TEXT_MESSAGE_APP_VALUE)
+        get() = if (dataType == Portnums.PortNum.TEXT_MESSAGE_APP_VALUE || dataType == Portnums.PortNum.DETECTION_SENSOR_APP_VALUE)
             bytes?.decodeToString()
         else
             null

--- a/app/src/main/java/com/geeksville/mesh/database/dao/PacketDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/PacketDao.kt
@@ -19,13 +19,13 @@ interface PacketDao {
     @Insert
     fun insert(packet: Packet)
 
-    @Query("Select * from packet where port_num = 1 and contact_key = :contact order by received_time asc")
+    @Query("Select * from packet where port_num in (1, 10) and contact_key = :contact order by received_time asc")
     fun getMessagesFrom(contact: String): Flow<List<Packet>>
 
     @Query("Select * from packet where data = :data")
     fun findDataPacket(data: DataPacket): Packet?
 
-    @Query("Delete from packet where port_num = 1")
+    @Query("Delete from packet where port_num in (1, 10)")
     fun deleteAllMessages()
 
     @Query("Delete from packet where uuid in (:uuidList)")

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -171,7 +171,7 @@ class UIViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val contacts: LiveData<Map<String, Packet>> = _packets.mapLatest { list ->
-        list.filter { it.port_num == Portnums.PortNum.TEXT_MESSAGE_APP_VALUE }
+        list.filter { it.port_num == Portnums.PortNum.TEXT_MESSAGE_APP_VALUE || it.port_num == Portnums.PortNum.DETECTION_SENSOR_APP_VALUE }
             .associateBy { packet -> packet.contact_key }
     }.asLiveData()
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -620,6 +620,13 @@ class MeshService : Service(), Logging {
                             updateMessageNotification(dataPacket)
                         }
 
+                    Portnums.PortNum.DETECTION_SENSOR_APP_VALUE ->
+                        if (!fromUs) {
+                            debug("Received DETECTION_SENSOR alert text from $fromId")
+                            rememberDataPacket(dataPacket)
+                            updateMessageNotification(dataPacket)
+                        }
+
                     Portnums.PortNum.WAYPOINT_APP_VALUE -> {
                         val u = MeshProtos.Waypoint.parseFrom(data.payload)
                         // Validate locked Waypoints from the original sender


### PR DESCRIPTION
I had to remove Android Studio from my Macbook due to disk space, but I think this should work. I can pull it down later on my Windows PC.

Update: Tested and working on my Samsung Galaxy Note 10+. I'm seeing push notifications and the messages show up as texts in the normal chat view as well now.