### PR TITLE
Refactor: Consolidate DropdownMenu into RegularPreference

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/DropDownPreference.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/DropDownPreference.kt
@@ -18,7 +18,6 @@
 package com.geeksville.mesh.ui.common.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.KeyboardArrowDown
 import androidx.compose.material.icons.twotone.KeyboardArrowUp
@@ -85,7 +84,6 @@ fun <T> DropDownPreference(
             emptyList()
         }
     }
-
     RegularPreference(
         title = title,
         subtitle = items.find { it.first == selectedItem }?.second
@@ -100,38 +98,37 @@ fun <T> DropDownPreference(
             Icons.TwoTone.KeyboardArrowDown
         },
         summary = summary,
-    )
-
-    Box {
-        DropdownMenu(
-            expanded = dropDownExpanded,
-            onDismissRequest = { dropDownExpanded = !dropDownExpanded },
-        ) {
-            items.filterNot { it.first in deprecatedItems }.forEach { item ->
-                DropdownMenuItem(
-                    onClick = {
-                        dropDownExpanded = false
-                        onItemSelected(item.first)
-                    },
-                    modifier = modifier
-                        .background(
-                            color = if (selectedItem == item.first) {
-                                MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
-                            } else {
-                                Color.Unspecified
-                            },
-                        ),
-                    text = {
-                        Text(
-                            text = item.second,
-                            overflow = TextOverflow.Ellipsis,
-                            maxLines = 1,
-                        )
-                    }
-                )
+        dropdownMenu = {
+            DropdownMenu(
+                expanded = dropDownExpanded,
+                onDismissRequest = { dropDownExpanded = !dropDownExpanded },
+            ) {
+                items.filterNot { it.first in deprecatedItems }.forEach { item ->
+                    DropdownMenuItem(
+                        onClick = {
+                            dropDownExpanded = false
+                            onItemSelected(item.first)
+                        },
+                        modifier = modifier
+                            .background(
+                                color = if (selectedItem == item.first) {
+                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
+                                } else {
+                                    Color.Unspecified
+                                },
+                            ),
+                        text = {
+                            Text(
+                                text = item.second,
+                                overflow = TextOverflow.Ellipsis,
+                                maxLines = 1,
+                            )
+                        }
+                    )
+                }
             }
         }
-    }
+    )
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/RegularPreference.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/RegularPreference.kt
@@ -19,6 +19,7 @@ package com.geeksville.mesh.ui.common.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -47,6 +48,7 @@ fun RegularPreference(
     enabled: Boolean = true,
     summary: String? = null,
     trailingIcon: ImageVector? = null,
+    dropdownMenu: @Composable () -> Unit = {},
 ) {
     RegularPreference(
         title = title,
@@ -56,6 +58,7 @@ fun RegularPreference(
         enabled = enabled,
         summary = summary,
         trailingIcon = trailingIcon,
+        dropdownMenu = dropdownMenu,
     )
 }
 
@@ -69,6 +72,7 @@ fun RegularPreference(
     enabled: Boolean = true,
     summary: String? = null,
     trailingIcon: ImageVector? = null,
+    dropdownMenu: @Composable () -> Unit = {},
 ) {
     val color = if (enabled) {
         MaterialTheme.colorScheme.onSurface
@@ -107,14 +111,17 @@ fun RegularPreference(
                 )
             }
             if (trailingIcon != null) {
-                Icon(
-                    imageVector = trailingIcon,
-                    contentDescription = "trailingIcon",
-                    modifier = Modifier
-                        .padding(start = 8.dp)
-                        .wrapContentWidth(Alignment.End),
-                    tint = color,
-                )
+                Box {
+                    Icon(
+                        imageVector = trailingIcon,
+                        contentDescription = "trailingIcon",
+                        modifier = Modifier
+                            .padding(start = 8.dp)
+                            .wrapContentWidth(Alignment.End),
+                        tint = color,
+                    )
+                    dropdownMenu()
+                }
             }
         }
         if (summary != null) {


### PR DESCRIPTION
This commit refactors the `DropDownPreference` composable. The `DropdownMenu` functionality has been moved into the `RegularPreference` composable as an optional parameter.

This ensures the dropdown properly anchors to the trailing icon.
<img width="177" alt="Screenshot 2025-06-08 at 1 44 32 PM" src="https://github.com/user-attachments/assets/300ead37-dfa2-4d91-a204-721f80cf244d" />
