### PR TITLE
fix #1615: Add explicit signed int editing preference

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/components/EditTextPreference.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EditTextPreference.kt
@@ -47,6 +47,40 @@ import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
 
 @Composable
+fun SignedIntegerEditTextPreference(
+    title: String,
+    value: Int,
+    enabled: Boolean,
+    keyboardActions: KeyboardActions,
+    onValueChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    onFocusChanged: (FocusState) -> Unit = {},
+    trailingIcon: (@Composable () -> Unit)? = null,
+) {
+    var valueState by remember(value) { mutableStateOf(value.toString()) }
+
+    EditTextPreference(
+        title = title,
+        value = valueState,
+        enabled = enabled,
+        isError = valueState.toIntOrNull() == null,
+        keyboardOptions = KeyboardOptions.Default.copy(
+            keyboardType = KeyboardType.Number, imeAction = ImeAction.Done
+        ),
+        keyboardActions = keyboardActions,
+        onValueChanged = {
+            valueState = it
+            it.toIntOrNull()?.let { int ->
+                onValueChanged(int)
+            }
+        },
+        onFocusChanged = onFocusChanged,
+        modifier = modifier,
+        trailingIcon = trailingIcon
+    )
+}
+
+@Composable
 fun EditTextPreference(
     title: String,
     value: Int,

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/LoRaConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/LoRaConfigItemList.kt
@@ -44,6 +44,7 @@ import com.geeksville.mesh.ui.components.EditListPreference
 import com.geeksville.mesh.ui.components.EditTextPreference
 import com.geeksville.mesh.ui.components.PreferenceCategory
 import com.geeksville.mesh.ui.components.PreferenceFooter
+import com.geeksville.mesh.ui.components.SignedIntegerEditTextPreference
 import com.geeksville.mesh.ui.components.SwitchPreference
 import com.geeksville.mesh.ui.radioconfig.RadioConfigViewModel
 
@@ -171,11 +172,13 @@ fun LoRaConfigItemList(
         item { Divider() }
 
         item {
-            EditTextPreference(title = "TX power (dBm)",
+            SignedIntegerEditTextPreference(
+                title = "TX power (dBm)",
                 value = loraInput.txPower,
                 enabled = enabled,
                 keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-                onValueChanged = { loraInput = loraInput.copy { txPower = it } })
+                onValueChanged = { loraInput = loraInput.copy { txPower = it } },
+            )
         }
 
         item {


### PR DESCRIPTION
Fixes #1615

Adds an explicit edit text preference for signed integers, and moves TX power to this preference so that negative values can be set.

| Before | After |
|------|-----|
| <video src="https://github.com/user-attachments/assets/8e80f931-6b13-4a61-8109-86b045cd966c" width="300"></video> | <video src="https://github.com/user-attachments/assets/93da5597-0425-4095-9858-7abc678a645e" width="300"></video> |

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->