### PR TITLE
feat: add Direct Message button to Node Detail screen

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/navigation/NodeDetailGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NodeDetailGraph.kt
@@ -58,14 +58,22 @@ fun NavGraphBuilder.nodeDetailGraph(
             }
             NodeDetailScreen(
                 uiViewModel = uiViewModel,
-                viewModel = hiltViewModel(parentEntry),
-            ) {
-                navController.navigate(it) {
-                    popUpTo(Route.NodeDetail()) {
-                        inclusive = false
+                navigateToMessages = {
+                    navController.navigate(Route.Messages(it)) {
+                        popUpTo(Route.NodeDetail()) {
+                            inclusive = false
+                        }
                     }
-                }
-            }
+                },
+                onNavigate = {
+                    navController.navigate(it) {
+                        popUpTo(Route.NodeDetail()) {
+                            inclusive = false
+                        }
+                    }
+                },
+                viewModel = hiltViewModel(parentEntry),
+            )
         }
         NodeDetailRoute.entries.forEach { nodeDetailRoute ->
             composable(nodeDetailRoute.route::class) { backStackEntry ->


### PR DESCRIPTION
This commit introduces a "Direct Message" button on the Node Detail screen, allowing users to initiate a direct message with the selected node.

Changes include:
- Added `navigateToMessages` lambda to `NodeDetailScreen` to handle navigation to the messages screen.
- Updated `NodeDetailGraph.kt` to pass the `navigateToMessages` lambda.
- Added a "Direct Message" `NodeActionButton` to the `NodeDetailScreen`.
- When the "Direct Message" button is clicked, it determines the appropriate channel (PKC or node's channel) and navigates to the messages screen with the user ID.
