### PR TITLE
Clarify request options to exchange for issue #1692

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/components/NodeMenu.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/NodeMenu.kt
@@ -114,14 +114,14 @@ fun NodeMenu(
                     onDismissRequest()
                     onAction(NodeMenuAction.RequestUserInfo(node))
                 },
-                content = { Text(stringResource(R.string.request_userinfo)) }
+                content = { Text(stringResource(R.string.exchange_userinfo)) }
             )
             DropdownMenuItem(
                 onClick = {
                     onDismissRequest()
                     onAction(NodeMenuAction.RequestPosition(node))
                 },
-                content = { Text(stringResource(R.string.request_position)) }
+                content = { Text(stringResource(R.string.exchange_position)) }
             )
             DropdownMenuItem(
                 onClick = {

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Избор на регион за сваляне</string>
     <string name="map_tile_download_estimate">Прогноза за изтегляне на картинки:</string>
     <string name="map_start_download">Започни свалянето</string>
-    <string name="request_position">Поискване на позиция</string>
+    <string name="exchange_position">Поискване на позиция</string>
     <string name="close">Затвори</string>
     <string name="device_settings">Конфигурация на радиото</string>
     <string name="module_settings">Конфигурация на модула</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Seleccionar regió a descarregar</string>
     <string name="map_tile_download_estimate">Estimació de descàrrega de tessel·les:</string>
     <string name="map_start_download">Iniciar descarrega</string>
-    <string name="request_position">Sol·licitar posició</string>
+    <string name="exchange_position">Sol·licitar posició</string>
     <string name="close">Tancar</string>
     <string name="device_settings">Configuració de ràdio</string>
     <string name="module_settings">Configuració de mòdul</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -195,7 +195,7 @@
     <string name="map_select_download_region">Vyberte oblast stahování</string>
     <string name="map_tile_download_estimate">Odhad stažení dlaždic:</string>
     <string name="map_start_download">Zahájit stahování</string>
-    <string name="request_position">Vyžádat pozici</string>
+    <string name="exchange_position">Vyžádat pozici</string>
     <string name="close">Zavřít</string>
     <string name="device_settings">Nastavení zařízení</string>
     <string name="module_settings">Nastavení modulů</string>
@@ -247,7 +247,7 @@
     <string name="encryption_pkc_text">Přímé zprávy používají novou infrastrukturu veřejných klíčů pro šifrování. Vyžaduje firmware verze 2.5 nebo vyšší.</string>
     <string name="encryption_error">Neshoda veřejného klíče</string>
     <string name="encryption_error_text">Veřejný klíč neodpovídá zaznamenanému klíči. Můžete odebrat uzel a nechat jej znovu vyměnit klíče, ale to může naznačovat závažnější bezpečnostní problém. Kontaktujte uživatele prostřednictvím jiného důvěryhodného kanálu, abyste zjistili, zda byla změna klíče způsobena resetováním továrního zařízení nebo jiným záměrným jednáním.</string>
-    <string name="request_userinfo">Vyžádat informace o uživateli</string>
+    <string name="exchange_userinfo">Vyžádat informace o uživateli</string>
     <string name="meshtastic_new_nodes_notifications">Oznámení o nových uzlech</string>
     <string name="more_details">Více detailů</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Herunterlade-Region auswählen</string>
     <string name="map_tile_download_estimate">Kachel-Herunterladen-Schätzung:</string>
     <string name="map_start_download">Herunterladen starten</string>
-    <string name="request_position">Position anfordern</string>
+    <string name="exchange_position">Position anfordern</string>
     <string name="close">Schließen</string>
     <string name="device_settings">Geräteeinstellungen</string>
     <string name="module_settings">Moduleinstellungen</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Direkte Nachrichten verwenden die neue öffentliche Schlüssel-Infrastruktur für die Verschlüsselung. Benötigt Firmware-Version 2.5 oder höher.</string>
     <string name="encryption_error">Public-Key Fehler</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Benutzerinfo anfordern</string>
+    <string name="exchange_userinfo">Benutzerinfo anfordern</string>
     <string name="meshtastic_new_nodes_notifications">Neue Node Benachrichtigung</string>
     <string name="more_details">Mehr Details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -194,7 +194,7 @@
     <string name="map_select_download_region">Επιλογή περιοχής λήψης</string>
     <string name="map_tile_download_estimate">Tile download estimate:</string>
     <string name="map_start_download">Εκκίνηση Λήψης</string>
-    <string name="request_position">Αίτηση θέσης</string>
+    <string name="exchange_position">Αίτηση θέσης</string>
     <string name="close">Κλείσιμο</string>
     <string name="device_settings">Ρυθμίσεις συσκευής</string>
     <string name="module_settings">Ρυθμίσεις πρόσθετου</string>
@@ -246,7 +246,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Ασυμφωνία δημόσιου κλειδιού</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Seleccionar región de descarga</string>
     <string name="map_tile_download_estimate">Estimación de descarga de ficha:</string>
     <string name="map_start_download">Comenzar Descarga</string>
-    <string name="request_position">Solicitar posición</string>
+    <string name="exchange_position">Solicitar posición</string>
     <string name="close">Cerrar</string>
     <string name="device_settings">Configuración de radio</string>
     <string name="module_settings">Configuración de módulo</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Vali allalaetav piirkond</string>
     <string name="map_tile_download_estimate">Paanide allalaadimise prognoos:</string>
     <string name="map_start_download">Alusta allalaadimist</string>
-    <string name="request_position">Küsi asukohta</string>
+    <string name="exchange_position">Küsi asukohta</string>
     <string name="close">Sule</string>
     <string name="device_settings">Raadio sätted</string>
     <string name="module_settings">Mooduli sätted</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Otsesõnumid kasutavad krüpteerimiseks uut avaliku võtme taristut. Eeldab püsivara versiooni 2.5 või uuemat.</string>
     <string name="encryption_error">Kokkusobimatu avalik võti</string>
     <string name="encryption_error_text">Avalik võti ei ühti salvestatud võtmega. Võite sõlme eemaldada ja lasta sellel uuesti võtmeid vahetada, kuid see võib viidata tõsisemale turvaprobleemile. Võtke kasutajaga ühendust mõne muu usaldusväärse kanali kaudu, et teha kindlaks, kas võtme muudatuse põhjuseks oli tehaseseadete taastamine või muu tahtlik tegevus.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Valitse ladattava kartta-alue</string>
     <string name="map_tile_download_estimate">Laattojen latauksessa kuluva aika-arvio:</string>
     <string name="map_start_download">Aloita Lataus</string>
-    <string name="request_position">Pyydä sijaintia</string>
+    <string name="exchange_position">Pyydä sijaintia</string>
     <string name="close">Sulje</string>
     <string name="device_settings">Radion asetukset</string>
     <string name="module_settings">Moduulin asetukset</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Suorat viestit käyttävät uutta julkisen avaimen infrastruktuuria salaukseen. Vaatii laiteohjelmiston version 2.5 tai uudemman.</string>
     <string name="encryption_error">Julkinen avain ei täsmää</string>
     <string name="encryption_error_text">Julkinen avain ei vastaa kirjattua avainta. Voit poistaa laitteen ja antaa sen vaihtaa avaimia uudelleen, mutta tämä saattaa merkitä vakavampaa turvallisuusongelmaa. Ota yhteyttä käyttäjään toisen luotetun kanavan kautta määrittääksesi, johtuiko avain tehtaan resetoinnista tai muusta tarkoituksellisesta toiminnosta.</string>
-    <string name="request_userinfo">Pyydä käyttäjätietoja</string>
+    <string name="exchange_userinfo">Pyydä käyttäjätietoja</string>
     <string name="meshtastic_new_nodes_notifications">Uuden laitteen ilmoitukset</string>
     <string name="more_details">Lisätietoja</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-fr-rHT/strings.xml
+++ b/app/src/main/res/values-fr-rHT/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Chwazi rejyon telechajman</string>
     <string name="map_tile_download_estimate">Estimasyon telechajman tèk</string>
     <string name="map_start_download">Kòmanse telechajman</string>
-    <string name="request_position">Mande pozisyon</string>
+    <string name="exchange_position">Mande pozisyon</string>
     <string name="close">Fèmen</string>
     <string name="device_settings">Konfigirasyon radyo</string>
     <string name="module_settings">Konfigirasyon modil</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Mesaj dirèk yo ap itilize nouvo enfrastrikti kle piblik pou chifreman. Sa mande vèsyon lojisyèl 2.5 oswa plis.</string>
     <string name="encryption_error">Pa matche kle piblik</string>
     <string name="encryption_error_text">Kle piblik la pa matche ak kle anrejistre a. Ou ka retire nœud la e kite li echanje kle ankò, men sa ka endike yon pwoblèm sekirite pi grav. Kontakte itilizatè a atravè yon lòt chanèl ki fè konfyans, pou detèmine si chanjman kle a te fèt akòz yon reyajisteman faktori oswa lòt aksyon entansyonèl.</string>
-    <string name="request_userinfo">Mande enfòmasyon itilizatè</string>
+    <string name="exchange_userinfo">Mande enfòmasyon itilizatè</string>
     <string name="meshtastic_new_nodes_notifications">Notifikasyon nouvo nœud</string>
     <string name="more_details">Plis detay</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Sélectionnez la région de téléchargement</string>
     <string name="map_tile_download_estimate">Estimation du téléchargement de tuiles :</string>
     <string name="map_start_download">Commencer le téléchargement</string>
-    <string name="request_position">Demander la position</string>
+    <string name="exchange_position">Demander la position</string>
     <string name="close">Fermer</string>
     <string name="device_settings">Réglages de l\'appareil</string>
     <string name="module_settings">Réglages du module</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Les messages directs utilisent la nouvelle infrastructure de clé publique pour le chiffrement. Nécessite une version de firmware 2.5 ou plus.</string>
     <string name="encryption_error">Les messages directs utilisent la nouvelle infrastructure de clé publique pour le chiffrement. Nécessite une version de firmware 2.5 ou plus.</string>
     <string name="encryption_error_text">La clé publique ne correspond pas à la clé enregistrée. Vous pouvez supprimer le nœud et le laisser à nouveau échanger les clés, mais cela peut indiquer un problème de sécurité plus grave. Contactez l\'utilisateur à travers un autre canal de confiance, pour déterminer si le changement de clé est dû à une réinitialisation d\'usine ou à une autre action intentionnelle.</string>
-    <string name="request_userinfo">Demander les informations de l\'utilisateur</string>
+    <string name="exchange_userinfo">Demander les informations de l\'utilisateur</string>
     <string name="meshtastic_new_nodes_notifications">Notifications de nouveaux nœuds</string>
     <string name="more_details">Plus de détails</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -196,7 +196,7 @@
     <string name="map_select_download_region">Roghnaigh réigiún íoslódála</string>
     <string name="map_tile_download_estimate">Meastachán íoslódála tile:</string>
     <string name="map_start_download">Tosaigh íoslódáil</string>
-    <string name="request_position">Iarr an suíomh</string>
+    <string name="exchange_position">Iarr an suíomh</string>
     <string name="close">Dún</string>
     <string name="device_settings">Cumraíocht raidió</string>
     <string name="module_settings">Cumraíocht an mhódule</string>
@@ -248,7 +248,7 @@
     <string name="encryption_pkc_text">Tá teachtaireachtaí díreacha á n-úsáid leis an gcórais eochair phoiblí nua do chriptiú. Riachtanach atá leagan firmware 2.5 nó níos mó.</string>
     <string name="encryption_error">Mícomhoiriúnacht na heochrach phoiblí</string>
     <string name="encryption_error_text">Ní chomhoireann an eochair phoiblí leis an eochair atá cláraithe. Féachfaidh tú le hiarraidh na nod agus athmhaoin na heochrach ach seo féadfaidh a léiriú fadhb níos tromchúisí i gcúrsaí slándála. Téigh i dteagmháil leis an úsáideoir tríd an gcainéal eile atá ar fáil chun a fháil amach an bhfuil athrú eochrach de réir athshocrú monarcha nó aidhm eile ar do chuid.</string>
-    <string name="request_userinfo">Iarr eolas úsáideoirí</string>
+    <string name="exchange_userinfo">Iarr eolas úsáideoirí</string>
     <string name="meshtastic_new_nodes_notifications">Fógartha faoi na nodes nua</string>
     <string name="more_details">Tuilleadh sonraí</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Seleccionar a rexión de descarga</string>
     <string name="map_tile_download_estimate">Descarga de \'tile\' estimada:</string>
     <string name="map_start_download">Comezar a descarga</string>
-    <string name="request_position">Solicitar posición</string>
+    <string name="exchange_position">Solicitar posición</string>
     <string name="close">Pechar</string>
     <string name="device_settings">Configuración de radio</string>
     <string name="module_settings">Configuración de módulo</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -194,7 +194,7 @@
     <string name="map_select_download_region">Označite regiju za preuzimanje</string>
     <string name="map_tile_download_estimate">Procjena preuzimanja:</string>
     <string name="map_start_download">Pokreni Preuzimanje</string>
-    <string name="request_position">Zatraži poziciju</string>
+    <string name="exchange_position">Zatraži poziciju</string>
     <string name="close">Zatvori</string>
     <string name="device_settings">Konfiguracija uređaja</string>
     <string name="module_settings">Konfiguracija modula</string>
@@ -246,7 +246,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Válassz letöltési régiót</string>
     <string name="map_tile_download_estimate">Csempe letöltés számítása:</string>
     <string name="map_start_download">Letöltés indítása</string>
-    <string name="request_position">Pozíció kérése</string>
+    <string name="exchange_position">Pozíció kérése</string>
     <string name="close">Bezárás</string>
     <string name="device_settings">Eszköz beállítások</string>
     <string name="module_settings">Modul beállítások</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Publikus kulcs nem egyezik</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Felhasználó információ kérése</string>
+    <string name="exchange_userinfo">Felhasználó információ kérése</string>
     <string name="meshtastic_new_nodes_notifications">Új állomás értesítések</string>
     <string name="more_details">Több részlet</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Veldu svæði til að niðurhala</string>
     <string name="map_tile_download_estimate">Áætlaður niðurhalstími reits:</string>
     <string name="map_start_download">Hefja niðurhal</string>
-    <string name="request_position">Óska eftir staðsetningu</string>
+    <string name="exchange_position">Óska eftir staðsetningu</string>
     <string name="close">Loka</string>
     <string name="device_settings">Stillingar radíós</string>
     <string name="module_settings">Stillingar aukaeininga</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Seleziona la regione da scaricare</string>
     <string name="map_tile_download_estimate">Stima dei riquadri da scaricare:</string>
     <string name="map_start_download">Inizia download</string>
-    <string name="request_position">Richiedi posizione</string>
+    <string name="exchange_position">Richiedi posizione</string>
     <string name="close">Chiudi</string>
     <string name="device_settings">Impostazioni dispositivo</string>
     <string name="module_settings">Impostazioni moduli</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">I messaggi privati utilizzano la nuova infrastruttura a chiave pubblica per la crittografia. Richiede la versione 2.5 o superiore.</string>
     <string name="encryption_error">Chiave pubblica errata</string>
     <string name="encryption_error_text">La chiave pubblica non corrisponde alla chiave salvata. È possibile rimuovere il nodo e lasciarlo scambiare le chiavi, ma questo può indicare un problema di sicurezza più serio. Contattare l\'utente attraverso un altro canale attendibile, per determinare se il cambiamento di chiave è dovuto a un ripristino di fabbrica o ad altre azioni intenzionali.</string>
-    <string name="request_userinfo">Richiedi informazioni utente</string>
+    <string name="exchange_userinfo">Richiedi informazioni utente</string>
     <string name="meshtastic_new_nodes_notifications">Notifiche di nuovi nodi</string>
     <string name="more_details">Ulteriori informazioni</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -195,7 +195,7 @@
     <string name="map_select_download_region">בחר אזור להורדה</string>
     <string name="map_tile_download_estimate">הערכת זמן להורדה:</string>
     <string name="map_start_download">התחל הורדה</string>
-    <string name="request_position">בקש מיקום</string>
+    <string name="exchange_position">בקש מיקום</string>
     <string name="close">סגור</string>
     <string name="device_settings">הגדרות רדיו</string>
     <string name="module_settings">הגדרות מודולות</string>
@@ -247,7 +247,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -192,7 +192,7 @@
     <string name="map_select_download_region">ダウンロードリージョンを選択する</string>
     <string name="map_tile_download_estimate">タイルダウンロードの見積もり:</string>
     <string name="map_start_download">ダウンロード開始</string>
-    <string name="request_position">位置を求める</string>
+    <string name="exchange_position">位置を求める</string>
     <string name="close">終了</string>
     <string name="device_settings">デバイスの設定</string>
     <string name="module_settings">モジュールの設定</string>
@@ -244,7 +244,7 @@
     <string name="encryption_pkc_text">ダイレクトメッセージは、新しい公開キーインフラストラクチャを使用して暗号化しています。ファームウェアバージョン 2.5 以上が必要です。</string>
     <string name="encryption_error">公開キーが一致しません</string>
     <string name="encryption_error_text">公開キーが保存されたキーと一致しません。 ノードを削除し、もう一度キーを交換させることもできますが、これはより深刻なセキュリティ上の問題を示している可能性があります。 別の信頼されたチャンネルを介してユーザーに連絡し、キーの変更が工場出荷時のリセットまたはその他の意図的なアクションによるものであったかどうかを判断してください。</string>
-    <string name="request_userinfo">ユーザー情報を要求する</string>
+    <string name="exchange_userinfo">ユーザー情報を要求する</string>
     <string name="meshtastic_new_nodes_notifications">新しいノードの通知</string>
     <string name="more_details">詳細を見る</string>
     <string name="snr">SN比</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -192,7 +192,7 @@
     <string name="map_select_download_region">다운로드 지역 선택</string>
     <string name="map_tile_download_estimate">타일 다운로드 예상:</string>
     <string name="map_start_download">다운로드 시작</string>
-    <string name="request_position">위치 요청</string>
+    <string name="exchange_position">위치 요청</string>
     <string name="close">닫기</string>
     <string name="device_settings">장치 설정</string>
     <string name="module_settings">모듈 설정</string>
@@ -244,7 +244,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -196,7 +196,7 @@ Suderinamus įrenginius galite pamatyti apsilankę adresu www.meshtastic.org/doc
     <string name="map_select_download_region">Pasirinkite atsisiuntimo regioną</string>
     <string name="map_tile_download_estimate">Plytelių atsisiuntimo apskaičiavimas:</string>
     <string name="map_start_download">Pradėti atsiuntimą</string>
-    <string name="request_position">Prašyti pozicijos</string>
+    <string name="exchange_position">Prašyti pozicijos</string>
     <string name="close">Uždaryti</string>
     <string name="device_settings">Radijo modulio konfigūracija</string>
     <string name="module_settings">Modulio konfigūracija</string>
@@ -248,7 +248,7 @@ Suderinamus įrenginius galite pamatyti apsilankę adresu www.meshtastic.org/doc
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Viešojo rakto neatitikimas</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Gauti naudotojo informaciją</string>
+    <string name="exchange_userinfo">Gauti naudotojo informaciją</string>
     <string name="meshtastic_new_nodes_notifications">Naujų įtaisų pranešimai</string>
     <string name="more_details">Daugiau info</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Select download region</string>
     <string name="map_tile_download_estimate">Tile download estimate:</string>
     <string name="map_start_download">Start nedlasting</string>
-    <string name="request_position">Forespør posisjon</string>
+    <string name="exchange_position">Forespør posisjon</string>
     <string name="close">Lukk</string>
     <string name="device_settings">Radiokonfigurasjon</string>
     <string name="module_settings">Modul konfigurasjon</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Selecteer regio om te downloaden</string>
     <string name="map_tile_download_estimate">Geschatte download tegels:</string>
     <string name="map_start_download">Download starten</string>
-    <string name="request_position">Positie aanvragen</string>
+    <string name="exchange_position">Positie aanvragen</string>
     <string name="close">Sluit</string>
     <string name="device_settings">Radioconfiguratie</string>
     <string name="module_settings">Module-configuratie</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Directe berichten gebruiken de nieuwe openbare sleutel infrastructuur voor versleuteling. Vereist firmware versie 2.5 of hoger.</string>
     <string name="encryption_error">Publieke sleutel komt niet overeen</string>
     <string name="encryption_error_text">De publieke sleutel komt niet overeen met de opgenomen sleutel. Je kan de node verwijderen en opnieuw een sleutel laten uitwisselen, maar dit kan duiden op een ernstiger beveiligingsprobleem. Neem contact op met de gebruiker via een ander vertrouwd kanaal, om te bepalen of de sleutel gewijzigd is door een reset naar de fabrieksinstellingen of andere opzettelijke actie.</string>
-    <string name="request_userinfo">Gebruikergegevens opvragen</string>
+    <string name="exchange_userinfo">Gebruikergegevens opvragen</string>
     <string name="meshtastic_new_nodes_notifications">Nieuwe node meldingen</string>
     <string name="more_details">Meer details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -195,7 +195,7 @@
     <string name="map_select_download_region">Wybierz region do pobrania</string>
     <string name="map_tile_download_estimate">Szacowany czas pobrania:</string>
     <string name="map_start_download">Rozpocznij pobieranie</string>
-    <string name="request_position">Poproś o pozycję</string>
+    <string name="exchange_position">Poproś o pozycję</string>
     <string name="close">Zamknij</string>
     <string name="device_settings">Ustawienia urządzenia</string>
     <string name="module_settings">Ustawienia modułu</string>
@@ -247,7 +247,7 @@
     <string name="encryption_pkc_text">Wiadomości bezpośrednie używają nowego systemu klucza publicznego do szyfrowania. Wymagana jest wersja firmware 2.5 lub wyższa.</string>
     <string name="encryption_error">Niezgodność klucza publicznego</string>
     <string name="encryption_error_text">Klucz publiczny nie pasuje do otrzymanego wcześniej klucza. Możesz usunąć węzeł i pozwolić na ponowną wymianę kluczy, ale może również wskazywać to na poważniejszy problem z bezpieczeństwem. Skontaktuj się z użytkownikiem za pomocą innego zaufanego kanału, aby ustalić, czy zmiana klucza była spowodowana przywróceniem ustawień fabrycznych czy innym działaniem.</string>
-    <string name="request_userinfo">Poproś o informacje</string>
+    <string name="exchange_userinfo">Poproś o informacje</string>
     <string name="meshtastic_new_nodes_notifications">Powiadomienia o nowych węzłach</string>
     <string name="more_details">Więcej...</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Selecione a região para download</string>
     <string name="map_tile_download_estimate">Estimativa de download do bloco:</string>
     <string name="map_start_download">Iniciar download</string>
-    <string name="request_position">Solicitar posição</string>
+    <string name="exchange_position">Solicitar posição</string>
     <string name="close">Fechar</string>
     <string name="device_settings">Configurações do dispositivo</string>
     <string name="module_settings">Configurações dos módulos</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Mensagens diretas estão usando a nova infraestrutura de chave pública para criptografia. Requer firmware versão 2.5 ou superior.</string>
     <string name="encryption_error">Chave pública não confere</string>
     <string name="encryption_error_text">A chave pública não corresponde à chave gravada. Você pode remover o nó e deixá-lo trocar as chaves novamente, mas isso pode indicar um problema de segurança mais sério. Contate o usuário através de outro canal confiável, para determinar se a chave mudou devido a uma restauração de fábrica ou outra ação intencional.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -142,7 +142,7 @@
     <string name="map_select_download_region">Selecione a região para download</string>
     <string name="map_tile_download_estimate">Estimativa de download do bloco:</string>
     <string name="map_start_download">Iniciar download</string>
-    <string name="request_position">Solicitar posição</string>
+    <string name="exchange_position">Solicitar posição</string>
     <string name="close">Fechar</string>
     <string name="device_settings">Configurações do dispositivo</string>
     <string name="module_settings">Configurações dos módulos</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -194,7 +194,7 @@
     <string name="map_select_download_region">Selectați regiunea pentru descărcare</string>
     <string name="map_tile_download_estimate">Estimare descărcare secțiuni:</string>
     <string name="map_start_download">Pornește descărcarea</string>
-    <string name="request_position">Solicită poziția</string>
+    <string name="exchange_position">Solicită poziția</string>
     <string name="close">Închide</string>
     <string name="device_settings">Configurare radio</string>
     <string name="module_settings">Configurare modul</string>
@@ -246,7 +246,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -195,7 +195,7 @@
     <string name="map_select_download_region">Выберите регион загрузки</string>
     <string name="map_tile_download_estimate">Предполагаемое время загрузки файла:</string>
     <string name="map_start_download">Начать скачивание</string>
-    <string name="request_position">Запросить позицию</string>
+    <string name="exchange_position">Запросить позицию</string>
     <string name="close">Закрыть</string>
     <string name="device_settings">Настройки устройства</string>
     <string name="module_settings">Настройки модуля</string>
@@ -247,7 +247,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -195,7 +195,7 @@
     <string name="map_select_download_region">Vybrať oblasť na stiahnutie</string>
     <string name="map_tile_download_estimate">Odhad sťahovania dlaždíc:</string>
     <string name="map_start_download">Spustiť sťahovanie</string>
-    <string name="request_position">Požiadať o pozíciu</string>
+    <string name="exchange_position">Požiadať o pozíciu</string>
     <string name="close">Zavrieť</string>
     <string name="device_settings">Konfigurácia vysielača</string>
     <string name="module_settings">Konfigurácia modulu</string>
@@ -247,7 +247,7 @@
     <string name="encryption_pkc_text">Priame správy využívajú na šifrovanie novú infraštruktúru verejného kľúča. Vyžaduje verziu firmvéru 2.5 alebo vyššiu.</string>
     <string name="encryption_error">Nezhoda verejného kľúča</string>
     <string name="encryption_error_text">Verejný kľúč sa nezhoduje so zaznamenaným kľúčom. Môžete odstrániť uzol a nechať ho znova vymeniť kľúče, ale to môže naznačovať vážnejší bezpečnostný problém. Kontaktujte používateľa prostredníctvom iného dôveryhodného kanála a zistite, či bola zmena kľúča spôsobená obnovením továrenských nastavení alebo inou úmyselnou akciou.</string>
-    <string name="request_userinfo">Požiadať o informácie o užívateľovi</string>
+    <string name="exchange_userinfo">Požiadať o informácie o užívateľovi</string>
     <string name="meshtastic_new_nodes_notifications">Notifikácie nových uzlov</string>
     <string name="more_details">Viac detailov</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -195,7 +195,7 @@
     <string name="map_select_download_region">Prenesi izbrano regijo</string>
     <string name="map_tile_download_estimate">Ocena prenosa plošče:</string>
     <string name="map_start_download">Začni prenos</string>
-    <string name="request_position">Zahtevaj položaj</string>
+    <string name="exchange_position">Zahtevaj položaj</string>
     <string name="close">Zapri</string>
     <string name="device_settings">Nastavitev radia</string>
     <string name="module_settings">Nastavitev modula</string>
@@ -247,7 +247,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Zgjidh rajonin për shkarkim</string>
     <string name="map_tile_download_estimate">Parashikimi i shkarkimit të pllakatës:</string>
     <string name="map_start_download">Filloni shkarkimin</string>
-    <string name="request_position">Kërkoni pozicionin</string>
+    <string name="exchange_position">Kërkoni pozicionin</string>
     <string name="close">Mbylle</string>
     <string name="device_settings">Konfigurimi i radios</string>
     <string name="module_settings">Konfigurimi i modulit</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Mesazhet direkte po përdorin infrastrukturën e re të çelësave publikë për kriptim. Kërkon versionin 2.5 të firmuerit ose më të ri.</string>
     <string name="encryption_error">Përputhje e Gabuar e Çelësit Publik</string>
     <string name="encryption_error_text">Çelësi publik nuk përputhet me çelësin e regjistruar. Mund të hiqni nyjën dhe të lejoni që ajo të shkëmbejë përsëri çelësat, por kjo mund të tregojë një problem më serioz të sigurisë. Kontaktoni përdoruesin përmes një kanali tjetër të besuar për të përcaktuar nëse ndryshimi i çelësit ishte si pasojë e një rikthimi në fabrikë ose një veprim tjetër të qëllimshëm.</string>
-    <string name="request_userinfo">Kërkoni informacionin e përdoruesit</string>
+    <string name="exchange_userinfo">Kërkoni informacionin e përdoruesit</string>
     <string name="meshtastic_new_nodes_notifications">Njoftimet për nyje të reja</string>
     <string name="more_details">Më shumë detaje</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -194,7 +194,7 @@
     <string name="map_select_download_region">Изаберите регион за преузимање</string>
     <string name="map_tile_download_estimate">Процена преузимања плочица:</string>
     <string name="map_start_download">Започни преузимање</string>
-    <string name="request_position">Захтевај позицију</string>
+    <string name="exchange_position">Захтевај позицију</string>
     <string name="close">Затвори</string>
     <string name="device_settings">Конфигурација радио уређаја</string>
     <string name="module_settings">Конфигурација модула</string>
@@ -246,7 +246,7 @@
     <string name="encryption_pkc_text">Директне поруке користе нову инфраструктуру јавног кључа за шифровање. Потребна је верзија фирмвера 2,5 или новија.</string>
     <string name="encryption_error">Неусаглашеност јавних кључева</string>
     <string name="encryption_error_text">Јавни кључ се не поклапа са забележеним кључем. Можете уклонити чвор и омогућити му поновну размену кључева, али ово може указивати на озбиљнији безбедносни проблем. Контактирајте корисника путем другог поузданог канала да бисте утврдили да ли је промена кључа резултат фабричког ресетовања или друге намерне акције.</string>
-    <string name="request_userinfo">Затражите информације о кориснику</string>
+    <string name="exchange_userinfo">Затражите информације о кориснику</string>
     <string name="meshtastic_new_nodes_notifications">Обавештење о новом чвору</string>
     <string name="more_details">Више детаља</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">Välj nedladdningsområde</string>
     <string name="map_tile_download_estimate">Kartdelar estimat:</string>
     <string name="map_start_download">Starta Hämtning</string>
-    <string name="request_position">Begär position</string>
+    <string name="exchange_position">Begär position</string>
     <string name="close">Stäng</string>
     <string name="device_settings">Konfiguration av radioenhet</string>
     <string name="module_settings">Modul konfiguration</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -193,7 +193,7 @@
     <string name="map_select_download_region">İndirilecek bölgeyi seçin</string>
     <string name="map_tile_download_estimate">Tahmini indirme boyutu:</string>
     <string name="map_start_download">İndirmeye başla</string>
-    <string name="request_position">Konum iste</string>
+    <string name="exchange_position">Konum iste</string>
     <string name="close">Kapat</string>
     <string name="device_settings">Cihaz ayarları</string>
     <string name="module_settings">Modül ayarları</string>
@@ -245,7 +245,7 @@
     <string name="encryption_pkc_text">Doğrudan mesajlar şifreleme için yeni genel anahtar alt yapısını kullanmaktadır. Bu bağlamda 2.5 ve üstü firmware yüklemeniz gerekmektedir.</string>
     <string name="encryption_error">Genel Anahtar Uyuşmazlığı</string>
     <string name="encryption_error_text">Genel anahtar, kayıtlı anahtarla eşleşmiyor. Düğümü kaldırabilir ve tekrar anahtar değişimi yapmasına izin verebilirsiniz, ancak bu daha ciddi bir güvenlik sorununa işaret edebilir. Anahtar değişikliğinin fabrika ayarlarına sıfırlamadan veya başka bir kasıtlı eylemden kaynaklanıp kaynaklanmadığını belirlemek için başka bir güvenilir kanal aracılığıyla kullanıcıyla iletişime geçiniz.</string>
-    <string name="request_userinfo">Kullanıcı bilgisi iste</string>
+    <string name="exchange_userinfo">Kullanıcı bilgisi iste</string>
     <string name="meshtastic_new_nodes_notifications">Yeni düğüm bildirimleri</string>
     <string name="more_details">Daha fazla detay</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -195,7 +195,7 @@
     <string name="map_select_download_region">Оберіть регіон завантаження</string>
     <string name="map_tile_download_estimate">Час завантаження фрагментів:</string>
     <string name="map_start_download">Почати завантаження</string>
-    <string name="request_position">Запит місцезнаходження</string>
+    <string name="exchange_position">Запит місцезнаходження</string>
     <string name="close">Закрити</string>
     <string name="device_settings">Налаштування пристрою</string>
     <string name="module_settings">Налаштування модуля</string>
@@ -247,7 +247,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -194,7 +194,7 @@
     <string name="map_select_download_region">选择下载地区</string>
     <string name="map_tile_download_estimate">局部地图下载估算:</string>
     <string name="map_start_download">开始下载</string>
-    <string name="request_position">请求位置</string>
+    <string name="exchange_position">请求位置</string>
     <string name="close">关闭</string>
     <string name="device_settings">设备配置</string>
     <string name="module_settings">模块设定</string>
@@ -246,7 +246,7 @@
     <string name="encryption_pkc_text">私信使用新的公钥基础设施（PKC）进行加密。需要固件版本 2.5 或更高。</string>
     <string name="encryption_error">公钥不匹配</string>
     <string name="encryption_error_text">公钥与记录的密钥不匹配。 您可以移除该节点并让它再次交换密钥，但这可能会显示一个更严重的安全问题。 通过另一个信任频道联系用户，以确定密钥更改是否是出厂重置或其他故意操作。</string>
-    <string name="request_userinfo">请求用户信息</string>
+    <string name="exchange_userinfo">请求用户信息</string>
     <string name="meshtastic_new_nodes_notifications">新节点通知</string>
     <string name="more_details">查看更多</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -192,7 +192,7 @@
     <string name="map_select_download_region">選擇下載地區</string>
     <string name="map_tile_download_estimate">圖磚下載估計:</string>
     <string name="map_start_download">開始下載</string>
-    <string name="request_position">要求位置</string>
+    <string name="exchange_position">要求位置</string>
     <string name="close">關閉</string>
     <string name="device_settings">設備設定</string>
     <string name="module_settings">模組設定</string>
@@ -244,7 +244,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Request user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,7 +229,7 @@
     <string name="map_select_download_region">Select download region</string>
     <string name="map_tile_download_estimate">Tile download estimate:</string>
     <string name="map_start_download">Start Download</string>
-    <string name="request_position">Request position</string>
+    <string name="exchange_position">Exchange position</string>
     <string name="close">Close</string>
     <string name="device_settings">Radio configuration</string>
     <string name="module_settings">Module configuration</string>
@@ -281,7 +281,7 @@
     <string name="encryption_pkc_text">Direct messages are using the new public key infrastructure for encryption. Requires firmware version 2.5 or greater.</string>
     <string name="encryption_error">Public key mismatch</string>
     <string name="encryption_error_text">The public key does not match the recorded key. You may remove the node and let it exchange keys again, but this may indicate a more serious security problem. Contact the user through another trusted channel, to determine if the key change was due to a factory reset or other intentional action.</string>
-    <string name="request_userinfo">Request user info</string>
+    <string name="exchange_userinfo">Exchange user info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="more_details">More details</string>
     <string name="snr">SNR</string>


### PR DESCRIPTION
Based on discord conversations, and issue #1692 I've updated the language from "request position" to "exchange position".  I have also extended this to the user info function as well since they both operate the same way.  When using either of these options your local radio will send a packet with its own info requesting acknowledgement, and that acknowledgment is the requested information.

I updated the foreign language string name, but not the actual translations in each language's xml files.  This was so that things could be kept clean when translations are completed.

![Screenshot_20250321_040749](https://github.com/user-attachments/assets/f0fe7f74-9c07-4c50-8e43-34715bf69a1c)
