### PR TITLE
Fix: Satisfy merge queue check for scheduled updates

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -9,6 +9,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # New job to satisfy the required check for the merge queue
+  scheduled_updates:
+    if: github.repository == 'meshtastic/Meshtastic-Android' # Keep consistent with other jobs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Always pass merge queue scheduled_updates check
+        run: echo "This check is primarily for PR entry; passing in merge queue."
+
   build_and_detekt:
     if: github.repository == 'meshtastic/Meshtastic-Android'
     uses: ./.github/workflows/reusable-android-build.yml
@@ -25,4 +33,3 @@ jobs:
       upload_artifacts: false
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-


### PR DESCRIPTION
This commit adds a new job `scheduled_updates` to the merge queue workflow. This job is configured to always pass, satisfying a required check for the merge queue that is primarily intended for PR entry.
