### PR TITLE
fix: correct base path in crowdin.yml

### DIFF
--- a/config/crowdin/crowdin.yml
+++ b/config/crowdin/crowdin.yml
@@ -9,7 +9,7 @@
 #
 "project_id_env": "CROWDIN_PROJECT_ID"
 "api_token_env": "CROWDIN_PERSONAL_TOKEN"
-"base_path": "."
+"base_path": "../../"
 "base_url": "https://meshtastic.crowdin.com/api/v2"
 
 #


### PR DESCRIPTION
Since moving the crowdin config yml to the `config/crowdin` folder, the base path needed to be updated to reflect the change in path.