### PR TITLE
Refactor: Use default FAB shape for MapButton

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/map/components/MapButton.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/components/MapButton.kt
@@ -19,7 +19,6 @@ package com.geeksville.mesh.ui.map.components
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Layers
 import androidx.compose.material3.FloatingActionButton
@@ -58,7 +57,6 @@ fun MapButton(
     FloatingActionButton(
         onClick = onClick,
         modifier = modifier,
-        shape = CircleShape,
     ) {
         Icon(
             imageVector = icon,


### PR DESCRIPTION
Removes the explicit `CircleShape` from the `MapButton` Composable, allowing it to use the default shape provided by `FloatingActionButton`.

![image](https://github.com/user-attachments/assets/435447cd-939d-43b1-a31e-5a7427f71ca6)
