### PR TITLE
feat: Add 'dependencies' label to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,6 @@
     "replacements:all",
     "workarounds:all"
   ],
-  "commitMessageTopic": "{{depName}}"
+  "commitMessageTopic": "{{depName}}",
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
Adds `dependencies` label to Renovate dependency update Pull Requests for ease of identification and sorting.
