### PR TITLE
Refactor: Remove dispatcher and use conditional start destination

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -210,7 +210,7 @@ class MetricsViewModel @Inject constructor(
     private val firmwareReleaseRepository: FirmwareReleaseRepository,
     private val preferences: SharedPreferences,
 ) : ViewModel(), Logging {
-    private val destNum = savedStateHandle.toRoute<NodesRoutes.NodeDetail>().destNum
+    private val destNum = savedStateHandle.toRoute<NodesRoutes.NodeDetailGraph>().destNum
 
     private fun MeshLog.hasValidTraceroute(): Boolean = with(fromRadio.packet) {
         hasDecoded() && decoded.wantResponse && from == 0 && to == destNum

--- a/app/src/main/java/com/geeksville/mesh/navigation/ConnectionsRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/ConnectionsRoutes.kt
@@ -66,7 +66,7 @@ fun NavGraphBuilder.connectionsGraph(
                 bluetoothViewModel = bluetoothViewModel,
                 radioConfigViewModel = hiltViewModel(parentEntry),
                 onNavigateToRadioConfig = { navController.navigate(RadioConfigRoutes.RadioConfig()) },
-                onNavigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetail(it)) },
+                onNavigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
                 onConfigNavigate = { route -> navController.navigate(route) }
             )
         }

--- a/app/src/main/java/com/geeksville/mesh/navigation/ContactsRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/ContactsRoutes.kt
@@ -74,7 +74,7 @@ fun NavGraphBuilder.contactsGraph(
                 message = args.message,
                 viewModel = uiViewModel,
                 navigateToMessages = { navController.navigate(ContactsRoutes.Messages(it)) },
-                navigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetail(it)) },
+                navigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
                 onNavigateBack = navController::navigateUp,
             )
         }

--- a/app/src/main/java/com/geeksville/mesh/navigation/MapRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/MapRoutes.kt
@@ -37,7 +37,7 @@ fun NavGraphBuilder.mapGraph(
         MapView(
             model = uiViewModel,
             navigateToNodeDetails = {
-                navController.navigate(NodesRoutes.NodeDetail(it))
+                navController.navigate(NodesRoutes.NodeDetailGraph(it))
             },
         )
     }

--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -19,11 +19,8 @@ package com.geeksville.mesh.navigation
 
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
@@ -50,9 +47,6 @@ const val DEEP_LINK_BASE_URI = "meshtastic://meshtastic"
 sealed interface Graph : Route
 @Serializable
 sealed interface Route {
-    @Serializable
-    data object Dispatcher : Route
-
     @Serializable
     data object DebugPanel : Route
 }
@@ -86,25 +80,15 @@ fun NavGraph(
 ) {
     NavHost(
         navController = navController,
-        startDestination = Route.Dispatcher,
+        startDestination = if (uIViewModel.isConnected()) {
+            NodesRoutes.NodesGraph
+        } else {
+            ConnectionsRoutes.ConnectionsGraph
+        },
         modifier = modifier,
     ) {
-        composable<Route.Dispatcher> {
-            val isConnected by uIViewModel.isConnected.collectAsStateWithLifecycle(false)
-            LaunchedEffect(isConnected) {
-                if (isConnected) {
-                    navController.navigate(NodesRoutes.NodesGraph) {
-                        popUpTo(Route.Dispatcher) { inclusive = true }
-                    }
-                } else {
-                    navController.navigate(ConnectionsRoutes.ConnectionsGraph) {
-                        popUpTo(Route.Dispatcher) { inclusive = true }
-                    }
-                }
-            }
-        }
         contactsGraph(navController, uIViewModel)
-        nodesGraph(navController, uIViewModel)
+        nodesGraph(navController, uIViewModel,)
         mapGraph(navController, uIViewModel)
         channelsGraph(navController, uIViewModel)
         connectionsGraph(navController, uIViewModel, bluetoothViewModel)

--- a/app/src/main/java/com/geeksville/mesh/navigation/NodesRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NodesRoutes.kt
@@ -55,7 +55,7 @@ sealed class NodesRoutes {
     data object NodesGraph : Graph
 
     @Serializable
-    data object NodeDetailGraph : Graph
+    data class NodeDetailGraph(val destNum: Int? = null) : Graph
 
     @Serializable
     data class NodeDetail(val destNum: Int? = null) : Route
@@ -102,7 +102,7 @@ fun NavGraphBuilder.nodesGraph(
                     navController.navigate(ContactsRoutes.Messages(it))
                 },
                 navigateToNodeDetails = {
-                    navController.navigate(NodesRoutes.NodeDetail(it))
+                    navController.navigate(NodesRoutes.NodeDetailGraph(it))
                 },
             )
         }
@@ -115,7 +115,7 @@ fun NavGraphBuilder.nodeDetailGraph(
     uiViewModel: UIViewModel,
 ) {
     navigation<NodesRoutes.NodeDetailGraph>(
-        startDestination = NodesRoutes.NodeDetail()
+        startDestination = NodesRoutes.NodeDetail(),
     ) {
         composable<NodesRoutes.NodeDetail> { backStackEntry ->
             val parentEntry = remember(backStackEntry) {

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -277,7 +277,7 @@ fun MainScreen(
                         when (action) {
                             is NodeMenuAction.MoreDetails -> {
                                 navController.navigate(
-                                    NodesRoutes.NodeDetail(
+                                    NodesRoutes.NodeDetailGraph(
                                         action.node.num
                                     ),
                                     {


### PR DESCRIPTION
This commit removes the `Route.Dispatcher` and instead sets the `startDestination` of the `NavHost` conditionally based on the connection status.

It also updates various navigation calls to use `NodesRoutes.NodeDetailGraph` instead of `NodesRoutes.NodeDetail` where appropriate, ensuring correct navigation to node details.