### PR TITLE
Feat/2105 debug panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ keystore.properties
 
 # Kotlin compiler
 .kotlin
+
+# VS code
+.vscode/settings.json

--- a/app/src/main/java/com/geeksville/mesh/model/DebugViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/DebugViewModel.kt
@@ -36,6 +36,8 @@ import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Locale
 import javax.inject.Inject
+import com.geeksville.mesh.Portnums.PortNum
+
 
 @HiltViewModel
 class DebugViewModel @Inject constructor(
@@ -134,4 +136,9 @@ class DebugViewModel @Inject constructor(
     companion object {
         private val TIME_FORMAT = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
     }
+
+    val presetFilters = arrayOf(
+        "own 0x", // will need to get that from connected nodes??
+        "0xffffffff",     // broadcast
+    ) + PortNum.entries.map { it.name } // all apps
 }

--- a/app/src/main/java/com/geeksville/mesh/model/DebugViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/DebugViewModel.kt
@@ -138,7 +138,7 @@ class DebugViewModel @Inject constructor(
     }
 
     val presetFilters = arrayOf(
-        "own 0x", // will need to get that from connected nodes??
-        "0xffffffff",     // broadcast
+        // "!xxxxxxxx", // Should be able to get the address of the connected node. ie. messages to us.
+        "!ffffffff",     // broadcast
     ) + PortNum.entries.map { it.name } // all apps
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
@@ -18,25 +18,40 @@
 package com.geeksville.mesh.ui.debug
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.outlined.CloudDownload
+import androidx.compose.material.icons.twotone.FilterAlt
+import androidx.compose.material.icons.twotone.FilterAltOff
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,7 +65,9 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -60,6 +77,10 @@ import com.geeksville.mesh.model.DebugViewModel
 import com.geeksville.mesh.model.DebugViewModel.UiMeshLog
 import com.geeksville.mesh.ui.common.theme.AppTheme
 import com.geeksville.mesh.ui.common.components.CopyIconButton
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.width
+
 
 private val REGEX_ANNOTATED_NODE_ID = Regex("\\(![0-9a-fA-F]{8}\\)$", RegexOption.MULTILINE)
 
@@ -70,9 +91,23 @@ internal fun DebugScreen(
     val listState = rememberLazyListState()
     val logs by viewModel.meshLog.collectAsStateWithLifecycle()
 
+    var filterTexts by remember { mutableStateOf(listOf<String>()) }
+    var customFilterText by remember { mutableStateOf("") }
+    var showFilterMenu by remember { mutableStateOf(false) }
+    
+    val filteredLogs by remember(logs) {
+        derivedStateOf {
+            logs.filter { log ->
+                filterTexts.isEmpty() || filterTexts.any { filterText ->
+                    log.logMessage.contains(filterText, ignoreCase = true)
+                }
+            }
+        }
+    }
+
     val shouldAutoScroll by remember { derivedStateOf { listState.firstVisibleItemIndex < 3 } }
     if (shouldAutoScroll) {
-        LaunchedEffect(logs) {
+        LaunchedEffect(filteredLogs) {
             if (!listState.isScrollInProgress) {
                 listState.animateScrollToItem(0)
             }
@@ -83,7 +118,174 @@ internal fun DebugScreen(
         modifier = Modifier.fillMaxSize(),
         state = listState,
     ) {
-        items(logs, key = { it.uuid }) { log ->
+        item {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(8.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.Start,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Box {
+                                TextButton(
+                                    onClick = { showFilterMenu = !showFilterMenu }
+                                ) {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Text(
+                                            text = stringResource(R.string.debug_filters),
+                                            style = TextStyle(fontWeight = FontWeight.Bold)
+                                        )
+                                        Icon(
+                                            imageVector = if (filterTexts.isNotEmpty()) 
+                                                Icons.TwoTone.FilterAlt else Icons.TwoTone.FilterAltOff,
+                                            contentDescription = "Filter"
+                                        )
+                                    }
+                                }
+                                DropdownMenu(
+                                    expanded = showFilterMenu,
+                                    onDismissRequest = { showFilterMenu = false },
+                                    offset = DpOffset(0.dp, 8.dp)
+                                ) {
+                                    Column(
+                                        modifier = Modifier
+                                            .padding(8.dp)
+                                            .width(300.dp)
+                                    ) {
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(bottom = 4.dp),
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            OutlinedTextField(
+                                                value = customFilterText,
+                                                onValueChange = { customFilterText = it },
+                                                modifier = Modifier.weight(1f),
+                                                placeholder = { Text("Add custom filter") },
+                                                singleLine = true,
+                                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                                                keyboardActions = KeyboardActions(
+                                                    onDone = {
+                                                        if (customFilterText.isNotBlank()) {
+                                                            filterTexts = filterTexts + customFilterText
+                                                            customFilterText = ""
+                                                        }
+                                                    }
+                                                )
+                                            )
+                                            Spacer(modifier = Modifier.padding(horizontal = 8.dp))
+                                            IconButton(
+                                                onClick = {
+                                                    if (customFilterText.isNotBlank()) {
+                                                        filterTexts = filterTexts + customFilterText
+                                                        customFilterText = ""
+                                                    }
+                                                },
+                                                enabled = customFilterText.isNotBlank()
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Default.Add,
+                                                    contentDescription = "Add filter"
+                                                )
+                                            }
+                                        }
+
+                                        Text(
+                                            text = "Preset Filters",
+                                            style = TextStyle(fontWeight = FontWeight.Bold),
+                                            modifier = Modifier.padding(vertical = 4.dp)
+                                        )
+                                        FlowRow(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(bottom = 0.dp),
+                                            horizontalArrangement = Arrangement.spacedBy(2.dp),
+                                            verticalArrangement = Arrangement.spacedBy(0.dp)
+                                        ) {
+                                            for (filter in viewModel.presetFilters) {
+                                                FilterChip(
+                                                    selected = filter in filterTexts,
+                                                    onClick = {
+                                                        filterTexts = if (filter in filterTexts) {
+                                                            filterTexts - filter
+                                                        } else {
+                                                            filterTexts + filter
+                                                        }
+                                                    },
+                                                    label = { Text(filter) }
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (filterTexts.isNotEmpty()) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 2.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = stringResource(R.string.debug_active_filters),
+                                style = TextStyle(fontWeight = FontWeight.Bold)
+                            )
+                            IconButton(
+                                onClick = { filterTexts = emptyList() }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Clear,
+                                    contentDescription = "Clear all filters"
+                                )
+                            }
+                        }
+                        FlowRow(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 0.dp),
+                            horizontalArrangement = Arrangement.spacedBy(2.dp),
+                            verticalArrangement = Arrangement.spacedBy(0.dp)
+                        ) {
+                            for (filter in filterTexts) {
+                                FilterChip(
+                                    selected = true,
+                                    onClick = {
+                                        filterTexts = filterTexts - filter
+                                    },
+                                    label = { Text(filter) },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = Icons.TwoTone.FilterAlt,
+                                            contentDescription = null
+                                        )
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        items(filteredLogs, key = { it.uuid }) { log ->
             DebugItem(
                 modifier = Modifier.animateItem(),
                 log = log
@@ -203,6 +405,7 @@ fun DebugMenuActions(
     viewModel: DebugViewModel = hiltViewModel(),
     modifier: Modifier = Modifier,
 ) {
+
     // Button(
     //     // FIXME: needs to do what it says on the label 
     //     onClick = viewModel::deleteAllLogs,

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
@@ -59,6 +59,7 @@ import com.geeksville.mesh.R
 import com.geeksville.mesh.model.DebugViewModel
 import com.geeksville.mesh.model.DebugViewModel.UiMeshLog
 import com.geeksville.mesh.ui.common.theme.AppTheme
+import com.geeksville.mesh.ui.common.components.CopyIconButton
 
 private val REGEX_ANNOTATED_NODE_ID = Regex("\\(![0-9a-fA-F]{8}\\)$", RegexOption.MULTILINE)
 
@@ -116,6 +117,10 @@ internal fun DebugItem(
                         text = log.messageType,
                         modifier = Modifier.weight(1f),
                         style = TextStyle(fontWeight = FontWeight.Bold),
+                    )
+                    CopyIconButton(
+                        valueToCopy = log.logMessage,
+                        modifier = Modifier.padding(start = 8.dp)
                     )
                     Icon(
                         imageVector = Icons.Outlined.CloudDownload,
@@ -198,6 +203,13 @@ fun DebugMenuActions(
     viewModel: DebugViewModel = hiltViewModel(),
     modifier: Modifier = Modifier,
 ) {
+    // Button(
+    //     // FIXME: needs to do what it says on the label 
+    //     onClick = viewModel::deleteAllLogs,
+    //     modifier = modifier,
+    // ) {
+    //     Text(text = stringResource(R.string.map_start_download)) // should rename to be generic 
+    // }
     Button(
         onClick = viewModel::deleteAllLogs,
         modifier = modifier,

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
@@ -526,7 +526,7 @@ private fun rememberAnnotatedString(
     val theme = androidx.compose.material3.MaterialTheme.colorScheme
     val highlightStyle = SpanStyle(
         background = theme.primary.copy(alpha = 0.3f),
-        color = theme.onPrimary
+        color = theme.onSurface
     )
     
     return remember(text, searchText) {
@@ -557,7 +557,7 @@ private fun rememberAnnotatedLogMessage(log: UiMeshLog, searchText: String): Ann
     )
     val highlightStyle = SpanStyle(
         background = theme.primary.copy(alpha = 0.3f),
-        color = theme.onPrimary
+        color = theme.onSurface
     )
     
     return remember(log.uuid, searchText) {

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
@@ -171,7 +171,7 @@ private fun rememberAnnotatedLogMessage(log: UiMeshLog): AnnotatedString {
 
 @PreviewLightDark
 @Composable
-private fun DebugScreenPreview() {
+private fun DebugPacketPreview() {
     AppTheme {
         DebugItem(
             UiMeshLog(

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -82,6 +82,7 @@
     <string name="text_messages">Mensaxes de texto</string>
     <string name="channel_invalid">A ligazón desta canle non é válida e non pode usarse</string>
     <string name="debug_panel">Panel de depuración</string>
+    <string name="debug_logs_export">Export Logs</string>
     <string name="debug_last_messages">Últimas 500 mensaxes</string>
     <string name="clear">Limpar</string>
     <string name="updating_firmware">Actualizando firmware, espera ata oito minutos…</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -72,6 +72,7 @@
     <string name="text_messages">Textaskilaboð</string>
     <string name="channel_invalid">Þetta rásar URL er ógilt og ónothæft</string>
     <string name="debug_panel">Villuleitarborð</string>
+
     <string name="debug_last_messages">Síðustu 500 skilaboð</string>
     <string name="clear">Hreinsa</string>
     <string name="updating_firmware">Uppfæri fastbúnað, hinkrið allt að átta mínútum…</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -135,6 +135,7 @@
     <string name="text_messages">Messaggi di testo</string>
     <string name="channel_invalid">L\'URL di questo Canale non è valida e non può essere usata</string>
     <string name="debug_panel">Pannello Di Debug</string>
+
     <string name="debug_last_messages">Ultimi 500 messaggi</string>
     <string name="clear">Svuota</string>
     <string name="updating_firmware">Aggiornamento del firmware in corso, attendere fino a otto minuti…</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -85,6 +85,7 @@
     <string name="text_messages">הודעות טקסט</string>
     <string name="channel_invalid">כתובת ערוץ זה אינו תקין ולא ניתן לעשות בו שימוש</string>
     <string name="debug_panel">פאנל דיבאג</string>
+
     <string name="debug_last_messages">500 ההודעות האחרונות</string>
     <string name="clear">נקה</string>
     <string name="updating_firmware">מעדכן קושחה, המתן עד ל-8 דקות…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -135,6 +135,7 @@
     <string name="text_messages">メッセージ</string>
     <string name="channel_invalid">このチャンネルURLは無効なため使用できません。</string>
     <string name="debug_panel">デバッグ</string>
+
     <string name="debug_last_messages">最新500件のメッセージ</string>
     <string name="clear">削除</string>
     <string name="updating_firmware">ファームウェア更新中．．．最大８分お待ちください。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -134,6 +134,7 @@
     <string name="text_messages">문자 메시지</string>
     <string name="channel_invalid">이 채널 URL은 잘못 되었습니다. 따라서 사용할 수 없습니다.</string>
     <string name="debug_panel">디버그 패널</string>
+
     <string name="debug_last_messages">500개의 마지막 메시지</string>
     <string name="clear">초기화</string>
     <string name="updating_firmware">펌웨어 업데이트 중, 최대 8분 소요 예정…</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -120,6 +120,7 @@
     <string name="text_messages">Teksto žinutės</string>
     <string name="channel_invalid">Šio kanalo URL yra neteisingas ir negali būti naudojamas</string>
     <string name="debug_panel">Derinimo skydelis</string>
+
     <string name="debug_last_messages">Paskutiniai 500 pranešimų</string>
     <string name="clear">Išvalyti</string>
     <string name="updating_firmware">Atnaujinama programinė įranga, palaukite iki aštuonių minučių…</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -127,6 +127,7 @@
     <string name="text_messages">Tekstmeldinger</string>
     <string name="channel_invalid">Denne kanall URL er ugyldig og kan ikke benyttes</string>
     <string name="debug_panel">Feilsøkningspanel</string>
+
     <string name="debug_last_messages">500 siste meldinger</string>
     <string name="clear">Tøm</string>
     <string name="updating_firmware">Oppdaterer firmware, vent opptil åtte minutter…</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -134,6 +134,7 @@
     <string name="text_messages">Tekstberichten</string>
     <string name="channel_invalid">Deze Kanaal URL is ongeldig en kan niet worden gebruikt</string>
     <string name="debug_panel">Debug-paneel</string>
+
     <string name="debug_last_messages">500 laatste berichten</string>
     <string name="clear">Wis</string>
     <string name="updating_firmware">Firmware wordt bijgewerkt, wacht tot acht minuten…</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -133,6 +133,7 @@
     <string name="text_messages">Wiadomości tekstowe</string>
     <string name="channel_invalid">Ten adres URL kanału jest nieprawidłowy i nie można go użyć</string>
     <string name="debug_panel">Panel debugowania</string>
+
     <string name="debug_last_messages">Ostatnie 500 zdarzeń</string>
     <string name="clear">Czyść</string>
     <string name="updating_firmware">Aktualizuję oprogramowanie, poczekaj chwilę…</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -127,6 +127,7 @@
     <string name="text_messages">Mensagens de texto</string>
     <string name="channel_invalid">Este link de canal é inválido e não pode ser usado</string>
     <string name="debug_panel">Painel de depuração</string>
+
     <string name="debug_last_messages">500 últimas mensagens</string>
     <string name="clear">Limpar</string>
     <string name="updating_firmware">Atualizando firmware, aguarde até 8 minutos…</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -136,6 +136,7 @@
     <string name="text_messages">Mensagem de Texto</string>
     <string name="channel_invalid">O Link Deste Canal é inválido e não pode ser usado</string>
     <string name="debug_panel">Painel de depuração</string>
+
     <string name="debug_last_messages">500 últimas mensagens</string>
     <string name="clear">Limpar</string>
     <string name="updating_firmware">Atualizando firmware, aguarde até 8 minutos…</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -74,6 +74,7 @@
     <string name="text_messages">Mesaje Text</string>
     <string name="channel_invalid">Acest URL de canal este invalid și nu poate fi folosit</string>
     <string name="debug_panel">Panou debug</string>
+
     <string name="debug_last_messages">Ultimele 500 mesaje</string>
     <string name="clear">Șterge</string>
     <string name="updating_firmware">Se actualizează firmware-ul, așteptați până la opt minute…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -134,6 +134,7 @@
     <string name="text_messages">Текстовые сообщения</string>
     <string name="channel_invalid">Этот URL-адрес канала недействителен и не может быть использован</string>
     <string name="debug_panel">Панель отладки</string>
+
     <string name="debug_last_messages">500 последних сообщений</string>
     <string name="clear">Очистить</string>
     <string name="updating_firmware">Обновление прошивки, подождите до восьми минут…</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -134,6 +134,7 @@
     <string name="text_messages">Textové správy</string>
     <string name="channel_invalid">URL adresa tohoto kanála nie je platná a nedá sa použiť</string>
     <string name="debug_panel">Debug okno</string>
+
     <string name="debug_last_messages">500 posledných správ</string>
     <string name="clear">Zmazať</string>
     <string name="updating_firmware">Aktualizácia firmvéru, môže to trvať do 8 minút…</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -127,6 +127,7 @@
     <string name="text_messages">Sporočila</string>
     <string name="channel_invalid">Neveljaven kanal</string>
     <string name="debug_panel">Plošča za odpravljanje napak</string>
+
     <string name="debug_last_messages">Odpravi napake zadnjih sporočil</string>
     <string name="clear">Počisti</string>
     <string name="updating_firmware">Posodobitev programske opreme…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,6 +161,7 @@
     <string name="text_messages">Text messages</string>
     <string name="channel_invalid">This Channel URL is invalid and can not be used</string>
     <string name="debug_panel">Debug Panel</string>
+    <string name="debug_logs_export">Export Logs</string>
     <string name="debug_last_messages">500 last messages</string>
     <string name="debug_filters">filters</string>
     <string name="debug_active_filters">Active filters</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,7 +162,9 @@
     <string name="channel_invalid">This Channel URL is invalid and can not be used</string>
     <string name="debug_panel">Debug Panel</string>
     <string name="debug_last_messages">500 last messages</string>
-    <string name="clear">Clear</string>
+    <string name="debug_filters">filters</string>
+    <string name="debug_active_filters">Active filters</string>
+    <string name="clear">Clear Logs</string>
     <string name="updating_firmware">Updating firmware, wait up to eight minutes…</string>
     <string name="update_successful">Update successful</string>
     <string name="update_failed">Update failed</string>


### PR DESCRIPTION
#2105 & #2118

# Improvements to the debug panel 
- [x] Add search 
- [x] Add filters 
- [x] Add export logs 
- [x] Copy Packet info to clipboard
- [x] Make text larger on selected ones


## TODOs 
- [ ] Add strings in other languages - is there a process to automate that? 
- [ ] Are there any other filters that should be in the default list? 
   - [ ] add "To me" filter (get own address from attatched nodes]
- [ ] conflate CONFIG_APP to 'config' etc. on packets that do get fully decoded
- [ ] Look at decoding additional packet types 


## Screenshots 
Base screen
<img width="314" alt="image" src="https://github.com/user-attachments/assets/6fba4f24-91a8-4409-88f3-da8b8b4b2d4e" />
<img width="314" alt="image" src="https://github.com/user-attachments/assets/6fba4f24-91a8-4409-88f3-da8b8b4b2d4e" />

Search  & Zoom on selected
<img width="298" alt="image" src="https://github.com/user-attachments/assets/8a081ce1-147e-49b5-8fcc-9900f51ece6c" />
<img width="298" alt="image" src="https://github.com/user-attachments/assets/8a081ce1-147e-49b5-8fcc-9900f51ece6c" />


Filters 
<img width="304" alt="image" src="https://github.com/user-attachments/assets/571a6e3a-4bd4-400d-b092-3909a25b4553" />
<img width="304" alt="image" src="https://github.com/user-attachments/assets/571a6e3a-4bd4-400d-b092-3909a25b4553" />


