### PR TITLE
Refactor BLE exceptions and handle ServiceAction exceptions

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/BLEException.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/BLEException.kt
@@ -17,10 +17,10 @@
 
 package com.geeksville.mesh.service
 
-import java.io.IOException
-import java.util.*
+import android.os.RemoteException
+import java.util.UUID
 
-open class BLEException(msg: String) : IOException(msg)
+open class BLEException(msg: String) : RemoteException(msg)
 
 open class BLECharacteristicNotFoundException(uuid: UUID) :
     BLEException("Can't get characteristic $uuid")

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -81,6 +81,7 @@ import com.geeksville.mesh.repository.radio.RadioServiceConnectionState
 import com.geeksville.mesh.telemetry
 import com.geeksville.mesh.user
 import com.geeksville.mesh.util.anonymize
+import com.geeksville.mesh.util.ignoreException
 import com.geeksville.mesh.util.toOneLineString
 import com.geeksville.mesh.util.toPIIString
 import com.geeksville.mesh.util.toRemoteExceptions
@@ -1932,12 +1933,14 @@ class MeshService : Service(), Logging {
     }
 
     private fun onServiceAction(action: ServiceAction) {
-        when (action) {
-            is ServiceAction.GetDeviceMetadata -> getDeviceMetadata(action.destNum)
-            is ServiceAction.Favorite -> favoriteNode(action.node)
-            is ServiceAction.Ignore -> ignoreNode(action.node)
-            is ServiceAction.Reaction -> sendReaction(action)
-            is ServiceAction.AddSharedContact -> importContact(action.contact)
+        ignoreException {
+            when (action) {
+                is ServiceAction.GetDeviceMetadata -> getDeviceMetadata(action.destNum)
+                is ServiceAction.Favorite -> favoriteNode(action.node)
+                is ServiceAction.Ignore -> ignoreNode(action.node)
+                is ServiceAction.Reaction -> sendReaction(action)
+                is ServiceAction.AddSharedContact -> importContact(action.contact)
+            }
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/service/RadioNotConnectedException.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/RadioNotConnectedException.kt
@@ -17,5 +17,7 @@
 
 package com.geeksville.mesh.service
 
+import android.os.RemoteException
+
 open class RadioNotConnectedException(message: String = "Not connected to radio") :
-    BLEException(message)
+    RemoteException(message)


### PR DESCRIPTION
- Change `RadioNotConnectedException` and `BLEException` to extend `RemoteException`.
- Wrap `ServiceAction` handling in `MeshService` with `ignoreException` to prevent crashes.