### PR TITLE
refactor(connections)!: Use sealed class for device list entries

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
@@ -41,7 +41,6 @@ import com.geeksville.mesh.service.ServiceRepository
 import com.geeksville.mesh.util.anonymize
 import com.hoho.android.usbserial.driver.UsbSerialDriver
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -54,6 +53,49 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * A sealed class is used here to represent the different types of devices that can be displayed in the list. This is
+ * more type-safe and idiomatic than using a base class with boolean flags (e.g., isBLE, isUSB). It allows for
+ * exhaustive `when` expressions in the code, making it more robust and readable.
+ *
+ * @param name The display name of the device.
+ * @param fullAddress The unique address of the device, prefixed with a type identifier.
+ * @param bonded Indicates whether the device is bonded (for BLE) or has permission (for USB).
+ */
+sealed class DeviceListEntry(open val name: String, open val fullAddress: String, open val bonded: Boolean) {
+    val address: String
+        get() = fullAddress.substring(1)
+
+    override fun toString(): String =
+        "DeviceListEntry(name=${name.anonymize}, addr=${address.anonymize}, bonded=$bonded)"
+
+    @Suppress("MissingPermission")
+    data class Ble(val device: BluetoothDevice) :
+        DeviceListEntry(
+            name = device.name ?: "unnamed-${device.address}",
+            fullAddress = "x${device.address}",
+            bonded = device.bondState == BluetoothDevice.BOND_BONDED,
+        )
+
+    data class Usb(
+        private val radioInterfaceService: RadioInterfaceService,
+        private val usbManager: UsbManager,
+        val driver: UsbSerialDriver,
+    ) : DeviceListEntry(
+        name = driver.device.deviceName,
+        fullAddress = radioInterfaceService.toInterfaceAddress(InterfaceId.SERIAL, driver.device.deviceName),
+        bonded = usbManager.hasPermission(driver.device),
+    )
+
+    data class Tcp(override val name: String, override val fullAddress: String) :
+        DeviceListEntry(name, fullAddress, true)
+
+    data class Disconnect(override val name: String) : DeviceListEntry(name, NO_DEVICE_SELECTED, true)
+
+    data class Mock(override val name: String) : DeviceListEntry(name, "m", true)
+}
 
 @HiltViewModel
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -68,132 +110,80 @@ constructor(
     private val networkRepository: NetworkRepository,
     private val radioInterfaceService: RadioInterfaceService,
     private val recentAddressesRepository: RecentAddressesRepository,
-) : ViewModel(), Logging {
+) : ViewModel(),
+    Logging {
     private val context: Context
         get() = application.applicationContext
 
-    val devices = MutableLiveData<MutableMap<String, DeviceListEntry>>(mutableMapOf())
     val errorText = MutableLiveData<String?>(null)
 
-    private val recentIpAddresses = recentAddressesRepository.recentAddresses
-
-    private val showMockInterface: StateFlow<Boolean>
+    val showMockInterface: StateFlow<Boolean>
         get() = MutableStateFlow(radioInterfaceService.isMockInterface()).asStateFlow()
 
-    init {
-        combine(
-                bluetoothRepository.state,
-                networkRepository.resolvedList,
-                recentIpAddresses,
-                usbRepository.serialDevicesWithDrivers,
-                showMockInterface,
-            ) { ble, tcp, recent, usb, showMockInterface ->
-                devices.value =
-                    mutableMapOf<String, DeviceListEntry>().apply {
-                        fun addDevice(entry: DeviceListEntry) {
-                            this[entry.fullAddress] = entry
-                        }
+    private val bleDevicesFlow: StateFlow<List<DeviceListEntry.Ble>> =
+        bluetoothRepository.state
+            .map { ble -> ble.bondedDevices.map { DeviceListEntry.Ble(it) }.sortedBy { it.name } }
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
-                        // Include a placeholder for "None"
-                        addDevice(
-                            DeviceListEntry(
-                                context.getString(R.string.none),
-                                NO_DEVICE_SELECTED,
-                                true,
-                            )
-                        )
+    private val tcpDevicesFlow: StateFlow<List<DeviceListEntry.Tcp>> =
+        combine(networkRepository.resolvedList, recentAddressesRepository.recentAddresses) { tcp, recent ->
+            val recentMap = recent.associateBy({ it.address }, { it.name })
+            val tcpDevices =
+                tcp.map { service ->
+                    val address = "t${service.toAddressString()}"
+                    val txtRecords = service.attributes // Map<String, ByteArray?>
+                    val shortNameBytes = txtRecords["shortname"]
+                    val idBytes = txtRecords["id"]
 
-                        if (showMockInterface) {
-                            addDevice(DeviceListEntry("Demo Mode", "m", true))
-                        }
-
-                        // Include paired Bluetooth devices
-                        ble.bondedDevices
-                            .map(::BLEDeviceListEntry)
-                            .sortedBy { it.name }
-                            .forEach(::addDevice)
-
-                        // Include Network Service Discovery
-                        tcp.forEach { service ->
-                            val address = service.toAddressString()
-                            val txtRecords = service.attributes // Map<String, ByteArray?>
-                            val shortNameBytes = txtRecords["shortname"]
-                            val idBytes = txtRecords["id"]
-
-                            val shortName =
-                                shortNameBytes?.let { String(it, Charsets.UTF_8) }
-                                    ?: context.getString(R.string.meshtastic)
-                            val deviceId =
-                                idBytes?.let { String(it, Charsets.UTF_8) }?.replace("!", "")
-                            var displayName = shortName
-                            if (deviceId != null) {
-                                displayName += "_$deviceId"
-                            }
-                            addDevice(DeviceListEntry(displayName, "t$address", true))
-                        }
-
-                        // Include saved IP connections
-                        recent.forEach { addDevice(DeviceListEntry(it.name, it.address, true)) }
-
-                        usb.forEach { (_, d) ->
-                            addDevice(
-                                USBDeviceListEntry(radioInterfaceService, usbManagerLazy.get(), d)
-                            )
-                        }
+                    val shortName =
+                        shortNameBytes?.let { String(it, Charsets.UTF_8) } ?: context.getString(R.string.meshtastic)
+                    val deviceId = idBytes?.let { String(it, Charsets.UTF_8) }?.replace("!", "")
+                    var displayName = recentMap[address] ?: shortName
+                    if (deviceId != null && !displayName.contains(deviceId)) {
+                        displayName += "_$deviceId"
                     }
-            }
-            .launchIn(viewModelScope)
+                    DeviceListEntry.Tcp(displayName, address)
+                }
 
+            val tcpAddresses = tcpDevices.map { it.fullAddress }
+            val recentDevices =
+                recent
+                    .map { DeviceListEntry.Tcp(it.name, it.address) }
+                    .filterNot { tcpAddresses.contains(it.fullAddress) }
+
+            (tcpDevices + recentDevices).sortedBy { it.name }
+        }
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    private val usbDevicesFlow: StateFlow<List<DeviceListEntry.Usb>> =
+        usbRepository.serialDevicesWithDrivers
+            .map { usb -> usb.map { (_, d) -> DeviceListEntry.Usb(radioInterfaceService, usbManagerLazy.get(), d) } }
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    private val disconnectDevice = DeviceListEntry.Disconnect(context.getString(R.string.none))
+
+    private val mockDevice = DeviceListEntry.Mock("Demo Mode")
+
+    val bleDevicesForUi: StateFlow<List<DeviceListEntry>> =
+        bleDevicesFlow
+            .map { devices -> listOf(disconnectDevice) + devices }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), listOf(disconnectDevice))
+
+    val tcpDevicesForUi: StateFlow<List<DeviceListEntry>> =
+        tcpDevicesFlow
+            .map { devices -> listOf(disconnectDevice) + devices }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), listOf(disconnectDevice))
+
+    val usbDevicesForUi: StateFlow<List<DeviceListEntry>> =
+        combine(usbDevicesFlow, showMockInterface) { usb, showMock ->
+            listOf(disconnectDevice) + usb + if (showMock) listOf(mockDevice) else emptyList()
+        }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), listOf(disconnectDevice))
+
+    init {
         serviceRepository.statusMessage.onEach { errorText.value = it }.launchIn(viewModelScope)
-
         debug("BTScanModel created")
     }
