### PR TITLE
feat(#2080): Add scroll to bottom button in message list

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/MessageList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/MessageList.kt
@@ -109,6 +109,7 @@ fun DeliveryInfo(
 @Composable
 internal fun MessageList(
     modifier: Modifier = Modifier,
+    listState: LazyListState = rememberLazyListState(),
     messages: List<Message>,
     selectedIds: MutableState<Set<Long>>,
     onUnreadChanged: (Long) -> Unit,
@@ -120,9 +121,6 @@ internal fun MessageList(
 ) {
     val haptics = LocalHapticFeedback.current
     val inSelectionMode by remember { derivedStateOf { selectedIds.value.isNotEmpty() } }
-    val listState = rememberLazyListState(
-        initialFirstVisibleItemIndex = messages.indexOfLast { !it.read }.coerceAtLeast(0)
-    )
     AutoScrollToBottom(listState, messages)
     UpdateUnreadCount(listState, messages, onUnreadChanged)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -704,4 +704,5 @@
     <string name="no_ble_devices">No Bluetooth devices found.</string>
     <string name="no_network_devices">No Network devices found.</string>
     <string name="no_usb_devices">No USB Serial devices found.</string>
+    <string name="scroll_to_bottom">Scroll to bottom</string>
 </resources>


### PR DESCRIPTION
This commit introduces a "scroll to bottom" floating action button in the message list view.

The button appears when the user can scroll backward (i.e., when not at the very bottom of the list). Clicking the button smoothly animates the list to the newest message.

The `LazyListState` is now initialized in the `MessageScreen` and passed down to `MessageList` to enable this functionality. A new string resource `scroll_to_bottom` has also been added.

https://github.com/user-attachments/assets/3128ffba-5bf9-427f-811b-78a773499ed4

