### PR TITLE
feat: show node details by long-pressing a node marker on map

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/navigation/MapRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/MapRoutes.kt
@@ -18,6 +18,7 @@
 package com.geeksville.mesh.navigation
 
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import com.geeksville.mesh.model.UIViewModel
@@ -33,6 +34,7 @@ sealed class MapRoutes {
 }
 
 fun NavGraphBuilder.mapGraph(
+    navController: NavHostController,
     uiViewModel: UIViewModel,
 ) {
     navigation<MapRoutes.MapGraph>(
@@ -41,6 +43,9 @@ fun NavGraphBuilder.mapGraph(
         composable<MapRoutes.Map> {
             MapView(
                 model = uiViewModel,
+                navigateToNodeDetails = {
+                    navController.navigate(NodesRoutes.NodeDetail(it))
+                },
             )
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/navigation/MapRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/MapRoutes.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.ui.map.MapView
+import kotlinx.serialization.Serializable
+
+sealed class MapRoutes {
+    @Serializable
+    data object Map : Route
+
+    @Serializable
+    data object MapGraph : Graph
+}
+
+fun NavGraphBuilder.mapGraph(
+    uiViewModel: UIViewModel,
+) {
+    navigation<MapRoutes.MapGraph>(
+        startDestination = MapRoutes.Map,
+    ) {
+        composable<MapRoutes.Map> {
+            MapView(
+                model = uiViewModel,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -31,7 +31,6 @@ import com.geeksville.mesh.R
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.TopLevelDestination.Companion.isTopLevel
 import com.geeksville.mesh.ui.debug.DebugScreen
-import com.geeksville.mesh.ui.map.MapView
 import kotlinx.serialization.Serializable
 
 enum class AdminRoute(@StringRes val title: Int) {
@@ -47,10 +46,6 @@ const val DEEP_LINK_BASE_URI = "meshtastic://meshtastic"
 sealed interface Graph : Route
 @Serializable
 sealed interface Route {
-
-    @Serializable
-    data object Map : Route
-
     @Serializable
     data object DebugPanel : Route
 }
@@ -92,7 +87,7 @@ fun NavGraph(
     ) {
         contactsGraph(navController, uIViewModel)
         nodesGraph(navController, uIViewModel,)
-        composable<Route.Map> { MapView(uIViewModel) }
+        mapGraph(uIViewModel)
         channelsGraph(navController, uIViewModel)
         connectionsGraph(navController, uIViewModel)
         composable<Route.DebugPanel> { DebugScreen() }

--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -87,7 +87,7 @@ fun NavGraph(
     ) {
         contactsGraph(navController, uIViewModel)
         nodesGraph(navController, uIViewModel,)
-        mapGraph(uIViewModel)
+        mapGraph(navController, uIViewModel)
         channelsGraph(navController, uIViewModel)
         connectionsGraph(navController, uIViewModel)
         composable<Route.DebugPanel> { DebugScreen() }

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -77,6 +77,7 @@ import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.navigation.ChannelsRoutes
 import com.geeksville.mesh.navigation.ConnectionsRoutes
 import com.geeksville.mesh.navigation.ContactsRoutes
+import com.geeksville.mesh.navigation.MapRoutes
 import com.geeksville.mesh.navigation.NavGraph
 import com.geeksville.mesh.navigation.NodesRoutes
 import com.geeksville.mesh.navigation.RadioConfigRoutes
@@ -92,7 +93,7 @@ import com.geeksville.mesh.ui.debug.DebugMenuActions
 enum class TopLevelDestination(@StringRes val label: Int, val icon: ImageVector, val route: Route) {
     Contacts(R.string.contacts, Icons.AutoMirrored.TwoTone.Chat, ContactsRoutes.Contacts),
     Nodes(R.string.nodes, Icons.TwoTone.People, NodesRoutes.Nodes),
-    Map(R.string.map, Icons.TwoTone.Map, Route.Map),
+    Map(R.string.map, Icons.TwoTone.Map, MapRoutes.Map),
     Channels(R.string.channels, Icons.TwoTone.Contactless, ChannelsRoutes.Channels),
     Connections(R.string.connections, Icons.TwoTone.CloudOff, ConnectionsRoutes.Connections),
     ;

--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapView.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapView.kt
@@ -211,9 +211,11 @@ private fun Context.purgeTileSource(onResult: (String) -> Unit) {
     builder.show()
 }
 
+@Suppress("CyclomaticComplexMethod", "LongMethod")
 @Composable
 fun MapView(
     model: UIViewModel = viewModel(),
+    navigateToNodeDetails: (Int) -> Unit,
 ) {
     var mapFilterExpanded by remember { mutableStateOf(false) }
 
@@ -343,6 +345,10 @@ fun MapView(
                     setPrecisionBits(0)
                 } else {
                     setPrecisionBits(p.precisionBits)
+                }
+                setOnLongClickListener {
+                    navigateToNodeDetails(node.num)
+                    true
                 }
             }
         }


### PR DESCRIPTION
Long-pressing a map node marker opens up a node detail screen.

Also factored out `MapRoutes` from `NavGraph` for consistency with other UI areas and for future map-related screens.