### PR TITLE
[Quick UI Update] Animate user node list items on details expansion

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
@@ -79,6 +79,7 @@ fun NodeItem(
     gpsFormat: Int,
     distanceUnits: Int,
     tempInFahrenheit: Boolean,
+    modifier: Modifier = Modifier,
     onAction: (NodeMenuAction) -> Unit = {},
     expanded: Boolean = false,
     currentTimeMillis: Long,
@@ -114,7 +115,7 @@ fun NodeItem(
     val (detailsShown, showDetails) = remember { mutableStateOf(expanded) }
 
     Card(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 8.dp, vertical = 4.dp)
             .defaultMinSize(minHeight = 80.dp),

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
@@ -130,6 +131,7 @@ fun NodesScreen(
 
         items(nodes, key = { it.num }) { node ->
             NodeItem(
+                modifier = Modifier.animateContentSize(),
                 thisNode = ourNode,
                 thatNode = node,
                 gpsFormat = state.gpsFormat,


### PR DESCRIPTION
Adds a simple animation when expanding/collapsing details for user node list items.


| Before | After |
| ------- | ------ |
| <video src="https://github.com/user-attachments/assets/7d30d0dc-7069-4808-b0a7-bd3cfe77e6c0" width="300"></video> | <video src="https://github.com/user-attachments/assets/5268e024-d626-442d-b605-a8f6bab2d757" width="300"></video> |
