### PR TITLE
Allow copying text from public key field while preventing edits

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/components/EditBase64Preference.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/EditBase64Preference.kt
@@ -60,6 +60,7 @@ fun EditBase64Preference(
     modifier: Modifier = Modifier,
     onGenerateKey: (() -> Unit)? = null,
     trailingIcon: (@Composable () -> Unit)? = null,
+    readOnly: Boolean = false,
 ) {
     fun ByteString.encodeToString() = Base64.encodeToString(this.toByteArray(), Base64.NO_WRAP)
     fun String.toByteString() = Base64.decode(this, Base64.NO_WRAP).toByteString()
@@ -84,13 +85,16 @@ fun EditBase64Preference(
     OutlinedTextField(
         value = valueState,
         onValueChange = {
-            valueState = it
-            runCatching { it.toByteString() }.onSuccess(onValueChange)
+            if (!readOnly) {
+                valueState = it
+                runCatching { it.toByteString() }.onSuccess(onValueChange)
+            }
         },
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState -> isFocused = focusState.isFocused },
         enabled = enabled,
+        readOnly = readOnly,
         label = { Text(text = title) },
         isError = isError,
         keyboardOptions = KeyboardOptions.Default.copy(

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/SecurityConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/SecurityConfigItemList.kt
@@ -83,7 +83,8 @@ fun SecurityConfigItemList(
             EditBase64Preference(
                 title = "Public Key",
                 value = securityInput.publicKey,
-                enabled = false,
+                enabled = true,
+                readOnly = true,
                 keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                 onValueChange = {
                     if (it.size() == 32) {


### PR DESCRIPTION
https://github.com/meshtastic/Meshtastic-Android/commit/b6876bba64c7ead09e0d22dca6b120e7f8dc438b changes the public key field such that it can't be copied.

My fix aims to continue to disable editing it, as it's a computed value, but allow for it to be copied and pasted.