### PR TITLE
feat: split message notifications into direct- and broadcast messages

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -340,7 +340,8 @@ class MeshService : Service(), Logging {
         serviceNotifications.updateMessageNotification(
             contactKey,
             getSenderName(dataPacket),
-            message
+            message,
+            isBroadcast = dataPacket.to == DataPacket.ID_BROADCAST
         )
     }
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -66,6 +66,7 @@ class MeshServiceNotifications(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             createNotificationChannel()
             createMessageNotificationChannel()
+            createBroadcastNotificationChannel()
             createAlertNotificationChannel()
             createNewNodeNotificationChannel()
             createLowBatteryNotificationChannel()
@@ -101,6 +102,32 @@ class MeshServiceNotifications(
                 channelId,
                 channelName,
                 NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                lightColor = notificationLightColor
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                setShowBadge(true)
+                setSound(
+                    RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .build()
+                )
+            }
+            notificationManager.createNotificationChannel(channel)
+        }
+        return channelId
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createBroadcastNotificationChannel(): String {
+        val channelId = "my_broadcasts"
+        if (notificationManager.getNotificationChannel(channelId) == null) {
+            val channelName = context.getString(R.string.meshtastic_broadcast_notifications)
+            val channel = NotificationChannel(
+                channelId,
+                channelName,
+                NotificationManager.IMPORTANCE_DEFAULT
             ).apply {
                 lightColor = notificationLightColor
                 lockscreenVisibility = Notification.VISIBILITY_PUBLIC
@@ -274,6 +301,14 @@ class MeshServiceNotifications(
         }
     }
 
+    private val broadcastChannelId: String by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createBroadcastNotificationChannel()
+        } else {
+            ""
+        }
+    }
+
     private val alertChannelId: String by lazy {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             createAlertNotificationChannel()
@@ -349,10 +384,10 @@ class MeshServiceNotifications(
         notificationManager.cancel(contactKey.hashCode())
     }
 
-    fun updateMessageNotification(contactKey: String, name: String, message: String) =
+    fun updateMessageNotification(contactKey: String, name: String, message: String, isBroadcast: Boolean) =
         notificationManager.notify(
             contactKey.hashCode(), // show unique notifications,
-            createMessageNotification(contactKey, name, message)
+            createMessageNotification(contactKey, name, message, isBroadcast)
         )
 
     fun showAlertNotification(contactKey: String, name: String, alert: String) {
@@ -486,10 +521,12 @@ class MeshServiceNotifications(
     private fun createMessageNotification(
         contactKey: String,
         name: String,
-        message: String
+        message: String,
+        isBroadcast: Boolean,
     ): Notification {
+        val channelId = if (isBroadcast) broadcastChannelId else messageChannelId
         val messageNotificationBuilder: NotificationCompat.Builder =
-            commonBuilder(messageChannelId, createOpenMessageIntent(contactKey))
+            commonBuilder(channelId, createOpenMessageIntent(contactKey))
 
         val person = Person.Builder().setName(name).build()
         // Key for the string that's delivered in the action's intent.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,7 +175,8 @@
     <string name="message_reception_time">message reception time</string>
     <string name="message_reception_state">message reception state</string>
     <string name="message_delivery_status">Message delivery status</string>
-    <string name="meshtastic_messages_notifications">Message notifications</string>
+    <string name="meshtastic_messages_notifications">Direct message notifications</string>
+    <string name="meshtastic_broadcast_notifications">Broadcast message notifications</string>
     <string name="meshtastic_alerts_notifications">Alert notifications</string>
     <string name="protocol_stress_test">Protocol stress test</string>
     <string name="firmware_too_old">Firmware update required.</string>


### PR DESCRIPTION
This change splits existing message notifications into broadcast (channel) messages and direct (user-to-user) messages. The goal is to allow end user to customize sound, priority and notification type separately for both message types.

Existing notification channel "Message notifications" keeps its ID (`my_messages`) and importance (`IMPORTANCE_HIGH`), but is renamed to "Direct message notifications" and is used for direct messages only. New notification channel "Broadcast message notifications" has `IMPORTANCE_DEFAULT` and is used for broadcast messages.