### PR TITLE
Signal Metrics

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -41,22 +41,18 @@ class MetricsViewModel @Inject constructor(
     val state = destNum.flatMapLatest { destNum ->
         combine(
             meshLogRepository.getTelemetryFrom(destNum),
-            meshLogRepository.getMeshPacketsFrom(destNum)
-//            radioConfigRepository.moduleConfigFlow,
-        ) { telemetry, meshPackets ->
+            meshLogRepository.getMeshPacketsFrom(destNum),
+            radioConfigRepository.moduleConfigFlow,
+        ) { telemetry, meshPackets, config ->
             MetricsState(
                 deviceMetrics = telemetry.filter { it.hasDeviceMetrics() },
                 environmentMetrics = telemetry.filter {
                     it.hasEnvironmentMetrics() && it.environmentMetrics.relativeHumidity >= 0f
                 },
-                signalMetrics = meshPackets.filter { it.rxTime > 0 }, // TODO if needed I can filter anything out here <---
-                // TODO might have to filter times = 0 <----
-//                signalMetrics = meshPackets
-                // TODO maybe it could be moved to its own or the packets can <--
-//                environmentDisplayFahrenheit = config.telemetry.environmentDisplayFahrenheit, // TODO getting this is taking up that second spot <---
+                signalMetrics = meshPackets.filter { it.rxTime > 0 },
+                environmentDisplayFahrenheit = config.telemetry.environmentDisplayFahrenheit,
             )
         }
-        // TODO maybe i can set the bla F thing here <--
     }.stateIn(
         scope = viewModelScope,
         started = WhileSubscribed(),

--- a/app/src/main/java/com/geeksville/mesh/ui/DeviceSettingsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/DeviceSettingsFragment.kt
@@ -101,6 +101,7 @@ import com.geeksville.mesh.service.MeshService.ConnectionState
 import com.geeksville.mesh.ui.components.DeviceMetricsScreen
 import com.geeksville.mesh.ui.components.EnvironmentMetricsScreen
 import com.geeksville.mesh.ui.components.PreferenceCategory
+import com.geeksville.mesh.ui.components.SignalMetricsScreen
 import com.geeksville.mesh.ui.components.config.AmbientLightingConfigItemList
 import com.geeksville.mesh.ui.components.config.AudioConfigItemList
 import com.geeksville.mesh.ui.components.config.BluetoothConfigItemList
@@ -332,6 +333,9 @@ fun RadioConfigNavHost(
                 metricsState.environmentMetrics,
                 metricsState.environmentDisplayFahrenheit,
             )
+        }
+        composable("SignalMetrics") {
+            SignalMetricsScreen(metricsState.signalMetrics)
         }
         composable("RadioConfig") {
             RadioConfigScreen(

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeDetailsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeDetailsScreen.kt
@@ -130,7 +130,7 @@ private fun NodeDetailsItemList(
 
         item {
             NavCard(
-                title = "Device Metrics Logs",
+                title = stringResource(R.string.device_metrics_logs),
                 icon = Icons.Default.ChargingStation,
                 enabled = metricsState.hasDeviceMetrics()
             ) {
@@ -138,7 +138,7 @@ private fun NodeDetailsItemList(
             }
 
             NavCard(
-                title = "Environment Metrics Logs",
+                title = stringResource(R.string.env_metrics_logs),
                 icon = Icons.Default.Thermostat,
                 enabled = metricsState.hasEnvironmentMetrics()
             ) {
@@ -146,7 +146,7 @@ private fun NodeDetailsItemList(
             }
 
             NavCard(
-                title = "Signal Metrics Logs",
+                title = stringResource(R.string.sig_metrics_logs),
                 icon = Icons.Default.SignalCellularAlt,
                 enabled = metricsState.hasSignalMetrics()
             ) {

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeDetailsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeDetailsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.filled.Numbers
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Power
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SignalCellularAlt
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material.icons.filled.WaterDrop
@@ -142,6 +143,14 @@ private fun NodeDetailsItemList(
                 enabled = metricsState.hasEnvironmentMetrics()
             ) {
                 onNavigate("EnvironmentMetrics")
+            }
+
+            NavCard(
+                title = "Signal Metrics Logs",
+                icon = Icons.Default.SignalCellularAlt,
+                enabled = metricsState.hasSignalMetrics()
+            ) {
+                onNavigate("SignalMetrics")
             }
 
             NavCard(

--- a/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
@@ -45,7 +45,6 @@ import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 import com.geeksville.mesh.ui.components.CommonCharts.LEFT_LABEL_SPACING
 import java.text.DateFormat
 
-
 object CommonCharts {
     val TIME_FORMAT: DateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
     const val X_AXIS_SPACING = 8f
@@ -187,7 +186,7 @@ fun Legend(legendData: List<LegendData>, promptInfoDialog: () -> Unit) {
         horizontalArrangement = Arrangement.Center,
     ) {
         Spacer(modifier = Modifier.weight(1f))
-        for(data in legendData) {
+        for (data in legendData) {
             LegendLabel(
                 text = stringResource(data.nameRes),
                 color = data.color,
@@ -225,7 +224,7 @@ fun LegendInfoDialog(pairedRes: List<Pair<Int, Int>>, onDismiss: () -> Unit) {
         },
         text = {
             Column {
-                for(pair in pairedRes) {
+                for (pair in pairedRes) {
                     Text(
                         text = stringResource(pair.first),
                         style = TextStyle(fontWeight = FontWeight.Bold),

--- a/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
@@ -252,7 +252,7 @@ fun LegendInfoDialog(pairedRes: List<Pair<Int, Int>>, onDismiss: () -> Unit) {
 }
 
 @Composable
-fun LegendLabel(text: String, color: Color, isLine: Boolean = false) {
+private fun LegendLabel(text: String, color: Color, isLine: Boolean = false) {
     Canvas(
         modifier = Modifier.size(4.dp)
     ) {

--- a/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
@@ -27,18 +27,22 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
+import com.geeksville.mesh.ui.components.CommonCharts.LINE_LIMIT
+import com.geeksville.mesh.ui.components.CommonCharts.TEXT_PAINT_ALPHA
 import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
+import com.geeksville.mesh.ui.components.CommonCharts.LEFT_LABEL_SPACING
 import java.text.DateFormat
 
 
 object CommonCharts {
     val TIME_FORMAT: DateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
     const val LEFT_CHART_SPACING = 8f
+    const val LEFT_LABEL_SPACING = 36
     const val MS_PER_SEC = 1000.0f
+    const val LINE_LIMIT = 4
+    const val TEXT_PAINT_ALPHA = 192
 }
 
-private const val LINE_LIMIT = 4
-private const val TEXT_PAINT_ALPHA = 192
 private const val LINE_ON = 10f
 private const val LINE_OFF = 20f
 
@@ -62,20 +66,23 @@ fun ChartHeader(amount: Int) {
 /**
  * Draws chart lines and labels with respect to the Y-axis range; defined by (`maxValue` - `minValue`).
  * Assumes `lineColors` is a list of 5 `Color`s with index 0 being the lowest line on the chart.
+ * `leaveSpace` when true the lines will leave space for Y labels on the left side of the graph.
  */
 @Composable
 fun ChartOverlay(
     modifier: Modifier,
-    graphColor: Color,
+    labelColor: Color,
     lineColors: List<Color>,
     minValue: Float,
-    maxValue: Float
+    maxValue: Float,
+    leaveSpace: Boolean = false
 ) {
     val range = maxValue - minValue
     val verticalSpacing = range / LINE_LIMIT
     val density = LocalDensity.current
     Canvas(modifier = modifier) {
 
+        val lineStart = if (leaveSpace) LEFT_LABEL_SPACING.dp.toPx() else 0f
         val height = size.height
         val width = size.width - 28.dp.toPx()
 
@@ -85,7 +92,7 @@ fun ChartOverlay(
             val ratio = (lineY - minValue) / range
             val y = height - (ratio * height)
             drawLine(
-                start = Offset(0f, y),
+                start = Offset(lineStart, y),
                 end = Offset(width, y),
                 color = lineColors[i],
                 strokeWidth = 1.dp.toPx(),
@@ -98,7 +105,7 @@ fun ChartOverlay(
         /* Y Labels */
 
         val textPaint = Paint().apply {
-            color = graphColor.toArgb()
+            color = labelColor.toArgb()
             textAlign = Paint.Align.LEFT
             textSize = density.run { 12.dp.toPx() }
             typeface = setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD))

--- a/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
@@ -3,15 +3,24 @@ package com.geeksville.mesh.ui.components
 import android.graphics.Paint
 import android.graphics.Typeface
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,6 +34,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.geeksville.mesh.R
@@ -47,6 +58,7 @@ object CommonCharts {
 private const val LINE_ON = 10f
 private const val LINE_OFF = 20f
 
+data class LegendData(val nameRes: Int, val color: Color, val isLine: Boolean = false)
 
 @Composable
 fun ChartHeader(amount: Int) {
@@ -66,8 +78,10 @@ fun ChartHeader(amount: Int) {
 
 /**
  * Draws chart lines and labels with respect to the Y-axis range; defined by (`maxValue` - `minValue`).
- * Assumes `lineColors` is a list of 5 `Color`s with index 0 being the lowest line on the chart.
- * `leaveSpace` when true the lines will leave space for Y labels on the left side of the graph.
+ *
+ * @param labelColor The color to be used for the Y labels.
+ * @param lineColors A list of 5 `Color`s for the chart lines, 0 being the lowest line on the chart.
+ * @param leaveSpace When true the lines will leave space for Y labels on the left side of the graph.
  */
 @Composable
 fun ChartOverlay(
@@ -157,6 +171,84 @@ fun TimeLabels(
             fontSize = 12.sp
         )
     }
+}
+
+/**
+ * Creates the legend that identifies the colors used for the graph.
+ *
+ * @param legendData A list containing the `LegendData` to build the labels.
+ * @param promptInfoDialog Executes when the user presses the info icon.
+ */
+@Composable
+fun Legend(legendData: List<LegendData>, promptInfoDialog: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+        for(data in legendData) {
+            LegendLabel(
+                text = stringResource(data.nameRes),
+                color = data.color,
+                isLine = data.isLine
+            )
+
+            Spacer(modifier = Modifier.width(4.dp))
+        }
+
+        Icon(
+            imageVector = Icons.Default.Info,
+            modifier = Modifier.clickable { promptInfoDialog() },
+            contentDescription = stringResource(R.string.info)
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+/**
+ * Displays a dialog with information about the legend items.
+ *
+ * @param pairedRes A list of `Pair`s containing (term, definition).
+ * @param onDismiss Executes when the user presses the close button.
+ */
+@Composable
+fun LegendInfoDialog(pairedRes: List<Pair<Int, Int>>, onDismiss: () -> Unit) {
+    AlertDialog(
+        title = {
+            Text(
+                text = stringResource(R.string.info),
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+        },
+        text = {
+            Column {
+                for(pair in pairedRes) {
+                    Text(
+                        text = stringResource(pair.first),
+                        style = TextStyle(fontWeight = FontWeight.Bold),
+                        textDecoration = TextDecoration.Underline
+                    )
+                    Text(
+                        text = stringResource(pair.second),
+                        style = TextStyle.Default,
+                    )
+
+                    Spacer(modifier = Modifier.height(24.dp))
+                }
+            }
+        },
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.close))
+            }
+        },
+        shape = RoundedCornerShape(16.dp),
+        backgroundColor = MaterialTheme.colors.background
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
@@ -48,7 +48,7 @@ import java.text.DateFormat
 
 object CommonCharts {
     val TIME_FORMAT: DateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
-    const val LEFT_CHART_SPACING = 8f
+    const val X_AXIS_SPACING = 8f
     const val LEFT_LABEL_SPACING = 36
     const val MS_PER_SEC = 1000.0f
     const val LINE_LIMIT = 4

--- a/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/CommonCharts.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.geeksville.mesh.R
 import com.geeksville.mesh.ui.components.CommonCharts.LINE_LIMIT
 import com.geeksville.mesh.ui.components.CommonCharts.TEXT_PAINT_ALPHA
@@ -134,36 +135,27 @@ fun ChartOverlay(
  */
 @Composable
 fun TimeLabels(
-    modifier: Modifier,
-    graphColor: Color,
     oldest: Float,
     newest: Float
 ) {
-    val density = LocalDensity.current
-    Canvas(modifier = modifier) {
-
-        val textPaint = Paint().apply {
-            color = graphColor.toArgb()
-            textAlign = Paint.Align.LEFT
-            textSize = density.run { 12.dp.toPx() }
-            typeface = setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD))
-            alpha = TEXT_PAINT_ALPHA
-        }
-
-        drawContext.canvas.nativeCanvas.apply {
-            drawText(
-                TIME_FORMAT.format(oldest),
-                8.dp.toPx(),
-                12.dp.toPx(),
-                textPaint
-            )
-            drawText(
-                TIME_FORMAT.format(newest),
-                size.width - 140.dp.toPx(),
-                12.dp.toPx(),
-                textPaint
-            )
-        }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = TIME_FORMAT.format(oldest),
+            modifier = Modifier.wrapContentWidth(),
+            style = TextStyle(fontWeight = FontWeight.Bold),
+            fontSize = 12.sp,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = TIME_FORMAT.format(newest),
+            modifier = Modifier.wrapContentWidth(),
+            style = TextStyle(fontWeight = FontWeight.Bold),
+            fontSize = 12.sp
+        )
     }
 }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
@@ -1,7 +1,6 @@
 package com.geeksville.mesh.ui.components
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,20 +11,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material.AlertDialog
 import androidx.compose.material.Card
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.material.TextButton
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,9 +33,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
 import com.geeksville.mesh.TelemetryProtos.Telemetry
@@ -55,6 +44,16 @@ import com.geeksville.mesh.ui.theme.Orange
 
 private val DEVICE_METRICS_COLORS = listOf(Color.Green, Color.Magenta, Color.Cyan)
 private const val MAX_PERCENT_VALUE = 100f
+private enum class Device {
+    BATTERY,
+    CH_UTIL,
+    AIR_UTIL
+}
+private val LEGEND_DATA = listOf(
+    LegendData(nameRes = R.string.battery, color = DEVICE_METRICS_COLORS[Device.BATTERY.ordinal], isLine = true),
+    LegendData(nameRes = R.string.channel_utilization, color = DEVICE_METRICS_COLORS[Device.CH_UTIL.ordinal]),
+    LegendData(nameRes = R.string.air_utilization, color = DEVICE_METRICS_COLORS[Device.AIR_UTIL.ordinal]),
+)
 
 @Composable
 fun DeviceMetricsScreen(telemetries: List<Telemetry>) {
@@ -64,7 +63,13 @@ fun DeviceMetricsScreen(telemetries: List<Telemetry>) {
     Column {
 
         if (displayInfoDialog) {
-            DeviceInfoDialog { displayInfoDialog = false }
+            LegendInfoDialog(
+                pairedRes = listOf(
+                    Pair(R.string.channel_utilization, R.string.ch_util_definition),
+                    Pair(R.string.air_utilization, R.string.air_util_definition)
+                ),
+                onDismiss = { displayInfoDialog = false }
+            )
         }
 
         DeviceMetricsChart(
@@ -141,7 +146,7 @@ private fun DeviceMetricsChart(
                     val chUtilRatio = telemetry.deviceMetrics.channelUtilization / MAX_PERCENT_VALUE
                     val yChUtil = height - spacing - (chUtilRatio * height)
                     drawCircle(
-                        color = DEVICE_METRICS_COLORS[1],
+                        color = DEVICE_METRICS_COLORS[Device.CH_UTIL.ordinal],
                         radius = dataPointRadius,
                         center = Offset(x1, yChUtil)
                     )
@@ -150,7 +155,7 @@ private fun DeviceMetricsChart(
                     val airUtilRatio = telemetry.deviceMetrics.airUtilTx / MAX_PERCENT_VALUE
                     val yAirUtil = height - spacing - (airUtilRatio * height)
                     drawCircle(
-                        color = DEVICE_METRICS_COLORS[2],
+                        color = DEVICE_METRICS_COLORS[Device.AIR_UTIL.ordinal],
                         radius = dataPointRadius,
                         center = Offset(x1, yAirUtil)
                     )
@@ -170,7 +175,7 @@ private fun DeviceMetricsChart(
             /* Battery Line */
             drawPath(
                 path = strokePath,
-                color = DEVICE_METRICS_COLORS[0],
+                color = DEVICE_METRICS_COLORS[Device.BATTERY.ordinal],
                 style = Stroke(
                     width = dataPointRadius,
                     cap = StrokeCap.Round
@@ -180,7 +185,7 @@ private fun DeviceMetricsChart(
     }
     Spacer(modifier = Modifier.height(16.dp))
 
-    DeviceLegend(promptInfoDialog)
+    Legend(legendData = LEGEND_DATA, promptInfoDialog)
 
     Spacer(modifier = Modifier.height(16.dp))
 }
@@ -240,87 +245,4 @@ private fun DeviceMetricsCard(telemetry: Telemetry) {
             }
         }
     }
-}
-
-@Composable
-private fun DeviceLegend(promptInfoDialog: () -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center,
-    ) {
-        Spacer(modifier = Modifier.weight(1f))
-
-        LegendLabel(text = stringResource(R.string.battery), color = DEVICE_METRICS_COLORS[0], isLine = true)
-
-        Spacer(modifier = Modifier.width(4.dp))
-
-        LegendLabel(text = stringResource(R.string.channel_utilization), color = DEVICE_METRICS_COLORS[1])
-
-        Spacer(modifier = Modifier.width(4.dp))
-
-        LegendLabel(text = stringResource(R.string.air_utilization), color = DEVICE_METRICS_COLORS[2])
-
-        Spacer(modifier = Modifier.width(4.dp))
-
-        Icon(
-            imageVector = Icons.Default.Info,
-            modifier = Modifier.clickable { promptInfoDialog() },
-            contentDescription = stringResource(R.string.info)
-        )
-
-        Spacer(modifier = Modifier.weight(1f))
-    }
-}
-
-@Composable
-private fun DeviceInfoDialog(onDismiss: () -> Unit) {
-    AlertDialog(
-        title = {
-            Text(
-                text = stringResource(R.string.info),
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center
-            )
-        },
-        text = {
-            Column {
-                Text(
-                    text = stringResource(R.string.channel_utilization),
-                    style = TextStyle(fontWeight = FontWeight.Bold),
-                    textDecoration = TextDecoration.Underline
-                )
-                Text(
-                    text = stringResource(R.string.ch_util_definition),
-                    style = TextStyle.Default,
-                )
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                Text(
-                    text = stringResource(R.string.air_utilization),
-                    style = TextStyle(fontWeight = FontWeight.Bold),
-                    textDecoration = TextDecoration.Underline
-                )
-                Text(
-                    text = stringResource(R.string.air_util_definition),
-                    style = TextStyle.Default
-                )
-            }
-        },
-        onDismissRequest = onDismiss,
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.close))
-            }
-        },
-        shape = RoundedCornerShape(16.dp),
-        backgroundColor = MaterialTheme.colors.background
-    )
-}
-
-@Preview
-@Composable
-private fun DeviceInfoDialogPreview() {
-    DeviceInfoDialog {}
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
@@ -94,6 +94,11 @@ private fun DeviceMetricsChart(
     ChartHeader(amount = telemetries.size)
     if (telemetries.isEmpty()) return
 
+    TimeLabels(
+        oldest = telemetries.first().time * MS_PER_SEC,
+        newest = telemetries.last().time * MS_PER_SEC
+    )
+
     Spacer(modifier = Modifier.height(16.dp))
 
     val graphColor = MaterialTheme.colors.onSurface
@@ -172,13 +177,6 @@ private fun DeviceMetricsChart(
                 )
             )
         }
-
-        TimeLabels(
-            modifier = modifier,
-            graphColor = graphColor,
-            oldest = telemetries.first().time * MS_PER_SEC,
-            newest = telemetries.last().time * MS_PER_SEC
-        )
     }
     Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
 import com.geeksville.mesh.TelemetryProtos.Telemetry
 import com.geeksville.mesh.ui.BatteryInfo
-import com.geeksville.mesh.ui.components.CommonCharts.LEFT_CHART_SPACING
+import com.geeksville.mesh.ui.components.CommonCharts.X_AXIS_SPACING
 import com.geeksville.mesh.ui.components.CommonCharts.MS_PER_SEC
 import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 import com.geeksville.mesh.ui.theme.Orange
@@ -107,7 +107,7 @@ private fun DeviceMetricsChart(
     Spacer(modifier = Modifier.height(16.dp))
 
     val graphColor = MaterialTheme.colors.onSurface
-    val spacing = LEFT_CHART_SPACING
+    val spacing = X_AXIS_SPACING
 
     Box(contentAlignment = Alignment.TopStart) {
 

--- a/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
@@ -140,11 +140,11 @@ private fun DeviceMetricsChart(
                     val rightRatio = nextTelemetry.deviceMetrics.batteryLevel / MAX_PERCENT_VALUE
 
                     val x1 = spacing + i * spacePerEntry
-                    val y1 = height - spacing - (leftRatio * height)
+                    val y1 = height - (leftRatio * height)
 
                     /* Channel Utilization */
                     val chUtilRatio = telemetry.deviceMetrics.channelUtilization / MAX_PERCENT_VALUE
-                    val yChUtil = height - spacing - (chUtilRatio * height)
+                    val yChUtil = height - (chUtilRatio * height)
                     drawCircle(
                         color = DEVICE_METRICS_COLORS[Device.CH_UTIL.ordinal],
                         radius = dataPointRadius,
@@ -153,7 +153,7 @@ private fun DeviceMetricsChart(
 
                     /* Air Utilization Transmit  */
                     val airUtilRatio = telemetry.deviceMetrics.airUtilTx / MAX_PERCENT_VALUE
-                    val yAirUtil = height - spacing - (airUtilRatio * height)
+                    val yAirUtil = height - (airUtilRatio * height)
                     drawCircle(
                         color = DEVICE_METRICS_COLORS[Device.AIR_UTIL.ordinal],
                         radius = dataPointRadius,
@@ -161,7 +161,7 @@ private fun DeviceMetricsChart(
                     )
 
                     val x2 = spacing + (i + 1) * spacePerEntry
-                    val y2 = height - spacing - (rightRatio * height)
+                    val y2 = height - (rightRatio * height)
                     if (i == 0) {
                         moveTo(x1, y1)
                     }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
@@ -20,7 +20,10 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -43,6 +46,16 @@ import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 
 
 private val ENVIRONMENT_METRICS_COLORS = listOf(Color.Red, Color.Blue, Color.Green)
+private enum class Environment {
+    TEMPERATURE,
+    HUMIDITY,
+    IAQ
+}
+private val LEGEND_DATA = listOf(
+    LegendData(nameRes = R.string.temperature, color = ENVIRONMENT_METRICS_COLORS[Environment.TEMPERATURE.ordinal], isLine = true),
+    LegendData(nameRes = R.string.humidity, color = ENVIRONMENT_METRICS_COLORS[Environment.HUMIDITY.ordinal], isLine = true),
+    LegendData(nameRes = R.string.iaq, color = ENVIRONMENT_METRICS_COLORS[Environment.IAQ.ordinal], isLine = true),
+)
 
 @Composable
 fun EnvironmentMetricsScreen(telemetries: List<Telemetry>, environmentDisplayFahrenheit: Boolean) {
@@ -65,12 +78,25 @@ fun EnvironmentMetricsScreen(telemetries: List<Telemetry>, environmentDisplayFah
         telemetries
     }
 
+    var displayInfoDialog by remember { mutableStateOf(false) }
+
     Column {
+
+        if (displayInfoDialog) {
+            LegendInfoDialog(
+                pairedRes = listOf(
+                    Pair(R.string.iaq, R.string.iaq_definition)
+                ),
+                onDismiss = { displayInfoDialog = false }
+            )
+        }
+
         EnvironmentMetricsChart(
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight(fraction = 0.33f),
             telemetries = processedTelemetries.reversed(),
+            promptInfoDialog = { displayInfoDialog = true }
         )
 
         /* Environment Metric Cards */
@@ -89,7 +115,11 @@ fun EnvironmentMetricsScreen(telemetries: List<Telemetry>, environmentDisplayFah
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
-private fun EnvironmentMetricsChart(modifier: Modifier = Modifier, telemetries: List<Telemetry>) {
+private fun EnvironmentMetricsChart(
+    modifier: Modifier = Modifier,
+    telemetries: List<Telemetry>,
+    promptInfoDialog: () -> Unit
+) {
     ChartHeader(amount = telemetries.size)
     if (telemetries.isEmpty()) {
         return
@@ -102,9 +132,9 @@ private fun EnvironmentMetricsChart(modifier: Modifier = Modifier, telemetries: 
     Spacer(modifier = Modifier.height(16.dp))
 
     val graphColor = MaterialTheme.colors.onSurface
-    val transparentTemperatureColor = remember { ENVIRONMENT_METRICS_COLORS[0].copy(alpha = 0.5f) }
-    val transparentHumidityColor = remember { ENVIRONMENT_METRICS_COLORS[1].copy(alpha = 0.5f) }
-    val transparentIAQColor = remember { ENVIRONMENT_METRICS_COLORS[2].copy(alpha = 0.5f) }
+    val transparentTemperatureColor = remember { ENVIRONMENT_METRICS_COLORS[Environment.TEMPERATURE.ordinal].copy(alpha = 0.5f) }
+    val transparentHumidityColor = remember { ENVIRONMENT_METRICS_COLORS[Environment.HUMIDITY.ordinal].copy(alpha = 0.5f) }
+    val transparentIAQColor = remember { ENVIRONMENT_METRICS_COLORS[Environment.IAQ.ordinal].copy(alpha = 0.5f) }
     val spacing = LEFT_CHART_SPACING
 
     /* Since both temperature and humidity are being plotted we need a combined min and max. */
@@ -199,7 +229,7 @@ private fun EnvironmentMetricsChart(modifier: Modifier = Modifier, telemetries: 
 
             drawPath(
                 path = temperaturePath,
-                color = ENVIRONMENT_METRICS_COLORS[0],
+                color = ENVIRONMENT_METRICS_COLORS[Environment.TEMPERATURE.ordinal],
                 style = Stroke(
                     width = 2.dp.toPx(),
                     cap = StrokeCap.Round
@@ -252,7 +282,7 @@ private fun EnvironmentMetricsChart(modifier: Modifier = Modifier, telemetries: 
 
             drawPath(
                 path = humidityPath,
-                color = ENVIRONMENT_METRICS_COLORS[1],
+                color = ENVIRONMENT_METRICS_COLORS[Environment.HUMIDITY.ordinal],
                 style = Stroke(
                     width = 2.dp.toPx(),
                     cap = StrokeCap.Round
@@ -308,7 +338,7 @@ private fun EnvironmentMetricsChart(modifier: Modifier = Modifier, telemetries: 
 
             drawPath(
                 path = iaqPath,
-                color = ENVIRONMENT_METRICS_COLORS[2],
+                color = ENVIRONMENT_METRICS_COLORS[Environment.IAQ.ordinal],
                 style = Stroke(
                     width = 2.dp.toPx(),
                     cap = StrokeCap.Round
@@ -319,7 +349,7 @@ private fun EnvironmentMetricsChart(modifier: Modifier = Modifier, telemetries: 
 
     Spacer(modifier = Modifier.height(16.dp))
 
-    EnvironmentLegend()
+    Legend(LEGEND_DATA, promptInfoDialog)
 
     Spacer(modifier = Modifier.height(16.dp))
 }
@@ -409,32 +439,5 @@ private fun EnvironmentMetricsCard(telemetry: Telemetry, environmentDisplayFahre
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun EnvironmentLegend() {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center,
-    ) {
-        Spacer(modifier = Modifier.weight(1f))
-
-        LegendLabel(text = stringResource(R.string.temperature), color = ENVIRONMENT_METRICS_COLORS[0], isLine = true)
-
-        Spacer(modifier = Modifier.width(8.dp))
-
-        LegendLabel(text = stringResource(R.string.humidity), color = ENVIRONMENT_METRICS_COLORS[1], isLine = true)
-
-        Spacer(modifier = Modifier.width(8.dp))
-
-        LegendLabel(
-            text = stringResource(R.string.iaq),
-            color = ENVIRONMENT_METRICS_COLORS[2],
-            isLine = true
-        )
-
-        Spacer(modifier = Modifier.weight(1f))
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
@@ -94,6 +94,10 @@ private fun EnvironmentMetricsChart(modifier: Modifier = Modifier, telemetries: 
     if (telemetries.isEmpty()) {
         return
     }
+    TimeLabels(
+        oldest = telemetries.first().time * MS_PER_SEC,
+        newest = telemetries.last().time * MS_PER_SEC
+    )
 
     Spacer(modifier = Modifier.height(16.dp))
 
@@ -311,12 +315,6 @@ private fun EnvironmentMetricsChart(modifier: Modifier = Modifier, telemetries: 
                 )
             )
         }
-        TimeLabels(
-            modifier = modifier,
-            graphColor = graphColor,
-            oldest = telemetries.first().time * MS_PER_SEC,
-            newest = telemetries.last().time * MS_PER_SEC
-        )
     }
 
     Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
 import com.geeksville.mesh.TelemetryProtos.Telemetry
 import com.geeksville.mesh.copy
-import com.geeksville.mesh.ui.components.CommonCharts.LEFT_CHART_SPACING
+import com.geeksville.mesh.ui.components.CommonCharts.X_AXIS_SPACING
 import com.geeksville.mesh.ui.components.CommonCharts.MS_PER_SEC
 import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 
@@ -135,7 +135,7 @@ private fun EnvironmentMetricsChart(
     val transparentTemperatureColor = remember { ENVIRONMENT_METRICS_COLORS[Environment.TEMPERATURE.ordinal].copy(alpha = 0.5f) }
     val transparentHumidityColor = remember { ENVIRONMENT_METRICS_COLORS[Environment.HUMIDITY.ordinal].copy(alpha = 0.5f) }
     val transparentIAQColor = remember { ENVIRONMENT_METRICS_COLORS[Environment.IAQ.ordinal].copy(alpha = 0.5f) }
-    val spacing = LEFT_CHART_SPACING
+    val spacing = X_AXIS_SPACING
 
     /* Since both temperature and humidity are being plotted we need a combined min and max. */
     val (minTemp, maxTemp) = remember(key1 = telemetries) {

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
@@ -194,10 +194,10 @@ private fun EnvironmentMetricsChart(
                     val rightRatio = (nextEnvMetrics.temperature - min) / diff
 
                     val x1 = spacing + i * spacePerEntry
-                    val y1 = height - spacing - (leftRatio * height)
+                    val y1 = height- (leftRatio * height)
 
                     val x2 = spacing + (i + 1) * spacePerEntry
-                    val y2 = height - spacing - (rightRatio * height)
+                    val y2 = height - (rightRatio * height)
                     if (i == 0) {
                         moveTo(x1, y1)
                     }
@@ -211,8 +211,8 @@ private fun EnvironmentMetricsChart(
             val fillPath = android.graphics.Path(temperaturePath.asAndroidPath())
                 .asComposePath()
                 .apply {
-                    lineTo(lastTempX, height - spacing)
-                    lineTo(spacing, height - spacing)
+                    lineTo(lastTempX, height)
+                    lineTo(spacing, height)
                     close()
                 }
 
@@ -223,7 +223,7 @@ private fun EnvironmentMetricsChart(
                         transparentTemperatureColor,
                         Color.Transparent
                     ),
-                    endY = height - spacing
+                    endY = height
                 ),
             )
 
@@ -247,10 +247,10 @@ private fun EnvironmentMetricsChart(
                     val rightRatio = (nextEnvMetrics.relativeHumidity - min) / diff
 
                     val x1 = spacing + i * spacePerEntry
-                    val y1 = height - spacing - (leftRatio * height)
+                    val y1 = height - (leftRatio * height)
 
                     val x2 = spacing + (i + 1) * spacePerEntry
-                    val y2 = height - spacing - (rightRatio * height)
+                    val y2 = height - (rightRatio * height)
                     if (i == 0) {
                         moveTo(x1, y1)
                     }
@@ -264,8 +264,8 @@ private fun EnvironmentMetricsChart(
             val fillHumidityPath = android.graphics.Path(humidityPath.asAndroidPath())
                 .asComposePath()
                 .apply {
-                    lineTo(lastHumidityX, height - spacing)
-                    lineTo(spacing, height - spacing)
+                    lineTo(lastHumidityX, height)
+                    lineTo(spacing, height)
                     close()
                 }
 
@@ -276,7 +276,7 @@ private fun EnvironmentMetricsChart(
                         transparentHumidityColor,
                         Color.Transparent
                     ),
-                    endY = height - spacing
+                    endY = height
                 ),
             )
 
@@ -300,11 +300,10 @@ private fun EnvironmentMetricsChart(
                     val rightRatio = (nextEnvMetrics.iaq - min) / diff
 
                     val x1 = spacing + i * spacePerEntry
-                    val y1 = height - spacing - (leftRatio * height)
+                    val y1 = height - (leftRatio * height)
 
                     val x2 = spacing + (i + 1) * spacePerEntry
-
-                    val y2 = height - spacing - (rightRatio * height)
+                    val y2 = height - (rightRatio * height)
                     if (i == 0) {
                         moveTo(x1, y1)
                     }
@@ -321,8 +320,8 @@ private fun EnvironmentMetricsChart(
             val fillIaqPath = android.graphics.Path(iaqPath.asAndroidPath())
                 .asComposePath()
                 .apply {
-                    lineTo(lastIaqX, height - spacing)
-                    lineTo(spacing, height - spacing)
+                    lineTo(lastIaqX, height)
+                    lineTo(spacing, height)
                     close()
                 }
             drawPath(
@@ -332,7 +331,7 @@ private fun EnvironmentMetricsChart(
                         transparentIAQColor,
                         Color.Transparent
                     ),
-                    endY = height - spacing
+                    endY = height
                 ),
             )
 

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
@@ -44,7 +44,6 @@ import com.geeksville.mesh.ui.components.CommonCharts.X_AXIS_SPACING
 import com.geeksville.mesh.ui.components.CommonCharts.MS_PER_SEC
 import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 
-
 private val ENVIRONMENT_METRICS_COLORS = listOf(Color.Red, Color.Blue, Color.Green)
 private enum class Environment {
     TEMPERATURE,
@@ -52,9 +51,21 @@ private enum class Environment {
     IAQ
 }
 private val LEGEND_DATA = listOf(
-    LegendData(nameRes = R.string.temperature, color = ENVIRONMENT_METRICS_COLORS[Environment.TEMPERATURE.ordinal], isLine = true),
-    LegendData(nameRes = R.string.humidity, color = ENVIRONMENT_METRICS_COLORS[Environment.HUMIDITY.ordinal], isLine = true),
-    LegendData(nameRes = R.string.iaq, color = ENVIRONMENT_METRICS_COLORS[Environment.IAQ.ordinal], isLine = true),
+    LegendData(
+        nameRes = R.string.temperature,
+        color = ENVIRONMENT_METRICS_COLORS[Environment.TEMPERATURE.ordinal],
+        isLine = true
+    ),
+    LegendData(
+        nameRes = R.string.humidity,
+        color = ENVIRONMENT_METRICS_COLORS[Environment.HUMIDITY.ordinal],
+        isLine = true
+    ),
+    LegendData(
+        nameRes = R.string.iaq,
+        color = ENVIRONMENT_METRICS_COLORS[Environment.IAQ.ordinal],
+        isLine = true
+    ),
 )
 
 @Composable
@@ -132,9 +143,15 @@ private fun EnvironmentMetricsChart(
     Spacer(modifier = Modifier.height(16.dp))
 
     val graphColor = MaterialTheme.colors.onSurface
-    val transparentTemperatureColor = remember { ENVIRONMENT_METRICS_COLORS[Environment.TEMPERATURE.ordinal].copy(alpha = 0.5f) }
-    val transparentHumidityColor = remember { ENVIRONMENT_METRICS_COLORS[Environment.HUMIDITY.ordinal].copy(alpha = 0.5f) }
-    val transparentIAQColor = remember { ENVIRONMENT_METRICS_COLORS[Environment.IAQ.ordinal].copy(alpha = 0.5f) }
+    val transparentTemperatureColor = remember {
+        ENVIRONMENT_METRICS_COLORS[Environment.TEMPERATURE.ordinal].copy(alpha = 0.5f)
+    }
+    val transparentHumidityColor = remember {
+        ENVIRONMENT_METRICS_COLORS[Environment.HUMIDITY.ordinal].copy(alpha = 0.5f)
+    }
+    val transparentIAQColor = remember {
+        ENVIRONMENT_METRICS_COLORS[Environment.IAQ.ordinal].copy(alpha = 0.5f)
+    }
     val spacing = X_AXIS_SPACING
 
     /* Since both temperature and humidity are being plotted we need a combined min and max. */
@@ -194,7 +211,7 @@ private fun EnvironmentMetricsChart(
                     val rightRatio = (nextEnvMetrics.temperature - min) / diff
 
                     val x1 = spacing + i * spacePerEntry
-                    val y1 = height- (leftRatio * height)
+                    val y1 = height - (leftRatio * height)
 
                     val x2 = spacing + (i + 1) * spacePerEntry
                     val y2 = height - (rightRatio * height)

--- a/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EnvironmentMetrics.kt
@@ -137,7 +137,7 @@ private fun EnvironmentMetricsChart(modifier: Modifier = Modifier, telemetries: 
     Box(contentAlignment = Alignment.TopStart) {
         ChartOverlay(
             modifier = modifier,
-            graphColor = graphColor,
+            labelColor = graphColor,
             lineColors = List(size = 5) { graphColor },
             minValue = min,
             maxValue = max

--- a/app/src/main/java/com/geeksville/mesh/ui/components/LoraSignalIndicator.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/LoraSignalIndicator.kt
@@ -33,19 +33,20 @@ private enum class Quality(
     val color: Color
 ) {
     NONE(R.string.none_quality, Icons.Default.SignalCellularAlt1Bar, Color.Red),
-    BAD(R.string.bad, Icons.Default.SignalCellularAlt2Bar, Color(247, 147, 26)),
-    FAIR(R.string.fair, Icons.Default.SignalCellularAlt, Color(255, 230, 0)),
+    BAD(R.string.bad, Icons.Default.SignalCellularAlt2Bar, Color(red = 247, green = 147, blue = 26)),
+    FAIR(R.string.fair, Icons.Default.SignalCellularAlt, Color(red = 255, green = 230, blue = 0)),
     GOOD(R.string.good, Icons.Default.SignalCellular4Bar, Color.Green)
 }
 
 @Composable
 fun Snr(snr: Float) {
-    val color: Color = if (snr > SNR_GOOD_THRESHOLD)
+    val color: Color = if (snr > SNR_GOOD_THRESHOLD) {
         Quality.GOOD.color
-    else if (snr > SNR_FAIR_THRESHOLD)
+    } else if (snr > SNR_FAIR_THRESHOLD) {
         Quality.FAIR.color
-    else
+    } else {
         Quality.BAD.color
+    }
 
     Text(
         text = "%s %.2fdB".format(
@@ -59,12 +60,13 @@ fun Snr(snr: Float) {
 
 @Composable
 fun Rssi(rssi: Int) {
-    val color: Color = if (rssi > RSSI_GOOD_THRESHOLD)
+    val color: Color = if (rssi > RSSI_GOOD_THRESHOLD) {
         Quality.GOOD.color
-    else if (rssi > RSSI_FAIR_THRESHOLD)
+    } else if (rssi > RSSI_FAIR_THRESHOLD) {
         Quality.FAIR.color
-    else
+    } else {
         Quality.BAD.color
+    }
     Text(
         text = "%s %ddB".format(
             stringResource(id = R.string.rssi),
@@ -96,13 +98,10 @@ fun LoraSignalIndicator(snr: Float, rssi: Int) {
     }
 }
 
-private fun determineSignalQuality(snr: Float, rssi: Int) : Quality {
-    return if (snr > SNR_GOOD_THRESHOLD && rssi > RSSI_GOOD_THRESHOLD)
-        Quality.GOOD
-    else if (snr > SNR_GOOD_THRESHOLD && rssi > RSSI_FAIR_THRESHOLD || snr > SNR_FAIR_THRESHOLD && rssi > RSSI_GOOD_THRESHOLD)
-        Quality.FAIR
-    else if (snr <= SNR_FAIR_THRESHOLD && rssi <= RSSI_FAIR_THRESHOLD)
-        Quality.NONE
-    else
-        Quality.BAD
+private fun determineSignalQuality(snr: Float, rssi: Int): Quality = when {
+    snr > SNR_GOOD_THRESHOLD && rssi > RSSI_GOOD_THRESHOLD -> Quality.GOOD
+    snr > SNR_GOOD_THRESHOLD && rssi > RSSI_FAIR_THRESHOLD -> Quality.FAIR
+    snr > SNR_FAIR_THRESHOLD && rssi > RSSI_GOOD_THRESHOLD -> Quality.FAIR
+    snr <= SNR_FAIR_THRESHOLD && rssi <= RSSI_FAIR_THRESHOLD -> Quality.NONE
+    else -> Quality.BAD
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/LoraSignalIndicator.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/LoraSignalIndicator.kt
@@ -1,0 +1,108 @@
+package com.geeksville.mesh.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SignalCellular4Bar
+import androidx.compose.material.icons.filled.SignalCellularAlt
+import androidx.compose.material.icons.filled.SignalCellularAlt1Bar
+import androidx.compose.material.icons.filled.SignalCellularAlt2Bar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.geeksville.mesh.R
+
+private const val SNR_GOOD_THRESHOLD = -7f
+private const val SNR_FAIR_THRESHOLD = -15f
+
+private const val RSSI_GOOD_THRESHOLD = -115
+private const val RSSI_FAIR_THRESHOLD = -126
+
+private enum class Quality(
+    val nameRes: Int,
+    val imageVector: ImageVector,
+    val color: Color
+) {
+    NONE(R.string.none_quality, Icons.Default.SignalCellularAlt1Bar, Color.Red),
+    BAD(R.string.bad, Icons.Default.SignalCellularAlt2Bar, Color(247, 147, 26)),
+    FAIR(R.string.fair, Icons.Default.SignalCellularAlt, Color(255, 230, 0)),
+    GOOD(R.string.good, Icons.Default.SignalCellular4Bar, Color.Green)
+}
+
+@Composable
+fun Snr(snr: Float) {
+    val color: Color = if (snr > SNR_GOOD_THRESHOLD)
+        Quality.GOOD.color
+    else if (snr > SNR_FAIR_THRESHOLD)
+        Quality.FAIR.color
+    else
+        Quality.BAD.color
+
+    Text(
+        text = "%s %.2fdB".format(
+            stringResource(id = R.string.snr),
+            snr
+        ),
+            color = color,
+            fontSize = MaterialTheme.typography.button.fontSize
+        )
+}
+
+@Composable
+fun Rssi(rssi: Int) {
+    val color: Color = if (rssi > RSSI_GOOD_THRESHOLD)
+        Quality.GOOD.color
+    else if (rssi > RSSI_FAIR_THRESHOLD)
+        Quality.FAIR.color
+    else
+        Quality.BAD.color
+    Text(
+        text = "%s %ddB".format(
+            stringResource(id = R.string.rssi),
+            rssi
+        ),
+        color = color,
+        fontSize = MaterialTheme.typography.button.fontSize
+    )
+}
+
+@Composable
+fun LoraSignalIndicator(snr: Float, rssi: Int) {
+
+    val quality = determineSignalQuality(snr, rssi)
+
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(8.dp)
+    ) {
+        Icon(
+            imageVector = quality.imageVector,
+            contentDescription = stringResource(R.string.signal_quality),
+            tint = quality.color
+        )
+        Text(text = "${stringResource(R.string.signal)} ${stringResource(quality.nameRes)}")
+    }
+}
+
+private fun determineSignalQuality(snr: Float, rssi: Int) : Quality {
+    return if (snr > SNR_GOOD_THRESHOLD && rssi > RSSI_GOOD_THRESHOLD)
+        Quality.GOOD
+    else if (snr > SNR_GOOD_THRESHOLD && rssi > RSSI_FAIR_THRESHOLD || snr > SNR_FAIR_THRESHOLD && rssi > RSSI_GOOD_THRESHOLD)
+        Quality.FAIR
+    else if (snr <= SNR_FAIR_THRESHOLD && rssi <= RSSI_FAIR_THRESHOLD)
+        Quality.NONE
+    else
+        Quality.BAD
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
@@ -1,0 +1,176 @@
+package com.geeksville.mesh.ui.components
+
+import android.graphics.Paint
+import android.graphics.Typeface
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import com.geeksville.mesh.MeshProtos.MeshPacket
+import com.geeksville.mesh.ui.components.CommonCharts.MS_PER_SEC
+import com.geeksville.mesh.ui.components.CommonCharts.LINE_LIMIT
+import com.geeksville.mesh.ui.components.CommonCharts.TEXT_PAINT_ALPHA
+import com.geeksville.mesh.ui.components.CommonCharts.LEFT_LABEL_SPACING
+
+
+private val METRICS_COLORS = listOf(Color.Green, Color.Blue)
+private enum class Metric(val min: Float, val max: Float) {
+    SNR(-20f, 10f),
+    RSSI(-140f, -20f);
+    /**
+     * Difference between the metrics `max` and `min` values.
+     */
+    fun difference() = max - min
+}
+
+@Composable
+fun SignalMetricsScreen(meshPackets: List<MeshPacket>) {
+    Column {
+        SignalMetricsChart(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(fraction = 0.33f),
+            meshPackets = meshPackets
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            items(meshPackets.reversed()) { meshPacket -> SignalMetricsCard(meshPacket)}
+        }
+    }
+}
+
+@Composable
+private fun SignalMetricsChart(modifier: Modifier = Modifier, meshPackets: List<MeshPacket>) {
+
+    ChartHeader(amount = meshPackets.size)
+    if (meshPackets.isEmpty())
+        return
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    val graphColor = MaterialTheme.colors.onSurface
+    val snrDiff = Metric.SNR.difference()
+    val rssiDiff = Metric.RSSI.difference()
+
+    Box(contentAlignment = Alignment.TopStart) {
+
+        ChartOverlay(
+            modifier = modifier,
+            lineColors = List(size = 5) { graphColor },
+            labelColor = METRICS_COLORS[Metric.SNR.ordinal],
+            minValue = Metric.SNR.min,
+            maxValue = Metric.SNR.max,
+            leaveSpace = true
+        )
+        LeftYLabels(modifier = modifier, labelColor = METRICS_COLORS[Metric.RSSI.ordinal])
+
+        /* Plot SNR and RSSI */
+        Canvas(modifier = modifier) {
+
+            val height = size.height
+            val width = size.width - 28.dp.toPx()
+            val spacing = LEFT_LABEL_SPACING.dp.toPx()
+            val spacePerEntry = (width - spacing) / meshPackets.size
+
+            /* Plot */
+            val dataPointRadius = 2.dp.toPx()
+            for ((i, packet) in meshPackets.withIndex()) {
+
+                val x = spacing + i * spacePerEntry
+
+                /* SNR */
+                val snrRatio = (packet.rxSnr - Metric.SNR.min) / snrDiff
+                val ySNR = height - spacing - (snrRatio * height)
+                drawCircle(
+                    color = METRICS_COLORS[Metric.SNR.ordinal],
+                    radius = dataPointRadius,
+                    center = Offset(x, ySNR)
+                )
+
+                /* RSSI */
+                val rssiRatio = (packet.rxRssi - Metric.RSSI.min) / rssiDiff
+                val yRssi= height - spacing - (rssiRatio * height)
+                drawCircle(
+                    color = METRICS_COLORS[Metric.RSSI.ordinal],
+                    radius = dataPointRadius,
+                    center = Offset(x, yRssi)
+                )
+            }
+        }
+        TimeLabels(
+            modifier = modifier,
+            graphColor = graphColor,
+            oldest = meshPackets.last().rxTime * MS_PER_SEC,
+            newest = meshPackets.first().rxTime * MS_PER_SEC
+        )
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    // TODO legend
+
+    Spacer(modifier = Modifier.height(16.dp))
+}
+
+/**
+ * Draws a set of Y labels on the left side of the graph.
+ * Currently only used for the RSSI labels.
+ */
+@Composable
+private fun LeftYLabels(
+    modifier: Modifier,
+    labelColor: Color,
+) {
+    val range = Metric.RSSI.difference()
+    val verticalSpacing = range / LINE_LIMIT
+    val density = LocalDensity.current
+    Canvas(modifier = modifier) {
+
+        val height = size.height
+
+        /* Y Labels */
+
+        val textPaint = Paint().apply {
+            color = labelColor.toArgb()
+            textAlign = Paint.Align.LEFT
+            textSize = density.run { 12.dp.toPx() }
+            typeface = setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD))
+            alpha = TEXT_PAINT_ALPHA
+        }
+        drawContext.canvas.nativeCanvas.apply {
+            var label = Metric.RSSI.min
+            for (i in 0..LINE_LIMIT) {
+                val ratio = (label - Metric.RSSI.min) / range
+                val y = height - (ratio * height)
+                drawText(
+                    "${label.toInt()}",
+                    4.dp.toPx(),
+                    y + 4.dp.toPx(),
+                    textPaint
+                )
+                label += verticalSpacing
+            }
+        }
+    }
+}
+
+@Composable
+private fun SignalMetricsCard(meshPacket: MeshPacket) {}

--- a/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -32,7 +33,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -220,48 +220,51 @@ private fun SignalMetricsCard(meshPacket: MeshPacket) {
     ) {
         Surface {
             SelectionContainer {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(8.dp)
+                Row(
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    /* Time */
-                    Row(
+
+                    /* Data */
+                    Box(
                         modifier = Modifier
-                            .fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
+                            .weight(5f)
+                            .height(IntrinsicSize.Min)
                     ) {
-                        Text(
-                            text = TIME_FORMAT.format(time),
-                            style = TextStyle(fontWeight = FontWeight.Bold),
-                            fontSize = MaterialTheme.typography.button.fontSize
-                        )
+                        Column(
+                            modifier = Modifier
+                                .padding(8.dp)
+                        ) {
+                            /* Time */
+                            Row(
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(
+                                    text = TIME_FORMAT.format(time),
+                                    style = TextStyle(fontWeight = FontWeight.Bold),
+                                    fontSize = MaterialTheme.typography.button.fontSize
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            /* SNR and RSSI */
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Snr(meshPacket.rxSnr)
+                                Rssi(meshPacket.rxRssi)
+                            }
+                        }
                     }
 
-                    Spacer(modifier = Modifier.height(4.dp))
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
+                    /* Signal Indicator */
+                    Box(
+                        modifier = Modifier
+                            .weight(3f)
+                            .height(IntrinsicSize.Max)
                     ) {
-                        /* SNR */
-                        Text(
-                            text = "%s %.2fdB".format(
-                                stringResource(id = R.string.snr),
-                                meshPacket.rxSnr,
-                            ),
-                            color = MaterialTheme.colors.onSurface,
-                            fontSize = MaterialTheme.typography.button.fontSize
-                        )
-                        /* RSSI */
-                        Text(
-                            text = "%s %ddB".format(
-                                stringResource(id = R.string.rssi),
-                                meshPacket.rxRssi,
-                            ),
-                            color = MaterialTheme.colors.onSurface,
-                            fontSize = MaterialTheme.typography.button.fontSize
-                        )
+                        LoraSignalIndicator(meshPacket.rxSnr, meshPacket.rxRssi)
                     }
                 }
             }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
@@ -64,6 +64,11 @@ private fun SignalMetricsChart(modifier: Modifier = Modifier, meshPackets: List<
     if (meshPackets.isEmpty())
         return
 
+    TimeLabels(
+            oldest = meshPackets.last().rxTime * MS_PER_SEC,
+            newest = meshPackets.first().rxTime * MS_PER_SEC
+    )
+
     Spacer(modifier = Modifier.height(16.dp))
 
     val graphColor = MaterialTheme.colors.onSurface
@@ -115,12 +120,6 @@ private fun SignalMetricsChart(modifier: Modifier = Modifier, meshPackets: List<
                 )
             }
         }
-        TimeLabels(
-            modifier = modifier,
-            graphColor = graphColor,
-            oldest = meshPackets.last().rxTime * MS_PER_SEC,
-            newest = meshPackets.first().rxTime * MS_PER_SEC
-        )
     }
 
     Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
@@ -3,16 +3,23 @@ package com.geeksville.mesh.ui.components
 import android.graphics.Paint
 import android.graphics.Typeface
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.Card
+import androidx.compose.material.Surface
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,6 +32,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.MeshProtos.MeshPacket
 import com.geeksville.mesh.R
@@ -32,6 +42,7 @@ import com.geeksville.mesh.ui.components.CommonCharts.MS_PER_SEC
 import com.geeksville.mesh.ui.components.CommonCharts.LINE_LIMIT
 import com.geeksville.mesh.ui.components.CommonCharts.TEXT_PAINT_ALPHA
 import com.geeksville.mesh.ui.components.CommonCharts.LEFT_LABEL_SPACING
+import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 
 
 private val METRICS_COLORS = listOf(Color.Green, Color.Blue)
@@ -69,14 +80,14 @@ fun SignalMetricsScreen(meshPackets: List<MeshPacket>) {
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight(fraction = 0.33f),
-            meshPackets = meshPackets,
+            meshPackets = meshPackets.reversed(),
             promptInfoDialog = { displayInfoDialog = true }
         )
 
         LazyColumn(
             modifier = Modifier.fillMaxSize()
         ) {
-            items(meshPackets.reversed()) { meshPacket -> SignalMetricsCard(meshPacket)}
+            items(meshPackets) { meshPacket -> SignalMetricsCard(meshPacket)}
         }
     }
 }
@@ -93,8 +104,8 @@ private fun SignalMetricsChart(
         return
 
     TimeLabels(
-            oldest = meshPackets.last().rxTime * MS_PER_SEC,
-            newest = meshPackets.first().rxTime * MS_PER_SEC
+            oldest = meshPackets.first().rxTime * MS_PER_SEC,
+            newest = meshPackets.last().rxTime * MS_PER_SEC
     )
 
     Spacer(modifier = Modifier.height(16.dp))
@@ -200,4 +211,60 @@ private fun LeftYLabels(
 }
 
 @Composable
-private fun SignalMetricsCard(meshPacket: MeshPacket) {}
+private fun SignalMetricsCard(meshPacket: MeshPacket) {
+    val time = meshPacket.rxTime * MS_PER_SEC
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Surface {
+            SelectionContainer {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp)
+                ) {
+                    /* Time */
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = TIME_FORMAT.format(time),
+                            style = TextStyle(fontWeight = FontWeight.Bold),
+                            fontSize = MaterialTheme.typography.button.fontSize
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        /* SNR */
+                        Text(
+                            text = "%s %.2fdB".format(
+                                stringResource(id = R.string.snr),
+                                meshPacket.rxSnr,
+                            ),
+                            color = MaterialTheme.colors.onSurface,
+                            fontSize = MaterialTheme.typography.button.fontSize
+                        )
+                        /* RSSI */
+                        Text(
+                            text = "%s %ddB".format(
+                                stringResource(id = R.string.rssi),
+                                meshPacket.rxRssi,
+                            ),
+                            color = MaterialTheme.colors.onSurface,
+                            fontSize = MaterialTheme.typography.button.fontSize
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
@@ -44,8 +44,9 @@ import com.geeksville.mesh.ui.components.CommonCharts.TEXT_PAINT_ALPHA
 import com.geeksville.mesh.ui.components.CommonCharts.LEFT_LABEL_SPACING
 import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 
-
 private val METRICS_COLORS = listOf(Color.Green, Color.Blue)
+
+@Suppress("MagicNumber")
 private enum class Metric(val min: Float, val max: Float) {
     SNR(-20f, 12f), /* Selected 12 as the max to get 4 equal vertical sections. */
     RSSI(-140f, -20f);
@@ -69,8 +70,8 @@ fun SignalMetricsScreen(meshPackets: List<MeshPacket>) {
         if (displayInfoDialog) {
             LegendInfoDialog(
                 pairedRes = listOf(
-                    Pair(R.string.snr,R.string.snr_definition),
-                    Pair(R.string.rssi,R.string.rssi_definition)
+                    Pair(R.string.snr, R.string.snr_definition),
+                    Pair(R.string.rssi, R.string.rssi_definition)
                 ),
                 onDismiss = { displayInfoDialog = false }
             )
@@ -87,7 +88,7 @@ fun SignalMetricsScreen(meshPackets: List<MeshPacket>) {
         LazyColumn(
             modifier = Modifier.fillMaxSize()
         ) {
-            items(meshPackets) { meshPacket -> SignalMetricsCard(meshPacket)}
+            items(meshPackets) { meshPacket -> SignalMetricsCard(meshPacket) }
         }
     }
 }
@@ -100,8 +101,9 @@ private fun SignalMetricsChart(
 ) {
 
     ChartHeader(amount = meshPackets.size)
-    if (meshPackets.isEmpty())
+    if (meshPackets.isEmpty()) {
         return
+    }
 
     TimeLabels(
         oldest = meshPackets.first().rxTime * MS_PER_SEC,
@@ -151,7 +153,7 @@ private fun SignalMetricsChart(
 
                 /* RSSI */
                 val rssiRatio = (packet.rxRssi - Metric.RSSI.min) / rssiDiff
-                val yRssi= height - (rssiRatio * height)
+                val yRssi = height - (rssiRatio * height)
                 drawCircle(
                     color = METRICS_COLORS[Metric.RSSI.ordinal],
                     radius = dataPointRadius,
@@ -227,7 +229,7 @@ private fun SignalMetricsCard(meshPacket: MeshPacket) {
                     /* Data */
                     Box(
                         modifier = Modifier
-                            .weight(5f)
+                            .weight(weight = 5f)
                             .height(IntrinsicSize.Min)
                     ) {
                         Column(
@@ -261,7 +263,7 @@ private fun SignalMetricsCard(meshPacket: MeshPacket) {
                     /* Signal Indicator */
                     Box(
                         modifier = Modifier
-                            .weight(3f)
+                            .weight(weight = 3f)
                             .height(IntrinsicSize.Max)
                     ) {
                         LoraSignalIndicator(meshPacket.rxSnr, meshPacket.rxRssi)

--- a/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
@@ -14,6 +14,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -23,6 +27,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.MeshProtos.MeshPacket
+import com.geeksville.mesh.R
 import com.geeksville.mesh.ui.components.CommonCharts.MS_PER_SEC
 import com.geeksville.mesh.ui.components.CommonCharts.LINE_LIMIT
 import com.geeksville.mesh.ui.components.CommonCharts.TEXT_PAINT_ALPHA
@@ -38,15 +43,34 @@ private enum class Metric(val min: Float, val max: Float) {
      */
     fun difference() = max - min
 }
+private val LEGEND_DATA = listOf(
+    LegendData(nameRes = R.string.snr, color = METRICS_COLORS[Metric.SNR.ordinal]),
+    LegendData(nameRes = R.string.rssi, color = METRICS_COLORS[Metric.RSSI.ordinal])
+)
 
 @Composable
 fun SignalMetricsScreen(meshPackets: List<MeshPacket>) {
+
+    var displayInfoDialog by remember { mutableStateOf(false) }
+
     Column {
+
+        if (displayInfoDialog) {
+            LegendInfoDialog(
+                pairedRes = listOf(
+                    Pair(R.string.snr,R.string.snr_definition),
+                    Pair(R.string.rssi,R.string.rssi_definition)
+                ),
+                onDismiss = { displayInfoDialog = false }
+            )
+        }
+
         SignalMetricsChart(
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight(fraction = 0.33f),
-            meshPackets = meshPackets
+            meshPackets = meshPackets,
+            promptInfoDialog = { displayInfoDialog = true }
         )
 
         LazyColumn(
@@ -58,7 +82,11 @@ fun SignalMetricsScreen(meshPackets: List<MeshPacket>) {
 }
 
 @Composable
-private fun SignalMetricsChart(modifier: Modifier = Modifier, meshPackets: List<MeshPacket>) {
+private fun SignalMetricsChart(
+    modifier: Modifier = Modifier,
+    meshPackets: List<MeshPacket>,
+    promptInfoDialog: () -> Unit
+) {
 
     ChartHeader(amount = meshPackets.size)
     if (meshPackets.isEmpty())
@@ -124,7 +152,7 @@ private fun SignalMetricsChart(modifier: Modifier = Modifier, meshPackets: List<
 
     Spacer(modifier = Modifier.height(16.dp))
 
-    // TODO legend
+    Legend(legendData = LEGEND_DATA, promptInfoDialog)
 
     Spacer(modifier = Modifier.height(16.dp))
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/SignalMetrics.kt
@@ -47,7 +47,7 @@ import com.geeksville.mesh.ui.components.CommonCharts.TIME_FORMAT
 
 private val METRICS_COLORS = listOf(Color.Green, Color.Blue)
 private enum class Metric(val min: Float, val max: Float) {
-    SNR(-20f, 10f),
+    SNR(-20f, 12f), /* Selected 12 as the max to get 4 equal vertical sections. */
     RSSI(-140f, -20f);
     /**
      * Difference between the metrics `max` and `min` values.
@@ -104,8 +104,8 @@ private fun SignalMetricsChart(
         return
 
     TimeLabels(
-            oldest = meshPackets.first().rxTime * MS_PER_SEC,
-            newest = meshPackets.last().rxTime * MS_PER_SEC
+        oldest = meshPackets.first().rxTime * MS_PER_SEC,
+        newest = meshPackets.last().rxTime * MS_PER_SEC
     )
 
     Spacer(modifier = Modifier.height(16.dp))
@@ -142,7 +142,7 @@ private fun SignalMetricsChart(
 
                 /* SNR */
                 val snrRatio = (packet.rxSnr - Metric.SNR.min) / snrDiff
-                val ySNR = height - spacing - (snrRatio * height)
+                val ySNR = height - (snrRatio * height)
                 drawCircle(
                     color = METRICS_COLORS[Metric.SNR.ordinal],
                     radius = dataPointRadius,
@@ -151,7 +151,7 @@ private fun SignalMetricsChart(
 
                 /* RSSI */
                 val rssiRatio = (packet.rxRssi - Metric.RSSI.min) / rssiDiff
-                val yRssi= height - spacing - (rssiRatio * height)
+                val yRssi= height - (rssiRatio * height)
                 drawCircle(
                     color = METRICS_COLORS[Metric.RSSI.ordinal],
                     radius = dataPointRadius,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -273,4 +273,9 @@
     <string name="request_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New nodes notifications</string>
     <string name="more_details">More details</string>
+    <string name="snr">SNR</string>
+    <string name="snr_definition">Signal-to-Noise Ratio, a measure used in communications to quantify the level of a desired signal to the level of background noise. In Meshtastic and other wireless systems, a higher SNR indicates a clearer signal that can enhance the reliability and quality of data transmission.</string>
+    <string name="rssi">RSSI</string>
+    <string name="rssi_definition">Received Signal Strength Indicator, a measurement used to determine the power level being received by the antenna. A higher RSSI value generally indicates a stronger and more stable connection.</string>
+    <string name="iaq_definition">(Indoor Air Quality) relative scale IAQ value as measured by Bosch BME680. Value Range 0–500.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,4 +278,7 @@
     <string name="rssi">RSSI</string>
     <string name="rssi_definition">Received Signal Strength Indicator, a measurement used to determine the power level being received by the antenna. A higher RSSI value generally indicates a stronger and more stable connection.</string>
     <string name="iaq_definition">(Indoor Air Quality) relative scale IAQ value as measured by Bosch BME680. Value Range 0–500.</string>
+    <string name="device_metrics_logs">Device Metrics Logs</string>
+    <string name="env_metrics_logs">Environment Metrics Logs</string>
+    <string name="sig_metrics_logs">Signal Metrics Logs</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -281,4 +281,10 @@
     <string name="device_metrics_logs">Device Metrics Logs</string>
     <string name="env_metrics_logs">Environment Metrics Logs</string>
     <string name="sig_metrics_logs">Signal Metrics Logs</string>
+    <string name="bad">Bad</string>
+    <string name="fair">Fair</string>
+    <string name="good">Good</string>
+    <string name="none_quality">None</string>
+    <string name="signal">Signal</string>
+    <string name="signal_quality">Signal Quality</string>
 </resources>


### PR DESCRIPTION
### Major
Added a signal graph that plots the rx snr and rssi of a mesh packet.

### Minor
- Moved the time labels above and outside of the graph area.
- Implemented info dialogs for all existing graphs.
- Implemented a signal indicator to visualize the signal quality for each data entry.

![Screenshot from 2024-10-23 00-01-55](https://github.com/user-attachments/assets/897dc9e0-de1b-4c92-aed6-cba15ae12668)

### Concerns
Retrieving the data from the DB, do I need to filter anything out with respect to hops or from?

### TODO
Planning on completing this during the review.
- Since we don't receive mesh packets from our connected node, the nav card shouldn't be available when clicking on More details for our nodes.