### PR TITLE
fix: Handle node public key mismatch and show warning

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
@@ -107,7 +107,7 @@ class NodeRepository @Inject constructor(
     }
 
     suspend fun installNodeDB(mi: MyNodeEntity, nodes: List<NodeEntity>) = withContext(dispatchers.io) {
-        val isDifferentNode = myNodeInfo.value?.myNodeNum == mi.myNodeNum
+        val isDifferentNode = myNodeInfo.value?.myNodeNum != mi.myNodeNum
         nodeInfoDao.clearMyNodeInfo()
         nodeInfoDao.setMyNodeInfo(mi) // set MyNodeEntity first
         if (isDifferentNode) {

--- a/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
@@ -103,7 +103,7 @@ class NodeRepository @Inject constructor(
     ).mapLatest { list -> list.map { it.toModel() } }.flowOn(dispatchers.io).conflate()
 
     suspend fun upsert(node: NodeEntity) = withContext(dispatchers.io) {
-        nodeInfoDao.upsert(node)
+        nodeInfoDao.upsertCheckKeyMatch(node)
     }
 
     suspend fun installNodeDB(mi: MyNodeEntity, nodes: List<NodeEntity>) = withContext(dispatchers.io) {

--- a/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
@@ -107,9 +107,12 @@ class NodeRepository @Inject constructor(
     }
 
     suspend fun installNodeDB(mi: MyNodeEntity, nodes: List<NodeEntity>) = withContext(dispatchers.io) {
+        val isDifferentNode = myNodeInfo.value?.myNodeNum == mi.myNodeNum
         nodeInfoDao.clearMyNodeInfo()
         nodeInfoDao.setMyNodeInfo(mi) // set MyNodeEntity first
-        nodeInfoDao.clearNodeInfo()
+        if (isDifferentNode) {
+            nodeInfoDao.clearNodeInfo()
+        }
         nodeInfoDao.putAll(nodes)
     }
 

--- a/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
@@ -110,7 +110,7 @@ interface NodeInfoDao {
     @Upsert
     fun upsert(node: NodeEntity)
 
-    fun upsertCheckKeyMatch(node: NodeEntity){
+    fun upsertCheckKeyMatch(node: NodeEntity) {
         val existingNode = getNodeByNum(node.num)
         if (existingNode != null && existingNode.user.publicKey != node.user.publicKey) {
             Log.w(TAG, "Node ${node.num} has changed its public key")

--- a/app/src/main/java/com/geeksville/mesh/database/entity/NodeEntity.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/entity/NodeEntity.kt
@@ -151,7 +151,7 @@ data class NodeEntity(
 
     val isUnknownUser get() = user.hwModel == MeshProtos.HardwareModel.UNSET
     val hasPKC get() = !user.publicKey.isEmpty
-    val errorByteString: ByteString get() = ByteString.copyFrom(ByteArray(32) { 0 })
+    val errorByteString: ByteString get() = ERROR_BYTE_STRING
 
     fun setPosition(p: MeshProtos.Position, defaultTime: Int = currentTime()) {
         position = p.copy { time = if (p.time != 0) p.time else defaultTime }
@@ -174,6 +174,7 @@ data class NodeEntity(
         fun degD(i: Int) = i * 1e-7
         fun degI(d: Double) = (d * 1e7).toInt()
 
+        val ERROR_BYTE_STRING: ByteString = ByteString.copyFrom(ByteArray(32) { 0 })
         fun currentTime() = (System.currentTimeMillis() / 1000).toInt()
     }
 

--- a/app/src/main/java/com/geeksville/mesh/model/Node.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Node.kt
@@ -24,10 +24,10 @@ import com.geeksville.mesh.PaxcountProtos
 import com.geeksville.mesh.TelemetryProtos.DeviceMetrics
 import com.geeksville.mesh.TelemetryProtos.EnvironmentMetrics
 import com.geeksville.mesh.TelemetryProtos.PowerMetrics
+import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.util.GPSFormat
 import com.geeksville.mesh.util.latLongToMeter
 import com.geeksville.mesh.util.toDistanceString
-import com.google.protobuf.ByteString
 
 @Suppress("MagicNumber")
 data class Node(
@@ -59,8 +59,7 @@ data class Node(
 
     val isUnknownUser get() = user.hwModel == MeshProtos.HardwareModel.UNSET
     val hasPKC get() = !user.publicKey.isEmpty
-    val errorByteString: ByteString get() = ByteString.copyFrom(ByteArray(32) { 0 })
-    val mismatchKey get() = user.publicKey == errorByteString
+    val mismatchKey get() = user.publicKey == NodeEntity.ERROR_BYTE_STRING
 
     val hasEnvironmentMetrics: Boolean
         get() = environmentMetrics != EnvironmentMetrics.getDefaultInstance()

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -184,6 +184,8 @@ internal fun MessageScreen(
         DataPacket.ID_BROADCAST -> channelName
         else -> viewModel.getUser(nodeId).longName
     }
+    val mismatchKey =
+        DataPacket.PKC_CHANNEL_INDEX == channelIndex && viewModel.getNode(nodeId).mismatchKey
 
 //    if (channelIndex != DataPacket.PKC_CHANNEL_INDEX && nodeId != DataPacket.ID_BROADCAST) {
 //        subtitle = "(ch: $channelIndex - $channelName)"
@@ -242,7 +244,7 @@ internal fun MessageScreen(
                     }
                 }
             } else {
-                MessageTopBar(title, channelIndex, onNavigateBack)
+                MessageTopBar(title, channelIndex, mismatchKey, onNavigateBack)
             }
         },
         bottomBar = {
@@ -368,6 +370,7 @@ private fun ActionModeTopBar(
 private fun MessageTopBar(
     title: String,
     channelIndex: Int?,
+    mismatchKey: Boolean = false,
     onNavigateBack: () -> Unit
 ) = TopAppBar(
     title = { Text(text = title) },
@@ -381,7 +384,7 @@ private fun MessageTopBar(
     },
     actions = {
         if (channelIndex == DataPacket.PKC_CHANNEL_INDEX) {
-            NodeKeyStatusIcon(hasPKC = true, mismatchKey = false)
+            NodeKeyStatusIcon(hasPKC = true, mismatchKey = mismatchKey)
         }
     }
 )


### PR DESCRIPTION
- Add a mismatchKey flag to Node and MessageTopBar to indicate a public key mismatch.
- Set the public key to a default error value (all zeros) when a node's public key changes.
- Display a warning in the MessageTopBar when a key mismatch is detected in PKC.
- Only clear all nodes when a different mynode number is present.