### PR TITLE
fix: Replace "unknown" with "?" for unknown hop count

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/SignalInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SignalInfo.kt
@@ -32,7 +32,7 @@ fun signalInfo(
             val hopsString = "%s: %s".format(
                 stringResource(R.string.hops_away),
                 if (node.hopsAway == -1) {
-                    stringResource(R.string.unknown)
+                    "?"
                 } else {
                     node.hopsAway.toString()
                 }


### PR DESCRIPTION
This replaces the string "unknown" with a question mark `?` when displaying the hop count for a
 node if the hop count is unknown `-1`. This provides a more concise and visually clear indication of an unknown hop count.

fixes #1306 
