### PR TITLE
Refactor: Use JVM toolchain and disable Crashlytics for F-Droid

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.FileInputStream
 import java.util.Properties
 
@@ -124,12 +123,6 @@ android {
         aidl = true
         buildConfig = true
     }
-    // Configure the build-logic plugins to target JDK 21
-    // This matches the JDK used to build the project, and is not related to what is running on device.
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
     lint {
         abortOnError = false
         disable.add("MissingTranslation")
@@ -142,9 +135,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmToolchain {
-            JvmTarget.JVM_21
-        }
+        jvmToolchain(21)
         freeCompilerArgs.addAll(
             "-opt-in=kotlin.RequiresOptIn",
             "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
@@ -256,4 +247,13 @@ repositories {
 detekt {
     config.setFrom("../config/detekt/detekt.yml")
     baseline = file("../config/detekt/detekt-baseline.xml")
+}
+
+tasks.configureEach {
+    if (
+        name.contains("crashlytics", ignoreCase = true) && name.contains("fdroid", ignoreCase = true)
+    ) {
+        project.logger.lifecycle("Disabling Crashlytics task for F-Droid: $name")
+        enabled = false
+    }
 }

--- a/mesh_service_example/build.gradle.kts
+++ b/mesh_service_example/build.gradle.kts
@@ -15,42 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
-/*
- * Copyright (c) 2025 Meshtastic LLC
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
-/*
- * Copyright (c) 2025 Meshtastic LLC
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -84,19 +48,13 @@ android {
             )
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
-    }
     buildFeatures {
         aidl = true
     }
 }
 
 kotlin {
-    compilerOptions {
-        jvmTarget = JvmTarget.JVM_21
-    }
+    jvmToolchain(21)
 }
 
 // per protobuf-gradle-plugin docs, this is recommended for android

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
@@ -36,10 +35,6 @@ android {
     }
 
     namespace = "com.geeksville.mesh.network"
-    compileOptions {
-        sourceCompatibility(JavaVersion.VERSION_21)
-        targetCompatibility(JavaVersion.VERSION_21)
-    }
 
     flavorDimensions += "default"
     productFlavors {
@@ -53,9 +48,7 @@ android {
 }
 
 kotlin {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_21)
-    }
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,3 +17,17 @@
 
 include(":app", ":network", ":mesh_service_example")
 rootProject.name = "Meshtastic Android"
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver") version "1.0.0"
+}
+
+toolchainManagement {
+    jvm {
+        javaRepositories {
+            repository("foojay") {
+                resolverClass.set(org.gradle.toolchains.foojay.FoojayToolchainResolver::class.java)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Implement JVM toolchain (JDK 21) across all modules (app, network, mesh_service_example) for consistent build environment.
- Add Foojay toolchain resolver to settings.gradle.kts for automatic JDK provisioning.
- Disable Crashlytics tasks for F-Droid builds in app/build.gradle.kts to avoid including proprietary libraries.
- Remove redundant compileOptions for Java version and JvmTarget settings as they are now handled by the toolchain.
- Clean up commented-out license headers in mesh_service_example/build.gradle.kts.

