### PR TITLE
Include image/video tag examples in PR Template comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,20 @@
 - If your other co-developers have comments on your PR please tweak as needed
 - Do not use any external image service, just paste or drag and drop the image here and it will be uploaded automatically
 - Please also enable "Allow edits by maintainers".
+
+<!--
+If you have screenshots or recordings to display your change, please include them!
+
+You can use this template for displaying a single screenshot:
+<img src="" width="300"/>
+
+or a video recording:
+<video src="" width="300"></video>
+
+
+And if you want to display the state before and after a change, you can use this table template:
+
+| Before | After |
+|------|-----|
+| <img src="" width="300"/> | <img src="" width="300"/> |
+-->


### PR DESCRIPTION
Last PR of the day: I often include screenshots/recordings in my PRs to help reviewers easily see changes. It's nice to have quick templates available for copy/pasting in new PRs to encourage contributors to add these.

Referenced table looks like this in markdown (imagine images are included):

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |