### PR TITLE
fix: unintended line break in node chip

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/node/components/NodeChip.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/components/NodeChip.kt
@@ -56,7 +56,7 @@ fun NodeChip(
         AssistChip(
             modifier = modifier
                 .width(IntrinsicSize.Min)
-                .defaultMinSize(minHeight = 24.dp, minWidth = 48.dp),
+                .defaultMinSize(minHeight = 24.dp, minWidth = 72.dp),
             colors = AssistChipDefaults.assistChipColors(
                 containerColor = Color(nodeColor),
                 labelColor = Color(textColor),
@@ -69,6 +69,7 @@ fun NodeChip(
                     fontSize = MaterialTheme.typography.labelLarge.fontSize,
                     textDecoration = TextDecoration.LineThrough.takeIf { isIgnored },
                     textAlign = TextAlign.Center,
+                    maxLines = 1,
                 )
             },
             onClick = {},


### PR DESCRIPTION
Change #2191 caused node chips with hyphen or space **and** full-width letters (`W`, `M` etc) to be displayed in two lines (see 2nd message in the screenshot). This change reverts `minWidth` from `48dp` back to `72dp` and also adds `maxLines = 1` as a safeguard when someone puts line breaks or other exotic unicode characters in `shortName`.

<img src="https://github.com/user-attachments/assets/9684da98-3a97-40a0-8c68-0f7a81265da0" width="300" />