### PR TITLE
Feature: Copy message to clipboard

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/ContactsFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ContactsFragment.kt
@@ -127,6 +127,7 @@ class ContactsFragment : ScreenFragment("Messages"), Logging {
         override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
             mode.menuInflater.inflate(R.menu.menu_messages, menu)
             menu.findItem(R.id.resendButton).isVisible = false
+            menu.findItem(R.id.copyButton).isVisible = false
             mode.title = "1"
             return true
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -17,6 +17,9 @@
 
 package com.geeksville.mesh.ui
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -40,6 +43,7 @@ import androidx.lifecycle.lifecycleScope
 import com.geeksville.mesh.DataPacket
 import com.geeksville.mesh.R
 import com.geeksville.mesh.android.Logging
+import com.geeksville.mesh.android.toast
 import com.geeksville.mesh.database.entity.QuickChatAction
 import com.geeksville.mesh.databinding.MessagesFragmentBinding
 import com.geeksville.mesh.model.Message
@@ -272,17 +276,17 @@ class MessagesFragment : Fragment(), Logging {
                         actionMode?.title = selectedList.size.toString()
                     }
                 }
-
                 R.id.resendButton -> lifecycleScope.launch {
                     debug("User clicked resendButton")
-                    var resendText = ""
-                    selectedList.forEach {
-                        resendText = resendText + it.text + System.lineSeparator()
-                    }
-                    if (resendText != "") {
-                        resendText = resendText.substring(0, resendText.length - 1)
-                    }
+                    var resendText = getSelectedMessagesText()
                     binding.messageInputText.setText(resendText)
+                    mode.finish()
+                }
+                R.id.copyButton -> lifecycleScope.launch {
+                    var copyText = getSelectedMessagesText()
+                    val clipboardManager = requireActivity().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboardManager.setPrimaryClip(ClipData.newPlainText("message text", copyText))
+                    requireActivity().toast(getString(R.string.copied))
                     mode.finish()
                 }
             }
@@ -300,5 +304,16 @@ class MessagesFragment : Fragment(), Logging {
             parentFragmentManager.popBackStack()
             model.focusUserNode(node)
         }
+    }
+
+    private fun getSelectedMessagesText(): String {
+        var messageText = ""
+        selectedList.forEach {
+            messageText = messageText + it.text + System.lineSeparator()
+        }
+        if (messageText != "") {
+            messageText = messageText.substring(0, messageText.length - 1)
+        }
+        return messageText
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/MessagesFragment.kt
@@ -278,13 +278,14 @@ class MessagesFragment : Fragment(), Logging {
                 }
                 R.id.resendButton -> lifecycleScope.launch {
                     debug("User clicked resendButton")
-                    var resendText = getSelectedMessagesText()
+                    val resendText = getSelectedMessagesText()
                     binding.messageInputText.setText(resendText)
                     mode.finish()
                 }
                 R.id.copyButton -> lifecycleScope.launch {
-                    var copyText = getSelectedMessagesText()
-                    val clipboardManager = requireActivity().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    val copyText = getSelectedMessagesText()
+                    val clipboardManager =
+                        requireActivity().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                     clipboardManager.setPrimaryClip(ClipData.newPlainText("message text", copyText))
                     requireActivity().toast(getString(R.string.copied))
                     mode.finish()

--- a/app/src/main/res/drawable/ic_twotone_content_copy_24.xml
+++ b/app/src/main/res/drawable/ic_twotone_content_copy_24.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:pathData="M8,7h11v14H8z"
+      android:strokeAlpha="0.3"
+      android:fillColor="@android:color/white"
+      android:fillAlpha="0.3"/>
+  <path
+      android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z"
+      android:fillColor="@android:color/white"/>
+</vector>

--- a/app/src/main/res/menu/menu_messages.xml
+++ b/app/src/main/res/menu/menu_messages.xml
@@ -38,4 +38,9 @@
         android:icon="@drawable/ic_twotone_select_all_24"
         android:title="@string/select_all"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/copyButton"
+        android:icon="@drawable/ic_twotone_content_copy_24"
+        android:title="@string/copy"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -277,4 +277,6 @@
         <item quantity="other">%d skoków</item>
     </plurals>
     <string name="traceroute_diff">Skoki do: %1$d. Skoki od: %2$d</string>
+    <string name="copy">Kopiuj</string>
+    <string name="copied">Skopiowano</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -308,4 +308,6 @@
     <string name="selected">Selected</string>
     <string name="not_selected">Not Selected</string>
     <string name="unknown_age">Unknown Age</string>
+    <string name="copy">Copy</string>
+    <string name="copied">Copied</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -79,6 +79,7 @@
     <style name="MyActionBar" parent="@style/ThemeOverlay.MaterialComponents.ActionBar">
         <item name="background">@color/colorPrimary</item>
         <item name="android:textColorPrimary">@color/colorOnPrimary</item>
+        <item name="tint">@color/colorOnPrimary</item>
     </style>
 
     <style name="MyToolbar" parent="Widget.MaterialComponents.Toolbar">


### PR DESCRIPTION
Implements feature request: #1358

Adds action to copy selected message(s) to the clipboard. Unfortunately there is place for only 3 icons (at least on my device) that are already there. Adding 4th pushes two icons to overflow menu, so only 2 icons are visible (third is overflow menu icon).

I also had to style the overflow menu and back button's icons. They weren't visible on dark theme.

That's my first PR. Any feedback is appreciated!

![image](https://github.com/user-attachments/assets/2c0231e0-6ecf-4fcf-bc65-a8965b7e784d)
![image](https://github.com/user-attachments/assets/5024653e-34fc-4285-876b-51780087a044)
