### PR TITLE
feat: filter node list by user id or node number

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
@@ -70,8 +70,8 @@ interface NodeInfoDao {
         AND (:filter = ''
             OR (long_name LIKE '%' || :filter || '%'
             OR short_name LIKE '%' || :filter || '%'
-            OR '!' || substr(printf('%08x', num), -8) LIKE '%' || :filter || '%'
-            OR printf('%i', num) LIKE '%' || :filter || '%'))
+            OR printf('!%08x', CASE WHEN num < 0 THEN num + 4294967296 ELSE num END) LIKE '%' || :filter || '%'
+            OR CASE WHEN num < 0 THEN num + 4294967296 ELSE num END LIKE '%' || :filter || '%'))
         AND (:lastHeardMin = -1 OR last_heard >= :lastHeardMin)
         AND (:hopsAwayMax = -1 OR (hops_away <= :hopsAwayMax AND hops_away >= 0) OR num = (SELECT myNodeNum FROM my_node LIMIT 1))
     ORDER BY CASE

--- a/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
@@ -69,7 +69,9 @@ interface NodeInfoDao {
     WHERE (:includeUnknown = 1 OR short_name IS NOT NULL)
         AND (:filter = ''
             OR (long_name LIKE '%' || :filter || '%'
-            OR short_name LIKE '%' || :filter || '%'))
+            OR short_name LIKE '%' || :filter || '%'
+            OR '!' || substr(printf('%08x', num), -8) LIKE '%' || :filter || '%'
+            OR printf('%i', num) LIKE '%' || :filter || '%'))
         AND (:lastHeardMin = -1 OR last_heard >= :lastHeardMin)
         AND (:hopsAwayMax = -1 OR (hops_away <= :hopsAwayMax AND hops_away >= 0) OR num = (SELECT myNodeNum FROM my_node LIMIT 1))
     ORDER BY CASE

--- a/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
@@ -71,7 +71,7 @@ interface NodeInfoDao {
             OR (long_name LIKE '%' || :filter || '%'
             OR short_name LIKE '%' || :filter || '%'
             OR printf('!%08x', CASE WHEN num < 0 THEN num + 4294967296 ELSE num END) LIKE '%' || :filter || '%'
-            OR CASE WHEN num < 0 THEN num + 4294967296 ELSE num END LIKE '%' || :filter || '%'))
+            OR CAST(CASE WHEN num < 0 THEN num + 4294967296 ELSE num END AS TEXT) LIKE '%' || :filter || '%'))
         AND (:lastHeardMin = -1 OR last_heard >= :lastHeardMin)
         AND (:hopsAwayMax = -1 OR (hops_away <= :hopsAwayMax AND hops_away >= 0) OR num = (SELECT myNodeNum FROM my_node LIMIT 1))
     ORDER BY CASE


### PR DESCRIPTION
With this change, node list filter now recognizes partial or complete node number (decimal) and user id (hex, with optional exclamation mark prefix).