### PR TITLE
Feat/2334 channel indicators

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -93,6 +93,8 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.roundToInt
+import com.geeksville.mesh.ui.common.components.isPreciseLocation
+import com.geeksville.mesh.ui.common.components.isLowEntropyKey
 
 // Given a human name, strip out the first letter of the first three words and return that as the initials for
 // that user, ignoring emojis. If the original name is only one word, strip vowels from the original
@@ -177,7 +179,8 @@ data class Contact(
     val isMuted: Boolean,
     val isUnmessageable: Boolean,
     val nodeColors: Pair<Int, Int>? = null,
-    val isLowEntropyKey: Boolean? = false
+    val isLowEntropyKey: Boolean? = false,
+    val isPreciseLocation: Boolean? = false
 )
 
 @Suppress("LongParameterList", "LargeClass")
@@ -543,7 +546,13 @@ class UIViewModel @Inject constructor(
                 } else {
                     null
                 },
-                isLowEntropyKey = isLowEntropyKey
+                isLowEntropyKey = isLowEntropyKey,
+                isPreciseLocation = if (toBroadcast) {
+                    val _channel = channelSet.getChannel(data.channel)
+                    _channel?.isPreciseLocation() ?: false
+                } else {
+                    false
+                }
             )
         }
     }.stateIn(

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -177,7 +177,7 @@ data class Contact(
     val isMuted: Boolean,
     val isUnmessageable: Boolean,
     val nodeColors: Pair<Int, Int>? = null,
-    val isDefaultPSK: Boolean? = false
+    val isLowEntropyKey: Boolean? = false
 )
 
 @Suppress("LongParameterList", "LargeClass")
@@ -520,12 +520,10 @@ class UIViewModel @Inject constructor(
             } else {
                 user.longName
             }
-            val isDefaultPSK = if (toBroadcast) {
+            val isLowEntropyKey = if (toBroadcast) {
                 val _channel = channelSet.getChannel(data.channel)
-                val isDefaultPSK = (_channel?.settings?.psk?.size() == 1 &&
-                     _channel.settings.psk.byteAt(0) == 1.toByte()) ||
-                     _channel?.settings?.psk?.toByteArray()?.isEmpty() == true
-                isDefaultPSK
+                val isLowEntropyKey = _channel?.psk?.size() ?: 0 <= 1
+                isLowEntropyKey
             } else {
                 false
             }
@@ -545,7 +543,7 @@ class UIViewModel @Inject constructor(
                 } else {
                     null
                 },
-                isDefaultPSK = isDefaultPSK
+                isLowEntropyKey = isLowEntropyKey
             )
         }
     }.stateIn(

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -176,9 +176,7 @@ data class Contact(
     val messageCount: Int,
     val isMuted: Boolean,
     val isUnmessageable: Boolean,
-    val nodeColors: Pair<Int, Int>? = null,
-    val isLowEntropyKey: Boolean? = false,
-    val isPreciseLocation: Boolean? = false
+    val nodeColors: Pair<Int, Int>? = null
 )
 
 @Suppress("LongParameterList", "LargeClass")
@@ -520,13 +518,6 @@ class UIViewModel @Inject constructor(
                 channelSet.getChannel(data.channel)?.name ?: app.getString(R.string.channel_name)
             } else {
                 user.longName
-            }
-            val isLowEntropyKey = if (toBroadcast) {
-                val _channel = channelSet.getChannel(data.channel)
-                val isLowEntropyKey = _channel?.psk?.size() ?: 0 <= 1
-                isLowEntropyKey
-            } else {
-                false
             }
 
             Contact(

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -545,13 +545,6 @@ class UIViewModel @Inject constructor(
                     node.colors
                 } else {
                     null
-                },
-                isLowEntropyKey = isLowEntropyKey,
-                isPreciseLocation = if (toBroadcast) {
-                    val _channel = channelSet.getChannel(data.channel)
-                    _channel?.isPreciseLocation() ?: false
-                } else {
-                    false
                 }
             )
         }

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -93,8 +93,6 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.roundToInt
-import com.geeksville.mesh.ui.common.components.isPreciseLocation
-import com.geeksville.mesh.ui.common.components.isLowEntropyKey
 
 // Given a human name, strip out the first letter of the first three words and return that as the initials for
 // that user, ignoring emojis. If the original name is only one word, strip vowels from the original

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -506,7 +506,7 @@ private fun MainMenuActions(
     IconButton(onClick = { showMenu = true }) {
         Icon(
             imageVector = Icons.Default.MoreVert,
-            contentDescription = "Overflow menu",
+            contentDescription = stringResource(R.string.overflow_menu),
         )
     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/IndoorAirQuality.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/IndoorAirQuality.kt
@@ -129,7 +129,7 @@ fun IndoorAirQuality(iaq: Int, displayMode: IaqDisplayMode = IaqDisplayMode.Pill
                         )
                         Icon(
                             imageVector = if (iaq < 100) Icons.Default.ThumbUp else Icons.Filled.Warning,
-                            contentDescription = "AQI Icon",
+                            contentDescription = stringResource(R.string.air_quality_icon),
                             tint = Color.White
                         )
                     }

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/ScannedQrCodeDialog.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/ScannedQrCodeDialog.kt
@@ -136,6 +136,7 @@ fun ScannedQrCodeDialog(
                     )
                 }
                 itemsIndexed(channelSet.settingsList) { index, channel ->
+                    val channelObj = Channel(channel, channelSet.loraConfig)
                     ChannelSelection(
                         index = index,
                         title = channel.name.ifEmpty { modemPresetName },
@@ -146,6 +147,7 @@ fun ScannedQrCodeDialog(
                                 channelSelections[index] = it
                             }
                         },
+                        channel = channelObj,
                     )
                 }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
@@ -19,34 +19,45 @@ package com.geeksville.mesh.ui.common.components
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.AppOnlyProtos
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.Channel
 import com.geeksville.mesh.channelSet
 import com.geeksville.mesh.model.getChannel
+@Suppress("TooManyFunctions") // lots of overloads
 
 private const val PRECISE_POSITION_BITS = 32
-
 /**
- * Returns the appropriate security icon and color based on the channel's security settings.
+ * Returns the appropriate security icon composable based on the channel's security settings.
  *
  * @param isLowEntropyKey Whether the channel uses a low entropy key (0 or 1 byte PSK)
  * @param isPreciseLocation Whether the channel has precise location enabled (32 bits)
- * @return A pair of (ImageVector, Color) representing the security icon and its color
+ * @param isMqttEnabled Whether MQTT is enabled (adds warning icon)
+ * @param contentDescription The content description for the icon
+ * @return A composable Icon element with appropriate imageVector and tint
  */
 @Composable
