### PR TITLE
refactor: FirmwareReleaseDao to return non-nullable lists

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/dao/FirmwareReleaseDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/FirmwareReleaseDao.kt
@@ -33,8 +33,8 @@ interface FirmwareReleaseDao {
     suspend fun deleteAll()
 
     @Query("SELECT * FROM firmware_release")
-    suspend fun getAllReleases(): List<FirmwareReleaseEntity>?
+    suspend fun getAllReleases(): List<FirmwareReleaseEntity>
 
     @Query("SELECT * FROM firmware_release WHERE release_type = :releaseType")
-    suspend fun getReleasesByType(releaseType: FirmwareReleaseType): List<FirmwareReleaseEntity>?
+    suspend fun getReleasesByType(releaseType: FirmwareReleaseType): List<FirmwareReleaseEntity>
 }

--- a/app/src/main/java/com/geeksville/mesh/repository/api/FirmwareReleaseLocalDataSource.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/api/FirmwareReleaseLocalDataSource.kt
@@ -52,7 +52,7 @@ class FirmwareReleaseLocalDataSource @Inject constructor(
     suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? =
         withContext(Dispatchers.IO) {
             val releases = firmwareReleaseDao.getReleasesByType(releaseType)
-            if (releases.isNullOrEmpty()) {
+            if (releases.isEmpty()) {
                 return@withContext null
             } else {
                 val latestRelease =


### PR DESCRIPTION
The DAO methods `getAllReleases` and `getReleasesByType` already returned an empty `List<FirmwareReleaseEntity>` instead of `null`.

Fixes a build warning.
