### PR TITLE
fix: Display correct hardware info in NodeInfo

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/NodeInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeInfo.kt
@@ -157,7 +157,7 @@ fun NodeInfo(
                     textDecoration = TextDecoration.LineThrough.takeIf { isIgnored },
                 )
 
-                val hwInfoString = thisNodeInfo?.user?.hwModelString
+                val hwInfoString = thatNodeInfo.user?.hwModelString
                 if (hwInfoString != null){
                     Text(
                         modifier = Modifier.constrainAs(hw) {


### PR DESCRIPTION
The hardware information displayed in the NodeInfo view was incorrect(using `thisNodeInfo`). This commit fixes the issue by using the correct node (`thatNodeInfo`) information to retrieve the hardware model string.