### PR TITLE
2387: change config pages footer to "clear changes"

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/PreferenceFooter.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/PreferenceFooter.kt
@@ -41,7 +41,7 @@ fun PreferenceFooter(
 ) {
     PreferenceFooter(
         enabled = enabled,
-        negativeText = R.string.cancel,
+        negativeText = R.string.clear_changes,
         onNegativeClicked = onCancelClicked,
         positiveText = R.string.send,
         onPositiveClicked = onSaveClicked,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -121,6 +121,7 @@
     <string name="url_for_join">A URL for joining a Meshtastic mesh</string>
     <string name="accept">Accept</string>
     <string name="cancel">Cancel</string>
+    <string name="clear_changes">Clear changes</string>
     <string name="change_channel">Change channel</string>
     <string name="are_you_sure_channel">Are you sure you want to change the channel? All communication with other nodes will stop until you share the new channel settings.</string>
     <string name="new_channel_rcvd">New Channel URL received</string>


### PR DESCRIPTION
 from cancel, as cancel implies it will leave the page

I think I've checked all the places preference footer is used without an override. 