### PR TITLE
Refactor NsdManager and improve service display

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/network/NetworkRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/network/NetworkRepository.kt
@@ -41,16 +41,13 @@ class NetworkRepository @Inject constructor(
             .conflate()
 
     val resolvedList: Flow<List<NsdServiceInfo>>
-        get() = nsdManagerLazy.get().serviceList(SERVICE_TYPES, SERVICE_NAME)
+        get() = nsdManagerLazy.get().serviceList(SERVICE_TYPE)
             .flowOn(dispatchers.io)
             .conflate()
 
     companion object {
-        // To find all available services use SERVICE_TYPE = "_services._dns-sd._udp"
-        internal const val SERVICE_NAME = "Meshtastic"
         internal const val SERVICE_PORT = 4403
         private const val SERVICE_TYPE = "_meshtastic._tcp"
-        internal val SERVICE_TYPES = setOf("_http._tcp", SERVICE_TYPE)
 
         fun NsdServiceInfo.toAddressString() = buildString {
             append(@Suppress("DEPRECATION") host.toString().substring(1))

--- a/app/src/main/java/com/geeksville/mesh/repository/network/NsdManager.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/network/NsdManager.kt
@@ -24,27 +24,16 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.coroutines.resume
 
-internal fun NsdManager.serviceList(
-    serviceTypes: Set<String>,
-    serviceName: String,
-): Flow<List<NsdServiceInfo>> {
-    val flows = serviceTypes.map { serviceType -> serviceList(serviceType, serviceName) }
-    return combine(flows) { lists -> lists.flatMap { it } }
-}
-
 @OptIn(ExperimentalCoroutinesApi::class)
 internal fun NsdManager.serviceList(
     serviceType: String,
-    serviceName: String,
 ): Flow<List<NsdServiceInfo>> = discoverServices(serviceType).mapLatest { serviceList ->
     serviceList
-        .filter { it.serviceName.contains(serviceName) }
         .mapNotNull { resolveService(it) }
 }
 


### PR DESCRIPTION
This commit refactors the NsdManager to simplify service discovery and enhances the display of discovered network services.

Specifically, the following changes were made:
- Removed the overloaded `serviceList` function in `NsdManager.kt` that accepted a set of service types and a service name.
- Modified the remaining `serviceList` function in `NsdManager.kt` to no longer filter by service name, as this is now handled by specifying a more specific `SERVICE_TYPE`.
- Updated `BTScanModel.kt` to use TXT records ("shortname" and "id") from discovered network services to create more descriptive display names.
- In `NetworkRepository.kt`, simplified service discovery by using a single `SERVICE_TYPE` ("_meshtastic._tcp") instead of a set of service types and a generic service name.

this is work to support https://github.com/meshtastic/firmware/pull/7162/ by @vidplace7 