### PR TITLE
feat: Add ability to display environment metrics in Fahrenheit

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -30,7 +30,7 @@ data class MetricsState(
     val isLoading: Boolean = false,
     val deviceMetrics: List<Telemetry> = emptyList(),
     val environmentMetrics: List<Telemetry> = emptyList(),
-    val environmentDisplayTempInFahrenheit: Boolean = false,
+    val environmentDisplayFahrenheit: Boolean = false,
 ) {
     companion object {
         val Empty = MetricsState()
@@ -58,7 +58,7 @@ class MetricsViewModel @Inject constructor(
             isLoading = isLoading,
             deviceMetrics = device,
             environmentMetrics = environment,
-            environmentDisplayTempInFahrenheit = profile.moduleConfig.telemetry.environmentDisplayFahrenheit,
+            environmentDisplayFahrenheit = profile.moduleConfig.telemetry.environmentDisplayFahrenheit,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/app/src/main/java/com/geeksville/mesh/ui/MetricsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MetricsFragment.kt
@@ -179,7 +179,7 @@ fun MetricsPagerScreen(
                     MetricsPage.DEVICE -> DeviceMetricsScreen(deviceMetrics)
                     MetricsPage.ENVIRONMENT -> EnvironmentMetricsScreen(
                         environmentMetrics,
-                        state.environmentDisplayTempInFahrenheit
+                        state.environmentDisplayFahrenheit
                     )
                 }
             }

--- a/app/src/main/java/com/geeksville/mesh/ui/MetricsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MetricsFragment.kt
@@ -70,8 +70,9 @@ class MetricsFragment : ScreenFragment("Metrics"), Logging {
         savedInstanceState: Bundle?
     ): View {
         val nodeNum = arguments?.getInt("nodeNum")
-        if (nodeNum != null)
+        if (nodeNum != null) {
             model.setSelectedNode(nodeNum)
+        }
 
         val nodeName = model.getNodeName(nodeNum ?: 0)
 
@@ -176,7 +177,10 @@ fun MetricsPagerScreen(
             } else {
                 when (pages[index]) {
                     MetricsPage.DEVICE -> DeviceMetricsScreen(deviceMetrics)
-                    MetricsPage.ENVIRONMENT -> EnvironmentMetricsScreen(environmentMetrics)
+                    MetricsPage.ENVIRONMENT -> EnvironmentMetricsScreen(
+                        environmentMetrics,
+                        state.environmentDisplayTempInFahrenheit
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
@@ -42,7 +42,7 @@ import com.geeksville.mesh.ui.components.CommonCharts.MS_PER_SEC
 import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 
 
-private val ENVIRONMENT_METRICS_COLORS = listOf(Color.Red, Color.Blue)
+private val ENVIRONMENT_METRICS_COLORS = listOf(Color.Red, Color.Blue, Color.Green)
 
 @Composable
 fun EnvironmentMetricsScreen(telemetries: List<Telemetry>, environmentDisplayFahrenheit: Boolean) {

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
@@ -45,6 +45,7 @@ import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 @Composable
 fun EnvironmentMetricsScreen(telemetries: List<Telemetry>, environmentDisplayFahrenheit: Boolean) {
     /* Convert Celsius to Fahrenheit */
+    @Suppress("MagicNumber")
     fun celsiusToFahrenheit(celsius: Float): Float {
         return (celsius * 1.8F) + 32
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
 import com.geeksville.mesh.TelemetryProtos.Telemetry
 import com.geeksville.mesh.copy
-import com.geeksville.mesh.ui.components.CommonCharts.ENVIRONMENT_METRICS_COLORS
 import com.geeksville.mesh.ui.components.CommonCharts.LEFT_CHART_SPACING
 import com.geeksville.mesh.ui.components.CommonCharts.MS_PER_SEC
 import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT


### PR DESCRIPTION
The temperature values in the
 environment metrics charts and cards are now displayed in Fahrenheit or Celsius based on the user's preference.
Celsius is still used as the base unit for calculations and storage.
 
resolves #1251