### PR TITLE
Closing popup navs back to settings page

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/PacketResponseStateDialog.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/radioconfig/components/PacketResponseStateDialog.kt
@@ -87,7 +87,7 @@ fun <T> PacketResponseStateDialog(
                 Button(
                     onClick = {
                         onDismiss()
-                        if (state is ResponseState.Success || state is ResponseState.Error  ) {
+                        if (state is ResponseState.Success || state is ResponseState.Error) {
                             backDispatcher?.onBackPressed()
                         }
                     },


### PR DESCRIPTION
Closing popups on config pages will nav you back to the main settings page.
- prevents desync of state between device and app 
- hides issues caused by the device rebooting
- matches expected behaviour more clearly

**caution, risky merge** I'm not sure I've checked every place this is being used for collateral damage 

