### PR TITLE
fix(ci): Gradle cache and auth requests for `setup-java`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'jetbrains'
+          cache: 'gradle'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build F-Droid release
         run: ./gradlew assembleFdroidRelease
@@ -136,6 +139,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'jetbrains'
+          cache: 'gradle'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Play Store release
         run: ./gradlew bundleGoogleRelease assembleGoogleRelease

--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'jetbrains'
+          cache: 'gradle'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Gradle User Home
         uses: actions/cache@v4
         with:

--- a/.github/workflows/reusable-android-test.yml
+++ b/.github/workflows/reusable-android-test.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'jetbrains'
+          cache: 'gradle'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Gradle User Home
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
We were running into rate-limiting for the `setup-java` action in our workflows.
![image](https://github.com/user-attachments/assets/d9518999-d79c-4fe7-bb66-8a7ef9e36205)


This commit enables Gradle build caching in the GitHub Actions workflows for Android builds, tests, and releases.

This is achieved by:
- Setting the `cache: 'gradle'` input for the `actions/setup-java` action.
- Passing `GITHUB_TOKEN` as an environment variable to the `actions/setup-java` for making authorized requests to avoid being rate-limited.

This change aims to speed up build times by caching Gradle dependencies and mitigate rate limiting by making authorized requests.

https://github.com/actions/setup-java?tab=readme-ov-file#caching-gradle-dependencies

https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#jetbrains



