### PR TITLE
feat: Add more details screen for nodes

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
@@ -194,9 +195,18 @@ class UIViewModel @Inject constructor(
         nodeDB.getNodes(state.sort, state.filter, state.includeUnknown)
     }.stateIn(
         scope = viewModelScope,
-        started = WhileSubscribed(5_000),
+        started = WhileSubscribed(STOP_TIMEOUT_MILLIS),
         initialValue = emptyList(),
     )
+
+    fun getNodeByNum(nodeNum: Int): StateFlow<NodeInfo?> = nodeList.map { list ->
+        list.firstOrNull { it.num == nodeNum }
+    }.stateIn(
+        scope = viewModelScope,
+        started = WhileSubscribed(STOP_TIMEOUT_MILLIS),
+        initialValue = null,
+    )
+
 
     // hardware info about our local device (can be null)
     val myNodeInfo: StateFlow<MyNodeInfo?> get() = nodeDB.myNodeInfo
@@ -315,6 +325,7 @@ class UIViewModel @Inject constructor(
     }
 
     companion object {
+        private const val STOP_TIMEOUT_MILLIS = 5_000L
         fun getPreferences(context: Context): SharedPreferences =
             context.getSharedPreferences("ui-prefs", Context.MODE_PRIVATE)
     }

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -199,8 +199,9 @@ class UIViewModel @Inject constructor(
         initialValue = emptyList(),
     )
 
-    fun getNodeByNum(nodeNum: Int): StateFlow<NodeInfo?> = nodeList.map { list ->
-        list.firstOrNull { it.num == nodeNum }
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun getNodeByNum(nodeNum: Int): StateFlow<NodeInfo?> = nodeDB.nodeDBbyNum.mapLatest { nodes ->
+        nodes[nodeNum]
     }.stateIn(
         scope = viewModelScope,
         started = WhileSubscribed(STOP_TIMEOUT_MILLIS),

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeDetailsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeDetailsFragment.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentManager
@@ -84,14 +86,18 @@ fun NodeDetailsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
+                backgroundColor = colorResource(R.color.toolbarBackground),
+                contentColor = colorResource(R.color.toolbarText),
                 title = {
-                    Text("Node Details: ${detailsNodeInfo?.user?.shortName}")
+                    Text(
+                        text = "Node Details: ${detailsNodeInfo?.user?.shortName}",
+                    )
                 },
                 navigationIcon = {
                     IconButton(onClick = navigateBack) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Localized description"
+                            contentDescription = stringResource(R.string.navigate_back),
                         )
                     }
                 }

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeDetailsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeDetailsFragment.kt
@@ -1,0 +1,112 @@
+package com.geeksville.mesh.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.activityViewModels
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.geeksville.mesh.R
+import com.geeksville.mesh.android.Logging
+import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.ui.theme.AppTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+internal fun FragmentManager.navigateToNodeDetails(nodeNum: Int? = null) {
+    val nodeDetailsFragment = NodeDetailsFragment().apply {
+        arguments = bundleOf("nodeNum" to nodeNum)
+    }
+    beginTransaction()
+        .replace(R.id.mainActivityLayout, nodeDetailsFragment)
+        .addToBackStack(null)
+        .commit()
+}
+
+@AndroidEntryPoint
+class NodeDetailsFragment : ScreenFragment("NodeDetails"), Logging {
+
+    private val model: UIViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val nodeNum = arguments?.getInt("nodeNum")
+
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                AppTheme {
+                    NodeDetailsScreen(
+                        model = model,
+                        nodeNum = nodeNum,
+                        navigateBack = {
+                            parentFragmentManager.popBackStack()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun NodeDetailsScreen(
+    model: UIViewModel = hiltViewModel(),
+    nodeNum: Int? = null,
+    navigateBack: () -> Unit,
+) {
+    val ourNodeInfo by model.ourNodeInfo.collectAsStateWithLifecycle()
+    val detailsNodeInfo by model.getNodeByNum(nodeNum ?: ourNodeInfo?.num ?: 0)
+        .collectAsStateWithLifecycle()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("Node Details: ${detailsNodeInfo?.user?.shortName}")
+                },
+                navigationIcon = {
+                    IconButton(onClick = navigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Localized description"
+                        )
+                    }
+                }
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                modifier = Modifier.padding(8.dp),
+                text = detailsNodeInfo?.user?.longName.orEmpty(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -81,6 +81,10 @@ class UsersFragment : ScreenFragment("Users"), Logging {
                 R.id.remote_admin -> {
                     navigateToRadioConfig(node)
                 }
+
+                R.id.more_details -> {
+                    navigateToMoreDetails(node)
+                }
             }
         }
     }
@@ -94,6 +98,11 @@ class UsersFragment : ScreenFragment("Users"), Logging {
     private fun navigateToRadioConfig(node: NodeInfo) {
         info("calling RadioConfig --> destNum: ${node.num}")
         parentFragmentManager.navigateToRadioConfig(node.num)
+    }
+
+    private fun navigateToMoreDetails(node: NodeInfo) {
+        info("calling MoreDetails --> destNum: ${node.num}")
+        parentFragmentManager.navigateToNodeDetails(node.num)
     }
 
 

--- a/app/src/main/res/menu/menu_nodes.xml
+++ b/app/src/main/res/menu/menu_nodes.xml
@@ -23,6 +23,10 @@
             android:id="@+id/remove"
             android:title="@string/remove"
             app:showAsAction="withText" />
+        <item
+            android:id="@+id/more_details"
+            android:title="@string/more_details"
+            app:showAsAction="withText" />
     </group>
     <group android:id="@+id/group_admin">
         <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="node_sort_last_heard">Last heard</string>
     <string name="node_sort_via_mqtt">via MQTT</string>
 
+    <string name="more_details">More Details</string>
+
     <string name="elevation_suffix" translatable="false">MSL</string>
 
     <string name="channel_name">Channel Name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -216,4 +216,5 @@
     <string name="scanned_channels">Scanned Channels</string>
     <string name="current_channels">Current Channels</string>
     <string name="replace">Replace</string>
+    <string name="navigate_back">Navigate Back</string>
 </resources>


### PR DESCRIPTION
This commit introduces a new "More Details" screen for nodes, accessible via the node chip's context menu.
![image](https://github.com/user-attachments/assets/9f573d23-f91f-426e-9946-69f457677a13) ![Screenshot_20240801_125524 (1)](https://github.com/user-attachments/assets/fb9126e4-3ec4-4048-9469-dc36d222eff4)
