### PR TITLE
fix: New message notifications now correctly show the receive time in the notification drawer

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -281,6 +281,8 @@ class MeshServiceNotifications(
             setStyle(
                 NotificationCompat.MessagingStyle(person).addMessage(message, System.currentTimeMillis(), person)
             )
+            setWhen(System.currentTimeMillis())
+            setShowWhen(true)
         }
         return messageNotificationBuilder.build()
     }


### PR DESCRIPTION
Sets the new message notification time to the time of the received message instead of the time of the app startup.