### PR TITLE
refactor: recommended and required firmware updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,8 @@ android {
         versionCode Configs.VERSION_CODE // format is Mmmss (where M is 1+the numeric major number
         versionName Configs.VERSION_NAME
         testInstrumentationRunner "com.geeksville.mesh.TestRunner"
-        buildConfigField("String", "MIN_DEVICE_VERSION", "\"${Configs.MIN_DEVICE_VERSION}\"")
+        buildConfigField("String", "MIN_FW_VERSION", "\"${Configs.MIN_FW_VERSION}\"")
+        buildConfigField("String", "ABS_MIN_FW_VERSION", "\"${Configs.ABS_MIN_FW_VERSION}\"")
         // per https://developer.android.com/studio/write/vector-asset-studio
         vectorDrawables.useSupportLibrary = true
     }
@@ -110,6 +111,23 @@ android {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
 }
+
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 // per protobuf-gradle-plugin docs, this is recommended for android
 protobuf {

--- a/app/src/main/java/com/geeksville/mesh/database/entity/FirmwareReleaseEntity.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/entity/FirmwareReleaseEntity.kt
@@ -80,6 +80,12 @@ fun FirmwareReleaseEntity.asDeviceVersion(): DeviceVersion {
     )
 }
 
+fun FirmwareRelease.asDeviceVersion(): DeviceVersion {
+    return DeviceVersion(
+        id.substringBeforeLast(".").replace("v", "")
+    )
+}
+
 enum class FirmwareReleaseType {
     STABLE,
     ALPHA

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -55,6 +55,8 @@ import com.geeksville.mesh.database.QuickChatActionRepository
 import com.geeksville.mesh.database.entity.MyNodeEntity
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.database.entity.QuickChatAction
+import com.geeksville.mesh.database.entity.asDeviceVersion
+import com.geeksville.mesh.repository.api.FirmwareReleaseRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.repository.location.LocationRepository
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
@@ -77,6 +79,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -183,6 +186,7 @@ class UIViewModel @Inject constructor(
     private val packetRepository: PacketRepository,
     private val quickChatActionRepository: QuickChatActionRepository,
     private val locationRepository: LocationRepository,
+    firmwareReleaseRepository: FirmwareReleaseRepository,
     private val preferences: SharedPreferences
 ) : ViewModel(), Logging {
 
@@ -559,6 +563,8 @@ class UIViewModel @Inject constructor(
         errormsg("Channel url error: ${ex.message}")
         showSnackbar(R.string.channel_invalid)
     }
+
+    val latestStableFirmwareRelease = firmwareReleaseRepository.stableRelease.mapNotNull { it?.asDeviceVersion() }
 
     /**
      * Called immediately after activity observes requestChannelUrl

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -193,7 +193,8 @@ class MeshService : Service(), Logging {
         /** The minimum firmware version we know how to talk to. We'll still be able
          * to talk to 2.0 firmwares but only well enough to ask them to firmware update.
          */
-        val minDeviceVersion = DeviceVersion(BuildConfig.MIN_DEVICE_VERSION)
+        val minDeviceVersion = DeviceVersion(BuildConfig.MIN_FW_VERSION)
+        val absoluteMinDeviceVersion = DeviceVersion(BuildConfig.ABS_MIN_FW_VERSION)
     }
 
     enum class ConnectionState {

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -195,6 +196,8 @@ private fun VersionChecks(
     val connectionState by viewModel.connectionState.collectAsStateWithLifecycle()
     val myNodeInfo by viewModel.myNodeInfo.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val latestStableFirmwareRelease by
+    viewModel.latestStableFirmwareRelease.collectAsState(DeviceVersion("2.6.4"))
     // Check if the device is running an old app version or firmware version
     LaunchedEffect(connectionState, myNodeInfo) {
         if (connectionState == MeshService.ConnectionState.CONNECTED) {
@@ -211,17 +214,30 @@ private fun VersionChecks(
                             MeshService.changeDeviceAddress(context, service, "n")
                         }
                     )
-                } else if (curVer < MeshService.minDeviceVersion) {
+                } else if (curVer < MeshService.absoluteMinDeviceVersion) {
                     val title = context.getString(R.string.firmware_too_old)
                     val message = context.getString(R.string.firmware_old)
                     viewModel.showAlert(
                         title = title,
-                        message = message,
+                        html = message,
                         dismissable = false,
                         onConfirm = {
                             val service = viewModel.meshService ?: return@showAlert
                             MeshService.changeDeviceAddress(context, service, "n")
                         }
+                    )
+                } else if (curVer < MeshService.minDeviceVersion) {
+                    val title = context.getString(R.string.should_update_firmware)
+                    val message =
+                        context.getString(
+                            R.string.should_update,
+                            latestStableFirmwareRelease.asString
+                        )
+                    viewModel.showAlert(
+                        title = title,
+                        message = message,
+                        dismissable = false,
+                        onConfirm = {}
                     )
                 }
             }

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/AlertDialogs.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/AlertDialogs.kt
@@ -55,7 +55,7 @@ fun SimpleAlertDialog(
                 style = SpanStyle(
                     textDecoration = TextDecoration.Underline,
                     fontStyle = FontStyle.Italic,
-                    color = MaterialTheme.colorScheme.tertiary
+                    color = MaterialTheme.colorScheme.primary
                 )
             )
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,7 +170,7 @@
     <string name="meshtastic_messages_notifications">Message notifications</string>
     <string name="meshtastic_alerts_notifications">Alert notifications</string>
     <string name="protocol_stress_test">Protocol stress test</string>
-    <string name="firmware_too_old">Firmware update required</string>
+    <string name="firmware_too_old">Firmware update required.</string>
     <string name="firmware_old">The radio firmware is too old to talk to this application. For more information on this see <a href="https://meshtastic.org/docs/getting-started/flashing-firmware">our Firmware Installation guide</a>.</string>
     <string name="okay">OK</string>
     <string name="must_set_region">You must set a region!</string>
@@ -667,4 +667,6 @@
     <string name="map_reporting_consent_text">By enabling this feature, you acknowledge and expressly consent to the transmission of your device’s real-time geographic location over the MQTT protocol without encryption. This location data may be used for purposes such as live map reporting, device tracking, and related telemetry functions.</string>
     <string name="i_agree_to_share_my_location">I have read and understand the above. I voluntarily consent to the unencrypted transmission of my node data via MQTT</string>
     <string name="i_agree">I agree.</string>
+    <string name="should_update_firmware">Firmware Update Recommended.</string>
+    <string name="should_update">To benefit from the latest fixes and features, please update your node firmware.\n\nLatest stable firmware version: %1$s</string>
 </resources>

--- a/buildSrc/src/main/kotlin/Configs.kt
+++ b/buildSrc/src/main/kotlin/Configs.kt
@@ -23,5 +23,6 @@ object Configs {
     const val VERSION_CODE = 30609 // format is Mmmss (where M is 1+the numeric major number
     const val VERSION_NAME = "2.6.9"
     const val USE_CRASHLYTICS = false // Set to true if you want to use Firebase Crashlytics
-    const val MIN_DEVICE_VERSION = "2.5.14" // Minimum device firmware version supported by this app
+    const val MIN_FW_VERSION = "2.5.14" // Minimum device firmware version supported by this app
+    const val ABS_MIN_FW_VERSION = "2.3.15" // Minimum device firmware version supported by this app
 }


### PR DESCRIPTION
This commit introduces a distinction between a recommended minimum firmware version and an absolute minimum firmware version.

- If the device firmware is below the *absolute minimum*, the user will be forced to update before proceeding.
- If the device firmware is below the *recommended minimum* but above the absolute minimum, the user will see a recommendation to update to the latest stable version to benefit from new features and fixes.

This change aims to improve user experience by providing clearer guidance on firmware updates and ensuring compatibility while allowing users with slightly older, but still functional, firmware to continue using the app.
