### PR TITLE
Persist node sort preference across app restarts

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -272,7 +272,10 @@ class UIViewModel @Inject constructor(
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     private val nodeFilterText = MutableStateFlow("")
-    private val nodeSortOption = MutableStateFlow(NodeSortOption.VIA_FAVORITE)
+    private val nodeSortOption = MutableStateFlow(
+        NodeSortOption.entries.find { it.name == preferences.getString("node-sort-option", null) }
+            ?: NodeSortOption.VIA_FAVORITE
+    )
     private val includeUnknown = MutableStateFlow(preferences.getBoolean("include-unknown", false))
     private val showDetails = MutableStateFlow(preferences.getBoolean("show-details", false))
     private val onlyOnline = MutableStateFlow(preferences.getBoolean("only-online", false))
@@ -285,6 +288,7 @@ class UIViewModel @Inject constructor(
 
     fun setSortOption(sort: NodeSortOption) {
         nodeSortOption.value = sort
+        preferences.edit { putString("node-sort-option", sort.name) }
     }
 
     fun toggleShowDetails() {

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -273,8 +273,9 @@ class UIViewModel @Inject constructor(
 
     private val nodeFilterText = MutableStateFlow("")
     private val nodeSortOption = MutableStateFlow(
-        NodeSortOption.entries.find { it.name == preferences.getString("node-sort-option", null) }
-            ?: NodeSortOption.VIA_FAVORITE
+        NodeSortOption.entries.getOrElse(
+            preferences.getInt("node-sort-option", NodeSortOption.VIA_FAVORITE.ordinal)
+        ) { NodeSortOption.VIA_FAVORITE }
     )
     private val includeUnknown = MutableStateFlow(preferences.getBoolean("include-unknown", false))
     private val showDetails = MutableStateFlow(preferences.getBoolean("show-details", false))
@@ -288,7 +289,7 @@ class UIViewModel @Inject constructor(
 
     fun setSortOption(sort: NodeSortOption) {
         nodeSortOption.value = sort
-        preferences.edit { putString("node-sort-option", sort.name) }
+        preferences.edit { putInt("node-sort-option", sort.ordinal) }
     }
 
     fun toggleShowDetails() {


### PR DESCRIPTION
**Problem:** Node sort selection (Last Heard, Alphabetical, Distance, etc.) resets to "Favorites" every time the app is restarted, forcing users to re-select their preference.

**Solution:** 
- Save the selected sort option to SharedPreferences when changed
- Load the saved preference on app startup using enum ordinal values
- Follows the same reliable pattern used by other UI preferences like theme

**Result:** Users' preferred node sorting method now persists across app sessions, maintaining their chosen view of the nodes list.

Tested and working on a TCL T768S (test device)

Closes: #2114 