### PR TITLE
refactor: Client Notification Support

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -434,6 +434,18 @@ class UIViewModel @Inject constructor(
             )
         }.launchIn(viewModelScope)
 
+        radioConfigRepository.clientNotification.filterNotNull().onEach { notification ->
+            showAlert(
+                title = app.getString(R.string.client_notification),
+                message = notification.message,
+                onConfirm = {
+                    radioConfigRepository.clearClientNotification()
+                    meshServiceNotifications.clearClientNotification(notification)
+                },
+                dismissable = false
+            )
+        }.launchIn(viewModelScope)
+
         radioConfigRepository.localConfigFlow.onEach { config ->
             _localConfig.value = config
         }.launchIn(viewModelScope)

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -25,6 +25,7 @@ import com.geeksville.mesh.ConfigProtos.Config
 import com.geeksville.mesh.IMeshService
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.LocalOnlyProtos.LocalModuleConfig
+import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.MeshProtos.DeviceMetadata
 import com.geeksville.mesh.MeshProtos.MeshPacket
 import com.geeksville.mesh.ModuleConfigProtos.ModuleConfig
@@ -85,6 +86,7 @@ class RadioConfigRepository @Inject constructor(
     suspend fun installNodeDB(mi: MyNodeEntity, nodes: List<NodeEntity>) {
         nodeDB.installNodeDB(mi, nodes)
     }
+
     suspend fun insertMetadata(fromNum: Int, metadata: DeviceMetadata) {
         nodeDB.insertMetadata(MetadataEntity(fromNum, metadata))
     }
@@ -185,6 +187,16 @@ class RadioConfigRepository @Inject constructor(
                 fixedPosition = node.position
             }
         }
+    }
+
+    val clientNotification = serviceRepository.clientNotification
+
+    fun setClientNotification(notification: MeshProtos.ClientNotification?) {
+        serviceRepository.setClientNotification(notification)
+    }
+
+    fun clearClientNotification() {
+        serviceRepository.clearClientNotification()
     }
 
     val errorMessage: StateFlow<String?> get() = serviceRepository.errorMessage

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1723,7 +1723,8 @@ class MeshService : Service(), Logging {
 
     private fun handleClientNotification(notification: MeshProtos.ClientNotification) {
         debug("Received clientNotification ${notification.toOneLineString()}")
-        radioConfigRepository.setErrorMessage(notification.message)
+        radioConfigRepository.setClientNotification(notification)
+        serviceNotifications.showClientNotification(notification)
         // if the future for the originating request is still in the queue, complete as unsuccessful for now
         queueResponse.remove(notification.replyId)?.complete(false)
     }

--- a/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
@@ -18,6 +18,7 @@
 package com.geeksville.mesh.service
 
 import com.geeksville.mesh.IMeshService
+import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.MeshProtos.MeshPacket
 import com.geeksville.mesh.android.Logging
 import kotlinx.coroutines.channels.Channel
@@ -32,6 +33,7 @@ import javax.inject.Singleton
 /**
  * Repository class for managing the [IMeshService] instance and connection state
  */
+@Suppress("TooManyFunctions")
 @Singleton
 class ServiceRepository @Inject constructor() : Logging {
     var meshService: IMeshService? = null
@@ -47,6 +49,18 @@ class ServiceRepository @Inject constructor() : Logging {
 
     fun setConnectionState(connectionState: MeshService.ConnectionState) {
         _connectionState.value = connectionState
+    }
+
+    private val _clientNotification = MutableStateFlow<MeshProtos.ClientNotification?>(null)
+    val clientNotification: StateFlow<MeshProtos.ClientNotification?> get() = _clientNotification
+    fun setClientNotification(notification: MeshProtos.ClientNotification?) {
+        errormsg(notification?.message.orEmpty())
+
+        _clientNotification.value = notification
+    }
+
+    fun clearClientNotification() {
+        _clientNotification.value = null
     }
 
     private val _errorMessage = MutableStateFlow<String?>(null)


### PR DESCRIPTION
This commit introduces support for client notifications.

- Added `clientNotification` StateFlow to `ServiceRepository` and `RadioConfigRepository` to manage client notifications.
- Implemented methods to set and clear client notifications in both repositories.
- Updated `MeshService` to handle `ClientNotification` by setting it in `RadioConfigRepository` and showing a service notification.
- Modified `UIState` to observe `clientNotification` and display an alert dialog when a notification is received.
- Added a new notification channel and methods to show and clear client notifications in `MeshServiceNotifications`.
![image](https://github.com/user-attachments/assets/774dc332-851d-48c8-991b-f6f303286a6e)