### PR TITLE
fix: Propagate reply ID for DataPackets

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/DataPacket.kt
+++ b/app/src/main/java/com/geeksville/mesh/DataPacket.kt
@@ -131,7 +131,7 @@ data class DataPacket(
         parcel.readInt(),
         parcel.readFloat(),
         parcel.readInt(),
-        if (parcel.readInt() == 0) null else parcel.readInt()
+        parcel.readInt().let { if (it == 0) null else it }
     )
 
     @Suppress("CyclomaticComplexMethod")
@@ -232,7 +232,8 @@ data class DataPacket(
         const val PKC_CHANNEL_INDEX = 8
 
         fun nodeNumToDefaultId(n: Int): String = "!%08x".format(n)
-        fun idToDefaultNodeNum(id: String?): Int? = runCatching { id?.toLong(16)?.toInt() }.getOrNull()
+        fun idToDefaultNodeNum(id: String?): Int? =
+            runCatching { id?.toLong(16)?.toInt() }.getOrNull()
 
         override fun createFromParcel(parcel: Parcel): DataPacket {
             return DataPacket(parcel)

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -692,6 +692,9 @@ class MeshService : Service(), Logging {
         ) {
             portnumValue = p.dataType
             payload = ByteString.copyFrom(p.bytes)
+            if (p.replyId != null && p.replyId != 0) {
+                this.replyId = p.replyId!!
+            }
         }
     }
 


### PR DESCRIPTION
This change ensures that the `replyId` from a `DataPacket` is correctly propagated when creating a `MeshPacket`.

Specifically:
- In `MeshService.kt`, the `replyId` is now set on the `MeshPacket` if the incoming `DataPacket` has a non-null and non-zero `replyId`.
- In `DataPacket.kt`, the `replyId` is read from the parcel and set to `null` if it's 0, otherwise the read value is used.

