### PR TITLE
feat: show online and total node count in the title bar

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
@@ -29,6 +29,7 @@ import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.NodeSortOption
 import com.geeksville.mesh.util.onlineTimeThreshold
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -133,4 +134,12 @@ class NodeRepository @Inject constructor(
     suspend fun insertMetadata(metadata: MetadataEntity) = withContext(dispatchers.io) {
         nodeInfoDao.upsert(metadata)
     }
+
+    val onlineNodeCount: Flow<Int> = nodeInfoDao.nodeDBbyNum().mapLatest { map ->
+        map.values.count { it.node.lastHeard > onlineTimeThreshold() }
+    }.flowOn(dispatchers.io).conflate()
+
+    val totalNodeCount: Flow<Int> = nodeInfoDao.nodeDBbyNum().mapLatest { map ->
+        map.values.count()
+    }.flowOn(dispatchers.io).conflate()
 }

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -403,6 +403,18 @@ class UIViewModel @Inject constructor(
         initialValue = emptyList(),
     )
 
+    val onlineNodeCount = nodeDB.onlineNodeCount.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = 0,
+    )
+
+    val totalNodeCount = nodeDB.totalNodeCount.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = 0,
+    )
+
     val filteredNodeList: StateFlow<List<Node>> = nodeList.mapLatest { list ->
         list.filter { node ->
             !node.isIgnored

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -376,10 +376,15 @@ private fun MainAppBar(
         return
     }
     val title by viewModel.title.collectAsStateWithLifecycle("")
+    val onlineNodeCount by viewModel.onlineNodeCount.collectAsStateWithLifecycle(0)
+    val totalNodeCount by viewModel.totalNodeCount.collectAsStateWithLifecycle(0)
     TopAppBar(
         title = {
             val title = when {
-                currentDestination == null || isTopLevelRoute -> stringResource(id = R.string.app_name)
+                currentDestination == null -> stringResource(id = R.string.app_name)
+
+                currentDestination.hasRoute<NodesRoutes.Nodes>() -> stringResource(id = R.string.app_name) +
+                        " ($onlineNodeCount/$totalNodeCount)"
 
                 currentDestination.hasRoute<Route.DebugPanel>() -> stringResource(id = R.string.debug_panel)
 


### PR DESCRIPTION
This introduces a feature that displays the count of online and total nodes in the application's title bar.

The changes include:
- Adding `onlineNodeCount` and `totalNodeCount` StateFlows to `UIState.kt` to observe these values from the `NodeRepository`.
- Modifying `Main.kt` to collect these counts and update the `TopAppBar` title to show "App Name (online/total)" when viewing the nodes list.
- Adding `onlineNodeCount` and `totalNodeCount` Flows to `NodeRepository.kt` to provide the counts of online and total nodes from the database.

replaces #1958 