### PR TITLE
Fix: Handle null or empty release list in `getLatestRelease`

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/api/FirmwareReleaseLocalDataSource.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/api/FirmwareReleaseLocalDataSource.kt
@@ -52,8 +52,12 @@ class FirmwareReleaseLocalDataSource @Inject constructor(
     suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? =
         withContext(Dispatchers.IO) {
             val releases = firmwareReleaseDao.getReleasesByType(releaseType)
-            val latestRelease =
-                releases?.maxBy { it.asDeviceVersion() }
-            return@withContext latestRelease
+            if (releases.isNullOrEmpty()) {
+                return@withContext null
+            } else {
+                val latestRelease =
+                    releases.maxBy { it.asDeviceVersion() }
+                return@withContext latestRelease
+            }
         }
 }


### PR DESCRIPTION
The `getLatestRelease` function in `FirmwareReleaseLocalDataSource.kt` now checks if the list of releases retrieved from the DAO is null or empty before attempting to find the maximum version. If it is null or empty, the function returns null. This prevents a potential crash if no releases are found for the given `releaseType`.