### PR TITLE
Add new region: NP_865 "Nepal 865MHz"

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/ChannelOption.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/ChannelOption.kt
@@ -279,7 +279,7 @@ enum class RegionInfo(
      *
      * @see [Firmware Issue #7380](https://github.com/meshtastic/firmware/pull/7380)
      */
-    NP_865(RegionCode.NP_865, "Nepal 865Mhz", 865.0f, 868.0f, wideLora = false),
+    NP_865(RegionCode.NP_865, "Nepal 865MHz", 865.0f, 868.0f, wideLora = false),
 
     /**
      * Brazil 902MHz 902 - 907.5 MHz


### PR DESCRIPTION
This pull request adds support for Nepal 865MHz.

* Added Nepal-specific frequency configuration:
  * [`app/src/main/java/com/geeksville/mesh/model/ChannelOption.kt`](diffhunk://#diff-f517dfd94646a02d56f6d5eb7776697f184eee0f67a8447be9c0396503542e7cR295-R301): Introduced `NP_865` in the `RegionInfo` enum to represent the 865-868 MHz frequency range for Nepal, with `wideLora` set to `false`. 
  * This change references https://github.com/meshtastic/firmware/pull/7380

<img width="300" height="625" alt="img1" src="https://github.com/user-attachments/assets/6908f95a-0761-46e7-8cad-d3d56b06dc38" />
<img width="300" height="625" alt="img2" src="https://github.com/user-attachments/assets/03e3a694-9cf9-458e-9379-dc1f54e847e5" />
