### PR TITLE
Fix(i18n): zh_TW typo '藍牙'

### DIFF
--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -343,7 +343,7 @@
     <string name="network">網路</string>
     <string name="display">顯示</string>
     <string name="lora">LoRa</string>
-    <string name="bluetooth">藍芽</string>
+    <string name="bluetooth">藍牙</string>
     <string name="security">安全</string>
     <string name="mqtt">MQTT</string>
     <string name="serial">序號</string>


### PR DESCRIPTION
origin text: '藍芽' (not correct)