### PR TITLE
Fixes #1604: Stop overriding surface/onSurface in theme

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfig.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfig.kt
@@ -69,6 +69,7 @@ import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.ui.components.PreferenceCategory
 import com.geeksville.mesh.ui.radioconfig.components.EditDeviceProfileDialog
 import com.geeksville.mesh.ui.radioconfig.components.PacketResponseStateDialog
+import com.geeksville.mesh.ui.theme.AppTheme
 
 private fun getNavRouteFrom(routeName: String): Route? {
     return ConfigRoute.entries.find { it.name == routeName }?.route
@@ -332,7 +333,7 @@ private fun RadioConfigItemList(
 
 @Preview(showBackground = true)
 @Composable
-private fun RadioSettingsScreenPreview() {
+private fun RadioSettingsScreenPreview() = AppTheme {
     RadioConfigItemList(
         RadioConfigState(isLocal = true, connected = true)
     )

--- a/app/src/main/java/com/geeksville/mesh/ui/theme/Color.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/theme/Color.kt
@@ -33,8 +33,6 @@ val LightGreen = Color(0xFFCFE8A9)
 val LightRed = Color(0xFFFFB3B3)
 
 val MeshtasticGreen = Color(0xFF67EA94)
-val AlmostWhite = Color(0xB3FFFFFF)
-val AlmostBlack = Color(0x8A000000)
 
 val HyperlinkBlue = Color(0xFF43C3B0)
 val Orange = Color(255, 153, 0)

--- a/app/src/main/java/com/geeksville/mesh/ui/theme/Theme.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/theme/Theme.kt
@@ -27,16 +27,12 @@ private val DarkColorPalette = darkColors(
     primary = MeshtasticGreen,
     primaryVariant = Purple700,
     secondary = Teal200,
-    surface = AlmostBlack,
-    onSurface = AlmostWhite
 )
 
 private val LightColorPalette = lightColors(
     primary = MeshtasticGreen,
     primaryVariant = LightSkyBlue,
     secondary = Teal200,
-    surface = AlmostWhite,
-    onSurface = AlmostBlack
 
     /* Other default colors to override
     background = Color.White,


### PR DESCRIPTION
Fixes #1604: Stop overriding `surface` and `onSurface` in our `AppTheme` to remove issues from semi-transparency.

| Before | After |
| ------ | ------ |
| <img src="https://github.com/user-attachments/assets/f2c49db9-4851-44d7-b3de-f41ddd32094a" width="300"/>  | <img src="https://github.com/user-attachments/assets/7bd9ef81-1471-4abf-9ce1-c7c0f18cf769" width="300"/>  |
| <img src="https://github.com/user-attachments/assets/bfa4fa44-45cf-4895-860b-626e9c550c68" width="300"/>  | <img src="https://github.com/user-attachments/assets/4c916f24-a17a-4b58-8815-8baf3e3570a3" width="300"/>  |