### PR TITLE
fix: connections ui and unmessageable logic

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -552,7 +552,7 @@ class UIViewModel @Inject constructor(
     val connectionState get() = radioConfigRepository.connectionState
     fun isConnected() = connectionState.value != MeshService.ConnectionState.DISCONNECTED
     val isConnected =
-        radioConfigRepository.connectionState.map { it == MeshService.ConnectionState.CONNECTED }
+        radioConfigRepository.connectionState.map { it != MeshService.ConnectionState.DISCONNECTED }
 
     private val _requestChannelSet = MutableStateFlow<AppOnlyProtos.ChannelSet?>(null)
     val requestChannelSet: StateFlow<AppOnlyProtos.ChannelSet?> get() = _requestChannelSet

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -406,7 +407,22 @@ fun ConnectionsScreen(
                         value = manualIpAddress,
                         onValueChange = { manualIpAddress = it },
                         label = { Text(stringResource(R.string.ip_address)) },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number,
+                            imeAction = androidx.compose.ui.text.input.ImeAction.Done
+                        ),
+                        keyboardActions = KeyboardActions {
+                            if (manualIpAddress.isIPAddress()) {
+                                scanModel.onSelected(
+                                    BTScanModel.DeviceListEntry(
+                                        "",
+                                        "t$manualIpAddress:$manualIpPort",
+                                        true
+                                    )
+                                )
+                            }
+                        },
                         modifier = Modifier
                             .weight(0.7f)
                             .padding(start = 16.dp)
@@ -420,7 +436,22 @@ fun ConnectionsScreen(
                             }
                         },
                         label = { Text(stringResource(R.string.ip_port)) },
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Number,
+                            imeAction = androidx.compose.ui.text.input.ImeAction.Done
+                        ),
+                        keyboardActions = KeyboardActions {
+                            if (manualIpAddress.isIPAddress()) {
+                                scanModel.onSelected(
+                                    BTScanModel.DeviceListEntry(
+                                        "",
+                                        "t$manualIpAddress:$manualIpPort",
+                                        true
+                                    )
+                                )
+                            }
+                        },
                         modifier = Modifier
                             .weight(weight = 0.3f)
                             .padding(start = 8.dp)

--- a/app/src/main/java/com/geeksville/mesh/ui/node/components/NodeChip.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/components/NodeChip.kt
@@ -63,19 +63,19 @@ fun NodeChip(
             ),
             label = {
                 Text(
-                    modifier = Modifier.Companion
+                    modifier = Modifier
                         .fillMaxWidth(),
                     text = node.user.shortName.ifEmpty { "???" },
                     fontSize = MaterialTheme.typography.labelLarge.fontSize,
-                    textDecoration = TextDecoration.Companion.LineThrough.takeIf { isIgnored },
-                    textAlign = TextAlign.Companion.Center,
+                    textDecoration = TextDecoration.LineThrough.takeIf { isIgnored },
+                    textAlign = TextAlign.Center,
                 )
             },
             onClick = {},
             interactionSource = inputChipInteractionSource,
         )
         Box(
-            modifier = Modifier.Companion
+            modifier = Modifier
                 .matchParentSize()
                 .combinedClickable(
                     onClick = { onAction(NodeMenuAction.MoreDetails(node)) },

--- a/app/src/main/java/com/geeksville/mesh/ui/node/components/NodeItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/components/NodeItem.kt
@@ -49,7 +49,6 @@ import com.geeksville.mesh.ConfigProtos.Config.DeviceConfig
 import com.geeksville.mesh.ConfigProtos.Config.DisplayConfig
 import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.R
-import com.geeksville.mesh.model.DeviceVersion
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.isUnmessageableRole
 import com.geeksville.mesh.ui.common.components.BatteryInfo
@@ -101,11 +100,7 @@ fun NodeItem(
     val unmessageable = remember(thatNode) {
         when {
             thatNode.user.hasIsUnmessagable() -> thatNode.user.isUnmessagable
-            thatNode.user.role.isUnmessageableRole() ->
-                thatNode.metadata?.firmwareVersion?.let {
-                    DeviceVersion(it) < DeviceVersion("2.6.8")
-                } ?: true
-            else -> false
+            else -> thatNode.user.role.isUnmessageableRole()
         }
     }
 


### PR DESCRIPTION
The `isUnmessageableRole` check previously included a firmware version comparison. This has been removed as it is no longer necessary.

Additionally, this commit:
- Fixes `UIState.isConnected` to correctly reflect any connected state.
- Updates `NodeChip` to use `Modifier` directly instead of `Modifier.Companion`.
- Enables "Done" key action on manual IP/Port input fields in the Connections screen to initiate connection.
