### PR TITLE
Refactor: Improve MessageItem layout and display of reactions

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/MessageList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/MessageList.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.geeksville.mesh.DataPacket
 import com.geeksville.mesh.MessageStatus
 import com.geeksville.mesh.R
 import com.geeksville.mesh.database.entity.Reaction
@@ -57,7 +56,6 @@ import com.geeksville.mesh.model.Message
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.message.components.MessageItem
 import com.geeksville.mesh.ui.message.components.ReactionDialog
-import com.geeksville.mesh.ui.message.components.ReactionRow
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
@@ -167,7 +165,6 @@ internal fun MessageList(
         reverseLayout = true,
     ) {
         items(messages, key = { it.uuid }) { msg ->
-            val fromLocal = msg.node.user.id == DataPacket.ID_LOCAL
             val selected by remember { derivedStateOf { selectedIds.value.contains(msg.uuid) } }
             var node by remember {
                 mutableStateOf(nodes.find { it.num == msg.node.num } ?: msg.node)
@@ -175,7 +172,6 @@ internal fun MessageList(
             LaunchedEffect(nodes) {
                 node = nodes.find { it.num == msg.node.num } ?: msg.node
             }
-            ReactionRow(fromLocal, msg.emojis) { showReactionDialog = msg.emojis }
             Box(Modifier.wrapContentSize(Alignment.TopStart)) {
                 MessageItem(
                     node = node,
@@ -190,16 +186,20 @@ internal fun MessageList(
                     },
                     onAction = onNodeMenuAction,
                     onStatusClick = { showStatusDialog = msg },
-                    onSendReaction = { onSendReaction(it, msg.packetId) },
+                    emojis = msg.emojis,
+                    sendReaction = { onSendReaction(it, msg.packetId) },
+                    onShowReactions = { showReactionDialog = msg.emojis },
                     isConnected = isConnected,
                     snr = msg.snr,
                     rssi = msg.rssi,
-                    hopsAway = if (msg.hopsAway > 0) { "%s: %d".format(
+                    hopsAway = if (msg.hopsAway > 0) {
+                        "%s: %d".format(
                             stringResource(id = R.string.hops_away),
                             msg.hopsAway
-                        ) } else {
-                            null
-                        }
+                        )
+                    } else {
+                        null
+                    }
                 )
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.twotone.HowToReg
 import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -64,7 +65,7 @@ import com.geeksville.mesh.ui.node.components.NodeChip
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 internal fun MessageItem(
     node: Node,
@@ -141,6 +142,7 @@ internal fun MessageItem(
                     .fillMaxWidth()
                     .padding(4.dp),
                 text = messageText.orEmpty(),
+                style = MaterialTheme.typography.bodyMedium,
             )
             Row(
                 modifier = Modifier
@@ -151,18 +153,22 @@ internal fun MessageItem(
             ) {
                 if (!fromLocal) {
                     if (hopsAway == null) {
-                        Snr(snr, fontSize = MaterialTheme.typography.bodySmall.fontSize)
-                        Rssi(rssi, fontSize = MaterialTheme.typography.bodySmall.fontSize)
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Snr(snr, fontSize = MaterialTheme.typography.labelSmall.fontSize)
+                            Rssi(rssi, fontSize = MaterialTheme.typography.labelSmall.fontSize)
+                        }
                     } else {
                         Text(
                             text = hopsAway,
-                            fontSize = MaterialTheme.typography.bodySmall.fontSize,
+                            style = MaterialTheme.typography.labelSmall,
                         )
                     }
                 }
                 Text(
                     text = messageTime,
-                    fontSize = MaterialTheme.typography.bodySmall.fontSize,
+                    style = MaterialTheme.typography.labelSmall,
                 )
                 AnimatedVisibility(visible = fromLocal) {
                     Icon(

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/Reaction.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/Reaction.kt
@@ -19,10 +19,10 @@ package com.geeksville.mesh.ui.message.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,7 +32,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.EmojiEmotions
 import androidx.compose.material3.Badge
@@ -65,21 +64,22 @@ import com.geeksville.mesh.ui.common.theme.AppTheme
 @Composable
 fun ReactionButton(
     modifier: Modifier = Modifier,
-    onClick: (String) -> Unit = {}
+    onSendReaction: (String) -> Unit = {},
 ) {
     var showEmojiPickerDialog by remember { mutableStateOf(false) }
     if (showEmojiPickerDialog) {
         EmojiPickerDialog(
-            onConfirm = {
+            onConfirm = { selectedEmoji ->
                 showEmojiPickerDialog = false
-                onClick(it)
+                onSendReaction(selectedEmoji)
             },
             onDismiss = { showEmojiPickerDialog = false }
         )
     }
     IconButton(
-        modifier = modifier.size(48.dp),
-        onClick = { showEmojiPickerDialog = true }
+        modifier = modifier
+            .size(48.dp),
+        onClick = { showEmojiPickerDialog = true },
     ) {
         Icon(
             imageVector = Icons.Default.EmojiEmotions,
@@ -93,9 +93,9 @@ private fun ReactionItem(
     emoji: String,
     emojiCount: Int = 1,
     onClick: () -> Unit = {},
+    onLongClick: () -> Unit = {},
 ) {
     BadgedBox(
-        modifier = Modifier.padding(start = 2.dp, top = 2.dp, end = 2.dp, bottom = 4.dp),
         badge = {
             if (emojiCount > 1) {
                 Badge {
@@ -108,15 +108,14 @@ private fun ReactionItem(
         }
     ) {
         Surface(
-            modifier = Modifier
-                .clickable { onClick() },
+            modifier = Modifier.combinedClickable(onClick = onClick, onLongClick = onLongClick),
             color = MaterialTheme.colorScheme.primaryContainer,
-            shape = RoundedCornerShape(32.dp),
+            shape = CircleShape,
         ) {
             Text(
                 text = emoji,
                 modifier = Modifier
-                    .padding(8.dp)
+                    .padding(4.dp)
                     .clip(CircleShape),
             )
         }
@@ -126,35 +125,38 @@ private fun ReactionItem(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ReactionRow(
-    fromLocal: Boolean,
+    modifier: Modifier = Modifier,
     reactions: List<Reaction> = emptyList(),
-    onSendReaction: (String) -> Unit = {}
+    onSendReaction: (String) -> Unit = {},
+    onShowReactions: () -> Unit = {}
 ) {
-    val emojiList by remember(reactions) {
-        mutableStateOf(
-            reduceEmojis(
-                if (fromLocal) {
-                    reactions.map { it.emoji }
-                } else {
-                    reactions.map { it.emoji }.reversed()
-                }
-            ).entries
-        )
-    }
+    val emojiList =
+        reduceEmojis(
+            reactions.reversed().map { it.emoji }
+        ).entries
 
-    FlowRow(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        horizontalArrangement = if (fromLocal) Arrangement.End else Arrangement.Start
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+        reverseLayout = true
     ) {
-        emojiList.forEach { entry ->
+        item {
+            ReactionButton(
+                onSendReaction = onSendReaction,
+            )
+        }
+        items(
+            emojiList.size
+        ) { index ->
+            val entry = emojiList.elementAt(index)
             ReactionItem(
                 emoji = entry.key,
                 emojiCount = entry.value,
                 onClick = {
                     onSendReaction(entry.key)
-                }
+                },
+                onLongClick = onShowReactions,
             )
         }
     }
@@ -237,7 +239,6 @@ fun ReactionItemPreview() {
 fun ReactionRowPreview() {
     AppTheme {
         ReactionRow(
-            fromLocal = true,
             reactions = listOf(
                 Reaction(
                     replyId = 1,

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/Reaction.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/Reaction.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -108,7 +109,11 @@ private fun ReactionItem(
         }
     ) {
         Surface(
-            modifier = Modifier.combinedClickable(onClick = onClick, onLongClick = onLongClick),
+            modifier = Modifier
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = onLongClick
+                ),
             color = MaterialTheme.colorScheme.primaryContainer,
             shape = CircleShape,
         ) {
@@ -136,7 +141,7 @@ fun ReactionRow(
         ).entries
 
     LazyRow(
-        modifier = modifier,
+        modifier = modifier.height(48.dp).padding(bottom = 8.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically,
         reverseLayout = true


### PR DESCRIPTION
This commit refactors the `MessageItem` composable to improve its layout and how it displays message reactions.

fixes #2125

Key changes:
- `MessageItem` now uses a `Column` as its root element instead of a `Row` for better control over vertical arrangement.
- The `ReactionRow` is now directly embedded within the `MessageItem` with improved user experience.
- The message bubble color for messages from other users is now derived from the node's color with an alpha transparency.
- The sender's name and ID are displayed above the message content for non-local messages.
- The `hopsAway` and SNR/RSSI information for non-local messages is now displayed more consistently.
- Minor padding and spacing adjustments have been made for a cleaner appearance.


https://github.com/user-attachments/assets/0672fdd0-555b-482b-9834-033450daf3c9