### PR TITLE
fix: sticky messages

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -53,6 +53,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -150,6 +150,15 @@ internal fun MessageScreen(
     ) {
         mutableStateOf(TextFieldValue(message))
     }
+
+    // Track when a message is sent to clear the input
+    var messageSent by remember { mutableStateOf(false) }
+    LaunchedEffect(messageSent) {
+        if (messageSent) {
+            messageInput.value = TextFieldValue("")
+            messageSent = false
+        }
+    }
     var replyingTo by remember { mutableStateOf<Message?>(null) }
 
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -267,8 +276,7 @@ internal fun MessageScreen(
                         viewModel.sendMessage(message, contactKey, it.packetId)
                         replyingTo = null
                     } ?: viewModel.sendMessage(message, contactKey)
-                    // Clear the text input after sending the message and updating all state
-                    messageInput.value = TextFieldValue("")
+                    messageSent = true
                 }
             }
         }


### PR DESCRIPTION
## Summary of Changes
I've implemented a fix for the sticky message input issue using a LaunchedEffect approach:

- Added state tracking: Created a messageSent boolean flag to track when a message is sent
- Used LaunchedEffect: Added a LaunchedEffect that watches the messageSent flag and clears the text input in the next composition frame
- Updated message sending: Modified the message sending logic to set messageSent = true instead of directly clearing the text

This approach should resolve the race condition between state changes (like replyingTo = null) and text clearing operations by ensuring the text is cleared in a separate composition frame after all state updates are complete.

The fix addresses the core issue where the rememberSaveable state was potentially being restored during recomposition triggered by other state changes, causing the text input to reappear after being cleared.

Tested and working on a Pixel 6 Pro (Android 15)

Related issues: #1474 #2150