### PR TITLE
Fix unmessageable toggle

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/UserConfigItemList.kt
@@ -148,7 +148,7 @@ fun UserConfigItemList(
                         firmwareVersion < DeviceVersion("2.6.9") &&
                                 userInput.role.isUnmessageableRole()
                         ),
-                enabled = userInput.hasIsUnmessagable(),
+                enabled = userInput.hasIsUnmessagable() || firmwareVersion >= DeviceVersion("2.6.9"),
                 onCheckedChange = { userInput = userInput.copy { isUnmessagable = it } }
             )
         }


### PR DESCRIPTION
Allow unmessageable changes when `is_unmessagable` has not been set but is available (fw 2.6.9+).

@b8b8