### PR TITLE
Distinguish between an empty response and a network error

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/api/DeviceHardwareRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/api/DeviceHardwareRepository.kt
@@ -52,7 +52,9 @@ class DeviceHardwareRepository @Inject constructor(
             }
             try {
                 debug("Fetching device hardware from server")
-                localDataSource.insertAllDeviceHardware(apiDataSource.getAllDeviceHardware())
+                val deviceHardware = apiDataSource.getAllDeviceHardware()
+                    ?: throw IOException("empty response from server")
+                localDataSource.insertAllDeviceHardware(deviceHardware)
                 val cachedHardware = localDataSource.getByHwModel(hwModel)
                 val externalModel = cachedHardware?.asExternalModel()
                 return@withContext externalModel

--- a/app/src/main/java/com/geeksville/mesh/repository/api/FirmwareReleaseRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/api/FirmwareReleaseRepository.kt
@@ -61,6 +61,7 @@ class FirmwareReleaseRepository @Inject constructor(
         try {
             debug("Fetching firmware releases from server")
             val networkFirmwareReleases = apiDataSource.getFirmwareReleases()
+                ?: throw IOException("empty response from server")
             val releases = when (releaseType) {
                 FirmwareReleaseType.STABLE -> networkFirmwareReleases.releases.stable
                 FirmwareReleaseType.ALPHA -> networkFirmwareReleases.releases.alpha

--- a/network/src/fdroid/java/com/geeksville/mesh/network/retrofit/NoOpApiService.kt
+++ b/network/src/fdroid/java/com/geeksville/mesh/network/retrofit/NoOpApiService.kt
@@ -19,17 +19,19 @@ package com.geeksville.mesh.network.retrofit
 
 import com.geeksville.mesh.network.model.NetworkDeviceHardware
 import com.geeksville.mesh.network.model.NetworkFirmwareReleases
+import okhttp3.ResponseBody.Companion.toResponseBody
 import retrofit2.Response
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private const val ERROR_NO_OP = 420
 @Singleton
 class NoOpApiService@Inject constructor() : ApiService {
     override suspend fun getDeviceHardware(): Response<List<NetworkDeviceHardware>> {
-        return Response.success(emptyList())
+        return Response.error(ERROR_NO_OP, "Not Found".toResponseBody(null))
     }
 
     override suspend fun getFirmwareReleases(): Response<NetworkFirmwareReleases> {
-        return Response.success(NetworkFirmwareReleases(emptyList()))
+        return Response.error(ERROR_NO_OP, "Not Found".toResponseBody(null))
     }
 }

--- a/network/src/main/java/com/geeksville/mesh/network/DeviceHardwareRemoteDataSource.kt
+++ b/network/src/main/java/com/geeksville/mesh/network/DeviceHardwareRemoteDataSource.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
 class DeviceHardwareRemoteDataSource @Inject constructor(
     private val apiService: ApiService,
 ) {
-    suspend fun getAllDeviceHardware(): List<NetworkDeviceHardware> = withContext(Dispatchers.IO) {
-        apiService.getDeviceHardware().body() ?: emptyList()
+    suspend fun getAllDeviceHardware(): List<NetworkDeviceHardware>? = withContext(Dispatchers.IO) {
+        apiService.getDeviceHardware().body()
     }
 }

--- a/network/src/main/java/com/geeksville/mesh/network/FirmwareReleaseRemoteDataSource.kt
+++ b/network/src/main/java/com/geeksville/mesh/network/FirmwareReleaseRemoteDataSource.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
 class FirmwareReleaseRemoteDataSource @Inject constructor(
     private val apiService: ApiService,
 ) {
-    suspend fun getFirmwareReleases(): NetworkFirmwareReleases = withContext(Dispatchers.IO) {
-        apiService.getFirmwareReleases().body() ?: NetworkFirmwareReleases()
+    suspend fun getFirmwareReleases(): NetworkFirmwareReleases? = withContext(Dispatchers.IO) {
+        apiService.getFirmwareReleases().body()
     }
 }


### PR DESCRIPTION
The API data sources were returning empty lists or objects in case of a network error. This change makes the data sources return null in case of an error, so the repositories can distinguish between an empty response and a network error.

The F-Droid NoOpApiService now returns an error response instead of an empty list, so the repositories can detect that no data is available.