### PR TITLE
feat: adaptive nav

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -183,6 +183,7 @@ dependencies {
     implementation(libs.bundles.androidx)
     implementation(libs.bundles.ui)
     debugImplementation(libs.bundles.ui.tooling)
+    implementation(libs.bundles.adaptive)
     implementation(libs.bundles.lifecycle)
     implementation(libs.bundles.navigation)
     implementation(libs.bundles.coroutines)

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -37,15 +37,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.core.content.edit
 import androidx.core.net.toUri
@@ -157,16 +152,10 @@ class MainActivity : AppCompatActivity(), Logging {
                         AppCompatDelegate.setDefaultNightMode(theme)
                     }
                 }
-                Box(
-                    modifier = Modifier
-                        .background(MaterialTheme.colorScheme.background)
-                        .systemBarsPadding()
-                ) {
-                    MainScreen(
-                        viewModel = model,
-                        onAction = ::onMainMenuAction
-                    )
-                }
+                MainScreen(
+                    viewModel = model,
+                    onAction = ::onMainMenuAction,
+                )
             }
         }
         // Handle any intent

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,6 @@
 [versions]
+adaptive = "1.2.0-alpha06"
+adaptive-navigation-suite = "1.3.2"
 agp = "8.10.1"
 appcompat = "1.7.1"
 appintro = "6.3.1"
@@ -53,6 +55,11 @@ agp = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" 
 activity = { group = "androidx.activity", name = "activity" }
 actvity-ktx = { group = "androidx.activity", name = "activity-ktx" }
 activity-compose = { group = "androidx.activity", name = "activity-compose" }
+adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive", version.ref = "adaptive" }
+adaptive-layout = { group = "androidx.compose.material3.adaptive", name = "adaptive-layout", version.ref = "adaptive" }
+adaptive-navigation = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation", version.ref = "adaptive" }
+adaptive-navigation-android = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation-android", version.ref = "adaptive" }
+adaptive-navigation-suite = { group = "androidx.compose.material3", name = "material3-adaptive-navigation-suite", version.ref = "adaptive-navigation-suite" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 appcompat-resources = { group = "androidx.appcompat", name = "appcompat-resources", version.ref = "appcompat" }
 appintro = { group = "com.github.AppIntro", name = "AppIntro", version.ref = "appintro" }
@@ -139,6 +146,7 @@ androidx = ["core-ktx", "appcompat", "appcompat-resources", "cardview", "fragmen
 
 # UI
 ui = ["material", "constraintlayout", "viewpager2", "compose-material3", "compose-material-icons-extended", "compose-ui-tooling-preview", "compose-runtime-livedata"]
+adaptive = ["adaptive", "adaptive-layout", "adaptive-navigation", "adaptive-navigation-android", "adaptive-navigation-suite"]
 ui-tooling = ["compose-ui-tooling"] #Separate for debugImplementation
 
 # Lifecycle


### PR DESCRIPTION
refactor to [adaptive](https://developer.android.com/develop/ui/compose/layouts/adaptive) design.

This replaces the `Scaffold` and custom `BottomNavigation` in `MainScreen` with `NavigationSuiteScaffold` from the Material 3 adaptive library. This change allows the app's navigation to adapt to different screen sizes.

Dependencies for Material 3 adaptive components have been added to `gradle/libs.versions.toml` and `app/build.gradle.kts`.

The `MainScreen` composable now uses `NavigationSuiteScaffold` to display top-level destinations. The `MainAppBar` and `NavGraph` are now nested within a `Column` inside the `NavigationSuiteScaffold`.

The `BottomNavigation` composable has been removed as its functionality is now handled by `NavigationSuiteScaffold`.

In `MainActivity.kt`, the `Box` composable that wrapped `MainScreen` has been removed as `NavigationSuiteScaffold` handles the background and padding.