### PR TITLE
fix (#2128): MQTT map reporting interval input

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/EditTextPreference.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/EditTextPreference.kt
@@ -85,6 +85,7 @@ fun EditTextPreference(
     title: String,
     value: Int,
     enabled: Boolean,
+    isError: Boolean = false,
     keyboardActions: KeyboardActions,
     onValueChanged: (Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -97,7 +98,7 @@ fun EditTextPreference(
         title = title,
         value = valueState,
         enabled = enabled,
-        isError = value.toUInt().toString() != valueState,
+        isError = value.toUInt().toString() != valueState || isError,
         keyboardOptions = KeyboardOptions.Default.copy(
             keyboardType = KeyboardType.Number, imeAction = ImeAction.Done
         ),

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/MQTTConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/MQTTConfigItemList.kt
@@ -233,6 +233,13 @@ fun MQTTConfigItemList(
                         mapReportSettings = settings
                     }
                 },
+                publishIntervalSecs = mqttInput.mapReportSettings.publishIntervalSecs,
+                onPublishIntervalSecsChanged = {
+                    val settings = mqttInput.mapReportSettings.copy { publishIntervalSecs = it }
+                    mqttInput = mqttInput.copy {
+                        mapReportSettings = settings
+                    }
+                },
                 enabled = enabled,
                 focusManager = focusManager
             )
@@ -241,7 +248,8 @@ fun MQTTConfigItemList(
 
         item {
             val consentValid = if (mqttInput.mapReportingEnabled) {
-                mqttInput.mapReportSettings.shouldReportLocation
+                mqttInput.mapReportSettings.shouldReportLocation &&
+                        mqttConfig.mapReportSettings.publishIntervalSecs >= 3600
             } else {
                 true
             }

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/MapReportingPreference.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/MapReportingPreference.kt
@@ -138,6 +138,7 @@ fun MapReportingPreference(
                         modifier = Modifier.Companion.padding(bottom = 16.dp),
                         title = stringResource(R.string.map_reporting_interval_seconds),
                         value = publishIntervalSecs,
+                        isError = publishIntervalSecs < 3600,
                         enabled = enabled,
                         keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                         onValueChanged = onPublishIntervalSecsChanged,


### PR DESCRIPTION
This commit fixes the MQTT map reporting interval input. The interval is now displayed in the UI and can be changed by the user.

A validation check has been added to ensure the interval is not less than 3600 seconds (1 hour). If an invalid value is entered, the field displays the error state.

This change also updates the consent check for map reporting to consider the publish interval. If the interval is less than 1 hour, consent will be considered invalid.
