### PR TITLE
refactor: convert `ChannelSet` to protobuf extensions

### DIFF
--- a/app/src/androidTest/java/com/geeksville/mesh/ChannelTest.kt
+++ b/app/src/androidTest/java/com/geeksville/mesh/ChannelTest.kt
@@ -2,7 +2,9 @@ package com.geeksville.mesh
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.geeksville.mesh.model.Channel
-import com.geeksville.mesh.model.ChannelSet
+import com.geeksville.mesh.model.URL_PREFIX
+import com.geeksville.mesh.model.getChannelUrl
+import com.geeksville.mesh.model.toChannelSet
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -11,10 +13,14 @@ import org.junit.runner.RunWith
 class ChannelTest {
     @Test
     fun channelUrlGood() {
-        val ch = ChannelSet()
+        val ch = channelSet {
+            settings.add(Channel.default.settings)
+            loraConfig = Channel.default.loraConfig
+        }
+        val channelUrl = ch.getChannelUrl()
 
-        Assert.assertTrue(ch.getChannelUrl().toString().startsWith(ChannelSet.prefix))
-        Assert.assertEquals(ChannelSet(ch.getChannelUrl()), ch)
+        Assert.assertTrue(channelUrl.toString().startsWith(URL_PREFIX))
+        Assert.assertEquals(channelUrl.toChannelSet(), ch)
     }
 
     @Test

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -33,9 +33,10 @@ import com.geeksville.mesh.android.*
 import com.geeksville.mesh.concurrent.handledLaunch
 import com.geeksville.mesh.databinding.ActivityMainBinding
 import com.geeksville.mesh.model.BluetoothViewModel
-import com.geeksville.mesh.model.ChannelSet
 import com.geeksville.mesh.model.DeviceVersion
 import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.model.primaryChannel
+import com.geeksville.mesh.model.toChannelSet
 import com.geeksville.mesh.repository.radio.BluetoothInterface
 import com.geeksville.mesh.repository.radio.SerialInterface
 import com.geeksville.mesh.service.*
@@ -443,7 +444,7 @@ class MainActivity : AppCompatActivity(), Logging {
         if (url != null && model.isConnected()) {
             requestedChannelUrl = null
             try {
-                val channels = ChannelSet(url)
+                val channels = url.toChannelSet()
                 val primary = channels.primaryChannel
                 if (primary == null)
                     showSnackbar(R.string.channel_invalid)

--- a/app/src/main/java/com/geeksville/mesh/model/ChannelSet.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/ChannelSet.kt
@@ -3,76 +3,64 @@ package com.geeksville.mesh.model
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Base64
-import com.geeksville.mesh.android.Logging
-import com.geeksville.mesh.AppOnlyProtos
+import com.geeksville.mesh.AppOnlyProtos.ChannelSet
+import com.geeksville.mesh.android.BuildUtils.errormsg
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.MultiFormatWriter
 import com.journeyapps.barcodescanner.BarcodeEncoder
 import java.net.MalformedURLException
+import kotlin.jvm.Throws
 
-data class ChannelSet(
-    val protobuf: AppOnlyProtos.ChannelSet = AppOnlyProtos.ChannelSet.getDefaultInstance()
-) : Logging {
-    companion object {
+internal const val URL_PREFIX = "https://meshtastic.org/e/#"
+private const val BASE64FLAGS = Base64.URL_SAFE + Base64.NO_WRAP + Base64.NO_PADDING
 
-        const val prefix = "https://meshtastic.org/e/#"
+/**
+ * Return a [ChannelSet] that represents the URL
+ * @throws MalformedURLException when not recognized as a valid Meshtastic URL
+ */
+@Throws(MalformedURLException::class)
+fun Uri.toChannelSet(): ChannelSet {
+    val urlStr = this.toString()
 
-        private const val base64Flags = Base64.URL_SAFE + Base64.NO_WRAP + Base64.NO_PADDING
+    val pathRegex = Regex("$URL_PREFIX(.*)", RegexOption.IGNORE_CASE)
+    val (base64) = pathRegex.find(urlStr)?.destructured
+        ?: throw MalformedURLException("Not a Meshtastic URL: ${urlStr.take(40)}")
+    val bytes = Base64.decode(base64, BASE64FLAGS)
 
-        private fun urlToChannels(url: Uri): AppOnlyProtos.ChannelSet {
-            val urlStr = url.toString()
-
-            val pathRegex = Regex("$prefix(.*)", RegexOption.IGNORE_CASE)
-            val (base64) = pathRegex.find(urlStr)?.destructured
-                ?: throw MalformedURLException("Not a meshtastic URL: ${urlStr.take(40)}")
-            val bytes = Base64.decode(base64, base64Flags)
-
-            return AppOnlyProtos.ChannelSet.parseFrom(bytes)
-        }
-    }
-
-    constructor(url: Uri) : this(urlToChannels(url))
-
-    /// Can this channel be changed right now?
-    var editable = false
-
-    /**
-     * Return the primary channel info
-     */
-    val primaryChannel: Channel?
-        get() = with(protobuf) {
-            if (settingsCount > 0) Channel(getSettings(0), loraConfig) else null
-        }
-
-    /// Return an URL that represents the current channel values
-    /// @param upperCasePrefix - portions of the URL can be upper case to make for more efficient QR codes
-    fun getChannelUrl(upperCasePrefix: Boolean = false): Uri {
-        // If we have a valid radio config use it, otherwise use whatever we have saved in the prefs
-
-        val channelBytes = protobuf.toByteArray() ?: ByteArray(0) // if unset just use empty
-        val enc = Base64.encodeToString(channelBytes, base64Flags)
-
-        val p = if (upperCasePrefix) prefix.uppercase() else prefix
-        return Uri.parse("$p$enc")
-    }
-
-    val qrCode
-        get(): Bitmap? = try {
-            val multiFormatWriter = MultiFormatWriter()
-
-            // We encode as UPPER case for the QR code URL because QR codes are more efficient for that special case
-            val bitMatrix =
-                multiFormatWriter.encode(
-                    getChannelUrl(false).toString(),
-                    BarcodeFormat.QR_CODE,
-                    960,
-                    960
-                )
-            val barcodeEncoder = BarcodeEncoder()
-            barcodeEncoder.createBitmap(bitMatrix)
-        } catch (ex: Throwable) {
-            errormsg("URL was too complex to render as barcode")
-            null
-        }
+    return ChannelSet.parseFrom(bytes)
 }
 
+/**
+ * Return the primary channel info
+ */
+val ChannelSet.primaryChannel: Channel?
+    get() = if (settingsCount > 0) Channel(getSettings(0), loraConfig) else null
+
+/**
+ * Return a URL that represents the [ChannelSet]
+ * @param upperCasePrefix portions of the URL can be upper case to make for more efficient QR codes
+ */
+fun ChannelSet.getChannelUrl(upperCasePrefix: Boolean = false): Uri {
+    val channelBytes = this.toByteArray() ?: ByteArray(0) // if unset just use empty
+    val enc = Base64.encodeToString(channelBytes, BASE64FLAGS)
+    val p = if (upperCasePrefix) URL_PREFIX.uppercase() else URL_PREFIX
+    return Uri.parse("$p$enc")
+}
+
+val ChannelSet.qrCode: Bitmap?
+    get() = try {
+        val multiFormatWriter = MultiFormatWriter()
+
+        val bitMatrix =
+            multiFormatWriter.encode(
+                getChannelUrl(false).toString(),
+                BarcodeFormat.QR_CODE,
+                960,
+                960
+            )
+        val barcodeEncoder = BarcodeEncoder()
+        barcodeEncoder.createBitmap(bitMatrix)
+    } catch (ex: Throwable) {
+        errormsg("URL was too complex to render as barcode")
+        null
+    }

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -14,6 +14,7 @@ import com.geeksville.mesh.NodeInfo
 import com.geeksville.mesh.database.dao.MyNodeInfoDao
 import com.geeksville.mesh.database.dao.NodeInfoDao
 import com.geeksville.mesh.deviceProfile
+import com.geeksville.mesh.model.getChannelUrl
 import com.geeksville.mesh.service.ServiceRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -158,7 +159,7 @@ class RadioConfigRepository @Inject constructor(
                 longName = it.longName
                 shortName = it.shortName
             }
-            channelUrl = com.geeksville.mesh.model.ChannelSet(channels).getChannelUrl().toString()
+            channelUrl = channels.getChannelUrl().toString()
             config = localConfig
             moduleConfig = localModuleConfig
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -313,10 +313,10 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         }
 
         model.channels.asLiveData().observe(viewLifecycleOwner) {
-            if (!model.isConnected()) it.protobuf.let { ch ->
+            if (!model.isConnected()) {
                 val maxChannels = model.maxChannels
-                if (!ch.hasLoraConfig() && ch.settingsCount > 0)
-                    scanModel.setErrorText("Channels (${ch.settingsCount} / $maxChannels)")
+                if (!it.hasLoraConfig() && it.settingsCount > 0)
+                    scanModel.setErrorText("Channels (${it.settingsCount} / $maxChannels)")
             }
         }
 

--- a/app/src/test/java/com/geeksville/mesh/model/ChannelSetTest.kt
+++ b/app/src/test/java/com/geeksville/mesh/model/ChannelSetTest.kt
@@ -9,7 +9,7 @@ class ChannelSetTest {
     @Test
     fun matchPython() {
         val url = Uri.parse("https://meshtastic.org/e/#CgMSAQESBggBQANIAQ")
-        val cs = ChannelSet(url)
+        val cs = url.toChannelSet()
         Assert.assertEquals("LongFast", cs.primaryChannel!!.name)
         Assert.assertEquals("#LongFast-I", cs.primaryChannel!!.humanName)
         Assert.assertEquals(url, cs.getChannelUrl(false))


### PR DESCRIPTION
Refactors the `ChannelSet` class by converting it to `AppOnlyProtos.ChannelSet` protobuf extensions. Eliminates redundant methods and simplifies the process for creating and parsing Meshtastic URLs and QR Codes.