### PR TITLE
Fix: Colored transparent precision circles around nodes on map

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
@@ -27,8 +27,8 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
     }
 
     @Suppress("MagicNumber")
-    private val precisionMeters =
-        when (precisionBits) {
+    private fun getPrecisionMeters(): Double? {
+        return when (precisionBits) {
             10 -> 23345.484932
             11 -> 11672.7369
             12 -> 5836.36288
@@ -41,6 +41,7 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
             19 -> 45.58554
             else -> null
         }
+    }
 
 
     private var onLongClickListener: (() -> Boolean)? = null
@@ -96,7 +97,7 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
         c.drawText(mLabel, (p.x - 0F), (p.y - LABEL_Y_OFFSET), textPaint)
         mEmoji?.let { c.drawText(it, (p.x - 0f), (p.y - 30f), emojiPaint) }
 
-        precisionMeters?.let { radius ->
+        getPrecisionMeters()?.let { radius ->
             val polygon = Polygon(osmv).apply {
                 points = Polygon.pointsAsCircle(
                     position,

--- a/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
@@ -7,6 +7,7 @@ import android.graphics.RectF
 import android.view.MotionEvent
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
+import org.osmdroid.views.overlay.Polygon
 
 class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) : Marker(mapView) {
 
@@ -14,6 +15,33 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
         private const val LABEL_CORNER_RADIUS = 12F
         private const val LABEL_Y_OFFSET = 100F
     }
+
+    private var nodeColor: Int = Color.GRAY
+    fun setNodeColors(colors: Pair<Int, Int>) {
+        nodeColor = colors.first
+    }
+
+    private var precisionBits: Int? = null
+    fun setPrecisionBits(bits: Int) {
+        precisionBits = bits
+    }
+
+    @Suppress("MagicNumber")
+    private val precisionMeters =
+        when (precisionBits) {
+            10 -> 23345.484932
+            11 -> 11672.7369
+            12 -> 5836.36288
+            13 -> 2918.175876
+            14 -> 1459.0823719999053
+            15 -> 729.53562
+            16 -> 364.7622
+            17 -> 182.375556
+            18 -> 91.182212
+            19 -> 45.58554
+            else -> null
+        }
+
 
     private var onLongClickListener: (() -> Boolean)? = null
 
@@ -57,6 +85,7 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
         return super.onLongPress(event, mapView)
     }
 
+    @Suppress("MagicNumber")
     override fun draw(c: Canvas, osmv: MapView?, shadow: Boolean) {
         super.draw(c, osmv, false)
         val p = mPositionPixels
@@ -66,6 +95,23 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
         c.drawRoundRect(bgRect, LABEL_CORNER_RADIUS, LABEL_CORNER_RADIUS, bgPaint)
         c.drawText(mLabel, (p.x - 0F), (p.y - LABEL_Y_OFFSET), textPaint)
         mEmoji?.let { c.drawText(it, (p.x - 0f), (p.y - 30f), emojiPaint) }
-    }
 
+        precisionMeters?.let { radius ->
+            val polygon = Polygon(osmv).apply {
+                points = Polygon.pointsAsCircle(
+                    position,
+                    radius
+                )
+                fillPaint.apply {
+                    color = nodeColor
+                    alpha = 48
+                }
+                outlinePaint.apply {
+                    color = nodeColor
+                    alpha = 64
+                }
+            }
+            polygon.draw(c, osmv, false)
+        }
+    }
 }

--- a/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
@@ -18,7 +18,7 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
 
     private var nodeColor: Int = Color.GRAY
     fun setNodeColors(colors: Pair<Int, Int>) {
-        nodeColor = colors.first
+        nodeColor = colors.second
     }
 
     private var precisionBits: Int? = null


### PR DESCRIPTION
This updates precision circles around nodes on the map to better visually represent the accuracy of their positions. The circles are now colored according to the node's color and are now more transparent.

This adds precision circle to the `MarkerLabel` canvas, so it can be managed alongside markers. This fixes the redraw on zoom issue that users were experiencing.
