### PR TITLE
fix #1678: Update MeshService.kt to store the channel for received packets.

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1179,6 +1179,7 @@ class MeshService : Service(), Logging {
                 it.lastHeard = packet.rxTime
                 it.snr = packet.rxSnr
                 it.rssi = packet.rxRssi
+                it.channel = packet.channel
 
                 // Generate our own hopsAway, comparing hopStart to hopLimit.
                 it.hopsAway = if (packet.hopStart == 0 || packet.hopLimit > packet.hopStart) {


### PR DESCRIPTION
The channel for received packets is now stored - hopefully fixes #1678 .

@ianmcorvidae I'm not entirely sure how to test this one - do you have a good way to reproduce this? (you could snag the fdroid build off the ci workflow if you do)