### PR TITLE
feat: Use node colors for contact chip

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -167,6 +167,7 @@ data class Contact(
     val messageCount: Int,
     val isMuted: Boolean,
     val isUnmessageable: Boolean,
+    val nodeColors: Pair<Int, Int>? = null,
 )
 
 @Suppress("LongParameterList")
@@ -385,6 +386,7 @@ class UIViewModel @Inject constructor(
 
             // grab usernames from NodeInfo
             val user = getUser(if (fromLocal) data.to else data.from)
+            val node = getNode(if (fromLocal) data.to else data.from)
 
             val shortName = user.shortName
             val longName = if (toBroadcast) {
@@ -403,6 +405,11 @@ class UIViewModel @Inject constructor(
                 messageCount = packetRepository.getMessageCount(contactKey),
                 isMuted = settings[contactKey]?.isMuted == true,
                 isUnmessageable = user.isUnmessagable,
+                nodeColors = if (!toBroadcast) {
+                    node.colors
+                } else {
+                    null
+                },
             )
         }
     }.stateIn(

--- a/app/src/main/java/com/geeksville/mesh/ui/ContactItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/ContactItem.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.VolumeOff
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -69,6 +70,14 @@ fun ContactItem(
             .padding(horizontal = 8.dp, vertical = 6.dp),
         shape = RoundedCornerShape(12.dp),
     ) {
+        val colors = if (contact.nodeColors != null) {
+            AssistChipDefaults.assistChipColors(
+                labelColor = Color(contact.nodeColors.first),
+                containerColor = Color(contact.nodeColors.second),
+            )
+        } else {
+            AssistChipDefaults.assistChipColors()
+        }
 
         Row(
             modifier = Modifier
@@ -89,7 +98,8 @@ fun ContactItem(
                         fontWeight = FontWeight.Normal,
                         textAlign = TextAlign.Center,
                     )
-                }
+                },
+                colors = colors
             )
             Column(
                 modifier = Modifier.weight(1f),


### PR DESCRIPTION
This commit updates the contact list to use the node's defined colors for the contact chip, providing a more personalized and visually distinct experience.

If the contact is a Channel, the default chip colors will be used.