### PR TITLE
[Quick UI Update] Apply a background to the filter search sticky header

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -22,12 +22,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -113,6 +115,7 @@ fun NodesScreen(
             NodeFilterTextField(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .background(MaterialTheme.colors.background)
                     .padding(8.dp),
                 filterText = state.filter,
                 onTextChange = model::setNodeFilterText,


### PR DESCRIPTION

Noticed that the filter search sticker header in the users screen had a transparent background, and scrolled items could be seen behind it. This PR just adds a background to the sticky header so that list items can't be seen when scrolled behind it.


| Before | After |
| ------- | ------ |
| <video src="https://github.com/user-attachments/assets/d7c3ffa6-d6ff-4525-ae85-ec43fa8f925e" width="300"></video>  | <video src="https://github.com/user-attachments/assets/85ed2df2-3df8-445b-8b59-9aa816e16189" width="300"></video> |
