### PR TITLE
chore: Upgrade minSdkVersion to 23

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ android {
     compileSdk 36
     defaultConfig {
         applicationId "com.geeksville.mesh"
-        minSdkVersion 21 // The oldest emulator image I have tried is 22 (though 21 probably works)
+        minSdkVersion 23
         targetSdk 36
         versionCode 30602 // format is Mmmss (where M is 1+the numeric major number
         versionName "2.6.2"


### PR DESCRIPTION
this is required to use the latest version of osmdroid - bumps min version of android from 5.0(21) to 6.0(23)