### PR TITLE
Node Packet Counter

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,15 +2,39 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
   </profile>

--- a/app/schemas/com.geeksville.mesh.database.MeshtasticDatabase/9.json
+++ b/app/schemas/com.geeksville.mesh.database.MeshtasticDatabase/9.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 9,
-    "identityHash": "dc2d59cd4747857da210b4cf21de549c",
+    "identityHash": "cfce409437d68cdbeb5e4307483de717",
     "entities": [
       {
         "tableName": "MyNodeInfo",
@@ -98,7 +98,7 @@
       },
       {
         "tableName": "NodeInfo",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `snr` REAL NOT NULL, `rssi` INTEGER NOT NULL, `lastHeard` INTEGER NOT NULL, `channel` INTEGER NOT NULL, `hopsAway` INTEGER NOT NULL DEFAULT 0, `user_id` TEXT, `user_longName` TEXT, `user_shortName` TEXT, `user_hwModel` TEXT, `user_isLicensed` INTEGER, `user_role` INTEGER DEFAULT 0, `position_latitude` REAL, `position_longitude` REAL, `position_altitude` INTEGER, `position_time` INTEGER, `position_satellitesInView` INTEGER, `position_groundSpeed` INTEGER, `position_groundTrack` INTEGER, `position_precisionBits` INTEGER, `devMetrics_time` INTEGER, `devMetrics_batteryLevel` INTEGER, `devMetrics_voltage` REAL, `devMetrics_channelUtilization` REAL, `devMetrics_airUtilTx` REAL, `devMetrics_uptimeSeconds` INTEGER, `envMetrics_time` INTEGER, `envMetrics_temperature` REAL, `envMetrics_relativeHumidity` REAL, `envMetrics_barometricPressure` REAL, `envMetrics_gasResistance` REAL, `envMetrics_voltage` REAL, `envMetrics_current` REAL, `envMetrics_iaq` INTEGER, PRIMARY KEY(`num`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `snr` REAL NOT NULL, `rssi` INTEGER NOT NULL, `lastHeard` INTEGER NOT NULL, `channel` INTEGER NOT NULL, `hopsAway` INTEGER NOT NULL DEFAULT 0, `sendPackets` INTEGER NOT NULL DEFAULT 0, `user_id` TEXT, `user_longName` TEXT, `user_shortName` TEXT, `user_hwModel` TEXT, `user_isLicensed` INTEGER, `user_role` INTEGER DEFAULT 0, `position_latitude` REAL, `position_longitude` REAL, `position_altitude` INTEGER, `position_time` INTEGER, `position_satellitesInView` INTEGER, `position_groundSpeed` INTEGER, `position_groundTrack` INTEGER, `position_precisionBits` INTEGER, `devMetrics_time` INTEGER, `devMetrics_batteryLevel` INTEGER, `devMetrics_voltage` REAL, `devMetrics_channelUtilization` REAL, `devMetrics_airUtilTx` REAL, `devMetrics_uptimeSeconds` INTEGER, `envMetrics_time` INTEGER, `envMetrics_temperature` REAL, `envMetrics_relativeHumidity` REAL, `envMetrics_barometricPressure` REAL, `envMetrics_gasResistance` REAL, `envMetrics_voltage` REAL, `envMetrics_current` REAL, `envMetrics_iaq` INTEGER, PRIMARY KEY(`num`))",
         "fields": [
           {
             "fieldPath": "num",
@@ -133,6 +133,13 @@
           {
             "fieldPath": "hopsAway",
             "columnName": "hopsAway",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sendPackets",
+            "columnName": "sendPackets",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
@@ -514,7 +521,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dc2d59cd4747857da210b4cf21de549c')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cfce409437d68cdbeb5e4307483de717')"
     ]
   }
 }

--- a/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
+++ b/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
@@ -55,6 +55,7 @@ interface IMeshService {
 
     void setRemoteOwner(in int requestId, in byte []payload);
     void getRemoteOwner(in int requestId, in int destNum);
+    void updatePacketResetCounterInterval(in int interval);
 
     /// Return my unique user ID string
     String getMyId();

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -664,6 +664,10 @@ class MainActivity : AppCompatActivity(), Logging {
                 supportFragmentManager.navigateToRadioConfig()
                 return true
             }
+            R.id.application_config -> {
+                supportFragmentManager.navigateToApplicationConfig()
+                return true
+            }
             R.id.save_messages_csv -> {
                 val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
                     addCategory(Intent.CATEGORY_OPENABLE)

--- a/app/src/main/java/com/geeksville/mesh/NodeInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/NodeInfo.kt
@@ -233,7 +233,9 @@ data class NodeInfo(
     @Embedded(prefix = "envMetrics_")
     var environmentMetrics: EnvironmentMetrics? = null,
     @ColumnInfo(name = "hopsAway", defaultValue = "0")
-    var hopsAway: Int = 0
+    var hopsAway: Int = 0,
+    @ColumnInfo(name = "sendPackets", defaultValue = "0")
+    var sendPackets: Int = 0
 ) : Parcelable {
 
     val colors: Pair<Int, Int>

--- a/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
@@ -6,6 +6,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.geeksville.mesh.MyNodeInfo
 import com.geeksville.mesh.NodeInfo
 import com.geeksville.mesh.database.dao.PacketDao
@@ -34,7 +36,7 @@ import com.geeksville.mesh.database.entity.QuickChatAction
         AutoMigration (from = 7, to = 8),
         AutoMigration (from = 8, to = 9),
     ],
-    version = 9,
+    version = 10,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)
@@ -45,6 +47,14 @@ abstract class MeshtasticDatabase : RoomDatabase() {
     abstract fun quickChatActionDao(): QuickChatActionDao
 
     companion object {
+
+        // Adds sendPackets column for statistics purposes
+        val MIGRATION_9_10 = object : Migration(11, 12) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE NodeInfo ADD COLUMN sendPackets INTEGER DEFAULT 0 NOT NULL")
+            }
+        }
+
         fun getDatabase(context: Context): MeshtasticDatabase {
 
             return Room.databaseBuilder(

--- a/app/src/main/java/com/geeksville/mesh/model/ApplicationConfigViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/ApplicationConfigViewModel.kt
@@ -1,0 +1,48 @@
+package com.geeksville.mesh.model
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import com.geeksville.mesh.android.Logging
+import com.geeksville.mesh.repository.datastore.ApplicationConfigRepository
+import com.geeksville.mesh.service.ServiceRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+data class ApplicationConfigState(
+    val route: String = "",
+    val nodeListConfig: NodeListConfig = NodeListConfig()
+)
+
+@HiltViewModel
+class ApplicationConfigViewModel @Inject constructor(
+    private val app: Application,
+    private val applicationConfigRepository: ApplicationConfigRepository,
+    private val serviceRepository: ServiceRepository,
+
+    ) : ViewModel(), Logging {
+
+    private val _applicationConfigState = MutableStateFlow(ApplicationConfigState())
+    val applicationConfigState: StateFlow<ApplicationConfigState> = _applicationConfigState
+
+    init {
+        loadConfig()
+    }
+
+    private fun loadConfig() {
+        val savedConfig = applicationConfigRepository.getNodeListConfig()
+        _applicationConfigState.value = _applicationConfigState.value.copy(
+            nodeListConfig = savedConfig
+        )
+    }
+
+    fun saveNodeListConfig(config: NodeListConfig) {
+        _applicationConfigState.update { it.copy(nodeListConfig = config) }
+        applicationConfigRepository.saveNodeListConfig(config)
+        serviceRepository.meshService?.updatePacketResetCounterInterval(config.interval)
+
+    }
+
+}

--- a/app/src/main/java/com/geeksville/mesh/model/NodeListConfig.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/NodeListConfig.kt
@@ -1,0 +1,8 @@
+package com.geeksville.mesh.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NodeListConfig(
+    var interval: Int = 7200,
+)

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/ApplicationConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/ApplicationConfigRepository.kt
@@ -1,0 +1,33 @@
+package com.geeksville.mesh.repository.datastore
+
+import android.content.Context
+import com.geeksville.mesh.model.NodeListConfig
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+
+/**
+ * Class responsible for application configuration data.
+ */
+class ApplicationConfigRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    private val sharedPreferences = context.getSharedPreferences("app_preferences", Context.MODE_PRIVATE)
+
+    fun getNodeListConfig(): NodeListConfig {
+        val jsonString = sharedPreferences.getString("node_list_config", null)
+        return if (jsonString != null) {
+            Json.decodeFromString(jsonString)
+        } else {
+            NodeListConfig()
+        }
+    }
+
+    fun saveNodeListConfig(config: NodeListConfig) {
+        val jsonString = Json.encodeToString(config)
+        sharedPreferences.edit().putString("node_list_config", jsonString).apply()
+    }
+
+}

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -635,6 +635,8 @@ class MeshService : Service(), Logging {
             val fromId = toNodeID(packet.from)
             val dataPacket = toDataPacket(packet)
 
+            handleReceivedPacket(packet.from)
+
             if (dataPacket != null) {
 
                 // We ignore most messages that we sent
@@ -789,6 +791,13 @@ class MeshService : Service(), Logging {
                     warn("No special processing needed for ${a.payloadVariantCase}")
 
             }
+        }
+    }
+
+    /// Update our DB user send packets counter by one
+    private fun handleReceivedPacket(fromNodeNum: Int){
+        updateNodeInfo(fromNodeNum) {
+            it.sendPackets += 1
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/ApplicationSettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ApplicationSettingsFragment.kt
@@ -1,0 +1,225 @@
+package com.geeksville.mesh.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Card
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.twotone.KeyboardArrowRight
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.viewModels
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.geeksville.mesh.R
+import com.geeksville.mesh.android.Logging
+import com.geeksville.mesh.model.ApplicationConfigViewModel
+import com.geeksville.mesh.ui.components.PreferenceCategory
+import com.geeksville.mesh.ui.components.config.application.NodeListConfigItemList
+import com.google.accompanist.themeadapter.appcompat.AppCompatTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+internal fun FragmentManager.navigateToApplicationConfig() {
+    val applicationConfigFragment = ApplicationSettingsFragment().apply {}
+    beginTransaction()
+        .replace(R.id.mainActivityLayout, applicationConfigFragment)
+        .addToBackStack(null)
+        .commit()
+}
+
+@AndroidEntryPoint
+class ApplicationSettingsFragment : ScreenFragment("Application Configuration"), Logging {
+
+    private val model: ApplicationConfigViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setBackgroundColor(ContextCompat.getColor(context, R.color.colorAdvancedBackground))
+            setContent {
+
+                AppCompatTheme {
+                    val navController: NavHostController = rememberNavController()
+                    Scaffold(
+                        topBar = {
+                            MeshAppBar(
+                                currentScreen = stringResource(R.string.application_settings),
+                                canNavigateBack = true,
+                                navigateUp = {
+                                    if (navController.previousBackStackEntry != null) {
+                                        navController.navigateUp()
+                                    } else {
+                                        parentFragmentManager.popBackStack()
+                                    }
+                                },
+                            )
+                        }
+                    ) { innerPadding ->
+                        ApplicationConfigNavHost(
+                            viewModel = model,
+                            navController = navController,
+                            modifier = Modifier.padding(innerPadding),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum class ApplicationConfigRoute(val title: String, val configType: Int = 0) {
+    NODE_LIST("Node packets"),
+    ;
+}
+
+@Composable
+private fun MeshAppBar(
+    currentScreen: String,
+    canNavigateBack: Boolean,
+    navigateUp: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TopAppBar(
+        title = { Text(currentScreen) },
+        modifier = modifier,
+        navigationIcon = {
+            if (canNavigateBack) {
+                IconButton(onClick = navigateUp) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        null,
+                    )
+                }
+            }
+        }
+    )
+}
+
+@Composable
+fun ApplicationConfigNavHost(
+    viewModel: ApplicationConfigViewModel = hiltViewModel(),
+    navController: NavHostController = rememberNavController(),
+    modifier: Modifier,
+) {
+
+    val appConfigState by viewModel.applicationConfigState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    NavHost(
+        navController = navController,
+        startDestination = "home",
+        modifier = modifier,
+    ) {
+        composable("home") {
+            ApplicationSettingsScreen(
+                enabled = true,
+                onRouteClick = { route ->
+                    when (route) {
+                        ApplicationConfigRoute.NODE_LIST -> {
+                            navController.navigate(ApplicationConfigRoute.NODE_LIST.name)
+                        }
+                    }
+                },
+            )
+        }
+        composable(ApplicationConfigRoute.NODE_LIST.name) {
+            NodeListConfigItemList(
+                nodeConfig = appConfigState.nodeListConfig,
+                onSaveClicked = { nodeListConfig ->
+                    viewModel.saveNodeListConfig(nodeListConfig)
+                    Toast.makeText(context, "Settings saved successfully", Toast.LENGTH_SHORT).show()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun NavCard(
+    title: String,
+    enabled: Boolean,
+    onClick: () -> Unit
+) {
+    val color = if (enabled) MaterialTheme.colors.onSurface
+    else MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.disabled)
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp)
+            .clickable(enabled = enabled) { onClick() },
+        elevation = 4.dp
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 12.dp, horizontal = 12.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.body1,
+                color = color,
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                Icons.AutoMirrored.TwoTone.KeyboardArrowRight, "trailingIcon",
+                modifier = Modifier.wrapContentSize(),
+                tint = color,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ApplicationSettingsScreen(
+    enabled: Boolean = true,
+    onRouteClick: (Any) -> Unit = {},
+) {
+    LazyColumn(
+        modifier = Modifier.padding(horizontal = 16.dp)
+    ) {
+        item { PreferenceCategory(stringResource(R.string.node_list)) }
+        items(ApplicationConfigRoute.entries) { NavCard(it.title, enabled = enabled) { onRouteClick(it) } }
+
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ApplicationSettingsScreenPreview() {
+    ApplicationSettingsScreen()
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeInfo.kt
@@ -128,6 +128,7 @@ fun NodeInfo(
                         modifier = Modifier
                             .fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Chip(
                             modifier = Modifier
@@ -161,6 +162,11 @@ fun NodeInfo(
                         LastHeardInfo(
                             lastHeard = thatNodeInfo.lastHeard,
                             currentTimeMillis = currentTimeMillis
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+
+                        PacketCounterInfo(
+                            packets = thatNodeInfo.sendPackets
                         )
                     }
                     Row(

--- a/app/src/main/java/com/geeksville/mesh/ui/PacketCounterInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/PacketCounterInfo.kt
@@ -1,0 +1,53 @@
+package com.geeksville.mesh.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.geeksville.mesh.R
+import com.geeksville.mesh.ui.theme.AppTheme
+
+@Composable
+fun PacketCounterInfo(
+    modifier: Modifier = Modifier,
+    packets: Int,
+) {
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        Icon(
+            modifier = Modifier.height(18.dp),
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_twotone_layers_24),
+            contentDescription = null,
+            tint = MaterialTheme.colors.onSurface,
+        )
+        Text(
+            text = packets.toString(),
+            color = MaterialTheme.colors.onSurface,
+            fontSize = MaterialTheme.typography.button.fontSize
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+fun PacketCounterPreview() {
+    AppTheme {
+        LastHeardInfo(
+            lastHeard = (System.currentTimeMillis() / 1000).toInt() - 8600,
+            currentTimeMillis = System.currentTimeMillis()
+        )
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/components/config/application/NodeListConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/config/application/NodeListConfigItemList.kt
@@ -1,0 +1,78 @@
+package com.geeksville.mesh.ui.components.config.application
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import com.geeksville.mesh.model.NodeListConfig
+import com.geeksville.mesh.ui.components.EditTextPreference
+import com.geeksville.mesh.ui.components.PreferenceCategory
+import com.geeksville.mesh.ui.components.PreferenceFooter
+
+@Composable
+fun NodeListConfigItemList(
+    nodeConfig: NodeListConfig,
+    onSaveClicked: (NodeListConfig) -> Unit,
+) {
+    val focusManager = LocalFocusManager.current
+
+    var nodeConfigInput by remember { mutableStateOf(nodeConfig) }
+
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        item { PreferenceCategory(text = "Node list") }
+        item { Divider() }
+        item {
+            EditTextPreference(title = "Packet counter reset interval (seconds)",
+                value = nodeConfigInput.interval.toString(),
+                enabled = true,
+                isError = false,
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    keyboardType = KeyboardType.Number, imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+                onValueChanged = { newValue ->
+                    val interval = newValue.toIntOrNull()?.takeIf { it >= 0 } ?: 0
+                    nodeConfigInput = nodeConfigInput.copy(interval = interval)
+                })
+        }
+        item { Divider() }
+
+        item {
+            PreferenceFooter(
+                enabled = true,
+                onCancelClicked = {
+                    focusManager.clearFocus()
+                    nodeConfigInput = nodeConfig
+                },
+                onSaveClicked = {
+                    focusManager.clearFocus()
+                    onSaveClicked(nodeConfigInput)
+
+                }
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun UserConfigPreview() {
+    NodeListConfigItemList(
+        nodeConfig = NodeListConfig(),
+        onSaveClicked = { }
+    )
+}

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -11,7 +11,6 @@
         android:title="@string/disconnected"
         app:showAsAction="ifRoom"
         />
-
     <item
         android:id="@+id/debug"
         android:title="@string/debug_panel"
@@ -25,6 +24,10 @@
         android:id="@+id/radio_config"
         app:showAsAction="withText"
         android:title="@string/device_settings" />
+    <item
+        android:id="@+id/application_config"
+        app:showAsAction="withText"
+        android:title="@string/application_settings" />
     <item
         android:id="@+id/save_messages_csv"
         app:showAsAction="withText"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,4 +212,7 @@
         <item quantity="other">Do you want to add %d new channels?</item>
     </plurals>
     <string name="replace">Replace</string>
+    <string name="application_settings">Application settings</string>
+    <string name="node_settings">Node settings</string>
+    <string name="node_list">Node list</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ buildscript {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.4'
 
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
+
+        // application config serialization
+        classpath "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2"
+
     }
 }
 
@@ -37,6 +41,7 @@ plugins {
     id "org.jetbrains.kotlin.jvm" version "$kotlin_version" apply false
     id "com.google.devtools.ksp" version "2.0.10-1.0.24" apply false
     id "org.jetbrains.kotlin.plugin.compose" version "$kotlin_version" apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.10' apply false
 }
 
 allprojects {


### PR DESCRIPTION
I’ve implemented a packet counter column. This feature, while targeted towards advanced users, provides valuable statistical insights that can greatly enhance network analysis and optimization.

![packet_counter_v2](https://github.com/user-attachments/assets/818672a1-56fa-4e9c-8406-b258a28f025c)


**Benefits**:

- Network Load Analysis: The packet counter helps identify nodes that heavily load the network, enabling users to diagnose and mitigate potential bottlenecks, trolls or badly configured nodes.
- Antenna Tuning: Users can evaluate the effectiveness of different antennas by analyzing packet counts, aiding in fine-tuning for optimal performance.
- Node Discovery: This feature is useful for locating distant nodes, which is critical in scenarios like search and rescue or in remote areas.
- Enhanced Functionality: Currently, users mainly rely on node observations, last activity times, or sending Traceroute pings. The packet counter adds another layer of functionality, enriching the experience for advanced users and providing them with more tools for network analysis.

**Potential Drawbacks**:

- Interface Complexity: Adding another column may add complexity to the UI, which could be overwhelming for less experienced users.

Overall, this enhancement offers significant benefits for users needing deeper network insights, and I believe it will be a valuable addition to the project. This is just a suggestion based on needs of my community.