### PR TITLE
[chore] Restrict GH action runs to the main repository

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,6 +20,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/Meshtastic-Android'
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    if: github.repository == 'meshtastic/Meshtastic-Android'
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/Meshtastic-Android'
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-upload-sources.yml
+++ b/.github/workflows/crowdin-upload-sources.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/Meshtastic-Android'
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-upload-translations.yml
+++ b/.github/workflows/crowdin-upload-translations.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/Meshtastic-Android'
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
 
   release-build:
     runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/Meshtastic-Android'
     steps:
 
     - name: Checkout code

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,7 @@ jobs:
   stale_issues:
     name: Close Stale Issues
     runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/Meshtastic-Android'
 
     steps:
       - name: Stale PR+Issues

--- a/.github/workflows/update-firmware-releases-list.yml
+++ b/.github/workflows/update-firmware-releases-list.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update-hardware-list:
     runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/Meshtastic-Android'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update-hardware-list.yml
+++ b/.github/workflows/update-hardware-list.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update-hardware-list:
     runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/Meshtastic-Android'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Restricts GH actions to only the main repository, so that by default they won't attempt to run in forks. 

Re: https://discordapp.com/channels/867578229534359593/871539863307055134/1385276009745748008