### PR TITLE
Forget node menu changes

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -142,10 +142,15 @@ class UsersFragment : ScreenFragment("Users"), Logging {
                     }
                     R.id.forget_node -> {
                         debug("Forgetting node '${user.longName}'")
-
-                            model.forgetNode(node.num)
-                            onNodesChanged(nodes)
-
+                        MaterialAlertDialogBuilder(requireContext())
+                            .setTitle(R.string.forget_node)
+                            .setMessage(getString(R.string.forget_node_message))
+                            .setNeutralButton(R.string.cancel) { _, _ -> }
+                            .setPositiveButton(R.string.forget_node) {_,_ ->
+                                model.forgetNode(node.num)
+                                onNodesChanged(nodes)
+                            }
+                            .show()
 
                     }
                     R.id.ignore -> {

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -141,12 +141,13 @@ class UsersFragment : ScreenFragment("Users"), Logging {
                         model.requestTraceroute(node.num)
                     }
                     R.id.forget_node -> {
-                        debug("Forgetting node '${user.longName}'")
+
                         MaterialAlertDialogBuilder(requireContext())
                             .setTitle(R.string.forget_node)
                             .setMessage(getString(R.string.forget_node_message))
                             .setNeutralButton(R.string.cancel) { _, _ -> }
                             .setPositiveButton(R.string.forget_node) {_,_ ->
+                                debug("Forgetting node '${user.longName}'")
                                 model.forgetNode(node.num)
                                 onNodesChanged(nodes)
                             }

--- a/app/src/main/res/menu/menu_nodes.xml
+++ b/app/src/main/res/menu/menu_nodes.xml
@@ -11,10 +11,6 @@
             android:title="@string/request_position"
             app:showAsAction="withText" />
         <item
-            android:id="@+id/forget_node"
-            android:title="@string/forget_node"
-            app:showAsAction="withText" />
-        <item
             android:id="@+id/traceroute"
             android:title="@string/traceroute"
             app:showAsAction="withText" />
@@ -23,6 +19,10 @@
             android:checkable="true"
             android:checked="false"
             android:title="@string/ignore" />
+        <item
+            android:id="@+id/forget_node"
+            android:title="@string/forget_node"
+            app:showAsAction="withText" />
     </group>
     <group android:id="@+id/group_admin">
         <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,4 +188,5 @@
     <string name="waypoint_received">Received waypoint: %s</string>
     <string name="error_duty_cycle">Duty Cycle limit reached. Cannot send messages right now, please try again later.</string>
     <string name="forget_node">Forget Node</string>
+    <string name="forget_node_message">This node will be removed from your list until your node receives NodeInfo data from it again.</string>
 </resources>


### PR DESCRIPTION
Closes #964

Moves Forget Node in the node menu to the bottom, preventing people form pressing it accidentally when trying to traceroute. 

Also adds a dialog box to confirm the action of forgetting a node, similar to ignoring a node.
