### PR TITLE
feat: Add request metadata action to NodeDetail

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -626,4 +626,6 @@
     <string name="import_known_shared_contact_text">Warning: This contact is known, importing will overwrite the previous contact information.</string>
     <string name="public_key_changed">Public Key Changed</string>
     <string name="import_label">Import</string>
+    <string name="request_metadata">Request Metadata</string>
+    <string name="actions">Actions</string>
 </resources>

--- a/config/detekt/detekt-baseline.xml
+++ b/config/detekt/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues>
     <ID>TooManyFunctions:ContactSharing.kt$com.geeksville.mesh.ui.ContactSharing.kt</ID>
+    <ID>TooManyFunctions:NodeDetail.kt$com.geeksville.mesh.ui.NodeDetail.kt</ID>
   </ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>AbsentOrWrongFileLicense:LazyColumnDragAndDropDemo.kt$com.geeksville.mesh.ui.components.LazyColumnDragAndDropDemo.kt</ID>


### PR DESCRIPTION
This commit introduces a "Request Metadata" action to the NodeDetail screen for remote devices. This allows users to request updated metadata from the device.

The `NodeDetailList` now accepts a generic `onAction` callback, which can handle both `Route` for navigation and `ServiceAction` for service-related actions.

The `DeviceActions` composable has been created to group device-specific actions like "Share Contact" and the new "Request Metadata".

The `MetricsViewModel` has been updated to handle `ServiceAction` and determine if the current node is the local device.

replaces #1517 