### PR TITLE
fix #1567: Allow using a different TCP port than default 4403

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/Settings.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Settings.kt
@@ -88,6 +88,7 @@ import com.geeksville.mesh.model.BTScanModel
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.service.MeshService
+import com.geeksville.mesh.repository.network.NetworkRepository
 import kotlinx.coroutines.delay
 
 fun String?.isIPAddress(): Boolean {
@@ -145,6 +146,7 @@ fun SettingsScreen(
 
     // State for manual IP address input
     var manualIpAddress by remember { mutableStateOf("") }
+    var manualIpPort by remember { mutableStateOf(NetworkRepository.SERVICE_PORT.toString()) }
 
     // State for the device scan dialog
     var showScanDialog by remember { mutableStateOf(false) }
@@ -306,7 +308,7 @@ fun SettingsScreen(
                                 scanModel.onSelected(
                                     BTScanModel.DeviceListEntry(
                                         "",
-                                        "t$manualIpAddress",
+                                        "t$manualIpAddress:$manualIpPort",
                                         true
                                     )
                                 )
@@ -319,13 +321,13 @@ fun SettingsScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 RadioButton(
-                    selected = ("t$manualIpAddress" == selectedDevice),
+                    selected = ("t$manualIpAddress:$manualIpPort" == selectedDevice),
                     onClick = {
                         if (manualIpAddress.isIPAddress()) {
                             scanModel.onSelected(
                                 BTScanModel.DeviceListEntry(
                                     "",
-                                    "t$manualIpAddress",
+                                    "t$manualIpAddress:$manualIpPort",
                                     true
                                 )
                             )
@@ -340,8 +342,22 @@ fun SettingsScreen(
                     label = { Text(stringResource(R.string.ip_address)) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     modifier = Modifier
-                        .weight(1f)
+                        .weight(weight = 0.7f)
                         .padding(start = 16.dp)
+                )
+                OutlinedTextField(
+                    value = manualIpPort,
+                    onValueChange = {
+                        // Only allow numeric input for port
+                        if (it.all { char -> char.isDigit() }) {
+                            manualIpPort = it
+                        }
+                    },
+                    label = { Text(stringResource(R.string.ip_port)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier
+                        .weight(weight = 0.3f)
+                        .padding(start = 8.dp)
                 )
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
     <string name="connected_count">Connected: %1$s online</string>
     <string name="update_firmware">Update Firmware</string>
     <string name="ip_address">IP Address:</string>
+    <string name="ip_port">Port:</string>
     <string name="connected">Connected to radio</string>
     <string name="connected_to">Connected to radio (%s)</string>
     <string name="not_connected">Not connected</string>


### PR DESCRIPTION
I implemented #1567 by adding another text element with pre-selected default TCP port, which can be changed by the user. Showing default port is a good UX practice, otherwise it isn't clear which protocol is actually used (see messages in #1567 where user was confused by thinking the app uses HTTP API at port 80).
![Screenshot from 2025-05-15 23-04-26](https://github.com/user-attachments/assets/80a9bf3f-100f-4f65-8d63-663d3c00e1d6)
