### PR TITLE
2.5.19

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,8 +32,8 @@ android {
         applicationId "com.geeksville.mesh"
         minSdkVersion 21 // The oldest emulator image I have tried is 22 (though 21 probably works)
         targetSdk 34
-        versionCode 30518 // format is Mmmss (where M is 1+the numeric major number
-        versionName "2.5.18"
+        versionCode 30519 // format is Mmmss (where M is 1+the numeric major number
+        versionName "2.5.19"
         testInstrumentationRunner "com.geeksville.mesh.TestRunner"
 
         // per https://developer.android.com/studio/write/vector-asset-studio


### PR DESCRIPTION
This increments the app's internal version code and the user-facing version name in the build.gradle file.

Should fix #1654 