### PR TITLE
fix #1616: Calculate DP to pixel value for map label offset

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/android/ContextExtensions.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextExtensions.kt
@@ -40,3 +40,7 @@ fun Activity.hideKeyboard() {
 // Converts SP to pixels.
 fun Context.spToPx(sp: Float): Int =
     TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, sp, resources.displayMetrics).toInt()
+
+// Converts DP to pixels.
+fun Context.dpToPx(dp: Float): Int =
+    TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, resources.displayMetrics).toInt()

--- a/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/map/MarkerWithLabel.kt
@@ -22,6 +22,7 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
 import android.view.MotionEvent
+import com.geeksville.mesh.android.dpToPx
 import com.geeksville.mesh.android.spToPx
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
@@ -30,10 +31,18 @@ import org.osmdroid.views.overlay.Polygon
 class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) : Marker(mapView) {
 
     companion object {
-        private const val LABEL_CORNER_RADIUS = 12F
-        private const val LABEL_Y_OFFSET = 100F
+        private const val LABEL_CORNER_RADIUS_DP = 4f
+        private const val LABEL_Y_OFFSET_DP = 34f
         private const val FONT_SIZE_SP = 14f
         private const val EMOJI_FONT_SIZE_SP = 20f
+    }
+
+    private val labelYOffsetPx by lazy {
+        mapView?.context?.dpToPx(LABEL_Y_OFFSET_DP) ?: 100
+    }
+
+    private val labelCornerRadiusPx by lazy {
+        mapView?.context?.dpToPx(LABEL_CORNER_RADIUS_DP) ?: 12
     }
 
     private var nodeColor: Int = Color.GRAY
@@ -109,12 +118,12 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
     override fun draw(c: Canvas, osmv: MapView?, shadow: Boolean) {
         super.draw(c, osmv, false)
         val p = mPositionPixels
-        val bgRect = getTextBackgroundSize(mLabel, (p.x - 0F), (p.y - LABEL_Y_OFFSET))
+        val bgRect = getTextBackgroundSize(mLabel, p.x.toFloat(), (p.y - labelYOffsetPx.toFloat()))
         bgRect.inset(-8F, -2F)
 
         if (mLabel.isNotEmpty()) {
-            c.drawRoundRect(bgRect, LABEL_CORNER_RADIUS, LABEL_CORNER_RADIUS, bgPaint)
-            c.drawText(mLabel, (p.x - 0F), (p.y - LABEL_Y_OFFSET), textPaint)
+            c.drawRoundRect(bgRect, labelCornerRadiusPx.toFloat(), labelCornerRadiusPx.toFloat(), bgPaint)
+            c.drawText(mLabel, (p.x - 0F), (p.y - labelYOffsetPx.toFloat()), textPaint)
         }
         mEmoji?.let { c.drawText(it, (p.x - 0f), (p.y - 30f), emojiPaint) }
 


### PR DESCRIPTION
Similar to the change to label text [here](https://github.com/meshtastic/Meshtastic-Android/pull/1630), this PR modifies the map label offset to use DP instead of a static pixel value. This makes sure that any device will have a more uniform offset for the map labels.

I don't have my tablet available atm, but this is before and after on my S23 ultra:

| Before | After |
|------|-----|
| <img src="https://github.com/user-attachments/assets/f8a63776-4128-4611-9c96-f23ae3a56df9" width="300"/> | <img src="https://github.com/user-attachments/assets/ded2d53e-7b44-48cc-b4b7-b1eb4b7c1b43" width="300"/> |

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->