### PR TITLE
fix(#2094): remove redundant mapView.onDetach() call

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapViewWithLifecycle.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapViewWithLifecycle.kt
@@ -90,10 +90,12 @@ internal fun rememberMapViewWithLifecycle(
     tileSource: ITileSource = TileSourceFactory.DEFAULT_TILE_SOURCE,
 ): MapView {
     var savedZoom by rememberSaveable { mutableDoubleStateOf(zoomLevel) }
-    var savedCenter by rememberSaveable(stateSaver = Saver(
-        save = { mapOf("latitude" to it.latitude, "longitude" to it.longitude) },
-        restore = { GeoPoint(it["latitude"] ?: 0.0, it["longitude"] ?: .0) }
-    )) { mutableStateOf(mapCenter) }
+    var savedCenter by rememberSaveable(
+        stateSaver = Saver(
+            save = { mapOf("latitude" to it.latitude, "longitude" to it.longitude) },
+            restore = { GeoPoint(it["latitude"] ?: 0.0, it["longitude"] ?: .0) }
+        )
+    ) { mutableStateOf(mapCenter) }
 
     val context = LocalContext.current
     val mapView = remember {
@@ -155,7 +157,6 @@ internal fun rememberMapViewWithLifecycle(
         onDispose {
             lifecycle.removeObserver(observer)
             wakeLock.safeRelease()
-            mapView.onDetach()
         }
     }
     return mapView


### PR DESCRIPTION
Removes redundant onDetatch in favor of lifecycle handling.
Fixes NPE crash when navigating into and away from the map quickly.

fixes #2094 

