### PR TITLE
Line Breaks According to the TimeFrame

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -147,6 +147,20 @@ enum class TimeFrame(
     }
 
     /**
+     * Used to detect a significant time separation between [Telemetry]s.
+     */
+    fun timeThreshold(): Long {
+        return when (this.ordinal) {
+            TWENTY_FOUR_HOURS.ordinal ->
+                TimeUnit.HOURS.toSeconds(6)
+            FORTY_EIGHT_HOURS.ordinal ->
+                TimeUnit.HOURS.toSeconds(12)
+            else ->
+                TimeUnit.DAYS.toSeconds(1)
+        }
+    }
+
+    /**
      * Calculates the needed [Dp] depending on the amount of time being plotted.
      *
      * @param time in seconds

--- a/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/DeviceMetrics.kt
@@ -234,7 +234,8 @@ private fun DeviceMetricsChart(
                         path = path,
                         oldestTime = oldest.time,
                         timeRange = timeDiff,
-                        width = width
+                        width = width,
+                        timeThreshold = selectedTime.timeThreshold()
                     ) { i ->
                         val telemetry = telemetries.getOrNull(i) ?: telemetries.last()
                         val ratio = telemetry.deviceMetrics.batteryLevel / MAX_PERCENT_VALUE

--- a/app/src/main/java/com/geeksville/mesh/util/GraphUtil.kt
+++ b/app/src/main/java/com/geeksville/mesh/util/GraphUtil.kt
@@ -22,9 +22,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawContext
 import com.geeksville.mesh.TelemetryProtos.Telemetry
-import java.util.concurrent.TimeUnit
-
-private const val TIME_SEPARATION_THRESHOLD = 2L
 
 object GraphUtil {
 
@@ -59,6 +56,7 @@ object GraphUtil {
      * @param path [Path] that will be used to draw
      * @param timeRange The time range for the data set
      * @param width of the [DrawContext]
+     * @param timeThreshold to determine significant breaks in time between [Telemetry]s
      * @param calculateY (`index`) -> `y` coordinate
      */
     fun createPath(
@@ -68,6 +66,7 @@ object GraphUtil {
         oldestTime: Int,
         timeRange: Int,
         width: Float,
+        timeThreshold: Long,
         calculateY: (Int) -> Float
     ): Int {
         var i = index
@@ -78,7 +77,7 @@ object GraphUtil {
                 val nextTelemetry = telemetries.getOrNull(i + 1) ?: telemetries.last()
 
                 /* Check to see if we have a significant time break between telemetries. */
-                if (nextTelemetry.time - telemetry.time > TimeUnit.HOURS.toSeconds(TIME_SEPARATION_THRESHOLD)) {
+                if (nextTelemetry.time - telemetry.time > timeThreshold) {
                     i++
                     break
                 }


### PR DESCRIPTION
## Situation
As a start point the time separation threshold was shared across selected time frames. This next step is the beginning of using more appropriate thresholds depending on the time frame selected by the user.

## Before
https://github.com/user-attachments/assets/340440d9-e1ce-4002-abb7-88b98a41c26c

## After
https://github.com/user-attachments/assets/319da6f2-b219-4038-906c-13c73fac4212