### PR TITLE
fix: Display for self-sent messages

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Message.kt
@@ -1,7 +1,7 @@
 package com.geeksville.mesh.model
 
+import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.MeshProtos.Routing
-import com.geeksville.mesh.MeshUser
 import com.geeksville.mesh.MessageStatus
 import com.geeksville.mesh.R
 
@@ -29,7 +29,7 @@ val Routing.Error.stringRes: Int
 data class Message(
     val uuid: Long,
     val receivedTime: Long,
-    val user: MeshUser,
+    val user: MeshProtos.User,
     val text: String,
     val time: Long,
     val read: Boolean,

--- a/app/src/main/java/com/geeksville/mesh/model/NodeDB.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/NodeDB.kt
@@ -42,6 +42,7 @@ class NodeDB @Inject constructor(
     fun getUser(userId: String): MeshProtos.User =
         nodeDBbyNum.value.values.find { it.user.id == userId }?.user
             ?: MeshProtos.User.newBuilder()
+                .setId(userId)
                 .setLongName("Meshtastic ${userId.takeLast(n = 4)}")
                 .setShortName(userId.takeLast(n = 4))
                 .setHwModel(MeshProtos.HardwareModel.UNSET)

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -335,7 +335,7 @@ class UIViewModel @Inject constructor(
             Message(
                 uuid = it.uuid,
                 receivedTime = it.received_time,
-                user = MeshUser(getUser(it.data.from)), // FIXME convert to proto User
+                user = getUser(it.data.from),
                 text = it.data.text.orEmpty(),
                 time = it.data.time,
                 read = it.read,


### PR DESCRIPTION
fixes #1349

This commit updates the `getUser` function in `NodeDB` to set the ID of the user when creating a new `User` object, ensuring that the user ID is always populated.

Additionally, it refactors the `Message` class to use the proto `User` object instead of the `MeshUser` class. This change simplifies the code and improves consistency by utilizing the proto definition for user information.
