### PR TITLE
fix: Only show DM button if node is messageable

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -372,6 +372,12 @@ private fun DeviceActions(
     var displayFavoriteDialog by remember { mutableStateOf(false) }
     var displayIgnoreDialog by remember { mutableStateOf(false) }
     var displayRemoveDialog by remember { mutableStateOf(false) }
+    val isUnmessageable = if (node.user.hasIsUnmessagable()) {
+        node.user.isUnmessagable
+    } else {
+        // for older firmwares
+        node.user.role?.isUnmessageableRole() == true
+    }
     NodeActionDialogs(
         node = node,
         displayFavoriteDialog = displayFavoriteDialog,
@@ -393,14 +399,16 @@ private fun DeviceActions(
     )
 
     if (!isLocal) {
-        NodeActionButton(
-            title = stringResource(id = R.string.direct_message),
-            icon = Icons.AutoMirrored.TwoTone.Message,
-            enabled = true,
-            onClick = {
-                onAction(NodeMenuAction.DirectMessage(node))
-            }
-        )
+        if (!isUnmessageable) {
+            NodeActionButton(
+                title = stringResource(id = R.string.direct_message),
+                icon = Icons.AutoMirrored.TwoTone.Message,
+                enabled = true,
+                onClick = {
+                    onAction(NodeMenuAction.DirectMessage(node))
+                }
+            )
+        }
         NodeActionButton(
             title = stringResource(id = R.string.request_metadata),
             icon = Icons.Default.Memory,


### PR DESCRIPTION
Check if the node can receive DMs before showing the direct message button. This considers the `isUnmessageable` field and also checks `isUnmessageableRole()` for older firmware versions.