### PR TITLE
Change max message length to 200

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -140,8 +140,8 @@ class MessagesFragment : Fragment(), Logging {
             sendMessageInputText()
         }
 
-        // max payload length should be 237 bytes but anything over 235 bytes crashes the radio
-        binding.messageInputText.filters += Utf8ByteLengthFilter(234)
+        // max payload length should be 237 bytes but anything over 200 becomes less reliable
+        binding.messageInputText.filters += Utf8ByteLengthFilter(200)
 
         binding.messageListView.setContent {
             val messages by model.getMessagesFrom(contactKey).collectAsStateWithLifecycle(listOf())

--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -284,7 +284,7 @@
     <ID>MagicNumber:MeshService.kt$MeshService$32</ID>
     <ID>MagicNumber:MeshService.kt$MeshService$60000</ID>
     <ID>MagicNumber:MeshService.kt$MeshService$8</ID>
-    <ID>MagicNumber:MessagesFragment.kt$MessagesFragment$234</ID>
+    <ID>MagicNumber:MessagesFragment.kt$MessagesFragment$200</ID>
     <ID>MagicNumber:MetricsViewModel.kt$MetricsViewModel$1000L</ID>
     <ID>MagicNumber:MetricsViewModel.kt$MetricsViewModel$1e-5</ID>
     <ID>MagicNumber:MetricsViewModel.kt$MetricsViewModel$1e-7</ID>


### PR DESCRIPTION
IPhone app uses 200 chars as it's message limit.

This was last updated after the introduction of PKI. Testing there revealed that with PKI the real max now is about 225, but reliability starts to dip before then. I confirmed this in testing wirh Android on a few devices just now.

Change Android app to match iPhone.