### PR TITLE
refactor: Improve node public key handling and security

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/MeshtasticDatabase.kt
@@ -71,8 +71,9 @@ import com.geeksville.mesh.database.entity.ReactionEntity
         AutoMigration(from = 15, to = 16),
         AutoMigration(from = 16, to = 17),
         AutoMigration(from = 17, to = 18),
+        AutoMigration(from = 18, to = 19),
     ],
-    version = 18,
+    version = 19,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/dao/NodeInfoDao.kt
@@ -25,11 +25,11 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
 import com.geeksville.mesh.android.BuildUtils.warn
-import com.geeksville.mesh.copy
 import com.geeksville.mesh.database.entity.MetadataEntity
 import com.geeksville.mesh.database.entity.MyNodeEntity
 import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.database.entity.NodeWithRelations
+import com.google.protobuf.ByteString
 import kotlinx.coroutines.flow.Flow
 
 @Suppress("TooManyFunctions")
@@ -113,40 +113,99 @@ interface NodeInfoDao {
         lastHeardMin: Int,
     ): Flow<List<NodeWithRelations>>
 
-    @Upsert
+    @Transaction
     fun upsert(node: NodeEntity) {
-        val found = getNodeByNum(node.num)?.node
-        found?.let {
-            val keyMatch = !it.hasPKC || it.user.publicKey == node.user.publicKey
-            it.user = if (keyMatch) {
-                node.user
-            } else {
-                node.user.copy {
-                    warn("Public key mismatch from $longName ($shortName)")
-                    publicKey = NodeEntity.ERROR_BYTE_STRING
+        // Populate the new publicKey field for lazy migration
+        node.publicKey = node.user.publicKey
+
+        val existingNode = getNodeByNum(node.num)?.node
+
+        if (existingNode == null) {
+            // This is a new node. We must check if its public key is already claimed by another node.
+            if (node.publicKey != null && node.publicKey?.isEmpty == false) {
+                val nodeWithSamePK = findNodeByPublicKey(node.publicKey)
+                if (nodeWithSamePK != null && nodeWithSamePK.num != node.num) {
+                    // This is the impersonation attempt we want to block.
+                    @Suppress("MaxLineLength")
+                    warn("NodeInfoDao: Blocking new node #${node.num} because its public key is already used by #${nodeWithSamePK.num}.")
+                    return // ABORT
                 }
             }
+            // If we're here, the new node is safe to add.
+            doUpsert(node)
+        } else {
+            // This is an update to an existing node.
+            val keyMatch =
+                existingNode.user.publicKey == node.user.publicKey || existingNode.user.publicKey.isEmpty
+            val nodeToUpsert = if (keyMatch) {
+                // Keys match, trust the incoming node completely.
+                // This allows for legit nodeId changes etc.
+                node
+            } else {
+                // Keys do NOT match. This is a potential attack.
+                // Log it, and create a NEW entity based on the EXISTING trusted one,
+                // only updating dynamic data and setting the public key to EMPTY to signal a conflict.
+                @Suppress("MaxLineLength")
+                warn("NodeInfoDao: Received packet for #${node.num} with non-matching public key. Identity data ignored, key set to EMPTY.")
+                existingNode.copy(
+                    lastHeard = node.lastHeard,
+                    snr = node.snr,
+                    position = node.position,
+                    user = existingNode.user.toBuilder().setPublicKey(ByteString.EMPTY).build(),
+                    publicKey = ByteString.EMPTY
+                )
+            }
+            doUpsert(nodeToUpsert)
         }
-        doUpsert(node)
     }
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Suppress("NestedBlockDepth")
+    @Transaction
     fun putAll(nodes: List<NodeEntity>) {
-        nodes.forEach { node ->
-            val found = getNodeByNum(node.num)?.node
-            found?.let {
-                val keyMatch = !it.hasPKC || it.user.publicKey == node.user.publicKey
-                it.user = if (keyMatch) {
-                    node.user
-                } else {
-                    node.user.copy {
-                        warn("Public key mismatch from $longName ($shortName)")
-                        publicKey = NodeEntity.ERROR_BYTE_STRING
+        val safeNodes = mutableListOf<NodeEntity>()
+        for (node in nodes) {
+            // Lazy migration
+            node.publicKey = node.user.publicKey
+
+            val existingNode = getNodeByNum(node.num)?.node
+
+            if (existingNode == null) {
+                // New node. Check for PK collision with a *different* node.
+                if (node.publicKey != null && (node.publicKey?.isEmpty == false)) {
+                    val nodeWithSamePK = findNodeByPublicKey(node.publicKey)
+                    if (nodeWithSamePK != null && nodeWithSamePK.num != node.num) {
+                        @Suppress("MaxLineLength")
+                        warn("NodeInfoDao: Blocking new node #${node.num} in batch because its public key is already used by #${nodeWithSamePK.num}.")
+                        continue // Continue to next node in loop
                     }
+                }
+                safeNodes.add(node)
+            } else {
+                // Existing node.
+                val keyMatch =
+                    existingNode.user.publicKey == node.user.publicKey || existingNode.user.publicKey.isEmpty
+                if (keyMatch) {
+                    safeNodes.add(node) // Trust it completely
+                } else {
+                    @Suppress("MaxLineLength")
+                    warn("NodeInfoDao: Received packet for #${node.num} in batch with non-matching public key. Identity data ignored, key set to EMPTY.")
+                    // Create a new entity based on the old one, with
+                    // updated dynamic data and an EMPTY key to signal conflict.
+                    val updatedNode = existingNode.copy(
+                        lastHeard = node.lastHeard,
+                        snr = node.snr,
+                        position = node.position,
+                        user = existingNode.user.toBuilder().setPublicKey(ByteString.EMPTY).build(),
+                        publicKey = ByteString.EMPTY
+                    )
+                    safeNodes.add(updatedNode)
                 }
             }
         }
-        doPutAll(nodes)
+
+        if (safeNodes.isNotEmpty()) {
+            doPutAll(safeNodes)
+        }
     }
 
     @Query("DELETE FROM nodes")
@@ -164,6 +223,8 @@ interface NodeInfoDao {
     @Query("SELECT * FROM nodes WHERE num=:num")
     @Transaction
     fun getNodeByNum(num: Int): NodeWithRelations?
+    @Query("SELECT * FROM nodes WHERE public_key = :publicKey LIMIT 1")
+    fun findNodeByPublicKey(publicKey: ByteString?): NodeEntity?
 
     @Upsert
     fun doUpsert(node: NodeEntity)

--- a/app/src/main/java/com/geeksville/mesh/database/entity/NodeEntity.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/entity/NodeEntity.kt
@@ -143,6 +143,9 @@ data class NodeEntity(
 
     @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
     var paxcounter: PaxcountProtos.Paxcount = PaxcountProtos.Paxcount.getDefaultInstance(),
+
+    @ColumnInfo(name = "public_key")
+    var publicKey: ByteString? = null,
 ) {
     val deviceMetrics: TelemetryProtos.DeviceMetrics
         get() = deviceTelemetry.deviceMetrics
@@ -152,7 +155,6 @@ data class NodeEntity(
 
     val isUnknownUser get() = user.hwModel == MeshProtos.HardwareModel.UNSET
     val hasPKC get() = !user.publicKey.isEmpty
-    val errorByteString: ByteString get() = ERROR_BYTE_STRING
 
     fun setPosition(p: MeshProtos.Position, defaultTime: Int = currentTime()) {
         position = p.copy { time = if (p.time != 0) p.time else defaultTime }

--- a/app/src/main/java/com/geeksville/mesh/model/Node.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Node.kt
@@ -29,6 +29,8 @@ import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.util.GPSFormat
 import com.geeksville.mesh.util.latLongToMeter
 import com.geeksville.mesh.util.toDistanceString
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.isNotEmpty
 
 @Suppress("MagicNumber")
 data class Node(
@@ -48,6 +50,7 @@ data class Node(
     val environmentMetrics: EnvironmentMetrics = EnvironmentMetrics.getDefaultInstance(),
     val powerMetrics: PowerMetrics = PowerMetrics.getDefaultInstance(),
     val paxcounter: PaxcountProtos.Paxcount = PaxcountProtos.Paxcount.getDefaultInstance(),
+    val publicKey: ByteString? = null,
 ) {
     val colors: Pair<Int, Int>
         get() { // returns foreground and background @ColorInt for each 'num'
@@ -59,8 +62,8 @@ data class Node(
         }
 
     val isUnknownUser get() = user.hwModel == MeshProtos.HardwareModel.UNSET
-    val hasPKC get() = !user.publicKey.isEmpty
-    val mismatchKey get() = user.publicKey == NodeEntity.ERROR_BYTE_STRING
+    val hasPKC get() = (publicKey ?: user.publicKey).isNotEmpty()
+    val mismatchKey get() = (publicKey ?: user.publicKey) == NodeEntity.ERROR_BYTE_STRING
 
     val hasEnvironmentMetrics: Boolean
         get() = environmentMetrics != EnvironmentMetrics.getDefaultInstance()


### PR DESCRIPTION
This commit introduces several changes to how node public keys are handled, aiming to improve security and data integrity:

- **New `publicKey` field in `NodeEntity`:** A dedicated `publicKey` field is added to the `NodeEntity` to store the public key directly. This facilitates easier querying and management of public keys.
- **Database schema migration:** The database version is incremented to 19, and an auto-migration is added to accommodate the new `publicKey` field.
- **Enhanced `upsert` and `putAll` logic in `NodeInfoDao`:**
    - **Lazy migration:** The `publicKey` field in `NodeEntity` is populated from `node.user.publicKey` during upsert operations for existing nodes.
    - **Impersonation prevention:**
        - When adding a **new node**, the system now checks if its public key is already associated with a different existing node. If a collision is found, the new node is **not** added to the database, and a warning is logged.
        - When **updating an existing node**, if the incoming public key does not match the existing node's public key (and the existing key is not empty), it's treated as a potential attack. In this case, only dynamic data (like `lastHeard`, `snr`, `position`) is updated. The node's identity information (like `user`) is preserved from the trusted existing record, and its `publicKey` is set to an empty `ByteString` to signal a conflict. A warning is logged.
- **Updated `Node` data class:**
    - The `Node` data class now includes a `publicKey` field.
    - The `hasPKC` and `mismatchKey` properties are updated to use the new `publicKey` field if available, otherwise falling back to `user.publicKey`. This ensures consistent key checking logic.
- **New `findNodeByPublicKey` query:** A new DAO method is added to find a node by its public key.
