### PR TITLE
fix: show maps pin when clicking on node coords

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/LinkedCoordinates.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/LinkedCoordinates.kt
@@ -40,7 +40,9 @@ fun LinkedCoordinates(
         val annotatedString = buildAnnotatedString {
             pushStringAnnotation(
                 tag = "gps",
-                annotation = "geo:${position.latitude},${position.longitude}?z=17&label=${
+                // URI scheme is defined at:
+                //  https://developer.android.com/guide/components/intents-common#Maps
+                annotation = "geo:0,0?q=${position.latitude},${position.longitude}&z=17&label=${
                     URLEncoder.encode(name, "utf-8")
                 }"
             )


### PR DESCRIPTION
Currently clicking on a node's location will open up the maps app, but does not 'pin' the real location. 

This change updates the URI used for the Maps intent to pass the coordinates in a way that will place a pin in the native Google Maps as well as 3rd party map applications (like OsmAnd).

Video of fix: 
https://github.com/meshtastic/Meshtastic-Android/assets/1168530/100e6efa-fa6a-42af-8bce-5059fb2580bd

