### PR TITLE
Refactor: Move "provide location" preference to DataStore

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -276,6 +276,8 @@ class MainActivity : AppCompatActivity(), Logging {
                 // if provideLocation enabled: Start providing location (from phone GPS) to mesh
                 if (model.provideLocation.value == true) {
                     service.startProvideLocation()
+                } else {
+                    service.stopProvideLocation()
                 }
             }
             checkNotificationPermissions()

--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -266,7 +266,9 @@ fun NavGraph(
                 }
             )
         ) { backStackEntry ->
-            SettingsScreen {
+            SettingsScreen(
+                uIViewModel,
+            ) {
                 navController.navigate(Route.RadioConfig()) {
                     popUpTo(Route.Settings) {
                         inclusive = false

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/DataStoreModule.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/DataStoreModule.kt
@@ -22,9 +22,13 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.dataStoreFile
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
 import com.geeksville.mesh.AppOnlyProtos.ChannelSet
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.LocalOnlyProtos.LocalModuleConfig
+import com.geeksville.mesh.repository.location.LOCATION_PREFERNCES_NAME
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -77,4 +81,11 @@ object DataStoreModule {
             scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         )
     }
+
+    @Singleton
+    @Provides
+    fun provideLocationPreferencesDataStore(@ApplicationContext appContext: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            produceFile = { appContext.preferencesDataStoreFile(LOCATION_PREFERNCES_NAME) }
+        )
 }

--- a/app/src/main/java/com/geeksville/mesh/repository/location/LocationRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/location/LocationRepository.kt
@@ -27,14 +27,16 @@ import androidx.core.location.LocationListenerCompat
 import androidx.core.location.LocationManagerCompat
 import androidx.core.location.LocationRequestCompat
 import androidx.core.location.altitude.AltitudeConverterCompat
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.android.Logging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -42,13 +44,22 @@ import javax.inject.Singleton
 class LocationRepository @Inject constructor(
     private val context: Application,
     private val locationManager: dagger.Lazy<LocationManager>,
+    private val locationPreferencesDataStore: DataStore<Preferences>,
 ) : Logging {
 
     /**
      * Status of whether the app is actively subscribed to location changes.
      */
-    private val _receivingLocationUpdates: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val receivingLocationUpdates: StateFlow<Boolean> get() = _receivingLocationUpdates
+    val locationPreferencesFlow = locationPreferencesDataStore.data.map {
+        it[PreferencesKeys.PROVIDE_LOCATION] == true
+    }
+
+    suspend fun updateLocationPreferences(provideLocation: Boolean) =
+        locationPreferencesDataStore.updateData { preferences ->
+            preferences.toMutablePreferences().apply {
+                set(PreferencesKeys.PROVIDE_LOCATION, provideLocation)
+            }
+        }
 
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     private fun LocationManager.requestLocationUpdates() = callbackFlow {
@@ -84,7 +95,8 @@ class LocationRepository @Inject constructor(
         }
 
         info("Starting location updates with $providerList intervalMs=${intervalMs}ms and minDistanceM=${minDistanceM}m")
-        _receivingLocationUpdates.value = true
+//        _receivingLocationUpdates.value = true
+        updateLocationPreferences(true)
         GeeksvilleApplication.analytics.track("location_start") // Figure out how many users needed to use the phone GPS
 
         try {
@@ -103,7 +115,7 @@ class LocationRepository @Inject constructor(
 
         awaitClose {
             info("Stopping location requests")
-            _receivingLocationUpdates.value = false
+//            _receivingLocationUpdates.value = false
             GeeksvilleApplication.analytics.track("location_stop")
 
             LocationManagerCompat.removeUpdates(this@requestLocationUpdates, locationListener)
@@ -116,3 +128,9 @@ class LocationRepository @Inject constructor(
     @RequiresPermission(anyOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
     fun getLocations() = locationManager.get().requestLocationUpdates()
 }
+
+private object PreferencesKeys {
+    val PROVIDE_LOCATION = booleanPreferencesKey("provide_location")
+}
+
+const val LOCATION_PREFERNCES_NAME = "location_preferences"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ kotlinx-coroutines-android = "1.10.2"
 kotlinx-serialization-json = "1.8.1"
 lifecycle = "2.9.0"
 material = "1.12.0"
-material3 = "1.2.0"
+material3 = "1.3.2"
 mgrs = "2.1.3"
 navigation = "2.9.0"
 org-eclipse-paho-client-mqttv3 = "1.2.5"
@@ -58,7 +58,7 @@ awesome-app-rating = { group = "com.suddenh4x.ratingdialog", name = "awesome-app
 cardview = { group = "androidx.cardview", name = "cardview", version.ref = "cardview" }
 coil = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-svg = { group = "io.coil-kt.coil3", name = "coil-svg", version.ref = "coil" }
-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
@@ -71,6 +71,7 @@ core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx
 core-location-altitude = { group = "androidx.core", name = "core-location-altitude", version.ref = "core-location-altitude" }
 core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "core-splashscreen" }
 datastore = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
+datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 emoji2-emojipicker = { group = "androidx.emoji2", name = "emoji2-emojipicker", version.ref = "emoji2" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
@@ -142,7 +143,7 @@ navigation = ["navigation-compose"]
 coroutines = ["kotlinx-coroutines-android", "kotlinx-coroutines-guava"]
 
 # Data Storage
-datastore = ["datastore"]
+datastore = ["datastore", "datastore-preferences"]
 room = ["room-runtime", "room-ktx"]
 
 # Dependency Injection


### PR DESCRIPTION
This commit refactors the "provide location" setting to use DataStore for persistence instead of SharedPreferences.

Key changes:
- Introduced `LocationRepository` to manage location-related data and preferences.
- Migrated the "provide location" preference to DataStore within `LocationRepository`.
- Updated `UIViewModel` to use `LocationRepository` for accessing and modifying the "provide location" setting.
- Modified `SettingsScreen` to reflect the changes in how "provide location" is handled.
- Ensured that changing the connected device resets the "provide location" setting to false.
- Ensured that re-connecting to the same device keeps the previous "provide location" setting
- Added necessary DataStore dependencies and module configurations.