### PR TITLE
add copy button to pbk for node status icon

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/node/components/NodeKeyStatusIcon.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/components/NodeKeyStatusIcon.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -55,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.Channel
+import com.geeksville.mesh.ui.common.components.CopyIconButton
 import com.geeksville.mesh.ui.common.theme.AppTheme
 import com.google.protobuf.ByteString
 
@@ -100,6 +102,11 @@ private fun KeyStatusDialog(
                             textAlign = TextAlign.Center,
                         )
                     }
+                    Spacer(Modifier.height(8.dp))
+                    CopyIconButton(
+                        valueToCopy = keyString,
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
                     Spacer(Modifier.height(16.dp))
                 }
                 Row(


### PR DESCRIPTION
Added a copy button to the Public key lock icon - #2093 

Tested and working on HW. 

<img width="355" alt="image" src="https://github.com/user-attachments/assets/5c2cb5fc-207a-4327-8af3-da5a446bfc4b" />
