### PR TITLE
feat: Implement message reply functionality

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/DataPacket.kt
+++ b/app/src/main/java/com/geeksville/mesh/DataPacket.kt
@@ -62,6 +62,7 @@ data class DataPacket(
     var hopStart: Int = 0,
     var snr: Float = 0f,
     var rssi: Int = 0,
+    var replyId: Int? = null,
 ) : Parcelable {
 
     /**
@@ -72,11 +73,12 @@ data class DataPacket(
     /**
      * Syntactic sugar to make it easy to create text messages
      */
-    constructor(to: String?, channel: Int, text: String) : this(
+    constructor(to: String?, channel: Int, text: String, replyId: Int? = null) : this(
         to = to,
         bytes = text.encodeToByteArray(),
         dataType = Portnums.PortNum.TEXT_MESSAGE_APP_VALUE,
-        channel = channel
+        channel = channel,
+        replyId = replyId
     )
 
     /**
@@ -129,6 +131,7 @@ data class DataPacket(
         parcel.readInt(),
         parcel.readFloat(),
         parcel.readInt(),
+        parcel.readInt()
     )
 
     @Suppress("CyclomaticComplexMethod")
@@ -151,6 +154,7 @@ data class DataPacket(
         if (hopStart != other.hopStart) return false
         if (snr != other.snr) return false
         if (rssi != other.rssi) return false
+        if (replyId != other.replyId) return false
 
         return true
     }
@@ -169,6 +173,7 @@ data class DataPacket(
         result = 31 * result + hopStart
         result = 31 * result + snr.hashCode()
         result = 31 * result + rssi
+        result = 31 * result + replyId.hashCode()
         return result
     }
 
@@ -186,6 +191,7 @@ data class DataPacket(
         parcel.writeInt(hopStart)
         parcel.writeFloat(snr)
         parcel.writeInt(rssi)
+        parcel.writeInt(replyId ?: -1)
     }
 
     override fun describeContents(): Int {
@@ -207,6 +213,7 @@ data class DataPacket(
         hopStart = parcel.readInt()
         snr = parcel.readFloat()
         rssi = parcel.readInt()
+        replyId = if (parcel.readInt() == -1) null else parcel.readInt()
     }
 
     companion object CREATOR : Parcelable.Creator<DataPacket> {

--- a/app/src/main/java/com/geeksville/mesh/DataPacket.kt
+++ b/app/src/main/java/com/geeksville/mesh/DataPacket.kt
@@ -213,7 +213,7 @@ data class DataPacket(
         hopStart = parcel.readInt()
         snr = parcel.readFloat()
         rssi = parcel.readInt()
-        replyId = if (parcel.readInt() == 0) null else parcel.readInt()
+        replyId = parcel.readInt().let { if (it == 0) null else it }
     }
 
     companion object CREATOR : Parcelable.Creator<DataPacket> {

--- a/app/src/main/java/com/geeksville/mesh/DataPacket.kt
+++ b/app/src/main/java/com/geeksville/mesh/DataPacket.kt
@@ -62,7 +62,7 @@ data class DataPacket(
     var hopStart: Int = 0,
     var snr: Float = 0f,
     var rssi: Int = 0,
-    var replyId: Int? = null,
+    var replyId: Int? = null // If this is a reply to a previous message, this is the ID of that message
 ) : Parcelable {
 
     /**
@@ -78,7 +78,7 @@ data class DataPacket(
         bytes = text.encodeToByteArray(),
         dataType = Portnums.PortNum.TEXT_MESSAGE_APP_VALUE,
         channel = channel,
-        replyId = replyId
+        replyId = replyId ?: 0
     )
 
     /**
@@ -102,7 +102,7 @@ data class DataPacket(
         to = to,
         bytes = waypoint.toByteArray(),
         dataType = Portnums.PortNum.WAYPOINT_APP_VALUE,
-        channel = channel
+        channel = channel,
     )
 
     val waypoint: MeshProtos.Waypoint?
@@ -131,7 +131,7 @@ data class DataPacket(
         parcel.readInt(),
         parcel.readFloat(),
         parcel.readInt(),
-        parcel.readInt()
+        if (parcel.readInt() == 0) null else parcel.readInt()
     )
 
     @Suppress("CyclomaticComplexMethod")
@@ -191,7 +191,7 @@ data class DataPacket(
         parcel.writeInt(hopStart)
         parcel.writeFloat(snr)
         parcel.writeInt(rssi)
-        parcel.writeInt(replyId ?: -1)
+        parcel.writeInt(replyId ?: 0)
     }
 
     override fun describeContents(): Int {
@@ -213,7 +213,7 @@ data class DataPacket(
         hopStart = parcel.readInt()
         snr = parcel.readFloat()
         rssi = parcel.readInt()
-        replyId = if (parcel.readInt() == -1) null else parcel.readInt()
+        replyId = if (parcel.readInt() == 0) null else parcel.readInt()
     }
 
     companion object CREATOR : Parcelable.Creator<DataPacket> {

--- a/app/src/main/java/com/geeksville/mesh/database/entity/Packet.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/entity/Packet.kt
@@ -73,7 +73,7 @@ data class Packet(
     @ColumnInfo(name = "data") val data: DataPacket,
     @ColumnInfo(name = "packet_id", defaultValue = "0") val packetId: Int = 0,
     @ColumnInfo(name = "routing_error", defaultValue = "-1") var routingError: Int = -1,
-    @ColumnInfo(name = "reply_id", defaultValue = "-1") val replyId: Int = -1,
+    @ColumnInfo(name = "reply_id", defaultValue = "0") val replyId: Int = 0,
     @ColumnInfo(name = "snr", defaultValue = "0") val snr: Float = 0f,
     @ColumnInfo(name = "rssi", defaultValue = "0") val rssi: Int = 0,
     @ColumnInfo(name = "hopsAway", defaultValue = "-1") val hopsAway: Int = -1,

--- a/app/src/main/java/com/geeksville/mesh/database/entity/Packet.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/entity/Packet.kt
@@ -49,6 +49,7 @@ data class PacketEntity(
             routingError = routingError,
             packetId = packetId,
             emojis = reactions.toReaction(getNode),
+            replyId = data.replyId
         )
     }
 }
@@ -72,7 +73,7 @@ data class Packet(
     @ColumnInfo(name = "data") val data: DataPacket,
     @ColumnInfo(name = "packet_id", defaultValue = "0") val packetId: Int = 0,
     @ColumnInfo(name = "routing_error", defaultValue = "-1") var routingError: Int = -1,
-    @ColumnInfo(name = "reply_id", defaultValue = "0") val replyId: Int = 0,
+    @ColumnInfo(name = "reply_id", defaultValue = "-1") val replyId: Int = -1,
     @ColumnInfo(name = "snr", defaultValue = "0") val snr: Float = 0f,
     @ColumnInfo(name = "rssi", defaultValue = "0") val rssi: Int = 0,
     @ColumnInfo(name = "hopsAway", defaultValue = "-1") val hopsAway: Int = -1,

--- a/app/src/main/java/com/geeksville/mesh/model/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Message.kt
@@ -59,6 +59,7 @@ data class Message(
     val snr: Float,
     val rssi: Int,
     val hopsAway: Int,
+    val replyId: Int?,
 ) {
     fun getStatusStringRes(): Pair<Int, Int> {
         val title = if (routingError > 0) R.string.error else R.string.message_delivery_status

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -534,7 +534,7 @@ class UIViewModel @Inject constructor(
         }
     }
 
-    fun sendMessage(str: String, contactKey: String = "0${DataPacket.ID_BROADCAST}") {
+    fun sendMessage(str: String, contactKey: String = "0${DataPacket.ID_BROADCAST}", replyId: Int? = null) {
         // contactKey: unique contact key filter (channel)+(nodeId)
         val channel = contactKey[0].digitToIntOrNull()
         val dest = if (channel != null) contactKey.substring(1) else contactKey
@@ -547,7 +547,7 @@ class UIViewModel @Inject constructor(
                 favoriteNode(nodeDB.getNode(dest))
             }
         }
-        val p = DataPacket(dest, channel ?: 0, str)
+        val p = DataPacket(dest, channel ?: 0, str, replyId)
         sendDataPacket(p)
     }
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -735,7 +735,7 @@ class MeshService : Service(), Logging {
             snr = dataPacket.snr,
             rssi = dataPacket.rssi,
             hopsAway = dataPacket.hopsAway,
-            replyId = dataPacket.replyId ?: -1
+            replyId = dataPacket.replyId ?: 0
         )
         serviceScope.handledLaunch {
             packetRepository.get().apply {

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -774,7 +774,7 @@ class MeshService : Service(), Logging {
 
                 when (data.portnumValue) {
                     Portnums.PortNum.TEXT_MESSAGE_APP_VALUE -> {
-                        if(data.replyId != 0 &&data.emoji == 0) {
+                        if (data.replyId != 0 && data.emoji == 0) {
                             debug("Received REPLY from $fromId")
                             rememberDataPacket(dataPacket)
                         } else if (data.replyId != 0 && data.emoji != 0) {

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -677,7 +677,8 @@ class MeshService : Service(), Logging {
                 wantAck = packet.wantAck,
                 hopStart = packet.hopStart,
                 snr = packet.rxSnr,
-                rssi = packet.rxRssi
+                rssi = packet.rxRssi,
+                replyId = data.replyId,
             )
         }
     }
@@ -733,7 +734,8 @@ class MeshService : Service(), Logging {
             data = dataPacket,
             snr = dataPacket.snr,
             rssi = dataPacket.rssi,
-            hopsAway = dataPacket.hopsAway
+            hopsAway = dataPacket.hopsAway,
+            replyId = dataPacket.replyId ?: -1
         )
         serviceScope.handledLaunch {
             packetRepository.get().apply {
@@ -772,7 +774,10 @@ class MeshService : Service(), Logging {
 
                 when (data.portnumValue) {
                     Portnums.PortNum.TEXT_MESSAGE_APP_VALUE -> {
-                        if (data.emoji != 0) {
+                        if(data.replyId != 0 &&data.emoji == 0) {
+                            debug("Received REPLY from $fromId")
+                            rememberDataPacket(dataPacket)
+                        } else if (data.replyId != 0 && data.emoji != 0) {
                             debug("Received EMOJI from $fromId")
                             rememberReaction(packet)
                         } else {

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -101,6 +101,7 @@ import com.geeksville.mesh.ui.sharing.SharedContactDialog
 import kotlinx.coroutines.launch
 
 private const val MESSAGE_CHARACTER_LIMIT = 200
+private const val SNIPPET_CHARACTER_LIMIT = 50
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
@@ -221,7 +222,7 @@ internal fun MessageScreen(
                 AnimatedVisibility(visible = replyingTo != null) {
                     val fromLocal = replyingTo?.node?.user?.id == DataPacket.ID_LOCAL
 
-                    val replyingToNode = if(fromLocal) {
+                    val replyingToNode = if (fromLocal) {
                         viewModel.ourNodeInfo.value
                     } else {
                         replyingTo?.node
@@ -244,8 +245,8 @@ internal fun MessageScreen(
                                 style = MaterialTheme.typography.labelMedium
                             )
                             Text(
-                                replyingTo?.text?.take(50)
-                                    ?.let { if (it.length == 50) "$it…" else it } ?: "", // Snippet
+                                replyingTo?.text?.take(SNIPPET_CHARACTER_LIMIT)
+                                    ?.let { if (it.length == SNIPPET_CHARACTER_LIMIT) "$it…" else it } ?: "", // Snippet
                                 style = MaterialTheme.typography.bodySmall,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/Reaction.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/Reaction.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.EmojiEmotions
+import androidx.compose.material.icons.filled.Reply
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.HorizontalDivider
@@ -90,6 +91,22 @@ fun ReactionButton(
 }
 
 @Composable
+fun ReplyButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+) = IconButton(
+    modifier = modifier
+        .size(48.dp),
+    onClick = onClick,
+    content = {
+        Icon(
+            imageVector = Icons.Default.Reply,
+            contentDescription = "reply",
+        )
+    }
+)
+
+@Composable
 private fun ReactionItem(
     emoji: String,
     emojiCount: Int = 1,
@@ -133,7 +150,8 @@ fun ReactionRow(
     modifier: Modifier = Modifier,
     reactions: List<Reaction> = emptyList(),
     onSendReaction: (String) -> Unit = {},
-    onShowReactions: () -> Unit = {}
+    onShowReactions: () -> Unit = {},
+    onSendReply: () -> Unit = {},
 ) {
     val emojiList =
         reduceEmojis(
@@ -141,11 +159,18 @@ fun ReactionRow(
         ).entries
 
     LazyRow(
-        modifier = modifier.height(48.dp).padding(bottom = 8.dp),
+        modifier = modifier
+            .height(48.dp)
+            .padding(bottom = 8.dp),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically,
         reverseLayout = true
     ) {
+        item {
+            ReplyButton {
+                onSendReply()
+            }
+        }
         item {
             ReactionButton(
                 onSendReaction = onSendReaction,


### PR DESCRIPTION
This commit introduces the ability to reply to messages within the application.

Key changes include:

- **Data Model Updates:**
    - `DataPacket` now includes an optional `replyId` field to link replies to original messages.
    - `Packet` entity in the database is updated to store `replyId`, defaulting to -1.
    - `Message` model now includes an optional `replyId`.

- **UI Enhancements:**
    - **Message Input:** - A visual indicator ("Replying to...") appears above the text input when a reply is being composed. - Users can cancel the reply using a close button.
    - **Message Display:**
        - Replies now display a quoted snippet of the original message.
        - The original message snippet is clickable, navigating the user to the original message in the chat history. - A "Reply" icon button is added to the message actions (next to reactions).
    - **MessageItem:** - Updated to handle and display reply information. - Takes an `originalMessage` parameter to show the quoted reply. - `onNavigateToOriginalMessage` callback for jumping to the original message.
    - **MessageScreen:**
        - Manages the `replyingTo` state.
        - Passes the `replyId` when sending a message.

- **Logic Updates:**
    - `UIViewModel.sendMessage` now accepts an optional `replyId`.
    - `MeshService` correctly processes and stores `replyId` for incoming and outgoing messages.
    - Incoming text messages with a `replyId` and no emoji are now correctly identified and processed as replies.

This feature enhances user interaction by allowing direct responses to specific messages, improving context and clarity in conversations.


https://github.com/user-attachments/assets/3e51503c-e4f2-4f5c-8288-bffc54d7cfb0

