### PR TITLE
fix (#2172): replace string template for `Hops Away:`

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
@@ -221,7 +221,7 @@ internal fun MessageItem(
                         }
                     } else {
                         Text(
-                            text = "${message.hopsAway}",
+                            text = stringResource(R.string.hops_away, message.hopsAway),
                             style = MaterialTheme.typography.labelSmall,
                         )
                     }


### PR DESCRIPTION
fixes #2172

thanks @lkosson 