### PR TITLE
chore(repo): Enable merge queue

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -163,3 +163,11 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           script: ./gradlew :app:connectedFdroidDebugAndroidTest && killall -INT crashpad_handler || true
+
+      - name: Upload Test Results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-test-reports-api-${{ matrix.api-level }}
+          path: app/build/outputs/androidTest-results/
+          retention-days: 30


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to trigger on `merge_group` events for the `main` branch, in addition to existing triggers.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

In addition, this also addresses #2269 by enabling kvm as recommended in the docs for the runner https://github.com/marketplace/actions/android-emulator-runner#running-hardware-accelerated-emulators-on-linux-runners

Also added a task to upload the test report artifacts - so we have better feedback on test success/fail.
