### PR TITLE
fix: clear local DB after reset

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
@@ -103,7 +103,7 @@ class NodeRepository @Inject constructor(
     ).mapLatest { list -> list.map { it.toModel() } }.flowOn(dispatchers.io).conflate()
 
     suspend fun upsert(node: NodeEntity) = withContext(dispatchers.io) {
-        nodeInfoDao.upsertCheckKeyMatch(node)
+        nodeInfoDao.upsert(node)
     }
 
     suspend fun installNodeDB(mi: MyNodeEntity, nodes: List<NodeEntity>) = withContext(dispatchers.io) {
@@ -114,6 +114,10 @@ class NodeRepository @Inject constructor(
             nodeInfoDao.clearNodeInfo()
         }
         nodeInfoDao.putAll(nodes)
+    }
+
+    suspend fun clearNodeDB() = withContext(dispatchers.io) {
+        nodeInfoDao.clearNodeInfo()
     }
 
     suspend fun deleteNode(num: Int) = withContext(dispatchers.io) {

--- a/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
@@ -32,7 +32,6 @@ import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.database.entity.NodeWithRelations
 import kotlinx.coroutines.flow.Flow
 
-private const val TAG = "NodeInfoDao"
 @Suppress("TooManyFunctions")
 @Dao
 interface NodeInfoDao {
@@ -113,9 +112,13 @@ interface NodeInfoDao {
         val found = getNodeByNum(node.num)?.node
         found?.let {
             val keyMatch = !it.hasPKC || it.user.publicKey == node.user.publicKey
-            it.user = if (keyMatch) node.user else node.user.copy {
-                warn("Public key mismatch from $longName ($shortName)")
-                publicKey = NodeEntity.ERROR_BYTE_STRING
+            it.user = if (keyMatch) {
+                node.user
+            } else {
+                node.user.copy {
+                    warn("Public key mismatch from $longName ($shortName)")
+                    publicKey = NodeEntity.ERROR_BYTE_STRING
+                }
             }
         }
         doUpsert(node)
@@ -127,9 +130,13 @@ interface NodeInfoDao {
             val found = getNodeByNum(node.num)?.node
             found?.let {
                 val keyMatch = !it.hasPKC || it.user.publicKey == node.user.publicKey
-                it.user = if (keyMatch) node.user else node.user.copy {
-                    warn("Public key mismatch from $longName ($shortName)")
-                    publicKey = NodeEntity.ERROR_BYTE_STRING
+                it.user = if (keyMatch) {
+                    node.user
+                } else {
+                    node.user.copy {
+                        warn("Public key mismatch from $longName ($shortName)")
+                        publicKey = NodeEntity.ERROR_BYTE_STRING
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -89,6 +89,10 @@ class RadioConfigRepository @Inject constructor(
         nodeDB.insertMetadata(MetadataEntity(fromNum, metadata))
     }
 
+    suspend fun clearNodeDB() {
+        nodeDB.clearNodeDB()
+    }
+
     /**
      * Flow representing the [ChannelSet] data store.
      */

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -906,7 +906,7 @@ class MeshService : Service(), Logging {
             val keyMatch = !it.hasPKC || it.user.publicKey == p.publicKey
             it.user = if (keyMatch) p else p.copy {
                 warn("Public key mismatch from $longName ($shortName)")
-                publicKey = it.errorByteString
+                publicKey = NodeEntity.ERROR_BYTE_STRING
             }
             it.longName = p.longName
             it.shortName = p.shortName

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -904,9 +904,13 @@ class MeshService : Service(), Logging {
             val newNode = (it.isUnknownUser && p.hwModel != MeshProtos.HardwareModel.UNSET)
 
             val keyMatch = !it.hasPKC || it.user.publicKey == p.publicKey
-            it.user = if (keyMatch) p else p.copy {
-                warn("Public key mismatch from $longName ($shortName)")
-                publicKey = NodeEntity.ERROR_BYTE_STRING
+            it.user = if (keyMatch) {
+                p
+            } else {
+                p.copy {
+                    warn("Public key mismatch from $longName ($shortName)")
+                    publicKey = NodeEntity.ERROR_BYTE_STRING
+                }
             }
             it.longName = p.longName
             it.shortName = p.shortName

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfigViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfigViewModel.kt
@@ -304,17 +304,27 @@ class RadioConfigViewModel @Inject constructor(
         "Request reboot error"
     )
 
-    private fun requestFactoryReset(destNum: Int) = request(
-        destNum,
-        { service, packetId, dest -> service.requestFactoryReset(packetId, dest) },
-        "Request factory reset error"
-    )
+    private fun requestFactoryReset(destNum: Int) {
+        request(
+            destNum,
+            { service, packetId, dest -> service.requestFactoryReset(packetId, dest) },
+            "Request factory reset error"
+        )
+        if (destNum == myNodeNum) {
+            viewModelScope.launch { radioConfigRepository.clearNodeDB() }
+        }
+    }
 
-    private fun requestNodedbReset(destNum: Int) = request(
-        destNum,
-        { service, packetId, dest -> service.requestNodedbReset(packetId, dest) },
-        "Request NodeDB reset error"
-    )
+    private fun requestNodedbReset(destNum: Int) {
+        request(
+            destNum,
+            { service, packetId, dest -> service.requestNodedbReset(packetId, dest) },
+            "Request NodeDB reset error"
+        )
+        if (destNum == myNodeNum) {
+            viewModelScope.launch { radioConfigRepository.clearNodeDB() }
+        }
+    }
 
     private fun sendAdminRequest(destNum: Int) {
         val route = radioConfigState.value.route


### PR DESCRIPTION
Another stab at fixing pubkey mismatch detection, added local nodeDb clearing when resetting device nodeDb or factory reset.