### PR TITLE
Fixes #1561: Accommodate large font for node filter

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/components/NodeFilterTextField.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/NodeFilterTextField.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
@@ -43,19 +44,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.NodeSortOption
+import com.geeksville.mesh.ui.compose.preview.LargeFontPreview
 import com.geeksville.mesh.ui.theme.AppTheme
 
 @Composable
@@ -80,6 +82,7 @@ fun NodeFilterTextField(
         )
 
         NodeSortButton(
+            modifier = Modifier.align(Alignment.CenterVertically),
             currentSortOption = currentSortOption,
             onSortSelect = onSortSelect,
             includeUnknown = includeUnknown,
@@ -101,7 +104,7 @@ private fun NodeFilterTextField(
 
     OutlinedTextField(
         modifier = modifier
-            .heightIn(max = 48.dp)
+            .defaultMinSize(minHeight = 48.dp)
             .onFocusEvent { isFocused = it.isFocused },
         value = filterText,
         placeholder = {
@@ -130,7 +133,7 @@ private fun NodeFilterTextField(
                 )
             }
         },
-        textStyle = TextStyle(
+        textStyle = MaterialTheme.typography.body1.copy(
             color = MaterialTheme.colors.onBackground
         ),
         maxLines = 1,
@@ -223,6 +226,7 @@ private fun NodeSortButton(
 }
 
 @PreviewLightDark
+@LargeFontPreview
 @Composable
 private fun NodeFilterTextFieldPreview() {
     AppTheme {

--- a/app/src/main/java/com/geeksville/mesh/ui/compose/preview/LargeFontPreview.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/compose/preview/LargeFontPreview.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.geeksville.mesh.ui.compose.preview
 
 import androidx.compose.ui.tooling.preview.Preview

--- a/app/src/main/java/com/geeksville/mesh/ui/compose/preview/LargeFontPreview.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/compose/preview/LargeFontPreview.kt
@@ -1,0 +1,6 @@
+package com.geeksville.mesh.ui.compose.preview
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(name = "Large Font", fontScale = 2f)
+annotation class LargeFontPreview


### PR DESCRIPTION
Fixes #1561

- Use `defaultMinSize` instead of setting a static height, so that the node filter TextField will accommodate devices with larger font settings
- Add `@LargeFontPreview` annotation for adding a preview with large font enabled

| Before | After |
| ----- | ----- |
| <img src="https://github.com/user-attachments/assets/e409bb27-3a09-4d08-96e6-a05df4738df2" width="300"/> | <img src="https://github.com/user-attachments/assets/4e0baded-b0d2-4100-9f87-e330c1bb806a" width="300"/> |
| <img src="https://github.com/user-attachments/assets/1f4f3fb4-ce42-4cea-9e46-c69348872f94" width="300"/> | <img src="https://github.com/user-attachments/assets/7b3aba72-fb47-4d7c-bab3-bfb5574184ef" width="300"/> |


Typing:

<video src="https://github.com/user-attachments/assets/74efd1b8-6bd8-4dd8-aeef-b142960e92d4" width="300"></video>