### PR TITLE
Update Crowdin config

### DIFF
--- a/config/crowdin/crowdin.yml
+++ b/config/crowdin/crowdin.yml
@@ -29,8 +29,10 @@
     "translation_replace": {
       "sr-Latn": "b+sr+Latn",
     },
-    "update_strings": true,
     "cleanup_mode": true,
-    "escape_special_characters": 1
+    "update_option:": "update_as_unapproved",
+    "escape_quotes": 2,
+    "escape_special_characters": 1,
+    "type": "android",
   }
 ]


### PR DESCRIPTION
- Use `update_as_unapproved` for `update_option`
- Set `escape_quotes` to 2
- Specify `android` as `type`
- Remove deprecated `update_strings`

closes #2344 