### PR TITLE
chore: Optimize node screen while scrolling

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -78,6 +79,10 @@ fun NodeScreen(
         )
     }
 
+    val isScrollInProgress by remember {
+        derivedStateOf { listState.isScrollInProgress }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -88,14 +93,14 @@ fun NodeScreen(
         ) {
             stickyHeader {
                 val animatedAlpha by animateFloatAsState(
-                    targetValue = if (!listState.isScrollInProgress) 1.0f else 0f,
+                    targetValue = if (!isScrollInProgress) 1.0f else 0f,
                     label = "alpha"
                 )
                 NodeFilterTextField(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surfaceDim.copy(alpha = animatedAlpha))
                         .graphicsLayer(alpha = animatedAlpha)
+                        .background(MaterialTheme.colorScheme.surfaceDim)
                         .padding(8.dp),
                     filterText = state.filter,
                     onTextChange = model::setNodeFilterText,
@@ -151,7 +156,7 @@ fun NodeScreen(
 
         AnimatedVisibility(
             modifier = Modifier.align(Alignment.BottomEnd),
-            visible = !listState.isScrollInProgress &&
+            visible = !isScrollInProgress &&
                     connectionState.isConnected() &&
                     shareCapable
         ) {


### PR DESCRIPTION
I was looking through nodes and noticed there was a bit of jitter while scrolling the node list. Checking layout inspector, I noticed that `NodeFilterTextField` was recomposing often while scrolling, which appears to be from animated alpha changes. I made a few changes to reduce overhead here:

- I put `listState.isScrollInProgress` behind a remembered derived state
- I set a static background before setting the `graphicsLayer` modifier for `NodeFilterTextField`. This will have the same effect as before the change, except only `graphicsLayer` will be updated vs the background color itself also updating in tandem

Checking layout inspector (surprisingly) seems to show the same number of recompositions both before and after (mostly skipped):
![layouinspector](https://github.com/user-attachments/assets/a096a918-a539-41ad-b657-7a5ee43866d1)
Though I believe there's a decrease in overhead from duplicate draws with background/alpha changing :thinking: 



Changes might not show well through video, but the scroll feels a bit smoother (to me at least):

| Before | After |
|------|-----|
| <video src="https://github.com/user-attachments/assets/d4c1496b-855b-4bfb-b84c-f4a727818305" width="300"></video> | <video src="https://github.com/user-attachments/assets/f53bc72b-9b20-4bfe-b8ce-df95795bb443" width="300"></video> |

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->