### PR TITLE
refactor: Remove automatic short name generation from long name.

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -38,7 +38,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.R
 import com.geeksville.mesh.copy
-import com.geeksville.mesh.model.getInitials
 import com.geeksville.mesh.ui.components.EditTextPreference
 import com.geeksville.mesh.ui.components.PreferenceCategory
 import com.geeksville.mesh.ui.components.PreferenceFooter
@@ -103,9 +102,6 @@ fun UserConfigItemList(
                 keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                 onValueChanged = {
                     userInput = userInput.copy { longName = it }
-                    if (getInitials(it).toByteArray().size <= 4) { // short_name max_size:5
-                        userInput = userInput.copy { shortName = getInitials(it) }
-                    }
                 }
             )
         }


### PR DESCRIPTION
removes the automatic short name generation from long name - mentioned by @garthvh a few times, and a good idea.

https://github.com/meshtastic/Meshtastic-Android/issues/1810#issuecomment-2845130576