### PR TITLE
fix: Remove nodeDb size from status string

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1574,7 +1574,7 @@ class MeshService : Service(), Logging {
         insertMeshLog(packetToSave)
 
         newNodes.add(info)
-        radioConfigRepository.setStatusMessage("Nodes (${newNodes.size} / 100)")
+        radioConfigRepository.setStatusMessage("Nodes (${newNodes.size})")
     }
 
     private var rawMyNodeInfo: MeshProtos.MyNodeInfo? = null


### PR DESCRIPTION
Previously the status string read `Nodes ( # / 100)` this updates the string to just show the raw node count `Nodes( # )` as a better representation, since a device's nodeDb may be smaller ( 80 in the case of nrf) or (200-250 for the cases of some esp32 devices with larger flash). 

resolves #1733