### PR TITLE
chore(ci): Decouple versioncode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
           submodules: 'recursive'
+          fetch-depth: 0
 
       - name: Cache Gradle packages
         uses: actions/cache@v4
@@ -79,8 +80,21 @@ jobs:
           java-version: '21'
           distribution: 'jetbrains'
 
+
+      - name: Calculate Version Code with Git Commit Count and Offset
+        id: calculate_version_code
+        run: |
+          GIT_COMMIT_COUNT=$(git rev-list --count HEAD)
+          OFFSET=30630 # to ensure versionCode is above 30630
+          VERSION_CODE=$((GIT_COMMIT_COUNT + OFFSET))
+          echo "Calculated versionCode: $VERSION_CODE (from $GIT_COMMIT_COUNT commits + $OFFSET offset)"
+          echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
+
       - name: Build F-Droid release
         run: ./gradlew assembleFdroidRelease
+        with:
+          env:
+            VERSION_CODE: ${{ env.VERSION_CODE }}
 
       - name: Upload F-Droid APK artifact (for release job)
         uses: actions/upload-artifact@v4
@@ -105,6 +119,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
           submodules: 'recursive'
+          fetch-depth: 0
 
       - name: Cache Gradle packages
         uses: actions/cache@v4
@@ -137,8 +152,20 @@ jobs:
           java-version: '21'
           distribution: 'jetbrains'
 
+      - name: Calculate Version Code with Git Commit Count and Offset
+        id: calculate_version_code
+        run: |
+          GIT_COMMIT_COUNT=$(git rev-list --count HEAD)
+          OFFSET=30630 # to ensure versionCode is above 30630
+          VERSION_CODE=$((GIT_COMMIT_COUNT + OFFSET))
+          echo "Calculated versionCode: $VERSION_CODE (from $GIT_COMMIT_COUNT commits + $OFFSET offset)"
+          echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
+
       - name: Build Play Store release
         run: ./gradlew bundleGoogleRelease assembleGoogleRelease
+        with:
+          env:
+            VERSION_CODE: ${{ env.VERSION_CODE }}
 
       - name: Upload Play Store AAB artifact (for release job)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,8 @@ jobs:
 
       - name: Build F-Droid release
         run: ./gradlew assembleFdroidRelease
-        with:
-          env:
-            VERSION_CODE: ${{ env.VERSION_CODE }}
+        env:
+          VERSION_CODE: ${{ env.VERSION_CODE }}
 
       - name: Upload F-Droid APK artifact (for release job)
         uses: actions/upload-artifact@v4
@@ -163,9 +162,8 @@ jobs:
 
       - name: Build Play Store release
         run: ./gradlew bundleGoogleRelease assembleGoogleRelease
-        with:
-          env:
-            VERSION_CODE: ${{ env.VERSION_CODE }}
+        env:
+          VERSION_CODE: ${{ env.VERSION_CODE }}
 
       - name: Upload Play Store AAB artifact (for release job)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Run Detekt, Build, Lint, and Local Tests
         run: ./gradlew detekt lintFdroidDebug lintGoogleDebug assembleDebug testFdroidDebug testGoogleDebug --configuration-cache --scan
+        env: 
+          VERSION_CODE: ${{ env.VERSION_CODE }}
       - name: Upload F-Droid debug artifact
         if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@v4
@@ -72,8 +74,6 @@ jobs:
           name: fdroidDebug
           path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
           retention-days: 14
-          env:
-            VERSION_CODE: ${{ env.VERSION_CODE }}
       - name: Upload Google debug artifact
         if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           submodules: 'recursive'
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
@@ -52,6 +53,16 @@ jobs:
           build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
           build-scan-terms-of-use-agree: 'yes'
           add-job-summary: always
+
+      - name: Calculate Version Code with Git Commit Count and Offset
+        id: calculate_version_code
+        run: |
+          GIT_COMMIT_COUNT=$(git rev-list --count HEAD)
+          OFFSET=30630 # to ensure versionCode is above 30630 (our last manual versionCode)
+          VERSION_CODE=$((GIT_COMMIT_COUNT + OFFSET))
+          echo "Calculated versionCode: $VERSION_CODE (from $GIT_COMMIT_COUNT commits + $OFFSET offset)"
+          echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
+
       - name: Run Detekt, Build, Lint, and Local Tests
         run: ./gradlew detekt lintFdroidDebug lintGoogleDebug assembleDebug testFdroidDebug testGoogleDebug --configuration-cache --scan
       - name: Upload F-Droid debug artifact
@@ -61,6 +72,8 @@ jobs:
           name: fdroidDebug
           path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
           retention-days: 14
+          env:
+            VERSION_CODE: ${{ env.VERSION_CODE }}
       - name: Upload Google debug artifact
         if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,7 +52,7 @@ android {
         applicationId = Configs.APPLICATION_ID
         minSdk = Configs.MIN_SDK_VERSION
         targetSdk = Configs.TARGET_SDK
-        versionCode = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
+        versionCode = System.getenv("VERSION_CODE")?.toIntOrNull()
             ?: 1
         versionName = Configs.VERSION_NAME
         testInstrumentationRunner = "com.geeksville.mesh.TestRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,8 +52,8 @@ android {
         applicationId = Configs.APPLICATION_ID
         minSdk = Configs.MIN_SDK_VERSION
         targetSdk = Configs.TARGET_SDK
-        versionCode =
-            Configs.VERSION_CODE // format is Mmmss (where M is 1+the numeric major number)
+        versionCode = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
+            ?: 1
         versionName = Configs.VERSION_NAME
         testInstrumentationRunner = "com.geeksville.mesh.TestRunner"
         buildConfigField("String", "MIN_FW_VERSION", "\"${Configs.MIN_FW_VERSION}\"")

--- a/buildSrc/src/main/kotlin/Configs.kt
+++ b/buildSrc/src/main/kotlin/Configs.kt
@@ -20,7 +20,6 @@ object Configs {
     const val MIN_SDK_VERSION = 26
     const val TARGET_SDK = 36
     const val COMPILE_SDK = 36
-    const val VERSION_CODE = 30630 // format is Mmmss (where M is 1+the numeric major number)
     const val VERSION_NAME = "2.6.30"
     const val MIN_FW_VERSION = "2.5.14" // Minimum device firmware version supported by this app
     const val ABS_MIN_FW_VERSION = "2.3.15" // Minimum device firmware version supported by this app


### PR DESCRIPTION
This commit introduces an automated `versionCode` generation strategy based on repository commit count for Android builds in the CI/CD pipeline.

Key changes:
- Updated GitHub Actions workflows (`release.yml`, `reusable-android-build.yml`) to:
- Set `fetch-depth: 0` for `actions/checkout` to get the full commit history.
- Add a step to calculate `versionCode` by adding an offset (30630) to the total Git commit count (`git rev-list --count HEAD`). This ensures `versionCode` always increases and is above previous manual values.
- Pass the calculated `VERSION_CODE` as an environment variable to Gradle build steps.
- Modified `app/build.gradle.kts` to read `versionCode` from the `VERSION_CODE` environment variable, falling back to 1 if not set.

This change aims to simplify the release process by automatically incrementing the `versionCode`, reducing the chance of manual errors and allowing greater flexibility to release incremental patches.

note - this was not added to the test workflow as those builds do not need to be versioned/or archived.