### PR TITLE
refactor: Improve IAQ display to add ranges, update colors

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/components/IndoorAirQuality.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/IndoorAirQuality.kt
@@ -42,15 +42,15 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.geeksville.mesh.R
 
-enum class Iaq(val color: Color, val description: String) {
-    Excellent(Color.Green, "Excellent"),
-    Good(Color.Green, "Good"),
-    LightlyPolluted(Color.Yellow, "Lightly Polluted"),
-    ModeratelyPolluted(Color.Orange, "Moderately Polluted"),
-    HeavilyPolluted(Color.Red, "Heavily Polluted"),
-    SeverelyPolluted(Color.Purple, "Severely Polluted"),
-    ExtremelyPolluted(Color.Purple, "Extremely Polluted"),
-    DangerouslyPolluted(Color.Brown, "Dangerously Polluted")
+enum class Iaq(val color: Color, val description: String, val range: IntRange) {
+    Excellent(Color.Green, "Excellent (0-50)", 0..50),
+    Good(Color.Green, "Good (51-100)", 51..100),
+    LightlyPolluted(Color.Yellow, "Lightly Polluted", 101..150),
+    ModeratelyPolluted(Color.Orange, "Moderately Polluted", 151..200),
+    HeavilyPolluted(Color.Red, "Heavily Polluted", 201..300),
+    SeverelyPolluted(Color.Purple, "Severely Polluted", 301..400),
+    ExtremelyPolluted(Color.Purple, "Extremely Polluted", 401..500),
+    DangerouslyPolluted(Color.Brown, "Dangerously Polluted", 501..Int.MAX_VALUE)
 }
 
 val Color.Companion.Mint: Color
@@ -65,13 +65,13 @@ val Color.Companion.Orange: Color
 @Suppress("MagicNumber")
 fun getIaq(iaq: Int): Iaq {
     return when {
-        iaq <= 50 -> Iaq.Excellent
-        iaq <= 100 -> Iaq.Good
-        iaq <= 150 -> Iaq.LightlyPolluted
-        iaq <= 200 -> Iaq.ModeratelyPolluted
-        iaq <= 300 -> Iaq.HeavilyPolluted
-        iaq <= 400 -> Iaq.SeverelyPolluted
-        iaq <= 500 -> Iaq.ExtremelyPolluted
+        iaq in Iaq.Excellent.range -> Iaq.Excellent
+        iaq in Iaq.Good.range -> Iaq.Good
+        iaq in Iaq.LightlyPolluted.range -> Iaq.LightlyPolluted
+        iaq in Iaq.ModeratelyPolluted.range -> Iaq.ModeratelyPolluted
+        iaq in Iaq.HeavilyPolluted.range -> Iaq.HeavilyPolluted
+        iaq in Iaq.SeverelyPolluted.range -> Iaq.SeverelyPolluted
+        iaq in Iaq.ExtremelyPolluted.range -> Iaq.ExtremelyPolluted
         else -> Iaq.DangerouslyPolluted
     }
 }
@@ -139,7 +139,7 @@ fun IndoorAirQuality(iaq: Int, displayMode: IaqDisplayMode = IaqDisplayMode.Pill
 
             IaqDisplayMode.Text -> {
                 Text(
-                    text = iaqEnum.description,
+                    text = "${iaqEnum.description} (${iaqEnum.range.first}-${iaqEnum.range.last})",
                     fontSize = 12.sp,
                     modifier = Modifier.clickable { isLegendOpen = true }
                 )

--- a/app/src/main/java/com/geeksville/mesh/ui/components/IndoorAirQuality.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/IndoorAirQuality.kt
@@ -42,27 +42,20 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.geeksville.mesh.R
 
+@Suppress("MagicNumber")
 enum class Iaq(val color: Color, val description: String, val range: IntRange) {
-    Excellent(Color.Green, "Excellent (0-50)", 0..50),
-    Good(Color.Green, "Good (51-100)", 51..100),
-    LightlyPolluted(Color.Yellow, "Lightly Polluted", 101..150),
-    ModeratelyPolluted(Color.Orange, "Moderately Polluted", 151..200),
-    HeavilyPolluted(Color.Red, "Heavily Polluted", 201..300),
-    SeverelyPolluted(Color.Purple, "Severely Polluted", 301..400),
-    ExtremelyPolluted(Color.Purple, "Extremely Polluted", 401..500),
-    DangerouslyPolluted(Color.Brown, "Dangerously Polluted", 501..Int.MAX_VALUE)
+    Excellent(Color(0xFF00E400), "Excellent", 0..50),
+    Good(Color(0xFF92D050), "Good", 51..100),
+    LightlyPolluted(Color(0xFFFFFF00), "Lightly Polluted", 101..150),
+    ModeratelyPolluted(Color(0xFFFF7300), "Moderately Polluted", 151..200),
+    HeavilyPolluted(Color(0xFFFF0000), "Heavily Polluted", 201..300),
+    SeverelyPolluted(Color(0xFF99004C), "Severely Polluted", 301..400),
+    ExtremelyPolluted(Color(0xFF663300), "Extremely Polluted", 401..500),
+    DangerouslyPolluted(Color(0xFF663300), "Dangerously Polluted", 501..Int.MAX_VALUE)
 }
 
-val Color.Companion.Mint: Color
-    get() = Color(0xFF98FB98)
-val Color.Companion.Purple: Color
-    get() = Color(0xFF800080)
-val Color.Companion.Brown: Color
-    get() = Color(0xFFA52A2A)
-val Color.Companion.Orange: Color
-    get() = Color(0xFFFFA500)
 
-@Suppress("MagicNumber")
+
 fun getIaq(iaq: Int): Iaq {
     return when {
         iaq in Iaq.Excellent.range -> Iaq.Excellent
@@ -76,6 +69,14 @@ fun getIaq(iaq: Int): Iaq {
     }
 }
 
+private fun getIaqDescriptionWithRange(iaqEnum: Iaq): String {
+    return if (iaqEnum.range.last == Int.MAX_VALUE){
+        "${iaqEnum.description} (${iaqEnum.range.first}+)"
+    } else {
+        "${iaqEnum.description} (${iaqEnum.range.first}-${iaqEnum.range.last})"
+    }
+}
+
 enum class IaqDisplayMode {
     Pill, Dot, Text, Gauge, Gradient
 }
@@ -86,10 +87,7 @@ fun IndoorAirQuality(iaq: Int, displayMode: IaqDisplayMode = IaqDisplayMode.Pill
     var isLegendOpen by remember { mutableStateOf(false) }
     val iaqEnum = getIaq(iaq)
     val gradient = Brush.linearGradient(
-        colors = listOf(
-            Color.Green, Color.Mint, Color.Yellow, Color.Orange, Color.Red,
-            Color.Purple, Color.Purple, Color.Brown, Color.Brown, Color.Brown, Color.Brown
-        )
+        colors = Iaq.entries.map { it.color },
     )
 
     Column {
@@ -139,7 +137,7 @@ fun IndoorAirQuality(iaq: Int, displayMode: IaqDisplayMode = IaqDisplayMode.Pill
 
             IaqDisplayMode.Text -> {
                 Text(
-                    text = "${iaqEnum.description} (${iaqEnum.range.first}-${iaqEnum.range.last})",
+                    text = getIaqDescriptionWithRange(iaqEnum),
                     fontSize = 12.sp,
                     modifier = Modifier.clickable { isLegendOpen = true }
                 )
@@ -221,11 +219,17 @@ fun IAQScale(modifier: Modifier = Modifier) {
                         .background(iaq.color)
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(iaq.description, style = MaterialTheme.typography.body2)
+                Text(getIaqDescriptionWithRange(iaq), style = MaterialTheme.typography.body2)
             }
             Spacer(modifier = Modifier.height(4.dp))
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun IAQScalePreview() {
+    IAQScale()
 }
 
 @Suppress("LongMethod")


### PR DESCRIPTION
Adds IAQ ranges and colors to the `Iaq` enum and updates the display to show the ranges alongside the
 descriptions, improving clarity for users.

This change enhances the indoor air quality information by providing context for the different IAQ levels.

Also updated the color values to match the chart [here](https://community.bosch-sensortec.com/t5/MEMS-sensors-forum/BME680-688-IAQ-meaning/m-p/45204)
![image](https://github.com/user-attachments/assets/e0d8b421-6665-4325-9a0e-1794291260e8)
