### PR TITLE
fix: sort nodes with unknown hops last

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
@@ -63,7 +63,11 @@ interface NodeInfoDao {
                     (longitude - (SELECT longitude FROM OurNode)) *
                     (longitude - (SELECT longitude FROM OurNode))
             END
-        WHEN :sort = 'hops_away' THEN hops_away
+        WHEN :sort = 'hops_away' THEN
+            CASE
+                WHEN hops_away = -1 THEN 999999999
+                ELSE hops_away
+            END
         WHEN :sort = 'channel' THEN channel
         WHEN :sort = 'via_mqtt' THEN long_name LIKE '%(MQTT)' -- viaMqtt
         ELSE 0


### PR DESCRIPTION
Nodes with -1 hops (unknown) are now sorted last when sorting by `Hops Away`.

fixes #1301 