### PR TITLE
feat: add feedback for configuration changes

### DIFF
--- a/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
+++ b/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
@@ -58,7 +58,7 @@ interface IMeshService {
     */
     void setOwner(in MeshUser user);
 
-    void setRemoteOwner(in int destNum, in byte []payload);
+    void setRemoteOwner(in int requestId, in byte []payload);
     void getRemoteOwner(in int requestId, in int destNum);
 
     /// Return my unique user ID string
@@ -91,11 +91,11 @@ interface IMeshService {
     void setConfig(in byte []payload);
 
     /// Set and get a Config protobuf via admin packet
-    void setRemoteConfig(in int destNum, in byte []payload);
+    void setRemoteConfig(in int requestId, in int destNum, in byte []payload);
     void getRemoteConfig(in int requestId, in int destNum, in int configTypeValue);
 
     /// Set and get a ModuleConfig protobuf via admin packet
-    void setModuleConfig(in int destNum, in byte []payload);
+    void setModuleConfig(in int requestId, in int destNum, in byte []payload);
     void getModuleConfig(in int requestId, in int destNum, in int moduleConfigTypeValue);
 
     /// Set and get the Ext Notification Ringtone string via admin packet
@@ -111,7 +111,7 @@ interface IMeshService {
     void setChannel(in byte []payload);
 
     /// Set and get a Channel protobuf via admin packet
-    void setRemoteChannel(in int destNum, in byte []payload);
+    void setRemoteChannel(in int requestId, in int destNum, in byte []payload);
     void getRemoteChannel(in int requestId, in int destNum, in int channelIndex);
 
     /// Send beginEditSettings admin packet to nodeNum

--- a/app/src/main/java/com/geeksville/mesh/ui/components/config/ChannelSettingsItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/config/ChannelSettingsItemList.kt
@@ -28,10 +28,10 @@ import androidx.compose.material.icons.twotone.Add
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -94,9 +94,7 @@ fun ChannelSettingsItemList(
     onPositiveClicked: (List<ChannelSettings>) -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
-    val settingsListInput = remember {
-        mutableStateListOf<ChannelSettings>().apply { addAll(settingsList) }
-    }
+    val settingsListInput = remember(settingsList) { settingsList.toMutableStateList() }
 
     val isEditing: Boolean = settingsList.size != settingsListInput.size
             || settingsList.zip(settingsListInput).any { (item1, item2) -> item1 != item2 }
@@ -172,10 +170,12 @@ fun ChannelSettingsItemList(
         ) {
             FloatingActionButton(
                 onClick = {
-                    settingsListInput.add(channelSettings {
-                        psk = Channel.default.settings.psk
-                    })
-                    showEditChannelDialog = settingsListInput.lastIndex
+                    if (maxChannels > settingsListInput.size) {
+                        settingsListInput.add(channelSettings {
+                            psk = Channel.default.settings.psk
+                        })
+                        showEditChannelDialog = settingsListInput.lastIndex
+                    }
                 },
                 modifier = Modifier.padding(16.dp)
             ) { Icon(Icons.TwoTone.Add, stringResource(R.string.add)) }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/config/PacketResponseStateDialog.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/config/PacketResponseStateDialog.kt
@@ -51,7 +51,7 @@ fun <T> PacketResponseStateDialog(
                     if (state.total == state.completed) onComplete()
                 }
                 if (state is ResponseState.Success) {
-                    Text("Success!")
+                    Text("Delivery confirmed.")
                 }
                 if (state is ResponseState.Error) {
                     Text(text = "Error\n", textAlign = TextAlign.Center)
@@ -67,13 +67,7 @@ fun <T> PacketResponseStateDialog(
                 Button(
                     onClick = onDismiss,
                     modifier = Modifier.padding(top = 16.dp)
-                ) {
-                    if (state is ResponseState.Loading) {
-                        Text(stringResource(R.string.cancel))
-                    } else {
-                        Text(stringResource(R.string.close))
-                    }
-                }
+                ) { Text(stringResource(R.string.close)) }
             }
         }
     )


### PR DESCRIPTION
Previously, UI feedback was limited to fetching configuration (getters). This PR adds feedback for configuration changes (setters).

- Loading: adds progress bar for each received delivery confirmation
  - asynchronous tracking of multiple admin packet request IDs
  - auto-update `total` based on number of requests
- Error: show message errors occurs
- Success: show a success message when all requests are delivered without errors
