### PR TITLE
Change CSV output to be RFC4180 compliant

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -434,11 +434,11 @@ class UIViewModel @Inject constructor(
                 val nodesById = nodes.values.associateBy { it.num }.toMutableMap()
                 val nodePositions = mutableMapOf<Int, MeshProtos.Position?>()
 
-                writer.appendLine("date;time;from;sender name;sender lat;sender long;rx lat;rx long;rx elevation;rx snr;distance;hop limit;payload")
+                writer.appendLine("\"date\",\"time\",\"from\",\"sender name\",\"sender lat\",\"sender long\",\"rx lat\",\"rx long\",\"rx elevation\",\"rx snr\",\"distance\",\"hop limit\",\"payload\"")
 
                 // Packets are ordered by time, we keep most recent position of
                 // our device in localNodePosition.
-                val dateFormat = SimpleDateFormat("yyyy-MM-dd;HH:mm:ss", Locale.getDefault())
+                val dateFormat = SimpleDateFormat("\"yyyy-MM-dd\",\"HH:mm:ss\"", Locale.getDefault())
                 meshLogRepository.getAllLogsInReceiveOrder(Int.MAX_VALUE).first().forEach { packet ->
                     // If we get a NodeInfo packet, use it to update our position data (if valid)
                     packet.nodeInfo?.let { nodeInfo ->
@@ -494,14 +494,14 @@ class UIViewModel @Inject constructor(
                                     Portnums.PortNum.TEXT_MESSAGE_APP_VALUE,
                                     Portnums.PortNum.RANGE_TEST_APP_VALUE,
                                 ) -> "<${proto.decoded.portnum}>"
-                                proto.hasDecoded() -> "\"" + proto.decoded.payload.toStringUtf8()
-                                    .replace("\"", "\\\"") + "\""
+                                proto.hasDecoded() -> proto.decoded.payload.toStringUtf8()
+                                    .replace("\"", "\"\"")
                                 proto.hasEncrypted() -> "${proto.encrypted.size()} encrypted bytes"
                                 else -> ""
                             }
 
                             //  date,time,from,sender name,sender lat,sender long,rx lat,rx long,rx elevation,rx snr,distance,hop limit,payload
-                            writer.appendLine("$rxDateTime;$rxFrom;$senderName;$senderLat;$senderLong;$rxLat;$rxLong;$rxAlt;$rxSnr;$dist;$hopLimit;$payload")
+                            writer.appendLine("$rxDateTime,\"$rxFrom\",\"$senderName\",\"$senderLat\",\"$senderLong\",\"$rxLat\",\"$rxLong\",\"$rxAlt\",\"$rxSnr\",\"$dist\",\"$hopLimit\",\"$payload\"")
                         }
                     }
                 }


### PR DESCRIPTION
Second attempt/approach at fixing #818.

This approach retains the delimiter but uses double quotes around the values, conforming to [RFC4180](https://datatracker.ietf.org/doc/html/rfc4180)

I tested the resulting file by loading it into Excel and Numbers on my desktop, and Google Sheets on my mobile device.

I also tried switching my device language to Norwegian to test the comma as a decimal.  That worked for the fields which were in the immediate code path for generating the CSV.  Things like the lat and lon still had decimal point separators so I'm not sure how far we want to take it, but the CSV is parsed correctly now.

NOTE: I also locally hacked my source to test a message containing a single double quote character and this worked as well.  I had to hack the source because the message was on a mesh log with a SNR of 0, which was filtered out.  The SNR filter might need to be revisited since it seems like it drops more than just ADMIN packets now.