### PR TITLE
CI investigation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,14 +10,15 @@
 # supported CodeQL languages.
 #
 name: "CodeQL Advanced"
+# This has been disabled in the GH CLI.
 
 on:
-  # push:
+  # push:    # this has been disabled - why? 
   #   branches: [ "main" ]
   # pull_request:
   #   branches: [ "main" ]
-  schedule:
-    - cron: '0 0 * * 0'
+  # schedule:
+  #   - cron: '0 0 * * 0' # Run every Sunday at midnight
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,8 +1,16 @@
 name: Dependency Submission
-
+# This has been disabled in the GH web interface, so I don't know that we need to update it. 
 on:
   push:
     branches: [ 'main' ]
+    paths:
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/**'
+      - '**/build.gradle.kts'
+      - '**/build.gradle'
+      - 'gradle/libs.versions.toml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -115,11 +115,13 @@ jobs:
           retention-days: 14
 
   androidTest:
+    needs: [build, detekt]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       matrix:
-        api-level: [26, 35]
+        # api-level: [26, 35]
+        api-level: [35] # only do a single set on MRs, full test in the merge queue
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: Close Stale Issues
 on:
   schedule:
-    - cron: 0 6 * * *
+    - cron: 0 6 * * * # Run every day at 6am
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/update-firmware-releases-list.yml
+++ b/.github/workflows/update-firmware-releases-list.yml
@@ -2,7 +2,7 @@ name: Update Firmware Releases List
 
 on:
   schedule:
-    - cron: '0 * * * *'  # Run every hour
+    - cron: '0 */3 * * *'  # Run every 3 hours
   workflow_dispatch:     # Allow manual triggering
 
 jobs:

--- a/.github/workflows/update-hardware-list.yml
+++ b/.github/workflows/update-hardware-list.yml
@@ -2,7 +2,7 @@ name: Update Hardware List
 
 on:
   schedule:
-    - cron: '0 * * * *'  # Run every hour
+    - cron: '0 */3 * * *'  # Run every 3 hours
   workflow_dispatch:     # Allow manual triggering
 
 jobs:


### PR DESCRIPTION
Notes: 
minimum billing time is 1 min, recommend the cron scheduled ones either get made into jobs in a single workflow each hour, or increase the time between them. I don't see a need to do them more than 4 - 6 times a day. 

codeql has been disabled, 

PR workflow will take a little longer, but will fail out earlier on linting. Dropped api 26 test, as 35 should give adequate coverage, and both will be done on merge queue 