### PR TITLE
Refactor: Use FLAG_ACTIVITY_SINGLE_TOP for MainActivity intents

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -224,7 +224,9 @@ class MainActivity : AppCompatActivity(), Logging {
         val startActivityIntent = Intent(
             Intent.ACTION_VIEW, deepLink.toUri(),
             this, MainActivity::class.java
-        )
+        ).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
 
         val resultPendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
             addNextIntentWithParentStack(startActivityIntent)
@@ -234,11 +236,13 @@ class MainActivity : AppCompatActivity(), Logging {
     }
 
     private fun createSettingsIntent(): PendingIntent {
-        val deepLink = "$DEEP_LINK_BASE_URI/settings"
+        val deepLink = "$DEEP_LINK_BASE_URI/connections"
         val startActivityIntent = Intent(
             Intent.ACTION_VIEW, deepLink.toUri(),
             this, MainActivity::class.java
-        )
+        ).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
 
         val resultPendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
             addNextIntentWithParentStack(startActivityIntent)
@@ -387,7 +391,6 @@ class MainActivity : AppCompatActivity(), Logging {
 
     override fun onStart() {
         super.onStart()
-
         bluetoothViewModel.enabled.observe(this) { enabled ->
             if (!enabled && !requestedEnable && model.selectedBluetooth) {
                 requestedEnable = true

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -355,7 +355,9 @@ class MeshServiceNotifications(
         PendingIntent.getActivity(
             context,
             0,
-            Intent(context, MainActivity::class.java),
+            Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
             PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
     }
@@ -368,13 +370,16 @@ class MeshServiceNotifications(
     }
 
     private fun createOpenMessageIntent(contactKey: String): PendingIntent {
+        val intentFlags = Intent.FLAG_ACTIVITY_SINGLE_TOP
         val deepLink = "$DEEP_LINK_BASE_URI/messages/$contactKey"
         val deepLinkIntent = Intent(
             Intent.ACTION_VIEW,
             deepLink.toUri(),
             context,
             MainActivity::class.java
-        )
+        ).apply {
+            flags = intentFlags
+        }
 
         val deepLinkPendingIntent: PendingIntent = TaskStackBuilder.create(context).run {
             addNextIntentWithParentStack(deepLinkIntent)


### PR DESCRIPTION
This change ensures that when `MainActivity` is launched via an intent (e.g., from a notification or shortcut), an existing instance of the activity is brought to the front instead of creating a new one. This improves the user experience by preventing multiple instances of the main activity from being created.
