### PR TITLE
revert: do not clear databases on disconnect

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1991,7 +1991,7 @@ class MeshService : Service(), Logging {
 
     lateinit var sharedPreferences: SharedPreferences
 
-    fun clearNodeDB() = serviceScope.handledLaunch {
+    fun clearDatabases() = serviceScope.handledLaunch {
         debug("Clearing nodeDB")
         radioConfigRepository.clearNodeDB()
     }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1991,7 +1991,7 @@ class MeshService : Service(), Logging {
 
     lateinit var sharedPreferences: SharedPreferences
 
-    fun clearDatabases() = serviceScope.handledLaunch {
+    fun clearNodeDB() = serviceScope.handledLaunch {
         debug("Clearing nodeDB")
         radioConfigRepository.clearNodeDB()
     }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1992,10 +1992,8 @@ class MeshService : Service(), Logging {
     lateinit var sharedPreferences: SharedPreferences
 
     fun clearDatabases() = serviceScope.handledLaunch {
-        debug("Clearing all databases")
+        debug("Clearing nodeDB")
         radioConfigRepository.clearNodeDB()
-        packetRepository.get().clearPacketDB()
-        meshLogRepository.get().deleteAll()
     }
 
     private fun updateLastAddress(deviceAddr: String?) {


### PR DESCRIPTION
This commit removes the clearing of the packet and mesh log databases when the device disconnects. The node database is still cleared.