### PR TITLE
Refactor: Inject BluetoothViewModel into ConnectionsScreen

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -146,7 +146,8 @@ class MainActivity : AppCompatActivity(), Logging {
                     }
                 }
                 MainScreen(
-                    viewModel = model,
+                    uIViewModel = model,
+                    bluetoothViewModel = bluetoothViewModel,
                     onAction = ::onMainMenuAction,
                 )
             }

--- a/app/src/main/java/com/geeksville/mesh/navigation/ConnectionsRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/ConnectionsRoutes.kt
@@ -24,6 +24,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
 import androidx.navigation.navigation
+import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.connections.ConnectionsScreen
 import com.geeksville.mesh.ui.radioconfig.components.LoRaConfigScreen
@@ -41,7 +42,11 @@ sealed class ConnectionsRoutes {
 /**
  * Navigation graph for for the top level ConnectionsScreen - [ConnectionsRoutes.Connections].
  */
-fun NavGraphBuilder.connectionsGraph(navController: NavHostController, uiViewModel: UIViewModel) {
+fun NavGraphBuilder.connectionsGraph(
+    navController: NavHostController,
+    uiViewModel: UIViewModel,
+    bluetoothViewModel: BluetoothViewModel
+) {
     navigation<ConnectionsRoutes.ConnectionsGraph>(
         startDestination = ConnectionsRoutes.Connections,
     ) {
@@ -57,7 +62,8 @@ fun NavGraphBuilder.connectionsGraph(navController: NavHostController, uiViewMod
                 navController.getBackStackEntry<ConnectionsRoutes.ConnectionsGraph>()
             }
             ConnectionsScreen(
-                uiViewModel,
+                uiViewModel = uiViewModel,
+                bluetoothViewModel = bluetoothViewModel,
                 radioConfigViewModel = hiltViewModel(parentEntry),
                 onNavigateToRadioConfig = { navController.navigate(RadioConfigRoutes.RadioConfig()) },
                 onNavigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetail(it)) },

--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -28,6 +28,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.geeksville.mesh.R
+import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.TopLevelDestination.Companion.isTopLevel
 import com.geeksville.mesh.ui.debug.DebugScreen
@@ -74,6 +75,7 @@ fun NavDestination.showLongNameTitle(): Boolean {
 fun NavGraph(
     modifier: Modifier = Modifier,
     uIViewModel: UIViewModel = hiltViewModel(),
+    bluetoothViewModel: BluetoothViewModel = hiltViewModel(),
     navController: NavHostController = rememberNavController(),
 ) {
     NavHost(
@@ -89,7 +91,7 @@ fun NavGraph(
         nodesGraph(navController, uIViewModel,)
         mapGraph(navController, uIViewModel)
         channelsGraph(navController, uIViewModel)
-        connectionsGraph(navController, uIViewModel)
+        connectionsGraph(navController, uIViewModel, bluetoothViewModel)
         composable<Route.DebugPanel> { DebugScreen() }
         radioConfigGraph(navController, uIViewModel)
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -76,6 +76,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.R
+import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.DeviceVersion
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.UIViewModel
@@ -119,22 +120,23 @@ enum class TopLevelDestination(@StringRes val label: Int, val icon: ImageVector,
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 fun MainScreen(
-    viewModel: UIViewModel = hiltViewModel(),
+    uIViewModel: UIViewModel = hiltViewModel(),
+    bluetoothViewModel: BluetoothViewModel = hiltViewModel(),
     onAction: (MainMenuAction) -> Unit,
 ) {
     val navController = rememberNavController()
-    val connectionState by viewModel.connectionState.collectAsStateWithLifecycle()
-    val localConfig by viewModel.localConfig.collectAsStateWithLifecycle()
-    val requestChannelSet by viewModel.requestChannelSet.collectAsStateWithLifecycle()
+    val connectionState by uIViewModel.connectionState.collectAsStateWithLifecycle()
+    val localConfig by uIViewModel.localConfig.collectAsStateWithLifecycle()
+    val requestChannelSet by uIViewModel.requestChannelSet.collectAsStateWithLifecycle()
     if (connectionState.isConnected()) {
         requestChannelSet?.let { newChannelSet ->
-            ScannedQrCodeDialog(viewModel, newChannelSet)
+            ScannedQrCodeDialog(uIViewModel, newChannelSet)
         }
     }
 
-    VersionChecks(viewModel)
+    VersionChecks(uIViewModel)
 
-    val alertDialogState by viewModel.currentAlert.collectAsStateWithLifecycle()
+    val alertDialogState by uIViewModel.currentAlert.collectAsStateWithLifecycle()
     alertDialogState?.let { state ->
         if (state.choices.isNotEmpty()) {
             MultipleChoiceAlertDialog(
@@ -154,7 +156,7 @@ fun MainScreen(
         }
     }
 
-    val clientNotification by viewModel.clientNotification.collectAsStateWithLifecycle()
+    val clientNotification by uIViewModel.clientNotification.collectAsStateWithLifecycle()
     clientNotification?.let { notification ->
         var message = notification.message
         val compromisedKeys =
@@ -173,12 +175,12 @@ fun MainScreen(
                 if (compromisedKeys) {
                     navController.navigate(RadioConfigRoutes.Security)
                 }
-                viewModel.clearClientNotification(notification)
+                uIViewModel.clearClientNotification(notification)
             },
         )
     }
 
-    val traceRouteResponse by viewModel.tracerouteResponse.observeAsState()
+    val traceRouteResponse by uIViewModel.tracerouteResponse.observeAsState()
     traceRouteResponse?.let { response ->
         SimpleAlertDialog(
             title = R.string.traceroute,
@@ -186,7 +188,7 @@ fun MainScreen(
                 Text(text = response)
             },
             dismissText = stringResource(id = R.string.okay),
-            onDismiss = { viewModel.clearTracerouteResponse() }
+            onDismiss = { uIViewModel.clearTracerouteResponse() }
         )
     }
     val navSuiteType =
@@ -258,7 +260,7 @@ fun MainScreen(
                 )
             }
             MainAppBar(
-                viewModel = viewModel,
+                viewModel = uIViewModel,
                 isManaged = localConfig.security.isManaged,
                 navController = navController,
                 onAction = { action ->
@@ -290,7 +292,8 @@ fun MainScreen(
                 },
             )
             NavGraph(
-                uIViewModel = viewModel,
+                uIViewModel = uIViewModel,
+                bluetoothViewModel = bluetoothViewModel,
                 navController = navController,
             )
         }


### PR DESCRIPTION
The `BluetoothViewModel` is now injected into the `ConnectionsScreen` and passed down through the navigation graph. This change allows the `ConnectionsScreen` to access Bluetooth-related data and functionality in the same scope as MainActivity.kt