### PR TITLE
feature: Add messages Reply functionality, improve Reaction ux

### DIFF
--- a/app/schemas/com.geeksville.mesh.database.MeshtasticDatabase/16.json
+++ b/app/schemas/com.geeksville.mesh.database.MeshtasticDatabase/16.json
@@ -1,0 +1,572 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "ee3730e776dbb036cc6c4423910e4d03",
+    "entities": [
+      {
+        "tableName": "my_node",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`myNodeNum` INTEGER NOT NULL, `model` TEXT, `firmwareVersion` TEXT, `couldUpdate` INTEGER NOT NULL, `shouldUpdate` INTEGER NOT NULL, `currentPacketId` INTEGER NOT NULL, `messageTimeoutMsec` INTEGER NOT NULL, `minAppVersion` INTEGER NOT NULL, `maxChannels` INTEGER NOT NULL, `hasWifi` INTEGER NOT NULL, PRIMARY KEY(`myNodeNum`))",
+        "fields": [
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "firmwareVersion",
+            "columnName": "firmwareVersion",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "couldUpdate",
+            "columnName": "couldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldUpdate",
+            "columnName": "shouldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPacketId",
+            "columnName": "currentPacketId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageTimeoutMsec",
+            "columnName": "messageTimeoutMsec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxChannels",
+            "columnName": "maxChannels",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasWifi",
+            "columnName": "hasWifi",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "myNodeNum"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "nodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `user` BLOB NOT NULL, `long_name` TEXT, `short_name` TEXT, `position` BLOB NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `snr` REAL NOT NULL, `rssi` INTEGER NOT NULL, `last_heard` INTEGER NOT NULL, `device_metrics` BLOB NOT NULL, `channel` INTEGER NOT NULL, `via_mqtt` INTEGER NOT NULL, `hops_away` INTEGER NOT NULL, `is_favorite` INTEGER NOT NULL, `is_ignored` INTEGER NOT NULL DEFAULT 0, `environment_metrics` BLOB NOT NULL, `power_metrics` BLOB NOT NULL, `paxcounter` BLOB NOT NULL, PRIMARY KEY(`num`))",
+        "fields": [
+          {
+            "fieldPath": "num",
+            "columnName": "num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user",
+            "columnName": "user",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeard",
+            "columnName": "last_heard",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceTelemetry",
+            "columnName": "device_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viaMqtt",
+            "columnName": "via_mqtt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hops_away",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIgnored",
+            "columnName": "is_ignored",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "environmentTelemetry",
+            "columnName": "environment_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "powerTelemetry",
+            "columnName": "power_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paxcounter",
+            "columnName": "paxcounter",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "num"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "packet",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `myNodeNum` INTEGER NOT NULL DEFAULT 0, `port_num` INTEGER NOT NULL, `contact_key` TEXT NOT NULL, `received_time` INTEGER NOT NULL, `read` INTEGER NOT NULL DEFAULT 1, `data` TEXT NOT NULL, `packet_id` INTEGER NOT NULL DEFAULT 0, `routing_error` INTEGER NOT NULL DEFAULT -1, `reply_id` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "port_num",
+            "columnName": "port_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_time",
+            "columnName": "received_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetId",
+            "columnName": "packet_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "routingError",
+            "columnName": "routing_error",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "replyId",
+            "columnName": "reply_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_packet_myNodeNum",
+            "unique": false,
+            "columnNames": [
+              "myNodeNum"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_myNodeNum` ON `${TABLE_NAME}` (`myNodeNum`)"
+          },
+          {
+            "name": "index_packet_port_num",
+            "unique": false,
+            "columnNames": [
+              "port_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_port_num` ON `${TABLE_NAME}` (`port_num`)"
+          },
+          {
+            "name": "index_packet_contact_key",
+            "unique": false,
+            "columnNames": [
+              "contact_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_contact_key` ON `${TABLE_NAME}` (`contact_key`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "contact_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contact_key` TEXT NOT NULL, `muteUntil` INTEGER NOT NULL, PRIMARY KEY(`contact_key`))",
+        "fields": [
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muteUntil",
+            "columnName": "muteUntil",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contact_key"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `type` TEXT NOT NULL, `received_date` INTEGER NOT NULL, `message` TEXT NOT NULL, `from_num` INTEGER NOT NULL DEFAULT 0, `port_num` INTEGER NOT NULL DEFAULT 0, `from_radio` BLOB NOT NULL DEFAULT x'', PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message_type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_date",
+            "columnName": "received_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raw_message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromNum",
+            "columnName": "from_num",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "portNum",
+            "columnName": "port_num",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fromRadio",
+            "columnName": "from_radio",
+            "affinity": "BLOB",
+            "notNull": true,
+            "defaultValue": "x''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_log_from_num",
+            "unique": false,
+            "columnNames": [
+              "from_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_log_from_num` ON `${TABLE_NAME}` (`from_num`)"
+          },
+          {
+            "name": "index_log_port_num",
+            "unique": false,
+            "columnNames": [
+              "port_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_log_port_num` ON `${TABLE_NAME}` (`port_num`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "quick_chat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `message` TEXT NOT NULL, `mode` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mode",
+            "columnName": "mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "reactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`reply_id` INTEGER NOT NULL, `user_id` TEXT NOT NULL, `emoji` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`reply_id`, `user_id`, `emoji`))",
+        "fields": [
+          {
+            "fieldPath": "replyId",
+            "columnName": "reply_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "reply_id",
+            "user_id",
+            "emoji"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reactions_reply_id",
+            "unique": false,
+            "columnNames": [
+              "reply_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reactions_reply_id` ON `${TABLE_NAME}` (`reply_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "replies",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`reply_id` INTEGER NOT NULL, `user_id` TEXT NOT NULL, `message` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`reply_id`, `user_id`, `message`))",
+        "fields": [
+          {
+            "fieldPath": "replyId",
+            "columnName": "reply_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "reply_id",
+            "user_id",
+            "message"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_replies_reply_id",
+            "unique": false,
+            "columnNames": [
+              "reply_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_replies_reply_id` ON `${TABLE_NAME}` (`reply_id`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ee3730e776dbb036cc6c4423910e4d03')"
+    ]
+  }
+}

--- a/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
@@ -36,6 +36,7 @@ import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.database.entity.QuickChatAction
 import com.geeksville.mesh.database.entity.ReactionEntity
+import com.geeksville.mesh.database.entity.ReplyEntity
 
 @Database(
     entities = [
@@ -46,6 +47,7 @@ import com.geeksville.mesh.database.entity.ReactionEntity
         MeshLog::class,
         QuickChatAction::class,
         ReactionEntity::class,
+        ReplyEntity::class,
     ],
     autoMigrations = [
         AutoMigration(from = 3, to = 4),
@@ -60,8 +62,9 @@ import com.geeksville.mesh.database.entity.ReactionEntity
         AutoMigration(from = 12, to = 13, spec = AutoMigration12to13::class),
         AutoMigration(from = 13, to = 14),
         AutoMigration(from = 14, to = 15),
+        AutoMigration(from = 15, to = 16),
     ],
-    version = 15,
+    version = 16,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/geeksville/mesh/database/PacketRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/PacketRepository.kt
@@ -24,6 +24,7 @@ import com.geeksville.mesh.database.dao.PacketDao
 import com.geeksville.mesh.database.entity.ContactSettings
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.database.entity.ReactionEntity
+import com.geeksville.mesh.database.entity.ReplyEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
@@ -106,5 +107,9 @@ class PacketRepository @Inject constructor(private val packetDaoLazy: dagger.Laz
 
     suspend fun insertReaction(reaction: ReactionEntity) = withContext(Dispatchers.IO) {
         packetDao.insert(reaction)
+    }
+
+    suspend fun insertReply(reply: ReplyEntity) = withContext(Dispatchers.IO) {
+        packetDao.insert(reply)
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/database/dao/PacketDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/PacketDao.kt
@@ -29,6 +29,7 @@ import com.geeksville.mesh.database.entity.ContactSettings
 import com.geeksville.mesh.database.entity.PacketEntity
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.database.entity.ReactionEntity
+import com.geeksville.mesh.database.entity.ReplyEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -214,4 +215,7 @@ interface PacketDao {
 
     @Upsert
     suspend fun insert(reaction: ReactionEntity)
+
+    @Upsert
+    suspend fun insert(reply: ReplyEntity)
 }

--- a/app/src/main/java/com/geeksville/mesh/model/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Message.kt
@@ -22,6 +22,7 @@ import com.geeksville.mesh.MessageStatus
 import com.geeksville.mesh.R
 import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.database.entity.Reaction
+import com.geeksville.mesh.database.entity.Reply
 
 val Routing.Error.stringRes: Int
     get() = when (this) {
@@ -55,6 +56,7 @@ data class Message(
     val routingError: Int,
     val packetId: Int,
     val emojis: List<Reaction>,
+    val replies: List<Reply>,
 ) {
     private fun getStatusStringRes(value: Int): Int {
         val error = Routing.Error.forNumber(value) ?: Routing.Error.UNRECOGNIZED

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -376,6 +376,10 @@ class UIViewModel @Inject constructor(
         radioConfigRepository.onServiceAction(ServiceAction.Reaction(emoji, replyId, contactKey))
     }
 
+    fun sendReply(message: String, replyId: Int, contactKey: String) = viewModelScope.launch {
+        radioConfigRepository.onServiceAction(ServiceAction.Reply(message, replyId, contactKey))
+    }
+
     fun requestTraceroute(destNum: Int) {
         info("Requesting traceroute for '$destNum'")
         try {

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -684,8 +684,6 @@ class MeshService : Service(), Logging {
         packetRepository.get().insertReply(reply)
     }
 
-
-
     private fun rememberDataPacket(dataPacket: DataPacket, updateNotification: Boolean = true) {
         if (dataPacket.dataType !in rememberDataType) return
         val fromLocal = dataPacket.from == DataPacket.ID_LOCAL

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -47,8 +47,8 @@ import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.Reply
-import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.automirrored.twotone.Reply
+import androidx.compose.material.icons.automirrored.twotone.Send
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.SelectAll
@@ -290,9 +290,13 @@ internal fun MessageScreen(
                 selectedIds = selectedIds,
                 onUnreadChanged = { viewModel.clearUnreadCount(contactKey, it) },
                 contentPadding = innerPadding,
-                onSendReaction = { emoji, id -> viewModel.sendReaction(emoji, id, contactKey) },
+                onSendReaction = { emoji, id ->
+                    viewModel.sendReaction(emoji, id, contactKey)
+                    selectedIds.value = emptySet()
+                },
                 onReplyClick = { msg ->
                     replyingTo = msg
+                    selectedIds.value = emptySet()
                 },
             ) { action ->
                 when (action) {
@@ -489,9 +493,9 @@ private fun TextInput(
         ) {
             Icon(
                 imageVector = if (isReply) {
-                    Icons.AutoMirrored.Filled.Reply
+                    Icons.AutoMirrored.TwoTone.Reply
                 } else {
-                    Icons.AutoMirrored.Default.Send
+                    Icons.AutoMirrored.TwoTone.Send
                 },
                 contentDescription = stringResource(id = R.string.send_text),
                 modifier = Modifier.scale(scale = 1.5f),

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -49,6 +50,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.twotone.Reply
 import androidx.compose.material.icons.automirrored.twotone.Send
+import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.SelectAll
@@ -269,7 +271,27 @@ internal fun MessageScreen(
                 }
                 val isReply = replyingTo != null
                 if (isReply) {
-                    Text("Replying to: ${replyingTo?.text}")
+                    Card {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Replying to: ${replyingTo?.text}",
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(8.dp)
+                            )
+                            IconButton(onClick = { replyingTo = null }) {
+                                Icon(
+                                    imageVector = Icons.Default.Cancel,
+                                    contentDescription = "Cancel"
+                                )
+                            }
+                        }
+                    }
                 }
                 TextInput(isConnected, isReply, messageInput) { message ->
                     if (isReply) {
@@ -464,7 +486,8 @@ private fun TextInput(
                 .weight(1f)
                 .onFocusEvent { isFocused = it.isFocused },
             enabled = enabled,
-            placeholder = { Text(
+            label = {
+                Text(
                 text = if (isReply) {
                     stringResource(id = R.string.send_reply)
                 } else {

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -460,6 +460,7 @@ private fun QuickChatRow(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun TextInput(
     enabled: Boolean,

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
@@ -41,6 +42,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.Reply
 import androidx.compose.material.icons.twotone.Cloud
 import androidx.compose.material.icons.twotone.CloudDone
 import androidx.compose.material.icons.twotone.CloudOff
@@ -61,9 +63,11 @@ import com.geeksville.mesh.DataPacket
 import com.geeksville.mesh.MessageStatus
 import com.geeksville.mesh.R
 import com.geeksville.mesh.database.entity.NodeEntity
+import com.geeksville.mesh.database.entity.Reply
 import com.geeksville.mesh.ui.components.AutoLinkText
 import com.geeksville.mesh.ui.preview.NodeEntityPreviewParameterProvider
 import com.geeksville.mesh.ui.theme.AppTheme
+import com.geeksville.mesh.util.getShortDateTime
 
 @Suppress("LongMethod")
 @OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
@@ -81,6 +85,7 @@ internal fun MessageItem(
     onStatusClick: () -> Unit = {},
     onSendReaction: (String) -> Unit = {},
     onReplyClick: () -> Unit = {},
+    replies: List<Reply> = emptyList(),
 
 ) = Row(
     modifier = Modifier
@@ -111,35 +116,36 @@ internal fun MessageItem(
             ),
             color = colorResource(id = messageColor),
         ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (!fromLocal) {
-                    Chip(
-                        onClick = onChipClick,
-                        modifier = Modifier
-                            .padding(end = 8.dp)
-                            .width(72.dp),
-                        colors = ChipDefaults.chipColors(
-                            backgroundColor = Color(node.colors.second),
-                            contentColor = Color(node.colors.first),
-                        ),
-                    ) {
-                        Text(
-                            text = node.user.shortName,
-                            modifier = Modifier.fillMaxWidth(),
-                            fontSize = MaterialTheme.typography.button.fontSize,
-                            fontWeight = FontWeight.Normal,
-                            textAlign = TextAlign.Center,
-                        )
-                    }
-                }
-                Column(
-                    modifier = Modifier.padding(top = 8.dp),
+            Column {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
+                    if (!fromLocal) {
+                        Chip(
+                            onClick = onChipClick,
+                            modifier = Modifier
+                                .padding(end = 8.dp)
+                                .width(72.dp),
+                            colors = ChipDefaults.chipColors(
+                                backgroundColor = Color(node.colors.second),
+                                contentColor = Color(node.colors.first),
+                            ),
+                        ) {
+                            Text(
+                                text = node.user.shortName,
+                                modifier = Modifier.fillMaxWidth(),
+                                fontSize = MaterialTheme.typography.button.fontSize,
+                                fontWeight = FontWeight.Normal,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                    }
+                    Column(
+                        modifier = Modifier.padding(top = 8.dp),
+                    ) {
 //                    if (!fromLocal) {
 //                        Text(
 //                            text = with(node.user) { "$longName ($id)" },
@@ -148,49 +154,113 @@ internal fun MessageItem(
 //                            fontSize = MaterialTheme.typography.caption.fontSize,
 //                        )
 //                    }
-                    AutoLinkText(
-                        text = messageText.orEmpty(),
-                        style = LocalTextStyle.current.copy(
-                            color = LocalContentColor.current,
-                        ),
-                    )
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = messageTime,
-                            color = MaterialTheme.colors.onSurface,
-                            fontSize = MaterialTheme.typography.caption.fontSize,
+                        AutoLinkText(
+                            text = messageText.orEmpty(),
+                            style = LocalTextStyle.current.copy(
+                                color = LocalContentColor.current,
+                            ),
                         )
-                        AnimatedVisibility(visible = fromLocal) {
-                            Icon(
-                                imageVector = when (messageStatus) {
-                                    MessageStatus.RECEIVED -> Icons.TwoTone.HowToReg
-                                    MessageStatus.QUEUED -> Icons.TwoTone.CloudUpload
-                                    MessageStatus.DELIVERED -> Icons.TwoTone.CloudDone
-                                    MessageStatus.ENROUTE -> Icons.TwoTone.Cloud
-                                    MessageStatus.ERROR -> Icons.TwoTone.CloudOff
-                                    else -> Icons.TwoTone.Warning
-                                },
-                                contentDescription = stringResource(R.string.message_delivery_status),
-                                modifier = Modifier
-                                    .padding(start = 8.dp)
-                                    .clickable { onStatusClick() },
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(
+                                text = messageTime,
+                                color = MaterialTheme.colors.onSurface,
+                                fontSize = MaterialTheme.typography.caption.fontSize,
                             )
+                            AnimatedVisibility(visible = fromLocal) {
+                                Icon(
+                                    imageVector = when (messageStatus) {
+                                        MessageStatus.RECEIVED -> Icons.TwoTone.HowToReg
+                                        MessageStatus.QUEUED -> Icons.TwoTone.CloudUpload
+                                        MessageStatus.DELIVERED -> Icons.TwoTone.CloudDone
+                                        MessageStatus.ENROUTE -> Icons.TwoTone.Cloud
+                                        MessageStatus.ERROR -> Icons.TwoTone.CloudOff
+                                        else -> Icons.TwoTone.Warning
+                                    },
+                                    contentDescription = stringResource(R.string.message_delivery_status),
+                                    modifier = Modifier
+                                        .padding(start = 8.dp)
+                                        .clickable { onStatusClick() },
+                                )
+                            }
                         }
                     }
+                }
+                replies.forEach { reply ->
+                    ReplyRow(reply = reply)
                 }
             }
         }
     }
-    if (!fromLocal && selected) {
+    if (selected) {
         ReactionButton(Modifier.padding(16.dp), onSendReaction)
 
         ReplyButton(Modifier.padding(16.dp), onReplyClick)
     } else if (!fromLocal) {
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(48.dp))
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun ReplyRow(
+    reply: Reply,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp, start = 32.dp, end = 4.dp),
+        elevation = 4.dp,
+    ) {
+        Surface(
+            color = MaterialTheme.colors.surface,
+            contentColor = MaterialTheme.colors.onSurface,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp),
+            ) {
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.Top,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = reply.user.shortName,
+                        fontSize = MaterialTheme.typography.caption.fontSize,
+                        fontWeight = FontWeight.Light,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = reply.message,
+                        modifier = Modifier.weight(1f),
+                        color = MaterialTheme.colors.onSurface,
+                        fontSize = MaterialTheme.typography.caption.fontSize,
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.TwoTone.Reply,
+                        contentDescription = stringResource(R.string.reply),
+                        modifier = Modifier.size(8.dp),
+                    )
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    Text(
+                        text = getShortDateTime(reply.timestamp),
+                        fontSize = MaterialTheme.typography.caption.fontSize,
+                        fontWeight = FontWeight.Light,
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -201,9 +271,23 @@ private fun MessageItemPreview() {
         MessageItem(
             node = NodeEntityPreviewParameterProvider().values.first(),
             messageText = stringResource(R.string.sample_message),
-            messageTime = "10:00",
+            messageTime = getShortDateTime(System.currentTimeMillis() - 720000),
             messageStatus = MessageStatus.DELIVERED,
             selected = false,
+            replies = listOf(
+                Reply(
+                    user = NodeEntityPreviewParameterProvider().values.first().user,
+                    message = "Nevermind, it's not scary. Phew!",
+                    replyId = 1,
+                    timestamp = System.currentTimeMillis() - 320000
+                ),
+                Reply(
+                    user = NodeEntityPreviewParameterProvider().values.last().user,
+                    message = "Nice, good job!",
+                    replyId = 2,
+                    timestamp = System.currentTimeMillis()
+                )
+            )
         )
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -79,6 +80,8 @@ internal fun MessageItem(
     onChipClick: () -> Unit = {},
     onStatusClick: () -> Unit = {},
     onSendReaction: (String) -> Unit = {},
+    onReplyClick: () -> Unit = {},
+
 ) = Row(
     modifier = Modifier
         .fillMaxWidth()
@@ -182,8 +185,12 @@ internal fun MessageItem(
             }
         }
     }
-    if (!fromLocal) {
+    if (!fromLocal && selected) {
         ReactionButton(Modifier.padding(16.dp), onSendReaction)
+
+        ReplyButton(Modifier.padding(16.dp), onReplyClick)
+    } else if (!fromLocal) {
+        Spacer(modifier = Modifier.width(16.dp))
     }
 }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
@@ -69,7 +69,7 @@ import com.geeksville.mesh.ui.preview.NodeEntityPreviewParameterProvider
 import com.geeksville.mesh.ui.theme.AppTheme
 import com.geeksville.mesh.util.getShortDateTime
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
 @Composable
 internal fun MessageItem(
@@ -264,6 +264,7 @@ private fun ReplyRow(
     }
 }
 
+@Suppress("MagicNumber")
 @PreviewLightDark
 @Composable
 private fun MessageItemPreview() {

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageList.kt
@@ -17,9 +17,12 @@
 
 package com.geeksville.mesh.ui.message.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -38,6 +41,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.DataPacket
 import com.geeksville.mesh.database.entity.Reaction
 import com.geeksville.mesh.model.Message
@@ -48,7 +52,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "MagicNumber")
 @Composable
 internal fun MessageList(
     messages: List<Message>,
@@ -95,35 +99,40 @@ internal fun MessageList(
             val fromLocal = msg.node.user.id == DataPacket.ID_LOCAL
             val selected by remember { derivedStateOf { selectedIds.value.contains(msg.uuid) } }
 
-            ReactionRow(fromLocal, msg.emojis) { showReactionDialog = msg.emojis }
-            Box(Modifier.wrapContentSize(Alignment.TopStart)) {
-                var expandedNodeMenu by remember { mutableStateOf(false) }
-                MessageItem(
-                    node = msg.node,
-                    messageText = msg.text,
-                    messageTime = msg.time,
-                    messageStatus = msg.status,
-                    selected = selected,
-                    onClick = { if (inSelectionMode) selectedIds.toggle(msg.uuid) },
-                    onLongClick = {
-                        selectedIds.toggle(msg.uuid)
-                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                    },
-                    onChipClick = {
-                        if (msg.node.num != 0) {
-                            expandedNodeMenu = true
-                        }
-                    },
-                    onStatusClick = { showStatusDialog = msg },
-                    onSendReaction = { onSendReaction(it, msg.packetId) },
-                )
-                NodeMenu(
-                    node = msg.node,
-                    showFullMenu = true,
-                    onDismissRequest = { expandedNodeMenu = false },
-                    expanded = expandedNodeMenu,
-                    onAction = onNodeMenuAction
-                )
+            Column(
+                modifier = Modifier.padding(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy((-12).dp)
+            ) {
+                Box(Modifier.wrapContentSize(Alignment.TopStart)) {
+                    var expandedNodeMenu by remember { mutableStateOf(false) }
+                    MessageItem(
+                        node = msg.node,
+                        messageText = msg.text,
+                        messageTime = msg.time,
+                        messageStatus = msg.status,
+                        selected = selected,
+                        onClick = { if (inSelectionMode) selectedIds.toggle(msg.uuid) },
+                        onLongClick = {
+                            selectedIds.toggle(msg.uuid)
+                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                        },
+                        onChipClick = {
+                            if (msg.node.num != 0) {
+                                expandedNodeMenu = true
+                            }
+                        },
+                        onStatusClick = { showStatusDialog = msg },
+                        onSendReaction = { onSendReaction(it, msg.packetId) },
+                    )
+                    NodeMenu(
+                        node = msg.node,
+                        showFullMenu = true,
+                        onDismissRequest = { expandedNodeMenu = false },
+                        expanded = expandedNodeMenu,
+                        onAction = onNodeMenuAction
+                    )
+                }
+                ReactionRow(fromLocal, msg.emojis) { showReactionDialog = msg.emojis }
             }
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageList.kt
@@ -124,7 +124,8 @@ internal fun MessageList(
                         },
                         onStatusClick = { showStatusDialog = msg },
                         onSendReaction = { onSendReaction(it, msg.packetId) },
-                        onReplyClick = { onReplyClick(msg) }
+                        onReplyClick = { onReplyClick(msg) },
+                        replies = msg.replies,
                     )
                     NodeMenu(
                         node = msg.node,

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageList.kt
@@ -60,6 +60,7 @@ internal fun MessageList(
     onUnreadChanged: (Long) -> Unit,
     contentPadding: PaddingValues,
     onSendReaction: (String, Int) -> Unit,
+    onReplyClick: (Message) -> Unit,
     onNodeMenuAction: (NodeMenuAction) -> Unit = {}
 ) {
     val haptics = LocalHapticFeedback.current
@@ -123,6 +124,7 @@ internal fun MessageList(
                         },
                         onStatusClick = { showStatusDialog = msg },
                         onSendReaction = { onSendReaction(it, msg.packetId) },
+                        onReplyClick = { onReplyClick(msg) }
                     )
                     NodeMenu(
                         node = msg.node,

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/Reaction.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/Reaction.kt
@@ -49,6 +49,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -88,6 +89,21 @@ fun ReactionButton(
         Icon(
             imageVector = Icons.Default.AddReaction,
             contentDescription = "emoji",
+            modifier = modifier.size(16.dp),
+            tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+        )
+    }
+}
+
+@Composable
+fun ReplyButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
+) {
+    IconButton(onClick = onClick) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.Reply,
+            contentDescription = "reply",
             modifier = modifier.size(16.dp),
             tint = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,7 @@
     <string name="unknown_username">Unknown Username</string>
     <string name="send">Send</string>
     <string name="send_text">Send Text</string>
+    <string name="send_reply">Send Reply</string>
     <string name="warning_not_paired">You haven\'t yet paired a Meshtastic compatible radio with this phone. Please pair a device and set your username.\n\nThis open-source application is in development, if you find problems please post on our forum: https://github.com/orgs/meshtastic/discussions.\n\nFor more information see our web page - www.meshtastic.org.</string>
     <string name="you">You</string>
     <string name="your_name">Your Name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,4 +313,5 @@
     <string name="unknown_age">Unknown Age</string>
     <string name="copy">Copy</string>
     <string name="alert_bell_text">Alert Bell Character!</string>
+    <string name="reply">Reply</string>
 </resources>


### PR DESCRIPTION
- Updates ReactionItem UI to a more modern style with borders and rounded corners.
- Implements an ellipsis indicator for overflowing reactions, allowing users to expand and view more.
- Changes the reaction button to a plus icon, indicating the ability to add a reaction.
- Adds a new Reply entity to the database.
- Adds a new ReplyRow composable to display replies.
- Updates the MessageItem composable to display replies.
- Updates the MessageList composable to display replies.
- Updates the MeshService to handle replies.
- Updates the PacketRepository to handle replies.
- Updates the PacketDao to handle replies.
- Updates the MessageItem to allow reactions and replies to sent messages.

[Screen_recording_20241214_134133.webm](https://github.com/user-attachments/assets/b5472e99-4342-442c-bfe5-1b01ce81f6ba)

