### PR TITLE
feat(#2060): Enforce valid names for UserConfig

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/PreferenceFooter.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/PreferenceFooter.kt
@@ -69,7 +69,6 @@ fun PreferenceFooter(
             modifier = modifier
                 .height(48.dp)
                 .weight(1f),
-            enabled = enabled,
             onClick = onNegativeClicked,
         ) {
             Text(

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -82,6 +82,9 @@ fun UserConfigItemList(
     var userInput by rememberSaveable { mutableStateOf(userConfig) }
     val firmwareVersion = DeviceVersion(metadata?.firmwareVersion ?: "")
 
+    val validLongName = userInput.longName.isNotBlank()
+    val validShortName = userInput.shortName.isNotBlank()
+    val validNames = validLongName && validShortName
     LazyColumn(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -102,7 +105,7 @@ fun UserConfigItemList(
                 value = userInput.longName,
                 maxSize = 39, // long_name max_size:40
                 enabled = enabled,
-                isError = userInput.longName.isEmpty(),
+                isError = !validLongName,
                 keyboardOptions = KeyboardOptions.Default.copy(
                     keyboardType = KeyboardType.Text, imeAction = ImeAction.Done
                 ),
@@ -119,7 +122,7 @@ fun UserConfigItemList(
                 value = userInput.shortName,
                 maxSize = 4, // short_name max_size:5
                 enabled = enabled,
-                isError = userInput.shortName.isEmpty(),
+                isError = !validShortName,
                 keyboardOptions = KeyboardOptions.Default.copy(
                     keyboardType = KeyboardType.Text, imeAction = ImeAction.Done
                 ),
@@ -165,7 +168,7 @@ fun UserConfigItemList(
 
         item {
             PreferenceFooter(
-                enabled = enabled && userInput != userConfig,
+                enabled = enabled && userInput != userConfig && validNames,
                 onCancelClicked = {
                     focusManager.clearFocus()
                     userInput = userConfig


### PR DESCRIPTION
This addresses #2060 by adding validation to  both the userInput `longName` and `shortName` fields for `isBlank` which ```Returns true if this char sequence is not empty and contains some characters except whitespace characters.``` This validation is then applied to the `Send` button enabled state.

Additionally, the redundant `enabled` property was removed from the "Cancel" button within `PreferenceFooter` as we want to allow the user to be able to cancel changes even when invalid.
