### PR TITLE
refactor(NodeItem): replace `NodeInfo` with `NodeEntity`

### DIFF
--- a/app/src/androidTest/java/com/geeksville/mesh/NodeInfoDaoTest.kt
+++ b/app/src/androidTest/java/com/geeksville/mesh/NodeInfoDaoTest.kt
@@ -140,7 +140,9 @@ class NodeInfoDaoTest {
     @Test
     fun testSortByDistance() = runBlocking {
         val nodes = getNodes(sort = NodeSortOption.DISTANCE)
-        val sortedNodes = nodes.sortedBy { it.distance(ourNode) }
+        val sortedNodes = nodes.sortedWith( // nodes with invalid (null) positions at the end
+            compareBy<NodeEntity> { it.validPosition == null }.thenBy { it.distance(ourNode) }
+        )
         assertEquals(sortedNodes, nodes)
     }
 

--- a/app/src/main/java/com/geeksville/mesh/model/NodeDB.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/NodeDB.kt
@@ -3,10 +3,8 @@ package com.geeksville.mesh.model
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
 import com.geeksville.mesh.MyNodeInfo
-import com.geeksville.mesh.NodeInfo
 import com.geeksville.mesh.database.dao.NodeInfoDao
 import com.geeksville.mesh.database.entity.NodeEntity
-import com.geeksville.mesh.database.entity.toNodeInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,8 +24,8 @@ class NodeDB @Inject constructor(
     val myNodeInfo: StateFlow<MyNodeInfo?> get() = _myNodeInfo
 
     // our node info
-    private val _ourNodeInfo = MutableStateFlow<NodeInfo?>(null)
-    val ourNodeInfo: StateFlow<NodeInfo?> get() = _ourNodeInfo
+    private val _ourNodeInfo = MutableStateFlow<NodeEntity?>(null)
+    val ourNodeInfo: StateFlow<NodeEntity?> get() = _ourNodeInfo
 
     // The unique userId of our node
     private val _myId = MutableStateFlow<String?>(null)
@@ -47,7 +45,7 @@ class NodeDB @Inject constructor(
 
         nodeInfoDao.nodeDBbyNum().onEach {
             _nodeDBbyNum.value = it
-            val ourNodeInfo = it.values.firstOrNull()?.toNodeInfo()
+            val ourNodeInfo = it.values.firstOrNull()
             _ourNodeInfo.value = ourNodeInfo
             _myId.value = ourNodeInfo?.user?.id
         }.launchIn(processLifecycle.coroutineScope)

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -240,7 +240,7 @@ class UIViewModel @Inject constructor(
 
     // hardware info about our local device (can be null)
     val myNodeInfo: StateFlow<MyNodeInfo?> get() = nodeDB.myNodeInfo
-    val ourNodeInfo: StateFlow<NodeInfo?> get() = nodeDB.ourNodeInfo
+    val ourNodeInfo: StateFlow<NodeEntity?> get() = nodeDB.ourNodeInfo
 
     // FIXME only used in MapFragment
     val initialNodes get() = nodeDB.nodeDBbyNum.value.values.map { it.toNodeInfo() }
@@ -545,10 +545,15 @@ class UIViewModel @Inject constructor(
         }
     }
 
-    fun setOwner(user: MeshUser) {
+    fun setOwner(name: String) {
+        val user = ourNodeInfo.value?.user?.copy {
+            longName = name
+            shortName = getInitials(name)
+        } ?: return
+
         try {
             // Note: we use ?. here because we might be running in the emulator
-            meshService?.setOwner(user)
+            meshService?.setRemoteOwner(myNodeNum ?: return, user.toByteArray())
         } catch (ex: RemoteException) {
             errormsg("Can't set username on device, is device offline? ${ex.message}")
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -26,7 +26,6 @@ import com.geeksville.mesh.databinding.SettingsFragmentBinding
 import com.geeksville.mesh.model.BTScanModel
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
-import com.geeksville.mesh.model.getInitials
 import com.geeksville.mesh.repository.location.LocationRepository
 import com.geeksville.mesh.service.MeshService
 import com.geeksville.mesh.util.exceptionToSnackbar
@@ -218,10 +217,7 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         binding.usernameEditText.onEditorAction(EditorInfo.IME_ACTION_DONE) {
             debug("received IME_ACTION_DONE")
             val n = binding.usernameEditText.text.toString().trim()
-            model.ourNodeInfo.value?.user?.let {
-                val user = it.copy(longName = n, shortName = getInitials(n))
-                if (n.isNotEmpty()) model.setOwner(user)
-            }
+            if (n.isNotEmpty()) model.setOwner(n)
             requireActivity().hideKeyboard()
         }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/SignalInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SignalInfo.kt
@@ -8,31 +8,31 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.geeksville.mesh.NodeInfo
 import com.geeksville.mesh.R
-import com.geeksville.mesh.ui.preview.NodeInfoPreviewParameterProvider
+import com.geeksville.mesh.database.entity.NodeEntity
+import com.geeksville.mesh.ui.preview.NodeEntityPreviewParameterProvider
 import com.geeksville.mesh.ui.theme.AppTheme
 
 @Composable
 fun signalInfo(
     modifier: Modifier = Modifier,
-    nodeInfo: NodeInfo,
+    node: NodeEntity,
     isThisNode: Boolean
 ): Boolean {
     val text = if (isThisNode) {
         stringResource(R.string.channel_air_util).format(
-            nodeInfo.deviceMetrics?.channelUtilization,
-            nodeInfo.deviceMetrics?.airUtilTx
+            node.deviceMetrics.channelUtilization,
+            node.deviceMetrics.airUtilTx
         )
     } else {
         buildList {
-            if (nodeInfo.channel > 0) add("ch:${nodeInfo.channel}")
-            if (nodeInfo.hopsAway == 0) {
-                if (nodeInfo.snr < 100F && nodeInfo.rssi < 0) {
-                    add("RSSI: %d SNR: %.1f".format(nodeInfo.rssi, nodeInfo.snr))
+            if (node.channel > 0) add("ch:${node.channel}")
+            if (node.hopsAway == 0) {
+                if (node.snr < 100F && node.rssi < 0) {
+                    add("RSSI: %d SNR: %.1f".format(node.rssi, node.snr))
                 }
             } else {
-                add("%s: %d".format(stringResource(R.string.hops_away), nodeInfo.hopsAway))
+                add("%s: %d".format(stringResource(R.string.hops_away), node.hopsAway))
             }
         }.joinToString(" ")
     }
@@ -54,15 +54,12 @@ fun signalInfo(
 fun SignalInfoSimplePreview() {
     AppTheme {
         signalInfo(
-            nodeInfo = NodeInfo(
+            node = NodeEntity(
                 num = 1,
-                position = null,
                 lastHeard = 0,
                 channel = 0,
                 snr = 12.5F,
                 rssi = -42,
-                deviceMetrics = null,
-                user = null,
                 hopsAway = 0
             ),
             isThisNode = false
@@ -73,12 +70,12 @@ fun SignalInfoSimplePreview() {
 @PreviewLightDark
 @Composable
 fun SignalInfoPreview(
-    @PreviewParameter(NodeInfoPreviewParameterProvider::class)
-    nodeInfo: NodeInfo
+    @PreviewParameter(NodeEntityPreviewParameterProvider::class)
+    node: NodeEntity
 ) {
     AppTheme {
         signalInfo(
-            nodeInfo = nodeInfo,
+            node = node,
             isThisNode = false
         )
     }
@@ -87,12 +84,12 @@ fun SignalInfoPreview(
 @Composable
 @PreviewLightDark
 fun SignalInfoSelfPreview(
-    @PreviewParameter(NodeInfoPreviewParameterProvider::class)
-    nodeInfo: NodeInfo
+    @PreviewParameter(NodeEntityPreviewParameterProvider::class)
+    node: NodeEntity
 ) {
     AppTheme {
         signalInfo(
-            nodeInfo = nodeInfo,
+            node = node,
             isThisNode = true
         )
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -133,7 +133,7 @@ fun NodesScreen(
     val state by model.nodesUiState.collectAsStateWithLifecycle()
 
     val nodes by model.nodeList.collectAsStateWithLifecycle()
-    val ourNodeInfo by model.ourNodeInfo.collectAsStateWithLifecycle()
+    val ourNode by model.ourNodeInfo.collectAsStateWithLifecycle()
 
     val listState = rememberLazyListState()
     val focusedNode by model.focusedNode.collectAsStateWithLifecycle()
@@ -172,8 +172,8 @@ fun NodesScreen(
         items(nodes, key = { it.num }) { node ->
             val nodeInfo = node.toNodeInfo()
             NodeItem(
-                thisNodeInfo = ourNodeInfo,
-                thatNodeInfo = nodeInfo,
+                thisNode = ourNode,
+                thatNode = node,
                 gpsFormat = state.gpsFormat,
                 distanceUnits = state.distanceUnits,
                 tempInFahrenheit = state.tempInFahrenheit,
@@ -185,7 +185,6 @@ fun NodesScreen(
                 blinking = nodeInfo == focusedNode,
                 expanded = state.showDetails,
                 currentTimeMillis = currentTimeMillis,
-                hasPublicKey = !node.user.publicKey.isEmpty
             )
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
@@ -318,7 +318,7 @@ fun MapView(
 
     fun MapView.onNodesChanged(nodes: Collection<NodeInfo>): List<MarkerWithLabel> {
         val nodesWithPosition = nodes.filter { it.validPosition != null }
-        val ourNode = model.ourNodeInfo.value
+        val ourNode = model.ourNodeInfo.value?.toNodeInfo()
         val gpsFormat = model.config.display.gpsFormat.number
         val displayUnits = model.config.display.units.number
         return nodesWithPosition.map { node ->

--- a/app/src/main/java/com/geeksville/mesh/ui/preview/NodeEntityPreviewParameterProvider.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/preview/NodeEntityPreviewParameterProvider.kt
@@ -1,0 +1,146 @@
+package com.geeksville.mesh.ui.preview
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.geeksville.mesh.DeviceMetrics.Companion.currentTime
+import com.geeksville.mesh.MeshProtos
+import com.geeksville.mesh.database.entity.NodeEntity
+import com.geeksville.mesh.deviceMetrics
+import com.geeksville.mesh.environmentMetrics
+import com.geeksville.mesh.paxcount
+import com.geeksville.mesh.position
+import com.geeksville.mesh.telemetry
+import com.geeksville.mesh.user
+import kotlin.random.Random
+
+class NodeEntityPreviewParameterProvider : PreviewParameterProvider<NodeEntity> {
+
+    val mickeyMouse = NodeEntity(
+        num = 1955,
+        user = user {
+            id = "mickeyMouseId"
+            longName = "Mickey Mouse"
+            shortName = "MM"
+            hwModel = MeshProtos.HardwareModel.TBEAM
+        },
+        longName = "Mickey Mouse",
+        shortName = "MM",
+        position = position {
+            latitudeI = 338125110
+            longitudeI = -1179189760
+            altitude = 138
+            satsInView = 4
+        },
+        latitude = 33.812511,
+        longitude = -117.918976,
+        lastHeard = currentTime(),
+        channel = 0,
+        snr = 12.5F,
+        rssi = -42,
+        deviceTelemetry = telemetry {
+            deviceMetrics = deviceMetrics {
+                channelUtilization = 2.4F
+                airUtilTx = 3.5F
+                batteryLevel = 85
+                voltage = 3.7F
+                uptimeSeconds = 3600
+            }
+        },
+        hopsAway = 0
+    )
+
+    private val minnieMouse = mickeyMouse.copy(
+        num = Random.nextInt(),
+        user = user {
+            longName = "Minnie Mouse"
+            shortName = "MiMo"
+            id = "minnieMouseId"
+            hwModel = MeshProtos.HardwareModel.HELTEC_V3
+        },
+        longName = "Minnie Mouse",
+        shortName = "MiMo",
+        snr = 12.5F,
+        rssi = -42,
+        position = position {},
+        latitude = 0.0,
+        longitude = 0.0,
+        hopsAway = 1
+    )
+
+    private val donaldDuck = NodeEntity(
+        num = Random.nextInt(),
+        position = position {
+            latitudeI = 338052347
+            longitudeI = -1179208460
+            altitude = 121
+            satsInView = 66
+        },
+        latitude = 33.8052347,
+        longitude = -117.9208460,
+        lastHeard = currentTime() - 300,
+        channel = 0,
+        snr = 12.5F,
+        rssi = -42,
+        deviceTelemetry = telemetry {
+            deviceMetrics = deviceMetrics {
+                channelUtilization = 2.4F
+                airUtilTx = 3.5F
+                batteryLevel = 85
+                voltage = 3.7F
+                uptimeSeconds = 3600
+            }
+        },
+        user = user {
+            id = "donaldDuckId"
+            longName = "Donald Duck, the Grand Duck of the Ducks"
+            shortName = "DoDu"
+            hwModel = MeshProtos.HardwareModel.HELTEC_V3
+        },
+        longName = "Donald Duck, the Grand Duck of the Ducks",
+        shortName = "DoDu",
+        environmentTelemetry = telemetry {
+            environmentMetrics = environmentMetrics {
+                temperature = 28.0F
+                relativeHumidity = 50.0F
+                barometricPressure = 1013.25F
+                gasResistance = 0.0F
+                voltage = 3.7F
+                current = 0.0F
+                iaq = 100
+            }
+        },
+        paxcounter = paxcount {
+            wifi = 30
+            ble = 39
+            uptime = 420
+        },
+        hopsAway = 2
+    )
+
+    private val unknown = donaldDuck.copy(
+        user = user {
+            id = "myId"
+            longName = "Meshtastic myId"
+            shortName = "myId"
+            hwModel = MeshProtos.HardwareModel.UNSET
+        },
+        longName = "Meshtastic myId",
+        shortName = null,
+        environmentTelemetry = telemetry {
+            environmentMetrics = environmentMetrics {}
+        },
+        paxcounter = paxcount {},
+    )
+
+    private val almostNothing = NodeEntity(
+        num = Random.nextInt(),
+    )
+
+    override val values: Sequence<NodeEntity>
+        get() = sequenceOf(
+            mickeyMouse, // "this" node
+            unknown,
+            almostNothing,
+            minnieMouse,
+            donaldDuck
+        )
+}

--- a/app/src/main/java/com/geeksville/mesh/util/LocationUtils.kt
+++ b/app/src/main/java/com/geeksville/mesh/util/LocationUtils.kt
@@ -58,6 +58,34 @@ object GPSFormat {
             MGRS.northing
         )
     }
+
+    fun toDEC(latitude: Double, longitude: Double): String {
+        return "%.5f %.5f".format(latitude, longitude).replace(",", ".")
+    }
+
+    fun toDMS(latitude: Double, longitude: Double): String {
+        val lat = degreesToDMS(latitude, true)
+        val lon = degreesToDMS(longitude, false)
+        fun string(a: Array<String>) = "%s°%s'%.5s\"%s".format(a[0], a[1], a[2], a[3])
+        return string(lat) + " " + string(lon)
+    }
+
+    fun toUTM(latitude: Double, longitude: Double): String {
+        val UTM = UTM.from(Point.point(longitude, latitude))
+        return "%s%s %.6s %.7s".format(UTM.zone, UTM.toMGRS().band, UTM.easting, UTM.northing)
+    }
+
+    fun toMGRS(latitude: Double, longitude: Double): String {
+        val MGRS = MGRS.from(Point.point(longitude, latitude))
+        return "%s%s %s%s %05d %05d".format(
+            MGRS.zone,
+            MGRS.band,
+            MGRS.column,
+            MGRS.row,
+            MGRS.easting,
+            MGRS.northing
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
Continued work on #1250 to decouple the `NodeInfo` API layer from the database by using `NodeEntity`.