### PR TITLE
Bluetooth connection automatic change

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -310,6 +310,14 @@ class UIViewModel @Inject constructor(
     private val showPrecisionCircleOnMap =
         MutableStateFlow(preferences.getBoolean("show-precision-circle-on-map", true))
 
+    private val _btAutoSwitchToStrongest =
+        MutableStateFlow(preferences.getBoolean("bt-auto-switch-to-strongest", false))
+    val btAutoSwitchToStrongest: StateFlow<Boolean> get() = _btAutoSwitchToStrongest.asStateFlow()
+    fun setBtAutoSwitchToStrongest(value: Boolean) {
+        preferences.edit { putBoolean("bt-auto-switch-to-strongest", value) }
+        _btAutoSwitchToStrongest.value = value
+    }
+
     fun setSortOption(sort: NodeSortOption) {
         nodeSortOption.value = sort
         preferences.edit { putInt("node-sort-option", sort.ordinal) }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -96,7 +96,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.NonCancellable.isActive
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -41,7 +41,6 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Settings
@@ -103,7 +102,6 @@ import com.geeksville.mesh.navigation.RadioConfigRoutes
 import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.navigation.getNavRouteFrom
 import com.geeksville.mesh.service.MeshService
-import com.geeksville.mesh.ui.common.components.SimpleAlertDialog
 import com.geeksville.mesh.ui.connections.components.BLEDevices
 import com.geeksville.mesh.ui.connections.components.NetworkDevices
 import com.geeksville.mesh.ui.connections.components.UsbDevices

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Settings
@@ -102,6 +103,7 @@ import com.geeksville.mesh.navigation.RadioConfigRoutes
 import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.navigation.getNavRouteFrom
 import com.geeksville.mesh.service.MeshService
+import com.geeksville.mesh.ui.common.components.SimpleAlertDialog
 import com.geeksville.mesh.ui.connections.components.BLEDevices
 import com.geeksville.mesh.ui.connections.components.NetworkDevices
 import com.geeksville.mesh.ui.connections.components.UsbDevices

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -704,4 +704,6 @@
     <string name="no_ble_devices">No Bluetooth devices found.</string>
     <string name="no_network_devices">No Network devices found.</string>
     <string name="no_usb_devices">No USB Serial devices found.</string>
+    <string name="bluetooth_auto_switch">Automatic device change</string>
+    <string name="bluetooth_auto_switch_info">When enabled, if Bluetooth device connection is lost, app will try to connect to the strongest signal available.\nScan for available devices is every 60 seconds.</string>
 </resources>


### PR DESCRIPTION
Hello 👋

I'm developer from Czechia and in our community was requirement to implement automatic changing of connected Bluetooth nodes.
The request was primarily from multi-node users. 

_You're at home - app is connected to home node. You go for a walk - app loses connection with home node and switches to travel node etc._

**The feature is optional.**

It works as follows:
- State of checkbox is save in ui-prefs SharedPreferences. UIState.kt handles saving to prefs.
- In MeshService.kt function `onConnectionChanged()` calls logic when connection state goes CONNECTED -> DISCONNECTED.  Then is called `manageAutoConnectScanOnDisconnect()` which based on saved prefs decides if run further logic (user checked checkbox) or not.
- Scanning runs every 60 seconds and is for 2 seconds. In those 2 seconds it'll detect all available nodes and based on average signal strength (RSSI) chooses the strongest (this was added because in house can be multiple nodes).

This is my very first commit, so I expect there will be flaws and I would appreciate your constructive criticism and advice.

Happy coding! 🧑‍💻

<img src="https://github.com/user-attachments/assets/68ee3913-9a9b-4f3e-ba9f-a4fead47f9ff" width="300"/>