### PR TITLE
ci: add Gradle `configuration-cache` encryption key

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -40,6 +40,8 @@ jobs:
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
+      with:
+        cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
     - name: Check lint
       run: ./gradlew lintFdroidDebug lintGoogleDebug


### PR DESCRIPTION
Adds `GRADLE_ENCRYPTION_KEY` secret to repository, otherwise no configuration cache is saved or restored.

- https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#saving-configuration-cache-data
- https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:secrets