### PR TITLE
refactor: Move MIN_DEVICE_VERSION to build config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
         versionCode Configs.VERSION_CODE // format is Mmmss (where M is 1+the numeric major number
         versionName Configs.VERSION_NAME
         testInstrumentationRunner "com.geeksville.mesh.TestRunner"
-
+        buildConfigField("String", "MIN_DEVICE_VERSION", "\"${Configs.MIN_DEVICE_VERSION}\"")
         // per https://developer.android.com/studio/write/vector-asset-studio
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -185,7 +185,7 @@ class MeshService : Service(), Logging {
         /** The minimum firmware version we know how to talk to. We'll still be able
          * to talk to 2.0 firmwares but only well enough to ask them to firmware update.
          */
-        val minDeviceVersion = DeviceVersion("2.3.15")
+        val minDeviceVersion = DeviceVersion(BuildConfig.MIN_DEVICE_VERSION)
     }
 
     enum class ConnectionState {

--- a/buildSrc/src/main/kotlin/Configs.kt
+++ b/buildSrc/src/main/kotlin/Configs.kt
@@ -23,4 +23,5 @@ object Configs {
     const val VERSION_CODE = 30604 // format is Mmmss (where M is 1+the numeric major number
     const val VERSION_NAME = "2.6.4"
     const val USE_CRASHLYTICS = true // Set to false if you don't want to use Firebase Crashlytics
+    const val MIN_DEVICE_VERSION = "2.5.14" // Minimum device firmware version supported by this app
 }


### PR DESCRIPTION
This commit moves the `MIN_DEVICE_VERSION` constant from `MeshService.kt` to the `Configs.kt` file within the `buildSrc` directory.

The value is now accessible via `BuildConfig.MIN_DEVICE_VERSION` and is set to "2.5.14".

This change centralizes build-related configurations and improves maintainability.
