### PR TITLE
#783 Fix of issue for quick message  input

### DIFF
--- a/app/src/main/res/layout/dialog_add_quick_chat.xml
+++ b/app/src/main/res/layout/dialog_add_quick_chat.xml
@@ -14,7 +14,8 @@
         android:layout_margin="8dp"
         android:ems="10"
         android:hint="@string/message"
-        android:inputType="textShortMessage"
+        android:inputType="textMultiLine|textCapSentences"
+        android:maxLength="228"
         android:minHeight="48dp" />
 
     <EditText


### PR DESCRIPTION
#783 Fix of issue for quick message  input.

Currently, the input for the quick message is a single line of text (android:inputType="textShortMessage") this does not correlate with the type of input that is used when writing a message (android:inputType="textMultiLine|textCapSentences") whitch is multiline-capable.

Problem:
With textShortMessage you can only have single line quick message.

Solution:
Change android:inputType="textShortMessage" to android:inputType="textMultiLine|textCapSentences" on line 17 in file app/src/main/res/layout/dialog_add_quick_chat.xml
Also added maxLength="228" acording to @andrekir tip