### PR TITLE
2269 - CI testing not failing correctly

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -178,7 +178,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
-          script: ./gradlew :app:connectedFdroidDebugAndroidTest --configuration-cache --scan && killall -INT crashpad_handler
+          script: ./gradlew :app:connectedFdroidDebugAndroidTest --configuration-cache --scan && ( killall -INT crashpad_handler || true )
 
       - name: Upload Test Results
         if: ${{ !cancelled() }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -78,7 +78,7 @@ jobs:
 
   detekt:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
 
     steps:
 
@@ -115,7 +115,7 @@ jobs:
 
   androidTest:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       matrix:
         api-level: [26, 35]
@@ -178,7 +178,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
-          script: ./gradlew :app:connectedFdroidDebugAndroidTest --configuration-cache --scan && killall -INT crashpad_handler || true
+          script: ./gradlew :app:connectedFdroidDebugAndroidTest --configuration-cache --scan && killall -INT crashpad_handler
 
       - name: Upload Test Results
         if: ${{ !cancelled() }}

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/DebugFilters.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/DebugFilters.kt
@@ -207,8 +207,7 @@ internal fun DebugFilterBar(
                     DebugPresetFilters(
                         presetFilters = presetFilters,
                         filterTexts = filterTexts,
-                        onFilterTextsChange = onFilterTextsChange,
-                        intentionalFail = True
+                        onFilterTextsChange = onFilterTextsChange
                     )
                 }
             }

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/DebugFilters.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/DebugFilters.kt
@@ -207,7 +207,8 @@ internal fun DebugFilterBar(
                     DebugPresetFilters(
                         presetFilters = presetFilters,
                         filterTexts = filterTexts,
-                        onFilterTextsChange = onFilterTextsChange
+                        onFilterTextsChange = onFilterTextsChange,
+                        intentionalFail = True
                     )
                 }
             }


### PR DESCRIPTION
- reduce timeouts (still ~3x typical) 
- nest the || true that is there to stop the dependence on crashpad existing, so it doesn't override the result. 

To verify: 
Look at the last 2 workflows on the branch - only change is whether they have an intentional failure or not. 