### PR TITLE
fix: cancel new message notification when message is marked as read

### DIFF
--- a/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
+++ b/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
@@ -171,7 +171,4 @@ interface IMeshService {
 
     /// Send request for node UserInfo
     void requestUserInfo(in int destNum);
-
-    /// Cancels a new message notification for a given channel/contact
-    void cancelMessageNotification(String contactKey);
 }

--- a/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
+++ b/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
@@ -171,4 +171,7 @@ interface IMeshService {
 
     /// Send request for node UserInfo
     void requestUserInfo(in int destNum);
+
+    /// Cancels a new message notification for a given channel/contact
+    void cancelMessageNotification(String contactKey);
 }

--- a/app/src/main/java/com/geeksville/mesh/ApplicationModule.kt
+++ b/app/src/main/java/com/geeksville/mesh/ApplicationModule.kt
@@ -23,6 +23,7 @@ import android.content.SharedPreferences
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.geeksville.mesh.service.MeshServiceNotifications
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -44,5 +45,10 @@ object ApplicationModule {
     @Provides
     fun provideProcessLifecycle(processLifecycleOwner: LifecycleOwner): Lifecycle {
         return processLifecycleOwner.lifecycle
+    }
+
+    @Provides
+    fun providesMeshServiceNotifications(application: Application): MeshServiceNotifications {
+        return MeshServiceNotifications(application)
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -61,6 +61,7 @@ import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.repository.location.LocationRepository
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.service.MeshService
+import com.geeksville.mesh.service.MeshServiceNotifications
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.ui.map.MAP_STYLE_ID
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
@@ -187,7 +188,8 @@ class UIViewModel @Inject constructor(
     private val quickChatActionRepository: QuickChatActionRepository,
     private val locationRepository: LocationRepository,
     firmwareReleaseRepository: FirmwareReleaseRepository,
-    private val preferences: SharedPreferences
+    private val preferences: SharedPreferences,
+    private val meshServiceNotifications: MeshServiceNotifications
 ) : ViewModel(), Logging {
 
     private val _theme =
@@ -542,7 +544,7 @@ class UIViewModel @Inject constructor(
     fun clearUnreadCount(contact: String, timestamp: Long) = viewModelScope.launch(Dispatchers.IO) {
         packetRepository.clearUnreadCount(contact, timestamp)
         val unreadCount = packetRepository.getUnreadCount(contact)
-        if (unreadCount == 0) meshService?.cancelMessageNotification(contact)
+        if (unreadCount == 0) meshServiceNotifications.cancelMessageNotification(contact)
     }
 
     companion object {

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -61,7 +61,6 @@ import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.repository.location.LocationRepository
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.service.MeshService
-import com.geeksville.mesh.service.MeshServiceNotifications
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.ui.map.MAP_STYLE_ID
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
@@ -190,8 +189,6 @@ class UIViewModel @Inject constructor(
     firmwareReleaseRepository: FirmwareReleaseRepository,
     private val preferences: SharedPreferences
 ) : ViewModel(), Logging {
-
-    private val notifications = MeshServiceNotifications(app)
 
     private val _theme =
         MutableStateFlow(preferences.getInt("theme", AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM))
@@ -545,7 +542,7 @@ class UIViewModel @Inject constructor(
     fun clearUnreadCount(contact: String, timestamp: Long) = viewModelScope.launch(Dispatchers.IO) {
         packetRepository.clearUnreadCount(contact, timestamp)
         val unreadCount = packetRepository.getUnreadCount(contact)
-        if (unreadCount == 0) notifications.cancelMessageNotification(contact)
+        if (unreadCount == 0) meshService?.cancelMessageNotification(contact)
     }
 
     companion object {

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -61,6 +61,7 @@ import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.repository.location.LocationRepository
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.service.MeshService
+import com.geeksville.mesh.service.MeshServiceNotifications
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.ui.map.MAP_STYLE_ID
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
@@ -189,6 +190,8 @@ class UIViewModel @Inject constructor(
     firmwareReleaseRepository: FirmwareReleaseRepository,
     private val preferences: SharedPreferences
 ) : ViewModel(), Logging {
+
+    private val notifications = MeshServiceNotifications(app)
 
     private val _theme =
         MutableStateFlow(preferences.getInt("theme", AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM))
@@ -541,6 +544,8 @@ class UIViewModel @Inject constructor(
 
     fun clearUnreadCount(contact: String, timestamp: Long) = viewModelScope.launch(Dispatchers.IO) {
         packetRepository.clearUnreadCount(contact, timestamp)
+        val unreadCount = packetRepository.getUnreadCount(contact)
+        if (unreadCount == 0) notifications.cancelMessageNotification(contact)
     }
 
     companion object {

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -150,6 +150,9 @@ class MeshService : Service(), Logging {
     @Inject
     lateinit var mqttRepository: MQTTRepository
 
+    @Inject
+    lateinit var serviceNotifications: MeshServiceNotifications
+
     companion object : Logging {
 
         // Intents broadcast by MeshService
@@ -212,7 +215,6 @@ class MeshService : Service(), Logging {
 
     // A mapping of receiver class name to package name - used for explicit broadcasts
     private val clientPackages = mutableMapOf<String, String>()
-    private val serviceNotifications = MeshServiceNotifications(this)
     private val serviceBroadcasts = MeshServiceBroadcasts(this, clientPackages) {
         connectionState.also { radioConfigRepository.setConnectionState(it) }
     }
@@ -2326,10 +2328,6 @@ class MeshService : Service(), Logging {
             sendToRadio(newMeshPacketTo(destNum).buildAdminPacket(id = requestId) {
                 nodedbReset = 1
             })
-        }
-
-        override fun cancelMessageNotification(contactKey: String) = toRemoteExceptions {
-            serviceNotifications.cancelMessageNotification(contactKey)
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -2327,5 +2327,9 @@ class MeshService : Service(), Logging {
                 nodedbReset = 1
             })
         }
+
+        override fun cancelMessageNotification(contactKey: String) = toRemoteExceptions {
+            serviceNotifications.cancelMessageNotification(contactKey)
+        }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/service/ReplyReceiver.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/ReplyReceiver.kt
@@ -35,6 +35,9 @@ class ReplyReceiver : BroadcastReceiver() {
     @Inject
     lateinit var serviceRepository: ServiceRepository
 
+    @Inject
+    lateinit var meshServiceNotifications: MeshServiceNotifications
+
     companion object {
         const val REPLY_ACTION = "com.geeksville.mesh.REPLY_ACTION"
         const val CONTACT_KEY = "contactKey"


### PR DESCRIPTION
When a message list with unread messages is opened and scrolled to most recent item, an obsolete notification about unread messages in this channel/DM is now cancelled. Prior to this change notification had to be manually dismissed.