### PR TITLE
Fix: Soil temperature shows air temperature when Fahrenheit is selected

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/Node.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/Node.kt
@@ -124,7 +124,7 @@ data class Node(
         val humidity = if (relativeHumidity != 0f) "%.0f%%".format(relativeHumidity) else null
         val soilTemperatureStr = if (soilTemperature != 0f) {
             if (isFahrenheit) {
-                "%.1f°F".format(celsiusToFahrenheit(temperature))
+                "%.1f°F".format(celsiusToFahrenheit(soilTemperature))
             } else {
                 "%.1f°C".format(soilTemperature)
             }


### PR DESCRIPTION
The soil temperature display was incorrectly showing the air temperature when the temperature unit was set to Fahrenheit. This commit corrects the logic to display the actual soil temperature in Fahrenheit.