### PR TITLE
Refactor node detail navigation

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -37,7 +37,6 @@ import com.geeksville.mesh.ui.debug.DebugScreen
 import com.geeksville.mesh.ui.map.MapView
 import com.geeksville.mesh.ui.message.MessageScreen
 import com.geeksville.mesh.ui.message.QuickChatScreen
-import com.geeksville.mesh.ui.node.NodeScreen
 import com.geeksville.mesh.ui.sharing.ShareScreen
 import kotlinx.serialization.Serializable
 
@@ -53,9 +52,6 @@ const val DEEP_LINK_BASE_URI = "meshtastic://meshtastic"
 @Serializable
 sealed interface Graph : Route {
     @Serializable
-    data class NodeDetailGraph(val destNum: Int) : Graph
-
-    @Serializable
     data class RadioConfigGraph(val destNum: Int? = null) : Graph
 }
 
@@ -63,9 +59,6 @@ sealed interface Graph : Route {
 sealed interface Route {
     @Serializable
     data object Contacts : Route
-
-    @Serializable
-    data object Nodes : Route
 
     @Serializable
     data object Map : Route
@@ -223,13 +216,6 @@ fun NavGraph(
                 onNavigate = { navController.navigate(Route.Messages(it)) }
             )
         }
-        composable<Route.Nodes> {
-            NodeScreen(
-                model = uIViewModel,
-                navigateToMessages = { navController.navigate(Route.Messages(it)) },
-                navigateToNodeDetails = { navController.navigate(Route.NodeDetail(it)) },
-            )
-        }
         composable<Route.Map> {
             MapView(uIViewModel)
         }
@@ -262,7 +248,7 @@ fun NavGraph(
         composable<Route.QuickChat> {
             QuickChatScreen()
         }
-        nodeDetailGraph(
+        nodesGraph(
             navController,
             uIViewModel,
         )

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -77,6 +77,7 @@ import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.navigation.ChannelsRoutes
 import com.geeksville.mesh.navigation.ConnectionsRoutes
 import com.geeksville.mesh.navigation.NavGraph
+import com.geeksville.mesh.navigation.NodesRoutes
 import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.navigation.showLongNameTitle
 import com.geeksville.mesh.service.MeshService
@@ -88,7 +89,7 @@ import com.geeksville.mesh.ui.debug.DebugMenuActions
 
 enum class TopLevelDestination(@StringRes val label: Int, val icon: ImageVector, val route: Route) {
     Contacts(R.string.contacts, Icons.AutoMirrored.TwoTone.Chat, Route.Contacts),
-    Nodes(R.string.nodes, Icons.TwoTone.People, Route.Nodes),
+    Nodes(R.string.nodes, Icons.TwoTone.People, NodesRoutes.Nodes),
     Map(R.string.map, Icons.TwoTone.Map, Route.Map),
     Channels(R.string.channels, Icons.TwoTone.Contactless, ChannelsRoutes.Channels),
     Connections(R.string.connections, Icons.TwoTone.CloudOff, ConnectionsRoutes.Connections),


### PR DESCRIPTION
This commit refactors the navigation for the node detail screen.
- Renames `NodeDetailGraph.kt` to `NodesGraph.kt`.
- Creates a new sealed class `NodesRoutes` to encapsulate routes related to nodes.
- Moves the `Nodes` route from the main `Route` sealed interface to `NodesRoutes`.
- Updates the main navigation graph to use the new `nodesGraph` and `NodesRoutes`.
- Adjusts how ViewModels are retrieved in `NodeDetailScreen` and related composables.