### PR TITLE
Instead of last position, show last activity time (packet) on map marker

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
@@ -245,7 +245,7 @@ fun MapView(
             val (p, u) = node.position!! to node.user!!
             MarkerWithLabel(
                 mapView = this,
-                label = "${u.shortName} ${formatAgo(p.time)}"
+                label = "${u.shortName} ${formatAgo(node.lastHeard)}"
             ).apply {
                 id = u.id
                 title = "${u.longName} ${node.batteryStr}"


### PR DESCRIPTION
Instead of displaying the last received position time on the map (which might be updated infrequently and can cause confusion by suggesting that a given node was last heard from a long time ago), I propose showing the time of the last received packet instead.