### PR TITLE
Update to 2 hour online window

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/NodeInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/NodeInfo.kt
@@ -186,7 +186,7 @@ data class NodeInfo(
     val isOnline: Boolean
         get() {
             val now = System.currentTimeMillis() / 1000
-            val timeout = 15 * 60
+            val timeout = 2 * 60 * 60
             return (now - lastHeard <= timeout)
         }
 


### PR DESCRIPTION
Per GUVWAF's conversation in firmware. The changes to interval broadcasts in recent history have made the 15 minute window no longer accurate for considering a node "online". This PR seeks to increase that threshold to 2 hours.