### PR TITLE
Fix location sharing

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -270,14 +270,6 @@ class MainActivity : AppCompatActivity(), Logging {
     // Called when we gain/lose a connection to our mesh radio
     private fun onMeshConnectionChanged(newConnection: MeshService.ConnectionState) {
         if (newConnection == MeshService.ConnectionState.CONNECTED) {
-            serviceRepository.meshService?.let { service ->
-                // if provideLocation enabled: Start providing location (from phone GPS) to mesh
-                if (model.provideLocation.value == true) {
-                    service.startProvideLocation()
-                } else {
-                    service.stopProvideLocation()
-                }
-            }
             checkNotificationPermissions()
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/DataStoreModule.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/DataStoreModule.kt
@@ -22,13 +22,9 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.dataStoreFile
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStoreFile
 import com.geeksville.mesh.AppOnlyProtos.ChannelSet
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.LocalOnlyProtos.LocalModuleConfig
-import com.geeksville.mesh.repository.location.LOCATION_PREFERNCES_NAME
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -81,11 +77,4 @@ object DataStoreModule {
             scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         )
     }
-
-    @Singleton
-    @Provides
-    fun provideLocationPreferencesDataStore(@ApplicationContext appContext: Context): DataStore<Preferences> =
-        PreferenceDataStoreFactory.create(
-            produceFile = { appContext.preferencesDataStoreFile(LOCATION_PREFERNCES_NAME) }
-        )
 }


### PR DESCRIPTION
This commit fixes an issue where location sharing settings were not being applied correctly when switching between different Meshtastic devices. The "Provide location to mesh" setting is now saved per device, ensuring that your preference is respected for each connected node.

Additionally, the UI has been updated to reflect the actual status of location updates being sent to the mesh. The checkbox will now accurately show whether location data is being shared.
