### PR TITLE
fix #1554 (a11y): Add content description to tabs for screen reader support

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -37,6 +37,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
@@ -182,31 +183,31 @@ class MainActivity : AppCompatActivity(), Logging {
             }
         }
 
-    data class TabInfo(val text: String, val icon: Int, val content: Fragment)
+    data class TabInfo(@StringRes val textResId: Int, val icon: Int, val content: Fragment)
 
     private val tabInfos = arrayOf(
         TabInfo(
-            "Messages",
+            R.string.main_tab_messages,
             R.drawable.ic_twotone_message_24,
             ContactsFragment()
         ),
         TabInfo(
-            "Users",
+            R.string.main_tab_users,
             R.drawable.ic_twotone_people_24,
             UsersFragment()
         ),
         TabInfo(
-            "Map",
+            R.string.main_tab_map,
             R.drawable.ic_twotone_map_24,
             MapFragment()
         ),
         TabInfo(
-            "Channel",
+            R.string.main_tab_channel,
             R.drawable.ic_twotone_contactless_24,
             ChannelFragment()
         ),
         TabInfo(
-            "Settings",
+            R.string.main_tab_settings,
             R.drawable.ic_twotone_settings_applications_24,
             SettingsFragment()
         )
@@ -249,8 +250,8 @@ class MainActivity : AppCompatActivity(), Logging {
             false // Gestures for screen switching doesn't work so good with the map view
         // pager.offscreenPageLimit = 0 // Don't keep any offscreen pages around, because we want to make sure our bluetooth scanning stops
         TabLayoutMediator(binding.tabLayout, binding.pager, false, false) { tab, position ->
-            // tab.text = tabInfos[position].text // I think it looks better with icons only
             tab.icon = ContextCompat.getDrawable(this, tabInfos[position].icon)
+            tab.contentDescription = ContextCompat.getString(this, tabInfos[position].textResId)
         }.attach()
 
         binding.tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,12 @@
     <string name="sample_coords" translatable="false">55.332244 34.442211</string>
     <string name="sample_message" translatable="false">hey I found the cache, it is over here next to the big tiger. I\'m kinda scared.</string>
 
+    <string name="main_tab_messages">Messages</string>
+    <string name="main_tab_users">Users</string>
+    <string name="main_tab_map">Map</string>
+    <string name="main_tab_channel">Channel</string>
+    <string name="main_tab_settings">Settings</string>
+
     <string name="unknown_node_short_name" translatable="false">\???</string>
     <string name="node_filter_placeholder">Filter</string>
     <string name="desc_node_filter_clear">clear node filter</string>


### PR DESCRIPTION
Fixes #1554

Adds content descriptions to main tabs for screen reader support. Also moves to using string resources for these values so that they can be translated.

Apologies for the potato recording, the combo of the device being in TalkBack mode and not being able to record audio from logcat made it easier to just record from my other phone lol:

<video src="https://github.com/user-attachments/assets/0db8ffa9-2bb9-4eab-a641-bffb449da508" width="300"></video>

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->