### PR TITLE
fix: NodeMenu hiding details action

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/components/NodeMenu.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/NodeMenu.kt
@@ -193,13 +193,14 @@ fun NodeMenu(
         }
         val firmware = DeviceVersion(firmwareVersion ?: "0.0.0")
         if (firmware.supportsQrCodeSharing()) {
-        DropdownMenuItem(
-            onClick = {
-                onDismissRequest()
-                onAction(NodeMenuAction.Share(node))
-            },
-            text = { Text(stringResource(R.string.share_contact)) }
-        )
+            DropdownMenuItem(
+                onClick = {
+                    onDismissRequest()
+                    onAction(NodeMenuAction.Share(node))
+                },
+                text = { Text(stringResource(R.string.share_contact)) }
+            )
+        }
         DropdownMenuItem(
             onClick = {
                 onDismissRequest()
@@ -207,7 +208,6 @@ fun NodeMenu(
             },
             text = { Text(stringResource(R.string.more_details)) }
         )
-        }
     }
 }
 


### PR DESCRIPTION
Node menu show details action was being unintentionally hidden for old firmwares - this resolves that issue.