### PR TITLE
chore: Update minimum required firmware version 2.3.2 -> 2.3.15

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -184,7 +184,7 @@ class MeshService : Service(), Logging {
         /** The minimum firmware version we know how to talk to. We'll still be able
          * to talk to 2.0 firmwares but only well enough to ask them to firmware update.
          */
-        val minDeviceVersion = DeviceVersion("2.3.2")
+        val minDeviceVersion = DeviceVersion("2.3.15")
     }
 
     enum class ConnectionState {


### PR DESCRIPTION
Updated the minimum required firmware version to 2.3.15 - [aligns with iOS](https://github.com/meshtastic/Meshtastic-Apple/blob/6e6de4da64facb30120e39b17191243407876ebe/Meshtastic/Helpers/BLEManager.swift#L30).