### PR TITLE
fix: message input clearing with proper state management (#1474 & #2150)

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -267,6 +267,8 @@ internal fun MessageScreen(
                         viewModel.sendMessage(message, contactKey, it.packetId)
                         replyingTo = null
                     } ?: viewModel.sendMessage(message, contactKey)
+                    // Clear the text input after sending the message and updating all state
+                    messageInput.value = TextFieldValue("")
                 }
             }
         }
@@ -468,7 +470,6 @@ private fun TextInput(
                     val str = message.value.text.trim()
                     if (str.isNotEmpty()) {
                         onClick(str)
-                        message.value = TextFieldValue("")
                     }
                     true // Consume the event
                 } else {
@@ -486,7 +487,6 @@ private fun TextInput(
                 val str = message.value.text.trim()
                 if (str.isNotEmpty()) {
                     onClick(str)
-                    message.value = TextFieldValue("")
                 }
             }
         ),
@@ -498,7 +498,6 @@ private fun TextInput(
                     val str = message.value.text.trim()
                     if (str.isNotEmpty()) {
                         onClick(str)
-                        message.value = TextFieldValue("")
                         focusManager.clearFocus()
                     }
                 },

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -144,7 +144,10 @@ internal fun MessageScreen(
     val quickChat by viewModel.quickChatActions.collectAsStateWithLifecycle()
     val messages by viewModel.getMessagesFrom(contactKey).collectAsStateWithLifecycle(listOf())
 
-    val messageInput = rememberSaveable(stateSaver = TextFieldValue.Saver) {
+    val messageInput = rememberSaveable(
+        key = contactKey, // Use contactKey as key so state resets when switching conversations
+        stateSaver = TextFieldValue.Saver
+    ) {
         mutableStateOf(TextFieldValue(message))
     }
     var replyingTo by remember { mutableStateOf<Message?>(null) }
@@ -264,8 +267,6 @@ internal fun MessageScreen(
                         viewModel.sendMessage(message, contactKey, it.packetId)
                         replyingTo = null
                     } ?: viewModel.sendMessage(message, contactKey)
-                    // Clear the text input after sending the message and updating all state
-                    messageInput.value = TextFieldValue("")
                 }
             }
         }
@@ -467,6 +468,7 @@ private fun TextInput(
                     val str = message.value.text.trim()
                     if (str.isNotEmpty()) {
                         onClick(str)
+                        message.value = TextFieldValue("")
                     }
                     true // Consume the event
                 } else {
@@ -484,6 +486,7 @@ private fun TextInput(
                 val str = message.value.text.trim()
                 if (str.isNotEmpty()) {
                     onClick(str)
+                    message.value = TextFieldValue("")
                 }
             }
         ),
@@ -495,6 +498,7 @@ private fun TextInput(
                     val str = message.value.text.trim()
                     if (str.isNotEmpty()) {
                         onClick(str)
+                        message.value = TextFieldValue("")
                         focusManager.clearFocus()
                     }
                 },


### PR DESCRIPTION
Resolves issue where message text field wouldn't clear after sending messages.

**Root Cause:** rememberSaveable without key caused state interference between conversations and recompositions.

**Solution:** Added contactKey as rememberSaveable key + centralized text clearing in MessageScreen callback for single responsibility and reliable behavior.

Tested on a TCL T768S

First attempt was #2161 in but these changes are necessary as well

Related issues: #1474, #2150