### PR TITLE
Refactor: Move version checks to Main.kt

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -63,7 +63,6 @@ import com.geeksville.mesh.android.permissionMissing
 import com.geeksville.mesh.android.shouldShowRequestPermissionRationale
 import com.geeksville.mesh.concurrent.handledLaunch
 import com.geeksville.mesh.model.BluetoothViewModel
-import com.geeksville.mesh.model.DeviceVersion
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.navigation.DEEP_LINK_BASE_URI
 import com.geeksville.mesh.service.MeshService
@@ -272,33 +271,6 @@ class MainActivity : AppCompatActivity(), Logging {
     private fun onMeshConnectionChanged(newConnection: MeshService.ConnectionState) {
         if (newConnection == MeshService.ConnectionState.CONNECTED) {
             serviceRepository.meshService?.let { service ->
-                try {
-                    val info: MyNodeInfo? = service.myNodeInfo // this can be null
-
-                    if (info != null) {
-                        val isOld = info.minAppVersion > BuildConfig.VERSION_CODE
-                        if (isOld) {
-                            model.showAlert(
-                                getString(R.string.app_too_old),
-                                getString(R.string.must_update),
-                                dismissable = false,
-                            )
-                        } else {
-                            // If we are already doing an update don't put up a dialog or try to get device info
-                            val isUpdating = service.updateStatus >= 0
-                            if (!isUpdating) {
-                                val curVer = DeviceVersion(info.firmwareVersion ?: "0.0.0")
-                                if (curVer < MeshService.minDeviceVersion) {
-                                    val title = getString(R.string.firmware_too_old)
-                                    val message = getString(R.string.firmware_old)
-                                    model.showAlert(title, message, dismissable = false)
-                                }
-                            }
-                        }
-                    }
-                } catch (ex: RemoteException) {
-                    warn("Abandoning connect $ex, because we probably just lost device connection")
-                }
                 // if provideLocation enabled: Start providing location (from phone GPS) to mesh
                 if (model.provideLocation.value == true) {
                     service.startProvideLocation()
@@ -349,7 +321,6 @@ class MainActivity : AppCompatActivity(), Logging {
                     onConfirm = {
                         showAlertAppNotificationSettings()
                     },
-                    dismissable = true
                 ).also {
                     prefs.edit { putBoolean("dnd_rationale_shown", true) }
                 }

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -221,7 +221,7 @@ class UIViewModel @Inject constructor(
                 html = html,
                 onConfirm = {
                     onConfirm?.invoke()
-                    if (dismissable) dismissAlert()
+                    dismissAlert()
                 },
                 onDismiss = {
                     if (dismissable) dismissAlert()

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -197,7 +197,7 @@ private fun VersionChecks(
         if (connectionState == MeshService.ConnectionState.CONNECTED) {
             myNodeInfo?.let { info ->
                 val isOld = info.minAppVersion > BuildConfig.VERSION_CODE
-                val curVer = DeviceVersion(BuildConfig.MIN_DEVICE_VERSION)
+                val curVer = DeviceVersion(info.firmwareVersion ?: "0.0.0")
                 if (isOld) {
                     viewModel.showAlert(
                         context.getString(R.string.app_too_old),

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -56,6 +57,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -68,7 +70,9 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.R
+import com.geeksville.mesh.model.DeviceVersion
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.navigation.NavGraph
 import com.geeksville.mesh.navigation.Route
@@ -112,6 +116,9 @@ fun MainScreen(
             ScannedQrCodeDialog(viewModel, newChannelSet)
         }
     }
+
+    VersionChecks(viewModel)
+
     val title by viewModel.title.collectAsStateWithLifecycle()
 
     val alertDialogState by viewModel.currentAlert.collectAsStateWithLifecycle()
@@ -175,6 +182,47 @@ fun MainScreen(
             uIViewModel = viewModel,
             navController = navController,
         )
+    }
+}
+
+@Composable
+private fun VersionChecks(
+    viewModel: UIViewModel,
+) {
+    val connectionState by viewModel.connectionState.collectAsStateWithLifecycle()
+    val myNodeInfo by viewModel.myNodeInfo.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    // Check if the device is running an old app version or firmware version
+    LaunchedEffect(connectionState, myNodeInfo) {
+        if (connectionState == MeshService.ConnectionState.CONNECTED) {
+            myNodeInfo?.let { info ->
+                val isOld = info.minAppVersion > BuildConfig.VERSION_CODE
+                val curVer = DeviceVersion(BuildConfig.MIN_DEVICE_VERSION)
+                if (isOld) {
+                    viewModel.showAlert(
+                        context.getString(R.string.app_too_old),
+                        context.getString(R.string.must_update),
+                        dismissable = false,
+                        onConfirm = {
+                            val service = viewModel.meshService ?: return@showAlert
+                            MeshService.changeDeviceAddress(context, service, "n")
+                        }
+                    )
+                } else if (curVer < MeshService.minDeviceVersion) {
+                    val title = context.getString(R.string.firmware_too_old)
+                    val message = context.getString(R.string.firmware_old)
+                    viewModel.showAlert(
+                        title = title,
+                        message = message,
+                        dismissable = false,
+                        onConfirm = {
+                            val service = viewModel.meshService ?: return@showAlert
+                            MeshService.changeDeviceAddress(context, service, "n")
+                        }
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/AlertDialogs.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/AlertDialogs.kt
@@ -24,11 +24,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -55,7 +55,7 @@ fun SimpleAlertDialog(
                 style = SpanStyle(
                     textDecoration = TextDecoration.Underline,
                     fontStyle = FontStyle.Italic,
-                    color = Color.Blue
+                    color = MaterialTheme.colorScheme.tertiary
                 )
             )
         )


### PR DESCRIPTION
The version checking logic for app and firmware compatibility has been moved from `MainActivity.kt` to `Main.kt`.

This change ensures that:
- Version checks are performed within the Composable UI layer.
- Alerts for outdated app or firmware versions are now displayed using the `UIViewModel.showAlert` mechanism.
- On confirming these alerts, the device address is changed to "n", effectively disconnecting.
- The `UIState.kt` alert dialog now always dismisses itself on confirm, regardless of the `dismissable` flag.


https://github.com/user-attachments/assets/328814f9-24aa-4f07-ba23-f927493b04a5


