### PR TITLE
refactor: Support Meshtastic URL deep link scheme in HTTPS only

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -174,7 +174,7 @@
                 <!-- The QR codes to share channel settings are shared as meshtastic URLS
 
                 an approximate example:
-                http://meshtastic.org/e/YXNkZnF3ZXJhc2RmcXdlcmFzZGZxd2Vy
+                https://meshtastic.org/e/YXNkZnF3ZXJhc2RmcXdlcmFzZGZxd2Vy
                 -->
                 <action android:name="android.intent.action.VIEW" />
 
@@ -182,7 +182,6 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:scheme="http" />
                 <data android:host="meshtastic.org" />
                 <data android:pathPrefix="/e/" />
                 <data android:pathPrefix="/E/" />


### PR DESCRIPTION
This commit updates the AndroidManifest.xml to only support HTTPS for Meshtastic URLs. HTTP support has been removed.

in response to questions on #829 