### PR TITLE
Refactor: Update Gradle cache keys and task execution in CI

### DIFF
--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -38,14 +38,14 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties', 'settings.gradle*') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', '**/gradle.properties', '**/libs.versions.toml') }}
           restore-keys: |
             gradle-${{ runner.os }}-
       - name: Cache Android build cache
         uses: actions/cache@v4
         with:
           path: ~/.android/build-cache
-          key: android-build-cache-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties', 'settings.gradle*') }}
+          key: android-build-cache-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', '**/gradle.properties', '**/libs.versions.toml') }}
           restore-keys: |
             android-build-cache-${{ runner.os }}-
       - name: Setup Gradle
@@ -67,8 +67,8 @@ jobs:
           echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
 
       - name: Run Detekt, Build, Lint, and Local Tests
-        run: ./gradlew detekt lintFdroidDebug lintGoogleDebug assembleDebug testFdroidDebug testGoogleDebug --configuration-cache --scan
-        env: 
+        run: ./gradlew :app:detekt :app:lintFdroidDebug :app:lintGoogleDebug :app:assembleDebug :app:testFdroidDebug :app:testGoogleDebug --configuration-cache --scan
+        env:
           VERSION_CODE: ${{ env.VERSION_CODE }}
       - name: Upload F-Droid debug artifact
         if: ${{ inputs.upload_artifacts }}

--- a/.github/workflows/reusable-android-test.yml
+++ b/.github/workflows/reusable-android-test.yml
@@ -48,7 +48,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('''**/*.gradle*''', '''**/gradle-wrapper.properties*''', '''gradle.properties*''', '''settings.gradle*''') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle.properties', 'app/build.gradle.kts', 'buildSrc/build.gradle.kts') }}
           restore-keys: |
             gradle-${{ runner.os }}-
       - name: Setup Gradle
@@ -66,7 +66,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}-${{ hashFiles('''**/*.gradle*''', '''**/gradle-wrapper.properties*''') }}
+          key: avd-${{ matrix.api-level }}-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle.properties', 'app/build.gradle.kts', 'buildSrc/build.gradle.kts') }}
           restore-keys: |
             avd-${{ matrix.api-level }}-
       - name: Create AVD and generate snapshot for caching


### PR DESCRIPTION
This commit updates the Gradle cache keys in the reusable Android build and test workflows to be more specific and include `libs.versions.toml` and `.kts` files.

It also modifies the execution of Gradle tasks in the build workflow to explicitly target the `:app` module for `detekt`, `lint`, `assemble`, and `test` tasks.