### PR TITLE
refactor(config): move business logic to ViewModel

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/entity/MeshLog.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/entity/MeshLog.kt
@@ -51,14 +51,4 @@ data class MeshLog(@PrimaryKey val uuid: String,
                 return null
             } ?: nodeInfo?.position
         }
-
-    val routeDiscovery: MeshProtos.RouteDiscovery?
-        get() {
-            return meshPacket?.run {
-                if (hasDecoded() && decoded.portnumValue == Portnums.PortNum.TRACEROUTE_APP_VALUE) {
-                    return MeshProtos.RouteDiscovery.parseFrom(decoded.payload)
-                }
-                return null
-            }
-        }
 }

--- a/app/src/main/java/com/geeksville/mesh/model/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Channel.kt
@@ -12,8 +12,8 @@ fun byteArrayOfInts(vararg ints: Int) = ByteArray(ints.size) { pos -> ints[pos].
 fun xorHash(b: ByteArray) = b.fold(0) { acc, x -> acc xor (x.toInt() and 0xff) }
 
 data class Channel(
-    val settings: ChannelProtos.ChannelSettings,
-    val loraConfig: ConfigProtos.Config.LoRaConfig
+    val settings: ChannelProtos.ChannelSettings = default.settings,
+    val loraConfig: ConfigProtos.Config.LoRaConfig = default.loraConfig,
 ) {
     companion object {
         // These bytes must match the well known and not secret bytes used the default channel AES128 key device code

--- a/app/src/main/java/com/geeksville/mesh/ui/ChannelFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ChannelFragment.kt
@@ -143,7 +143,7 @@ fun ChannelScreen(
 
     val primaryChannel = ChannelSet(channelSet).primaryChannel
     val channelUrl = ChannelSet(channelSet).getChannelUrl()
-    val modemPresetName = Channel(Channel.default.settings, channelSet.loraConfig).name
+    val modemPresetName = Channel(loraConfig = channelSet.loraConfig).name
 
     val barcodeLauncher = rememberLauncherForActivityResult(ScanContract()) { result ->
         if (result.contents != null) {

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -314,7 +314,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
 
         model.channels.asLiveData().observe(viewLifecycleOwner) {
             if (!model.isConnected()) it.protobuf.let { ch ->
-                val maxChannels = model.myNodeInfo.value?.maxChannels ?: "8"
+                val maxChannels = model.maxChannels
                 if (!ch.hasLoraConfig() && ch.settingsCount > 0)
                     scanModel.setErrorText("Channels (${ch.settingsCount} / $maxChannels)")
             }

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -332,24 +332,14 @@ class UsersFragment : ScreenFragment("Users"), Logging {
             }
         }
 
-        model.packetResponse.asLiveData().observe(viewLifecycleOwner) { meshLog ->
-            meshLog?.meshPacket?.let { meshPacket ->
-                val routeList = meshLog.routeDiscovery?.routeList ?: return@let
-                fun nodeName(num: Int) = model.nodeDB.nodesByNum?.get(num)?.user?.longName
-                    ?: getString(R.string.unknown_username)
+        model.tracerouteResponse.observe(viewLifecycleOwner) { response ->
+            MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.traceroute)
+                .setMessage(response ?: return@observe)
+                .setPositiveButton(R.string.okay) { _, _ -> }
+                .show()
 
-                var routeStr = "${nodeName(meshPacket.to)} --> "
-                routeList.forEach { num -> routeStr += "${nodeName(num)} --> " }
-                routeStr += nodeName(meshPacket.from)
-
-                MaterialAlertDialogBuilder(requireContext())
-                    .setTitle(R.string.traceroute)
-                    .setMessage(routeStr)
-                    .setPositiveButton(R.string.okay) { _, _ -> }
-                    .show()
-
-                model.clearPacketResponse()
-            }
+            model.clearTracerouteResponse()
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/components/config/PacketResponseStateDialog.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/config/PacketResponseStateDialog.kt
@@ -14,24 +14,26 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
-import com.geeksville.mesh.ui.PacketResponseState
+import com.geeksville.mesh.ui.ResponseState
 
 @Composable
-fun PacketResponseStateDialog(
-    state: PacketResponseState,
-    onDismiss: () -> Unit
+fun <T> PacketResponseStateDialog(
+    state: ResponseState<T>,
+    onDismiss: () -> Unit = {},
+    onComplete: () -> Unit = {},
 ) {
     AlertDialog(
-        onDismissRequest = { },
+        onDismissRequest = {},
         title = {
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                if (state is PacketResponseState.Loading) {
+                if (state is ResponseState.Loading) {
                     val progress = state.completed.toFloat() / state.total.toFloat()
                     Text("%.0f%%".format(progress * 100))
                     LinearProgressIndicator(
@@ -41,12 +43,14 @@ fun PacketResponseStateDialog(
                             .padding(top = 8.dp),
                         color = MaterialTheme.colors.onSurface,
                     )
+                    if (state.total == state.completed) onComplete()
                 }
-                if (state is PacketResponseState.Success) {
+                if (state is ResponseState.Success) {
                     Text("Success!")
                 }
-                if (state is PacketResponseState.Error) {
-                    Text("Error: ${state.error}")
+                if (state is ResponseState.Error) {
+                    Text(text = "Error\n", textAlign = TextAlign.Center)
+                    Text(state.error)
                 }
             }
         },
@@ -59,7 +63,7 @@ fun PacketResponseStateDialog(
                     onClick = onDismiss,
                     modifier = Modifier.padding(top = 16.dp)
                 ) {
-                    if (state is PacketResponseState.Loading) {
+                    if (state is ResponseState.Loading) {
                         Text(stringResource(R.string.cancel))
                     } else {
                         Text(stringResource(R.string.close))
@@ -74,10 +78,9 @@ fun PacketResponseStateDialog(
 @Composable
 private fun PacketResponseStateDialogPreview() {
     PacketResponseStateDialog(
-        state = PacketResponseState.Loading.apply {
-            total = 17
-            completed = 5
-        },
-        onDismiss = { }
+        state = ResponseState.Loading(
+            total = 17,
+            completed = 5,
+        ),
     )
 }


### PR DESCRIPTION
Refactor UI to simply consume data from ViewModel improving code organization and separation of concerns:
- generalized `ResponseState` for wider use;
- consolidate state variables into `RadioConfigState`;
- moved config getters/setters processing to ViewModel;
- added error handling for a few extra cases.