### PR TITLE
chore(renovate): Update Renovate config to group Kotlin and KSP dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,16 @@
     "workarounds:all"
   ],
   "commitMessageTopic": "{{depName}}",
-  "labels": ["dependencies"]
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Kotlin and KSP",
+      "matchPackageNames": [
+        "com.google.devtools.ksp:{/,}**",
+        "org.jetbrains.kotlin:{/,}**"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Should consolidate Kotlin and KSP PRs from Renovate - which are dependent on each other