### PR TITLE
Refactor: Improve version code and name generation for builds

### DIFF
--- a/.github/actions/calculate-version-code/action.yml
+++ b/.github/actions/calculate-version-code/action.yml
@@ -1,0 +1,19 @@
+name: 'Calculate Version Code'
+description: 'Calculates the Android versionCode based on the Git commit count plus an offset.'
+outputs:
+  versionCode:
+    description: "The calculated version code"
+    value: ${{ steps.calculate_version.outputs.VERSION_CODE }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Calculate Version Code
+      id: calculate_version
+      shell: bash
+      run: |
+        # This action assumes that the repo has been checked out with `fetch-depth: 0`
+        GIT_COMMIT_COUNT=$(git rev-list --count HEAD)
+        OFFSET=30630
+        VERSION_CODE=$((GIT_COMMIT_COUNT + OFFSET))
+        echo "Calculated versionCode: $VERSION_CODE (from $GIT_COMMIT_COUNT commits + $OFFSET offset)"
+        echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,20 +21,24 @@ jobs:
   prepare-release-info:
     runs-on: ubuntu-latest
     outputs:
-      versionCode: ${{ steps.get_version.outputs.versionCode }}
-      versionName: ${{ steps.get_version.outputs.versionName }}
+      versionCode: ${{ steps.calculate_version_code.outputs.versionCode }}
+      versionNameBase: ${{ steps.get_version.outputs.versionNameBase }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           submodules: 'recursive'
+          fetch-depth: 0 # Needed for git rev-list
 
-      - name: Get `versionCode` & `versionName`
+      - name: Get `versionNameBase`
         id: get_version
         run: |
-          echo "versionCode=$(grep -oP 'VERSION_CODE = \K\d+' ./buildSrc/src/main/kotlin/Configs.kt)" >> $GITHUB_OUTPUT
-          echo "versionName=$(grep -oP 'VERSION_NAME = \"\K[^\"]+' ./buildSrc/src/main/kotlin/Configs.kt)" >> $GITHUB_OUTPUT
+          echo "versionNameBase=$(grep -oP 'VERSION_NAME_BASE = \"\K[^\"]+' ./buildSrc/src/main/kotlin/Configs.kt)" >> $GITHUB_OUTPUT
+
+      - name: Calculate Version Code
+        id: calculate_version_code
+        uses: ./.github/actions/calculate-version-code
 
   # Job for F-Droid build
   build-fdroid:
@@ -43,7 +47,7 @@ jobs:
     if: github.repository == 'meshtastic/Meshtastic-Android'
     outputs:
       apk_path: app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
-      apk_name: fdroidRelease-${{ needs.prepare-release-info.outputs.versionName }}.apk
+      apk_name: fdroidRelease-${{ needs.prepare-release-info.outputs.versionNameBase }}-${{ needs.prepare-release-info.outputs.versionCode }}.apk
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -83,20 +87,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-
-      - name: Calculate Version Code with Git Commit Count and Offset
-        id: calculate_version_code
-        run: |
-          GIT_COMMIT_COUNT=$(git rev-list --count HEAD)
-          OFFSET=30630 # to ensure versionCode is above 30630
-          VERSION_CODE=$((GIT_COMMIT_COUNT + OFFSET))
-          echo "Calculated versionCode: $VERSION_CODE (from $GIT_COMMIT_COUNT commits + $OFFSET offset)"
-          echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
-
       - name: Build F-Droid release
         run: ./gradlew assembleFdroidRelease
         env:
-          VERSION_CODE: ${{ env.VERSION_CODE }}
+          VERSION_CODE: ${{ needs.prepare-release-info.outputs.versionCode }}
 
       - name: Upload F-Droid APK artifact (for release job)
         uses: actions/upload-artifact@v4
@@ -112,9 +106,9 @@ jobs:
     if: github.repository == 'meshtastic/Meshtastic-Android'
     outputs:
       aab_path: app/build/outputs/bundle/googleRelease/app-google-release.aab
-      aab_name: googleRelease-${{ needs.prepare-release-info.outputs.versionName }}.aab
+      aab_name: googleRelease-${{ needs.prepare-release-info.outputs.versionNameBase }}-${{ needs.prepare-release-info.outputs.versionCode }}.aab
       apk_path: app/build/outputs/apk/google/release/app-google-release.apk
-      apk_name: googleRelease-${{ needs.prepare-release-info.outputs.versionName }}.apk
+      apk_name: googleRelease-${{ needs.prepare-release-info.outputs.versionNameBase }}-${{ needs.prepare-release-info.outputs.versionCode }}.apk
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -157,19 +151,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Calculate Version Code with Git Commit Count and Offset
-        id: calculate_version_code
-        run: |
-          GIT_COMMIT_COUNT=$(git rev-list --count HEAD)
-          OFFSET=30630 # to ensure versionCode is above 30630
-          VERSION_CODE=$((GIT_COMMIT_COUNT + OFFSET))
-          echo "Calculated versionCode: $VERSION_CODE (from $GIT_COMMIT_COUNT commits + $OFFSET offset)"
-          echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
-
       - name: Build Play Store release
         run: ./gradlew bundleGoogleRelease assembleGoogleRelease
         env:
-          VERSION_CODE: ${{ env.VERSION_CODE }}
+          VERSION_CODE: ${{ needs.prepare-release-info.outputs.versionCode }}
 
       - name: Upload Play Store AAB artifact (for release job)
         uses: actions/upload-artifact@v4
@@ -192,28 +177,23 @@ jobs:
     # Only run this job if the input create_github_release is true
     if: github.repository == 'meshtastic/Meshtastic-Android' && github.event.inputs.create_github_release == 'true'
     steps:
-      # We need version info again for release name and tag
-      # Alternatively, we could pass it as an artifact, but this is simpler for just two values
-      - name: Checkout code (for version_info.txt and version retrieval)
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch }} # Checkout the specified branch
-
-      - name: Get `versionCode` & `versionName` (again for this job's env)
-        id: get_version # Unique ID within this job
+      - name: Set up version info
+        id: set_version_info
         run: |
-          echo "versionCode=$(grep -oP 'VERSION_CODE = \K\d+' ./buildSrc/src/main/kotlin/Configs.kt)" >> $GITHUB_ENV
-          echo "versionName=$(grep -oP 'VERSION_NAME = \"\K[^\"]+' ./buildSrc/src/main/kotlin/Configs.kt)" >> $GITHUB_ENV
+          echo "versionCode=${{ needs.prepare-release-info.outputs.versionCode }}" >> $GITHUB_ENV
+          echo "versionNameBase=${{ needs.prepare-release-info.outputs.versionNameBase }}" >> $GITHUB_ENV
+          echo "versionNameFdroid=${{ needs.prepare-release-info.outputs.versionNameBase }} (${{ needs.prepare-release-info.outputs.versionCode }}) fdroid" >> $GITHUB_ENV
+          echo "versionNameGoogle=${{ needs.prepare-release-info.outputs.versionNameBase }} (${{ needs.prepare-release-info.outputs.versionCode }}) google" >> $GITHUB_ENV
 
       - name: Create version_info.txt
         run: |
-          echo -e "versionCode=${{ env.versionCode }}\nversionName=${{ env.versionName }}" > ./version_info.txt
+          echo -e "versionCode=${{ env.versionCode }}\nversionNameBase=${{ env.versionNameBase }}" > ./version_info.txt
 
       - name: Download F-Droid APK
         uses: actions/download-artifact@v4
         with:
           name: fdroid-apk
-          path: ./fdroid-apk-download # Download to a specific folder
+          path: ./fdroid-apk-download
 
       - name: Download Google AAB
         uses: actions/download-artifact@v4
@@ -233,12 +213,15 @@ jobs:
         with:
           draft: true
           prerelease: true
-          release_name: Meshtastic Android ${{ env.versionName }} alpha (Branch ${{ github.event.inputs.branch }})
-          tag_name: ${{ env.versionName }} # Consider making tag unique if version can be same across branches, e.g., ${{ env.versionName }}-${{ github.event.inputs.branch }}
+          release_name: Meshtastic Android ${{ env.versionNameBase }} (${{ env.versionCode }}) alpha
+          tag_name: v${{ env.versionNameBase }}
           target_commitish: ${{ github.event.inputs.branch }}
           body: |
-            Release built from branch: `${{ github.event.inputs.branch }}`
-            Version: ${{ env.versionName }} (Code: ${{ env.versionCode }})
+            Version: ${{ env.versionNameBase }} (${{ env.versionCode }})
+
+            F-Droid version name: `${{ env.versionNameFdroid }}`
+            
+            Google Play version name: `${{ env.versionNameGoogle }}`
 
             Autogenerated by GitHub Action. Please review and edit before publishing.
         env:
@@ -250,8 +233,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release_step.outputs.upload_url }}
-          asset_path: ./fdroid-apk-download/app-fdroid-release.apk # Path from download
-          asset_name: fdroidRelease-${{ env.versionName }}.apk
+          asset_path: ./fdroid-apk-download/app-fdroid-release.apk
+          asset_name: ${{ needs.build-fdroid.outputs.apk_name }}
           asset_content_type: application/vnd.android.package-archive
 
       - name: Add Play Store AAB to release
