### PR TITLE
refactor: convert `NodeDB` to repository

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -180,10 +180,6 @@ class MainActivity : AppCompatActivity(), Logging {
         override fun createFragment(position: Int): Fragment = tabInfos[position].content
     }
 
-    private val isInTestLab: Boolean by lazy {
-        (application as GeeksvilleApplication).isInTestLab
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
@@ -364,7 +360,6 @@ class MainActivity : AppCompatActivity(), Logging {
                 debug("Getting latest DeviceConfig from service")
                 try {
                     val info: MyNodeInfo? = service.myNodeInfo // this can be null
-                    model.setMyNodeInfo(info)
 
                     if (info != null) {
                         val isOld = info.minAppVersion > BuildConfig.VERSION_CODE
@@ -380,9 +375,6 @@ class MainActivity : AppCompatActivity(), Logging {
                                     showAlert(R.string.firmware_too_old, R.string.firmware_old)
                                 else {
                                     // If our app is too old/new, we probably don't understand the new DeviceConfig messages, so we don't read them until here
-
-                                    // model.setLocalConfig(LocalOnlyProtos.LocalConfig.parseFrom(service.deviceConfig))
-                                    // model.setChannels(ChannelSet(AppOnlyProtos.ChannelSet.parseFrom(service.channels)))
 
                                     model.updateNodesFromDevice()
 
@@ -525,8 +517,6 @@ class MainActivity : AppCompatActivity(), Logging {
 
                     // We don't start listening for packets until after we are connected to the service
                     registerMeshReceiver()
-
-                    model.setMyNodeInfo(service.myNodeInfo) // Note: this could be NULL!
 
                     val connectionState =
                         MeshService.ConnectionState.valueOf(service.connectionState())

--- a/app/src/main/java/com/geeksville/mesh/database/dao/MyNodeInfoDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/MyNodeInfoDao.kt
@@ -14,7 +14,7 @@ interface MyNodeInfoDao {
     fun getMyNodeInfo(): Flow<MyNodeInfo?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun setMyNodeInfo(myInfo: MyNodeInfo?)
+    fun setMyNodeInfo(myInfo: MyNodeInfo)
 
     @Query("DELETE FROM MyNodeInfo")
     fun clearMyNodeInfo()

--- a/app/src/main/java/com/geeksville/mesh/model/NodeDB.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/NodeDB.kt
@@ -1,23 +1,50 @@
 package com.geeksville.mesh.model
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.asLiveData
 import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.MeshUser
+import com.geeksville.mesh.MyNodeInfo
 import com.geeksville.mesh.NodeInfo
 import com.geeksville.mesh.Position
+import com.geeksville.mesh.database.dao.MyNodeInfoDao
+import com.geeksville.mesh.database.dao.NodeInfoDao
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
 
-/// NodeDB lives inside the UIViewModel, but it needs a backpointer to reach the service
-class NodeDB(private val ui: UIViewModel) {
+@Singleton
+class NodeDB @Inject constructor(
+    private val myNodeInfoDao: MyNodeInfoDao,
+    private val nodeInfoDao: NodeInfoDao,
+) {
+
+    fun myNodeInfoFlow(): Flow<MyNodeInfo?> = myNodeInfoDao.getMyNodeInfo()
+    private suspend fun setMyNodeInfo(myInfo: MyNodeInfo) = withContext(Dispatchers.IO) {
+        myNodeInfoDao.setMyNodeInfo(myInfo)
+    }
+
+    fun nodeInfoFlow(): Flow<List<NodeInfo>> = nodeInfoDao.getNodes()
+    suspend fun upsert(node: NodeInfo) = withContext(Dispatchers.IO) {
+        nodeInfoDao.upsert(node)
+    }
+
+    suspend fun installNodeDB(mi: MyNodeInfo, nodes: List<NodeInfo>) {
+        myNodeInfoDao.clearMyNodeInfo()
+        nodeInfoDao.clearNodeInfo()
+        nodeInfoDao.putAll(nodes)
+        setMyNodeInfo(mi) // set MyNodeInfo last
+    }
+
     private val testPositions = arrayOf(
         Position(32.776665, -96.796989, 35, 123), // dallas
         Position(32.960758, -96.733521, 35, 456), // richardson
-        Position(32.912901, -96.781776, 35, 789) // north dallas
+        Position(32.912901, -96.781776, 35, 789), // north dallas
     )
 
-    val testNodeNoPosition = NodeInfo(
+    private val testNodeNoPosition = NodeInfo(
         8,
         MeshUser(
             "+16508765308".format(8),
@@ -29,7 +56,7 @@ class NodeDB(private val ui: UIViewModel) {
         null
     )
 
-    private val testNodes = testPositions.mapIndexed { index, it ->
+    private val testNodes = (listOf(testNodeNoPosition) + testPositions.mapIndexed { index, it ->
         NodeInfo(
             9 + index,
             MeshUser(
@@ -41,22 +68,26 @@ class NodeDB(private val ui: UIViewModel) {
             ),
             it
         )
-    }.associateBy { it.user?.id!! }
+    }).associateBy { it.user?.id!! }
 
     private val seedWithTestNodes = false
 
     // The unique userId of our node
-    private val _myId = MutableLiveData<String?>(if (seedWithTestNodes) "+16508765309" else null)
-    val myId: LiveData<String?> get() = _myId
+    private val _myId = MutableStateFlow(if (seedWithTestNodes) "+16508765309" else null)
+    val myId: StateFlow<String?> get() = _myId
 
     fun setMyId(myId: String?) {
         _myId.value = myId
     }
 
+    // A map from nodeNum to NodeInfo
+    private val _nodeDBbyNum = MutableStateFlow<Map<Int, NodeInfo>>(mapOf())
+    val nodeDBbyNum: StateFlow<Map<Int, NodeInfo>> get() = _nodeDBbyNum
+    val nodesByNum get() = nodeDBbyNum.value
+
     // A map from userId to NodeInfo
     private val _nodes = MutableStateFlow(if (seedWithTestNodes) testNodes else mapOf())
-    val nodes: LiveData<Map<String, NodeInfo>> = _nodes.asLiveData()
-    val nodesByNum get() = nodes.value?.values?.associateBy { it.num }
+    val nodes: StateFlow<Map<String, NodeInfo>> get() = _nodes
 
     fun setNodes(nodes: Map<String, NodeInfo>) {
         _nodes.value = nodes
@@ -64,5 +95,6 @@ class NodeDB(private val ui: UIViewModel) {
 
     fun setNodes(list: List<NodeInfo>) {
         setNodes(list.associateBy { it.user?.id!! })
+        _nodeDBbyNum.value = list.associateBy { it.num }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
@@ -1,9 +1,14 @@
 package com.geeksville.mesh.service
 
 import com.geeksville.mesh.IMeshService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Repository class for managing the [IMeshService] instance and connection state
+ */
 @Singleton
 class ServiceRepository @Inject constructor() {
     var meshService: IMeshService? = null
@@ -11,5 +16,13 @@ class ServiceRepository @Inject constructor() {
 
     fun setMeshService(service: IMeshService?) {
         meshService = service
+    }
+
+    // Connection state to our radio device
+    private val _connectionState = MutableStateFlow(MeshService.ConnectionState.DISCONNECTED)
+    val connectionState: StateFlow<MeshService.ConnectionState> get() = _connectionState
+
+    fun setConnectionState(connectionState: MeshService.ConnectionState) {
+        _connectionState.value = connectionState
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/ContactsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ContactsFragment.kt
@@ -87,7 +87,7 @@ class ContactsFragment : ScreenFragment("Messages"), Logging {
             val toBroadcast = contact.to == DataPacket.ID_BROADCAST
 
             // grab usernames from NodeInfo
-            val nodes = model.nodeDB.nodes.value!!
+            val nodes = model.nodeDB.nodes.value
             val node = nodes[if (fromLocal) contact.to else contact.from]
 
             //grab channel names from DeviceConfig
@@ -212,7 +212,7 @@ class ContactsFragment : ScreenFragment("Messages"), Logging {
             contactsAdapter.onChannelsChanged()
         }
 
-        model.nodeDB.nodes.observe(viewLifecycleOwner) {
+        model.nodeDB.nodes.asLiveData().observe(viewLifecycleOwner) {
             contactsAdapter.notifyDataSetChanged()
         }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -93,7 +93,7 @@ class MessagesFragment : Fragment(), Logging {
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
             val packet = messages[position]
             val msg = packet.data
-            val nodes = model.nodeDB.nodes.value!!
+            val nodes = model.nodeDB.nodes.value
             val node = nodes[msg.from]
             // Determine if this is my message (originated on this device)
             val isLocal = msg.from == DataPacket.ID_LOCAL

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -321,7 +321,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         }
 
         // Also watch myNodeInfo because it might change later
-        model.myNodeInfo.observe(viewLifecycleOwner) {
+        model.myNodeInfo.asLiveData().observe(viewLifecycleOwner) {
             updateNodeInfo()
         }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -322,7 +322,7 @@ class UsersFragment : ScreenFragment("Users"), Logging {
                 values
             }.toTypedArray()
 
-        model.nodeDB.nodes.observe(viewLifecycleOwner) {
+        model.nodeDB.nodes.asLiveData().observe(viewLifecycleOwner) {
             nodesAdapter.onNodesChanged(it.perhapsReindexBy(model.myNodeNum))
         }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.DataPacket
@@ -187,7 +188,7 @@ fun MapView(model: UIViewModel = viewModel()) {
         requestPermissionAndToggleLauncher.launch(context.getLocationPermissions())
     }
 
-    val nodes by model.nodeDB.nodes.observeAsState(emptyMap())
+    val nodes by model.nodeDB.nodes.collectAsStateWithLifecycle()
     val waypoints by model.waypoints.observeAsState(emptyMap())
 
     var showDownloadButton: Boolean by remember { mutableStateOf(false) }
@@ -256,8 +257,7 @@ fun MapView(model: UIViewModel = viewModel()) {
     }
 
     fun getUsername(id: String?) = if (id == DataPacket.ID_LOCAL) context.getString(R.string.you)
-    else model.nodeDB.nodes.value?.get(id)?.user?.longName
-        ?: context.getString(R.string.unknown_username)
+    else model.nodeDB.nodes.value[id]?.user?.longName ?: context.getString(R.string.unknown_username)
 
     fun MapView.onWaypointChanged(waypoints: Collection<Packet>): List<MarkerWithLabel> {
         return waypoints.mapNotNull { waypoint ->


### PR DESCRIPTION
This PR converts the `NodeDB` class into a singleton repository using Hilt dependency injection. Transitions from a monolithic ViewModel to individual ViewModels tailored for each fragments or screens. This change enhances decoupling and modularity, making the codebase cleaner and easier to use.
