### PR TITLE
feat: sort device list while keeping None (disable) at the top of the list

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/SettingsFragment.kt
@@ -360,7 +360,11 @@ class SettingsFragment : ScreenFragment("Settings"), Logging {
         if (devices == null) return
 
         var hasShownOurDevice = false
-        devices.values.forEach { device ->
+        devices.values
+            // Display the device list in alphabetical order while keeping the "None (Disabled)"
+            // device (fullAddress == n) at the top
+            .sortedBy { dle -> if (dle.fullAddress == "n") "0" else dle.name  }
+            .forEach { device ->
             if (device.fullAddress == scanModel.selectedNotNull)
                 hasShownOurDevice = true
             addDeviceButton(device, true)


### PR DESCRIPTION
On my phone, I have 5 devices linked.  They currently appear like so:
<img width="401" alt="image" src="https://github.com/user-attachments/assets/9a368b32-563d-479e-b021-17f0e3637a7a">

I'd prefer that they at least displayed in alphabetical order, while maintaining "None (disable)" at the top of the list. 

Here are before and after using the simulator:

### Before
<img width="391" alt="before" src="https://github.com/user-attachments/assets/cb6a15c5-5596-46e1-afca-184977231bf8"> 

### After
<img width="388" alt="after" src="https://github.com/user-attachments/assets/0bbe8a5b-2cf3-48d8-8c59-2de3a9595784">
