### PR TITLE
chore: Add issue templates and disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug"]
+projects: ["meshtastic/Meshtastic-Android"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com, discord username
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: app_version
+    attributes:
+      label: App Version
+      description: What version of Meshtastic Android are you running?
+      placeholder: 2.4.1
+    validations:
+      required: true
+  - type: textarea
+    id: phone
+    attributes:
+      label: Phone
+      description: What phone/tablet and OS are you running it on?
+      placeholder: Pixel 8a, Android 15
+    validations:
+      required: true
+  - type: textarea
+    id: radio
+    attributes:
+      label: Device
+      description: Which meshtastic radio device are you connecting to?
+      placeholder: heltec v3
+    validations:
+      required: true
+  - type: textarea
+    id: firmware
+    attributes:
+      label: Firmware
+      description: Which meshtastic firmware is running on the device?
+      placeholder: 2.4.1.394e0e1 Beta
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://meshtastic.org/docs/legal/conduct/).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Meshtastic-Android Discussions
+    url: https://github.com/meshtastic/Meshtastic-Android/discussions
+    about: Please ask and answer questions here.
+  - name: Meshtastic Website
+    url: https://meshtastic.org/
+    about: Docs and other ways to contact us here.
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: File a request for new feature or functionality.
+title: "[Feature Request]: "
+labels: ["enhancement"]
+projects: ["meshtastic/Meshtastic-Android"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com, discord username
+    validations:
+      required: false
+  - type: textarea
+    id: request
+    attributes:
+      label: Tell us your idea.
+      description: Tell us what you'd like the app to do. Give as much detail as you can.
+      placeholder: Your idea
+      value: "I'd like the app to..."
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://meshtastic.org/docs/legal/conduct/).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
This commit adds feature request and bug report templates to the repository. It also disables the ability to create blank issues, requiring users to use one of the provided templates.