### PR TITLE
fix #1645: Ensure test run completion on Android by killing crashpad_handler

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -151,4 +151,4 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
-          script: ./gradlew connectedFdroidDebugAndroidTest
+          script: ./gradlew connectedFdroidDebugAndroidTest && killall -INT crashpad_handler || true


### PR DESCRIPTION
as suggested in https://github.com/ReactiveCircus/android-emulator-runner/issues/385#issuecomment-2492035091