### PR TITLE
refactor: Improve device details layout

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeDetail.kt
@@ -140,9 +140,11 @@ private fun NodeDetailList(
         modifier = modifier.fillMaxSize(),
         contentPadding = PaddingValues(horizontal = 16.dp),
     ) {
-        item {
-            PreferenceCategory("Device") {
-                DeviceDetailsContent(metricsState)
+        if (metricsState.deviceHardware != null) {
+            item {
+                PreferenceCategory("Device") {
+                    DeviceDetailsContent(metricsState)
+                }
             }
         }
         item {
@@ -198,7 +200,8 @@ private fun NodeDetailRow(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Icon(
             imageVector = icon,
@@ -206,10 +209,9 @@ private fun NodeDetailRow(
             modifier = Modifier.size(24.dp),
             tint = iconTint
         )
-        Spacer(modifier = Modifier.width(8.dp))
         Text(label)
         Spacer(modifier = Modifier.weight(1f))
-        Text(value)
+        Text(textAlign = TextAlign.End, text = value)
     }
 }
 


### PR DESCRIPTION
- Device details section visible only if device hardware is available.
- Added spacing between icon, label, and value in node details rows.
- Right-aligned the values in node details rows for better readability.

Before:
![markup_1000003935.png](https://github.com/user-attachments/assets/6dfa4b13-8d5c-4447-9922-1e6860c33f61)

After:
![markup_1000003937.png](https://github.com/user-attachments/assets/e761f1ba-4c4c-4abf-aca8-ad390595af46)

