### PR TITLE
Increase MIN_SDK_VERSION to 26

### DIFF
--- a/buildSrc/src/main/kotlin/Configs.kt
+++ b/buildSrc/src/main/kotlin/Configs.kt
@@ -17,7 +17,7 @@
 
 object Configs {
     const val APPLICATION_ID = "com.geeksville.mesh"
-    const val MIN_SDK_VERSION = 23
+    const val MIN_SDK_VERSION = 26
     const val TARGET_SDK = 36
     const val COMPILE_SDK = 36
     const val VERSION_CODE = 30616 // format is Mmmss (where M is 1+the numeric major number


### PR DESCRIPTION
Bumps minSdkVersion to 26.
Dependencies (protos) have since bumped.