### PR TITLE
Potential fix for code scanning alert no. 30: Improper verification of intent by broadcast receiver

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/BootCompleteReceiver.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/BootCompleteReceiver.kt
@@ -25,6 +25,10 @@ import com.geeksville.mesh.android.Logging
 
 class BootCompleteReceiver : BroadcastReceiver(), Logging {
     override fun onReceive(mContext: Context, intent: Intent) {
+        // Verify the intent action
+        if (Intent.ACTION_BOOT_COMPLETED != intent.action) {
+            return
+        }
         // start listening for bluetooth messages from our device
         MeshService.startServiceLater(mContext)
     }


### PR DESCRIPTION
Potential fix for [https://github.com/meshtastic/Meshtastic-Android/security/code-scanning/30](https://github.com/meshtastic/Meshtastic-Android/security/code-scanning/30)

To fix the issue, the `onReceive` method should verify that the received intent's action matches the expected `Intent.ACTION_BOOT_COMPLETED`. If the action does not match, the method should return early without performing any operations. This ensures that the receiver only processes valid intents and mitigates the risk of malicious exploitation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
