### PR TITLE
skip test and lint on scheduled-updates

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Android CI (PR)
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 concurrency:
   group: build-pr-${{ github.ref }}
@@ -10,7 +11,7 @@ concurrency:
 
 jobs:
   build_and_detekt:
-    if: github.repository == 'meshtastic/Meshtastic-Android'
+    if: github.repository == 'meshtastic/Meshtastic-Android' && github.head_ref != 'scheduled-updates'
     uses: ./.github/workflows/reusable-android-build.yml
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -18,7 +19,7 @@ jobs:
 
   androidTest:
     # AssumingandroidTest should also only run for the main repository
-    if: github.repository == 'meshtastic/Meshtastic-Android'
+    if: github.repository == 'meshtastic/Meshtastic-Android' && github.head_ref != 'scheduled-updates'
     uses: ./.github/workflows/reusable-android-test.yml
     with:
       api_levels: '[35]' # Run only on API 35 for PRs


### PR DESCRIPTION
- It shouldn't touch code, so it should be safe to skip the tests on every update of an MR. 
- It will still get tested overall in the merge queue, but it'll save repeated runs. 