-fun getSecurityIcon(
+fun SecurityIcon(
     isLowEntropyKey: Boolean,
-    isPreciseLocation: Boolean = false
-): Pair<ImageVector, Color> {
-    return when {
+    isPreciseLocation: Boolean = false,
+    isMqttEnabled: Boolean = false,
+    contentDescription: String = "Security status"
+) {
+    val (icon, color) = when {
         !isLowEntropyKey -> {
             // Secure channel - green lock
             Icons.Default.Lock to Color.Green
+        }
+        isPreciseLocation && isMqttEnabled -> {
+            // MQTT enabled - warning icon in red
+            Icons.Default.Warning to Color.Red
         }
         isPreciseLocation -> {
             // Insecure channel with precise location - red unlocked icon
@@ -57,6 +68,12 @@ fun getSecurityIcon(
             ImageVector.vectorResource(R.drawable.ic_lock_open_right_24) to Color.Yellow
         }
     }
+
+    androidx.compose.material3.Icon(
+        imageVector = icon,
+        contentDescription = contentDescription,
+        tint = color
+    )
 }
 
 /**
@@ -73,7 +90,8 @@ fun Channel.isLowEntropyKey(): Boolean = settings.psk.size() <= 1
  * @param channel The channel to check
  * @return true if the channel has precise location enabled, false otherwise
  */
-fun Channel.isPreciseLocation(): Boolean = settings.getModuleSettings().positionPrecision == PRECISE_POSITION_BITS
+fun Channel.isPreciseLocation(): Boolean =
+    settings.getModuleSettings().positionPrecision == PRECISE_POSITION_BITS
 
 /**
  * Calculates whether a channel uses a low entropy key (0 or 1 byte PSK).
@@ -81,7 +99,8 @@ fun Channel.isPreciseLocation(): Boolean = settings.getModuleSettings().position
  * @param channelSettings The channel settings to check
  * @return true if the channel uses a low entropy key, false otherwise
  */
-fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isLowEntropyKey(): Boolean = psk.size() <= 1
+fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isLowEntropyKey(): Boolean =
+    psk.size() <= 1
 
 /**
  * Calculates whether a channel has precise location enabled (32 bits).
@@ -93,36 +112,83 @@ fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isPreciseLocation(): Boole
     getModuleSettings().positionPrecision == PRECISE_POSITION_BITS
 
 /**
+ * Calculates whether MQTT is effectively enabled for a channel.
+ * This checks if the channel has uplink enabled, which means
+ * messages from this channel will be sent to MQTT by the wider network.
+ *
+ * @param channel The channel to check
+ * @return true if the channel uses uplink, false otherwise
+ */
+fun Channel.isMqttEnabled(): Boolean = settings.uplinkEnabled
+
+/**
+ * Calculates whether MQTT is effectively enabled for channel settings.
+ * This checks if the channel has uplink enabled, which means
+ * messages from this channel will be sent to MQTT by the wider network.
+ *
+ * @param channelSettings The channel settings to check
+ * @return true if the channel uses uplink, false otherwise
+ */
+fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isMqttEnabled(): Boolean = uplinkEnabled
+
+/**
  * Gets the security icon for a channel.
  *
  * @param channel The channel to get the security icon for
- * @return A pair of (ImageVector, Color) representing the security icon and its color
+ * @param isMqttEnabled Whether MQTT is enabled
+ * @param contentDescription The content description for the icon
+ * @return A composable Icon element with appropriate imageVector and tint
  */
 @Composable
-fun getSecurityIcon(channel: Channel): Pair<ImageVector, Color> =
-    getSecurityIcon(channel.isLowEntropyKey(), channel.isPreciseLocation())
+fun SecurityIcon(
+    channel: Channel,
+    isMqttEnabled: Boolean = false,
+    contentDescription: String = "Security status"
+) = SecurityIcon(
+    channel.isLowEntropyKey(),
+    channel.isPreciseLocation(),
+    isMqttEnabled,
+    contentDescription
+)
 
 /**
  * Gets the security icon for channel settings.
  *
  * @param channelSettings The channel settings to get the security icon for
- * @return A pair of (ImageVector, Color) representing the security icon and its color
+ * @param isMqttEnabled Whether MQTT is enabled
+ * @param contentDescription The content description for the icon
+ * @return A composable Icon element with appropriate imageVector and tint
  */
 @Composable
-fun getSecurityIcon(channelSettings: com.geeksville.mesh.ChannelProtos.ChannelSettings): Pair<ImageVector, Color> =
-    getSecurityIcon(channelSettings.isLowEntropyKey(), channelSettings.isPreciseLocation())
+fun SecurityIcon(
+    channelSettings: com.geeksville.mesh.ChannelProtos.ChannelSettings,
+    isMqttEnabled: Boolean = false,
+    contentDescription: String = "Security status"
+) = SecurityIcon(
+    channelSettings.isLowEntropyKey(),
+    channelSettings.isPreciseLocation(),
+    isMqttEnabled,
+    contentDescription
+)
 
 /**
  * Gets the security icon for a channel by index from a channel set.
  *
  * @param channelSet The channel set containing the channel
  * @param channelIndex The index of the channel in the channel set
- * @return A pair of (ImageVector, Color) representing the security icon and its color, or null if channel not found
+ * @param isMqttEnabled Whether MQTT is enabled
+ * @param contentDescription The content description for the icon
+ * @return A composable Icon element with appropriate imageVector and tint, or null if channel not found
  */
 @Composable
-fun getSecurityIcon(channelSet: AppOnlyProtos.ChannelSet, channelIndex: Int): Pair<ImageVector, Color>? {
-    val channel = channelSet.getChannel(channelIndex) ?: return null
-    return getSecurityIcon(channel)
+fun SecurityIcon(
+    channelSet: AppOnlyProtos.ChannelSet,
+    channelIndex: Int,
+    isMqttEnabled: Boolean = false,
+    contentDescription: String = "Security status"
+) {
+    val channel = channelSet.getChannel(channelIndex) ?: return
+    SecurityIcon(channel, isMqttEnabled, contentDescription)
 }
 
 /**
@@ -130,11 +196,194 @@ fun getSecurityIcon(channelSet: AppOnlyProtos.ChannelSet, channelIndex: Int): Pa
  *
  * @param channelSet The channel set containing the channel
  * @param channelName The name of the channel to find
- * @return A pair of (ImageVector, Color) representing the security icon and its color, or null if channel not found
+ * @param isMqttEnabled Whether MQTT is enabled
+ * @param contentDescription The content description for the icon
+ * @return A composable Icon element with appropriate imageVector and tint, or null if channel not found
  */
 @Composable
-fun getSecurityIcon(channelSet: AppOnlyProtos.ChannelSet, channelName: String): Pair<ImageVector, Color>? {
-    val channel = channelSet.settingsList.find { Channel(it, channelSet.loraConfig).name == channelName }
-        ?.let { Channel(it, channelSet.loraConfig) } ?: return null
-    return getSecurityIcon(channel)
+fun SecurityIcon(
+    channelSet: AppOnlyProtos.ChannelSet,
+    channelName: String,
+    isMqttEnabled: Boolean = false,
+    contentDescription: String = "Security status"
+) {
+    val channel = channelSet.settingsList.find {
+        Channel(it, channelSet.loraConfig).name == channelName
+    }?.let { Channel(it, channelSet.loraConfig) } ?: return
+    SecurityIcon(channel, isMqttEnabled, contentDescription)
+}
+
+/**
+ * Gets the security icon for a channel by index from a channel set.
+ * This automatically determines if MQTT is enabled for this specific channel.
+ *
+ * @param channelSet The channel set containing the channel
+ * @param channelIndex The index of the channel in the channel set
+ * @param contentDescription The content description for the icon
+ * @return A composable Icon element with appropriate imageVector and tint, or null if channel not found
+ */
+@Composable
+fun SecurityIcon(
+    channelSet: AppOnlyProtos.ChannelSet,
+    channelIndex: Int,
+    contentDescription: String = "Security status"
+) {
+    val channel = channelSet.getChannel(channelIndex) ?: return
+    SecurityIcon(channel, channel.isMqttEnabled(), contentDescription)
+}
+
+/**
+ * Gets the security icon for a channel by name from a channel set.
+ * This automatically determines if MQTT is enabled for this specific channel.
+ *
+ * @param channelSet The channel set containing the channel
+ * @param channelName The name of the channel to find
+ * @param contentDescription The content description for the icon
+ * @return A composable Icon element with appropriate imageVector and tint, or null if channel not found
+ */
+@Composable
+fun SecurityIcon(
+    channelSet: AppOnlyProtos.ChannelSet,
+    channelName: String,
+    contentDescription: String = "Security status"
+) {
+    val channel = channelSet.settingsList.find {
+        Channel(it, channelSet.loraConfig).name == channelName
+    }?.let { Channel(it, channelSet.loraConfig) } ?: return
+    SecurityIcon(channel, channel.isMqttEnabled(), contentDescription)
+}
+
+/**
+ * Gets the security icon for a channel.
+ * This automatically determines if MQTT is enabled for this specific channel.
+ *
+ * @param channel The channel to get the security icon for
+ * @param contentDescription The content description for the icon
+ * @return A composable Icon element with appropriate imageVector and tint
+ */
+@Composable
+fun SecurityIcon(
+    channel: Channel,
+    contentDescription: String = "Security status"
+) {
+    SecurityIcon(channel, channel.isMqttEnabled(), contentDescription)
+}
+
+/**
+ * Gets the security icon for channel settings.
+ * This automatically determines if MQTT is enabled for this specific channel.
+ *
+ * @param channelSettings The channel settings to get the security icon for
+ * @param contentDescription The content description for the icon
+ * @return A composable Icon element with appropriate imageVector and tint
+ */
+@Composable
+fun SecurityIcon(
+    channelSettings: com.geeksville.mesh.ChannelProtos.ChannelSettings,
+    contentDescription: String = "Security status"
+) {
+    SecurityIcon(channelSettings, channelSettings.isMqttEnabled(), contentDescription)
+}
+
+// Preview functions for development and testing
+@Preview(name = "Secure Channel - Green Lock")
+@Composable
+private fun PreviewSecureChannel() {
+    SecurityIcon(
+        isLowEntropyKey = false,
+        isPreciseLocation = false,
+        isMqttEnabled = false
+    )
+}
+
+@Preview(name = "Insecure Channel with Precise Location - Red Unlock")
+@Composable
+private fun PreviewInsecureChannelWithPreciseLocation() {
+    SecurityIcon(
+        isLowEntropyKey = true,
+        isPreciseLocation = true,
+        isMqttEnabled = false
+    )
+}
+
+@Preview(name = "Insecure Channel without Precise Location - Yellow Unlock")
+@Composable
+private fun PreviewInsecureChannelWithoutPreciseLocation() {
+    SecurityIcon(
+        isLowEntropyKey = true,
+        isPreciseLocation = false,
+        isMqttEnabled = false
+    )
+}
+
+@Preview(name = "MQTT Enabled - Red Warning")
+@Composable
+private fun PreviewMqttEnabled() {
+    SecurityIcon(
+        isLowEntropyKey = false,
+        isPreciseLocation = false,
+        isMqttEnabled = true
+    )
+}
+
+@Preview(name = "All Security Icons")
+@Composable
+private fun PreviewAllSecurityIcons() {
+    androidx.compose.foundation.layout.Column(
+        horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
+        verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp)
+    ) {
+        androidx.compose.material3.Text(
+            "Security Icons Preview",
+            style = androidx.compose.material3.MaterialTheme.typography.headlineSmall
+        )
+
+        androidx.compose.foundation.layout.Row(
+            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+        ) {
+            SecurityIcon(
+                isLowEntropyKey = false,
+                isPreciseLocation = false,
+                isMqttEnabled = false
+            )
+            androidx.compose.material3.Text("Secure")
+        }
+
+        androidx.compose.foundation.layout.Row(
+            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+        ) {
+            SecurityIcon(
+                isLowEntropyKey = true,
+                isPreciseLocation = true,
+                isMqttEnabled = false
+            )
+            androidx.compose.material3.Text("Insecure + Precise Location")
+        }
+
+        androidx.compose.foundation.layout.Row(
+            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+        ) {
+            SecurityIcon(
+                isLowEntropyKey = true,
+                isPreciseLocation = false,
+                isMqttEnabled = false
+            )
+            androidx.compose.material3.Text("Insecure")
+        }
+
+        androidx.compose.foundation.layout.Row(
+            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+        ) {
+            SecurityIcon(
+                isLowEntropyKey = false,
+                isPreciseLocation = false,
+                isMqttEnabled = true
+            )
+            androidx.compose.material3.Text("MQTT Enabled")
+        }
+    }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Warning
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -48,30 +49,30 @@ fun SecurityIcon(
     isLowEntropyKey: Boolean,
     isPreciseLocation: Boolean = false,
     isMqttEnabled: Boolean = false,
-    contentDescription: String? = null
+    contentDescription: String = stringResource(id = R.string.security_icon_description)
 ) {
     val (icon, color, computedDescription) = when {
         !isLowEntropyKey -> {
-            // Secure channel - green lock
-            Icons.Default.Lock to Color.Green to "Secure channel"
+            Triple(Icons.Default.Lock, Color.Green, stringResource(id = R.string.security_icon_secure))
         }
         isPreciseLocation && isMqttEnabled -> {
-            // MQTT enabled - warning icon in red
-            Icons.Default.Warning to Color.Red to "MQTT warning"
+            Triple(Icons.Default.Warning, Color.Red, stringResource(id = R.string.security_icon_warning))
         }
         isPreciseLocation -> {
-            // Insecure channel with precise location - red unlocked icon
-            ImageVector.vectorResource(R.drawable.ic_lock_open_right_24) to Color.Red to "Insecure – precise location"
+            Triple(ImageVector.vectorResource(R.drawable.ic_lock_open_right_24),
+                Color.Red,
+                stringResource(id = R.string.security_icon_insecure_precise))
         }
         else -> {
-            // Insecure channel without precise location - yellow unlocked icon
-            ImageVector.vectorResource(R.drawable.ic_lock_open_right_24) to Color.Yellow to "Insecure channel"
+            Triple(ImageVector.vectorResource(R.drawable.ic_lock_open_right_24),
+                Color.Yellow,
+                stringResource(id = R.string.security_icon_insecure))
         }
     }
 
     androidx.compose.material3.Icon(
         imageVector = icon,
-        contentDescription = contentDescription ?: computedDescription,
+        contentDescription = contentDescription + computedDescription,
         tint = color
     )
 }
@@ -83,7 +84,7 @@ fun Channel.isMqttEnabled(): Boolean = settings.uplinkEnabled
 @Composable
 fun SecurityIcon(
     channel: Channel,
-    contentDescription: String = "Security status"
+    contentDescription: String = stringResource(id = R.string.security_icon_description)
 ) = SecurityIcon(
     channel.isLowEntropyKey(),
     channel.isPreciseLocation(),
@@ -95,7 +96,7 @@ fun SecurityIcon(
 fun SecurityIcon(
     channelSet: AppOnlyProtos.ChannelSet,
     channelIndex: Int,
-    contentDescription: String = "Security status"
+    contentDescription: String = stringResource(id = R.string.security_icon_description)
 ) {
     val channel = channelSet.getChannel(channelIndex) ?: return
     SecurityIcon(channel, contentDescription)
@@ -105,7 +106,7 @@ fun SecurityIcon(
 fun SecurityIcon(
     channelSet: AppOnlyProtos.ChannelSet,
     channelName: String,
-    contentDescription: String = "Security status"
+    contentDescription: String = stringResource(id = R.string.security_icon_description)
 ) {
     val channel = channelSet.settingsList.find {
         Channel(it, channelSet.loraConfig).name == channelName

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
@@ -31,9 +31,9 @@ import com.geeksville.mesh.R
 import com.geeksville.mesh.model.Channel
 import com.geeksville.mesh.channelSet
 import com.geeksville.mesh.model.getChannel
-@Suppress("TooManyFunctions") // lots of overloads
 
 private const val PRECISE_POSITION_BITS = 32
+
 /**
  * Returns the appropriate security icon composable based on the channel's security settings.
  *
@@ -76,152 +76,21 @@ fun SecurityIcon(
     )
 }
 
-/**
- * Calculates whether a channel uses a low entropy key (0 or 1 byte PSK).
- *
- * @param channel The channel to check
- * @return true if the channel uses a low entropy key, false otherwise
- */
 fun Channel.isLowEntropyKey(): Boolean = settings.psk.size() <= 1
-
-/**
- * Calculates whether a channel has precise location enabled (32 bits).
- *
- * @param channel The channel to check
- * @return true if the channel has precise location enabled, false otherwise
- */
-fun Channel.isPreciseLocation(): Boolean =
-    settings.getModuleSettings().positionPrecision == PRECISE_POSITION_BITS
-
-/**
- * Calculates whether a channel uses a low entropy key (0 or 1 byte PSK).
- *
- * @param channelSettings The channel settings to check
- * @return true if the channel uses a low entropy key, false otherwise
- */
-fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isLowEntropyKey(): Boolean =
-    psk.size() <= 1
-
-/**
- * Calculates whether a channel has precise location enabled (32 bits).
- *
- * @param channelSettings The channel settings to check
- * @return true if the channel has precise location enabled, false otherwise
- */
-fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isPreciseLocation(): Boolean =
-    getModuleSettings().positionPrecision == PRECISE_POSITION_BITS
-
-/**
- * Calculates whether MQTT is effectively enabled for a channel.
- * This checks if the channel has uplink enabled, which means
- * messages from this channel will be sent to MQTT by the wider network.
- *
- * @param channel The channel to check
- * @return true if the channel uses uplink, false otherwise
- */
+fun Channel.isPreciseLocation(): Boolean = settings.getModuleSettings().positionPrecision == PRECISE_POSITION_BITS
 fun Channel.isMqttEnabled(): Boolean = settings.uplinkEnabled
 
-/**
- * Calculates whether MQTT is effectively enabled for channel settings.
- * This checks if the channel has uplink enabled, which means
- * messages from this channel will be sent to MQTT by the wider network.
- *
- * @param channelSettings The channel settings to check
- * @return true if the channel uses uplink, false otherwise
- */
-fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isMqttEnabled(): Boolean = uplinkEnabled
-
-/**
- * Gets the security icon for a channel.
- *
- * @param channel The channel to get the security icon for
- * @param isMqttEnabled Whether MQTT is enabled
- * @param contentDescription The content description for the icon
- * @return A composable Icon element with appropriate imageVector and tint
- */
 @Composable
 fun SecurityIcon(
     channel: Channel,
-    isMqttEnabled: Boolean = false,
     contentDescription: String = "Security status"
 ) = SecurityIcon(
     channel.isLowEntropyKey(),
     channel.isPreciseLocation(),
-    isMqttEnabled,
+    channel.isMqttEnabled(),
     contentDescription
 )
 
-/**
- * Gets the security icon for channel settings.
- *
- * @param channelSettings The channel settings to get the security icon for
- * @param isMqttEnabled Whether MQTT is enabled
- * @param contentDescription The content description for the icon
- * @return A composable Icon element with appropriate imageVector and tint
- */
-@Composable
-fun SecurityIcon(
-    channelSettings: com.geeksville.mesh.ChannelProtos.ChannelSettings,
-    isMqttEnabled: Boolean = false,
-    contentDescription: String = "Security status"
-) = SecurityIcon(
-    channelSettings.isLowEntropyKey(),
-    channelSettings.isPreciseLocation(),
-    isMqttEnabled,
-    contentDescription
-)
-
-/**
- * Gets the security icon for a channel by index from a channel set.
- *
- * @param channelSet The channel set containing the channel
- * @param channelIndex The index of the channel in the channel set
- * @param isMqttEnabled Whether MQTT is enabled
- * @param contentDescription The content description for the icon
- * @return A composable Icon element with appropriate imageVector and tint, or null if channel not found
- */
-@Composable
-fun SecurityIcon(
-    channelSet: AppOnlyProtos.ChannelSet,
-    channelIndex: Int,
-    isMqttEnabled: Boolean = false,
-    contentDescription: String = "Security status"
-) {
-    val channel = channelSet.getChannel(channelIndex) ?: return
-    SecurityIcon(channel, isMqttEnabled, contentDescription)
-}
-
-/**
- * Gets the security icon for a channel by name from a channel set.
- *
- * @param channelSet The channel set containing the channel
- * @param channelName The name of the channel to find
- * @param isMqttEnabled Whether MQTT is enabled
- * @param contentDescription The content description for the icon
- * @return A composable Icon element with appropriate imageVector and tint, or null if channel not found
- */
-@Composable
-fun SecurityIcon(
-    channelSet: AppOnlyProtos.ChannelSet,
-    channelName: String,
-    isMqttEnabled: Boolean = false,
-    contentDescription: String = "Security status"
-) {
-    val channel = channelSet.settingsList.find {
-        Channel(it, channelSet.loraConfig).name == channelName
-    }?.let { Channel(it, channelSet.loraConfig) } ?: return
-    SecurityIcon(channel, isMqttEnabled, contentDescription)
-}
-
-/**
- * Gets the security icon for a channel by index from a channel set.
- * This automatically determines if MQTT is enabled for this specific channel.
- *
- * @param channelSet The channel set containing the channel
- * @param channelIndex The index of the channel in the channel set
- * @param contentDescription The content description for the icon
- * @return A composable Icon element with appropriate imageVector and tint, or null if channel not found
- */
 @Composable
 fun SecurityIcon(
     channelSet: AppOnlyProtos.ChannelSet,
@@ -229,18 +98,9 @@ fun SecurityIcon(
     contentDescription: String = "Security status"
 ) {
     val channel = channelSet.getChannel(channelIndex) ?: return
-    SecurityIcon(channel, channel.isMqttEnabled(), contentDescription)
+    SecurityIcon(channel, contentDescription)
 }
 
-/**
- * Gets the security icon for a channel by name from a channel set.
- * This automatically determines if MQTT is enabled for this specific channel.
- *
- * @param channelSet The channel set containing the channel
- * @param channelName The name of the channel to find
- * @param contentDescription The content description for the icon
- * @return A composable Icon element with appropriate imageVector and tint, or null if channel not found
- */
 @Composable
 fun SecurityIcon(
     channelSet: AppOnlyProtos.ChannelSet,
@@ -250,39 +110,7 @@ fun SecurityIcon(
     val channel = channelSet.settingsList.find {
         Channel(it, channelSet.loraConfig).name == channelName
     }?.let { Channel(it, channelSet.loraConfig) } ?: return
-    SecurityIcon(channel, channel.isMqttEnabled(), contentDescription)
-}
-
-/**
- * Gets the security icon for a channel.
- * This automatically determines if MQTT is enabled for this specific channel.
- *
- * @param channel The channel to get the security icon for
- * @param contentDescription The content description for the icon
- * @return A composable Icon element with appropriate imageVector and tint
- */
-@Composable
-fun SecurityIcon(
-    channel: Channel,
-    contentDescription: String = "Security status"
-) {
-    SecurityIcon(channel, channel.isMqttEnabled(), contentDescription)
-}
-
-/**
- * Gets the security icon for channel settings.
- * This automatically determines if MQTT is enabled for this specific channel.
- *
- * @param channelSettings The channel settings to get the security icon for
- * @param contentDescription The content description for the icon
- * @return A composable Icon element with appropriate imageVector and tint
- */
-@Composable
-fun SecurityIcon(
-    channelSettings: com.geeksville.mesh.ChannelProtos.ChannelSettings,
-    contentDescription: String = "Security status"
-) {
-    SecurityIcon(channelSettings, channelSettings.isMqttEnabled(), contentDescription)
+    SecurityIcon(channel, contentDescription)
 }
 
 // Preview functions for development and testing

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
@@ -48,30 +48,30 @@ fun SecurityIcon(
     isLowEntropyKey: Boolean,
     isPreciseLocation: Boolean = false,
     isMqttEnabled: Boolean = false,
-    contentDescription: String = "Security status"
+    contentDescription: String? = null
 ) {
-    val (icon, color) = when {
+    val (icon, color, computedDescription) = when {
         !isLowEntropyKey -> {
             // Secure channel - green lock
-            Icons.Default.Lock to Color.Green
+            Icons.Default.Lock to Color.Green to "Secure channel"
         }
         isPreciseLocation && isMqttEnabled -> {
             // MQTT enabled - warning icon in red
-            Icons.Default.Warning to Color.Red
+            Icons.Default.Warning to Color.Red to "MQTT warning"
         }
         isPreciseLocation -> {
             // Insecure channel with precise location - red unlocked icon
-            ImageVector.vectorResource(R.drawable.ic_lock_open_right_24) to Color.Red
+            ImageVector.vectorResource(R.drawable.ic_lock_open_right_24) to Color.Red to "Insecure – precise location"
         }
         else -> {
             // Insecure channel without precise location - yellow unlocked icon
-            ImageVector.vectorResource(R.drawable.ic_lock_open_right_24) to Color.Yellow
+            ImageVector.vectorResource(R.drawable.ic_lock_open_right_24) to Color.Yellow to "Insecure channel"
         }
     }
 
     androidx.compose.material3.Icon(
         imageVector = icon,
-        contentDescription = contentDescription,
+        contentDescription = contentDescription ?: computedDescription,
         tint = color
     )
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.ui.common.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import com.geeksville.mesh.AppOnlyProtos
+import com.geeksville.mesh.R
+import com.geeksville.mesh.model.Channel
+import com.geeksville.mesh.channelSet
+import com.geeksville.mesh.model.getChannel
+
+private const val PRECISE_POSITION_BITS = 32
+
+/**
+ * Returns the appropriate security icon and color based on the channel's security settings.
+ *
+ * @param isLowEntropyKey Whether the channel uses a low entropy key (0 or 1 byte PSK)
+ * @param isPreciseLocation Whether the channel has precise location enabled
+ * @return A pair of (ImageVector, Color) representing the security icon and its color
+ */
+@Composable
+fun getSecurityIcon(
+    isLowEntropyKey: Boolean,
+    isPreciseLocation: Boolean = false
+): Pair<ImageVector, Color> {
+    return when {
+        !isLowEntropyKey -> {
+            // Secure channel - green lock
+            Icons.Default.Lock to Color.Green
+        }
+        isPreciseLocation -> {
+            // Insecure channel with precise location - red unlocked icon
+            ImageVector.vectorResource(R.drawable.ic_lock_open_right_24) to Color.Red
+        }
+        else -> {
+            // Insecure channel without precise location - yellow unlocked icon
+            ImageVector.vectorResource(R.drawable.ic_lock_open_right_24) to Color.Yellow
+        }
+    }
+}
+
+/**
+ * Calculates whether a channel uses a low entropy key (0 or 1 byte PSK).
+ *
+ * @param channel The channel to check
+ * @return true if the channel uses a low entropy key, false otherwise
+ */
+fun Channel.isLowEntropyKey(): Boolean = psk.size() <= 1
+
+/**
+ * Calculates whether a channel has precise location enabled.
+ *
+ * @param channel The channel to check
+ * @return true if the channel has precise location enabled, false otherwise
+ */
+fun Channel.isPreciseLocation(): Boolean = settings.getModuleSettings().positionPrecision == PRECISE_POSITION_BITS
+
+/**
+ * Calculates whether a channel uses a low entropy key (0 or 1 byte PSK).
+ *
+ * @param channelSettings The channel settings to check
+ * @return true if the channel uses a low entropy key, false otherwise
+ */
+fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isLowEntropyKey(): Boolean = psk.size() <= 1
+
+/**
+ * Calculates whether a channel has precise location enabled.
+ *
+ * @param channelSettings The channel settings to check
+ * @return true if the channel has precise location enabled, false otherwise
+ */
+fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isPreciseLocation(): Boolean =
+    getModuleSettings().positionPrecision == PRECISE_POSITION_BITS
+
+/**
+ * Gets the security icon for a channel.
+ *
+ * @param channel The channel to get the security icon for
+ * @return A pair of (ImageVector, Color) representing the security icon and its color
+ */
+@Composable
+fun getSecurityIcon(channel: Channel): Pair<ImageVector, Color> =
+    getSecurityIcon(channel.isLowEntropyKey(), channel.isPreciseLocation())
+
+/**
+ * Gets the security icon for channel settings.
+ *
+ * @param channelSettings The channel settings to get the security icon for
+ * @return A pair of (ImageVector, Color) representing the security icon and its color
+ */
+@Composable
+fun getSecurityIcon(channelSettings: com.geeksville.mesh.ChannelProtos.ChannelSettings): Pair<ImageVector, Color> =
+    getSecurityIcon(channelSettings.isLowEntropyKey(), channelSettings.isPreciseLocation())
+
+/**
+ * Gets the security icon for a channel by index from a channel set.
+ *
+ * @param channelSet The channel set containing the channel
+ * @param channelIndex The index of the channel in the channel set
+ * @return A pair of (ImageVector, Color) representing the security icon and its color, or null if channel not found
+ */
+@Composable
+fun getSecurityIcon(channelSet: AppOnlyProtos.ChannelSet, channelIndex: Int): Pair<ImageVector, Color>? {
+    val channel = channelSet.getChannel(channelIndex) ?: return null
+    return getSecurityIcon(channel)
+}
+
+/**
+ * Gets the security icon for a channel by name from a channel set.
+ *
+ * @param channelSet The channel set containing the channel
+ * @param channelName The name of the channel to find
+ * @return A pair of (ImageVector, Color) representing the security icon and its color, or null if channel not found
+ */
+@Composable
+fun getSecurityIcon(channelSet: AppOnlyProtos.ChannelSet, channelName: String): Pair<ImageVector, Color>? {
+    val channel = channelSet.settingsList.find { Channel(it, channelSet.loraConfig).name == channelName }
+        ?.let { Channel(it, channelSet.loraConfig) } ?: return null
+    return getSecurityIcon(channel)
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
@@ -17,10 +17,17 @@
 
 package com.geeksville.mesh.ui.common.components
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -30,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.AppOnlyProtos
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.Channel
-import com.geeksville.mesh.channelSet
 import com.geeksville.mesh.model.getChannel
 
 private const val PRECISE_POSITION_BITS = 32
@@ -70,7 +76,7 @@ fun SecurityIcon(
         }
     }
 
-    androidx.compose.material3.Icon(
+    Icon(
         imageVector = icon,
         contentDescription = contentDescription + computedDescription,
         tint = color
@@ -158,61 +164,61 @@ private fun PreviewMqttEnabled() {
 @Preview(name = "All Security Icons")
 @Composable
 private fun PreviewAllSecurityIcons() {
-    androidx.compose.foundation.layout.Column(
-        horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
-        verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        androidx.compose.material3.Text(
+        Text(
             "Security Icons Preview",
-            style = androidx.compose.material3.MaterialTheme.typography.headlineSmall
+            style = MaterialTheme.typography.headlineSmall
         )
 
-        androidx.compose.foundation.layout.Row(
-            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             SecurityIcon(
                 isLowEntropyKey = false,
                 isPreciseLocation = false,
                 isMqttEnabled = false
             )
-            androidx.compose.material3.Text("Secure")
+            Text("Secure")
         }
 
-        androidx.compose.foundation.layout.Row(
-            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             SecurityIcon(
                 isLowEntropyKey = true,
                 isPreciseLocation = true,
                 isMqttEnabled = false
             )
-            androidx.compose.material3.Text("Insecure + Precise Location")
+            Text("Insecure + Precise Location")
         }
 
-        androidx.compose.foundation.layout.Row(
-            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             SecurityIcon(
                 isLowEntropyKey = true,
                 isPreciseLocation = false,
                 isMqttEnabled = false
             )
-            androidx.compose.material3.Text("Insecure")
+            Text("Insecure")
         }
 
-        androidx.compose.foundation.layout.Row(
-            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             SecurityIcon(
                 isLowEntropyKey = false,
                 isPreciseLocation = false,
                 isMqttEnabled = true
             )
-            androidx.compose.material3.Text("MQTT Enabled")
+            Text("MQTT Enabled")
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
@@ -35,7 +35,7 @@ private const val PRECISE_POSITION_BITS = 32
  * Returns the appropriate security icon and color based on the channel's security settings.
  *
  * @param isLowEntropyKey Whether the channel uses a low entropy key (0 or 1 byte PSK)
- * @param isPreciseLocation Whether the channel has precise location enabled
+ * @param isPreciseLocation Whether the channel has precise location enabled (32 bits)
  * @return A pair of (ImageVector, Color) representing the security icon and its color
  */
 @Composable
@@ -65,10 +65,10 @@ fun getSecurityIcon(
  * @param channel The channel to check
  * @return true if the channel uses a low entropy key, false otherwise
  */
-fun Channel.isLowEntropyKey(): Boolean = psk.size() <= 1
+fun Channel.isLowEntropyKey(): Boolean = settings.psk.size() <= 1
 
 /**
- * Calculates whether a channel has precise location enabled.
+ * Calculates whether a channel has precise location enabled (32 bits).
  *
  * @param channel The channel to check
  * @return true if the channel has precise location enabled, false otherwise
@@ -84,7 +84,7 @@ fun Channel.isPreciseLocation(): Boolean = settings.getModuleSettings().position
 fun com.geeksville.mesh.ChannelProtos.ChannelSettings.isLowEntropyKey(): Boolean = psk.size() <= 1
 
 /**
- * Calculates whether a channel has precise location enabled.
+ * Calculates whether a channel has precise location enabled (32 bits).
  *
  * @param channelSettings The channel settings to check
  * @return true if the channel has precise location enabled, false otherwise

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import com.geeksville.mesh.AppOnlyProtos
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.Contact
 import com.geeksville.mesh.ui.common.theme.AppTheme
@@ -60,6 +61,7 @@ fun ContactItem(
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = {},
+    channels: AppOnlyProtos.ChannelSet? = null,
 ) = with(contact) {
     Card(
         modifier = modifier
@@ -118,17 +120,18 @@ fun ContactItem(
                         val isBroadcast = contact.contactKey.getOrNull(1) == '^' ||
                              contact.contactKey.endsWith("^all") ||
                              contact.contactKey.endsWith("^broadcast")
-                        if (isBroadcast) {
+                        if (isBroadcast && channels != null) {
                             Spacer(modifier = Modifier.width(10.dp))
-                            val (icon, tint) = getSecurityIcon(
-                                isLowEntropyKey = isLowEntropyKey ?: false,
-                                isPreciseLocation = isPreciseLocation ?: false
-                            )
-                            Icon(
-                                imageVector = icon,
-                                contentDescription = if (!(isLowEntropyKey ?: false)) "Secure" else "Unlocked",
-                                tint = tint,
-                            )
+                            val channelIndex = contact.contactKey[0].digitToIntOrNull()
+                            channelIndex?.let { index ->
+                                getSecurityIcon(channels, index)?.let { (icon, tint) ->
+                                    Icon(
+                                        imageVector = icon,
+                                        contentDescription = "Security status",
+                                        tint = tint,
+                                    )
+                                }
+                            }
                         }
                     }
                     Text(

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
@@ -51,7 +51,7 @@ import com.geeksville.mesh.AppOnlyProtos
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.Contact
 import com.geeksville.mesh.ui.common.theme.AppTheme
-import com.geeksville.mesh.ui.common.components.getSecurityIcon
+import com.geeksville.mesh.ui.common.components.SecurityIcon
 
 @Suppress("LongMethod")
 @Composable
@@ -124,13 +124,7 @@ fun ContactItem(
                         if (isBroadcast && channels != null) {
                             val channelIndex = contact.contactKey[0].digitToIntOrNull()
                             channelIndex?.let { index ->
-                                getSecurityIcon(channels, index)?.let { (icon, tint) ->
-                                    Icon(
-                                        imageVector = icon,
-                                        contentDescription = "Security status",
-                                        tint = tint,
-                                    )
-                                }
+                                SecurityIcon(channels, index)
                             }
                             Spacer(modifier = Modifier.width(8.dp))
                         }

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.VolumeOff
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
@@ -119,12 +120,26 @@ fun ContactItem(
                         val isBroadcast = contact.contactKey.getOrNull(1) == '^' ||
                              contact.contactKey.endsWith("^all") ||
                              contact.contactKey.endsWith("^broadcast")
+                        if (isBroadcast && isLowEntropyKey == false) { // secure 
+                            Spacer(modifier = Modifier.width(10.dp))
+                            Icon(
+                                imageVector = Icons.Default.Lock,
+                                contentDescription = "Secure",
+                                tint = Color.Green,
+                            )
+                        }
+                        // Check if the channel for this contact has precise location enabled
+                        val channelIndex = contact.contactKey.getOrNull(0)?.digitToIntOrNull()
+//                        val isPreciseLocation = channel.moduleSettings.positionPrecision == 32
+                        val isPreciseLocation = channelIndex == 0 // && // needs other flags, but this is a start
+                            // viewModel.channels.getOrNull(channelIndex ?: -1)?.preciseLocation == true
 
-                        if (isBroadcast && isDefaultPSK == true) {
+                        if (isBroadcast && isLowEntropyKey == false) {
                             Spacer(modifier = Modifier.width(10.dp))
                             Icon(
                                 imageVector = ImageVector.vectorResource(R.drawable.ic_lock_open_right_24),
-                                contentDescription = "Unlocked"
+                                contentDescription = "Unlocked",
+                                tint = if (isPreciseLocation) Color.Red else Color.Yellow,
                             )
                         }
                     }

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.VolumeOff
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
@@ -43,7 +42,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -52,7 +50,7 @@ import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.Contact
 import com.geeksville.mesh.ui.common.theme.AppTheme
-import androidx.compose.ui.graphics.vector.ImageVector
+import com.geeksville.mesh.ui.common.components.getSecurityIcon
 
 @Suppress("LongMethod")
 @Composable
@@ -120,26 +118,16 @@ fun ContactItem(
                         val isBroadcast = contact.contactKey.getOrNull(1) == '^' ||
                              contact.contactKey.endsWith("^all") ||
                              contact.contactKey.endsWith("^broadcast")
-                        if (isBroadcast && isLowEntropyKey == false) { // secure
+                        if (isBroadcast) {
                             Spacer(modifier = Modifier.width(10.dp))
-                            Icon(
-                                imageVector = Icons.Default.Lock,
-                                contentDescription = "Secure",
-                                tint = Color.Green,
+                            val (icon, tint) = getSecurityIcon(
+                                isLowEntropyKey = isLowEntropyKey ?: false,
+                                isPreciseLocation = isPreciseLocation ?: false
                             )
-                        }
-                        // Check if the channel for this contact has precise location enabled
-                        val channelIndex = contact.contactKey.getOrNull(0)?.digitToIntOrNull()
-//                        val isPreciseLocation = channel.moduleSettings.positionPrecision == 32
-                        val isPreciseLocation = channelIndex == 0 // && // needs other flags, but this is a start
-                            // viewModel.channels.getOrNull(channelIndex ?: -1)?.preciseLocation == true
-
-                        if (isBroadcast && isLowEntropyKey == false) {
-                            Spacer(modifier = Modifier.width(10.dp))
                             Icon(
-                                imageVector = ImageVector.vectorResource(R.drawable.ic_lock_open_right_24),
-                                contentDescription = "Unlocked",
-                                tint = if (isPreciseLocation) Color.Red else Color.Yellow,
+                                imageVector = icon,
+                                contentDescription = if (!(isLowEntropyKey ?: false)) "Secure" else "Unlocked",
+                                tint = tint,
                             )
                         }
                     }

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
@@ -120,7 +120,7 @@ fun ContactItem(
                         val isBroadcast = contact.contactKey.getOrNull(1) == '^' ||
                              contact.contactKey.endsWith("^all") ||
                              contact.contactKey.endsWith("^broadcast")
-                        if (isBroadcast && isLowEntropyKey == false) { // secure 
+                        if (isBroadcast && isLowEntropyKey == false) { // secure
                             Spacer(modifier = Modifier.width(10.dp))
                             Icon(
                                 imageVector = Icons.Default.Lock,

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
@@ -112,16 +112,16 @@ fun ContactItem(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
-                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = longName,
-                        )
+                    Text(
+                        text = longName,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         // Show unlock icon for broadcast with default PSK
                         val isBroadcast = contact.contactKey.getOrNull(1) == '^' ||
                              contact.contactKey.endsWith("^all") ||
                              contact.contactKey.endsWith("^broadcast")
                         if (isBroadcast && channels != null) {
-                            Spacer(modifier = Modifier.width(10.dp))
                             val channelIndex = contact.contactKey[0].digitToIntOrNull()
                             channelIndex?.let { index ->
                                 getSecurityIcon(channels, index)?.let { (icon, tint) ->
@@ -132,13 +132,15 @@ fun ContactItem(
                                     )
                                 }
                             }
+                            Spacer(modifier = Modifier.width(8.dp))
                         }
+                        Text(
+                            text = lastMessageTime.orEmpty(),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontSize = MaterialTheme.typography.labelLarge.fontSize,
+                            modifier = Modifier.width(80.dp),
+                        )
                     }
-                    Text(
-                        text = lastMessageTime.orEmpty(),
-                        color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = MaterialTheme.typography.labelLarge.fontSize,
-                    )
                 }
                 Row(
                     modifier = Modifier

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/Contacts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/Contacts.kt
@@ -305,7 +305,7 @@ fun SelectionToolbar(
         title = { Text(text = "$selectedCount") },
         navigationIcon = {
             IconButton(onClick = onCloseSelection) {
-                Icon(Icons.Default.Close, contentDescription = "Close selection")
+                Icon(Icons.Default.Close, contentDescription = stringResource(R.string.close_selection))
             }
         },
         actions = {
@@ -324,10 +324,10 @@ fun SelectionToolbar(
                 )
             }
             IconButton(onClick = onDeleteSelected) {
-                Icon(Icons.Default.Delete, contentDescription = "Delete selected")
+                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.delete_selection))
             }
             IconButton(onClick = onSelectAll) {
-                Icon(Icons.Default.SelectAll, contentDescription = "Select all")
+                Icon(Icons.Default.SelectAll, contentDescription = stringResource(R.string.select_all))
             }
         }
     )

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/Contacts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/Contacts.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.geeksville.mesh.AppOnlyProtos
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.Contact
 import com.geeksville.mesh.model.UIViewModel
@@ -136,12 +137,14 @@ fun ContactsScreen(
             }
         }
     ) { paddingValues ->
+        val channels by uiViewModel.channels.collectAsStateWithLifecycle()
         ContactListView(
             contacts = contacts,
             selectedList = selectedContactKeys,
             onClick = onContactClick,
             onLongClick = onContactLongClick,
-            contentPadding = paddingValues
+            contentPadding = paddingValues,
+            channels = channels
         )
     }
     DeleteConfirmationDialog(
@@ -336,7 +339,8 @@ fun ContactListView(
     selectedList: List<String>,
     onClick: (Contact) -> Unit,
     onLongClick: (Contact) -> Unit,
-    contentPadding: PaddingValues
+    contentPadding: PaddingValues,
+    channels: AppOnlyProtos.ChannelSet? = null
 ) {
     val haptics = LocalHapticFeedback.current
     LazyColumn(
@@ -355,6 +359,7 @@ fun ContactListView(
                     onLongClick(contact)
                     haptics.performHapticFeedback(HapticFeedbackType.LongPress)
                 },
+                channels = channels
             )
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
@@ -494,7 +494,7 @@ private fun DebugMenuActionsPreview() {
             ) {
                 Icon(
                     imageVector = Icons.Outlined.FileDownload,
-                    contentDescription = "Export Logs"
+                    contentDescription = stringResource(id = R.string.debug_logs_export)
                 )
             }
             IconButton(
@@ -503,7 +503,7 @@ private fun DebugMenuActionsPreview() {
             ) {
                 Icon(
                     imageVector = Icons.Default.Delete,
-                    contentDescription = "Clear All"
+                    contentDescription = stringResource(id = R.string.debug_clear)
                 )
             }
         }
@@ -559,7 +559,7 @@ private fun DebugScreenEmptyPreview() {
                                             )
                                             Icon(
                                                 imageVector = Icons.TwoTone.FilterAltOff,
-                                                contentDescription = "Filter"
+                                                contentDescription = stringResource(id = R.string.debug_filters)
                                             )
                                         }
                                     }
@@ -709,7 +709,7 @@ fun DebugMenuActions(
     ) {
         Icon(
             imageVector = Icons.Outlined.FileDownload,
-            contentDescription = "Export Logs"
+            contentDescription = stringResource(id = R.string.debug_logs_export)
         )
     }
     IconButton(
@@ -718,7 +718,7 @@ fun DebugMenuActions(
     ) {
         Icon(
             imageVector = Icons.Default.Delete,
-            contentDescription = "Clear All"
+            contentDescription = stringResource(id = R.string.debug_clear)
         )
     }
     if (showDeleteLogsDialog) {

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/DebugFilters.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/DebugFilters.kt
@@ -270,7 +270,7 @@ internal fun DebugActiveFilters(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Clear,
-                        contentDescription = stringResource(id = R.string.debug_clear)
+                        contentDescription = stringResource(id = R.string.debug_filter_clear)
                     )
                 }
             }

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/DebugFilters.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/DebugFilters.kt
@@ -101,7 +101,7 @@ fun DebugCustomFilterInput(
         ) {
             Icon(
                 imageVector = Icons.Default.Add,
-                contentDescription = "Add filter"
+                contentDescription = stringResource(id = R.string.debug_filter_add)
             )
         }
     }
@@ -151,7 +151,7 @@ internal fun DebugPresetFilters(
                     leadingIcon = { if (filter in filterTexts) {
                         Icon(
                             imageVector = Icons.Filled.Done,
-                            contentDescription = "Done icon",
+                            contentDescription = stringResource(id = R.string.debug_filter_included),
                         )
                         }
                     }
@@ -194,7 +194,7 @@ internal fun DebugFilterBar(
                         } else {
                             Icons.TwoTone.FilterAltOff
                         },
-                        contentDescription = "Filter"
+                        contentDescription = stringResource(id = R.string.debug_filters)
                     )
                 }
             }
@@ -270,7 +270,7 @@ internal fun DebugActiveFilters(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Clear,
-                        contentDescription = "Clear all filters"
+                        contentDescription = stringResource(id = R.string.debug_clear)
                     )
                 }
             }

--- a/app/src/main/java/com/geeksville/mesh/ui/debug/DebugSearch.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/DebugSearch.kt
@@ -83,7 +83,7 @@ internal fun DebugSearchNavigation(
         ) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowUp,
-                contentDescription = "Previous match",
+                contentDescription = stringResource(R.string.debug_search_prev),
                 modifier = Modifier.size(16.dp)
             )
         }
@@ -94,7 +94,7 @@ internal fun DebugSearchNavigation(
         ) {
             Icon(
                 imageVector = Icons.Default.KeyboardArrowDown,
-                contentDescription = "Next match",
+                contentDescription = stringResource(R.string.debug_search_next),
                 modifier = Modifier.size(16.dp)
             )
         }
@@ -143,7 +143,7 @@ internal fun DebugSearchBar(
                     ) {
                         Icon(
                             imageVector = Icons.Default.Clear,
-                            contentDescription = "Clear search",
+                            contentDescription = stringResource(R.string.debug_search_clear),
                             modifier = Modifier.size(16.dp)
                         )
                     }

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -99,7 +99,7 @@ import com.geeksville.mesh.ui.node.components.NodeKeyStatusIcon
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import com.geeksville.mesh.ui.sharing.SharedContactDialog
 import kotlinx.coroutines.launch
-import com.geeksville.mesh.ui.common.components.getSecurityIcon
+import com.geeksville.mesh.ui.common.components.SecurityIcon
 
 private const val MESSAGE_CHARACTER_LIMIT = 200
 private const val SNIPPET_CHARACTER_LIMIT = 50
@@ -458,13 +458,7 @@ private fun MessageTopBar(
             Spacer(modifier = Modifier.width(10.dp))
 
             channelIndexParam?.let { index ->
-                getSecurityIcon(channels, index)?.let { (icon, tint) ->
-                    Icon(
-                        imageVector = icon,
-                        contentDescription = "Security status",
-                        tint = tint,
-                    )
-                }
+                SecurityIcon(channels, index)
             }
         }
     },

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -123,12 +123,13 @@ internal fun MessageScreen(
     val channelIndex = contactKey[0].digitToIntOrNull()
     val nodeId = contactKey.substring(1)
     val channels by viewModel.channels.collectAsStateWithLifecycle()
-    val channelName by remember(channelIndex) {
+    val unknownChannelText = stringResource(id = R.string.unknown_channel)
+    val channelName by remember(channelIndex, unknownChannelText) {
         derivedStateOf {
             channelIndex?.let {
                 val channel = channels.getChannel(it)
-                channel?.name ?: stringResource(id = R.string.unknown_channel)
-            } ?: stringResource(id = R.string.unknown_channel)
+                channel?.name ?: unknownChannelText
+            } ?: unknownChannelText
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -127,8 +127,8 @@ internal fun MessageScreen(
         derivedStateOf {
             channelIndex?.let {
                 val channel = channels.getChannel(it)
-                channel?.name ?: "Unknown Channel"
-            } ?: "Unknown Channel"
+                channel?.name ?: stringResource(id = R.string.unknown_channel)
+            } ?: stringResource(id = R.string.unknown_channel)
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -128,15 +128,13 @@ internal fun MessageScreen(
             channelIndex?.let {
                 val channel = channels.getChannel(it)
                 val name = channel?.name ?: "Unknown Channel"
-                // Check if PSK is the default (base64 'AQ==', i.e., single byte 0x01)
-                val isDefaultPSK = (channel?.settings?.psk?.size() == 1 &&
-                    channel.settings.psk.byteAt(0) == 1.toByte()) ||
-                    channel?.psk?.toByteArray()?.isEmpty() == true
-                Pair(name, isDefaultPSK)
+                // Check if PSK is the default (0 or 1 byte key)
+                val isLowEntropyKey = channel?.psk?.size() ?: 0 <= 1
+                Pair(name, isLowEntropyKey)
             } ?: Pair("Unknown Channel", false)
         }
     }
-    val (channelTitle, isDefaultPsk) = channelName
+    val (channelTitle, isLowEntropyKey) = channelName
     val title = when (nodeId) {
         DataPacket.ID_BROADCAST -> channelTitle
         else -> viewModel.getUser(nodeId).longName
@@ -212,7 +210,7 @@ internal fun MessageScreen(
                     }
                 }
             } else {
-                MessageTopBar(title, channelIndex, mismatchKey, onNavigateBack, isDefaultPsk = isDefaultPsk
+                MessageTopBar(title, channelIndex, mismatchKey, onNavigateBack, isLowEntropyKey = isLowEntropyKey
         )
             }
         },
@@ -455,12 +453,12 @@ private fun MessageTopBar(
     channelIndex: Int?,
     mismatchKey: Boolean = false,
     onNavigateBack: () -> Unit,
-    isDefaultPsk: Boolean = false
+    isLowEntropyKey: Boolean = false
 ) = TopAppBar(
     title = {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(text = title)
-            if (isDefaultPsk
+            if (isLowEntropyKey
             ) {
                 Spacer(modifier = Modifier.width(10.dp))
                     Icon(

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfig.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/RadioConfig.kt
@@ -255,7 +255,7 @@ private fun NavButton(@StringRes title: Int, enabled: Boolean, onClick: () -> Un
                 ) {
                     Icon(
                         imageVector = Icons.TwoTone.Warning,
-                        contentDescription = "warning",
+                        contentDescription = stringResource(id = R.string.warning),
                         modifier = Modifier.padding(end = 8.dp)
                     )
                     Text(
@@ -263,7 +263,7 @@ private fun NavButton(@StringRes title: Int, enabled: Boolean, onClick: () -> Un
                     )
                     Icon(
                         imageVector = Icons.TwoTone.Warning,
-                        contentDescription = "warning",
+                        contentDescription = stringResource(id = R.string.warning),
                         modifier = Modifier.padding(start = 8.dp)
                     )
                 }

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
@@ -145,7 +145,7 @@ fun ChannelCard(
     } else {
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_lock_open_right_24),
-            contentDescription = "Unlocked", 
+            contentDescription = "Unlocked",
             tint = if (isPreciseLocation) Color.Red else Color.Yellow,
         )
         Spacer(modifier = Modifier.width(10.dp))

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
@@ -79,7 +79,7 @@ import com.geeksville.mesh.ui.common.components.dragContainer
 import com.geeksville.mesh.ui.common.components.dragDropItemsIndexed
 import com.geeksville.mesh.ui.common.components.rememberDragDropState
 import com.geeksville.mesh.ui.radioconfig.RadioConfigViewModel
-import com.geeksville.mesh.ui.common.components.getSecurityIcon
+import com.geeksville.mesh.ui.common.components.SecurityIcon
 
 @Composable
 private fun ChannelItem(
@@ -131,13 +131,7 @@ fun ChannelCard(
     enabled = enabled,
     onClick = onEditClick,
 ) {
-    getSecurityIcon(channel)?.let { (icon, tint) ->
-        Icon(
-            imageVector = icon,
-            contentDescription = "Security status",
-            tint = tint,
-        )
-    }
+    SecurityIcon(channel)
     Spacer(modifier = Modifier.width(10.dp))
     IconButton(onClick = { onDeleteClick() }) {
         Icon(
@@ -162,13 +156,7 @@ fun ChannelSelection(
     enabled = enabled,
     onClick = {},
 ) {
-    getSecurityIcon(channel)?.let { (icon, tint) ->
-        Icon(
-            imageVector = icon,
-            contentDescription = "Security status",
-            tint = tint,
-        )
-    }
+    SecurityIcon(channel)
     Spacer(modifier = Modifier.width(10.dp))
     Checkbox(
         enabled = enabled,

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
@@ -80,8 +80,6 @@ import com.geeksville.mesh.ui.common.components.dragDropItemsIndexed
 import com.geeksville.mesh.ui.common.components.rememberDragDropState
 import com.geeksville.mesh.ui.radioconfig.RadioConfigViewModel
 import com.geeksville.mesh.ui.common.components.getSecurityIcon
-import com.geeksville.mesh.ui.common.components.isPreciseLocation
-import com.geeksville.mesh.ui.common.components.isLowEntropyKey
 
 @Composable
 private fun ChannelItem(
@@ -126,20 +124,20 @@ fun ChannelCard(
     enabled: Boolean,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
-    isLowEntropyKey: Boolean = false,
-    isPreciseLocation: Boolean = false,
+    channel: Channel,
 ) = ChannelItem(
     index = index,
     title = title,
     enabled = enabled,
     onClick = onEditClick,
 ) {
-    val (icon, tint) = getSecurityIcon(isLowEntropyKey, isPreciseLocation)
-    Icon(
-        imageVector = icon,
-        contentDescription = if (!isLowEntropyKey) "Secure" else "Unlocked",
-        tint = tint,
-    )
+    getSecurityIcon(channel)?.let { (icon, tint) ->
+        Icon(
+            imageVector = icon,
+            contentDescription = "Security status",
+            tint = tint,
+        )
+    }
     Spacer(modifier = Modifier.width(10.dp))
     IconButton(onClick = { onDeleteClick() }) {
         Icon(
@@ -157,20 +155,20 @@ fun ChannelSelection(
     enabled: Boolean,
     isSelected: Boolean,
     onSelected: (Boolean) -> Unit,
-    isLowEntropyKey: Boolean = false,
-    isPreciseLocation: Boolean = false,
+    channel: Channel,
 ) = ChannelItem(
     index = index,
     title = title,
     enabled = enabled,
     onClick = {},
 ) {
-    val (icon, tint) = getSecurityIcon(isLowEntropyKey, isPreciseLocation)
-    Icon(
-        imageVector = icon,
-        contentDescription = if (!isLowEntropyKey) "Secure" else "Unlocked",
-        tint = tint,
-    )
+    getSecurityIcon(channel)?.let { (icon, tint) ->
+        Icon(
+            imageVector = icon,
+            contentDescription = "Security status",
+            tint = tint,
+        )
+    }
     Spacer(modifier = Modifier.width(10.dp))
     Checkbox(
         enabled = enabled,
@@ -296,14 +294,14 @@ fun ChannelSettingsItemList(
                     items = settingsListInput,
                     dragDropState = dragDropState,
                 ) { index, channel, isDragging ->
+                    val channelObj = Channel(channel, loraConfig)
                     ChannelCard(
                         index = index,
                         title = channel.name.ifEmpty { primaryChannel.name },
                         enabled = enabled,
                         onEditClick = { showEditChannelDialog = index },
                         onDeleteClick = { settingsListInput.removeAt(index) },
-                        isLowEntropyKey = channel.isLowEntropyKey(),
-                        isPreciseLocation = channel.isPreciseLocation()
+                        channel = channelObj
                     )
                     if (index == 0 && !isDragging) {
                         Text(

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.twotone.Add
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material3.AssistChip
@@ -59,6 +60,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
@@ -125,17 +127,26 @@ fun ChannelCard(
     enabled: Boolean,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
-    isDefaultPSK: Boolean = false,
+    isLowEntropyKey: Boolean = false,
+    isPreciseLocation: Boolean = false,
 ) = ChannelItem(
     index = index,
     title = title,
     enabled = enabled,
     onClick = onEditClick,
 ) {
-    if (isDefaultPSK) {
+
+    if (!isLowEntropyKey) {
+        Icon(
+            imageVector = Icons.Default.Lock,
+            contentDescription = "Secure",
+            tint = Color.Green,
+        )
+    } else {
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_lock_open_right_24),
-            contentDescription = "Unlocked"
+            contentDescription = "Unlocked", 
+            tint = if (isPreciseLocation) Color.Red else Color.Yellow,
         )
         Spacer(modifier = Modifier.width(10.dp))
     }
@@ -155,19 +166,28 @@ fun ChannelSelection(
     enabled: Boolean,
     isSelected: Boolean,
     onSelected: (Boolean) -> Unit,
-    isDefaultPSK: Boolean = false,
+    isLowEntropyKey: Boolean = false,
+    isPreciseLocation: Boolean = false,
 ) = ChannelItem(
     index = index,
     title = title,
     enabled = enabled,
     onClick = {},
 ) {
-    if (isDefaultPSK) {
+    if (!isLowEntropyKey) {
+        Icon(
+            imageVector = Icons.Default.Lock,
+            contentDescription = "Secure",
+            tint = Color.Green,
+        )
+    } else {
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_lock_open_right_24),
-            contentDescription = "Unlocked"
+            contentDescription = "Unlocked",
+            tint = if (isPreciseLocation) Color.Red else Color.Yellow,
         )
     }
+    Spacer(modifier = Modifier.width(10.dp))
     Checkbox(
         enabled = enabled,
         checked = isSelected,
@@ -292,15 +312,16 @@ fun ChannelSettingsItemList(
                     items = settingsListInput,
                     dragDropState = dragDropState,
                 ) { index, channel, isDragging ->
-                    val isDefaultPSK = (channel.psk.size() == 1 && channel.psk.byteAt(0) == 1.toByte()) ||
-                        channel.psk.toByteArray().isEmpty()
+                    val isLowEntropyKey = channel.psk.size() <= 1
+                    val isPreciseLocation = channel.moduleSettings.positionPrecision == 32
                     ChannelCard(
                         index = index,
                         title = channel.name.ifEmpty { primaryChannel.name },
                         enabled = enabled,
                         onEditClick = { showEditChannelDialog = index },
                         onDeleteClick = { settingsListInput.removeAt(index) },
-                        isDefaultPSK = isDefaultPSK
+                        isLowEntropyKey = isLowEntropyKey,
+                        isPreciseLocation = isPreciseLocation
                     )
                     if (index == 0 && !isDragging) {
                         Text(

--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/ChannelSettingsItemList.kt
@@ -39,7 +39,6 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.twotone.Add
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material3.AssistChip
@@ -60,11 +59,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -82,7 +79,9 @@ import com.geeksville.mesh.ui.common.components.dragContainer
 import com.geeksville.mesh.ui.common.components.dragDropItemsIndexed
 import com.geeksville.mesh.ui.common.components.rememberDragDropState
 import com.geeksville.mesh.ui.radioconfig.RadioConfigViewModel
-import androidx.compose.ui.graphics.vector.ImageVector
+import com.geeksville.mesh.ui.common.components.getSecurityIcon
+import com.geeksville.mesh.ui.common.components.isPreciseLocation
+import com.geeksville.mesh.ui.common.components.isLowEntropyKey
 
 @Composable
 private fun ChannelItem(
@@ -135,21 +134,13 @@ fun ChannelCard(
     enabled = enabled,
     onClick = onEditClick,
 ) {
-
-    if (!isLowEntropyKey) {
-        Icon(
-            imageVector = Icons.Default.Lock,
-            contentDescription = "Secure",
-            tint = Color.Green,
-        )
-    } else {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_lock_open_right_24),
-            contentDescription = "Unlocked",
-            tint = if (isPreciseLocation) Color.Red else Color.Yellow,
-        )
-        Spacer(modifier = Modifier.width(10.dp))
-    }
+    val (icon, tint) = getSecurityIcon(isLowEntropyKey, isPreciseLocation)
+    Icon(
+        imageVector = icon,
+        contentDescription = if (!isLowEntropyKey) "Secure" else "Unlocked",
+        tint = tint,
+    )
+    Spacer(modifier = Modifier.width(10.dp))
     IconButton(onClick = { onDeleteClick() }) {
         Icon(
             imageVector = Icons.TwoTone.Close,
@@ -174,19 +165,12 @@ fun ChannelSelection(
     enabled = enabled,
     onClick = {},
 ) {
-    if (!isLowEntropyKey) {
-        Icon(
-            imageVector = Icons.Default.Lock,
-            contentDescription = "Secure",
-            tint = Color.Green,
-        )
-    } else {
-        Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_lock_open_right_24),
-            contentDescription = "Unlocked",
-            tint = if (isPreciseLocation) Color.Red else Color.Yellow,
-        )
-    }
+    val (icon, tint) = getSecurityIcon(isLowEntropyKey, isPreciseLocation)
+    Icon(
+        imageVector = icon,
+        contentDescription = if (!isLowEntropyKey) "Secure" else "Unlocked",
+        tint = tint,
+    )
     Spacer(modifier = Modifier.width(10.dp))
     Checkbox(
         enabled = enabled,
@@ -312,16 +296,14 @@ fun ChannelSettingsItemList(
                     items = settingsListInput,
                     dragDropState = dragDropState,
                 ) { index, channel, isDragging ->
-                    val isLowEntropyKey = channel.psk.size() <= 1
-                    val isPreciseLocation = channel.moduleSettings.positionPrecision == 32
                     ChannelCard(
                         index = index,
                         title = channel.name.ifEmpty { primaryChannel.name },
                         enabled = enabled,
                         onEditClick = { showEditChannelDialog = index },
                         onDeleteClick = { settingsListInput.removeAt(index) },
-                        isLowEntropyKey = isLowEntropyKey,
-                        isPreciseLocation = isPreciseLocation
+                        isLowEntropyKey = channel.isLowEntropyKey(),
+                        isPreciseLocation = channel.isPreciseLocation()
                     )
                     if (index == 0 && !isDragging) {
                         Text(

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
@@ -113,6 +113,9 @@ import com.geeksville.mesh.ui.radioconfig.components.PacketResponseStateDialog
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import kotlinx.coroutines.launch
+import com.geeksville.mesh.ui.common.components.getSecurityIcon
+import com.geeksville.mesh.ui.common.components.isPreciseLocation
+import com.geeksville.mesh.ui.common.components.isLowEntropyKey
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
@@ -448,8 +451,7 @@ private fun ChannelListView(
     AdaptiveTwoPane(
         first = {
             channelSet.settingsList.forEachIndexed { index, channel ->
-                val isLowEntropyKey = channel.psk.size() <= 1
-                val isPreciseLocation = channel.moduleSettings.positionPrecision == 1
+                val (icon, tint) = getSecurityIcon(channel)
                 val displayTitle = channel.name.ifEmpty { modemPresetName }
 
                 ChannelSelection(
@@ -462,8 +464,8 @@ private fun ChannelListView(
                             channelSelections[index] = it
                         }
                     },
-                    isLowEntropyKey = isLowEntropyKey,
-                    isPreciseLocation = isPreciseLocation
+                    isLowEntropyKey = channel.isLowEntropyKey(),
+                    isPreciseLocation = channel.isPreciseLocation()
                 )
             }
             OutlinedButton(

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
@@ -448,8 +448,8 @@ private fun ChannelListView(
     AdaptiveTwoPane(
         first = {
             channelSet.settingsList.forEachIndexed { index, channel ->
-                val isDefaultPSK = (channel.psk.size() == 1 && channel.psk.byteAt(0) == 1.toByte()) ||
-                    channel.psk.toByteArray().isEmpty()
+                val isLowEntropyKey = channel.psk.size() <= 1
+                val isPreciseLocation = channel.moduleSettings.positionPrecision == 1
                 val displayTitle = channel.name.ifEmpty { modemPresetName }
 
                 ChannelSelection(
@@ -462,7 +462,8 @@ private fun ChannelListView(
                             channelSelections[index] = it
                         }
                     },
-                    isDefaultPSK = isDefaultPSK
+                    isLowEntropyKey = isLowEntropyKey,
+                    isPreciseLocation = isPreciseLocation
                 )
             }
             OutlinedButton(

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
@@ -113,7 +113,6 @@ import com.geeksville.mesh.ui.radioconfig.components.PacketResponseStateDialog
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import kotlinx.coroutines.launch
-import com.geeksville.mesh.ui.common.components.getSecurityIcon
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
@@ -114,8 +114,6 @@ import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import kotlinx.coroutines.launch
 import com.geeksville.mesh.ui.common.components.getSecurityIcon
-import com.geeksville.mesh.ui.common.components.isPreciseLocation
-import com.geeksville.mesh.ui.common.components.isLowEntropyKey
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
@@ -451,7 +449,7 @@ private fun ChannelListView(
     AdaptiveTwoPane(
         first = {
             channelSet.settingsList.forEachIndexed { index, channel ->
-                val (icon, tint) = getSecurityIcon(channel)
+                val channelObj = Channel(channel, channelSet.loraConfig)
                 val displayTitle = channel.name.ifEmpty { modemPresetName }
 
                 ChannelSelection(
@@ -464,8 +462,7 @@ private fun ChannelListView(
                             channelSelections[index] = it
                         }
                     },
-                    isLowEntropyKey = channel.isLowEntropyKey(),
-                    isPreciseLocation = channel.isPreciseLocation()
+                    channel = channelObj
                 )
             }
             OutlinedButton(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,11 @@
     <string name="debug_filters">Filters</string>
     <string name="debug_active_filters">Active filters</string>
     <string name="debug_default_search">Search in logs…</string>
+    <string name="debug_search_next">Next match</string>
+    <string name="debug_search_prev">Previous match</string>
+    <string name="debug_search_clear">Clear search</string>
+    <string name="debug_filter_add">Add filter</string>
+    <string name="debug_filter_included">Filter included</string>
     <string name="debug_clear">Clear Logs</string>
     <string name="match_any">Match Any | All</string>
     <string name="match_all">Match All | Any</string>
@@ -219,6 +224,8 @@
     <string name="delete_for_everyone">Delete for everyone</string>
     <string name="delete_for_me">Delete for me</string>
     <string name="select_all">Select all</string>
+    <string name="close_selection">Close selection</string>
+    <string name="delete_selection">Delete selected</string>
     <string name="modem_config_slow_long">Long Range / Slow</string>
     <string name="map_style_selection">Style Selection</string>
     <string name="map_download_region">Download Region</string>
@@ -604,6 +611,7 @@
     <string name="environment_metrics_use_fahrenheit">Environment metrics use Fahrenheit</string>
     <string name="air_quality_metrics_module_enabled">Air quality metrics module enabled</string>
     <string name="air_quality_metrics_update_interval_seconds">Air quality metrics update interval (seconds)</string>
+    <string name="air_quality_icon">Air quality icon</string>
     <string name="power_metrics_module_enabled">Power metrics module enabled</string>
     <string name="power_metrics_update_interval_seconds">Power metrics update interval (seconds)</string>
     <string name="power_metrics_on_screen_enabled">Power metrics on-screen enabled</string>
@@ -716,4 +724,7 @@
     <string name="security_icon_warning"> - WARN, insecure MQTT</string>
     <string name="security_icon_insecure"> - WARN, low entropy key</string>
     <string name="security_icon_insecure_precise"> - WARNING, insecure location enabled</string>
+    <string name="unknown_channel">Unknown Channel</string>
+    <string name="warning">Warning</string>
+    <string name="overflow_menu">Overflow menu</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,7 @@
     <string name="debug_search_clear">Clear search</string>
     <string name="debug_filter_add">Add filter</string>
     <string name="debug_filter_included">Filter included</string>
+    <string name="debug_filter_clear">Clear all filters</string>
     <string name="debug_clear">Clear Logs</string>
     <string name="match_any">Match Any | All</string>
     <string name="match_all">Match All | Any</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -711,4 +711,9 @@
     <string name="app_intro_next_button">Next</string>
     <string name="app_intro_done_button">Done</string>
     <string name="app_intro_skip_button">Skip</string>
+    <string name="security_icon_description">Security Status</string>
+    <string name="security_icon_secure"> - Secure</string>
+    <string name="security_icon_warning"> - WARN, insecure MQTT</string>
+    <string name="security_icon_insecure"> - WARN, low entropy key</string>
+    <string name="security_icon_insecure_precise"> - WARNING, insecure location enabled</string>
 </resources>


### PR DESCRIPTION
#2334 
- Moved all of the security icons to a single source of truth
- Implemented colours depending on whether precisePrecision is enabled
- added mqtt warning triangle when precise location, low entropy key, and MQTT upload enabled. 

Settings > channels: 
![Screenshot 2025-07-06 at 1 18 24 pm](https://github.com/user-attachments/assets/00f31f47-aa68-43d1-8e2b-8f8445ad3f90)

Sharing channels: 
![Screenshot 2025-07-06 at 1 18 32 pm](https://github.com/user-attachments/assets/4f3ae3cf-d520-4bf6-8b84-6f2b71a58166)

Contact List: 
![Screenshot 2025-07-06 at 1 18 44 pm](https://github.com/user-attachments/assets/08856168-2257-4917-bde0-9430c3766d33)


Message: 
![Screenshot 2025-07-06 at 1 18 53 pm](https://github.com/user-attachments/assets/80ec9037-70bc-4b97-b8af-1b4c35638cf9)
