### PR TITLE
Complete request future if response is a ClientNotification

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1533,6 +1533,8 @@ class MeshService : Service(), Logging {
     private fun handleClientNotification(notification: MeshProtos.ClientNotification) {
         debug("Received clientNotification ${notification.toOneLineString()}")
         radioConfigRepository.setErrorMessage(notification.message)
+        // if the future for the originating request is still in the queue, complete as unsuccessful for now
+        queueResponse.remove(notification.replyId)?.complete(false)
     }
 
     /**


### PR DESCRIPTION
Fix for client requests stalling when firmware rate limit is triggered. Completes the request future per the `replyId` in the `ClientNotification` response. I'm not sure if this is the optimal solution considering how client notifications may be used in the future, but it solves the issue for now. If I can rework the fix, let me know!