### PR TITLE
feat: show distance to the node on node details screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -314,6 +314,7 @@
     <string name="device_metrics_log">Device Metrics Log</string>
     <string name="node_map">Node Map</string>
     <string name="position_log">Position Log</string>
+    <string name="last_position_update">Last position update</string>
     <string name="env_metrics_log">Environment Metrics Log</string>
     <string name="sig_metrics_log">Signal Metrics Log</string>
     <string name="administration">Administration</string>


### PR DESCRIPTION
This change extends node detail screen by adding last known distance to the node and time of last position update from the node.

While last known distance is available on the nodes list, before this change it was not easily accessible from channel/DM screen.

<img src="https://github.com/user-attachments/assets/75d32654-264f-46f7-a925-8cf1f4fedfec" width="300"/>
