### PR TITLE
Refactor node count display in MainAppBar

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -402,7 +402,7 @@ private fun MainAppBar(
             )
         },
         subtitle = {
-            if (currentDestination?.hasRoute<NodesRoutes.Nodes>() == true ){
+            if (currentDestination?.hasRoute<NodesRoutes.Nodes>() == true) {
                 Text(
                     text = stringResource(
                         R.string.node_count_template,

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.twotone.People
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -357,7 +358,7 @@ enum class MainMenuAction(@StringRes val stringRes: Int) {
     ABOUT(R.string.about),
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Suppress("LongMethod")
 @Composable
 private fun MainAppBar(
@@ -381,10 +382,7 @@ private fun MainAppBar(
     TopAppBar(
         title = {
             val title = when {
-                currentDestination == null -> stringResource(id = R.string.app_name)
-
-                currentDestination.hasRoute<NodesRoutes.Nodes>() -> stringResource(id = R.string.app_name) +
-                        " ($onlineNodeCount/$totalNodeCount)"
+                currentDestination == null || isTopLevelRoute -> stringResource(id = R.string.app_name)
 
                 currentDestination.hasRoute<Route.DebugPanel>() -> stringResource(id = R.string.debug_panel)
 
@@ -402,6 +400,17 @@ private fun MainAppBar(
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.titleLarge,
             )
+        },
+        subtitle = {
+            if (currentDestination?.hasRoute<NodesRoutes.Nodes>() == true ){
+                Text(
+                    text = stringResource(
+                        R.string.node_count_template,
+                        onlineNodeCount,
+                        totalNodeCount
+                    ),
+                )
+            }
         },
         modifier = modifier,
         navigationIcon = if (canNavigateBack && !isTopLevelRoute) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -694,4 +694,5 @@
     <string name="export_keys_confirmation">Exports public and private keys to a file. Please store somewhere securely.</string>
     <string name="modules_unlocked">Modules unlocked</string>
     <string name="remote">Remote</string>
+    <string name="node_count_template">(%1$d online / %2$d total)</string>
 </resources>


### PR DESCRIPTION
Moves the online/total node count from the title to the subtitle of the `MainAppBar` when the current destination is the Nodes screen. This change utilizes the `subtitle` parameter of the `TopAppBar` and introduces a new string resource `node_count_template` for formatting. 

Additionally, it opts into `ExperimentalMaterial3ExpressiveApi`.

![image](https://github.com/user-attachments/assets/7c8105f8-dea2-46f0-a696-dcea9298e94b)
