### PR TITLE
fix(#1874): Check that Meshtastic URL is for a channel set

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -168,9 +168,17 @@ class MainActivity : AppCompatActivity(), Logging {
 
         when (appLinkAction) {
             Intent.ACTION_VIEW -> {
-                debug("Asked to open a channel URL - ask user if they want to switch to that channel.  If so send the config to the radio")
-                appLinkData?.let(model::requestChannelUrl)
-                // We now wait for the device to connect, once connected, we ask the user if they want to switch to the new channel
+                appLinkData?.let {
+                    debug("App link data: $it")
+                    if (it.path?.startsWith("/e/") == true ||
+                        it.path?.startsWith("/E/") == true
+                    ) {
+                        debug("App link data is a channel set")
+                        model.requestChannelUrl(it)
+                    } else {
+                        debug("App link data is not a channel set")
+                    }
+                }
             }
 
             UsbManager.ACTION_USB_DEVICE_ATTACHED -> {

--- a/app/src/main/java/com/geeksville/mesh/model/ChannelSet.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/ChannelSet.kt
@@ -29,8 +29,8 @@ import java.net.MalformedURLException
 import kotlin.jvm.Throws
 
 private const val MESHTASTIC_HOST = "meshtastic.org"
-private const val MESHTASTIC_PATH = "/e/"
-internal const val URL_PREFIX = "https://$MESHTASTIC_HOST$MESHTASTIC_PATH#"
+private const val CHANNEL_PATH = "/e/"
+internal const val URL_PREFIX = "https://$MESHTASTIC_HOST$CHANNEL_PATH#"
 private const val BASE64FLAGS = Base64.URL_SAFE + Base64.NO_WRAP + Base64.NO_PADDING
 
 /**
@@ -41,7 +41,7 @@ private const val BASE64FLAGS = Base64.URL_SAFE + Base64.NO_WRAP + Base64.NO_PAD
 fun Uri.toChannelSet(): ChannelSet {
     if (fragment.isNullOrBlank() ||
         !host.equals(MESHTASTIC_HOST, true) ||
-        !path.equals(MESHTASTIC_PATH, true)
+        !path.equals(CHANNEL_PATH, true)
     ) {
         throw MalformedURLException("Not a valid Meshtastic URL: ${toString().take(40)}")
     }


### PR DESCRIPTION
This commit ensures that when the app is opened via a URL or VIEW intent, it checks if the URL path starts with `/e/` or `/E/` (case-insensitive) before attempting to parse it as a channel set. This prevents potential errors if the URL is for a different Meshtastic resource.

The `ChannelSet.kt` was also updated to use `/e/` as the `CHANNEL_PATH` for consistency.
fixes #1874 