### PR TITLE
fix: mark unread messages as read when displayed (#2216)

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -139,6 +139,7 @@ internal fun MessageScreen(
 
     val quickChat by viewModel.quickChatActions.collectAsStateWithLifecycle()
     val messages by viewModel.getMessagesFrom(contactKey).collectAsStateWithLifecycle(listOf())
+    val unreadIndex by remember { derivedStateOf { messages.indexOfLast { !it.read } } }
 
     val messageInput = rememberTextFieldState(message)
 
@@ -204,7 +205,12 @@ internal fun MessageScreen(
                 modifier = Modifier.weight(1f, fill = true),
                 messages = messages,
                 selectedIds = selectedIds,
-                onUnreadChanged = { viewModel.clearUnreadCount(contactKey, it) },
+                onUnreadChanged = { firstUnreadIndex ->
+                    if (unreadIndex != -1 && firstUnreadIndex <= unreadIndex) {
+                        val message = messages[firstUnreadIndex]
+                        viewModel.clearUnreadCount(contactKey, message.receivedTime)
+                    }
+                },
                 onSendReaction = { emoji, id ->
                     viewModel.sendReaction(
                         emoji,

--- a/app/src/main/java/com/geeksville/mesh/ui/message/MessageList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/MessageList.kt
@@ -111,7 +111,7 @@ internal fun MessageList(
     modifier: Modifier = Modifier,
     messages: List<Message>,
     selectedIds: MutableState<Set<Long>>,
-    onUnreadChanged: (Long) -> Unit,
+    onUnreadChanged: (Int) -> Unit,
     onSendReaction: (String, Int) -> Unit,
     onNodeMenuAction: (NodeMenuAction) -> Unit,
     viewModel: UIViewModel,
@@ -124,7 +124,7 @@ internal fun MessageList(
         initialFirstVisibleItemIndex = messages.indexOfLast { !it.read }.coerceAtLeast(0)
     )
     AutoScrollToBottom(listState, messages)
-    UpdateUnreadCount(listState, messages, onUnreadChanged)
+    UpdateUnreadCount(listState, onUnreadChanged)
 
     var showStatusDialog by remember { mutableStateOf<Message?>(null) }
     if (showStatusDialog != null) {
@@ -222,19 +222,16 @@ private fun <T> AutoScrollToBottom(
 @Composable
 private fun UpdateUnreadCount(
     listState: LazyListState,
-    messages: List<Message>,
-    onUnreadChanged: (Long) -> Unit,
+    onUnreadChanged: (Int) -> Unit,
 ) {
-    val unreadIndex by remember { derivedStateOf { messages.indexOfLast { !it.read } } }
     val firstVisibleItemIndex by remember { derivedStateOf { listState.firstVisibleItemIndex } }
 
-    if (unreadIndex != -1 && firstVisibleItemIndex != -1 && firstVisibleItemIndex <= unreadIndex) {
-        LaunchedEffect(firstVisibleItemIndex, unreadIndex) {
+    if (firstVisibleItemIndex != -1) {
+        LaunchedEffect(firstVisibleItemIndex) {
             snapshotFlow { listState.firstVisibleItemIndex }
                 .debounce(timeoutMillis = 500L)
                 .collectLatest { index ->
-                    val lastVisibleItem = messages[index]
-                    onUnreadChanged(lastVisibleItem.receivedTime)
+                    onUnreadChanged(index)
                 }
         }
     }


### PR DESCRIPTION
Related to #2216 

This change fixes a bug causing messages to stay unread even after being shown in message list. `unreadIndex` got pushed up to `MessageScreen` and now `onUnreadChanged` callback from `MessageList` receives a message index instead of timestamp, while `UpdateUnreadCount` don't observe message collection at all.

Apparently `UpdateUnreadCount` in `MessageList` kept seeing empty `messages` list, which caused `unreadIndex` to stay at `-1`, preventing calling `onUnreadChanged`. For reasons I cannot yet fathom, `messages` one frame up in the stack (i.e. in `MessageScreen`) were properly populated and reflected actual content of selected conversation, but state/flow/that-kotlin-compose-thingy didn't get properly passed to `UpdateUnreadCount` since UI refactor a few days ago. Please review carefully, as I have no clear understanding neither why it does work now nor why it didn't before the change.

