### PR TITLE
Fix unmessageable toggle not available over remote admin

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -328,7 +328,7 @@ private fun NodeDetailList(
                 NavCard(
                     title = stringResource(id = R.string.remote_admin),
                     icon = Icons.Default.Settings,
-                    enabled = metricsState.isLocal || node.metadata != null
+                    enabled = true
                 ) {
                     onAction(RadioConfigRoutes.RadioConfig(node.num))
                 }

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -328,7 +328,7 @@ private fun NodeDetailList(
                 NavCard(
                     title = stringResource(id = R.string.remote_admin),
                     icon = Icons.Default.Settings,
-                    enabled = true
+                    enabled = metricsState.isLocal || node.metadata != null
                 ) {
                     onAction(RadioConfigRoutes.RadioConfig(node.num))
                 }

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -140,17 +140,16 @@ fun UserConfigItemList(
         }
         item { HorizontalDivider() }
 
-        item {
-            SwitchPreference(
-                title = stringResource(R.string.unmessageable),
-                summary = stringResource(R.string.unmonitored_or_infrastructure),
-                checked = userInput.isUnmessagable || (
-                        firmwareVersion < DeviceVersion("2.6.9") &&
-                                userInput.role.isUnmessageableRole()
-                        ),
-                enabled = enabled,
-                onCheckedChange = { userInput = userInput.copy { isUnmessagable = it } }
-            )
+        if (userInput.hasIsUnmessagable()) {
+            item {
+                SwitchPreference(
+                    title = stringResource(R.string.unmessageable),
+                    summary = stringResource(R.string.unmonitored_or_infrastructure),
+                    checked = userInput.isUnmessagable,
+                    enabled = enabled,
+                    onCheckedChange = { userInput = userInput.copy { isUnmessagable = it } }
+                )
+            }
         }
 
         item { HorizontalDivider() }

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -141,6 +141,7 @@ fun UserConfigItemList(
         item { HorizontalDivider() }
 
         item {
+            val canEditUnmessageable = enabled && userInput.hasIsUnmessagable()
             SwitchPreference(
                 title = stringResource(R.string.unmessageable),
                 summary = stringResource(R.string.unmonitored_or_infrastructure),
@@ -148,7 +149,7 @@ fun UserConfigItemList(
                         firmwareVersion < DeviceVersion("2.6.9") &&
                                 userInput.role.isUnmessageableRole()
                         ),
-                enabled = userInput.hasIsUnmessagable(),
+                enabled = canEditUnmessageable,
                 onCheckedChange = { userInput = userInput.copy { isUnmessagable = it } }
             )
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -141,7 +141,6 @@ fun UserConfigItemList(
         item { HorizontalDivider() }
 
         item {
-            val canEditUnmessageable = enabled && userInput.hasIsUnmessagable()
             SwitchPreference(
                 title = stringResource(R.string.unmessageable),
                 summary = stringResource(R.string.unmonitored_or_infrastructure),
@@ -149,7 +148,7 @@ fun UserConfigItemList(
                         firmwareVersion < DeviceVersion("2.6.9") &&
                                 userInput.role.isUnmessageableRole()
                         ),
-                enabled = canEditUnmessageable,
+                enabled = enabled,
                 onCheckedChange = { userInput = userInput.copy { isUnmessagable = it } }
             )
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -140,16 +140,17 @@ fun UserConfigItemList(
         }
         item { HorizontalDivider() }
 
-        if (firmwareVersion >= DeviceVersion("2.6.9")) {
-            item {
-                SwitchPreference(
-                    title = stringResource(R.string.unmessageable),
-                    summary = stringResource(R.string.unmonitored_or_infrastructure),
-                    checked = userInput.isUnmessagable,
-                    enabled = enabled,
-                    onCheckedChange = { userInput = userInput.copy { isUnmessagable = it } }
-                )
-            }
+        item {
+            SwitchPreference(
+                title = stringResource(R.string.unmessageable),
+                summary = stringResource(R.string.unmonitored_or_infrastructure),
+                checked = userInput.isUnmessagable || (
+                        firmwareVersion < DeviceVersion("2.6.9") &&
+                                userInput.role.isUnmessageableRole()
+                        ),
+                enabled = enabled && firmwareVersion >= DeviceVersion("2.6.9"),
+                onCheckedChange = { userInput = userInput.copy { isUnmessagable = it } }
+            )
         }
 
         item { HorizontalDivider() }

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -140,7 +140,7 @@ fun UserConfigItemList(
         }
         item { HorizontalDivider() }
 
-        if (userInput.hasIsUnmessagable()) {
+        if (firmwareVersion >= DeviceVersion("2.6.9")) {
             item {
                 SwitchPreference(
                     title = stringResource(R.string.unmessageable),

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -64,7 +64,7 @@ fun UserConfigScreen(
 
     UserConfigItemList(
         userConfig = state.userConfig,
-        enabled = true,
+        enabled = state.connected,
         onSaveClicked = viewModel::setOwner,
         metadata = state.metadata,
     )

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -64,7 +64,7 @@ fun UserConfigScreen(
 
     UserConfigItemList(
         userConfig = state.userConfig,
-        enabled = state.connected,
+        enabled = true,
         onSaveClicked = viewModel::setOwner,
         metadata = state.metadata,
     )


### PR DESCRIPTION
## Problem
Unmessageable toggle was disabled when accessing remote admin due to unreliable firmware detection.

## Solution
- Always show toggle for consistent UX
- Enable only for firmware >= 2.6.9 AND admin permissions
- Show role-based status for older firmware (read-only)

## Changes
- Replace `enabled = userInput.hasIsUnmessagable()` with `enabled = enabled && firmwareVersion >= DeviceVersion("2.6.9")`
- Keep checked state logic for backward compatibility

## Result
- ✅ Toggle available in remote admin for supported firmware
- ✅ Clear feedback when feature unavailable (disabled toggle)


Tested with a rak4631 firmware v2.6.11 (toggle enabled) and t-beam v2.6.1 (toggle disabled)

Tested and working on a TCL T768S (Android 11)

Closes: #2064 