### PR TITLE
chore(ktlint): ignore function naming for composables

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -282,6 +282,9 @@ spotless {
         target("src/*/kotlin/**/*.kt", "src/*/java/**/*.kt")
         targetExclude("**/build/**/*.kt")
         ktlint()
+            .editorConfigOverride(
+                mapOf("ktlint_function_naming_ignore_when_annotated_with" to "Composable")
+            )
         ktfmt().kotlinlangStyle()
         licenseHeaderFile(rootProject.file("config/copyright.txt"))
     }


### PR DESCRIPTION
Allows Composable functions to start with a lowercase letter, aligning with Jetpack Compose conventions.
