### PR TITLE
fix: refactor MainActivity to use lifecycleScope for coroutines

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -143,7 +143,7 @@
 
         <activity
             android:name="com.geeksville.mesh.MainActivity"
-            android:launchMode="standard"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>


### PR DESCRIPTION
This commit refactors `MainActivity.kt` to utilize `lifecycleScope` for managing coroutines, replacing the custom `mainScope`. This change ensures coroutines are automatically cancelled when the Activity is destroyed, simplifying lifecycle management.

resolves an issue where messages wouldn't send after tapping a notification, fixes #1996 


Key changes:
- Removed `mainScope` and its manual cancellation in `onDestroy`.
- Replaced `mainScope.handledLaunch` with `lifecycleScope.handledLaunch` for service connection and setup.
- Removed explicit `unbindMeshService` and its call in `onStop` as `lifecycleScope` handles service disconnection automatically.
- Changed `MainActivity` launchMode in `AndroidManifest.xml` from `standard` to `singleTop` to prevent multiple instances when launched from a notification.
