### PR TITLE
fix: clear public key when private key edited

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -689,7 +689,7 @@
     <string name="client_notification">Client Notification</string>
     <string name="compromised_keys">Compromised keys detected, select OK to regenerate.</string>
     <string name="regenerate_private_key">Regenerate Private Key</string>
-    <string name="regenerate_keys_confirmation">Are you sure you want to regenerate your Private Key?</string>
+    <string name="regenerate_keys_confirmation">Are you sure you want to regenerate your Private Key?\n\nNodes that may have previously exchanged keys with this node will need to Remove that node and re-exchange keys in order to resume secure communication.</string>
     <string name="export_keys">Export Keys</string>
     <string name="export_keys_confirmation">Exports public and private keys to a file. Please store somewhere securely.</string>
 </resources>


### PR DESCRIPTION
clears publick key when private key is edited or regenerated, displays original public key if original private key is reset.

Additional messaging added for the dialog to explain that the changed key node must be `Removed` and key exchange must happen again before interaction.