### PR TITLE
Feat: Show channel number and name in direct message title

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -4,8 +4,15 @@ import android.graphics.Color
 import android.graphics.Rect
 import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
-import android.view.*
-import android.widget.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.cardview.widget.CardView
@@ -15,25 +22,30 @@ import androidx.core.view.allViews
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.DataPacket
 import com.geeksville.mesh.MessageStatus
 import com.geeksville.mesh.NodeInfo
 import com.geeksville.mesh.R
+import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.database.entity.QuickChatAction
 import com.geeksville.mesh.databinding.AdapterMessageLayoutBinding
 import com.geeksville.mesh.databinding.MessagesFragmentBinding
 import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.model.getChannel
 import com.geeksville.mesh.util.Utf8ByteLengthFilter
 import com.google.android.material.chip.Chip
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import java.text.DateFormat
-import java.util.*
+import java.util.Date
 
 // return time if within 24 hours, otherwise date/time
 internal fun getShortDateTime(date: Date): String {
@@ -232,7 +244,12 @@ class MessagesFragment : Fragment(), Logging {
                 holder.itemView.background = GradientDrawable().apply {
                     shape = GradientDrawable.RECTANGLE
                     cornerRadius = 32f
-                    setColor(ContextCompat.getColor(holder.itemView.context, R.color.colorAdvancedBackground))
+                    setColor(
+                        ContextCompat.getColor(
+                            holder.itemView.context,
+                            R.color.colorAdvancedBackground
+                        )
+                    )
                 }
             }
         }
@@ -288,7 +305,21 @@ class MessagesFragment : Fragment(), Logging {
 
         val contactKey = arguments?.getString("contactKey").toString()
         val contactName = arguments?.getString("contactName").toString()
-        binding.messageTitle.text = contactName
+        var title = contactName
+        binding.messageTitle.text = title
+        if (contactKey[1] == '!') {
+            lifecycleScope.launch {
+                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    val channelNumber = contactKey[0].digitToInt()
+                    model.channels.collect { channels ->
+                        val channelName =
+                            channels.getChannel(channelNumber)?.name ?: "Unknown Channel"
+                        title += "\n(ch: $channelNumber - $channelName)"
+                        binding.messageTitle.text = title
+                    }
+                }
+            }
+        }
 
         fun sendMessageInputText() {
             val str = binding.messageInputText.text.toString().trim()
@@ -358,12 +389,14 @@ class MessagesFragment : Fragment(), Logging {
                     button.text = action.name
                     button.isEnabled = model.isConnected()
                     if (action.mode == QuickChatAction.Mode.Instant) {
-                        button.backgroundTintList = ContextCompat.getColorStateList(requireActivity(), R.color.colorMyMsg)
+                        button.backgroundTintList =
+                            ContextCompat.getColorStateList(requireActivity(), R.color.colorMyMsg)
                     }
                     button.setOnClickListener {
                         if (action.mode == QuickChatAction.Mode.Append) {
                             val originalText = binding.messageInputText.text ?: ""
-                            val needsSpace = !originalText.endsWith(' ') && originalText.isNotEmpty()
+                            val needsSpace =
+                                !originalText.endsWith(' ') && originalText.isNotEmpty()
                             val newText = buildString {
                                 append(originalText)
                                 if (needsSpace) append(' ')
@@ -421,6 +454,7 @@ class MessagesFragment : Fragment(), Logging {
                         }
                         .show()
                 }
+
                 R.id.selectAllButton -> {
                     // if all selected -> unselect all
                     if (messagesAdapter.selectedList.size == messagesAdapter.messages.size) {
@@ -434,6 +468,7 @@ class MessagesFragment : Fragment(), Logging {
                     actionMode?.title = messagesAdapter.selectedList.size.toString()
                     messagesAdapter.notifyDataSetChanged()
                 }
+
                 R.id.resendButton -> {
                     debug("User clicked resendButton")
                     val selectedList = messagesAdapter.selectedList
@@ -441,7 +476,7 @@ class MessagesFragment : Fragment(), Logging {
                     selectedList.forEach {
                         resendText = resendText + it.data.text + System.lineSeparator()
                     }
-                    if (resendText!="")
+                    if (resendText != "")
                         resendText = resendText.substring(0, resendText.length - 1)
                     binding.messageInputText.setText(resendText)
                     mode.finish()

--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -305,8 +305,8 @@ class MessagesFragment : Fragment(), Logging {
 
         val contactKey = arguments?.getString("contactKey").toString()
         val contactName = arguments?.getString("contactName").toString()
-        var title = contactName
-        binding.messageTitle.text = title
+        val title = contactName
+        binding.toolbar.title  = title
         if (contactKey[1] == '!') {
             lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -314,8 +314,8 @@ class MessagesFragment : Fragment(), Logging {
                     model.channels.collect { channels ->
                         val channelName =
                             channels.getChannel(channelNumber)?.name ?: "Unknown Channel"
-                        title += "\n(ch: $channelNumber - $channelName)"
-                        binding.messageTitle.text = title
+                        val subtitle = "(ch: $channelNumber - $channelName)"
+                        binding.toolbar.subtitle = subtitle
                     }
                 }
             }

--- a/app/src/main/res/layout/messages_fragment.xml
+++ b/app/src/main/res/layout/messages_fragment.xml
@@ -10,28 +10,13 @@
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
         style="@style/MyToolbar"
+        android:title="@string/channel_name"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintHeight_min="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:background="@color/toolbarBackground"
         app:layout_constraintTop_toTopOf="parent"
-        app:navigationIcon="?android:attr/homeAsUpIndicator">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <TextView
-                android:id="@+id/messageTitle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/channel_name"
-                android:textAppearance="@style/TextAppearance.Widget.AppCompat.Toolbar.Title"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </com.google.android.material.appbar.MaterialToolbar>
+        app:navigationIcon="?android:attr/homeAsUpIndicator"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/messageListView"


### PR DESCRIPTION
This updates the message toolbar title to include the channel number and name when viewing direct messages.

This improves the user experience by providing more context about the conversation.

[Screen_recording_20240711_195141.webm](https://github.com/user-attachments/assets/64be42a6-f6dd-4aad-b00c-b83bd229b24b)


resolves #942 