@@ -260,9 +243,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release_step.outputs.upload_url }}
-          asset_path: ./google-aab-download/app-google-release.aab # Path from download
-          asset_name: googleRelease-${{ env.versionName }}.aab
-          asset_content_type: application/octet-stream # More generic for AAB
+          asset_path: ./google-aab-download/app-google-release.aab
+          asset_name: ${{ needs.build-google.outputs.aab_name }}
+          asset_content_type: application/octet-stream
 
       - name: Add Play Store APK to release
         uses: actions/upload-release-asset@v1
@@ -270,8 +253,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release_step.outputs.upload_url }}
-          asset_path: ./google-apk-download/app-google-release.apk # Path from download
-          asset_name: googleRelease-${{ env.versionName }}.apk
+          asset_path: ./google-apk-download/app-google-release.apk
+          asset_name: ${{ needs.build-google.outputs.apk_name }}
           asset_content_type: application/vnd.android.package-archive
 
       - name: Add version_info.txt to release

--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -57,14 +57,12 @@ jobs:
           build-scan-terms-of-use-agree: 'yes'
           add-job-summary: always
 
-      - name: Calculate Version Code with Git Commit Count and Offset
+      - name: Calculate Version Code
         id: calculate_version_code
-        run: |
-          GIT_COMMIT_COUNT=$(git rev-list --count HEAD)
-          OFFSET=30630 # to ensure versionCode is above 30630 (our last manual versionCode)
-          VERSION_CODE=$((GIT_COMMIT_COUNT + OFFSET))
-          echo "Calculated versionCode: $VERSION_CODE (from $GIT_COMMIT_COUNT commits + $OFFSET offset)"
-          echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
+        uses: ./.github/actions/calculate-version-code
+
+      - name: Expose Version Code as Environment Variable
+        run: echo "VERSION_CODE=${{ steps.calculate_version_code.outputs.versionCode }}" >> $GITHUB_ENV
 
       - name: Run Detekt, Build, Lint, and Local Tests
         run: ./gradlew :app:detekt :app:lintFdroidDebug :app:lintGoogleDebug :app:assembleDebug :app:testFdroidDebug :app:testGoogleDebug --configuration-cache --scan

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,26 +54,48 @@ android {
         targetSdk = Configs.TARGET_SDK
         versionCode = System.getenv("VERSION_CODE")?.toIntOrNull()
             ?: 30630
-        versionName = Configs.VERSION_NAME
         testInstrumentationRunner = "com.geeksville.mesh.TestRunner"
         buildConfigField("String", "MIN_FW_VERSION", "\"${Configs.MIN_FW_VERSION}\"")
         buildConfigField("String", "ABS_MIN_FW_VERSION", "\"${Configs.ABS_MIN_FW_VERSION}\"")
         // per https://developer.android.com/studio/write/vector-asset-studio
         vectorDrawables.useSupportLibrary = true
+        // We have to list all translated languages here, because some of our libs have bogus languages that google play
+        // doesn't like and we need to strip them (gr)
+        @Suppress("UnstableApiUsage")
+        androidResources.localeFilters.addAll(
+            listOf(
+                "bg", "ca", "cs", "de",
+                "el", "en", "es", "et",
+                "fi", "fr", "fr-rHT", "ga",
+                "gl", "hr", "hu", "is",
+                "it", "iw", "ja", "ko",
+                "lt", "nl", "nb", "pl",
+                "pt", "pt-rBR", "ro",
+                "ru", "sk", "sl", "sq",
+                "sr", "sv", "tr", "zh-rCN",
+                "zh-rTW", "uk"
+            )
+        )
+        ndk {
+            abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+        }
     }
     flavorDimensions.add("default")
     productFlavors {
+        val versionCode = defaultConfig.versionCode
         create("fdroid") {
             dimension = "default"
             dependenciesInfo {
                 includeInApk = false
             }
+            versionName = "${Configs.VERSION_NAME_BASE} ($versionCode) fdroid"
         }
         create("google") {
             dimension = "default"
             // Enable Firebase Crashlytics for Google Play builds
             apply(plugin = libs.plugins.google.services.get().pluginId)
             apply(plugin = libs.plugins.firebase.crashlytics.get().pluginId)
+            versionName = "${Configs.VERSION_NAME_BASE} ($versionCode) google"
         }
     }
     buildTypes {
@@ -90,26 +112,6 @@ android {
         }
         named("debug") {
             isPseudoLocalesEnabled = true
-        }
-    }
-    defaultConfig {
-        // We have to list all translated languages here, because some of our libs have bogus languages that google play
-        // doesn't like and we need to strip them (gr)
-        androidResources.localeFilters += listOf(
-            "bg", "ca", "cs", "de",
-            "el", "en", "es", "et",
-            "fi", "fr", "fr-rHT", "ga",
-            "gl", "hr", "hu", "is",
-            "it", "iw", "ja", "ko",
-            "lt", "nl", "nb", "pl",
-            "pt", "pt-rBR", "ro",
-            "ru", "sk", "sl", "sq",
-            "sr", "sv", "tr", "zh-rCN",
-            "zh-rTW", "uk"
-        )
-
-        ndk {
-            abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
         }
     }
     bundle {

--- a/buildSrc/src/main/kotlin/Configs.kt
+++ b/buildSrc/src/main/kotlin/Configs.kt
@@ -20,7 +20,7 @@ object Configs {
     const val MIN_SDK_VERSION = 26
     const val TARGET_SDK = 36
     const val COMPILE_SDK = 36
-    const val VERSION_NAME = "2.6.30"
+    const val VERSION_NAME_BASE = "2.6.30"
     const val MIN_FW_VERSION = "2.5.14" // Minimum device firmware version supported by this app
     const val ABS_MIN_FW_VERSION = "2.3.15" // Minimum device firmware version supported by this app
 }


### PR DESCRIPTION
This commit introduces the following changes:

*   **GitHub Actions Workflow:**
    *   Creates a new reusable GitHub Action `calculate-version-code` to determine the Android `versionCode`. This action calculates the `versionCode` by adding a fixed offset to the Git commit count.
    *   Updates the `reusable-android-build.yml` and `release.yml` workflows to utilize the new `calculate-version-code` action.
    *   Modifies `release.yml` to:
        *   Use `versionNameBase` from `Configs.kt` and the calculated `versionCode` to generate artifact names and release information.
        *   Ensure `fetch-depth: 0` is used when checking out code for accurate commit counting.
        *   Populate `version_info.txt` with `versionCode` and `versionNameBase`.
        *   Update release name and tag format to include `versionNameBase` and `versionCode`.

*   **Build Configuration:**
    *   Renames `VERSION_NAME` to `VERSION_NAME_BASE` in `buildSrc/src/main/kotlin/Configs.kt`.
    *   Updates `app/build.gradle.kts` to:
        *   Generate `versionName` for `fdroid` and `google` product flavors by combining `Configs.VERSION_NAME_BASE` and the `versionCode`.
        *   Move `androidResources.localeFilters` and `ndk.abiFilters` from `defaultConfig` into the `android` block to apply them globally.
## Example markup for a release:


# Meshtastic Android 2.6.30 (30753) alpha

Version: 2.6.30 (30753)

F-Droid version name: `2.6.30 (30753) fdroid`

Google Play version name: `2.6.30 (30753) google`

Autogenerated by GitHub Action. Please review and edit before publishing.