-
-    /** @param fullAddress Interface [prefix] + [address] (example: "x7C:9E:BD:F0:BE:BE") */
-    open class DeviceListEntry(val name: String, val fullAddress: String, val bonded: Boolean) {
-        val prefix
-            get() = fullAddress[0]
-
-        val address
-            get() = fullAddress.substring(1)
-
-        override fun toString(): String =
-            "DeviceListEntry(name=${name.anonymize}, addr=${address.anonymize}, bonded=$bonded)"
-
-        val isBLE: Boolean
-            get() = prefix == 'x'
-
-        val isUSB: Boolean
-            get() = prefix == 's'
-
-        val isTCP: Boolean
-            get() = prefix == 't'
-
-        val isMock: Boolean
-            get() = prefix == 'm'
-
-        val isDisconnect: Boolean
-            get() = prefix == 'n'
-    }
-
-    @SuppressLint("MissingPermission")
-    class BLEDeviceListEntry(device: BluetoothDevice) :
-        DeviceListEntry(
-            device.name ?: "unnamed-${device.address}", // some devices might not have a name
-            "x${device.address}",
-            device.bondState == BluetoothDevice.BOND_BONDED,
-        )
-
-    class USBDeviceListEntry(
-        radioInterfaceService: RadioInterfaceService,
-        usbManager: UsbManager,
-        val usb: UsbSerialDriver,
-    ) :
-        DeviceListEntry(
-            usb.device.deviceName,
-            radioInterfaceService.toInterfaceAddress(InterfaceId.SERIAL, usb.device.deviceName),
-            usbManager.hasPermission(usb.device),
-        )
 
     override fun onCleared() {
         super.onCleared()
@@ -230,9 +220,7 @@ constructor(
             try {
                 scanJob?.cancel()
             } catch (ex: Throwable) {
-                warn(
-                    "Ignoring error stopping scan, probably BT adapter was disabled suddenly: ${ex.message}"
-                )
+                warn("Ignoring error stopping scan, probably BT adapter was disabled suddenly: ${ex.message}")
             } finally {
                 scanJob = null
             }
@@ -250,35 +238,26 @@ constructor(
                 .scan()
                 .onEach { result ->
                     val fullAddress =
-                        radioInterfaceService.toInterfaceAddress(
-                            InterfaceId.BLUETOOTH,
-                            result.device.address,
-                        )
+                        radioInterfaceService.toInterfaceAddress(InterfaceId.BLUETOOTH, result.device.address)
                     // prevent log spam because we'll get lots of redundant scan results
-                    val isBonded = result.device.bondState == BluetoothDevice.BOND_BONDED
                     val oldDevs = scanResult.value!!
                     val oldEntry = oldDevs[fullAddress]
                     // Don't spam the GUI with endless updates for non changing nodes
-                    if (oldEntry == null || oldEntry.bonded != isBonded) {
-                        val entry = DeviceListEntry(result.device.name, fullAddress, isBonded)
+                    if (
+                        oldEntry == null || oldEntry.bonded != (result.device.bondState == BluetoothDevice.BOND_BONDED)
+                    ) {
+                        val entry = DeviceListEntry.Ble(result.device)
                         oldDevs[entry.fullAddress] = entry
                         scanResult.value = oldDevs
                     }
                 }
-                .catch { ex ->
-                    serviceRepository.setErrorMessage(
-                        "Unexpected Bluetooth scan failure: ${ex.message}"
-                    )
-                }
+                .catch { ex -> serviceRepository.setErrorMessage("Unexpected Bluetooth scan failure: ${ex.message}") }
                 .launchIn(viewModelScope)
     }
 
     private fun changeDeviceAddress(address: String) {
         try {
-            serviceRepository.meshService?.let { service ->
-                MeshService.changeDeviceAddress(context, service, address)
-            }
-            devices.value = devices.value // Force a GUI update
+            serviceRepository.meshService?.let { service -> MeshService.changeDeviceAddress(context, service, address) }
         } catch (ex: RemoteException) {
             errormsg("changeDeviceSelection failed, probably it is shutting down", ex)
             // ignore the failure and the GUI won't be updating anyways
@@ -286,8 +265,7 @@ constructor(
     }
 
     @SuppressLint("MissingPermission")
-    private fun requestBonding(it: DeviceListEntry) {
-        val device = bluetoothRepository.getRemoteDevice(it.address) ?: return
+    private fun requestBonding(device: BluetoothDevice) {
         info("Starting bonding for ${device.anonymize}")
 
         bluetoothRepository
@@ -298,7 +276,7 @@ constructor(
                     debug("Bonding completed, state=$state")
                     if (state == BluetoothDevice.BOND_BONDED) {
                         setErrorText(context.getString(R.string.pairing_completed))
-                        changeDeviceAddress(it.fullAddress)
+                        changeDeviceAddress("x${device.address}")
                     } else {
                         setErrorText(context.getString(R.string.pairing_failed_try_again))
                     }
@@ -311,9 +289,9 @@ constructor(
             .launchIn(viewModelScope)
     }
 
-    private fun requestPermission(it: USBDeviceListEntry) {
+    private fun requestPermission(it: DeviceListEntry.Usb) {
         usbRepository
-            .requestPermission(it.usb.device)
+            .requestPermission(it.driver.device)
             .onEach { granted ->
                 if (granted) {
                     info("User approved USB access")
@@ -325,13 +303,9 @@ constructor(
             .launchIn(viewModelScope)
     }
 
-    // Remove 'name' parameter from addRecentAddress and related logic
-    fun addRecentAddress(address: String, overrideName: String? = null) {
+    fun addRecentAddress(address: String, name: String) {
         if (!address.startsWith("t")) return
-        viewModelScope.launch {
-            val displayName = overrideName ?: context.getString(R.string.meshtastic)
-            recentAddressesRepository.add(RecentAddress(address, displayName))
-        }
+        viewModelScope.launch { recentAddressesRepository.add(RecentAddress(address, name)) }
     }
 
     fun removeRecentAddress(address: String) {
@@ -341,33 +315,49 @@ constructor(
     // Called by the GUI when a new device has been selected by the user
     // @returns true if we were able to change to that item
     fun onSelected(it: DeviceListEntry): Boolean {
-        // If the device is paired, let user select it, otherwise start the pairing flow
-        if (it.bonded) {
-            addRecentAddress(it.fullAddress, connectedNodeLongName)
-            changeDeviceAddress(it.fullAddress)
-            return true
-        } else {
-            // Handle requesting USB or bluetooth permissions for the device
-            debug("Requesting permissions for the device")
-
-            if (it.isBLE) {
-                requestBonding(it)
+        // Using a `when` expression on the sealed class is much cleaner and safer than if/else chains.
+        // It ensures that all device types are handled, and the compiler can catch any omissions.
+        return when (it) {
+            is DeviceListEntry.Ble -> {
+                if (it.bonded) {
+                    changeDeviceAddress(it.fullAddress)
+                    true
+                } else {
+                    requestBonding(it.device)
+                    false
+                }
             }
 
-            if (it.isUSB) {
-                requestPermission(it as USBDeviceListEntry)
+            is DeviceListEntry.Usb -> {
+                if (it.bonded) {
+                    changeDeviceAddress(it.fullAddress)
+                    true
+                } else {
+                    requestPermission(it)
+                    false
+                }
             }
 
-            return false
+            is DeviceListEntry.Tcp -> {
+                viewModelScope.launch {
+                    addRecentAddress(it.fullAddress, it.name)
+                    changeDeviceAddress(it.fullAddress)
+                }
+                true
+            }
+
+            is DeviceListEntry.Disconnect,
+            is DeviceListEntry.Mock,
+            -> {
+                changeDeviceAddress(it.fullAddress)
+                true
+            }
         }
     }
 
     private val _spinner = MutableStateFlow(false)
     val spinner: StateFlow<Boolean>
         get() = _spinner.asStateFlow()
-
-    // Add a new property to hold the connected node's long name
-    var connectedNodeLongName: String? = null
 }
 
 const val NO_DEVICE_SELECTED = "n"

--- a/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/BTScanModel.kt
@@ -140,7 +140,7 @@ constructor(
                         shortNameBytes?.let { String(it, Charsets.UTF_8) } ?: context.getString(R.string.meshtastic)
                     val deviceId = idBytes?.let { String(it, Charsets.UTF_8) }?.replace("!", "")
                     var displayName = recentMap[address] ?: shortName
-                    if (deviceId != null && !displayName.contains(deviceId)) {
+                    if (deviceId != null && !displayName.split("_").none { it == deviceId }) {
                         displayName += "_$deviceId"
                     }
                     DeviceListEntry.Tcp(displayName, address)
@@ -186,7 +186,7 @@ constructor(
         processedDiscoveredTcpDevicesFlow.stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(SHARING_STARTED_TIMEOUT_MS),
-            listOf(disconnectDevice),
+            listOf(),
         )
 
     /** UI StateFlow for recently connected TCP devices that are not currently discovered. */
@@ -194,7 +194,7 @@ constructor(
         filteredRecentTcpDevicesFlow.stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(SHARING_STARTED_TIMEOUT_MS),
-            listOf(disconnectDevice),
+            listOf(),
         )
 
     val usbDevicesForUi: StateFlow<List<DeviceListEntry>> =

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -322,6 +322,14 @@ constructor(
         MutableStateFlow(preferences.getBoolean("show-precision-circle-on-map", true))
 
     private val showIgnored = MutableStateFlow(preferences.getBoolean("show-ignored", false))
+    private val _hasShownNotPairedWarning =
+        MutableStateFlow(preferences.getBoolean(HAS_SHOWN_NOT_PAIRED_WARNING_PREF, false))
+    val hasShownNotPairedWarning: StateFlow<Boolean> = _hasShownNotPairedWarning.asStateFlow()
+
+    fun suppressNoPairedWarning() {
+        _hasShownNotPairedWarning.value = true
+        preferences.edit { putBoolean(HAS_SHOWN_NOT_PAIRED_WARNING_PREF, true) }
+    }
 
     fun toggleShowIgnored() {
         showIgnored.value = !showIgnored.value
@@ -355,7 +363,7 @@ constructor(
 
     fun setOnlyFavorites(value: Boolean) {
         onlyFavorites.value = value
-        preferences.edit { putBoolean("only-favorites", onlyFavorites.value) }
+        preferences.edit { putBoolean("only-favorites", value) }
     }
 
     fun setShowWaypointsOnMap(value: Boolean) {
@@ -725,6 +733,8 @@ constructor(
     companion object {
         fun getPreferences(context: Context): SharedPreferences =
             context.getSharedPreferences("ui-prefs", Context.MODE_PRIVATE)
+
+        const val HAS_SHOWN_NOT_PAIRED_WARNING_PREF = "has_shown_not_paired_warning"
     }
 
     // Connection state to our radio device

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -148,7 +148,8 @@ fun ConnectionsScreen(
             connectionState == MeshService.ConnectionState.CONNECTED
 
     val bleDevices by scanModel.bleDevicesForUi.collectAsStateWithLifecycle()
-    val tcpDevices by scanModel.tcpDevicesForUi.collectAsStateWithLifecycle()
+    val discoveredTcpDevices by scanModel.discoveredTcpDevicesForUi.collectAsStateWithLifecycle()
+    val recentTcpDevices by scanModel.recentTcpDevicesForUi.collectAsStateWithLifecycle()
     val usbDevices by scanModel.usbDevicesForUi.collectAsStateWithLifecycle()
 
     /* Animate waiting for the configurations */
@@ -387,7 +388,8 @@ fun ConnectionsScreen(
                     DeviceType.TCP -> {
                         NetworkDevices(
                             connectionState = connectionState,
-                            networkDevices = tcpDevices,
+                            discoveredNetworkDevices = discoveredTcpDevices,
+                            recentNetworkDevices = recentTcpDevices,
                             selectedDevice = selectedDevice,
                             scanModel = scanModel,
                         )

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
@@ -42,24 +42,25 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.geeksville.mesh.R
 import com.geeksville.mesh.android.getBluetoothPermissions
 import com.geeksville.mesh.model.BTScanModel
+import com.geeksville.mesh.model.DeviceListEntry
 import com.geeksville.mesh.service.MeshService
 
 @Suppress("LongMethod")
 @Composable
 fun BLEDevices(
     connectionState: MeshService.ConnectionState,
-    btDevices: List<BTScanModel.DeviceListEntry>,
+    btDevices: List<DeviceListEntry>,
     selectedDevice: String,
     showBluetoothRationaleDialog: () -> Unit,
     requestBluetoothPermission: (Array<String>) -> Unit,
-    scanModel: BTScanModel
+    scanModel: BTScanModel,
 ) {
     val context = LocalContext.current
     val isScanning by scanModel.spinner.collectAsStateWithLifecycle(false)
     Text(
         text = stringResource(R.string.bluetooth),
         style = MaterialTheme.typography.titleLarge,
-        modifier = Modifier.padding(vertical = 8.dp)
+        modifier = Modifier.padding(vertical = 8.dp),
     )
     btDevices.forEach { device ->
         DeviceListItem(
@@ -67,41 +68,29 @@ fun BLEDevices(
             device = device,
             selected = device.fullAddress == selectedDevice,
             onSelect = { scanModel.onSelected(device) },
-            modifier = Modifier
+            modifier = Modifier,
         )
     }
     if (isScanning) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
-            horizontalAlignment = CenterHorizontally
-        ) {
-            CircularProgressIndicator(
-                modifier = Modifier.size(96.dp)
-            )
+        Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalAlignment = CenterHorizontally) {
+            CircularProgressIndicator(modifier = Modifier.size(96.dp))
             Text(
                 text = stringResource(R.string.scanning),
                 style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(vertical = 8.dp)
+                modifier = Modifier.padding(vertical = 8.dp),
             )
         }
-    } else if (btDevices.filterNot { it.isDisconnect }.isEmpty()) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
-            horizontalAlignment = CenterHorizontally
-        ) {
+    } else if (btDevices.filterNot { it is DeviceListEntry.Disconnect }.isEmpty()) {
+        Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalAlignment = CenterHorizontally) {
             Icon(
                 imageVector = Icons.Default.BluetoothDisabled,
                 contentDescription = stringResource(R.string.no_ble_devices),
-                modifier = Modifier.size(96.dp)
+                modifier = Modifier.size(96.dp),
             )
             Text(
                 text = stringResource(R.string.no_ble_devices),
                 style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(vertical = 8.dp)
+                modifier = Modifier.padding(vertical = 8.dp),
             )
         }
     }
@@ -114,11 +103,9 @@ fun BLEDevices(
                 // If no permissions needed, trigger the scan directly (or via ViewModel)
                 scanModel.startScan()
             } else {
-                if (bluetoothPermissions.any { permission ->
-                        ActivityCompat.shouldShowRequestPermissionRationale(
-                            context as Activity,
-                            permission
-                        )
+                if (
+                    bluetoothPermissions.any { permission ->
+                        ActivityCompat.shouldShowRequestPermissionRationale(context as Activity, permission)
                     }
                 ) {
                     showBluetoothRationaleDialog()
@@ -126,12 +113,9 @@ fun BLEDevices(
                     requestBluetoothPermission(bluetoothPermissions)
                 }
             }
-        }
+        },
     ) {
-        Icon(
-            imageVector = Icons.Default.Bluetooth,
-            contentDescription = stringResource(R.string.scan)
-        )
+        Icon(imageVector = Icons.Default.Bluetooth, contentDescription = stringResource(R.string.scan))
         Text(stringResource(R.string.scan))
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
@@ -37,7 +37,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.geeksville.mesh.R
-import com.geeksville.mesh.model.BTScanModel
+import com.geeksville.mesh.model.DeviceListEntry
 import com.geeksville.mesh.service.MeshService
 import com.geeksville.mesh.ui.common.theme.StatusColors.StatusGreen
 import com.geeksville.mesh.ui.common.theme.StatusColors.StatusRed
@@ -46,40 +46,32 @@ import com.geeksville.mesh.ui.common.theme.StatusColors.StatusRed
 @Composable
 fun DeviceListItem(
     connectionState: MeshService.ConnectionState,
-    device: BTScanModel.DeviceListEntry,
+    device: DeviceListEntry,
     selected: Boolean,
     onSelect: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val icon =
-        if (device.isBLE) {
-            Icons.Default.Bluetooth
-        } else if (device.isUSB) {
-            Icons.Default.Usb
-        } else if (device.isTCP) {
-            Icons.Default.Wifi
-        } else if (device.isDisconnect) { // This is the "Disconnect" entry type
-            Icons.Default.Cancel
-        } else {
-            Icons.Default.Add
+        when (device) {
+            is DeviceListEntry.Ble -> Icons.Default.Bluetooth
+            is DeviceListEntry.Usb -> Icons.Default.Usb
+            is DeviceListEntry.Tcp -> Icons.Default.Wifi
+            is DeviceListEntry.Disconnect -> Icons.Default.Cancel
+            is DeviceListEntry.Mock -> Icons.Default.Add
         }
 
     val contentDescription =
-        if (device.isBLE) {
-            stringResource(R.string.bluetooth)
-        } else if (device.isUSB) {
-            stringResource(R.string.serial)
-        } else if (device.isTCP) {
-            stringResource(R.string.network)
-        } else if (device.isDisconnect) { // This is the "Disconnect" entry type
-            stringResource(R.string.disconnect)
-        } else {
-            stringResource(R.string.add)
+        when (device) {
+            is DeviceListEntry.Ble -> stringResource(R.string.bluetooth)
+            is DeviceListEntry.Usb -> stringResource(R.string.serial)
+            is DeviceListEntry.Tcp -> stringResource(R.string.network)
+            is DeviceListEntry.Disconnect -> stringResource(R.string.disconnect)
+            is DeviceListEntry.Mock -> stringResource(R.string.add)
         }
 
     val colors =
         when {
-            selected && device.isDisconnect -> {
+            selected && device is DeviceListEntry.Disconnect -> {
                 ListItemDefaults.colors(
                     containerColor = MaterialTheme.colorScheme.errorContainer,
                     headlineColor = MaterialTheme.colorScheme.onErrorContainer,
@@ -126,12 +118,12 @@ fun DeviceListItem(
             )
         },
         supportingContent = {
-            if (device.isTCP) {
+            if (device is DeviceListEntry.Tcp) {
                 Text(device.address)
             }
         },
         trailingContent = {
-            if (device.isDisconnect) {
+            if (device is DeviceListEntry.Disconnect) {
                 Icon(imageVector = Icons.Default.CloudOff, contentDescription = stringResource(R.string.disconnect))
             } else if (connectionState == MeshService.ConnectionState.CONNECTED) {
                 Icon(imageVector = Icons.Default.CloudDone, contentDescription = stringResource(R.string.connected))

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
@@ -61,7 +61,8 @@ import com.geeksville.mesh.ui.connections.isIPAddress
 @Composable
 fun NetworkDevices(
     connectionState: MeshService.ConnectionState,
-    networkDevices: List<DeviceListEntry>,
+    discoveredNetworkDevices: List<DeviceListEntry>,
+    recentNetworkDevices: List<DeviceListEntry>,
     selectedDevice: String,
     scanModel: BTScanModel,
 ) {
@@ -74,27 +75,49 @@ fun NetworkDevices(
         style = MaterialTheme.typography.titleLarge,
         modifier = Modifier.padding(vertical = 8.dp),
     )
-    networkDevices.forEach { device ->
-        val isRecent = device is DeviceListEntry.Tcp && device.fullAddress.startsWith("t")
-        val modifier =
-            if (isRecent) {
+    DeviceListItem(
+        connectionState = connectionState,
+        device = scanModel.disconnectDevice,
+        selected = scanModel.disconnectDevice.fullAddress == selectedDevice,
+        onSelect = { scanModel.onSelected(scanModel.disconnectDevice) },
+    )
+    if (discoveredNetworkDevices.isNotEmpty()) {
+        Text(
+            text = stringResource(R.string.discovered_network_devices),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
+        discoveredNetworkDevices.forEach { device ->
+            DeviceListItem(
+                connectionState,
+                device,
+                device.fullAddress == selectedDevice,
+                onSelect = { scanModel.onSelected(device) },
+            )
+        }
+    }
+    if (recentNetworkDevices.isNotEmpty()) {
+        Text(
+            text = stringResource(R.string.recent_network_devices),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
+        recentNetworkDevices.forEach { device ->
+            DeviceListItem(
+                connectionState,
+                device,
+                device.fullAddress == selectedDevice,
+                onSelect = { scanModel.onSelected(device) },
+                modifier =
                 Modifier.combinedClickable(
                     onClick = { scanModel.onSelected(device) },
                     onLongClick = {
                         deviceToDelete = device
                         showDeleteDialog = true
                     },
-                )
-            } else {
-                Modifier
-            }
-        DeviceListItem(
-            connectionState,
-            device,
-            device.fullAddress == selectedDevice,
-            onSelect = { scanModel.onSelected(device) },
-            modifier = modifier,
-        )
+                ),
+            )
+        }
     }
     if (showDeleteDialog && deviceToDelete != null) {
         AlertDialog(
@@ -116,7 +139,7 @@ fun NetworkDevices(
             },
         )
     }
-    if (networkDevices.filterNot { it is DeviceListEntry.Disconnect }.isEmpty()) {
+    if (discoveredNetworkDevices.isEmpty() && recentNetworkDevices.isEmpty()) {
         Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalAlignment = CenterHorizontally) {
             Icon(
                 imageVector = Icons.Default.WifiFind,

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
@@ -17,6 +17,7 @@
 
 package com.geeksville.mesh.ui.connections.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -56,7 +57,7 @@ import com.geeksville.mesh.repository.network.NetworkRepository
 import com.geeksville.mesh.service.MeshService
 import com.geeksville.mesh.ui.connections.isIPAddress
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class, androidx.compose.foundation.ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalFoundationApi::class)
 @Suppress("MagicNumber", "LongMethod")
 @Composable
 fun NetworkDevices(

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
@@ -33,19 +33,20 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.BTScanModel
+import com.geeksville.mesh.model.DeviceListEntry
 import com.geeksville.mesh.service.MeshService
 
 @Composable
 fun UsbDevices(
     connectionState: MeshService.ConnectionState,
-    usbDevices: List<BTScanModel.DeviceListEntry>,
+    usbDevices: List<DeviceListEntry>,
     selectedDevice: String,
-    scanModel: BTScanModel
+    scanModel: BTScanModel,
 ) {
     Text(
         text = stringResource(R.string.serial),
         style = MaterialTheme.typography.titleLarge,
-        modifier = Modifier.padding(vertical = 8.dp)
+        modifier = Modifier.padding(vertical = 8.dp),
     )
     usbDevices.forEach { device ->
         DeviceListItem(
@@ -53,25 +54,20 @@ fun UsbDevices(
             device = device,
             selected = device.fullAddress == selectedDevice,
             onSelect = { scanModel.onSelected(device) },
-            modifier = Modifier
+            modifier = Modifier,
         )
     }
-    if (usbDevices.filterNot { it.isDisconnect || it.isMock }.isEmpty()) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
-            horizontalAlignment = CenterHorizontally
-        ) {
+    if (usbDevices.filterNot { it is DeviceListEntry.Disconnect || it is DeviceListEntry.Mock }.isEmpty()) {
+        Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalAlignment = CenterHorizontally) {
             Icon(
                 imageVector = Icons.Default.UsbOff,
                 contentDescription = stringResource(R.string.no_usb_devices),
-                modifier = Modifier.size(96.dp)
+                modifier = Modifier.size(96.dp),
             )
             Text(
                 text = stringResource(R.string.no_usb_devices),
                 style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(vertical = 8.dp)
+                modifier = Modifier.padding(vertical = 8.dp),
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -804,4 +804,6 @@
     <string name="latest_alpha_firmware">Latest alpha</string>
     <string name="supported_by_community">Supported by Meshtastic Community</string>
     <string name="firmware_edition">Firmware Edition</string>
+    <string name="recent_network_devices">Recent Network Devices</string>
+    <string name="discovered_network_devices">Discovered Network Devices</string>
 </resources>


### PR DESCRIPTION
This commit refactors the device list management in the connections screen and related components. It introduces a `DeviceListEntry` sealed class to represent different types of devices (BLE, USB, TCP, Disconnect, Mock) in a more type-safe and idiomatic Kotlin way.

This change improves code readability and robustness by enabling exhaustive `when` expressions and reducing the reliance on boolean flags (e.g., `isBLE`, `isUSB`).

The `BTScanModel` has been updated to use these sealed classes and provides separate StateFlows for each device type (`bleDevicesForUi`, `tcpDevicesForUi`, `usbDevicesForUi`). This simplifies the UI logic for displaying and filtering devices.

The "Warning Not Paired" message on the connections screen will now only be shown once per app installation if no BLE devices are paired and the user is not connected.

BREAKING CHANGE: The `BTScanModel.devices` LiveData which was a `MutableMap<String, DeviceListEntry>` has been removed and replaced with specific StateFlows for each connection type (`bleDevicesForUi`, `tcpDevicesForUi`, `usbDevicesForUi`). Consumers of `BTScanModel` will need to update to observe these new flows. The `DeviceListEntry` class and its subclasses (e.g., `BLEDeviceListEntry`, `USBDeviceListEntry`) have been replaced by the sealed class `DeviceListEntry` and its specific types (e.g., `DeviceListEntry.Ble`, `DeviceListEntry.Usb`). The `connectedNodeLongName` property in `BTScanModel` has been removed as recent TCP device names are now persisted with their address.

fixes #2499 

**draft** need to test against multiple network nodes (have another one coming monday)