### PR TITLE
refactor: improve connection status feedback

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -115,6 +115,8 @@ class UIViewModel @Inject constructor(
     val bondedAddress get() = radioInterfaceService.getBondedDeviceAddress()
     val selectedBluetooth get() = radioInterfaceService.getDeviceAddress()?.getOrNull(0) == 'x'
 
+    val wantConfigState get() = radioConfigRepository.wantConfigState
+
     private val _packets = MutableStateFlow<List<Packet>>(emptyList())
     val packets: StateFlow<List<Packet>> = _packets
 

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -17,6 +17,7 @@ import com.geeksville.mesh.model.NodeDB
 import com.geeksville.mesh.model.getChannelUrl
 import com.geeksville.mesh.service.MeshService.ConnectionState
 import com.geeksville.mesh.service.ServiceRepository
+import com.geeksville.mesh.service.WantConfigState
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
@@ -37,6 +38,28 @@ class RadioConfigRepository @Inject constructor(
     private val moduleConfigRepository: ModuleConfigRepository,
 ) {
     val meshService: IMeshService? get() = serviceRepository.meshService
+
+    val wantConfigState: StateFlow<WantConfigState> = serviceRepository.wantConfigState
+
+    fun clearWantConfigState() {
+        serviceRepository.setWantConfigState { WantConfigState() }
+    }
+
+    fun increaseNodeCount() {
+        serviceRepository.setWantConfigState { it.copy(nodeCount = it.nodeCount + 1) }
+    }
+
+    fun increaseChannelCount() {
+        serviceRepository.setWantConfigState { it.copy(channelCount = it.channelCount + 1) }
+    }
+
+    fun increaseConfigCount() {
+        serviceRepository.setWantConfigState { it.copy(configCount = it.configCount + 1) }
+    }
+
+    fun increaseModuleCount() {
+        serviceRepository.setWantConfigState { it.copy(moduleCount = it.moduleCount + 1) }
+    }
 
     // Connection state to our radio device
     val connectionState get() = serviceRepository.connectionState

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1255,6 +1255,7 @@ class MeshService : Service(), Logging {
         )
         insertMeshLog(packetToSave)
         setLocalConfig(config)
+        radioConfigRepository.increaseConfigCount()
     }
 
     private fun handleModuleConfig(config: ModuleConfigProtos.ModuleConfig) {
@@ -1267,6 +1268,7 @@ class MeshService : Service(), Logging {
         )
         insertMeshLog(packetToSave)
         setLocalModuleConfig(config)
+        radioConfigRepository.increaseModuleCount()
     }
 
     private fun handleQueueStatus(queueStatus: MeshProtos.QueueStatus) {
@@ -1289,6 +1291,7 @@ class MeshService : Service(), Logging {
         )
         insertMeshLog(packetToSave)
         if (ch.role != ChannelProtos.Channel.Role.DISABLED) updateChannelSettings(ch)
+        radioConfigRepository.increaseChannelCount()
     }
 
     /**
@@ -1330,6 +1333,7 @@ class MeshService : Service(), Logging {
         insertMeshLog(packetToSave)
 
         newNodes.add(info)
+        radioConfigRepository.increaseNodeCount()
     }
 
 
@@ -1540,6 +1544,7 @@ class MeshService : Service(), Logging {
         configNonce += 1
         newNodes.clear()
         newMyNodeInfo = null
+        radioConfigRepository.clearWantConfigState()
 
         if (BluetoothInterface.invalidVersion) onHasSettings() // Device firmware is too old
 

--- a/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
@@ -7,8 +7,16 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.updateAndGet
 import javax.inject.Inject
 import javax.inject.Singleton
+
+data class WantConfigState(
+    var nodeCount: Int = 0,
+    var channelCount: Int = 0,
+    var configCount: Int = 0,
+    var moduleCount: Int = 0,
+)
 
 /**
  * Repository class for managing the [IMeshService] instance and connection state
@@ -41,6 +49,12 @@ class ServiceRepository @Inject constructor() : Logging {
     fun clearErrorMessage() {
         _errorMessage.value = null
     }
+
+    private val _wantConfigState = MutableStateFlow(WantConfigState())
+    val wantConfigState: StateFlow<WantConfigState> = _wantConfigState
+
+    fun setWantConfigState(update: (old: WantConfigState) -> WantConfigState): WantConfigState =
+        _wantConfigState.updateAndGet(update)
 
     private val _meshPacketFlow = MutableSharedFlow<MeshPacket>()
     val meshPacketFlow: SharedFlow<MeshPacket> get() = _meshPacketFlow


### PR DESCRIPTION
- create new state with `wantConfig` information, including node count;
- use state in fragment for more detailed connection status feedback.

closes #1006