### PR TITLE
Improved detection of emulator environments

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -144,6 +144,14 @@ class RadioInterfaceService @Inject constructor(
         return BuildConfig.DEBUG || (context as GeeksvilleApplication).isInTestLab
     }
 
+    /**
+     * Determines whether to default to mock interface for device address.
+     * This keeps the decision logic separate and easy to extend.
+     */
+    private fun shouldDefaultToMockInterface(): Boolean {
+        return BuildUtils.isEmulator
+    }
+
     /** Return the device we are configured to use, or null for none
      * device address strings are of the form:
      *
@@ -157,7 +165,7 @@ class RadioInterfaceService @Inject constructor(
         var address = prefs.getString(DEVADDR_KEY, null)
 
         // If we are running on the emulator we default to the mock interface, so we can have some data to show to the user
-        if (address == null && BuildUtils.isEmulator) {
+        if (address == null && shouldDefaultToMockInterface()) {
             address = mockInterfaceAddress
         }
 

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -26,6 +26,7 @@ import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.CoroutineDispatchers
 import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.android.BinaryLogFile
+import com.geeksville.mesh.android.BuildUtils
 import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.concurrent.handledLaunch
@@ -156,7 +157,7 @@ class RadioInterfaceService @Inject constructor(
         var address = prefs.getString(DEVADDR_KEY, null)
 
         // If we are running on the emulator we default to the mock interface, so we can have some data to show to the user
-        if (address == null && isMockInterface()) {
+        if (address == null && BuildUtils.isEmulator) {
             address = mockInterfaceAddress
         }
 


### PR DESCRIPTION
This PR refactors the device address detection logic in `RadioInterfaceService.kt` by replacing the broader `isMockInterface()` check with a more specific `BuildUtils.isEmulator` check. The change makes the mock interface address fallback more precise by targeting only emulator environments rather than all debug builds and test lab scenarios.

**Key Changes:**
- Added import for `BuildUtils`
- Replaced `isMockInterface()` method call with `BuildUtils.isEmulator` in `getDeviceAddress()`
- Narrowed the scope of when mock interface address is used as fallback

The mock interface was being auto loaded on physical devices which was making troubleshooting connection & state issues difficult on physical devices.

Demo mode is still available in the Serial tab if needed on a physical device.

Tested on a TCL T768S (Android 11) and in Android Studio emulator.