### PR TITLE
Fix lat/lng/alt config validation errors when position is null

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/DeviceSettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/DeviceSettingsFragment.kt
@@ -57,6 +57,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.geeksville.mesh.NodeInfo
+import com.geeksville.mesh.Position
 import com.geeksville.mesh.R
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.config
@@ -413,12 +414,12 @@ fun RadioConfigNavHost(
         }
         composable(ConfigRoute.POSITION.name) {
             PositionConfigItemList(
-                location = node?.position,
+                location = node?.position ?: Position(0.0, 0.0, 0),
                 positionConfig = radioConfigState.radioConfig.position,
                 enabled = connected,
                 onSaveClicked = { locationInput, positionInput ->
                     if (positionInput.fixedPosition) {
-                        if (locationInput != null && locationInput != node?.position) {
+                        if (locationInput != node?.position) {
                             viewModel.setFixedPosition(destNum, locationInput)
                         }
                     } else {

--- a/app/src/main/java/com/geeksville/mesh/ui/components/config/PositionConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/config/PositionConfigItemList.kt
@@ -26,10 +26,10 @@ import com.geeksville.mesh.ui.components.SwitchPreference
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 fun PositionConfigItemList(
-    location: Position?,
+    location: Position,
     positionConfig: PositionConfig,
     enabled: Boolean,
-    onSaveClicked: (position: Position?, config: PositionConfig) -> Unit,
+    onSaveClicked: (position: Position, config: PositionConfig) -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
     var locationInput by rememberSaveable { mutableStateOf(location) }
@@ -93,31 +93,31 @@ fun PositionConfigItemList(
         if (positionInput.fixedPosition) {
             item {
                 EditTextPreference(title = "Latitude",
-                    value = locationInput?.latitude ?: 0.0,
+                    value = locationInput.latitude,
                     enabled = enabled,
                     keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                     onValueChanged = { value ->
                         if (value >= -90 && value <= 90.0)
-                            locationInput?.let { locationInput = it.copy(latitude = value) }
+                            locationInput = locationInput.copy(latitude = value)
                     })
             }
             item {
                 EditTextPreference(title = "Longitude",
-                    value = locationInput?.longitude ?: 0.0,
+                    value = locationInput.longitude,
                     enabled = enabled,
                     keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                     onValueChanged = { value ->
                         if (value >= -180 && value <= 180.0)
-                            locationInput?.let { locationInput = it.copy(longitude = value) }
+                            locationInput = locationInput.copy(longitude = value)
                     })
             }
             item {
                 EditTextPreference(title = "Altitude (meters)",
-                    value = locationInput?.altitude ?: 0,
+                    value = locationInput.altitude,
                     enabled = enabled,
                     keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                     onValueChanged = { value ->
-                        locationInput?.let { locationInput = it.copy(altitude = value) }
+                        locationInput = locationInput.copy(altitude = value)
                     })
             }
         }
@@ -196,7 +196,7 @@ fun PositionConfigItemList(
 @Composable
 private fun PositionConfigPreview() {
     PositionConfigItemList(
-        location = null,
+        location = Position(0.0, 0.0, 0),
         positionConfig = PositionConfig.getDefaultInstance(),
         enabled = true,
         onSaveClicked = { _, _ -> },


### PR DESCRIPTION
This fixes persistent validation errors when setting fixed latitude, longitude and altitude when the Position object is null.

Root issue: state comparison always fails during error checking when passing a literal double or int value into EditTextPreference (in this case 0.0 for lat and lng, and 0 for altitude).