### PR TITLE
fix: Clear notifications on device switch

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -2040,8 +2040,13 @@ class MeshService : Service(), Logging {
                     putString("device_address", deviceAddr)
                 }
                 clearDatabases()
+                clearNotifications()
             }
         }
+    }
+
+    private fun clearNotifications() {
+        serviceNotifications.clearNotifications()
     }
     private val binder = object : IMeshService.Stub() {
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -61,6 +61,10 @@ class MeshServiceNotifications(
     // We have two notification channels: one for general service status and another one for messages
     val notifyId = 101
 
+    fun clearNotifications() {
+        notificationManager.cancelAll()
+    }
+
     fun initChannels() {
         // create notification channels on service creation
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
This commit introduces a change to clear all notifications when a user changes devices. This is achieved by calling `clearNotifications()` in `MeshService` which in turn calls a new `clearNotifications()` function in `MeshServiceNotifications` that uses `notificationManager.cancelAll()`.

Prevents Tom from talking to himself (via mesh).