### PR TITLE
feat: Improve (battery) notification behavior

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -949,6 +949,8 @@ class MeshService : Service(), Logging {
                         if (t.deviceMetrics.voltage > batteryPercentUnsupported &&
                             t.deviceMetrics.batteryLevel < batteryPercentLowThreshold) {
                             serviceNotifications.showOrUpdateLowBatteryNotification(it, isRemote)
+                        } else {
+                            serviceNotifications.cancelLowBatteryNotification(it)
                         }
                     }
                 }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -56,6 +56,7 @@ class MeshServiceNotifications(
         const val ALERT_GROUP = "ALERT_NOTIFICATION_GROUP"
         const val NEW_NODE_GROUP = "NEW_NODE_NOTIFICATION_GROUP"
         const val LOW_BATTERY_GROUP = "LOW_BATTERY_NOTIFICATION_GROUP"
+        const val MAX_BATTERY_LEVEL = 100
     }
 
     private val notificationManager: NotificationManager get() = context.notificationManager
@@ -527,6 +528,7 @@ class MeshServiceNotifications(
             setShowWhen(true)
             setOnlyAlertOnce(true)
             setWhen(System.currentTimeMillis())
+            setProgress(MAX_BATTERY_LEVEL, node.deviceMetrics.batteryLevel, false)
             setContentTitle(
                 context.getString(R.string.low_battery_title).format(
                     node.shortName

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -51,6 +51,11 @@ class MeshServiceNotifications(
         const val OPEN_MESSAGE_ACTION = "com.geeksville.mesh.OPEN_MESSAGE_ACTION"
         const val OPEN_MESSAGE_EXTRA_CONTACT_KEY =
             "com.geeksville.mesh.OPEN_MESSAGE_EXTRA_CONTACT_KEY"
+        const val SERVICE_GROUP = "SERVICE_NOTIFICATION_GROUP"
+        const val MESSAGE_GROUP = "MESSAGE_NOTIFICATION_GROUP"
+        const val ALERT_GROUP = "ALERT_NOTIFICATION_GROUP"
+        const val NEW_NODE_GROUP = "NEW_NODE_NOTIFICATION_GROUP"
+        const val LOW_BATTERY_GROUP = "LOW_BATTERY_NOTIFICATION_GROUP"
     }
 
     private val notificationManager: NotificationManager get() = context.notificationManager
@@ -215,6 +220,7 @@ class MeshServiceNotifications(
             ).apply {
                 lightColor = notificationLightColor
                 lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                enableVibration(true)
                 setShowBadge(true)
                 setSound(
                     RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
@@ -339,6 +345,10 @@ class MeshServiceNotifications(
         )
     }
 
+    fun cancelLowBatteryNotification(node: NodeEntity) {
+        notificationManager.cancel(node.num)
+    }
+
     private val openAppIntent: PendingIntent by lazy {
         PendingIntent.getActivity(
             context,
@@ -396,6 +406,7 @@ class MeshServiceNotifications(
         }
         with(serviceNotificationBuilder) {
             priority = NotificationCompat.PRIORITY_MIN
+            setGroup(SERVICE_GROUP)
             setCategory(Notification.CATEGORY_SERVICE)
             setOngoing(true)
             setContentTitle(name)
@@ -434,6 +445,7 @@ class MeshServiceNotifications(
             setContentIntent(openMessageIntent(contactKey))
             priority = NotificationCompat.PRIORITY_DEFAULT
             setCategory(Notification.CATEGORY_MESSAGE)
+            setGroup(MESSAGE_GROUP)
             setAutoCancel(true)
             setStyle(
                 NotificationCompat.MessagingStyle(person)
@@ -459,6 +471,7 @@ class MeshServiceNotifications(
             setContentIntent(openMessageIntent(contactKey))
             priority = NotificationCompat.PRIORITY_HIGH
             setCategory(Notification.CATEGORY_ALARM)
+            setGroup(ALERT_GROUP)
             setAutoCancel(true)
             setStyle(
                 NotificationCompat.MessagingStyle(person)
@@ -475,6 +488,7 @@ class MeshServiceNotifications(
         }
         with(newNodeSeenNotificationBuilder) {
             priority = NotificationCompat.PRIORITY_DEFAULT
+            setGroup(NEW_NODE_GROUP)
             setCategory(Notification.CATEGORY_STATUS)
             setAutoCancel(true)
             setContentTitle("New Node Seen: $name")
@@ -508,7 +522,8 @@ class MeshServiceNotifications(
         with(tempNotificationBuilder) {
             priority = NotificationCompat.PRIORITY_DEFAULT
             setCategory(Notification.CATEGORY_STATUS)
-            setAutoCancel(true)
+            setOngoing(true)
+            setGroup(LOW_BATTERY_GROUP)
             setShowWhen(true)
             setOnlyAlertOnce(true)
             setWhen(System.currentTimeMillis())


### PR DESCRIPTION
Noticed some chatter on #1653 and wondered if this might be a potential solve. I changed up the notification to be non-dismissable, but also added logic to clear the notification when the battery status is back above the threshhold.

Also adds a progress bar to indicate battery percentage for a little flair.

This also adds some grouping to the growing variety of notifications as well that may help logically consolidate them in the drawer.

- Changes low battery notifications to be non-cancelable
- Cancel low battery notifications when battery level is no longer low.
- Add notification groups and improve notification settings.
- Add vibration to low battery notifications.
- Add progress bar to low battery notifications
<img src="https://github.com/user-attachments/assets/4443e48c-5e00-462d-8f3e-c435c57ee53a" width=300/>
(note: i artificially set the threshhold very high for testing)