### PR TITLE
Bluetooth reconnect fix android15

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -259,7 +259,7 @@ class RadioInterfaceService @Inject constructor(
      * @return true if the device changed, false if no change
      */
     private fun setBondedDeviceAddress(address: String?): Boolean {
-        return if (getBondedDeviceAddress() == address && isStarted) {
+        return if (getBondedDeviceAddress() == address && isStarted && isConnected) {
             warn("Ignoring setBondedDevice ${address.anonymize}, because we are already using that device")
             false
         } else {

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -276,7 +276,7 @@ class RadioInterfaceService @Inject constructor(
      * @return true if the device changed, false if no change
      */
     private fun setBondedDeviceAddress(address: String?): Boolean {
-        return if (getBondedDeviceAddress() == address && isStarted && isConnected) {
+        return if (getBondedDeviceAddress() == address && isStarted) {
             warn("Ignoring setBondedDevice ${address.anonymize}, because we are already using that device")
             false
         } else {

--- a/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
@@ -210,7 +210,7 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
                                 lowLevelConnect(true)
                             }
                         } else if (status == 147) {
-                            info( "got 147, calling lostConnection()")
+                            info("got 147, calling lostConnection()")
                             lostConnection("code 147")
                         }
 

--- a/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
@@ -209,6 +209,9 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
                                 closeGatt() // Close the old non-auto connection
                                 lowLevelConnect(true)
                             }
+                        } else if (status == 147) {
+                            info( "got 147, calling lostConnection()")
+                            lostConnection("code 147")
                         }
 
                         if (status == 257) { // mystery error code when phone is hung


### PR DESCRIPTION
This pull fixes two issues.
1.  The necessity to click None before manually selecting a reconnect from the BT device popup.
2.  The prolonged disconnection non-reconnect behaviour is fixed by trapping BT disconnect code 147 and calling lostConnection() function.  This sets up a reconnect attempt loop every 30 seconds. This might be power draining. Could add a user preference somewhere to do this or not. Built apk is available here for testing : https://wildc.net/tmp/meshtastic-fdroid-debug.apk