### PR TITLE
feat: Introduce Version Catalog for Dependency Management

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -141,9 +141,9 @@ androidComponents {
 
 dependencies {
 
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation(fileTree(dir: 'libs', include: ['*.jar']))
 
-    implementation libs.appcompat
+    implementation(libs.appcompat)
     // For loading and tinting drawables on older versions of the platform
     implementation(libs.appcompat.resources)
     implementation(libs.emoji2.emojipicker)
@@ -157,16 +157,16 @@ dependencies {
     implementation(libs.datastore)
 
     // Lifecycle
-    implementation libs.lifecycle.viewmodel.ktx
-    implementation libs.lifecycle.viewmodel.compose
-    implementation libs.lifecycle.livedata.ktx
-    implementation libs.lifecycle.runtime.ktx
-    implementation libs.lifecycle.runtime.compose
-    implementation libs.lifecycle.common.java8
-    implementation libs.lifecycle.process
+    implementation(libs.lifecycle.viewmodel.ktx)
+    implementation(libs.lifecycle.viewmodel.compose)
+    implementation(libs.lifecycle.livedata.ktx)
+    implementation(libs.lifecycle.runtime.ktx)
+    implementation(libs.lifecycle.runtime.compose)
+    implementation(libs.lifecycle.common.java8)
+    implementation(libs.lifecycle.process)
 
     // Room
-    implementation libs.room.runtime
+    implementation(libs.room.runtime)
     ksp libs.room.compiler
     // optional - Kotlin Extensions and Coroutines support for Room
     implementation libs.room.ktx
@@ -174,8 +174,8 @@ dependencies {
     androidTestImplementation libs.room.testing
 
     // Hilt
-    implementation libs.hilt.android
-    implementation libs.hilt.navigation.compose
+    implementation(libs.hilt.android)
+    implementation(libs.hilt.navigation.compose)
     ksp libs.hilt.compiler
     androidTestImplementation libs.hilt.android.testing
     kspAndroidTest libs.hilt.compiler
@@ -186,19 +186,20 @@ dependencies {
 
     // Compose
     def composeBom = platform(libs.compose.bom)
-    implementation composeBom
-    androidTestImplementation composeBom
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
 
-    implementation libs.compose.androidx.material
-    implementation libs.compose.material.icons.extended
-    implementation libs.compose.activity.compose
-    implementation libs.compose.runtime.livedata
+    implementation(libs.compose.material)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons.extended)
+    implementation(libs.compose.activity.compose)
+    implementation(libs.compose.runtime.livedata)
 
     // Immutable Collections (for Compose UI State)
     implementation(libs.kotlinx.collections.immutable)
 
     // Android Studio Preview support
-    implementation libs.compose.ui.tooling.preview
+    implementation(libs.compose.ui.tooling.preview)
     debugImplementation libs.compose.ui.tooling
 
     // UI Tests
@@ -206,23 +207,23 @@ dependencies {
     debugImplementation libs.compose.ui.test.manifest
 
     // Osmdroid & Maps
-    implementation libs.osmdroid.android
-    implementation libs.osmdroid.wms
+    implementation(libs.osmdroid.android)
+    implementation(libs.osmdroid.wms)
     implementation(libs.osmdroid.geopackage) {
         exclude group: 'com.j256.ormlite'
     }
-    implementation libs.osmbonuspack
-    implementation libs.mgrs
+    implementation(libs.osmbonuspack)
+    implementation(libs.mgrs)
 
-    testImplementation libs.junit
-    androidTestImplementation libs.ext.junit
-    androidTestImplementation libs.espresso.core
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.ext.junit)
+    androidTestImplementation(libs.espresso.core)
 
     // kotlin serialization
-    implementation libs.kotlinx.serialization.json
+    implementation(libs.kotlinx.serialization.json)
 
     // rate this app
-    googleImplementation libs.awesome.app.rating
+    googleImplementation(libs.awesome.app.rating)
 
     // Coroutines
     implementation libs.kotlinx.coroutines.android
@@ -232,32 +233,32 @@ dependencies {
     implementation libs.protobuf.kotlin
 
     // For UART access
-    implementation libs.usb.serial.android
+    implementation(libs.usb.serial.android)
 
     // For Firebase Crashlytics & Analytics
-    googleImplementation platform(libs.firebase.bom)
-    googleImplementation libs.firebase.crashlytics
-    googleImplementation libs.firebase.analytics
+    googleImplementation(platform(libs.firebase.bom))
+    googleImplementation(libs.firebase.crashlytics)
+    googleImplementation(libs.firebase.analytics)
 
     // barcode support
     // per https://github.com/journeyapps/zxing-android-embedded#older-sdk-versions for minSdkVersion 21
     implementation(libs.zxing.android.embedded) { transitive = false }
     //noinspection GradleDependency
-    implementation libs.zxing.core // <-- don't update
+    implementation(libs.zxing.core) // <-- don't update
 
     // Work Request - used to delay boot event handling
-    implementation libs.work.runtime.ktx
+    implementation(libs.work.runtime.ktx)
 
-    implementation libs.core.splashscreen
+    implementation(libs.core.splashscreen)
 
     // CompletableFuture backport for API 14+
-    implementation libs.streamsupport.minifuture
+    implementation(libs.streamsupport.minifuture)
 
     // App intro
-    implementation libs.appintro
+    implementation(libs.appintro)
 
     // MQTT
-    implementation libs.org.eclipse.paho.client.mqttv3
+    implementation(libs.org.eclipse.paho.client.mqttv3)
 
     // detekt ktlint formatting
     detektPlugins(libs.detekt.formatting)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-    id 'com.android.application'
-    id "org.jetbrains.kotlin.android"
-    id "org.jetbrains.kotlin.plugin.compose"
-    id "org.jetbrains.kotlin.plugin.parcelize"
-    id 'kotlinx-serialization'
-    id 'com.google.dagger.hilt.android'
-    id 'com.google.protobuf'
-    id "com.google.devtools.ksp"
-    id "io.gitlab.arturbosch.detekt" version "1.23.8"
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose)
+    alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.protobuf)
+    alias(libs.plugins.devtools.ksp)
+    alias(libs.plugins.detekt)
 }
 
 def keystorePropertiesFile = rootProject.file("keystore.properties")
@@ -110,7 +110,7 @@ android {
 // per protobuf-gradle-plugin docs, this is recommended for android
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:$protobuf_version"
+        artifact = libs.protobuf.protoc.get()
     }
     generateProtoTasks {
         all().each { task ->

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -187,10 +187,11 @@ dependencies {
 
     ksp(libs.room.compiler)
     ksp(libs.hilt.compiler)
+    kspAndroidTest(libs.hilt.compiler)
 
     testImplementation(libs.bundles.testing)
+    debugImplementation(libs.bundles.testing.android.manifest)
     androidTestImplementation(libs.bundles.testing.android)
-    androidTestImplementation(libs.bundles.testing.android.manifest)
     androidTestImplementation(libs.bundles.testing.hilt)
     androidTestImplementation(libs.bundles.testing.navigation)
     androidTestImplementation(libs.bundles.testing.room)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -143,124 +143,58 @@ dependencies {
 
     implementation(fileTree(dir: 'libs', include: ['*.jar']))
 
-    implementation(libs.appcompat)
-    // For loading and tinting drawables on older versions of the platform
-    implementation(libs.appcompat.resources)
-    implementation(libs.emoji2.emojipicker)
-    implementation(libs.core.ktx)
-    implementation(libs.core.location.altitude)
-    implementation(libs.fragment.ktx)
-    implementation(libs.cardview)
-    implementation(libs.constraintlayout)
-    implementation(libs.material)
-    implementation(libs.viewpager2)
-    implementation(libs.datastore)
+    // Bundles
+    implementation(libs.bundles.androidx)
+    implementation(libs.bundles.ui)
+    debugImplementation(libs.bundles.ui.tooling)
+    implementation(libs.bundles.lifecycle)
+    implementation(libs.bundles.navigation)
+    implementation(libs.bundles.coroutines)
+    implementation(libs.bundles.datastore)
+    implementation(libs.bundles.room)
+    implementation(libs.bundles.hilt)
+    implementation(libs.bundles.protobuf)
 
-    // Lifecycle
-    implementation(libs.lifecycle.viewmodel.ktx)
-    implementation(libs.lifecycle.viewmodel.compose)
-    implementation(libs.lifecycle.livedata.ktx)
-    implementation(libs.lifecycle.runtime.ktx)
-    implementation(libs.lifecycle.runtime.compose)
-    implementation(libs.lifecycle.common.java8)
-    implementation(libs.lifecycle.process)
+    //OSM
+    implementation(libs.bundles.osm)
+    implementation(libs.osmdroid.geopackage){ exclude group: "com.j256.ormlite" }
 
-    // Room
-    implementation(libs.room.runtime)
-    ksp libs.room.compiler
-    // optional - Kotlin Extensions and Coroutines support for Room
-    implementation libs.room.ktx
-    // optional - Test helpers
-    androidTestImplementation libs.room.testing
-
-    // Hilt
-    implementation(libs.hilt.android)
-    implementation(libs.hilt.navigation.compose)
-    ksp libs.hilt.compiler
-    androidTestImplementation libs.hilt.android.testing
-    kspAndroidTest libs.hilt.compiler
-
-    // Navigation
-    implementation libs.navigation.compose
-    androidTestImplementation libs.navigation.testing
-
-    // Compose
-    def composeBom = platform(libs.compose.bom)
-    implementation(composeBom)
-    androidTestImplementation(composeBom)
-
-    implementation(libs.compose.material)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.material.icons.extended)
-    implementation(libs.compose.activity.compose)
-    implementation(libs.compose.runtime.livedata)
-
-    // Immutable Collections (for Compose UI State)
-    implementation(libs.kotlinx.collections.immutable)
-
-    // Android Studio Preview support
-    implementation(libs.compose.ui.tooling.preview)
-    debugImplementation libs.compose.ui.tooling
-
-    // UI Tests
-    androidTestImplementation libs.compose.ui.test.junit4
-    debugImplementation libs.compose.ui.test.manifest
-
-    // Osmdroid & Maps
-    implementation(libs.osmdroid.android)
-    implementation(libs.osmdroid.wms)
-    implementation(libs.osmdroid.geopackage) {
-        exclude group: 'com.j256.ormlite'
-    }
-    implementation(libs.osmbonuspack)
-    implementation(libs.mgrs)
-
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.ext.junit)
-    androidTestImplementation(libs.espresso.core)
-
-    // kotlin serialization
-    implementation(libs.kotlinx.serialization.json)
-
-    // rate this app
-    googleImplementation(libs.awesome.app.rating)
-
-    // Coroutines
-    implementation libs.kotlinx.coroutines.android
-    implementation libs.kotlinx.coroutines.guava
-
-    // For now I'm not using javalite, because I want JSON printing
-    implementation libs.protobuf.kotlin
-
-    // For UART access
-    implementation(libs.usb.serial.android)
-
-    // For Firebase Crashlytics & Analytics
-    googleImplementation(platform(libs.firebase.bom))
-    googleImplementation(libs.firebase.crashlytics)
-    googleImplementation(libs.firebase.analytics)
-
-    // barcode support
-    // per https://github.com/journeyapps/zxing-android-embedded#older-sdk-versions for minSdkVersion 21
+    //ZXing
     implementation(libs.zxing.android.embedded) { transitive = false }
-    //noinspection GradleDependency
-    implementation(libs.zxing.core) // <-- don't update
+    implementation(libs.zxing.core)  // do not update
 
-    // Work Request - used to delay boot event handling
-    implementation(libs.work.runtime.ktx)
-
-    implementation(libs.core.splashscreen)
-
-    // CompletableFuture backport for API 14+
-    implementation(libs.streamsupport.minifuture)
-
-    // App intro
+    // Individual dependencies
     implementation(libs.appintro)
-
-    // MQTT
+    implementation(libs.awesome.app.rating)
+    implementation(libs.core.splashscreen)
+    implementation(libs.emoji2.emojipicker)
+    implementation(libs.kotlinx.collections.immutable)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.org.eclipse.paho.client.mqttv3)
+    implementation(libs.streamsupport.minifuture)
+    implementation(libs.usb.serial.android)
+    implementation(libs.work.runtime.ktx)
+    implementation(libs.core.location.altitude)
 
-    // detekt ktlint formatting
+    //Compose BOM
+    implementation(platform(libs.compose.bom))
+    androidTestImplementation(platform(libs.compose.bom))
+
+    //Firebase BOM
+    googleImplementation(platform(libs.firebase.bom)) //For Firebase
+    googleImplementation(libs.bundles.firebase)
+
+
+    ksp(libs.room.compiler)
+    ksp(libs.hilt.compiler)
+
+    testImplementation(libs.bundles.testing)
+    androidTestImplementation(libs.bundles.testing.android)
+    androidTestImplementation(libs.bundles.testing.android.manifest)
+    androidTestImplementation(libs.bundles.testing.hilt)
+    androidTestImplementation(libs.bundles.testing.navigation)
+    androidTestImplementation(libs.bundles.testing.room)
+
     detektPlugins(libs.detekt.formatting)
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,132 +142,125 @@ androidComponents {
 dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    def appcompat_version = '1.7.0'
-    implementation "androidx.appcompat:appcompat:$appcompat_version"
-    // For loading and tinting drawables on older versions of the platform
-    implementation "androidx.appcompat:appcompat-resources:$appcompat_version"
-    implementation "androidx.emoji2:emoji2-emojipicker:1.5.0"
 
-    implementation 'androidx.core:core-ktx:1.15.0'
-    implementation 'androidx.core:core-location-altitude:1.0.0-alpha03'
-    implementation 'androidx.fragment:fragment-ktx:1.8.6'
-    implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
-    implementation 'com.google.android.material:material:1.12.0'
-    implementation 'androidx.viewpager2:viewpager2:1.1.0'
-    implementation 'androidx.datastore:datastore:1.1.2'
+    implementation libs.appcompat
+    // For loading and tinting drawables on older versions of the platform
+    implementation(libs.appcompat.resources)
+    implementation(libs.emoji2.emojipicker)
+    implementation(libs.core.ktx)
+    implementation(libs.core.location.altitude)
+    implementation(libs.fragment.ktx)
+    implementation(libs.cardview)
+    implementation(libs.constraintlayout)
+    implementation(libs.material)
+    implementation(libs.viewpager2)
+    implementation(libs.datastore)
 
     // Lifecycle
-    def lifecycle_version = '2.8.7'
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-runtime-compose:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
-    implementation "androidx.lifecycle:lifecycle-process:$lifecycle_version"
+    implementation libs.lifecycle.viewmodel.ktx
+    implementation libs.lifecycle.viewmodel.compose
+    implementation libs.lifecycle.livedata.ktx
+    implementation libs.lifecycle.runtime.ktx
+    implementation libs.lifecycle.runtime.compose
+    implementation libs.lifecycle.common.java8
+    implementation libs.lifecycle.process
 
     // Room
-    def room_version = '2.6.1'
-    implementation "androidx.room:room-runtime:$room_version"
-    ksp "androidx.room:room-compiler:$room_version"
+    implementation libs.room.runtime
+    ksp libs.room.compiler
     // optional - Kotlin Extensions and Coroutines support for Room
-    implementation "androidx.room:room-ktx:$room_version"
+    implementation libs.room.ktx
     // optional - Test helpers
-    androidTestImplementation "androidx.room:room-testing:$room_version"
+    androidTestImplementation libs.room.testing
 
     // Hilt
-    implementation "com.google.dagger:hilt-android:$hilt_version"
-    implementation "androidx.hilt:hilt-navigation-compose:1.2.0"
-    ksp "com.google.dagger:hilt-compiler:$hilt_version"
-    androidTestImplementation "com.google.dagger:hilt-android-testing:$hilt_version"
-    kspAndroidTest "com.google.dagger:hilt-compiler:$hilt_version"
+    implementation libs.hilt.android
+    implementation libs.hilt.navigation.compose
+    ksp libs.hilt.compiler
+    androidTestImplementation libs.hilt.android.testing
+    kspAndroidTest libs.hilt.compiler
 
     // Navigation
-    def nav_version = "2.8.7"
-    implementation "androidx.navigation:navigation-compose:$nav_version"
-    androidTestImplementation "androidx.navigation:navigation-testing:$nav_version"
+    implementation libs.navigation.compose
+    androidTestImplementation libs.navigation.testing
 
     // Compose
-    def composeBom = platform('androidx.compose:compose-bom:2025.02.00')
+    def composeBom = platform(libs.compose.bom)
     implementation composeBom
     androidTestImplementation composeBom
 
-    implementation 'androidx.compose.material:material'
-    implementation 'androidx.compose.material:material-icons-extended'
-    implementation 'androidx.activity:activity-compose'
-    implementation 'androidx.compose.runtime:runtime-livedata'
+    implementation libs.compose.androidx.material
+    implementation libs.compose.material.icons.extended
+    implementation libs.compose.activity.compose
+    implementation libs.compose.runtime.livedata
 
     // Immutable Collections (for Compose UI State)
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.8")
+    implementation(libs.kotlinx.collections.immutable)
 
     // Android Studio Preview support
-    implementation 'androidx.compose.ui:ui-tooling-preview'
-    debugImplementation 'androidx.compose.ui:ui-tooling'
+    implementation libs.compose.ui.tooling.preview
+    debugImplementation libs.compose.ui.tooling
 
     // UI Tests
-    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+    androidTestImplementation libs.compose.ui.test.junit4
+    debugImplementation libs.compose.ui.test.manifest
 
     // Osmdroid & Maps
-    def osmdroid_version = '6.1.14'
-    implementation "org.osmdroid:osmdroid-android:$osmdroid_version"
-    implementation "org.osmdroid:osmdroid-wms:$osmdroid_version"
-    implementation("org.osmdroid:osmdroid-geopackage:$osmdroid_version") {
+    implementation libs.osmdroid.android
+    implementation libs.osmdroid.wms
+    implementation(libs.osmdroid.geopackage) {
         exclude group: 'com.j256.ormlite'
     }
-    implementation 'com.github.MKergall:osmbonuspack:6.9.0'
-    implementation "mil.nga:mgrs:2.1.3"
+    implementation libs.osmbonuspack
+    implementation libs.mgrs
 
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    testImplementation libs.junit
+    androidTestImplementation libs.ext.junit
+    androidTestImplementation libs.espresso.core
 
     // kotlin serialization
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0"
+    implementation libs.kotlinx.serialization.json
 
     // rate this app
-    googleImplementation 'com.suddenh4x.ratingdialog:awesome-app-rating:2.8.0'
+    googleImplementation libs.awesome.app.rating
 
     // Coroutines
-    def coroutines_version = '1.10.1'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-guava:$coroutines_version"
+    implementation libs.kotlinx.coroutines.android
+    implementation libs.kotlinx.coroutines.guava
 
     // For now I'm not using javalite, because I want JSON printing
-    implementation "com.google.protobuf:protobuf-kotlin:$protobuf_version"
+    implementation libs.protobuf.kotlin
 
     // For UART access
-    implementation 'com.github.mik3y:usb-serial-for-android:3.8.1'
+    implementation libs.usb.serial.android
 
     // For Firebase Crashlytics & Analytics
-    googleImplementation platform('com.google.firebase:firebase-bom:33.9.0')
-    googleImplementation 'com.google.firebase:firebase-crashlytics'
-    googleImplementation 'com.google.firebase:firebase-analytics'
+    googleImplementation platform(libs.firebase.bom)
+    googleImplementation libs.firebase.crashlytics
+    googleImplementation libs.firebase.analytics
 
     // barcode support
     // per https://github.com/journeyapps/zxing-android-embedded#older-sdk-versions for minSdkVersion 21
-    implementation('com.journeyapps:zxing-android-embedded:4.3.0') { transitive = false }
+    implementation(libs.zxing.android.embedded) { transitive = false }
     //noinspection GradleDependency
-    implementation 'com.google.zxing:core:3.3.0' // <-- don't update
+    implementation libs.zxing.core // <-- don't update
 
-    def work_version = '2.10.0'
     // Work Request - used to delay boot event handling
-    implementation "androidx.work:work-runtime-ktx:$work_version"
+    implementation libs.work.runtime.ktx
 
-    implementation "androidx.core:core-splashscreen:1.0.1"
+    implementation libs.core.splashscreen
 
     // CompletableFuture backport for API 14+
-    implementation 'net.sourceforge.streamsupport:streamsupport-minifuture:1.7.4'
+    implementation libs.streamsupport.minifuture
 
     // App intro
-    implementation 'com.github.AppIntro:AppIntro:6.3.1'
+    implementation libs.appintro
 
     // MQTT
-    implementation "org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5"
+    implementation libs.org.eclipse.paho.client.mqttv3
 
     // detekt ktlint formatting
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
+    detektPlugins(libs.detekt.formatting)
 }
 
 ksp {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -163,7 +163,7 @@ dependencies {
     implementation(libs.zxing.android.embedded) { transitive = false }
     implementation(libs.zxing.core)  // do not update
 
-    // Individual dependencies
+    //Individual dependencies
     implementation(libs.appintro)
     implementation(libs.awesome.app.rating)
     implementation(libs.core.splashscreen)
@@ -184,11 +184,12 @@ dependencies {
     googleImplementation(platform(libs.firebase.bom)) //For Firebase
     googleImplementation(libs.bundles.firebase)
 
-
+    //ksp
     ksp(libs.room.compiler)
     ksp(libs.hilt.compiler)
     kspAndroidTest(libs.hilt.compiler)
 
+    //Testing
     testImplementation(libs.bundles.testing)
     debugImplementation(libs.bundles.testing.android.manifest)
     androidTestImplementation(libs.bundles.testing.android)

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,6 @@
 buildscript {
     ext {
         useCrashlytics = false
-        kotlin_version = '2.1.10'
-        hilt_version = '2.55'
-        protobuf_version = '4.29.3'
     }
 
     repositories {
@@ -13,30 +10,30 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.8.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
+        classpath libs.gradle
+        classpath libs.kotlin.gradle.plugin
+        classpath libs.kotlin.serialization
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
         // Firebase Crashlytics
         if (useCrashlytics) {
-            classpath 'com.google.gms:google-services:4.4.2'
-            classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.3'
+            classpath libs.google.services
+            classpath libs.firebase.crashlytics.gradle
         }
 
         // protobuf plugin - docs here https://github.com/google/protobuf-gradle-plugin
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.9.4'
+        classpath libs.protobuf.gradle.plugin
 
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
+        classpath libs.hilt.android.gradle.plugin
     }
 }
 
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "$kotlin_version" apply false
-    id "com.google.devtools.ksp" version "2.1.10-1.0.30" apply false
-    id "org.jetbrains.kotlin.plugin.compose" version "$kotlin_version" apply false
+    alias (libs.plugins.kotlin.jvm) apply false
+    alias (libs.plugins.devtools.ksp) apply false
+    alias (libs.plugins.compose) apply false
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath libs.gradle
+        classpath libs.agp
         classpath libs.kotlin.gradle.plugin
         classpath libs.kotlin.serialization
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,7 +94,6 @@ lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtim
 lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-material3 = { group = "androidx.compose.material3", name = "material3" }
 mgrs = { group = "mil.nga", name = "mgrs", version.ref = "mgrs" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigation" }
@@ -122,7 +121,7 @@ zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing-c
 androidx = ["core-ktx", "appcompat", "appcompat-resources", "cardview", "fragment-ktx", "activity-compose"]
 
 # UI
-ui = ["material", "material3", "constraintlayout", "viewpager2", "compose-material", "compose-material-icons-extended", "compose-ui-tooling-preview", "compose-runtime-livedata"]
+ui = ["material", "constraintlayout", "viewpager2", "compose-material", "compose-material-icons-extended", "compose-ui-tooling-preview", "compose-runtime-livedata"]
 ui-tooling = ["compose-ui-tooling"] #Separate for debugImplementation
 
 # Lifecycle

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+agp = "8.8.1"
 appcompat = "1.7.0"
 appintro = "6.3.1"
 awesome-app-rating = "2.8.0"
@@ -16,7 +17,6 @@ espresso-core = "3.6.1"
 firebase-bom = "33.9.0"
 fragment-ktx = "1.8.6"
 google-services = "4.4.2"
-gradle = "8.8.1"
 hilt = "2.55"
 hilt-navigation-compose = "1.2.0"
 junit = "4.13.2"
@@ -44,42 +44,42 @@ zxing-android-embedded = "4.3.0"
 zxing-core = "3.3.0" #do not update
 
 [libraries]
+agp = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+activity-compose = { group = "androidx.activity", name = "activity-compose" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 appcompat-resources = { group = "androidx.appcompat", name = "appcompat-resources", version.ref = "appcompat" }
-appintro = { module = "com.github.AppIntro:AppIntro", version.ref = "appintro" }
-awesome-app-rating = { module = "com.suddenh4x.ratingdialog:awesome-app-rating", version.ref = "awesome-app-rating" }
+appintro = { group = "com.github.AppIntro", name = "AppIntro", version.ref = "appintro" }
+awesome-app-rating = { group = "com.suddenh4x.ratingdialog", name = "awesome-app-rating", version.ref = "awesome-app-rating" }
 cardview = { group = "androidx.cardview", name = "cardview", version.ref = "cardview" }
-compose-activity-compose = { module = "androidx.activity:activity-compose" }
-compose-androidx-material = { module = "androidx.compose.material:material" }
-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+compose-material = { group = "androidx.compose.material", name = "material" }
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
+compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 core-location-altitude = { group = "androidx.core", name = "core-location-altitude", version.ref = "core-location-altitude" }
-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
+core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "core-splashscreen" }
 datastore = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 emoji2-emojipicker = { group = "androidx.emoji2", name = "emoji2-emojipicker", version.ref = "emoji2" }
-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso-core" }
-ext-junit = { module = "androidx.test.ext:junit", version.ref = "junit-version" }
+espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
+ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junit-version" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics"}
-firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle" }
+firebase-crashlytics-gradle = { group = "com.google.firebase", name = "firebase-crashlytics-gradle" }
 fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment-ktx" }
-google-services = { module = "com.google.gms:google-services", version.ref = "google-services" }
-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
+google-services = { group = "com.google.gms", name = "google-services", version.ref = "google-services" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
-hilt-android-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
+hilt-android-gradle-plugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
-junit = { module = "junit:junit", version.ref = "junit" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-serialization = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
@@ -94,27 +94,69 @@ lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtim
 lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-mgrs = { module = "mil.nga:mgrs", version.ref = "mgrs" }
+material3 = { group = "androidx.compose.material3", name = "material3" }
+mgrs = { group = "mil.nga", name = "mgrs", version.ref = "mgrs" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigation" }
-org-eclipse-paho-client-mqttv3 = { module = "org.eclipse.paho:org.eclipse.paho.client.mqttv3", version.ref = "org-eclipse-paho-client-mqttv3" }
-osmbonuspack = { module = "com.github.MKergall:osmbonuspack", version.ref = "osmbonuspack" }
+org-eclipse-paho-client-mqttv3 = { group = "org.eclipse.paho", name = "org.eclipse.paho.client.mqttv3", version.ref = "org-eclipse-paho-client-mqttv3" }
+osmbonuspack = { group = "com.github.MKergall", name = "osmbonuspack", version.ref = "osmbonuspack" }
 osmdroid-android = { group = "org.osmdroid", name = "osmdroid-android", version.ref = "osmdroid-android" }
 osmdroid-geopackage = { group = "org.osmdroid", name = "osmdroid-geopackage", version.ref = "osmdroid-android" }
 osmdroid-wms = { group = "org.osmdroid", name = "osmdroid-wms", version.ref = "osmdroid-android" }
-protobuf-gradle-plugin = { module = "com.google.protobuf:protobuf-gradle-plugin", version.ref = "protobuf-gradle-plugin" }
-protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf-kotlin" }
+protobuf-gradle-plugin = { group = "com.google.protobuf", name = "protobuf-gradle-plugin", version.ref = "protobuf-gradle-plugin" }
+protobuf-kotlin = { group = "com.google.protobuf", name = "protobuf-kotlin", version.ref = "protobuf-kotlin" }
 protobuf-protoc = { group = "com.google.protobuf", name ="protoc", version.ref = "protobuf-kotlin" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
-streamsupport-minifuture = { module = "net.sourceforge.streamsupport:streamsupport-minifuture", version.ref = "streamsupport-minifuture" }
-usb-serial-android = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "usb-serial-android" }
+streamsupport-minifuture = { group = "net.sourceforge.streamsupport", name = "streamsupport-minifuture", version.ref = "streamsupport-minifuture" }
+usb-serial-android = { group = "com.github.mik3y", name = "usb-serial-for-android", version.ref = "usb-serial-android" }
 viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work-runtime-ktx" }
-zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxing-android-embedded" }
-zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
+work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work-runtime-ktx" }
+zxing-android-embedded = { group = "com.journeyapps", name = "zxing-android-embedded", version.ref = "zxing-android-embedded" }
+zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing-core" }
+
+[bundles]
+# Core AndroidX
+androidx = ["core-ktx", "appcompat", "appcompat-resources", "cardview", "fragment-ktx", "activity-compose"]
+
+# UI
+ui = ["material", "material3", "constraintlayout", "viewpager2", "compose-material", "compose-material-icons-extended", "compose-ui-tooling-preview", "compose-runtime-livedata"]
+ui-tooling = ["compose-ui-tooling"] #Separate for debugImplementation
+
+# Lifecycle
+lifecycle = ["lifecycle-runtime-ktx", "lifecycle-livedata-ktx", "lifecycle-viewmodel-ktx", "lifecycle-common-java8", "lifecycle-process", "lifecycle-viewmodel-compose", "lifecycle-runtime-compose"]
+
+# Navigation
+navigation = ["navigation-compose"]
+
+# Coroutines
+coroutines = ["kotlinx-coroutines-android", "kotlinx-coroutines-guava"]
+
+# Data Storage
+datastore = ["datastore"]
+room = ["room-runtime", "room-ktx"]
+
+# Dependency Injection
+hilt = ["hilt-android", "hilt-navigation-compose"]
+
+# Testing
+testing = ["junit", "ext-junit"]
+testing-android = ["espresso-core", "compose-ui-test-junit4"]
+testing-android-manifest = ["compose-ui-test-manifest"]
+testing-hilt = ["hilt-android-testing"]
+testing-navigation = ["navigation-testing"]
+testing-room = ["room-testing"]
+
+# OSM
+osm = ["osmdroid-android", "osmdroid-wms", "osmbonuspack", "mgrs"]
+
+# Firebase
+firebase = ["firebase-analytics", "firebase-crashlytics"]
+
+#Protobuf
+protobuf = ["protobuf-kotlin"]
 
 [plugins]
 android-application = { id = "com.android.application" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,13 @@
 appcompat = "1.7.0"
 appintro = "6.3.1"
 awesome-app-rating = "2.8.0"
-compose-bom = "2025.02.00"
-core-splashscreen = "1.0.1"
 cardview = "1.0.0"
+compose-bom = "2025.02.00"
 constraintlayout = "2.2.0"
 core-ktx = "1.15.0"
 core-location-altitude = "1.0.0-alpha03"
+core-splashscreen = "1.0.1"
+datastore = "1.1.2"
 detekt = "1.23.8"
 devtools-ksp = "2.1.10-1.0.30"
 emoji2 = "1.5.0"
@@ -37,7 +38,6 @@ room = "2.6.1"
 streamsupport-minifuture = "1.7.4"
 usb-serial-android = "3.8.1"
 viewpager2 = "1.1.0"
-datastore = "1.1.2"
 work-runtime-ktx = "2.10.0"
 zxing-android-embedded = "4.3.0"
 zxing-core = "3.3.0" #do not update
@@ -51,12 +51,12 @@ cardview = { group = "androidx.cardview", name = "cardview", version.ref = "card
 compose-activity-compose = { module = "androidx.activity:activity-compose" }
 compose-androidx-material = { module = "androidx.compose.material:material" }
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 core-location-altitude = { group = "androidx.core", name = "core-location-altitude", version.ref = "core-location-altitude" }
@@ -66,8 +66,8 @@ detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", 
 emoji2-emojipicker = { group = "androidx.emoji2", name = "emoji2-emojipicker", version.ref = "emoji2" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso-core" }
 ext-junit = { module = "androidx.test.ext:junit", version.ref = "junit-version" }
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics"}
 firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle" }
 fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment-ktx" }
@@ -85,13 +85,13 @@ kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotli
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines-android" }
 kotlinx-coroutines-guava = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-guava", version.ref = "kotlinx-coroutines-android" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 lifecycle-common-java8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "lifecycle" }
+lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
+lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 mgrs = { module = "mil.nga:mgrs", version.ref = "mgrs" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
@@ -99,14 +99,14 @@ navigation-testing = { group = "androidx.navigation", name = "navigation-testing
 org-eclipse-paho-client-mqttv3 = { module = "org.eclipse.paho:org.eclipse.paho.client.mqttv3", version.ref = "org-eclipse-paho-client-mqttv3" }
 osmbonuspack = { module = "com.github.MKergall:osmbonuspack", version.ref = "osmbonuspack" }
 osmdroid-android = { group = "org.osmdroid", name = "osmdroid-android", version.ref = "osmdroid-android" }
-osmdroid-wms = { group = "org.osmdroid", name = "osmdroid-wms", version.ref = "osmdroid-android" }
 osmdroid-geopackage = { group = "org.osmdroid", name = "osmdroid-geopackage", version.ref = "osmdroid-android" }
+osmdroid-wms = { group = "org.osmdroid", name = "osmdroid-wms", version.ref = "osmdroid-android" }
 protobuf-gradle-plugin = { module = "com.google.protobuf:protobuf-gradle-plugin", version.ref = "protobuf-gradle-plugin" }
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf-kotlin" }
 protobuf-protoc = { group = "com.google.protobuf", name ="protoc", version.ref = "protobuf-kotlin" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 streamsupport-minifuture = { module = "net.sourceforge.streamsupport:streamsupport-minifuture", version.ref = "streamsupport-minifuture" }
 usb-serial-android = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "usb-serial-android" }
@@ -122,7 +122,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "devtools-ksp" }
 hilt = { id = "com.google.dagger.hilt.android" }
 kotlin-android = { id = "org.jetbrains.kotlin.android" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize" }
 kotlin-serialization = { id = "kotlinx-serialization" }
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 protobuf = { id = "com.google.protobuf" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,19 +4,23 @@ appintro = "6.3.1"
 awesome-app-rating = "2.8.0"
 compose-bom = "2025.02.00"
 core-splashscreen = "1.0.1"
-detekt-formatting = "1.23.8"
-emoji2 = "1.5.0"
+cardview = "1.0.0"
+constraintlayout = "2.2.0"
 core-ktx = "1.15.0"
 core-location-altitude = "1.0.0-alpha03"
+detekt = "1.23.8"
+devtools-ksp = "2.1.10-1.0.30"
+emoji2 = "1.5.0"
 espresso-core = "3.6.1"
 firebase-bom = "33.9.0"
 fragment-ktx = "1.8.6"
-cardview = "1.0.0"
-constraintlayout = "2.2.0"
+google-services = "4.4.2"
+gradle = "8.8.1"
 hilt = "2.55"
 hilt-navigation-compose = "1.2.0"
 junit = "4.13.2"
 junit-version = "1.2.1"
+kotlin = "2.1.10"
 kotlinx-collections-immutable = "0.3.8"
 kotlinx-coroutines-android = "1.10.1"
 kotlinx-serialization-json = "1.8.0"
@@ -27,6 +31,7 @@ navigation = "2.8.7"
 org-eclipse-paho-client-mqttv3 = "1.2.5"
 osmbonuspack = "6.9.0"
 osmdroid-android = "6.1.14"
+protobuf-gradle-plugin = "0.9.4"
 protobuf-kotlin = "4.29.3"
 room = "2.6.1"
 streamsupport-minifuture = "1.7.4"
@@ -42,9 +47,6 @@ appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "a
 appcompat-resources = { group = "androidx.appcompat", name = "appcompat-resources", version.ref = "appcompat" }
 appintro = { module = "com.github.AppIntro:AppIntro", version.ref = "appintro" }
 awesome-app-rating = { module = "com.suddenh4x.ratingdialog:awesome-app-rating", version.ref = "awesome-app-rating" }
-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
-detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt-formatting" }
-emoji2-emojipicker = { group = "androidx.emoji2", name = "emoji2-emojipicker", version.ref = "emoji2" }
 cardview = { group = "androidx.cardview", name = "cardview", version.ref = "cardview" }
 compose-activity-compose = { module = "androidx.activity:activity-compose" }
 compose-androidx-material = { module = "androidx.compose.material:material" }
@@ -58,17 +60,27 @@ compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 core-location-altitude = { group = "androidx.core", name = "core-location-altitude", version.ref = "core-location-altitude" }
+core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
+datastore = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+emoji2-emojipicker = { group = "androidx.emoji2", name = "emoji2-emojipicker", version.ref = "emoji2" }
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso-core" }
 ext-junit = { module = "androidx.test.ext:junit", version.ref = "junit-version" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics"}
-firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics"}
+firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle" }
 fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment-ktx" }
+google-services = { module = "com.google.gms:google-services", version.ref = "google-services" }
+gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-android-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
 junit = { module = "junit:junit", version.ref = "junit" }
+kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlin-serialization = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines-android" }
 kotlinx-coroutines-guava = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-guava", version.ref = "kotlinx-coroutines-android" }
@@ -89,7 +101,9 @@ osmbonuspack = { module = "com.github.MKergall:osmbonuspack", version.ref = "osm
 osmdroid-android = { group = "org.osmdroid", name = "osmdroid-android", version.ref = "osmdroid-android" }
 osmdroid-wms = { group = "org.osmdroid", name = "osmdroid-wms", version.ref = "osmdroid-android" }
 osmdroid-geopackage = { group = "org.osmdroid", name = "osmdroid-geopackage", version.ref = "osmdroid-android" }
+protobuf-gradle-plugin = { module = "com.google.protobuf:protobuf-gradle-plugin", version.ref = "protobuf-gradle-plugin" }
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf-kotlin" }
+protobuf-protoc = { group = "com.google.protobuf", name ="protoc", version.ref = "protobuf-kotlin" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
@@ -97,7 +111,18 @@ room-testing = { group = "androidx.room", name = "room-testing", version.ref = "
 streamsupport-minifuture = { module = "net.sourceforge.streamsupport:streamsupport-minifuture", version.ref = "streamsupport-minifuture" }
 usb-serial-android = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "usb-serial-android" }
 viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
-datastore = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work-runtime-ktx" }
 zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxing-android-embedded" }
 zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }
+
+[plugins]
+android-application = { id = "com.android.application" }
+compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "devtools-ksp" }
+hilt = { id = "com.google.dagger.hilt.android" }
+kotlin-android = { id = "org.jetbrains.kotlin.android" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize" }
+kotlin-serialization = { id = "kotlinx-serialization" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+protobuf = { id = "com.google.protobuf" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ usb-serial-android = "3.8.1"
 viewpager2 = "1.1.0"
 work-runtime-ktx = "2.10.0"
 zxing-android-embedded = "4.3.0"
+#noinspection GradleDependency
 zxing-core = "3.3.0" #do not update
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,103 @@
+[versions]
+appcompat = "1.7.0"
+appintro = "6.3.1"
+awesome-app-rating = "2.8.0"
+compose-bom = "2025.02.00"
+core-splashscreen = "1.0.1"
+detekt-formatting = "1.23.8"
+emoji2 = "1.5.0"
+core-ktx = "1.15.0"
+core-location-altitude = "1.0.0-alpha03"
+espresso-core = "3.6.1"
+firebase-bom = "33.9.0"
+fragment-ktx = "1.8.6"
+cardview = "1.0.0"
+constraintlayout = "2.2.0"
+hilt = "2.55"
+hilt-navigation-compose = "1.2.0"
+junit = "4.13.2"
+junit-version = "1.2.1"
+kotlinx-collections-immutable = "0.3.8"
+kotlinx-coroutines-android = "1.10.1"
+kotlinx-serialization-json = "1.8.0"
+lifecycle = "2.8.7"
+material = "1.12.0"
+mgrs = "2.1.3"
+navigation = "2.8.7"
+org-eclipse-paho-client-mqttv3 = "1.2.5"
+osmbonuspack = "6.9.0"
+osmdroid-android = "6.1.14"
+protobuf-kotlin = "4.29.3"
+room = "2.6.1"
+streamsupport-minifuture = "1.7.4"
+usb-serial-android = "3.8.1"
+viewpager2 = "1.1.0"
+datastore = "1.1.2"
+work-runtime-ktx = "2.10.0"
+zxing-android-embedded = "4.3.0"
+zxing-core = "3.3.0" #do not update
+
+[libraries]
+appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+appcompat-resources = { group = "androidx.appcompat", name = "appcompat-resources", version.ref = "appcompat" }
+appintro = { module = "com.github.AppIntro:AppIntro", version.ref = "appintro" }
+awesome-app-rating = { module = "com.suddenh4x.ratingdialog:awesome-app-rating", version.ref = "awesome-app-rating" }
+core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt-formatting" }
+emoji2-emojipicker = { group = "androidx.emoji2", name = "emoji2-emojipicker", version.ref = "emoji2" }
+cardview = { group = "androidx.cardview", name = "cardview", version.ref = "cardview" }
+compose-activity-compose = { module = "androidx.activity:activity-compose" }
+compose-androidx-material = { module = "androidx.compose.material:material" }
+compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
+compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
+core-location-altitude = { group = "androidx.core", name = "core-location-altitude", version.ref = "core-location-altitude" }
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso-core" }
+ext-junit = { module = "androidx.test.ext:junit", version.ref = "junit-version" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics"}
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics"}
+fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragment-ktx" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines-android" }
+kotlinx-coroutines-guava = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-guava", version.ref = "kotlinx-coroutines-android" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
+lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
+lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+lifecycle-common-java8 = { group = "androidx.lifecycle", name = "lifecycle-common-java8", version.ref = "lifecycle" }
+lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+mgrs = { module = "mil.nga:mgrs", version.ref = "mgrs" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigation" }
+org-eclipse-paho-client-mqttv3 = { module = "org.eclipse.paho:org.eclipse.paho.client.mqttv3", version.ref = "org-eclipse-paho-client-mqttv3" }
+osmbonuspack = { module = "com.github.MKergall:osmbonuspack", version.ref = "osmbonuspack" }
+osmdroid-android = { group = "org.osmdroid", name = "osmdroid-android", version.ref = "osmdroid-android" }
+osmdroid-wms = { group = "org.osmdroid", name = "osmdroid-wms", version.ref = "osmdroid-android" }
+osmdroid-geopackage = { group = "org.osmdroid", name = "osmdroid-geopackage", version.ref = "osmdroid-android" }
+protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobuf-kotlin" }
+room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
+streamsupport-minifuture = { module = "net.sourceforge.streamsupport:streamsupport-minifuture", version.ref = "streamsupport-minifuture" }
+usb-serial-android = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "usb-serial-android" }
+viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
+datastore = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
+work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work-runtime-ktx" }
+zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version.ref = "zxing-android-embedded" }
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing-core" }


### PR DESCRIPTION
This introduces a version catalog via `libs.versions.toml` to centralize and manage project dependencies. It replaces the previous hardcoded dependency versions in `.gradle` files with references to the version catalog. This change enhances maintainability and organization by centralizing dependency management.

- Added `gradle/libs.versions.toml` to define dependencies, plugins, and their versions.
- Updated `build.gradle` to utilize references from the version catalog,
- Updated `app/build.gradle` to utilize references from the version catalog.
- Removed hardcoded version strings in gradle files.
- Added note and suppressed warning to avoid updating `zxing-core` dependency
- Consolidated dependencies into `[bundles]`
- Refactored to ensure consistency in version catalog definititons and gradle dependencies