### PR TITLE
Fix node removal hang by adding navigation callback

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/navigation/NodesRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NodesRoutes.kt
@@ -129,6 +129,9 @@ fun NavGraphBuilder.nodeDetailGraph(
                 onNavigate = {
                     navController.navigate(it)
                 },
+                onNavigateUp = {
+                    navController.navigateUp()
+                },
                 viewModel = hiltViewModel(parentEntry),
             )
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -184,10 +184,18 @@ fun NodeDetailScreen(
     uiViewModel: UIViewModel = hiltViewModel(),
     navigateToMessages: (String) -> Unit,
     onNavigate: (Route) -> Unit = {},
+    onNavigateUp: () -> Unit = {},
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val environmentState by viewModel.environmentState.collectAsStateWithLifecycle()
     val lastTracerouteTime by uiViewModel.lastTraceRouteTime.collectAsStateWithLifecycle()
+
+    // Navigate back when node is removed
+    LaunchedEffect(state.node) {
+        if (state.node == null) {
+            onNavigateUp()
+        }
+    }
 
     /* The order is with respect to the enum above: LogsType */
     val availabilities = remember(key1 = state, key2 = environmentState) {

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -190,13 +190,6 @@ fun NodeDetailScreen(
     val environmentState by viewModel.environmentState.collectAsStateWithLifecycle()
     val lastTracerouteTime by uiViewModel.lastTraceRouteTime.collectAsStateWithLifecycle()
 
-    // Navigate back when node is removed
-    LaunchedEffect(state.node) {
-        if (state.node == null) {
-            onNavigateUp()
-        }
-    }
-
     /* The order is with respect to the enum above: LogsType */
     val availabilities = remember(key1 = state, key2 = environmentState) {
         booleanArrayOf(
@@ -237,6 +230,9 @@ fun NodeDetailScreen(
                             val channel =
                                 if (hasPKC) DataPacket.PKC_CHANNEL_INDEX else node.channel
                             navigateToMessages("$channel${node.user.id}")
+                        } else if (action is NodeMenuAction.Remove) {
+                            uiViewModel.handleNodeMenuAction(action)
+                            onNavigateUp()
                         } else {
                             uiViewModel.handleNodeMenuAction(action)
                         }


### PR DESCRIPTION
**Problem:**
When removing a node from the node detail screen, the app would hang instead of navigating back to the previous screen. The "More details" action was also affected by the initial fix attempt.

**Solution:**
Navigate immediately after the remove action is confirmed, rather than trying to detect when the node becomes null in the state. This provides immediate user feedback and avoids interfering with other navigation actions.

**Changes:**
- Added `onNavigateUp` callback to `NodeDetailScreen`
- Navigate immediately after `NodeMenuAction.Remove` is processed
- Removed problematic `LaunchedEffect` that was triggering on any null state

**Testing:**
- Node removal now properly navigates back to previous screen
- "More details" and other navigation actions work correctly
- No hanging or UI freezing when removing nodes
- Tested and working on a TCL T768S (Android 11)

Fixes #2088