### PR TITLE
Fix text input not clearing after sending message

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -264,6 +264,8 @@ internal fun MessageScreen(
                         viewModel.sendMessage(message, contactKey, it.packetId)
                         replyingTo = null
                     } ?: viewModel.sendMessage(message, contactKey)
+                    // Clear the text input after sending the message and updating all state
+                    messageInput.value = TextFieldValue("")
                 }
             }
         }
@@ -465,7 +467,6 @@ private fun TextInput(
                     val str = message.value.text.trim()
                     if (str.isNotEmpty()) {
                         onClick(str)
-                        message.value = TextFieldValue("")
                     }
                     true // Consume the event
                 } else {
@@ -483,7 +484,6 @@ private fun TextInput(
                 val str = message.value.text.trim()
                 if (str.isNotEmpty()) {
                     onClick(str)
-                    message.value = TextFieldValue("")
                 }
             }
         ),
@@ -495,7 +495,6 @@ private fun TextInput(
                     val str = message.value.text.trim()
                     if (str.isNotEmpty()) {
                         onClick(str)
-                        message.value = TextFieldValue("")
                         focusManager.clearFocus()
                     }
                 },


### PR DESCRIPTION
Fixes an issue where the message text field would sometimes not clear after sending a message, leaving the old text visible even though the message was successfully sent.

**Problem:** Text clearing logic was happening inside the TextInput composable while state changes (like clearing reply state) were happening in the parent composable, creating a timing issue during recomposition.

**Solution:** Moved the text clearing to happen at the parent level after all message sending and state updates are complete.

**Testing:** Verified text field clears properly when sending both regular messages and replies, using the send button and the enter key.  Tested on a TCL T768S (Android 11)

Closes #2150 