### PR TITLE
Short duration for the "notification permissions denied" snackbar

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -137,7 +137,7 @@ class MainActivity : AppCompatActivity(), Logging {
                 info("Notification permissions granted")
             } else {
                 warn("Notification permissions denied")
-                showSnackbar(getString(R.string.notification_denied))
+                showSnackbar(getString(R.string.notification_denied), Snackbar.LENGTH_SHORT)
             }
         }
 
@@ -385,9 +385,9 @@ class MainActivity : AppCompatActivity(), Logging {
         }
     }
 
-    private fun showSnackbar(msg: String) {
+    private fun showSnackbar(msg: String, duration: Int = Snackbar.LENGTH_INDEFINITE) {
         try {
-            Snackbar.make(binding.root, msg, Snackbar.LENGTH_INDEFINITE)
+            Snackbar.make(binding.root, msg, duration)
                 .apply { view.findViewById<TextView>(R.id.snackbar_text).isSingleLine = false }
                 .setAction(R.string.okay) {
                     // dismiss


### PR DESCRIPTION
I try to avoid having notifications on for pretty much any Android app unless absolutely necessary, and having the snackbar continuously asking me to give the notification permission to Meshtastic is very annoying, especially since I have to keep dismissing it when switching between apps.

Change the duration from INDEFINITE to SHORT for those messages.