### PR TITLE
fix (#1647): Satellite icon sizing

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/components/SignalInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/SignalInfo.kt
@@ -17,6 +17,7 @@
 
 package com.geeksville.mesh.ui.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -60,18 +61,20 @@ fun SignalInfo(
             if (node.hopsAway != 0) add(hopsString)
         }.joinToString(" ")
     }
-    if (text.isNotEmpty()) {
-        Text(
-            modifier = modifier,
-            text = text,
-            color = MaterialTheme.colors.onSurface,
-            fontSize = MaterialTheme.typography.button.fontSize
-        )
-    }
-    /* We only know the Signal Quality from direct nodes aka 0 hop. */
-    if (node.hopsAway <= 0) {
-        if (node.snr < MAX_VALID_SNR && node.rssi < MAX_VALID_RSSI) {
-            NodeSignalQuality(node.snr, node.rssi)
+    Column {
+        if (text.isNotEmpty()) {
+            Text(
+                modifier = modifier,
+                text = text,
+                color = MaterialTheme.colors.onSurface,
+                fontSize = MaterialTheme.typography.caption.fontSize
+            )
+        }
+        /* We only know the Signal Quality from direct nodes aka 0 hop. */
+        if (node.hopsAway <= 0) {
+            if (node.snr < MAX_VALID_SNR && node.rssi < MAX_VALID_RSSI) {
+                NodeSignalQuality(node.snr, node.rssi)
+            }
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/compose/SatelliteCountInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/compose/SatelliteCountInfo.kt
@@ -19,7 +19,7 @@ package com.geeksville.mesh.ui.compose
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -44,7 +44,7 @@ fun SatelliteCountInfo(
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         Icon(
-            modifier = Modifier.height(18.dp),
+            modifier = Modifier.size(18.dp),
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_satellite),
             contentDescription = null,
             tint = MaterialTheme.colors.onSurface,


### PR DESCRIPTION
Change size of satellite icon,  reduce font size of signal info and wrap in column.

fixes #1647 