### PR TITLE
Make sure IP Address radio button stays enabled for valid IP

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -338,7 +338,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         val deviceSelectIPAddress = binding.radioButtonManual
         val inputIPAddress = binding.editManualAddress
 
-        deviceSelectIPAddress.isEnabled = false
+        deviceSelectIPAddress.isEnabled = inputIPAddress.text.isIPAddress()
         deviceSelectIPAddress.setOnClickListener {
             deviceSelectIPAddress.isChecked = scanModel.onSelected(BTScanModel.DeviceListEntry("", "t" + inputIPAddress.text, true))
         }


### PR DESCRIPTION
I have no idea what I'm doing but this supposedly fixes https://github.com/meshtastic/Meshtastic-Android/issues/982 and part of https://github.com/meshtastic/Meshtastic-Android/issues/691