### PR TITLE
Fix: Device selection lags

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
@@ -47,7 +47,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
@@ -160,12 +160,10 @@ class BTScanModel @Inject constructor(
     val selectedBluetooth: Boolean get() = selectedAddress?.getOrNull(0) == 'x'
 
     // / Use the string for the NopInterface
-    // val selectedNotNull: String get() = selectedAddress ?: NO_DEVICE_SELECTED
     val selectedAddressFlow: StateFlow<String?> = radioInterfaceService.currentDeviceAddressFlow
-        .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), radioInterfaceService.getDeviceAddress())
 
     val selectedNotNullFlow: StateFlow<String> = selectedAddressFlow
-        .mapLatest { it ?: NO_DEVICE_SELECTED }
+        .map { it ?: NO_DEVICE_SELECTED }
         .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), radioInterfaceService.getDeviceAddress() ?: NO_DEVICE_SELECTED)
 
     val scanResult = MutableLiveData<MutableMap<String, DeviceListEntry>>(mutableMapOf())

--- a/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
@@ -47,7 +47,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
@@ -158,7 +160,13 @@ class BTScanModel @Inject constructor(
     val selectedBluetooth: Boolean get() = selectedAddress?.getOrNull(0) == 'x'
 
     // / Use the string for the NopInterface
-    val selectedNotNull: String get() = selectedAddress ?: NO_DEVICE_SELECTED
+    // val selectedNotNull: String get() = selectedAddress ?: NO_DEVICE_SELECTED
+    val selectedAddressFlow: StateFlow<String?> = radioInterfaceService.currentDeviceAddressFlow
+        .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), radioInterfaceService.getDeviceAddress())
+
+    val selectedNotNullFlow: StateFlow<String> = selectedAddressFlow
+        .mapLatest { it ?: NO_DEVICE_SELECTED }
+        .stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), radioInterfaceService.getDeviceAddress() ?: NO_DEVICE_SELECTED)
 
     val scanResult = MutableLiveData<MutableMap<String, DeviceListEntry>>(mutableMapOf())
 

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -75,6 +75,7 @@ class RadioInterfaceService @Inject constructor(
     private val _receivedData = MutableSharedFlow<ByteArray>()
     val receivedData: SharedFlow<ByteArray> = _receivedData
 
+    // Thread-safe StateFlow for tracking device address changes
     private val _currentDeviceAddressFlow = MutableStateFlow<String?>(prefs.getString(DEVADDR_KEY, null))
     val currentDeviceAddressFlow: StateFlow<String?> = _currentDeviceAddressFlow.asStateFlow()
 

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -73,6 +74,9 @@ class RadioInterfaceService @Inject constructor(
 
     private val _receivedData = MutableSharedFlow<ByteArray>()
     val receivedData: SharedFlow<ByteArray> = _receivedData
+
+    private val _currentDeviceAddressFlow = MutableStateFlow<String?>(prefs.getString(DEVADDR_KEY, null))
+    val currentDeviceAddressFlow: StateFlow<String?> = _currentDeviceAddressFlow.asStateFlow()
 
     private val logSends = false
     private val logReceives = false
@@ -301,6 +305,7 @@ class RadioInterfaceService @Inject constructor(
                     putString(DEVADDR_KEY, address)
                 }
             }
+            _currentDeviceAddressFlow.value = address
 
             // Force the service to reconnect
             startInterface()

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -141,7 +141,7 @@ fun ConnectionsScreen(
     val context = LocalContext.current
     val app = (context.applicationContext as GeeksvilleApplication)
     val info by uiViewModel.myNodeInfo.collectAsState()
-    val selectedDevice = scanModel.selectedNotNull
+    val selectedDevice by scanModel.selectedNotNullFlow.collectAsStateWithLifecycle()
     val bluetoothEnabled by bluetoothViewModel.enabled.observeAsState()
     val regionUnset = currentRegion == ConfigProtos.Config.LoRaConfig.RegionCode.UNSET &&
             connectionState == MeshService.ConnectionState.CONNECTED


### PR DESCRIPTION
Improved device selection state handling with real-time updates, allowing the app to reactively reflect changes to the selected device address.

Closes: #1926, #2000, #2008