### PR TITLE
fix/2305 don't use filtered logs for availiable presets

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
@@ -167,7 +167,7 @@ internal fun DebugScreen(
                     searchState = searchState,
                     filterTexts = filterTexts,
                     presetFilters = viewModel.presetFilters,
-                    logs = filteredLogs,
+                    logs = logs,
                     filterMode = filterMode,
                     onFilterModeChange = { filterMode = it }
                 )


### PR DESCRIPTION
#2305 

Use all logs to decide which filters are included in the list. 