### PR TITLE
fix(ui): correct scroll direction for FAB visibility in message list

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -101,9 +101,9 @@ import com.geeksville.mesh.ui.common.theme.AppTheme
 import com.geeksville.mesh.ui.node.components.NodeKeyStatusIcon
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import com.geeksville.mesh.ui.sharing.SharedContactDialog
+import java.nio.charset.StandardCharsets
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import java.nio.charset.StandardCharsets
 
 private const val MESSAGE_CHARACTER_LIMIT_BYTES = 200
 private const val SNIPPET_CHARACTER_LIMIT = 50


### PR DESCRIPTION
The Floating Action Button (FAB) for scrolling to the bottom of the message list was previously shown when `listState.canScrollForward` was true. This has been corrected to use `listState.canScrollBackward`, which accurately reflects the ability to scroll towards the newest messages (index 0) in a reversed layout.

fixes #2496 
