### PR TITLE
refactor: ClientNotification messages as an alert dialog

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -424,8 +424,14 @@ class UIViewModel @Inject constructor(
 
     init {
         radioConfigRepository.errorMessage.filterNotNull().onEach {
-            showSnackbar(it)
-            radioConfigRepository.clearErrorMessage()
+            showAlert(
+                title = app.getString(R.string.client_notification),
+                message = it,
+                onConfirm = {
+                    radioConfigRepository.clearErrorMessage()
+                },
+                dismissable = false
+            )
         }.launchIn(viewModelScope)
 
         radioConfigRepository.localConfigFlow.onEach { config ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -678,4 +678,5 @@
     <string name="only_favorites">Only Favorites</string>
     <string name="show_waypoints">Show Waypoints</string>
     <string name="show_precision_circle">Show Precision Circles</string>
+    <string name="client_notification">Client Notification</string>
 </resources>


### PR DESCRIPTION
RadioConfig errors and therefore ClientNotification messages were previously shown as a temporary snackbar, but now they are shown as a dialog.

The dialog is not dismissable, so the user has to acknowledge the message before they can continue.

This provides a more prominent exposure and acknowledgement of Client Notification messages that may require a user's action or attention.

A new string `client_notification` has been added for the title of the alert.