### PR TITLE
fix: ensure bg loc permissions, unbind service

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -389,6 +389,25 @@ class MainActivity : AppCompatActivity(), Logging {
         )
     }
 
+    private fun unbindMeshService() {
+        // If we have received the service, and hence registered with
+        // it, then now is the time to unregister.
+        // if we never connected, do nothing
+        debug("Unbinding from mesh service!")
+        connectionJob?.let { job ->
+            connectionJob = null
+            warn("We had a pending onConnection job, so we are cancelling it")
+            job.cancel("unbinding")
+        }
+        mesh.close()
+        serviceRepository.setMeshService(null)
+    }
+
+    override fun onStop() {
+        unbindMeshService()
+        super.onStop()
+    }
+
     override fun onStart() {
         super.onStart()
         bluetoothViewModel.enabled.observe(this) { enabled ->

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -471,6 +471,16 @@ fun ConnectionsScreen(
             }
             AnimatedVisibility(isConnected) {
                 val provideLocation by uiViewModel.provideLocation.collectAsState(false)
+                LaunchedEffect(provideLocation) {
+                    if (provideLocation) {
+                        if (!context.hasLocationPermission()) {
+                            debug("Requesting location permission for providing location")
+                            showLocationRationaleDialog = true
+                        } else if (isGpsDisabled) {
+                            uiViewModel.showSnackbar(context.getString(R.string.location_disabled))
+                        }
+                    }
+                }
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()


### PR DESCRIPTION
When the "Provide Location to Mesh" setting is enabled, this change will:
- Request location permission if not already granted.
- Display a snackbar message if GPS is disabled.

Additionally, this commit unbinds the mesh service in `onStop()` to ensure proper cleanup.

