### PR TITLE
Add new region: BR_902 "Brazil 902Mhz"

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/ChannelOption.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/ChannelOption.kt
@@ -290,7 +290,14 @@ enum class RegionInfo(
      *
      * @see [Firmware Issue #7204](https://github.com/meshtastic/firmware/issues/7204)
      */
-    KZ_863(RegionCode.KZ_863, "Kazakhstan 863MHz", 863.0f, 868.0f, wideLora = true);
+    KZ_863(RegionCode.KZ_863, "Kazakhstan 863MHz", 863.0f, 868.0f, wideLora = true),
+
+    /**
+     * Brazil 902MHz 902 - 907.5 MHz
+     *
+     * @see [Firmware Issue #7399](https://github.com/meshtastic/firmware/pull/7399)
+     */
+    BR_902(RegionCode.BR_902, "Brazil 902MHz", 902.0f, 907.5f, wideLora = false);
 
     companion object {
         fun fromRegionCode(regionCode: RegionCode): RegionInfo? =


### PR DESCRIPTION
This pull request adds support for a new regional frequency option in the `RegionInfo` enum class, for Brazil's 902 MHz band.

### Key change:
* [`app/src/main/java/com/geeksville/mesh/model/ChannelOption.kt`](diffhunk://#diff-f517dfd94646a02d56f6d5eb7776697f184eee0f67a8447be9c0396503542e7cL293-R300): Added a new entry `BR_902` to the `RegionInfo` enum, representing the Brazil 902 MHz frequency range (902.0 MHz to 907.5 MHz) with `wideLora` set to `false`. 
* This change references https://github.com/meshtastic/firmware/pull/7399


<img width="423" height="890" alt="img1" src="https://github.com/user-attachments/assets/0fd8096e-1980-483c-8f30-300b18ccf5d7" />
<img width="423" height="890" alt="img2" src="https://github.com/user-attachments/assets/abd77485-b29e-43ff-9b08-f3370d6f0f58" />
