### PR TITLE
Update connected count string in strings.xml and MeshService.kt

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -228,8 +228,7 @@ class MeshService : Service(), Logging {
     private val notificationSummary
         get() = when (connectionState) {
             ConnectionState.CONNECTED -> getString(R.string.connected_count).format(
-                numOnlineNodes,
-                numNodes
+                numOnlineNodes
             )
             ConnectionState.DISCONNECTED -> getString(R.string.disconnected)
             ConnectionState.DEVICE_SLEEP -> getString(R.string.device_sleeping)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,7 +117,7 @@
     <string name="share">Share</string>
     <string name="disconnected">Disconnected</string>
     <string name="device_sleeping">Device sleeping</string>
-    <string name="connected_count">Connected: %1$s of %2$s online</string>
+    <string name="connected_count">Connected: %1$s online</string>
     <string name="update_firmware">Update Firmware</string>
     <string name="ip_address">IP Address:</string>
     <string name="connected">Connected to radio</string>


### PR DESCRIPTION
The string "Connected: %1$s of %2$s online" in strings.xml has been changed to "Connected: %1$s online". The corresponding change has been made in MeshService.kt to use the updated string format, removing the reference to numNodes as it no longer makes sense when retaining the app node db between same-device connections.