### PR TITLE
fix: ignore non-local localStats telemetry

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -983,7 +983,8 @@ class MeshService : Service(), Logging {
         fromNum: Int,
         t: TelemetryProtos.Telemetry,
     ) {
-        if (t.hasLocalStats()) {
+        val isRemote = (fromNum != myNodeNum)
+        if (!isRemote && t.hasLocalStats()) {
             localStatsTelemetry = t
             maybeUpdateServiceStatusNotification()
         }
@@ -991,7 +992,6 @@ class MeshService : Service(), Logging {
             when {
                 t.hasDeviceMetrics() -> {
                     it.deviceTelemetry = t
-                    val isRemote = (fromNum != myNodeNum)
                     if (fromNum == myNodeNum || (isRemote && it.isFavorite)) {
                         if (t.deviceMetrics.voltage > batteryPercentUnsupported &&
                             t.deviceMetrics.batteryLevel <= batteryPercentLowThreshold


### PR DESCRIPTION
Not sure if it belongs here, but worth a shot.

[Forked firmware](https://github.com/musznik/firmware) popular around here broadcasts telemetry with `hasLocalStats` over the radio for some reason, randomly replacing local stats in notification with the ones received from remote node. It shouldn't do it, but it does, breaking stats for everyone around. Not much can be done about operators running this firmware version, and official firmware never produces such messages, but such packets could be ignored without any harm.