### PR TITLE
refactor(l10n): Split Crowdin Action into Upload and Download Workflows

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,8 +1,8 @@
-name: Crowdin Action
+name: Crowdin Download Translations Action
 
 on:
-  push:
-    branches: [ master ]
+  schedule:              # Every Sunday at midnight
+    - cron: '0 0 * * 0'
   workflow_dispatch:     # Allow manual triggering
 
 jobs:
@@ -13,12 +13,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Synchronize with Crowdin
+      - name: Download translations with Crowdin
         uses: crowdin/github-action@v2
         with:
           base_url: 'https://meshtastic.crowdin.com/api/v2'
           config: 'config/crowdin/crowdin.yml'
-          upload_sources: true
+          upload_sources: false
           upload_translations: false
           download_translations: true
           localization_branch_name: l10n_crowdin_translations
@@ -30,11 +30,6 @@ jobs:
           pull_request_labels: 'l10n'
           crowdin_branch_name: 'master'
         env:
-          # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-
-          # Visit https://crowdin.com/settings#api-key to create this token
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,28 @@
+name: Crowdin Upload Sources Action
+
+on:
+  push:                  # Watch source strings.xml for changes on master
+    paths: [ 'app/src/main/res/values/strings.xml' ]
+    branches: [ master ]
+  workflow_dispatch:     # Allow manual triggering
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Upload sources with Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          base_url: 'https://meshtastic.crowdin.com/api/v2'
+          config: 'config/crowdin/crowdin.yml'
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          crowdin_branch_name: 'master'
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
This commit refactors the previous Crowdin Action workflow into two separate workflows: `crowdin-upload.yml` and `crowdin-download.yml`.

*   `crowdin-download.yml`: This workflow is now scheduled to run every Sunday at midnight, and can be manually triggered. It is responsible for downloading translations from Crowdin. It does not upload sources.
*   `crowdin-upload.yml`: This new workflow triggers on pushes to the `master` branch when the source `strings.xml` changes. It is responsible for uploading source files to Crowdin and can be manually triggered. It does not download translations.

