### PR TITLE
fix: update LoraSignalIndicator GOOD color

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/components/LoraSignalIndicator.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/LoraSignalIndicator.kt
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+@file:Suppress("MagicNumber")
 package com.geeksville.mesh.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
@@ -58,7 +59,7 @@ private enum class Quality(
     NONE(R.string.none_quality, Icons.Default.SignalCellularAlt1Bar, Color.Red),
     BAD(R.string.bad, Icons.Default.SignalCellularAlt2Bar, Color(red = 247, green = 147, blue = 26)),
     FAIR(R.string.fair, Icons.Default.SignalCellularAlt, Color(red = 255, green = 230, blue = 0)),
-    GOOD(R.string.good, Icons.Default.SignalCellular4Bar, Color.Green)
+    GOOD(R.string.good, Icons.Default.SignalCellular4Bar, Color(0xFF30C047))
 }
 
 /**


### PR DESCRIPTION
The green color for the GOOD signal quality in the LoraSignalIndicator has been updated from `Color.Green` to a more specific green shade (`#30C047`) . Matches PKC lock coloring

saves @NomDeTom 's :eyes: 