### PR TITLE
fix: Add elevation to NodeItem card

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
@@ -138,6 +138,7 @@ fun NodeItem(
             .fillMaxWidth()
             .padding(horizontal = 8.dp, vertical = 4.dp)
             .defaultMinSize(minHeight = 80.dp),
+        elevation = 4.dp,
         onClick = { showDetails(!detailsShown) },
     ) {
         Surface {


### PR DESCRIPTION
This commit adds elevation to the NodeItem card to visually distinguish it.

This also better visually aligns to the channel/user cards 4dp elevation, maintaining consistency.

resolves #1246 


![image](https://github.com/user-attachments/assets/1fdbd0ae-e97e-4382-84f8-b3d85f324d12)
