### PR TITLE
chore(renovate): Auto-merge minor and patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,11 @@
   },
   "packageRules": [
     {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
       "matchPackageNames": [
         "https://github.com/meshtastic/protobufs.git"
       ],


### PR DESCRIPTION
Configure Renovate to auto-merge minor and patch updates, except for pre-1.0 versions. This leverages Renovate's existing functionality for common update types.