### PR TITLE
Fixes #1616: Use SP font size for marker labels on the map

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/android/ContextExtensions.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextExtensions.kt
@@ -19,6 +19,7 @@ package com.geeksville.mesh.android
 
 import android.app.Activity
 import android.content.Context
+import android.util.TypedValue
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 
@@ -35,3 +36,7 @@ fun Activity.hideKeyboard() {
         imm?.hideSoftInputFromWindow(v.windowToken, 0)
     }
 }
+
+// Converts SP to pixels.
+fun Context.spToPx(sp: Float): Int =
+    TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, sp, resources.displayMetrics).toInt()

--- a/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
@@ -22,6 +22,7 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
 import android.view.MotionEvent
+import com.geeksville.mesh.android.spToPx
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 import org.osmdroid.views.overlay.Polygon
@@ -31,6 +32,8 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
     companion object {
         private const val LABEL_CORNER_RADIUS = 12F
         private const val LABEL_Y_OFFSET = 100F
+        private const val FONT_SIZE_SP = 14f
+        private const val EMOJI_FONT_SIZE_SP = 20f
     }
 
     private var nodeColor: Int = Color.GRAY
@@ -69,14 +72,14 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
     private val mLabel = label
     private val mEmoji = emoji
     private val textPaint = Paint().apply {
-        textSize = 40f
+        textSize = mapView?.context?.spToPx(FONT_SIZE_SP)?.toFloat() ?: 40f
         color = Color.DKGRAY
         isAntiAlias = true
         isFakeBoldText = true
         textAlign = Paint.Align.CENTER
     }
     private val emojiPaint = Paint().apply {
-        textSize = 80f
+        textSize = mapView?.context?.spToPx(EMOJI_FONT_SIZE_SP)?.toFloat() ?: 80f
         isAntiAlias = true
         textAlign = Paint.Align.CENTER
     }


### PR DESCRIPTION
Fixes #1616

Marker labels were using a fixed pixel size for text (40px for text, 80px for emojis). For some devices (e.g. lower resolution tablets) this would make the labels much larger than expected.

This change fixes that by using sp font values converted to pixels. This also makes sure that the marker labels respect your device's font sizing for accessibility purposes. 

I used arbitrary values that looked about the same as they did before the change on phone (14sp for text, 20sp for emoji) that we can modify if we'd like. Note they're slightly smaller on my phone here (S23 Ultra) and I use .9f font scaling, so this is expected.

| Device | Before | After |
|------|------|-----|
| Phone (S23 Ultra) | <img src="https://github.com/user-attachments/assets/a5828e7f-0783-493d-8006-d48016032f87" width="300"/> | <img src="https://github.com/user-attachments/assets/10519853-6608-4716-aa0c-3cf64c1bc9cd" width="300"/> |
| Tablet (Tab S8+) | <img src="https://github.com/user-attachments/assets/97fb603e-815c-4754-9379-b04514acd41e" width="500"/> | <img src="https://github.com/user-attachments/assets/eb79c33d-d335-4794-a01e-d8951c50c1e7" width="500"/> |


Recordings for font scaling updates:

| Phone | Tablet |
|------|-----|
| <video src="https://github.com/user-attachments/assets/4940efaf-d994-4000-a79d-94eeacdf23f6" width="300"></video> | <video src="https://github.com/user-attachments/assets/cb71500f-fe95-4816-a993-103171bcfb53" width="300"></video> |

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->