### PR TITLE
Refactor: Remove "include unmessageable" filter

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
@@ -28,7 +28,6 @@ import com.geeksville.mesh.database.entity.MyNodeEntity
 import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.NodeSortOption
-import com.geeksville.mesh.model.isUnmessageableRole
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -97,20 +96,13 @@ class NodeRepository @Inject constructor(
         sort: NodeSortOption = NodeSortOption.LAST_HEARD,
         filter: String = "",
         includeUnknown: Boolean = true,
-        includeUnmessageable: Boolean = true,
     ) = nodeInfoDao.getNodes(
         sort = sort.sqlValue,
         filter = filter,
         includeUnknown = includeUnknown,
     ).mapLatest { list ->
-        list.map { it.toModel() }.filter { node ->
-            val isUnmessageable: Boolean = if (node.user.hasIsUnmessagable()) {
-                node.user.isUnmessagable
-            } else {
-                // for older firmwares
-                node.user.role?.isUnmessageableRole() == true
-            }
-            return@filter includeUnmessageable || !isUnmessageable
+        list.map {
+            it.toModel()
         }
     }.flowOn(dispatchers.io).conflate()
 

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -147,7 +147,6 @@ data class NodesUiState(
     val sort: NodeSortOption = NodeSortOption.LAST_HEARD,
     val filter: String = "",
     val includeUnknown: Boolean = false,
-    val includeUnmessageable: Boolean = true,
     val gpsFormat: Int = 0,
     val distanceUnits: Int = 0,
     val tempInFahrenheit: Boolean = false,
@@ -263,8 +262,6 @@ class UIViewModel @Inject constructor(
     private val nodeSortOption = MutableStateFlow(NodeSortOption.LAST_HEARD)
     private val includeUnknown = MutableStateFlow(preferences.getBoolean("include-unknown", false))
     private val showDetails = MutableStateFlow(preferences.getBoolean("show-details", false))
-    private val includeUnmessageable =
-        MutableStateFlow(preferences.getBoolean("include-unmessageable", true))
 
     fun setSortOption(sort: NodeSortOption) {
         nodeSortOption.value = sort
@@ -273,11 +270,6 @@ class UIViewModel @Inject constructor(
     fun toggleShowDetails() {
         showDetails.value = !showDetails.value
         preferences.edit { putBoolean("show-details", showDetails.value) }
-    }
-
-    fun toggleIncludeUnmessageable() {
-        includeUnmessageable.value = !includeUnmessageable.value
-        preferences.edit { putBoolean("include-unmessageable", includeUnmessageable.value) }
     }
 
     fun toggleIncludeUnknown() {
@@ -301,8 +293,6 @@ class UIViewModel @Inject constructor(
             tempInFahrenheit = profile.moduleConfig.telemetry.environmentDisplayFahrenheit,
             showDetails = showDetails,
         )
-    }.combine(includeUnmessageable) { state, includeUnmessageable ->
-        state.copy(includeUnmessageable = includeUnmessageable)
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
@@ -316,7 +306,7 @@ class UIViewModel @Inject constructor(
     )
 
     val nodeList: StateFlow<List<Node>> = nodesUiState.flatMapLatest { state ->
-        nodeDB.getNodes(state.sort, state.filter, state.includeUnknown, state.includeUnmessageable)
+        nodeDB.getNodes(state.sort, state.filter, state.includeUnknown)
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeScreen.kt
@@ -95,8 +95,6 @@ fun NodeScreen(
                     onToggleIncludeUnknown = model::toggleIncludeUnknown,
                     showDetails = state.showDetails,
                     onToggleShowDetails = model::toggleShowDetails,
-                    includeUnmessageable = state.includeUnmessageable,
-                    onToggleIncludeUnmessageable = model::toggleIncludeUnmessageable
                 )
             }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/components/NodeFilterTextField.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/NodeFilterTextField.kt
@@ -70,8 +70,6 @@ fun NodeFilterTextField(
     onToggleIncludeUnknown: () -> Unit,
     showDetails: Boolean,
     onToggleShowDetails: () -> Unit,
-    includeUnmessageable: Boolean,
-    onToggleIncludeUnmessageable: () -> Unit,
 ) {
     Row(
         modifier = modifier.background(MaterialTheme.colorScheme.background),
@@ -90,8 +88,6 @@ fun NodeFilterTextField(
             onToggleIncludeUnknown = onToggleIncludeUnknown,
             showDetails = showDetails,
             onToggleShowDetails = onToggleShowDetails,
-            includeUnmessageable = includeUnmessageable,
-            onToggleIncludeUnmessageable = onToggleIncludeUnmessageable
         )
     }
 }
@@ -158,8 +154,6 @@ private fun NodeSortButton(
     onToggleIncludeUnknown: () -> Unit,
     showDetails: Boolean,
     onToggleShowDetails: () -> Unit,
-    onToggleIncludeUnmessageable: () -> Unit,
-    includeUnmessageable: Boolean,
     modifier: Modifier = Modifier,
 ) = Box(modifier) {
     var expanded by remember { mutableStateOf(false) }
@@ -234,27 +228,6 @@ private fun NodeSortButton(
                 }
             }
         )
-        HorizontalDivider()
-        DropdownMenuItem(
-            onClick = {
-                onToggleIncludeUnmessageable()
-                expanded = false
-            },
-            text = {
-                Row {
-                    AnimatedVisibility(visible = includeUnmessageable) {
-                        Icon(
-                            imageVector = Icons.Default.Done,
-                            contentDescription = null,
-                            modifier = Modifier.padding(end = 4.dp),
-                        )
-                    }
-                    Text(
-                        text = stringResource(id = R.string.node_filter_include_unmessageable),
-                    )
-                }
-            }
-        )
     }
 }
 
@@ -272,8 +245,6 @@ private fun NodeFilterTextFieldPreview() {
             onToggleIncludeUnknown = {},
             showDetails = false,
             onToggleShowDetails = {},
-            includeUnmessageable = false,
-            onToggleIncludeUnmessageable = {}
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -621,7 +621,6 @@
     <string name="scan_qr_code">Scan QR Code</string>
     <string name="share_contact">Share Contact</string>
     <string name="import_shared_contact">Import Shared Contact?</string>
-    <string name="node_filter_include_unmessageable">Include Unmessageable</string>
     <string name="unmessageable">Unmessageable</string>
     <string name="unmonitored_or_infrastructure">Unmonitored or Infrastructure</string>
     <string name="import_known_shared_contact_text">Warning: This contact is known, importing will overwrite the previous contact information.</string>


### PR DESCRIPTION
This commit removes the "include unmessageable" filter from the node list.

The functionality to filter out nodes based on their messageability status (e.g., repeaters, infrastructure nodes) has been removed from the UI and the underlying data layer.

The Direct Messaging visibility checks, and visual indication on the nodes are still in place.