### PR TITLE
Refactor: Simplify back stack entry retrieval and navigation

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/navigation/ChannelsRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/ChannelsRoutes.kt
@@ -47,7 +47,8 @@ fun NavGraphBuilder.channelsGraph(navController: NavHostController, uiViewModel:
     ) {
         composable<ChannelsRoutes.Channels> { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry<ChannelsRoutes.ChannelsGraph>()
+                val parentRoute = backStackEntry.destination.parent!!.route!!
+                navController.getBackStackEntry(parentRoute)
             }
             ChannelScreen(
                 viewModel = uiViewModel,
@@ -65,7 +66,8 @@ private fun NavGraphBuilder.configRoutes(
     ConfigRoute.entries.forEach { configRoute ->
         composable(configRoute.route::class) { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry<ChannelsRoutes.ChannelsGraph>()
+                val parentRoute = backStackEntry.destination.parent!!.route!!
+                navController.getBackStackEntry(parentRoute)
             }
             when (configRoute) {
                 ConfigRoute.CHANNELS -> ChannelConfigScreen(hiltViewModel(parentEntry))

--- a/app/src/main/java/com/geeksville/mesh/navigation/ConnectionsRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/ConnectionsRoutes.kt
@@ -59,7 +59,8 @@ fun NavGraphBuilder.connectionsGraph(
             )
         ) { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry<ConnectionsRoutes.ConnectionsGraph>()
+                val parentRoute = backStackEntry.destination.parent!!.route!!
+                navController.getBackStackEntry(parentRoute)
             }
             ConnectionsScreen(
                 uiViewModel = uiViewModel,
@@ -79,7 +80,8 @@ private fun NavGraphBuilder.configRoutes(
 ) {
     composable<RadioConfigRoutes.LoRa> { backStackEntry ->
         val parentEntry = remember(backStackEntry) {
-            navController.getBackStackEntry<ConnectionsRoutes.ConnectionsGraph>()
+            val parentRoute = backStackEntry.destination.parent!!.route!!
+            navController.getBackStackEntry(parentRoute)
         }
         LoRaConfigScreen(hiltViewModel(parentEntry))
     }

--- a/app/src/main/java/com/geeksville/mesh/navigation/NodesRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NodesRoutes.kt
@@ -119,7 +119,8 @@ fun NavGraphBuilder.nodeDetailGraph(
     ) {
         composable<NodesRoutes.NodeDetail> { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry<NodesRoutes.NodeDetailGraph>()
+                val parentRoute = backStackEntry.destination.parent!!.route!!
+                navController.getBackStackEntry(parentRoute)
             }
             NodeDetailScreen(
                 uiViewModel = uiViewModel,
@@ -138,7 +139,8 @@ fun NavGraphBuilder.nodeDetailGraph(
         NodeDetailRoute.entries.forEach { nodeDetailRoute ->
             composable(nodeDetailRoute.route::class) { backStackEntry ->
                 val parentEntry = remember(backStackEntry) {
-                    navController.getBackStackEntry<NodesRoutes.NodeDetailGraph>()
+                    val parentRoute = backStackEntry.destination.parent!!.route!!
+                    navController.getBackStackEntry(parentRoute)
                 }
                 when (nodeDetailRoute) {
                     NodeDetailRoute.DEVICE -> DeviceMetricsScreen(hiltViewModel(parentEntry))

--- a/app/src/main/java/com/geeksville/mesh/navigation/RadioConfigRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/RadioConfigRoutes.kt
@@ -165,7 +165,8 @@ fun NavGraphBuilder.radioConfigGraph(navController: NavHostController, uiViewMod
     ) {
         composable<RadioConfigRoutes.RadioConfig> { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry<RadioConfigRoutes.RadioConfigGraph>()
+                val parentRoute = backStackEntry.destination.parent!!.route!!
+                navController.getBackStackEntry(parentRoute)
             }
             RadioConfigScreen(
                 uiViewModel = uiViewModel,
@@ -189,7 +190,8 @@ private fun NavGraphBuilder.configRoutes(
     ConfigRoute.entries.forEach { configRoute ->
         composable(configRoute.route::class) { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry<RadioConfigRoutes.RadioConfigGraph>()
+                val parentRoute = backStackEntry.destination.parent!!.route!!
+                navController.getBackStackEntry(parentRoute)
             }
             when (configRoute) {
                 ConfigRoute.USER -> UserConfigScreen(hiltViewModel(parentEntry))
@@ -214,7 +216,8 @@ private fun NavGraphBuilder.moduleRoutes(
     ModuleRoute.entries.forEach { moduleRoute ->
         composable(moduleRoute.route::class) { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry<RadioConfigRoutes.RadioConfigGraph>()
+                val parentRoute = backStackEntry.destination.parent!!.route!!
+                navController.getBackStackEntry(parentRoute)
             }
             when (moduleRoute) {
                 ModuleRoute.MQTT -> MQTTConfigScreen(hiltViewModel(parentEntry))

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -103,11 +103,11 @@ import com.geeksville.mesh.ui.radioconfig.RadioConfigMenuActions
 import com.geeksville.mesh.ui.sharing.SharedContactDialog
 
 enum class TopLevelDestination(@StringRes val label: Int, val icon: ImageVector, val route: Route) {
-    Contacts(R.string.contacts, Icons.AutoMirrored.TwoTone.Chat, ContactsRoutes.Contacts),
-    Nodes(R.string.nodes, Icons.TwoTone.People, NodesRoutes.Nodes),
+    Contacts(R.string.contacts, Icons.AutoMirrored.TwoTone.Chat, ContactsRoutes.ContactsGraph),
+    Nodes(R.string.nodes, Icons.TwoTone.People, NodesRoutes.NodesGraph),
     Map(R.string.map, Icons.TwoTone.Map, MapRoutes.Map),
-    Channels(R.string.channels, Icons.TwoTone.Contactless, ChannelsRoutes.Channels),
-    Connections(R.string.connections, Icons.TwoTone.CloudOff, ConnectionsRoutes.Connections),
+    Channels(R.string.channels, Icons.TwoTone.Contactless, ChannelsRoutes.ChannelsGraph),
+    Connections(R.string.connections, Icons.TwoTone.CloudOff, ConnectionsRoutes.ConnectionsGraph),
     ;
 
     companion object {
@@ -230,20 +230,11 @@ fun MainScreen(
                         }
                     },
                     onClick = {
-                        if (!isSelected) {
-                            navController.navigate(destination.route) {
-                                // Pop up to the start destination of the graph to
-                                // avoid building up a large stack of destinations
-                                // on the back stack as users select items
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
-                                }
-                                // Avoid multiple copies of the same destination when
-                                // reselecting the same item
-                                launchSingleTop = true
-                                // Restore state when reselecting a previously selected item
-                                restoreState = true
+                        navController.navigate(destination.route) {
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
                             }
+                            launchSingleTop = true
                         }
                     }
                 )


### PR DESCRIPTION
This commit refactors the way parent back stack entries are retrieved in `NodesRoutes.kt`, `ChannelsRoutes.kt`, `RadioConfigRoutes.kt`, and `ConnectionsRoutes.kt`. It now uses `backStackEntry.destination.parent!!.route!!` to dynamically get the parent route.

Additionally, it simplifies the navigation logic in `Main.kt` for `TopLevelDestination` items by removing the explicit `isSelected` check and the `restoreState` flag, as these are handled by `launchSingleTop = true` and `popUpTo` with `saveState = true`.

The routes for `TopLevelDestination` enums have also been updated to point to their respective graph routes.
