### PR TITLE
fix: respect keyboard, edgeToEdge tweaks

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -37,14 +37,20 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowCompat
 import com.geeksville.mesh.android.BindFailedException
 import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.android.Logging
@@ -131,6 +137,7 @@ class MainActivity : AppCompatActivity(), Logging {
             (application as GeeksvilleApplication).askToRate(this)
         }
 
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             val theme by model.theme.collectAsState()
             val dynamic = theme == MODE_DYNAMIC
@@ -151,10 +158,16 @@ class MainActivity : AppCompatActivity(), Logging {
                         AppCompatDelegate.setDefaultNightMode(theme)
                     }
                 }
-                MainScreen(
-                    viewModel = model,
-                    onAction = ::onMainMenuAction
-                )
+                Box(
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.background)
+                        .systemBarsPadding()
+                ) {
+                    MainScreen(
+                        viewModel = model,
+                        onAction = ::onMainMenuAction
+                    )
+                }
             }
         }
         // Handle any intent

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -25,6 +25,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.twotone.Chat
@@ -147,7 +148,7 @@ fun MainScreen(
     }
 
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.safeDrawingPadding(),
         topBar = {
             MainAppBar(
                 title = title,


### PR DESCRIPTION
This change refactors edge-to-edge display in the `MainActivity` by:
- Setting `WindowCompat.setDecorFitsSystemWindows(window, false)`.
- Wrapping the `MainScreen` composable in a `Box` with background and system bars padding.
- Applying `safeDrawingPadding()` to the `Scaffold` in `Main.kt`.