### PR TITLE
refactor: use `is_unmessagable` flag

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
@@ -105,11 +105,13 @@ fun NodeItem(
 
     val (detailsShown, showDetails) = remember { mutableStateOf(expanded) }
     val unmessageable = remember(thatNode) {
-        val firmwareVersion = DeviceVersion(thatNode.metadata?.firmwareVersion ?: "")
-        if (firmwareVersion >= DeviceVersion("2.6.8")) {
-            thatNode.user.isUnmessagable
-        } else {
-            thatNode.user.role?.isUnmessageableRole() == true
+        when {
+            thatNode.user.hasIsUnmessagable() -> thatNode.user.isUnmessagable
+            thatNode.user.role.isUnmessageableRole() ->
+                thatNode.metadata?.firmwareVersion?.let {
+                    DeviceVersion(it) < DeviceVersion("2.6.8")
+                } ?: true
+            else -> false
         }
     }
 


### PR DESCRIPTION
This commit updates the `NodeItem` composable to correctly determine if a node is unmessageable.

Previously, it checked for firmware version "2.6.8" and the `isUnmessagable` user property.

Now, it prioritizes the new `hasIsUnmessagable()` flag on the user object. If this flag is not present, it falls back to checking the `isUnmessageableRole()` and the firmware version, defaulting to unmessageable if the firmware version is unavailable.
