### PR TITLE
Show nodes we have not yet received a NodeInfo from.

### DIFF
--- a/app/schemas/com.geeksville.mesh.database.MeshtasticDatabase/8.json
+++ b/app/schemas/com.geeksville.mesh.database.MeshtasticDatabase/8.json
@@ -1,0 +1,459 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "b1b419e8f96e390cad65e61bdfe07874",
+    "entities": [
+      {
+        "tableName": "MyNodeInfo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`myNodeNum` INTEGER NOT NULL, `hasGPS` INTEGER NOT NULL, `model` TEXT, `firmwareVersion` TEXT, `couldUpdate` INTEGER NOT NULL, `shouldUpdate` INTEGER NOT NULL, `currentPacketId` INTEGER NOT NULL, `messageTimeoutMsec` INTEGER NOT NULL, `minAppVersion` INTEGER NOT NULL, `maxChannels` INTEGER NOT NULL, `hasWifi` INTEGER NOT NULL, `channelUtilization` REAL NOT NULL, `airUtilTx` REAL NOT NULL, PRIMARY KEY(`myNodeNum`))",
+        "fields": [
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasGPS",
+            "columnName": "hasGPS",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firmwareVersion",
+            "columnName": "firmwareVersion",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "couldUpdate",
+            "columnName": "couldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldUpdate",
+            "columnName": "shouldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPacketId",
+            "columnName": "currentPacketId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageTimeoutMsec",
+            "columnName": "messageTimeoutMsec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxChannels",
+            "columnName": "maxChannels",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasWifi",
+            "columnName": "hasWifi",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelUtilization",
+            "columnName": "channelUtilization",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "airUtilTx",
+            "columnName": "airUtilTx",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "myNodeNum"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "NodeInfo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `snr` REAL NOT NULL, `rssi` INTEGER NOT NULL, `lastHeard` INTEGER NOT NULL, `channel` INTEGER NOT NULL, `hopsAway` INTEGER NOT NULL DEFAULT 0, `user_id` TEXT NOT NULL, `user_longName` TEXT NOT NULL, `user_shortName` TEXT NOT NULL, `user_hwModel` TEXT NOT NULL, `user_isLicensed` INTEGER NOT NULL, `position_latitude` REAL, `position_longitude` REAL, `position_altitude` INTEGER, `position_time` INTEGER, `position_satellitesInView` INTEGER, `position_groundSpeed` INTEGER, `position_groundTrack` INTEGER, `position_precisionBits` INTEGER, `devMetrics_time` INTEGER, `devMetrics_batteryLevel` INTEGER, `devMetrics_voltage` REAL, `devMetrics_channelUtilization` REAL, `devMetrics_airUtilTx` REAL, `envMetrics_time` INTEGER, `envMetrics_temperature` REAL, `envMetrics_relativeHumidity` REAL, `envMetrics_barometricPressure` REAL, `envMetrics_gasResistance` REAL, `envMetrics_voltage` REAL, `envMetrics_current` REAL, PRIMARY KEY(`num`))",
+        "fields": [
+          {
+            "fieldPath": "num",
+            "columnName": "num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeard",
+            "columnName": "lastHeard",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hopsAway",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "user.id",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user.longName",
+            "columnName": "user_longName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user.shortName",
+            "columnName": "user_shortName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user.hwModel",
+            "columnName": "user_hwModel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user.isLicensed",
+            "columnName": "user_isLicensed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position.latitude",
+            "columnName": "position_latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "position.longitude",
+            "columnName": "position_longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "position.altitude",
+            "columnName": "position_altitude",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "position.time",
+            "columnName": "position_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "position.satellitesInView",
+            "columnName": "position_satellitesInView",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "position.groundSpeed",
+            "columnName": "position_groundSpeed",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "position.groundTrack",
+            "columnName": "position_groundTrack",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "position.precisionBits",
+            "columnName": "position_precisionBits",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deviceMetrics.time",
+            "columnName": "devMetrics_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deviceMetrics.batteryLevel",
+            "columnName": "devMetrics_batteryLevel",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deviceMetrics.voltage",
+            "columnName": "devMetrics_voltage",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deviceMetrics.channelUtilization",
+            "columnName": "devMetrics_channelUtilization",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deviceMetrics.airUtilTx",
+            "columnName": "devMetrics_airUtilTx",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "environmentMetrics.time",
+            "columnName": "envMetrics_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "environmentMetrics.temperature",
+            "columnName": "envMetrics_temperature",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "environmentMetrics.relativeHumidity",
+            "columnName": "envMetrics_relativeHumidity",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "environmentMetrics.barometricPressure",
+            "columnName": "envMetrics_barometricPressure",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "environmentMetrics.gasResistance",
+            "columnName": "envMetrics_gasResistance",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "environmentMetrics.voltage",
+            "columnName": "envMetrics_voltage",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "environmentMetrics.current",
+            "columnName": "envMetrics_current",
+            "affinity": "REAL",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "num"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "packet",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `port_num` INTEGER NOT NULL, `contact_key` TEXT NOT NULL, `received_time` INTEGER NOT NULL, `data` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port_num",
+            "columnName": "port_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_time",
+            "columnName": "received_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "contact_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contact_key` TEXT NOT NULL, `muteUntil` INTEGER NOT NULL, PRIMARY KEY(`contact_key`))",
+        "fields": [
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muteUntil",
+            "columnName": "muteUntil",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contact_key"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `type` TEXT NOT NULL, `received_date` INTEGER NOT NULL, `message` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message_type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_date",
+            "columnName": "received_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raw_message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "quick_chat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `message` TEXT NOT NULL, `mode` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mode",
+            "columnName": "mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b1b419e8f96e390cad65e61bdfe07874')"
+    ]
+  }
+}

--- a/app/src/main/java/com/geeksville/mesh/DataPacket.kt
+++ b/app/src/main/java/com/geeksville/mesh/DataPacket.kt
@@ -168,7 +168,13 @@ data class DataPacket(
         const val NODENUM_BROADCAST = (0xffffffff).toInt()
 
         fun nodeNumToDefaultId(n: Int): String = "!%08x".format(n)
-        fun idToDefaultNodeNum(id: String?): Int? = id?.toLong(16)?.toInt()
+        fun idToDefaultNodeNum(id: String) : Int {
+            if (id == ID_BROADCAST) {
+                return NODENUM_BROADCAST;
+            } else {
+                return id.substring(1).toLong(16).toInt();
+            }
+        }
 
         override fun createFromParcel(parcel: Parcel): DataPacket {
             return DataPacket(parcel)

--- a/app/src/main/java/com/geeksville/mesh/NodeInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/NodeInfo.kt
@@ -2,10 +2,11 @@ package com.geeksville.mesh
 
 import android.graphics.Color
 import android.os.Parcelable
-import androidx.room.ColumnInfo
+import androidx.annotation.NonNull
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import androidx.room.ColumnInfo
 import com.geeksville.mesh.util.GPSFormat
 import com.geeksville.mesh.util.bearing
 import com.geeksville.mesh.util.latLongToMeter
@@ -213,8 +214,9 @@ data class EnvironmentMetrics(
 data class NodeInfo(
     @PrimaryKey(autoGenerate = false)
     val num: Int, // This is immutable, and used as a key
+    @NonNull()
     @Embedded(prefix = "user_")
-    var user: MeshUser? = null,
+    var user: MeshUser,
     @Embedded(prefix = "position_")
     var position: Position? = null,
     var snr: Float = Float.MAX_VALUE,

--- a/app/src/main/java/com/geeksville/mesh/database/Converters.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/Converters.kt
@@ -30,4 +30,5 @@ class Converters {
     fun protoToString(value: MeshPacket): String {
         return value.toString()
     }
+
 }

--- a/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
@@ -31,8 +31,9 @@ import com.geeksville.mesh.database.entity.QuickChatAction
         AutoMigration (from = 4, to = 5),
         AutoMigration (from = 5, to = 6),
         AutoMigration (from = 6, to = 7),
+        AutoMigration (from = 7, to = 8),
     ],
-    version = 7,
+    version = 8,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/geeksville/mesh/model/NodeDB.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/NodeDB.kt
@@ -1,10 +1,15 @@
 package com.geeksville.mesh.model
 
+import android.app.Application
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
+import com.geeksville.mesh.R
 import com.geeksville.mesh.MyNodeInfo
 import com.geeksville.mesh.NodeInfo
+import com.geeksville.mesh.MeshUser
+import com.geeksville.mesh.DataPacket
 import com.geeksville.mesh.database.dao.NodeInfoDao
+import com.geeksville.mesh.MeshProtos.HardwareModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +23,7 @@ import javax.inject.Singleton
 @Singleton
 class NodeDB @Inject constructor(
     processLifecycle: Lifecycle,
+    private val app: Application,
     private val nodeInfoDao: NodeInfoDao,
 ) {
 
@@ -60,6 +66,22 @@ class NodeDB @Inject constructor(
 
     fun myNodeInfoFlow(): Flow<MyNodeInfo?> = nodeInfoDao.getMyNodeInfo()
     fun nodeInfoFlow(): Flow<List<NodeInfo>> = nodeInfoDao.getNodes()
+    fun getNode(num: String): NodeInfo {
+        val node: NodeInfo? = nodes.value[num];
+        if (node != null) {
+            return node;
+        } else {
+            return NodeInfo(
+                DataPacket.idToDefaultNodeNum(num),
+                MeshUser(
+                    id = num,
+                    longName = app.getString(R.string.unknown_username, num),
+                    shortName = app.getString(R.string.unknown_node_short_name),
+                    hwModel = HardwareModel.UNSET,
+                )
+            );
+        }
+    }
     fun delNode(num: Int) {
         nodeInfoDao.delNode(num)
     }

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -145,8 +145,8 @@ class UIViewModel @Inject constructor(
         if (filterText.isBlank()) return@combine nodes
 
         nodes.filter { entry ->
-            entry.value.user?.longName?.contains(filterText, ignoreCase = true) == true ||
-            entry.value.user?.shortName?.contains(filterText, ignoreCase = true) == true
+            entry.value.user.longName.contains(filterText, ignoreCase = true) == true ||
+            entry.value.user.shortName.contains(filterText, ignoreCase = true) == true
         }
     }
 
@@ -204,8 +204,8 @@ class UIViewModel @Inject constructor(
             channelName ?: app.getString(R.string.channel_name)
         } else {
             // grab usernames from NodeInfo
-            val node = nodeDB.nodes.value[dest]
-            node?.user?.longName ?: app.getString(R.string.unknown_username)
+            val node = nodeDB.getNode(dest);
+            node.user.longName
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/DeviceSettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/DeviceSettingsFragment.kt
@@ -125,8 +125,7 @@ class DeviceSettingsFragment : ScreenFragment("Radio Configuration"), Logging {
                     Scaffold(
                         topBar = {
                             MeshAppBar(
-                                currentScreen = node?.user?.longName
-                                    ?: stringResource(R.string.unknown_username),
+                                currentScreen = node!!.user.longName,
                                 // canNavigateBack = navController.previousBackStackEntry != null,
                                 // navigateUp = { navController.navigateUp() },
                                 canNavigateBack = true,

--- a/app/src/main/java/com/geeksville/mesh/ui/LinkedCoordinates.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/LinkedCoordinates.kt
@@ -27,7 +27,7 @@ fun LinkedCoordinates(
     modifier : Modifier = Modifier,
     position: Position?,
     format: Int,
-    nodeName: String?
+    nodeName: String,
 ) {
     if (position?.isValid() == true) {
         val uriHandler = LocalUriHandler.current
@@ -36,7 +36,7 @@ fun LinkedCoordinates(
             fontSize = MaterialTheme.typography.button.fontSize,
             textDecoration = TextDecoration.Underline
         )
-        val name = nodeName ?: stringResource(id = R.string.unknown_username)
+        val name = nodeName
         val annotatedString = buildAnnotatedString {
             pushStringAnnotation(
                 tag = "gps",

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeInfo.kt
@@ -61,9 +61,8 @@ fun NodeInfo(
     val BLINK_DURATION = 250
 
     val unknownShortName = stringResource(id = R.string.unknown_node_short_name)
-    val unknownLongName = stringResource(id = R.string.unknown_username)
 
-    val nodeName = thatNodeInfo.user?.longName ?: unknownLongName
+    val nodeName = thatNodeInfo.user.longName
     val isThisNode = thisNodeInfo?.num == thatNodeInfo.num
     val distance = thisNodeInfo?.distanceStr(thatNodeInfo, distanceUnits)
     val (textColor, nodeColor) = thatNodeInfo.colors
@@ -116,7 +115,7 @@ fun NodeInfo(
                         content = {
                             Text(
                                 modifier = Modifier.fillMaxWidth(),
-                                text = (thatNodeInfo.user?.shortName ?: unknownShortName).strikeIf(isIgnored),
+                                text = (thatNodeInfo.user.shortName).strikeIf(isIgnored),
                                 fontWeight = FontWeight.Normal,
                                 fontSize = MaterialTheme.typography.button.fontSize,
                                 textAlign = TextAlign.Center,
@@ -137,7 +136,7 @@ fun NodeInfo(
                     )
                 }
 
-                val style = if (nodeName == unknownLongName) {
+                val style = if (thatNodeInfo.user.shortName == unknownShortName) {
                     LocalTextStyle.current.copy(fontStyle = FontStyle.Italic)
                 } else {
                     LocalTextStyle.current

--- a/app/src/main/java/com/geeksville/mesh/ui/SignalInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SignalInfo.kt
@@ -6,7 +6,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.geeksville.mesh.MeshProtos.HardwareModel
 import com.geeksville.mesh.NodeInfo
+import com.geeksville.mesh.MeshUser
 import com.geeksville.mesh.ui.preview.NodeInfoPreviewParameterProvider
 import com.geeksville.mesh.ui.theme.AppTheme
 
@@ -59,7 +61,12 @@ fun SignalInfoSimplePreview() {
                 snr = 12.5F,
                 rssi = -42,
                 deviceMetrics = null,
-                user = null,
+                user = MeshUser(
+                    id = "!12345678",
+                    longName = "Bob",
+                    shortName = "BQ1",
+                    hwModel = HardwareModel.UNSET,
+                ),
                 hopsAway = 0
             ),
             isThisNode = false

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -111,7 +111,6 @@ class UsersFragment : ScreenFragment("Users"), Logging {
 
         private fun popup(view: View, node: NodeInfo) {
             if (!model.isConnected()) return
-            val user = node.user ?: return
             val isOurNode = node.num == model.myNodeNum
             val showAdmin = isOurNode || model.hasAdminChannel
             val isIgnored = ignoreIncomingList.contains(node.num)
@@ -127,48 +126,46 @@ class UsersFragment : ScreenFragment("Users"), Logging {
             popup.setOnMenuItemClickListener { item: MenuItem ->
                 when (item.itemId) {
                     R.id.direct_message -> {
-                        debug("calling MessagesFragment filter: ${node.channel}${user.id}")
-                        model.setContactKey("${node.channel}${user.id}")
+                        debug("calling MessagesFragment filter: ${node.channel}${node.user.id}")
+                        model.setContactKey("${node.channel}${node.user.id}")
                         parentFragmentManager.beginTransaction()
                             .replace(R.id.mainActivityLayout, MessagesFragment())
                             .addToBackStack(null)
                             .commit()
                     }
                     R.id.request_position -> {
-                        debug("requesting position for '${user.longName}'")
+                        debug("requesting position for '${node.user.longName}'")
                         model.requestPosition(node.num)
                     }
                     R.id.traceroute -> {
-                        debug("requesting traceroute for '${user.longName}'")
+                        debug("requesting traceroute for '${node.user.longName}'")
                         model.requestTraceroute(node.num)
                     }
                     R.id.forget_node -> {
-
                         MaterialAlertDialogBuilder(requireContext())
                             .setTitle(R.string.forget_node)
                             .setMessage(getString(R.string.forget_node_message))
                             .setNeutralButton(R.string.cancel) { _, _ -> }
                             .setPositiveButton(R.string.forget_node) {_,_ ->
-                                debug("Forgetting node '${user.longName}'")
+                                debug("Forgetting node '${node.user.longName}'")
                                 model.forgetNode(node.num)
                                 onNodesChanged(nodes)
                             }
                             .show()
-
                     }
                     R.id.ignore -> {
                         val message = if (isIgnored) R.string.ignore_remove else R.string.ignore_add
                         MaterialAlertDialogBuilder(requireContext())
                             .setTitle(R.string.ignore)
-                            .setMessage(getString(message, user.longName))
+                            .setMessage(getString(message, node.user.longName))
                             .setNeutralButton(R.string.cancel) { _, _ -> }
                             .setPositiveButton(R.string.send) { _, _ ->
                                 model.ignoreIncomingList = ignoreIncomingList.apply {
                                     if (isIgnored) {
-                                        debug("removed '${user.longName}' from ignore list")
+                                        debug("removed '${node.user.longName}' from ignore list")
                                         remove(node.num)
                                     } else {
-                                        debug("added '${user.longName}' to ignore list")
+                                        debug("added '${node.user.longName}' to ignore list")
                                         add(node.num)
                                     }
                                 }
@@ -291,7 +288,7 @@ class UsersFragment : ScreenFragment("Users"), Logging {
 
         model.focusedNode.asLiveData().observe(viewLifecycleOwner) { node ->
             val idx = nodesAdapter.nodes.indexOfFirst {
-                it.user?.id == node?.user?.id
+                it.user.id == node?.user?.id
             }
 
             if (idx < 1) return@observe

--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
@@ -209,7 +209,7 @@ fun MapView(
         val gpsFormat = model.config.display.gpsFormat.number
         val displayUnits = model.config.display.units.number
         return nodesWithPosition.map { node ->
-            val (p, u) = node.position!! to node.user!!
+            val (p, u) = node.position!! to node.user
             MarkerWithLabel(
                 mapView = this,
                 label = "${u.shortName} ${formatAgo(p.time)}"
@@ -269,8 +269,8 @@ fun MapView(
             showDeleteMarkerDialog(waypoint)
     }
 
-    fun getUsername(id: String?) = if (id == DataPacket.ID_LOCAL) context.getString(R.string.you)
-    else model.nodeDB.nodes.value[id]?.user?.longName ?: context.getString(R.string.unknown_username)
+    fun getUsername(id: String) = if (id == DataPacket.ID_LOCAL) context.getString(R.string.you)
+    else model.nodeDB.getNode(id).user.longName
 
     fun MapView.onWaypointChanged(waypoints: Collection<Packet>): List<MarkerWithLabel> {
         return waypoints.mapNotNull { waypoint ->
@@ -282,7 +282,7 @@ fun MapView(
             val emoji = String(Character.toChars(if (pt.icon == 0) 128205 else pt.icon))
             MarkerWithLabel(this, label, emoji).apply {
                 id = "${pt.id}"
-                title = "${pt.name} (${getUsername(waypoint.data.from)}$lock)"
+                title = "${pt.name} (${getUsername(waypoint.data.from!!)}$lock)"
                 snippet = "[$time] " + pt.description
                 position = GeoPoint(pt.latitudeI * 1e-7, pt.longitudeI * 1e-7)
                 setVisible(false)

--- a/app/src/main/java/com/geeksville/mesh/ui/preview/PreviewParameterProviders.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/preview/PreviewParameterProviders.kt
@@ -88,12 +88,23 @@ class NodeInfoPreviewParameterProvider: PreviewParameterProvider<NodeInfo> {
     )
 
     private val unknown = donaldDuck.copy(
-        user = null,
+        user = MeshUser(
+            id = "!12345678",
+            longName = "UNK: !12345678",
+            shortName = "UNK",
+            hwModel = MeshProtos.HardwareModel.UNSET,
+        ),
         environmentMetrics = null
     )
 
     private val almostNothing = NodeInfo(
         num = Random.nextInt(),
+        user = MeshUser(
+            id = "!12345678",
+            longName = "UNK: !12345678",
+            shortName = "UNK",
+            hwModel = MeshProtos.HardwareModel.UNSET,
+        ),
     )
 
     override val values: Sequence<NodeInfo>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -5,7 +5,6 @@
     <string name="unset">Отказ</string>
     <string name="connection_status">Състояние на връзката</string>
     <string name="application_icon">икона на приложението</string>
-    <string name="unknown_username">Неизвестен потребител</string>
     <string name="send">Изпрати</string>
     <string name="send_text">Текст за изпращане</string>
     <string name="warning_not_paired">Все още не сте сдвоили радио, съвместимо с Meshtastic, с този телефон. Моля, сдвоете устройство и задайте вашето потребителско име.\n\nТова приложение с отворен код е в процес на разработка, ако откриете проблеми, моля, публикувайте в нашия форум: meshtastic.discourse.group.\n\nЗа повече информация вижте нашата уеб страница на адрес www.meshtastic.org.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Zrušit nastavení</string>
     <string name="connection_status">Stav připojení</string>
     <string name="application_icon">Ikona aplikace</string>
-    <string name="unknown_username">Neznámé uživatelské jméno</string>
     <string name="send">Odeslat</string>
     <string name="send_text">Odeslat text</string>
     <string name="warning_not_paired">You haven\'t yet paired a Meshtastic compatible radio with this phone. Please pair a device and set your username.\n\nThis open-source application is in alpha-testing, if you find problems please post on our forum: meshtastic.discourse.group.\n\nFor more information see our web page - www.meshtastic.org.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Nicht konfiguriert</string>
     <string name="connection_status">Verbindungsstatus</string>
     <string name="application_icon">Anwendungssymbol</string>
-    <string name="unknown_username">Unbekannter Nutzername</string>
     <string name="send">Senden</string>
     <string name="send_text">Text senden</string>
     <string name="warning_not_paired">Sie haben noch kein zu Meshtastic kompatibles Funkgerät mit diesem Telefon gekoppelt. Bitte koppeln Sie ein Gerät und legen Sie Ihren Benutzernamen fest.\n\nDiese quelloffene App befindet sich im Test. Wenn Sie Probleme finden, veröffentlichen Sie diese bitte auf unserer Website im Chat.\n\nWeitere Informationen finden Sie auf unserer Webseite - www.meshtastic.org.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Αναίρεση</string>
     <string name="connection_status">Κατάσταση Σύνδεσης</string>
     <string name="application_icon">Εικονίδιο εφαρμογής </string>
-    <string name="unknown_username">Άγνωστο Όνομα Χρήστη</string>
     <string name="send">Αποστολή</string>
     <string name="send_text">Αποστολή κειμένου</string>
     <string name="warning_not_paired">Δεν έχετε κάνει ακόμη pair μια συσκευή συμβατή με Meshtastic με το τηλέφωνο. Παρακαλώ κάντε pair μια συσκευή και ορίστε το όνομα χρήστη.\n\nΗ εφαρμογή ανοιχτού κώδικα βρίσκεται σε alpha-testing, αν εντοπίσετε προβλήματα παρακαλώ δημοσιεύστε τα στο forum: meshtastic.discourse.group.\n\nΠερισσότερες πληροφορίες στην ιστοσελίδα - www.meshtastic.org.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Sin configurar</string>
     <string name="connection_status">Estado de conexión</string>
     <string name="application_icon">icono de la aplicación</string>
-    <string name="unknown_username">Nombre de usuario desconocido</string>
     <string name="send">Enviar</string>
     <string name="send_text">Enviar texto</string>
     <string name="warning_not_paired">Aún no ha emparejado una radio compatible con Meshtastic con este teléfono. Empareje un dispositivo y configure su nombre de usuario. \n\nEsta aplicación de código abierto es una prueba alfa; si encuentra un problema publiquelo en el foro: meshtastic.discourse.group. \n\nPara obtener más información visite nuestra página web - www.meshtastic.org.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Yhdistämättä</string>
     <string name="connection_status">Verkon tila</string>
     <string name="application_icon">Ohjelman kuvake</string>
-    <string name="unknown_username">Tuntematon käyttäjänimi</string>
     <string name="send">Lähetä</string>
     <string name="send_text">Lähetä teksti</string>
     <string name="warning_not_paired">Et ole vielä yhdistänyt Meshtastic -yhteensopivaa radiota tähän puhelimeen. Parita laitteesi tämän puhelimen kanssa ja aseta käyttäjänimesi.\n\nTämä avoimen lähdekoodin (open source) ohjelma on alpha-testausvaiheessa. Mikäli huomaat ongelmia, lähetäthän viestin verkkosivumme keskustelupalstalle.\n\nLisätietoja verkkosivuiltamme - www.meshtastic.org.</string>

--- a/app/src/main/res/values-fr-rHT/strings.xml
+++ b/app/src/main/res/values-fr-rHT/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Pa konfigire</string>
     <string name="connection_status">Sitiyasyon koneksyon</string>
     <string name="application_icon">ikònn aplikasyon an</string>
-    <string name="unknown_username">Non itilizatè enkoni</string>
     <string name="send_text">Voye tèks</string>
     <string name="warning_not_paired">Ou ponkò koneke  yon radyo ki konpatib avek Meshtastic sou telefòn sa a. Tanpri konekte yon aparèy epi mete non itilizatè w lan.Sa se yon aplikasyon publik ki nan tès Alpha.  Si ou gen pwoblèm tanpri afichel sou fowòm nou an: meshtastic.discourse.groupPou plis enfòmasyon gade paj wèb nou an - www.meshtastic.org </string>
     <string name="your_name">Non Ou</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Non défini</string>
     <string name="connection_status">État de la connexion</string>
     <string name="application_icon">icône de l\'application</string>
-    <string name="unknown_username">Nom d\'Utilisateur inconnu</string>
     <string name="send">Envoyer</string>
     <string name="send_text">Envoyer Texte</string>
     <string name="warning_not_paired">Aucune radio Meshtastic compatible n\'a été jumelée à ce téléphone. Jumelez un appareil et spécifiez votre nom d\'utilisateur.\n\nL\'application open-source est en test alpha, si vous rencontrez des problèmes postez au chat sur notre site web.\n\nPour plus d\'information visitez notre site web - www.meshtastic.org.</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Díshocraigh</string>
     <string name="connection_status">Stádas ceangail</string>
     <string name="application_icon">deilbhín feidhmchláir</string>
-    <string name="unknown_username">Ainm Úsáideora Anaithnid</string>
     <string name="send_text">Seol Téacs</string>
     <string name="warning_not_paired">Níl raidió comhoiriúnach Meshtastic péireáilte leis an bhfón seo agat fós. Péireáil gléas le do thoil agus socraigh d’ainm úsáideora. Tá an feidhmchlár foinse oscailte seo faoi alfa-thástáil, má aimsíonn tú fadhbanna cuir leis an gcomhrá ar ár suíomh gréasáin iad le do thoil. Le haghaidh tuilleadh faisnéise féach ar ár leathanach gréasáin - www.meshtastic.org.</string>
     <string name="your_name">D\'ainm</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Nepostavljeno</string>
     <string name="connection_status">Stanje veze</string>
     <string name="application_icon">ikona aplikacije</string>
-    <string name="unknown_username">Nepoznato korisničko ime</string>
     <string name="send">Primijeni</string>
     <string name="send_text">Pošalji poruku</string>
     <string name="warning_not_paired">Još niste povezali Meshtastic radio uređaj s ovim telefonom. Povežite uređaj i postavite svoje korisničko ime.\n\nOva aplikacija otvorenog koda je u razvoju, ako naiđete na probleme, objavite na našem forumu: meshtastic.discourse.group.\n\nZa više informacija pogledajte našu web stranicu - www.meshtastic.org.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Nincs beállítva</string>
     <string name="connection_status">Kapcsolat állapota</string>
     <string name="application_icon">alkalmazás ikonja</string>
-    <string name="unknown_username">Ismeretlen felhasználónév</string>
     <string name="send">Küldeni</string>
     <string name="send_text">Szöveg elküldése</string>
     <string name="warning_not_paired">Még nem párosított egyetlen Meshtastic rádiót sem ehhez a telefonhoz. Kérem pároztasson egyet és állítsa be a felhasználónevet.\n\nEz a szabad forráskódú alkalmazás fejlesztés alatt áll, ha hibát talál kérem írjon a projekt fórumába: meshtastic.discourse.group.\n\nBővebb információért látogasson el a projekt veboldalára - www.meshtastic.org.</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Óstillt</string>
     <string name="connection_status">Staða tengingar</string>
     <string name="application_icon">tákn smáforrits</string>
-    <string name="unknown_username">Óþekkt notendanafn</string>
     <string name="send">Senda</string>
     <string name="send_text">Senda textaskilaboð</string>
     <string name="warning_not_paired">Þú hefur ekki parað Meshtastic radíó við þennan síma. Vinsamlegast paraðu búnað og veldu notendnafn.\n\nÞessi opni hugbúnaður er enn í þróun, finnir þú vandamál vinsamlegast búðu til þráð á spjallborðinu okkar: meshtastic.discourse.group.\n\nFyrir frekari upplýsingar sjá vefsíðu - www.meshtastic.org.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Non impostato</string>
     <string name="connection_status">Stato della Connessione</string>
     <string name="application_icon">Icona dell\'applicazione</string>
-    <string name="unknown_username">Nome Utente Sconosciuto</string>
     <string name="send">Invia</string>
     <string name="send_text">Invia Messaggio</string>
     <string name="warning_not_paired">Non è ancora stato abbinato un dispositivo radio compatibile Meshtastic a questo telefono. È necessario abbinare un dispositivo e impostare il nome utente.\n\nQuesta applicazione open-source è ancora in via di sviluppo, se si riscontrano problemi, rivolgersi al forum: meshtastic.discourse.group.\n\nPer maggiori informazioni visitare la pagina web - www.meshtastic.org.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">לא מוגדר</string>
     <string name="connection_status">סטטוס חיבור</string>
     <string name="application_icon">אייקון אפליקציה</string>
-    <string name="unknown_username">שם המשתמש אינו מוכר</string>
     <string name="send">שלח</string>
     <string name="send_text">שלח טקסט</string>
     <string name="warning_not_paired">עוד לא צימדת מכשיר תומך משטסטיק לטלפון זה. בבקשה צמד מכשיר והגדר שם משתמש.\n\nאפליקציית קוד פתוח זה נמצא בפיתוח, במקשר של בעיות בבקשה גש לפורום: meshtastic.discourse.group.\n\n למידע נוסף בקרו באתר - www.meshtastic.org.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">削除</string>
     <string name="connection_status">接続状態</string>
     <string name="application_icon">アプリアイコン</string>
-    <string name="unknown_username">Nanashisan</string>
     <string name="send">送信</string>
     <string name="send_text">メッセージを入力</string>
     <string name="warning_not_paired">このスマートフォンはMeshtasticデバイスとペアリングされていません。デバイスとペアリングしてユーザー名を設定してください。\n\nこのオープンソースアプリケーションはアルファテスト中です。問題を発見した場合はBBSに書き込んでください。 meshtastic.discourse.group \n\n詳しくはWEBページをご覧ください。 www.meshtastic.org</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">해제</string>
     <string name="connection_status">연결상태</string>
     <string name="application_icon">앱아이콘</string>
-    <string name="unknown_username">미확인 유저</string>
     <string name="send_text">텍스트 전송</string>
     <string name="warning_not_paired">아직 스마트폰과 메쉬타스틱 기기와 페어링을 하지 않았습니다. 장치와 페어링을 하고 사용자 이름을 정하세요. 이 오픈소스 응용 프로그램은 개발중입니다. 문제가 발견되면 포럼(meshtastic.discourse.group)을 통해 알려주세요. 자세한 정보는 웹페이지(www.meshtastic.org)를 참조하세요.</string>
     <string name="your_name">사용자 이름</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Nenustatyti</string>
     <string name="connection_status">Ryšio būsena</string>
     <string name="application_icon">aplikacijos piktograma</string>
-    <string name="unknown_username">Nežinomas vartotojo vardas</string>
     <string name="send">Siųsti</string>
     <string name="send_text">Siųsti tekstą</string>
     <string name="warning_not_paired">Šiuo telefonu dar susietas joks Meshtastic suderinamas radijas. Prašome suporuoti įrenginį ir nustatyti savo vartotojo vardą..\n\nŠi atvirojo kodo programa yra kūrimo stadijoje, jei pastebėsite problemas, prašome pranešti mūsų forume: meshtastic.discourse.group.\n\nDaugiau informacijos rasite mūsų interneto svetainėje - www.meshtastic.org.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Lås opp</string>
     <string name="connection_status">Tilkoblingsstatus</string>
     <string name="application_icon">applikasjon ikon</string>
-    <string name="unknown_username">Ukjent Brukernavn</string>
     <string name="send">Send</string>
     <string name="send_text">Send Tekst</string>
     <string name="warning_not_paired">Du har ikke paret en Meshtastic kompatibel radio med denne telefonen. Vennligst parr en enhet, og sett ditt brukernavn.\n\nDenne åpen kildekode applikasjonen er i alfa-testing, Hvis du finner problemer, vennligst post på vårt forum: meshtastic.discourse.group.\n\nFor mer informasjon, se vår nettside - www.meshtastic.org.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Terugzetten</string>
     <string name="connection_status">Verbindingsstatus</string>
     <string name="application_icon">applicatie icon</string>
-    <string name="unknown_username">Onbekende Gebruikersnaam</string>
     <string name="send">Verzenden</string>
     <string name="send_text">Stuur tekst</string>
     <string name="warning_not_paired">Je hebt nog geen Meshtastic compatibele radio met deze telefoon gekoppeld. Paar alstublieft een apparaat en voer je gebruikersnaam in.\n\nDeze open-source applicatie is in alpha-test, indien je een probleem vaststelt, kan je het posten op onze website chat.\n\nVoor meer informatie bezoek onze web pagina - www.meshtastic.org.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Odznacz</string>
     <string name="connection_status">Status połączenia</string>
     <string name="application_icon">ikona aplikacji</string>
-    <string name="unknown_username">Nieznana nazwa użytkownika</string>
     <string name="send">Wyślij</string>
     <string name="send_text">Wyślij wiadomość</string>
     <string name="warning_not_paired">Nie sparowałeś jeszcze radia kompatybilnego z Meshtastic z tym telefonem. Proszę sparować urządzenie i ustawić swoją nazwę użytkownika.\n\nTa aplikacja open-source jest w fazie rozwoju, jeśli znajdziesz problemy, napisz na naszym forum: meshtastic.discourse.group.\n\nWięcej informacji znajdziesz na naszej stronie internetowej -www.meshtastic.org.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Não definido</string>
     <string name="connection_status">Status da conexão</string>
     <string name="application_icon">ícone do aplicativo</string>
-    <string name="unknown_username">Nome desconhecido</string>
     <string name="send">Enviar</string>
     <string name="send_text">Enviar Texto</string>
     <string name="warning_not_paired">Você ainda não pareou um rádio compatível ao Meshtastic com este smartphone. Por favor pareie um dispositivo e configure seu nome de usuário.\n\nEste aplicativo open source está em desenvolvimento, caso encontre algum problema por favor publique em nosso fórum: meshtastic.discourse.group.\n\nPara mais informações acesse nossa página: www.meshtastic.org.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -5,7 +5,6 @@
     <string name="unset">Não Definido</string>
     <string name="connection_status">Estado da Conexão</string>
     <string name="application_icon">icone da aplicação</string>
-    <string name="unknown_username">Nome desconhecido</string>
     <string name="send">Enviar</string>
     <string name="send_text">Enviar Texto</string>
     <string name="warning_not_paired">Ainda não emparelhou um rádio compatível com Meshtastic com este telefone. Emparelhe um dispositivo e defina seu nome de usuário.\n\nEste aplicativo de código aberto está em teste alfa, se encontrar problemas, por favor reporte através do nosso forum em: meshtastic.discourse.group.\n\nPara obter mais informações, consulte a nossa página web - www.meshtastic.org.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Nesetat</string>
     <string name="connection_status">Statusul conexiunii</string>
     <string name="application_icon">Iconița aplicației</string>
-    <string name="unknown_username">Nume utilizator necunoscut</string>
     <string name="send">Trimite</string>
     <string name="send_text">Trimite textul</string>
     <string name="warning_not_paired">Încă nu ai asociat un radio compatibil cu Meshtastic cu acest telefon. Te rugăm să asociezi un dispozitiv și să îți setezi numele de utilizator.\n\nAceastă aplicaţie open-source este în dezvoltare, dacă întâmpinaţi probleme, vă rugăm să postaţi pe forumul nostru: meshtastic.discourse.group.\n\nPentru mai multe informații, consultați pagina noastră de internet - www.meshtastic.org.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Сбросить</string>
     <string name="connection_status">Статус соединения</string>
     <string name="application_icon">значок приложения</string>
-    <string name="unknown_username">Неизвестное имя пользователя</string>
     <string name="send">Отправить</string>
     <string name="send_text">Отправить текст</string>
     <string name="warning_not_paired">Вы еще не подключили к телефону устройство, совместимое с Meshtastic радио. Пожалуйста, подключите устройство и задайте имя пользователя.\n\nЭто приложение с открытым исходным кодом находится в альфа-тестировании, если вы обнаружите проблемы, пожалуйста, напишите в чате на нашем сайте.\n\nДля получения дополнительной информации посетите нашу веб-страницу - www.meshtastic.org.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Nenastavené</string>
     <string name="connection_status">Stav pripojenia</string>
     <string name="application_icon">Ikona aplikácie</string>
-    <string name="unknown_username">Neznáme užívateľské meno</string>
     <string name="send">Odoslať</string>
     <string name="send_text">Odoslať text</string>
     <string name="warning_not_paired">K tomuto telefónu ste ešte nespárovalii žiadne zariadenie kompatibilné s Meshtastic. Prosím spárujte zariadenie a nastavte svoje užívateľské meno. Táto open-source aplikácia je v alpha testovacej fáze, ak nájdete chybu, prosím popíšte ju na fóre: meshtastic.discourse.group.\n\n Pre viac informácií navštívte web stránku - www.meshtastic.org.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Ni nastavljeno</string>
     <string name="connection_status">Status povezave</string>
     <string name="application_icon">Ikona aplikacije</string>
-    <string name="unknown_username">Neznano uporabniško ime</string>
     <string name="send">Pošlji</string>
     <string name="send_text">Pošlji tekst</string>
     <string name="warning_not_paired">S tem telefonom še niste seznanili združljivega Meshtastic radia. Prosimo povežite napravo in nastavite svoje uporabniško ime. \n\nTa odprtokodna aplikacija je v alfa testiranju, če imate težave, objavite na našem spletnem klepetu.\n\nZa več informacij glejte našo spletno stran - www.meshtastic.org.</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">I pa konfiguruar</string>
     <string name="connection_status">Gjendja e komunikimit radio</string>
     <string name="application_icon">Ikona e aplikacionit</string>
-    <string name="unknown_username">Emri i përdoruesit është i panjohur</string>
     <string name="send_text">Dërgo një Mesazh</string>
     <string name="warning_not_paired">Ju ende nuk keni lidhur një paisje radio Meshtastic me këtë telefon. Ju lutem lidhni një paisje radio dhe vendosni emrin e përdoruesit. Ky aplikacion është software i lire "open-source" dhe në variantin Alpha për testim. Nëse hasni probleme, ju lutem shkruani në çatin e faqes tonë të internetit. Për më shum informacione vizitoni faqen tonë në internet - www.meshtastic.org.</string>
     <string name="your_name">Emri juaj</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Ej inställd</string>
     <string name="connection_status">Anslutningsstatus</string>
     <string name="application_icon">applikationsikon</string>
-    <string name="unknown_username">Okänt användarnamn</string>
     <string name="send">Skicka</string>
     <string name="send_text">Skicka text</string>
     <string name="warning_not_paired">Du har ännu inte parat en Meshtastic-kompatibel radio med den här telefonen. Koppla ihop en enhet och ange ditt användarnamn.\n\nDetta öppna källkodsprogram (open source) är under utveckling, om du hittar problem, vänligen publicera det på vårt forum: meshtastic.discourse.group\n\nFör mer information se vår webbsida - www.meshtastic.org.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Ayarlanmamış</string>
     <string name="connection_status">Bağlantı durumu</string>
     <string name="application_icon">uygulama ikonu</string>
-    <string name="unknown_username">Bilinmeyen kullanıcı adı</string>
     <string name="send">Gönder</string>
     <string name="send_text">Metni Gönder</string>
     <string name="warning_not_paired">Telefonu, Meshtastic uyumlu bir cihaz ile eşleştirmediniz. Bir cihazla eşleştirin ve kullanıcı adınızı belirleyin.\n\nAçık kaynaklı bu uygulama şu an alfa-test aşamasında, problem fark ederseniz forumda lütfen paylaşın: meshtastic.discourse.group.\n\nDaha fazla bilgi için, sitemiz: www.meshtastic.org.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -6,7 +6,6 @@
     <string name="unset">Скинути</string>
     <string name="connection_status">Статус з`єднання</string>
     <string name="application_icon">значок додатку</string>
-    <string name="unknown_username">Невідомий юзернейм</string>
     <string name="send">Надіслати</string>
     <string name="send_text">Відправити повідомлення</string>
     <string name="warning_not_paired">Ви ще не підєднали пристрій, сумісний з Meshtastic. Будьласка приєднайте пристрій і введіть ім’я користувача.\n\nЦя програма з відкритим вихідним кодом знаходиться в розробці, якщо ви виявите проблеми, опублікуйте їх на нашому форумі: meshtastic.discourse.group.\n\nДля отримання додаткової інформації відвідайте нашу веб-сторінку - www.meshtastic.org.</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="channel_name">頻道名稱</string>
     <string name="channel_options">頻道選項</string>
@@ -6,7 +5,6 @@
     <string name="unset">取消設定</string>
     <string name="connection_status">連線狀態</string>
     <string name="application_icon">應用程式圖示</string>
-    <string name="unknown_username">未知的使用者名称</string>
     <string name="send">传送</string>
     <string name="send_text">传送讯息</string>
     <string name="warning_not_paired">您尚未将手机与 Meshtastic 兼容的装置配对。请先配对装置并设置您的用户名称。\n\n此开源应用程序仍在开发中，如有问题，请在我们的论坛 meshtastic.discourse.group 上面发文询问。\n\n 也可参阅我们的网页 - www.meshtastic.org。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="sample_coords" translatable="false">55.332244 34.442211</string>
     <string name="sample_message" translatable="false">hey I found the cache, it is over here next to the big tiger. I\'m kinda scared.</string>
 
-    <string name="unknown_node_short_name" translatable="false">\???</string>
+    <string name="unknown_node_short_name">UNK</string>
     <string name="node_filter_placeholder">Filter</string>
     <string name="desc_node_filter_clear">clear node filter</string>
 
@@ -23,7 +23,7 @@
     <string name="unset">Unset</string>
     <string name="connection_status">Connection status</string>
     <string name="application_icon">application icon</string>
-    <string name="unknown_username">Unknown Username</string>
+    <string name="unknown_username">UNK: %1$s</string>
     <string name="send">Send</string>
     <string name="send_text">Send Text</string>
     <string name="warning_not_paired">You haven\'t yet paired a Meshtastic compatible radio with this phone. Please pair a device and set your username.\n\nThis open-source application is in development, if you find problems please post on our forum: meshtastic.discourse.group.\n\nFor more information see our web page - www.meshtastic.org.</string>


### PR DESCRIPTION
We will receive random packets from nodes with a marginal connection but often will never get a NodeInfo. The connection notification will then show more nodes online that are visible in the node list. This fixes #912.

I decided to give the unknown nodes the name "UNK: !<hex id>". This matches what was already being done in the chat view where only the hex id is used. It was also somewhat simpler because the `to` and `from` fields on `DataPacket` already had this format.

![Screenshot_20240415-200635](https://github.com/meshtastic/Meshtastic-Android/assets/4422/ed49a436-dd86-4e7e-9be2-d2be41b145c2)
![Screenshot_20240415-203556](https://github.com/meshtastic/Meshtastic-Android/assets/4422/d4d0c1a4-6252-4236-8b46-d878050779e5)
![Screenshot_20240415-203937](https://github.com/meshtastic/Meshtastic-Android/assets/4422/3d449066-33bd-4266-88c4-9b13246de7ce)
![Screenshot_20240415-204009](https://github.com/meshtastic/Meshtastic-Android/assets/4422/fab06b8c-8900-49b9-86dd-c45a4ff33324)
![Screenshot_20240415-223109](https://github.com/meshtastic/Meshtastic-Android/assets/4422/9733b833-392c-4b93-a244-2f34a455136d)
![Screenshot_20240415-223123](https://github.com/meshtastic/Meshtastic-Android/assets/4422/14205aa9-5a53-4d74-bc80-1f631112a633)
