### PR TITLE
fix: Remove imePadding modifier to internal scaffold box

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/components/BaseScaffold.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/BaseScaffold.kt
@@ -19,8 +19,6 @@ package com.geeksville.mesh.ui.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.FabPosition
 import androidx.compose.material.Icon
@@ -50,7 +48,6 @@ internal fun BaseScaffold(
     actions: @Composable (RowScope.() -> Unit)? = null,
     floatingActionButton: @Composable () -> Unit = {},
     floatingActionButtonPosition: FabPosition = FabPosition.End,
-    contentWindowInsets: WindowInsets = WindowInsets(0, 0, 0, 0),
     content: @Composable () -> Unit,
 ) {
     BaseScaffold(
@@ -76,7 +73,6 @@ internal fun BaseScaffold(
         },
         floatingActionButton = floatingActionButton,
         floatingActionButtonPosition = floatingActionButtonPosition,
-        contentWindowInsets = contentWindowInsets,
         content = content
     )
 }
@@ -91,11 +87,10 @@ internal fun BaseScaffold(
     floatingActionButtonPosition: FabPosition = FabPosition.End,
     backgroundColor: Color = MaterialTheme.colors.background,
     contentColor: Color = contentColorFor(backgroundColor),
-    contentWindowInsets: WindowInsets = WindowInsets(0, 0, 0, 0),
     content: @Composable () -> Unit,
 ) {
     Scaffold(
-        modifier = modifier.imePadding(),
+        modifier = modifier,
         topBar = topBar,
         bottomBar = bottomBar,
         snackbarHost = snackbarHost,
@@ -103,7 +98,6 @@ internal fun BaseScaffold(
         floatingActionButtonPosition = floatingActionButtonPosition,
         backgroundColor = backgroundColor,
         contentColor = contentColor,
-        contentWindowInsets = contentWindowInsets,
     ) { innerPadding ->
         Box(modifier = Modifier.padding(innerPadding)) {
             content()


### PR DESCRIPTION
fixes #1603
fixes #1767

`BaseScaffold` is applying `imePadding()` to an internal `Box` on all screen-level Composables. This is evidently unnecessary with our setup and applies double keyboard padding for older devices.

On my Samsung A10e, Android 9:
| Before | After |
|------|-----|
| <video src="https://github.com/user-attachments/assets/021e275c-0628-46b2-aa73-639ec5a4ed4c" width="300"></video> | <video src="https://github.com/user-attachments/assets/57737d25-4a3f-477c-be53-e1d7956e5a83" width="300"></video> |

Also tested on my Samsung S23 Ultra to verify this change didn't affect devices that didn't have this issue.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->