### PR TITLE
fix: Correctly compare hopStart and hopLimit for received packets

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1101,7 +1101,7 @@ class MeshService : Service(), Logging {
                 it.rssi = packet.rxRssi
 
                 // Generate our own hopsAway, comparing hopStart to hopLimit.
-                it.hopsAway = if (packet.hopStart == 0 || packet.hopLimit < packet.hopStart) {
+                it.hopsAway = if (packet.hopStart == 0 || packet.hopLimit > packet.hopStart) {
                     -1
                 } else {
                     packet.hopStart - packet.hopLimit


### PR DESCRIPTION
fixes: #1304

The calculation of `hopsAway` was using an incorrect comparison between `hopStart` and `hopLimit`. This commit fixes the logic to correctly determine the number of hops a packet has traveled.