### PR TITLE
feat: Initial implementation of low battery notifications for nodes

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -939,7 +939,17 @@ class MeshService : Service(), Logging {
         }
         updateNodeInfo(fromNum) {
             when {
-                t.hasDeviceMetrics() -> it.deviceTelemetry = t
+                t.hasDeviceMetrics() -> {
+                    it.deviceTelemetry = t
+                    when {
+                        fromNum == myNodeNum && (t.deviceMetrics.voltage > 0.0 && t.deviceMetrics.batteryLevel < 20.0) -> {
+                            serviceNotifications.showOrUpdateLowBatteryNotification(it)
+                        }
+                        (fromNum != myNodeNum && it.isFavorite) && (t.deviceMetrics.voltage > 0.0 && t.deviceMetrics.batteryLevel < 20.0) -> {
+                            serviceNotifications.showOrUpdateLowBatteryRemoteNotification(it)
+                        }
+                    }
+                }
                 t.hasEnvironmentMetrics() -> it.environmentTelemetry = t
                 t.hasPowerMetrics() -> it.powerTelemetry = t
             }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -945,10 +945,11 @@ class MeshService : Service(), Logging {
                 t.hasDeviceMetrics() -> {
                     it.deviceTelemetry = t
                     val isRemote = (fromNum != myNodeNum)
-                    if ((fromNum == myNodeNum || (isRemote && it.isFavorite)) &&
-                        t.deviceMetrics.voltage > batteryPercentUnsupported &&
-                        t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) {
+                    if (fromNum == myNodeNum || (isRemote && it.isFavorite)) {
+                        if (t.deviceMetrics.voltage > batteryPercentUnsupported &&
+                            t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) {
                             serviceNotifications.showOrUpdateLowBatteryNotification(it, isRemote)
+                        }
                     }
                 }
                 t.hasEnvironmentMetrics() -> it.environmentTelemetry = t

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -944,17 +944,11 @@ class MeshService : Service(), Logging {
             when {
                 t.hasDeviceMetrics() -> {
                     it.deviceTelemetry = t
-                    when {
-                        fromNum == myNodeNum && (
-                                t.deviceMetrics.voltage > batteryPercentUnsupported &&
-                                t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) -> {
-                            serviceNotifications.showOrUpdateLowBatteryNotification(it)
-                        }
-                        (fromNum != myNodeNum && it.isFavorite) && (
-                                t.deviceMetrics.voltage > batteryPercentUnsupported &&
-                                t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) -> {
-                            serviceNotifications.showOrUpdateLowBatteryRemoteNotification(it)
-                        }
+                    val isRemote = (fromNum != myNodeNum)
+                    if ((fromNum == myNodeNum || (isRemote && it.isFavorite)) &&
+                        t.deviceMetrics.voltage > batteryPercentUnsupported &&
+                        t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) {
+                            serviceNotifications.showOrUpdateLowBatteryNotification(it, isRemote)
                     }
                 }
                 t.hasEnvironmentMetrics() -> it.environmentTelemetry = t

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -213,6 +213,9 @@ class MeshService : Service(), Logging {
     private var locationFlow: Job? = null
     private var mqttMessageFlow: Job? = null
 
+    private val batteryPercentUnsupported= 0.0
+    private val batteryPercentLowThreshold = 20.0
+
     private fun getSenderName(packet: DataPacket?): String {
         val name = nodeDBbyID[packet?.from]?.user?.longName
         return name ?: getString(R.string.unknown_username)
@@ -942,10 +945,14 @@ class MeshService : Service(), Logging {
                 t.hasDeviceMetrics() -> {
                     it.deviceTelemetry = t
                     when {
-                        fromNum == myNodeNum && (t.deviceMetrics.voltage > 0.0 && t.deviceMetrics.batteryLevel < 20.0) -> {
+                        fromNum == myNodeNum && (
+                                t.deviceMetrics.voltage > batteryPercentUnsupported
+                                && t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) -> {
                             serviceNotifications.showOrUpdateLowBatteryNotification(it)
                         }
-                        (fromNum != myNodeNum && it.isFavorite) && (t.deviceMetrics.voltage > 0.0 && t.deviceMetrics.batteryLevel < 20.0) -> {
+                        (fromNum != myNodeNum && it.isFavorite) && (
+                                t.deviceMetrics.voltage > batteryPercentUnsupported
+                                && t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) -> {
                             serviceNotifications.showOrUpdateLowBatteryRemoteNotification(it)
                         }
                     }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -213,7 +213,7 @@ class MeshService : Service(), Logging {
     private var locationFlow: Job? = null
     private var mqttMessageFlow: Job? = null
 
-    private val batteryPercentUnsupported= 0.0
+    private val batteryPercentUnsupported = 0.0
     private val batteryPercentLowThreshold = 20.0
 
     private fun getSenderName(packet: DataPacket?): String {
@@ -946,13 +946,13 @@ class MeshService : Service(), Logging {
                     it.deviceTelemetry = t
                     when {
                         fromNum == myNodeNum && (
-                                t.deviceMetrics.voltage > batteryPercentUnsupported
-                                && t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) -> {
+                                t.deviceMetrics.voltage > batteryPercentUnsupported &&
+                                t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) -> {
                             serviceNotifications.showOrUpdateLowBatteryNotification(it)
                         }
                         (fromNum != myNodeNum && it.isFavorite) && (
-                                t.deviceMetrics.voltage > batteryPercentUnsupported
-                                && t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) -> {
+                                t.deviceMetrics.voltage > batteryPercentUnsupported &&
+                                t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) -> {
                             serviceNotifications.showOrUpdateLowBatteryRemoteNotification(it)
                         }
                     }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -200,7 +200,7 @@ class MeshServiceNotifications(
         return channelId
     }
 
-    // TODO: Once we get a dedicated settings page in the app, this function should be removed and
+    // FIXME, Once we get a dedicated settings page in the app, this function should be removed and
     //     the feature should be implemented in the regular low battery notification stuff
     @RequiresApi(Build.VERSION_CODES.O)
     private fun createLowBatteryRemoteNotificationChannel(): String {
@@ -272,7 +272,7 @@ class MeshServiceNotifications(
         }
     }
 
-    // TODO: Once we get a dedicated settings page in the app, this function should be removed and
+    // FIXME, Once we get a dedicated settings page in the app, this function should be removed and
     //     the feature should be implemented in the regular low battery notification stuff
     private val lowBatteryRemoteChannelId: String by lazy {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -338,7 +338,7 @@ class MeshServiceNotifications(
         )
     }
 
-    // TODO: Once we get a dedicated settings page in the app, this function should be removed and
+    // FIXME, Once we get a dedicated settings page in the app, this function should be removed and
     //     the feature should be implemented in the regular low battery notification stuff
     fun showOrUpdateLowBatteryRemoteNotification(node: NodeEntity) {
         notificationManager.notify(
@@ -531,7 +531,7 @@ class MeshServiceNotifications(
         return lowBatteryNotificationBuilder.build()
     }
 
-    // TODO: Once we get a dedicated settings page in the app, this function should be removed and
+    // FIXME, Once we get a dedicated settings page in the app, this function should be removed and
     //     the feature should be implemented in the regular low battery notification stuff
     lateinit var lowBatteryRemoteNotificationBuilder: NotificationCompat.Builder
     private fun createLowBatteryRemoteNotification(node: NodeEntity): Notification {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,4 +337,8 @@
     <string name="are_you_sure">Are you sure?</string>
     <string name="router_role_confirmation_text"><![CDATA[I have read the <a href="https://meshtastic.org/docs/configuration/radio/device/#roles">Device Role Documentation</a> and the blog post about <a href="http://meshtastic.org/blog/choosing-the-right-device-role">Choosing The Right Device Role</a>.]]></string>
     <string name="i_know_what_i_m_doing">I know what I\'m doing.</string>
+    <string name="low_battery_message">Node %s has a low battery (%d%%)</string>
+    <string name="meshtastic_low_battery_notifications">Low battery notifications</string>
+    <string name="low_battery_title">Low battery: %s</string>
+    <string name="meshtastic_low_battery_temporary_remote_notifications">Low battery notifications (favorite nodes)</string>
 </resources>


### PR DESCRIPTION
Closes #1395 and closes #1598

This PR adds low-battery notifications for both locally-connected and remote nodes that have been added as a favorite in the device's node DB.

Currently, the notification is sent when a device goes below 20% battery remaining, but if a device reports the battery voltage as "0.00" volts, it will be exempt from alerts as that is a magic number in the firmware for no battery voltage support. In the future, this threshold will be configurable, but it is currently fixed.

For now, separate notification channels are created for locally-connected nodes and remote favorite nodes, but in the future this will be grouped together under a single notification channel that has settings to enable or disable reporting of remote favorite nodes.