### PR TITLE
fix #1484: Filter out ignored nodes from map

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,7 +96,10 @@ android {
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
-        freeCompilerArgs += ['-opt-in=kotlin.RequiresOptIn']
+        freeCompilerArgs += [
+                '-opt-in=kotlin.RequiresOptIn',
+                '-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi'
+        ]
     }
     lint {
         abortOnError false

--- a/app/src/main/java/com/geeksville/mesh/database/MeshLogRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/MeshLogRepository.kt
@@ -18,12 +18,11 @@
 package com.geeksville.mesh.database
 
 import com.geeksville.mesh.CoroutineDispatchers
-import com.geeksville.mesh.Portnums
 import com.geeksville.mesh.MeshProtos.MeshPacket
+import com.geeksville.mesh.Portnums
 import com.geeksville.mesh.TelemetryProtos.Telemetry
 import com.geeksville.mesh.database.dao.MeshLogDao
 import com.geeksville.mesh.database.entity.MeshLog
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -54,7 +53,6 @@ class MeshLogRepository @Inject constructor(
             .toBuilder().setTime((log.received_date / MILLIS_TO_SECONDS).toInt()).build()
     }.getOrNull()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     fun getTelemetryFrom(nodeNum: Int): Flow<List<Telemetry>> =
         meshLogDao.getLogsFrom(nodeNum, Portnums.PortNum.TELEMETRY_APP_VALUE, MAX_MESH_PACKETS)
             .distinctUntilChanged()
@@ -73,7 +71,6 @@ class MeshLogRepository @Inject constructor(
      * Retrieves MeshPackets matching 'nodeNum' and 'portNum'.
      * If 'portNum' is not specified, returns all MeshPackets. Otherwise, filters by 'portNum'.
      */
-    @OptIn(ExperimentalCoroutinesApi::class)
     fun getMeshPacketsFrom(
         nodeNum: Int,
         portNum: Int = Portnums.PortNum.UNKNOWN_APP_VALUE,

--- a/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
@@ -28,7 +28,6 @@ import com.geeksville.mesh.database.entity.MyNodeEntity
 import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.NodeSortOption
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -65,7 +64,6 @@ class NodeRepository @Inject constructor(
         .map { map -> map.mapValues { (_, it) -> it.toEntity() } }
 
     // A map from nodeNum to Node
-    @OptIn(ExperimentalCoroutinesApi::class)
     val nodeDBbyNum: StateFlow<Map<Int, Node>> = nodeInfoDao.nodeDBbyNum()
         .mapLatest { map -> map.mapValues { (_, it) -> it.toModel() } }
         .onEach {
@@ -94,7 +92,6 @@ class NodeRepository @Inject constructor(
                 .setHwModel(MeshProtos.HardwareModel.UNSET)
                 .build()
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     fun getNodes(
         sort: NodeSortOption = NodeSortOption.LAST_HEARD,
         filter: String = "",

--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -43,7 +43,6 @@ import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.ui.map.MAP_STYLE_ID
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asFlow
@@ -224,7 +223,6 @@ class MetricsViewModel @Inject constructor(
     private var deviceHardwareList: List<DeviceHardware> = listOf()
 
     init {
-        @OptIn(ExperimentalCoroutinesApi::class)
         radioConfigRepository.nodeDBbyNum
             .mapLatest { nodes -> nodes[destNum] }
             .distinctUntilChanged()

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -244,6 +244,17 @@ class UIViewModel @Inject constructor(
         initialValue = emptyList(),
     )
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val filteredNodeList: StateFlow<List<Node>> = nodeList.mapLatest { list ->
+        list.filter { node ->
+            !node.isIgnored
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = emptyList(),
+    )
+
     // hardware info about our local device (can be null)
     val myNodeInfo: StateFlow<MyNodeEntity?> get() = nodeDB.myNodeInfo
     val ourNodeInfo: StateFlow<Node?> get() = nodeDB.ourNodeInfo

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -234,7 +234,6 @@ class UIViewModel @Inject constructor(
         initialValue = NodesUiState.Empty,
     )
 
-
     val nodeList: StateFlow<List<Node>> = nodesUiState.flatMapLatest { state ->
         nodeDB.getNodes(state.sort, state.filter, state.includeUnknown)
     }.stateIn(
@@ -242,7 +241,6 @@ class UIViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5_000),
         initialValue = emptyList(),
     )
-
 
     val filteredNodeList: StateFlow<List<Node>> = nodeList.mapLatest { list ->
         list.filter { node ->
@@ -338,10 +336,8 @@ class UIViewModel @Inject constructor(
         initialValue = emptyList(),
     )
 
-
     fun getMessagesFrom(contactKey: String) = packetRepository.getMessagesFrom(contactKey)
         .mapLatest { list -> list.map { it.toMessage(::getNode) } }
-
 
     val waypoints = packetRepository.getWaypoints().mapLatest { list ->
         list.associateBy { packet -> packet.data.waypoint!!.id }

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -63,7 +63,6 @@ import com.geeksville.mesh.util.getShortDate
 import com.geeksville.mesh.util.positionToMeter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -235,7 +234,7 @@ class UIViewModel @Inject constructor(
         initialValue = NodesUiState.Empty,
     )
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+
     val nodeList: StateFlow<List<Node>> = nodesUiState.flatMapLatest { state ->
         nodeDB.getNodes(state.sort, state.filter, state.includeUnknown)
     }.stateIn(
@@ -244,7 +243,7 @@ class UIViewModel @Inject constructor(
         initialValue = emptyList(),
     )
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+
     val filteredNodeList: StateFlow<List<Node>> = nodeList.mapLatest { list ->
         list.filter { node ->
             !node.isIgnored
@@ -339,11 +338,11 @@ class UIViewModel @Inject constructor(
         initialValue = emptyList(),
     )
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+
     fun getMessagesFrom(contactKey: String) = packetRepository.getMessagesFrom(contactKey)
         .mapLatest { list -> list.map { it.toMessage(::getNode) } }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
+
     val waypoints = packetRepository.getWaypoints().mapLatest { list ->
         list.associateBy { packet -> packet.data.waypoint!!.id }
             .filterValues { it.data.waypoint!!.expire > System.currentTimeMillis() / 1000 }

--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
@@ -304,7 +304,7 @@ fun MapView(
             if (permissions.entries.all { it.value }) map.toggleMyLocation()
         }
 
-    val nodes by model.nodeList.collectAsStateWithLifecycle()
+    val nodes by model.filteredNodeList.collectAsStateWithLifecycle()
     val waypoints by model.waypoints.collectAsStateWithLifecycle(emptyMap())
 
     val markerIcon = remember {

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfigViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfigViewModel.kt
@@ -51,7 +51,6 @@ import com.geeksville.mesh.util.UiText
 import com.google.protobuf.MessageLite
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -103,7 +102,6 @@ class RadioConfigViewModel @Inject constructor(
     val currentDeviceProfile get() = _currentDeviceProfile.value
 
     init {
-        @OptIn(ExperimentalCoroutinesApi::class)
         radioConfigRepository.nodeDBbyNum
             .mapLatest { nodes -> nodes[destNum] ?: nodes.values.firstOrNull() }
             .distinctUntilChanged()


### PR DESCRIPTION
- Created a new `filteredNodeList` `StateFlow` in `UIState.kt` that filters out nodes marked as ignored.
- Updated `MapFragment.kt` to use `filteredNodeList` instead of `nodeList`, ensuring that ignored nodes are not displayed on the map.

fixes #1484 


https://github.com/user-attachments/assets/eab5b07a-9f65-49fe-8a64-421e5b0586fb

