### PR TITLE
fix #1654: Move the app rating dependency to googleImplementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,7 +165,7 @@ dependencies {
 
     //Individual dependencies
     implementation(libs.appintro)
-    implementation(libs.awesome.app.rating)
+    googleImplementation(libs.awesome.app.rating)
     implementation(libs.core.splashscreen)
     implementation(libs.emoji2.emojipicker)
     implementation(libs.kotlinx.collections.immutable)

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -59,6 +59,7 @@ import com.geeksville.mesh.android.BindFailedException
 import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.android.ServiceClient
+import com.geeksville.mesh.android.dpToPx
 import com.geeksville.mesh.android.getBluetoothPermissions
 import com.geeksville.mesh.android.getNotificationPermissions
 import com.geeksville.mesh.android.hasBluetoothPermission
@@ -450,6 +451,7 @@ class MainActivity : AppCompatActivity(), Logging {
         }
     }
 
+    @Suppress("MagicNumber")
     private fun checkAlertDnD() {
         if (
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
@@ -470,7 +472,7 @@ class MainActivity : AppCompatActivity(), Logging {
                 val messageTextView = TextView(this).also {
                     it.text = message
                     it.movementMethod = LinkMovementMethod.getInstance()
-                    it.setPadding(resources.getDimension(R.dimen.margin_normal).toInt())
+                    it.setPadding(dpToPx(16f))
                 }
                 MaterialAlertDialogBuilder(this)
                     .setTitle(R.string.alerts_dnd_request_title)


### PR DESCRIPTION
The `awesome.app.rating` dependency is now under `googleImplementation` instead of `implementation` in `app/build.gradle`.
fixes #1654 
