### PR TITLE
feat: Add a bit more info to the node marker popup

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
@@ -324,8 +324,13 @@ fun MapView(
                 label = "${u.shortName} ${formatAgo(p.time)}"
             ).apply {
                 id = u.id
-                title = "${u.longName} ${node.batteryStr}"
-                snippet = node.gpsString(gpsFormat)
+                title = u.longName
+                snippet = context.getString(R.string.map_node_popup_details,
+                    node.gpsString(gpsFormat),
+                    formatAgo(node.lastHeard),
+                    formatAgo(p.time),
+                    if (node.batteryStr != "") node.batteryStr else "?"
+                )
                 ourNode?.distanceStr(node, displayUnits)?.let { dist ->
                     subDescription =
                         context.getString(R.string.map_subDescription, ourNode.bearing(node), dist)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,4 +344,5 @@
     <string name="baro_pressure">Barometric Pressure</string>
     <string name="mesh_via_udp_enabled">Mesh via UDP enabled</string>
     <string name="udp_config">UDP Config</string>
+    <string name="map_node_popup_details"><![CDATA[%s<br>Last heard: %s<br>Last position: %s<br>Battery: %s]]></string>
 </resources>


### PR DESCRIPTION
This adds a bit more information to the marker popup for a node when tapped in the map view.

It comes up every so-often about the "time-ago" in the map being "incorrect" because it isn't immediately apparent that the duration displayed is actually the last received position packet, not the last received packet of any type. This attempts to help with that confusion by adding text showing both the node's last-heard time as well as the last-seen-position time.

Example:
![image](https://github.com/user-attachments/assets/53ee0a81-1627-4855-966f-94fcca69ca95)
