### PR TITLE
feat: Add notification for new node seen

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -803,6 +803,8 @@ class MeshService : Service(), Logging {
     // Update our DB of users based on someone sending out a User subpacket
     private fun handleReceivedUser(fromNum: Int, p: MeshProtos.User, channel: Int = 0) {
         updateNodeInfo(fromNum) {
+            val newNode = (it.isUnknownUser && p.hwModel != MeshProtos.HardwareModel.UNSET)
+
             val keyMatch = !it.hasPKC || it.user.publicKey == p.publicKey
             it.user = if (keyMatch) p else p.copy {
                 warn("Public key mismatch from $longName ($shortName)")
@@ -811,6 +813,9 @@ class MeshService : Service(), Logging {
             it.longName = p.longName
             it.shortName = p.shortName
             it.channel = channel
+            if (newNode) {
+                serviceNotifications.showNewNodeSeenNotification(it)
+            }
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+@Suppress("TooManyFunctions")
 class MeshServiceNotifications(
     private val context: Context
 ) : Closeable {
@@ -139,6 +140,13 @@ class MeshServiceNotifications(
             createMessageNotification(name, message)
         )
 
+    fun updateNewNodeSeenNotification(name: String) {
+        notificationManager.notify(
+            messageNotifyId,
+            createNewNodeSeenNotification(name)
+        )
+    }
+
     private val openAppIntent: PendingIntent by lazy {
         PendingIntent.getActivity(
             context,
@@ -222,6 +230,27 @@ class MeshServiceNotifications(
             )
         }
         return messageNotificationBuilder.build()
+    }
+
+    lateinit var newNodeSeenNotificationBuilder: NotificationCompat.Builder
+    private fun createNewNodeSeenNotification(name: String, message: String? = null): Notification {
+        if (!::newNodeSeenNotificationBuilder.isInitialized) {
+            newNodeSeenNotificationBuilder = commonBuilder(messageChannelId)
+        }
+        with(newNodeSeenNotificationBuilder) {
+            priority = NotificationCompat.PRIORITY_DEFAULT
+            setCategory(Notification.CATEGORY_STATUS)
+            setAutoCancel(true)
+            setContentTitle("New Node Seen: $name")
+            message?.let {
+                setContentText(it)
+                setStyle(
+                    NotificationCompat.BigTextStyle()
+                        .bigText(message),
+                )
+            }
+        }
+        return newNodeSeenNotificationBuilder.build()
     }
 
     override fun close() {

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -19,6 +19,7 @@ import com.geeksville.mesh.MainActivity
 import com.geeksville.mesh.R
 import com.geeksville.mesh.TelemetryProtos.LocalStats
 import com.geeksville.mesh.android.notificationManager
+import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.util.PendingIntentCompat
 import java.io.Closeable
 import java.text.SimpleDateFormat
@@ -140,10 +141,10 @@ class MeshServiceNotifications(
             createMessageNotification(name, message)
         )
 
-    fun updateNewNodeSeenNotification(name: String) {
+    fun showNewNodeSeenNotification(node: NodeEntity) {
         notificationManager.notify(
-            messageNotifyId,
-            createNewNodeSeenNotification(name)
+            node.num, // show unique notifications
+            createNewNodeSeenNotification(node.user.shortName, node.user.longName)
         )
     }
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -83,6 +83,30 @@ class MeshServiceNotifications(
         return channelId
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createNewNodeNotificationChannel(): String {
+        val channelId = "new_nodes"
+        val channelName = context.getString(R.string.meshtastic_new_nodes_notifications)
+        val channel = NotificationChannel(
+            channelId,
+            channelName,
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            lightColor = Color.BLUE
+            lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            setShowBadge(true)
+            setSound(
+                RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                    .build()
+            )
+        }
+        notificationManager.createNotificationChannel(channel)
+        return channelId
+    }
+
     private val channelId: String by lazy {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             createNotificationChannel()
@@ -99,6 +123,14 @@ class MeshServiceNotifications(
         } else {
             // If earlier version channel ID is not used
             // https://developer.android.com/reference/android/support/v4/app/NotificationCompat.Builder.html#NotificationCompat.Builder(android.content.Context)
+            ""
+        }
+    }
+
+    private val newNodeChannelId: String by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createNewNodeNotificationChannel()
+        } else {
             ""
         }
     }
@@ -236,7 +268,7 @@ class MeshServiceNotifications(
     lateinit var newNodeSeenNotificationBuilder: NotificationCompat.Builder
     private fun createNewNodeSeenNotification(name: String, message: String? = null): Notification {
         if (!::newNodeSeenNotificationBuilder.isInitialized) {
-            newNodeSeenNotificationBuilder = commonBuilder(messageChannelId)
+            newNodeSeenNotificationBuilder = commonBuilder(newNodeChannelId)
         }
         with(newNodeSeenNotificationBuilder) {
             priority = NotificationCompat.PRIORITY_DEFAULT

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,4 +271,5 @@
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
     <string name="request_userinfo">Request user info</string>
+    <string name="meshtastic_new_nodes_notifications">New nodes notifications</string>
 </resources>


### PR DESCRIPTION
Proposed change:  I'd like to know when a new node is seen/added to the NodeDb

Adds new Android notification when new node is seen.

resolves #914