### PR TITLE
feat: expand role confirmation to include REPEATER

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
@@ -133,9 +133,11 @@ fun RouterRoleConfirmationDialog(
             Column {
                 Text(text = annotatedDialogText)
                 Row(
-                    modifier = Modifier.fillMaxWidth().clickable(true) {
-                        confirmed = !confirmed
-                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(true) {
+                            confirmed = !confirmed
+                        },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Checkbox(
@@ -176,7 +178,6 @@ fun DeviceConfigItemList(
     var selectedRole by rememberSaveable { mutableStateOf(deviceInput.role) }
     val infrastructureRoles = listOf(
         DeviceConfig.Role.ROUTER,
-        DeviceConfig.Role.ROUTER_CLIENT,
         DeviceConfig.Role.REPEATER,
     )
     if (selectedRole != deviceInput.role) {

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
@@ -168,13 +168,12 @@ fun DeviceConfigItemList(
 ) {
     val focusManager = LocalFocusManager.current
     var deviceInput by rememberSaveable { mutableStateOf(deviceConfig) }
-
-    var showRouterRoleConfirmationDialog by rememberSaveable { mutableStateOf(false) }
-    if (showRouterRoleConfirmationDialog) {
+    var showRoleConfirmationDialog by rememberSaveable { mutableStateOf(false) }
+    if (showRoleConfirmationDialog) {
         RouterRoleConfirmationDialog(
-            onDismiss = { showRouterRoleConfirmationDialog = false },
+            onDismiss = { showRoleConfirmationDialog = false },
             onConfirm = {
-                showRouterRoleConfirmationDialog = false
+                showRoleConfirmationDialog = false
                 deviceInput = deviceInput.copy { role = DeviceConfig.Role.ROUTER }
             }
         )
@@ -190,8 +189,13 @@ fun DeviceConfigItemList(
                 enabled = enabled,
                 selectedItem = deviceInput.role,
                 onItemSelected = {
-                    if (it == DeviceConfig.Role.ROUTER && deviceInput.role != DeviceConfig.Role.ROUTER) {
-                        showRouterRoleConfirmationDialog = true
+                    if (it in listOf(
+                            DeviceConfig.Role.ROUTER,
+                            DeviceConfig.Role.ROUTER_CLIENT,
+                            DeviceConfig.Role.REPEATER
+                        )
+                    ) {
+                        showRoleConfirmationDialog = true
                     } else {
                         deviceInput = deviceInput.copy { role = it }
                     }

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/DeviceConfigItemList.kt
@@ -17,9 +17,11 @@
 
 package com.geeksville.mesh.ui.radioconfig.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -131,6 +133,9 @@ fun RouterRoleConfirmationDialog(
             Column {
                 Text(text = annotatedDialogText)
                 Row(
+                    modifier = Modifier.fillMaxWidth().clickable(true) {
+                        confirmed = !confirmed
+                    },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Checkbox(
@@ -168,15 +173,23 @@ fun DeviceConfigItemList(
 ) {
     val focusManager = LocalFocusManager.current
     var deviceInput by rememberSaveable { mutableStateOf(deviceConfig) }
-    var showRoleConfirmationDialog by rememberSaveable { mutableStateOf(false) }
-    if (showRoleConfirmationDialog) {
-        RouterRoleConfirmationDialog(
-            onDismiss = { showRoleConfirmationDialog = false },
-            onConfirm = {
-                showRoleConfirmationDialog = false
-                deviceInput = deviceInput.copy { role = DeviceConfig.Role.ROUTER }
-            }
-        )
+    var selectedRole by rememberSaveable { mutableStateOf(deviceInput.role) }
+    val infrastructureRoles = listOf(
+        DeviceConfig.Role.ROUTER,
+        DeviceConfig.Role.ROUTER_CLIENT,
+        DeviceConfig.Role.REPEATER,
+    )
+    if (selectedRole != deviceInput.role) {
+        if (selectedRole in infrastructureRoles) {
+            RouterRoleConfirmationDialog(
+                onDismiss = { selectedRole = deviceInput.role },
+                onConfirm = {
+                    deviceInput = deviceInput.copy { role = selectedRole }
+                }
+            )
+        } else {
+            deviceInput = deviceInput.copy { role = selectedRole }
+        }
     }
     LazyColumn(
         modifier = Modifier.fillMaxSize()
@@ -189,16 +202,7 @@ fun DeviceConfigItemList(
                 enabled = enabled,
                 selectedItem = deviceInput.role,
                 onItemSelected = {
-                    if (it in listOf(
-                            DeviceConfig.Role.ROUTER,
-                            DeviceConfig.Role.ROUTER_CLIENT,
-                            DeviceConfig.Role.REPEATER
-                        )
-                    ) {
-                        showRoleConfirmationDialog = true
-                    } else {
-                        deviceInput = deviceInput.copy { role = it }
-                    }
+                    selectedRole = it
                 },
                 summary = stringResource(id = deviceInput.role.stringRes),
             )


### PR DESCRIPTION
The role change logic was modified to show a confirmation dialog when the role is set to `ROUTER`, `ROUTER_CLIENT`, or `REPEATER`. Previously, the dialog was only displayed when setting the role to `ROUTER`.

Also the clickable area for the checkbox has been expanded to the full width of the Row.

<video src="https://github.com/user-attachments/assets/e3fd872a-9f34-405f-80b2-2228f4f3c7d8
" width="300"/>


