### PR TITLE
feat: Add support for conversation shortcuts on Android 11+

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -17,6 +17,8 @@
 
 package com.geeksville.mesh.ui.message
 
+import android.content.LocusId
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -137,7 +139,10 @@ class MessagesFragment : Fragment(), Logging {
     ): View {
         val contactKey = arguments?.getString("contactKey").toString()
         val message = arguments?.getString("message").toString()
-
+        val shortcutId = "conv_$contactKey"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            requireActivity().setLocusContext(LocusId(shortcutId), null)
+        }
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {


### PR DESCRIPTION
This introduces the functionality to create and manage conversation shortcuts on Android devices running Android 11 (API level 30) and above. These shortcuts provide quick access to ongoing conversations directly from the launcher.

Key changes include:

-  Upon opening a conversation in the app, a LocusId is set for the activity, enabling the system to associate the activity with a specific conversation shortcut.
- When a new message notification is received, the app now generates or updates a dynamic conversation shortcut using the ShortcutManagerCompat API. This shortcut includes relevant information such as the contact's name and an icon.
- The notification itself is enhanced to include the shortcut ID and LocusId, further integrating it with the conversation shortcuts feature.
<img src="https://github.com/user-attachments/assets/78e76e06-01d8-4e4e-9f9d-aa2456585af7" width="300"/>
