### PR TITLE
fix: Update Paxcount display condition

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/Node.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Node.kt
@@ -135,7 +135,7 @@ data class Node(
     }
 
     private fun PaxcountProtos.Paxcount.getDisplayString() =
-        "PAX: ${ble + wifi} (B:$ble/W:$wifi)".takeIf { ble != 0 && wifi != 0 }
+        "PAX: ${ble + wifi} (B:$ble/W:$wifi)".takeIf { ble != 0 || wifi != 0 }
 
     fun getTelemetryString(isFahrenheit: Boolean = false): String {
         return listOfNotNull(


### PR DESCRIPTION
Modify the Paxcount display logic to show the string if either `ble` or `wifi` is not zero, rather than requiring both to be non-zero.

fixes #1634 #1552 

thanks for the callout @Donnie650 !