### PR TITLE
feat: add text/plain intent to send message 

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,6 +2,7 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -154,6 +154,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+
             <intent-filter android:autoVerify="true">
                 <!-- The QR codes to share channel settings are shared as meshtastic URLS
 
@@ -222,6 +228,7 @@
                 <action android:name="com.atakmap.app.component" />
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -258,9 +258,8 @@ class MainActivity : AppCompatActivity(), Logging {
                 val mainTab = tab?.position ?: 0
                 model.setCurrentTab(mainTab)
             }
-
-            override fun onTabUnselected(tab: TabLayout.Tab?) {}
-            override fun onTabReselected(tab: TabLayout.Tab?) {}
+            override fun onTabUnselected(tab: TabLayout.Tab?) { }
+            override fun onTabReselected(tab: TabLayout.Tab?) { }
         })
 
         binding.composeView.setContent {
@@ -653,12 +652,10 @@ class MainActivity : AppCompatActivity(), Logging {
                 getVersionInfo()
                 return true
             }
-
             R.id.connectStatusImage -> {
                 Toast.makeText(applicationContext, item.title, Toast.LENGTH_SHORT).show()
                 return true
             }
-
             R.id.debug -> {
                 val fragmentManager: FragmentManager = supportFragmentManager
                 val fragmentTransaction: FragmentTransaction = fragmentManager.beginTransaction()
@@ -668,7 +665,6 @@ class MainActivity : AppCompatActivity(), Logging {
                 fragmentTransaction.commit()
                 return true
             }
-
             R.id.stress_test -> {
                 fun postPing() {
                     // Send ping message and arrange delayed recursion.
@@ -686,12 +682,10 @@ class MainActivity : AppCompatActivity(), Logging {
                 }
                 return true
             }
-
             R.id.radio_config -> {
                 supportFragmentManager.navigateToNavGraph()
                 return true
             }
-
             R.id.save_messages_csv -> {
                 val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
                     addCategory(Intent.CATEGORY_OPENABLE)
@@ -701,22 +695,18 @@ class MainActivity : AppCompatActivity(), Logging {
                 createDocumentLauncher.launch(intent)
                 return true
             }
-
             R.id.theme -> {
                 chooseThemeDialog()
                 return true
             }
-
             R.id.preferences_language -> {
                 chooseLangDialog()
                 return true
             }
-
             R.id.show_intro -> {
                 startActivity(Intent(this, AppIntroduction::class.java))
                 return true
             }
-
             R.id.preferences_quick_chat -> {
                 val fragmentManager: FragmentManager = supportFragmentManager
                 val fragmentTransaction: FragmentTransaction = fragmentManager.beginTransaction()
@@ -726,7 +716,6 @@ class MainActivity : AppCompatActivity(), Logging {
                 fragmentTransaction.commit()
                 return true
             }
-
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -337,6 +337,10 @@ class MainActivity : AppCompatActivity(), Logging {
             Intent.ACTION_MAIN -> {
             }
 
+            Intent.ACTION_SEND -> {
+
+            }
+
             else -> {
                 warn("Unexpected action $appLinkAction")
             }

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -79,6 +79,7 @@ import com.geeksville.mesh.ui.components.ScannedQrCodeDialog
 import com.geeksville.mesh.ui.map.MapFragment
 import com.geeksville.mesh.ui.navigateToMessages
 import com.geeksville.mesh.ui.navigateToNavGraph
+import com.geeksville.mesh.ui.navigateToShareMessage
 import com.geeksville.mesh.ui.theme.AppTheme
 import com.geeksville.mesh.util.Exceptions
 import com.geeksville.mesh.util.LanguageUtils

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -359,6 +359,7 @@ class MainActivity : AppCompatActivity(), Logging {
                         }
                     } catch (e: SerializationException) {
                         debug("Failed to decode JSON: ${e.message}; falling back to default message")
+                        shareMessages(text)
                     }
                 }
             }
@@ -637,6 +638,13 @@ class MainActivity : AppCompatActivity(), Logging {
         model.setCurrentTab(0)
         if (contactKey != null && contactName != null && message != null) {
             supportFragmentManager.navigateToPreInitMessages(contactKey, contactName, message)
+        }
+    }
+
+    private fun shareMessages(message: String?) {
+        model.setCurrentTab(0)
+        if (message != null) {
+            supportFragmentManager.navigateToShareMessage(message)
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -64,6 +64,7 @@ import com.geeksville.mesh.concurrent.handledLaunch
 import com.geeksville.mesh.databinding.ActivityMainBinding
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.DeviceVersion
+import com.geeksville.mesh.model.IntentMessage
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.service.MeshService
 import com.geeksville.mesh.service.MeshServiceNotifications
@@ -92,6 +93,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import java.text.DateFormat
 import java.util.Date
 import javax.inject.Inject
@@ -338,7 +341,17 @@ class MainActivity : AppCompatActivity(), Logging {
             }
 
             Intent.ACTION_SEND -> {
-
+                val text = intent.getStringExtra(Intent.EXTRA_TEXT)
+                if (text != null) {
+                    val json = Json
+                    try {
+                        val intentMessage: IntentMessage = json.decodeFromString(text)
+                        model.sendMessage(intentMessage.message, intentMessage.contactKey)
+                        showMessages(intentMessage.contactKey, intentMessage.contactName)
+                    } catch (e: SerializationException) {
+                        errormsg("Failed to decode JSON: ${e.message}")
+                    }
+                }
             }
 
             else -> {

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -64,7 +64,6 @@ import com.geeksville.mesh.concurrent.handledLaunch
 import com.geeksville.mesh.databinding.ActivityMainBinding
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.DeviceVersion
-import com.geeksville.mesh.model.IntentMessage
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.service.MeshService
 import com.geeksville.mesh.service.MeshServiceNotifications
@@ -93,8 +92,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
 import java.text.DateFormat
 import java.util.Date
 import javax.inject.Inject
@@ -344,23 +341,7 @@ class MainActivity : AppCompatActivity(), Logging {
             Intent.ACTION_SEND -> {
                 val text = intent.getStringExtra(Intent.EXTRA_TEXT)
                 if (text != null) {
-                    val json = Json
-                    try {
-                        val intentMessage: IntentMessage = json.decodeFromString(text)
-                        if (intentMessage.autoSend) {
-                            model.sendMessage(intentMessage.message, intentMessage.contactKey)
-                            showMessages(intentMessage.contactKey, intentMessage.contactName)
-                        } else {
-                            showMessagesPreInit(
-                                intentMessage.contactKey,
-                                intentMessage.contactName,
-                                intentMessage.message
-                            )
-                        }
-                    } catch (e: SerializationException) {
-                        debug("Failed to decode JSON: ${e.message}; falling back to default message")
-                        shareMessages(text)
-                    }
+                    shareMessages(text)
                 }
             }
 
@@ -631,13 +612,6 @@ class MainActivity : AppCompatActivity(), Logging {
         model.setCurrentTab(0)
         if (contactKey != null) {
             supportFragmentManager.navigateToMessages(contactKey)
-        }
-    }
-
-    private fun showMessagesPreInit(contactKey: String?, contactName: String?, message: String?) {
-        model.setCurrentTab(0)
-        if (contactKey != null && contactName != null && message != null) {
-            supportFragmentManager.navigateToPreInitMessages(contactKey, contactName, message)
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/model/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Message.kt
@@ -21,6 +21,8 @@ import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.MeshProtos.Routing
 import com.geeksville.mesh.MessageStatus
 import com.geeksville.mesh.R
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 val Routing.Error.stringRes: Int
     get() = when (this) {
@@ -69,3 +71,14 @@ data class Message(
         return title to text
     }
 }
+
+@Serializable
+data class IntentMessage (
+    val message: String,
+    @SerialName("contact_key")
+    val contactKey: String,
+    @SerialName("contact_name")
+    val contactName: String,
+    @SerialName("auto_send")
+    val autoSend: Boolean,
+)

--- a/app/src/main/java/com/geeksville/mesh/model/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Message.kt
@@ -21,8 +21,6 @@ import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.MeshProtos.Routing
 import com.geeksville.mesh.MessageStatus
 import com.geeksville.mesh.R
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 
 val Routing.Error.stringRes: Int
     get() = when (this) {
@@ -71,14 +69,3 @@ data class Message(
         return title to text
     }
 }
-
-@Serializable
-data class IntentMessage (
-    val message: String,
-    @SerialName("contact_key")
-    val contactKey: String,
-    @SerialName("contact_name")
-    val contactName: String,
-    @SerialName("auto_send")
-    val autoSend: Boolean,
-)

--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -132,7 +132,9 @@ class MessagesFragment : Fragment(), Logging {
         }
 
         contactKey = arguments?.getString("contactKey").toString()
-        if (arguments?.getString("message") != null) binding.messageInputText.setText(arguments?.getString("message").toString())
+        if (arguments?.getString("message") != null) {
+            binding.messageInputText.setText(arguments?.getString("message").toString())
+        }
         val channelIndex = contactKey[0].digitToIntOrNull()
         val nodeId = contactKey.substring(1)
         val channelName = channelIndex?.let { model.channels.value.getChannel(it)?.name }

--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -61,6 +61,15 @@ internal fun FragmentManager.navigateToMessages(contactKey: String) {
         .addToBackStack(null)
         .commit()
 }
+internal fun FragmentManager.navigateToPreInitMessages(contactKey: String, message: String) {
+    val messagesFragment = MessagesFragment().apply {
+        arguments = bundleOf("contactKey" to contactKey, "message" to message)
+    }
+    beginTransaction()
+        .add(R.id.mainActivityLayout, messagesFragment)
+        .addToBackStack(null)
+        .commit()
+}
 
 @AndroidEntryPoint
 class MessagesFragment : Fragment(), Logging {
@@ -123,6 +132,7 @@ class MessagesFragment : Fragment(), Logging {
         }
 
         contactKey = arguments?.getString("contactKey").toString()
+        if (arguments?.getString("message") != null) binding.messageInputText.setText(arguments?.getString("message").toString())
         val channelIndex = contactKey[0].digitToIntOrNull()
         val nodeId = contactKey.substring(1)
         val channelName = channelIndex?.let { model.channels.value.getChannel(it)?.name }

--- a/app/src/main/java/com/geeksville/mesh/ui/ShareFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ShareFragment.kt
@@ -105,7 +105,6 @@ class ShareFragment : ScreenFragment("Messages"), Logging {
     }
 }
 
-
 @Composable
 fun ShareContactListView(
     contacts: List<Contact>,

--- a/app/src/main/java/com/geeksville/mesh/ui/ShareFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ShareFragment.kt
@@ -1,0 +1,130 @@
+package com.geeksville.mesh.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.geeksville.mesh.android.Logging
+import com.geeksville.mesh.R
+import com.geeksville.mesh.databinding.ShareFragmentBinding
+import com.geeksville.mesh.model.Contact
+import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.ui.theme.AppTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+internal fun FragmentManager.navigateToShareMessage(message: String) {
+    val shareFragment = ShareFragment().apply {
+        arguments = bundleOf("message" to message)
+    }
+    beginTransaction()
+        .add(R.id.mainActivityLayout, shareFragment)
+        .addToBackStack(null)
+        .commit()
+}
+
+@AndroidEntryPoint
+class ShareFragment : ScreenFragment("Messages"), Logging {
+
+    private val model: UIViewModel by activityViewModels()
+    private var _binding: ShareFragmentBinding? = null
+
+    // This property is only valid between onCreateView and onDestroyView.
+    private val binding get() = _binding!!
+
+    private val contacts get() = model.contactList.value
+    private var selectedContact = mutableStateOf("")
+
+    private fun shareMessage(contact: Contact) {
+        debug("calling MessagesFragment filter:${contact.contactKey}")
+        parentFragmentManager.navigateToPreInitMessages(
+            contact.contactKey,
+            contact.longName,
+            arguments?.getString("message").toString()
+        )
+    }
+
+    private fun onClick(contact: Contact) {
+        if (selectedContact.value == contact.contactKey) {
+            selectedContact.value = ""
+            binding.shareButton.isEnabled = false
+        } else {
+            selectedContact.value = contact.contactKey
+            binding.shareButton.isEnabled = true
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = ShareFragmentBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    @Suppress("LongMethod", "CyclomaticComplexMethod")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.toolbar.setNavigationOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
+
+        binding.shareButton.isEnabled = false
+
+        binding.shareButton.setOnClickListener {
+            debug("User clicked shareButton")
+            val contact = contacts.find { c -> c.contactKey == selectedContact.value }
+            if (contact != null) {
+                shareMessage(contact)
+            }
+        }
+
+        binding.contactListView.setContent {
+            val contacts by model.contactList.collectAsStateWithLifecycle()
+            AppTheme {
+                ShareContactListView(
+                    contacts = contacts,
+                    selectedContact = selectedContact.value,
+                    onClick = ::onClick,
+                )
+            }
+        }
+    }
+}
+
+
+@Composable
+fun ShareContactListView(
+    contacts: List<Contact>,
+    selectedContact: String,
+    onClick: (Contact) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentPadding = PaddingValues(6.dp),
+    ) {
+        items(contacts, key = { it.contactKey }) { contact ->
+            val selected = contact.contactKey == selectedContact
+            ContactItem(
+                contact = contact,
+                selected = selected,
+                onClick = { onClick(contact) },
+                onLongClick = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/ShareFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ShareFragment.kt
@@ -51,7 +51,6 @@ class ShareFragment : ScreenFragment("Messages"), Logging {
         debug("calling MessagesFragment filter:${contact.contactKey}")
         parentFragmentManager.navigateToPreInitMessages(
             contact.contactKey,
-            contact.longName,
             arguments?.getString("message").toString()
         )
     }

--- a/app/src/main/res/layout/share_fragment.xml
+++ b/app/src/main/res/layout/share_fragment.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorAdvancedBackground">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/MyToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/toolbarBackground"
+        android:title="@string/share_to"
+        app:title="@string/share_to"
+        app:layout_constraintHeight_min="?attr/actionBarSize"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="?android:attr/homeAsUpIndicator"
+        app:titleMargin="4dp" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/contactListView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_margin="8dp"
+        android:contentDescription="@string/text_messages"
+        app:layout_constraintBottom_toTopOf="@+id/quickChatView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
+
+    </androidx.compose.ui.platform.ComposeView>
+
+    <HorizontalScrollView
+        android:id="@+id/quickChatView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toTopOf="@+id/shareButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <LinearLayout
+            android:id="@+id/quickChatLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" />
+    </HorizontalScrollView>
+
+
+    <ImageButton
+        android:id="@+id/shareButton"
+        android:layout_width="match_parent"
+        android:layout_height="64dp"
+        android:contentDescription="@string/share_message"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_twotone_send_24" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,8 @@
     <string name="fair">Fair</string>
     <string name="good">Good</string>
     <string name="none_quality">None</string>
+    <string name="share_to">Share to…</string>
+    <string name="share_message">Share message</string>
     <string name="signal">Signal</string>
     <string name="signal_quality">Signal Quality</string>
     <string name="traceroute_log">Traceroute Log</string>


### PR DESCRIPTION
This PR adds a text/plain intent that allow user to share a piece of text to a Meshtastic node through the application.

This PR is currently a WIP. As of right now, only the intent was added. 

The PR idea would be 2 fold:
1. Add a way to easily share the text to a user-selected contact. For this, I thought of adding an optional `txtToFill` variable to the [`navigateToMessages`](https://github.com/meshtastic/Meshtastic-Android/blob/227c65f1914cd5b4b379e94070bafc0463b08eb5/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt#L40) function (or create a new function altogether). If not empty, this variable would autofill the text input of the selected contact.
2. Create some kind of JSON struct that would be auto parsed, like 
```json
{
"contactKey": string,
"contactName": string,
"message": string,
"autosSend": bool
}
```

Upon completion, this PR would solve #1062 .