### PR TITLE
Changed title bar color to black for issue #1704 and #1633.

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/theme/Color.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/theme/Color.kt
@@ -32,6 +32,8 @@ val LightPink = Color(0xFFFFE6E6)
 val LightGreen = Color(0xFFCFE8A9)
 val LightRed = Color(0xFFFFB3B3)
 
+val Black = Color(0x000000)
+
 val MeshtasticGreen = Color(0xFF67EA94)
 
 val HyperlinkBlue = Color(0xFF43C3B0)

--- a/app/src/main/java/com/geeksville/mesh/ui/theme/Theme.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/theme/Theme.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 
 private val DarkColorPalette = darkColors(
     primary = MeshtasticGreen,
@@ -33,6 +34,7 @@ private val LightColorPalette = lightColors(
     primary = MeshtasticGreen,
     primaryVariant = LightSkyBlue,
     secondary = Teal200,
+    onPrimary = Color.Black
 
     /* Other default colors to override
     background = Color.White,

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -30,5 +30,5 @@
     <color name="colourGrey">#535353</color>
     <color name="colorAnnotation">#0288D1</color>
     <color name="toolbarBackground">#67EA94</color>
-    <color name="toolbarText">#FFFFFF</color>
+    <color name="toolbarText">#000000</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,7 +17,7 @@
 -->
 
 <resources>
-    <color name="colorOnPrimary">#FFFFFF</color>
+    <color name="colorOnPrimary">#000000</color>
     <color name="colorPrimary">#67EA94</color>
     <color name="colorPrimaryDark">#67EA94</color>
     <color name="colorMsg">#F2F2F2</color>


### PR DESCRIPTION
Updated title bar color as requested in light mode.  Original white on green was difficult to read.

Before:
![1704-before](https://github.com/user-attachments/assets/e75cb489-8860-4440-abd3-a8763d28f1ff)
After:
![1704-after](https://github.com/user-attachments/assets/4cec1528-e04e-4f40-ba45-78afb257dfbc)
