### PR TITLE
refactor: settings screen ui updates

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -274,13 +274,17 @@ fun NavGraph(
             ) { backStackEntry ->
                 SettingsScreen(
                     uIViewModel,
-                ) {
-                    navController.navigate(Route.RadioConfig()) {
-                        popUpTo(Route.Settings) {
-                            inclusive = false
+                    sharedTransitionScope = this@SharedTransitionLayout,
+                    animatedContentScope = this@composable,
+                    onNavigateToRadioConfig = {
+                        navController.navigate(Route.RadioConfig()) {
+                            popUpTo(Route.Settings) {
+                                inclusive = false
+                            }
                         }
-                    }
-                }
+                    },
+                    onNavigateToNodeDetails = { navController.navigate(Route.NodeDetail(it)) }
+                )
             }
             composable<Route.DebugPanel> {
                 DebugScreen()

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -178,7 +178,7 @@ fun MainScreen(
 
 enum class MainMenuAction(@StringRes val stringRes: Int) {
     DEBUG(R.string.debug_panel),
-    RADIO_CONFIG(R.string.device_settings),
+    RADIO_CONFIG(R.string.radio_configuration),
     EXPORT_MESSAGES(R.string.save_messages),
     THEME(R.string.theme),
     LANGUAGE(R.string.preferences_language),

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfig.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfig.kt
@@ -302,7 +302,7 @@ private fun RadioConfigItemList(
         modifier = modifier,
         contentPadding = PaddingValues(horizontal = 16.dp),
     ) {
-        item { PreferenceCategory(stringResource(R.string.device_settings)) }
+        item { PreferenceCategory(stringResource(R.string.radio_configuration)) }
         items(ConfigRoute.filterExcludedFrom(state.metadata)) {
             NavCard(
                 title = stringResource(it.title),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,7 +234,7 @@
     <string name="map_start_download">Start Download</string>
     <string name="exchange_position">Exchange position</string>
     <string name="close">Close</string>
-    <string name="device_settings">Radio configuration</string>
+    <string name="radio_configuration">Radio configuration</string>
     <string name="module_settings">Module configuration</string>
     <string name="add">Add</string>
     <string name="edit">Edit</string>

--- a/network/src/fdroid/java/com/geeksville/mesh/network/di/ApiModule.kt
+++ b/network/src/fdroid/java/com/geeksville/mesh/network/di/ApiModule.kt
@@ -29,7 +29,6 @@ import coil3.util.Logger
 import com.geeksville.mesh.network.BuildConfig
 import com.geeksville.mesh.network.retrofit.ApiService
 import com.geeksville.mesh.network.retrofit.NoOpApiService
-import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn


### PR DESCRIPTION
This commit enhances the settings interface by:

- Moving the "Set Region" button to a more prominent "Radio configuration" button on the Settings screen.
- Displaying the local node's chip and name on the Settings screen when connected.
- Showing an error message on the Settings screen if the region is unset.
- Enabling navigation from the local node chip on the Settings screen to the Node Details screen.
- Adding a "Share" option to the local node's menu on the Settings screen.
- Removing an unused import from `ApiModule.kt`.


https://github.com/user-attachments/assets/0c69420b-c3cd-4d5c-aaf5-8a00560c7d07

