### PR TITLE
fix: Use string template for hops away

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/components/MessageItem.kt
@@ -221,7 +221,7 @@ internal fun MessageItem(
                         }
                     } else {
                         Text(
-                            text = stringResource(R.string.hops_away, message.hopsAway),
+                            text = stringResource(R.string.hops_away_template, message.hopsAway),
                             style = MaterialTheme.typography.labelSmall,
                         )
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,6 +299,7 @@
     <string name="humidity">Humidity</string>
     <string name="logs">Logs</string>
     <string name="hops_away">Hops Away</string>
+    <string name="hops_away_template">Hops Away: %$1d</string>
     <string name="info">Information</string>
     <string name="ch_util_definition">Utilization for the current channel, including well formed TX, RX and malformed RX (aka noise).</string>
     <string name="air_util_definition">Percent of airtime for transmission used within the last hour.</string>


### PR DESCRIPTION
Updated the string resource for "hops away" to use a template for better localization support. Modified `MessageItem.kt` to utilize the new string template.

@lkosson 🙃 

https://github.com/meshtastic/Meshtastic-Android/issues/2172#issuecomment-2991637066