### PR TITLE
Fix waypoints

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -560,7 +560,9 @@ class UIViewModel @Inject constructor(
 
     val waypoints = packetRepository.getWaypoints().mapLatest { list ->
         list.associateBy { packet -> packet.data.waypoint!!.id }
-            .filterValues { it.data.waypoint!!.expire > System.currentTimeMillis() / 1000 }
+            .filterValues {
+                it.data.waypoint!!.expire == 0 || it.data.waypoint!!.expire > System.currentTimeMillis() / 1000
+            }
     }
 
     fun generatePacketId(): Int? {

--- a/app/src/main/java/com/geeksville/mesh/ui/map/components/EditWaypointDialog.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/components/EditWaypointDialog.kt
@@ -89,10 +89,7 @@ internal fun EditWaypointDialog(
     val emoji = if (waypointInput.icon == 0) 128205 else waypointInput.icon
     var showEmojiPickerView by remember { mutableStateOf(false) }
 
-    // State to hold selected date and time
-    var selectedDate by remember { mutableStateOf("") }
-    var selectedTime by remember { mutableStateOf("") }
-    var epochTime by remember { mutableStateOf<Long?>(null) }
+
 
     // Get current context for dialogs
     val context = LocalContext.current
@@ -123,6 +120,12 @@ internal fun EditWaypointDialog(
     } else {
         SimpleDateFormat("hh:mm a", locale)
     }
+
+
+    // State to hold selected date and time
+    var selectedDate by remember { mutableStateOf(dateFormat.format(calendar.time)) }
+    var selectedTime by remember { mutableStateOf(timeFormat.format(calendar.time)) }
+    var epochTime by remember { mutableStateOf<Long?>(null) }
 
     if (!showEmojiPickerView) {
         AlertDialog(

--- a/app/src/main/java/com/geeksville/mesh/ui/map/components/EditWaypointDialog.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/components/EditWaypointDialog.kt
@@ -89,7 +89,6 @@ internal fun EditWaypointDialog(
     val emoji = if (waypointInput.icon == 0) 128205 else waypointInput.icon
     var showEmojiPickerView by remember { mutableStateOf(false) }
 
-
     // Get current context for dialogs
     val context = LocalContext.current
     val calendar = Calendar.getInstance()

--- a/app/src/main/java/com/geeksville/mesh/ui/map/components/EditWaypointDialog.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/components/EditWaypointDialog.kt
@@ -90,7 +90,6 @@ internal fun EditWaypointDialog(
     var showEmojiPickerView by remember { mutableStateOf(false) }
 
 
-
     // Get current context for dialogs
     val context = LocalContext.current
     val calendar = Calendar.getInstance()
@@ -120,7 +119,6 @@ internal fun EditWaypointDialog(
     } else {
         SimpleDateFormat("hh:mm a", locale)
     }
-
 
     // State to hold selected date and time
     var selectedDate by remember { mutableStateOf(dateFormat.format(calendar.time)) }


### PR DESCRIPTION
The iOS app sends non-expiring waypoints as expire=0; we will now treat those as never expiring and always show them. Additionally, the Date and Time formatted strings sometimes did not display, so we now initialize them instead of using onChange.