### PR TITLE
feat #1611: Add confirmation dialog when changing to router role

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
@@ -211,7 +211,6 @@ fun DeviceConfigItemList(
                 onItemSelected = {
                     if (it == DeviceConfig.Role.ROUTER && deviceInput.role != DeviceConfig.Role.ROUTER) {
                         showRouterRoleConfirmationDialog = true
-                        return@DropDownPreference
                     } else {
                         deviceInput = deviceInput.copy { role = it }
                     }

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
@@ -187,8 +187,7 @@ fun DeviceConfigItemList(
     val focusManager = LocalFocusManager.current
     var deviceInput by rememberSaveable { mutableStateOf(deviceConfig) }
 
-    var showRouterRoleConfirmationDialog = true
-//    var showRouterRoleConfirmationDialog by rememberSaveable { mutableStateOf(false) }
+    var showRouterRoleConfirmationDialog by rememberSaveable { mutableStateOf(false) }
     if (showRouterRoleConfirmationDialog) {
         RouterRoleConfirmationDialog(
             onDismiss = { showRouterRoleConfirmationDialog = false },

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
@@ -38,13 +38,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.withLink
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -116,28 +115,11 @@ fun RouterRoleConfirmationDialog(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
-    val dialogTitle = "Are you sure?"
-    val annotatedDialogText = buildAnnotatedString {
-        append("I have read the ")
-        withLink(
-            link = LinkAnnotation.Url(
-                "https://meshtastic.org/docs/configuration/radio/device/#roles",
-                TextLinkStyles(style = SpanStyle(color = Color.Blue))
-            )
-        ) {
-            append("Device Role Documentation ")
-        }
-        append("and the blog post about ")
-        withLink(
-            link = LinkAnnotation.Url(
-                "http://meshtastic.org/blog/choosing-the-right-device-role",
-                TextLinkStyles(style = SpanStyle(color = Color.Blue))
-            )
-        ) {
-            append("Choosing The Right Device Role")
-        }
-        append(".")
-    }
+    val dialogTitle = stringResource(R.string.are_you_sure)
+    val annotatedDialogText = AnnotatedString.fromHtml(
+        htmlString = stringResource(R.string.router_role_confirmation_text),
+        linkStyles = TextLinkStyles(style = SpanStyle(color = Color.Blue))
+    )
 
     var confirmed by rememberSaveable { mutableStateOf(false) }
 
@@ -155,7 +137,7 @@ fun RouterRoleConfirmationDialog(
                         checked = confirmed,
                         onCheckedChange = { confirmed = it }
                     )
-                    Text("I know what I'm doing.")
+                    Text(stringResource(R.string.i_know_what_i_m_doing))
                 }
             }
         },
@@ -165,14 +147,14 @@ fun RouterRoleConfirmationDialog(
                 onClick = onConfirm,
                 enabled = confirmed
             ) {
-                Text("Confirm")
+                Text(stringResource(R.string.accept))
             }
         },
         dismissButton = {
             TextButton(
                 onClick = onDismiss
             ) {
-                Text("Dismiss")
+                Text(stringResource(R.string.cancel))
             }
         }
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -328,4 +328,7 @@
     <string name="channel_3">Channel 3</string>
     <string name="current">Current</string>
     <string name="voltage">Voltage</string>
+    <string name="are_you_sure">Are you sure?</string>
+    <string name="router_role_confirmation_text"><![CDATA[I have read the <a href="https://meshtastic.org/docs/configuration/radio/device/#roles">Device Role Documentation</a> and the blog post about <a href="http://meshtastic.org/blog/choosing-the-right-device-role">Choosing The Right Device Role</a>.]]></string>
+    <string name="i_know_what_i_m_doing">I know what I\'m doing.</string>
 </resources>


### PR DESCRIPTION
Introduced a confirmation dialog that will be shown when changing the device role to "router". The confirmation dialog includes links to the "Device Role Documentation" and "Choosing The Right Device Role" blog post. The user must check a checkbox to confirm.

resolves #1611 

<img src="https://github.com/user-attachments/assets/cc6ec848-d9cb-4557-8277-98946df001ff" width=300>
