### PR TITLE
feat: onboarding refresh

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -224,6 +224,7 @@ dependencies {
     implementation(libs.usb.serial.android)
     implementation(libs.work.runtime.ktx)
     implementation(libs.core.location.altitude)
+    implementation("com.google.accompanist:accompanist-permissions:0.37.3")
 
     // Compose BOM
     implementation(platform(libs.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -224,7 +224,7 @@ dependencies {
     implementation(libs.usb.serial.android)
     implementation(libs.work.runtime.ktx)
     implementation(libs.core.location.altitude)
-    implementation("com.google.accompanist:accompanist-permissions:0.37.3")
+    implementation(libs.accompanist.permissions)
 
     // Compose BOM
     implementation(platform(libs.compose.bom))

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -19,16 +19,12 @@ package com.geeksville.mesh
 
 import android.app.PendingIntent
 import android.app.TaskStackBuilder
-import android.bluetooth.BluetoothAdapter
 import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.hardware.usb.UsbManager
 import android.net.Uri
 import android.os.Bundle
-import android.os.RemoteException
-import android.provider.Settings
-import android.view.MotionEvent
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -45,19 +41,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalView
 import androidx.core.content.edit
 import androidx.core.net.toUri
-import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import com.geeksville.mesh.android.BindFailedException
 import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.android.ServiceClient
-import com.geeksville.mesh.android.getBluetoothPermissions
-import com.geeksville.mesh.android.getNotificationPermissions
-import com.geeksville.mesh.android.hasBluetoothPermission
-import com.geeksville.mesh.android.hasNotificationPermission
-import com.geeksville.mesh.android.permissionMissing
-import com.geeksville.mesh.android.shouldShowRequestPermissionRationale
 import com.geeksville.mesh.concurrent.handledLaunch
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
@@ -69,9 +58,8 @@ import com.geeksville.mesh.ui.MainMenuAction
 import com.geeksville.mesh.ui.MainScreen
 import com.geeksville.mesh.ui.common.theme.AppTheme
 import com.geeksville.mesh.ui.common.theme.MODE_DYNAMIC
-import com.geeksville.mesh.ui.sharing.toSharedContact
 import com.geeksville.mesh.ui.intro.AppIntroductionScreen
-import com.geeksville.mesh.util.Exceptions
+import com.geeksville.mesh.ui.sharing.toSharedContact
 import com.geeksville.mesh.util.LanguageUtils
 import com.geeksville.mesh.util.getPackageInfoCompat
 import dagger.hilt.android.AndroidEntryPoint
@@ -79,43 +67,19 @@ import kotlinx.coroutines.Job
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class MainActivity : AppCompatActivity(), Logging {
+class MainActivity :
+    AppCompatActivity(),
+    Logging {
     private val bluetoothViewModel: BluetoothViewModel by viewModels()
     private val model: UIViewModel by viewModels()
 
-    @Inject
-    internal lateinit var serviceRepository: ServiceRepository
+    @Inject internal lateinit var serviceRepository: ServiceRepository
 
     private var showAppIntro by mutableStateOf(false)
 
-    private val bluetoothPermissionsLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
-            if (result.entries.all { it.value }) {
-                info("Bluetooth permissions granted")
-            } else {
-                warn("Bluetooth permissions denied")
-                model.showSnackbar(permissionMissing)
-            }
-            requestedEnable = false
-            bluetoothViewModel.permissionsUpdated()
-        }
-
-    private val notificationPermissionsLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
-            if (result.entries.all { it.value }) {
-                info("Notification permissions granted")
-                checkAlertDnD()
-            } else {
-                warn("Notification permissions denied")
-                model.showSnackbar(getString(R.string.notification_denied))
-            }
-        }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
-        installSplashScreen()
         super.onCreate(savedInstanceState)
-
         val prefs = UIViewModel.getPreferences(this)
         if (savedInstanceState == null) {
             val lang = prefs.getString("lang", LanguageUtils.SYSTEM_DEFAULT)
@@ -133,30 +97,28 @@ class MainActivity : AppCompatActivity(), Logging {
         setContent {
             val theme by model.theme.collectAsState()
             val dynamic = theme == MODE_DYNAMIC
-            val dark = when (theme) {
-                AppCompatDelegate.MODE_NIGHT_YES -> true
-                AppCompatDelegate.MODE_NIGHT_NO -> false
-                AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM -> isSystemInDarkTheme()
-                else -> isSystemInDarkTheme()
-            }
+            val dark =
+                when (theme) {
+                    AppCompatDelegate.MODE_NIGHT_YES -> true
+                    AppCompatDelegate.MODE_NIGHT_NO -> false
+                    AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM -> isSystemInDarkTheme()
+                    else -> isSystemInDarkTheme()
+                }
 
-            AppTheme(
-                dynamicColor = dynamic,
-                darkTheme = dark,
-            ) {
+            AppTheme(dynamicColor = dynamic, darkTheme = dark) {
                 val view = LocalView.current
                 if (!view.isInEditMode) {
-                    SideEffect {
-                        AppCompatDelegate.setDefaultNightMode(theme)
-                    }
+                    SideEffect { AppCompatDelegate.setDefaultNightMode(theme) }
                 }
 
                 if (showAppIntro) {
-                    AppIntroductionScreen(onDone = {
-                        prefs.edit { putBoolean("app_intro_completed", true) }
-                        showAppIntro = false
-                        (application as GeeksvilleApplication).askToRate(this@MainActivity)
-                    })
+                    AppIntroductionScreen(
+                        onDone = {
+                            prefs.edit { putBoolean("app_intro_completed", true) }
+                            showAppIntro = false
+                            (application as GeeksvilleApplication).askToRate(this@MainActivity)
+                        },
+                    )
                 } else {
                     MainScreen(
                         uIViewModel = model,
@@ -182,14 +144,10 @@ class MainActivity : AppCompatActivity(), Logging {
             Intent.ACTION_VIEW -> {
                 appLinkData?.let {
                     debug("App link data: $it")
-                    if (it.path?.startsWith("/e/") == true ||
-                        it.path?.startsWith("/E/") == true
-                    ) {
+                    if (it.path?.startsWith("/e/") == true || it.path?.startsWith("/E/") == true) {
                         debug("App link data is a channel set")
                         model.requestChannelUrl(it)
-                    } else if (it.path?.startsWith("/v/") == true ||
-                        it.path?.startsWith("/V/") == true
-                    ) {
+                    } else if (it.path?.startsWith("/v/") == true || it.path?.startsWith("/V/") == true) {
                         val sharedContact = it.toSharedContact()
                         debug("App link data is a shared contact: ${sharedContact.user.longName}")
                         model.setSharedContactRequested(sharedContact)
@@ -204,8 +162,7 @@ class MainActivity : AppCompatActivity(), Logging {
                 showSettingsPage()
             }
 
-            Intent.ACTION_MAIN -> {
-            }
+            Intent.ACTION_MAIN -> {}
 
             Intent.ACTION_SEND -> {
                 val text = intent.getStringExtra(Intent.EXTRA_TEXT)
@@ -222,137 +179,59 @@ class MainActivity : AppCompatActivity(), Logging {
 
     private fun createShareIntent(message: String): PendingIntent {
         val deepLink = "$DEEP_LINK_BASE_URI/share?message=$message"
-        val startActivityIntent = Intent(
-            Intent.ACTION_VIEW, deepLink.toUri(),
-            this, MainActivity::class.java
-        ).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
+        val startActivityIntent =
+            Intent(Intent.ACTION_VIEW, deepLink.toUri(), this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
 
-        val resultPendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
-            addNextIntentWithParentStack(startActivityIntent)
-            getPendingIntent(0, PendingIntent.FLAG_IMMUTABLE)
-        }
+        val resultPendingIntent: PendingIntent? =
+            TaskStackBuilder.create(this).run {
+                addNextIntentWithParentStack(startActivityIntent)
+                getPendingIntent(0, PendingIntent.FLAG_IMMUTABLE)
+            }
         return resultPendingIntent!!
     }
 
     private fun createSettingsIntent(): PendingIntent {
         val deepLink = "$DEEP_LINK_BASE_URI/connections"
-        val startActivityIntent = Intent(
-            Intent.ACTION_VIEW, deepLink.toUri(),
-            this, MainActivity::class.java
-        ).apply {
-            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
+        val startActivityIntent =
+            Intent(Intent.ACTION_VIEW, deepLink.toUri(), this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
 
-        val resultPendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
-            addNextIntentWithParentStack(startActivityIntent)
-            getPendingIntent(0, PendingIntent.FLAG_IMMUTABLE)
-        }
+        val resultPendingIntent: PendingIntent? =
+            TaskStackBuilder.create(this).run {
+                addNextIntentWithParentStack(startActivityIntent)
+                getPendingIntent(0, PendingIntent.FLAG_IMMUTABLE)
+            }
         return resultPendingIntent!!
     }
 
-    private var requestedEnable = false
-    private val bleRequestEnable = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) {
-        requestedEnable = false
-    }
-
-    private val createDocumentLauncher = registerForActivityResult(
-        ActivityResultContracts.StartActivityForResult()
-    ) {
-        if (it.resultCode == RESULT_OK) {
-            it.data?.data?.let { file_uri -> model.saveMessagesCSV(file_uri) }
-        }
-    }
-
-    private fun onMeshConnectionChanged(newConnection: MeshService.ConnectionState) {
-        if (newConnection == MeshService.ConnectionState.CONNECTED) {
-            checkNotificationPermissions()
-        }
-    }
-
-    private fun checkNotificationPermissions() {
-        if (!hasNotificationPermission()) {
-            val notificationPermissions = getNotificationPermissions()
-            if (shouldShowRequestPermissionRationale(notificationPermissions)) {
-                val title = getString(R.string.notification_required)
-                val message = getString(R.string.why_notification_required)
-                model.showAlert(
-                    title = title,
-                    message = message,
-                    onConfirm = {
-                        notificationPermissionsLauncher.launch(notificationPermissions)
-                    },
-                )
-            } else {
-                notificationPermissionsLauncher.launch(notificationPermissions)
+    private val createDocumentLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (it.resultCode == RESULT_OK) {
+                it.data?.data?.let { file_uri -> model.saveMessagesCSV(file_uri) }
             }
         }
-    }
-
-    @Suppress("MagicNumber")
-    private fun checkAlertDnD() {
-        val prefs = UIViewModel.getPreferences(this)
-        val rationaleShown = prefs.getBoolean("dnd_rationale_shown", false)
-        if (!rationaleShown && hasNotificationPermission()) {
-            fun showAlertAppNotificationSettings() {
-                val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
-                intent.putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
-                intent.putExtra(Settings.EXTRA_CHANNEL_ID, "my_alerts")
-                startActivity(intent)
-            }
-            model.showAlert(
-                title = getString(R.string.alerts_dnd_request_title),
-                html = getString(R.string.alerts_dnd_request_text),
-                onConfirm = {
-                    showAlertAppNotificationSettings()
-                },
-            ).also {
-                prefs.edit { putBoolean("dnd_rationale_shown", true) }
-            }
-        }
-    }
-
-    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
-        return try {
-            super.dispatchTouchEvent(ev)
-        } catch (ex: Throwable) {
-            Exceptions.report(
-                ex,
-                "dispatchTouchEvent"
-            ) // hide this Compose error from the user but report to the mothership
-            false
-        }
-    }
 
     private var serviceSetupJob: Job? = null
 
-    private val mesh = object : ServiceClient<IMeshService>(IMeshService.Stub::asInterface) {
-        override fun onConnected(service: IMeshService) {
-            serviceSetupJob?.cancel()
-            serviceSetupJob = lifecycleScope.handledLaunch {
-                serviceRepository.setMeshService(service)
+    private val mesh =
+        object : ServiceClient<IMeshService>(IMeshService.Stub::asInterface) {
+            override fun onConnected(service: IMeshService) {
+                serviceSetupJob?.cancel()
+                serviceSetupJob =
+                    lifecycleScope.handledLaunch {
+                        serviceRepository.setMeshService(service)
+                        debug("connected to mesh service, connectionState=${model.connectionState.value}")
+                    }
+            }
 
-                try {
-                    val connectionState =
-                        MeshService.ConnectionState.valueOf(service.connectionState())
-
-                    onMeshConnectionChanged(connectionState)
-                } catch (ex: RemoteException) {
-                    errormsg("Device error during init ${ex.message}")
-                }
-
-                debug("connected to mesh service, connectionState=${model.connectionState.value}")
+            override fun onDisconnected() {
+                serviceSetupJob?.cancel()
+                serviceRepository.setMeshService(null)
             }
         }
-
-        override fun onDisconnected() {
-            serviceSetupJob?.cancel()
-            serviceRepository.setMeshService(null)
-        }
-    }
 
     private fun bindMeshService() {
         debug("Binding to mesh service!")
@@ -362,35 +241,11 @@ class MainActivity : AppCompatActivity(), Logging {
             errormsg("Failed to start service from activity - but ignoring because bind will work ${ex.message}")
         }
 
-        mesh.connect(
-            this,
-            MeshService.createIntent(),
-            BIND_AUTO_CREATE + BIND_ABOVE_CLIENT
-        )
+        mesh.connect(this, MeshService.createIntent(), BIND_AUTO_CREATE + BIND_ABOVE_CLIENT)
     }
 
     override fun onStart() {
         super.onStart()
-        bluetoothViewModel.enabled.observe(this) { enabled ->
-            if (!enabled && !requestedEnable && model.selectedBluetooth) {
-                requestedEnable = true
-                if (hasBluetoothPermission()) {
-                    val enableBtIntent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
-                    bleRequestEnable.launch(enableBtIntent)
-                } else {
-                    val bluetoothPermissions = getBluetoothPermissions()
-                    val title = getString(R.string.required_permissions)
-                    val message = permissionMissing
-                    model.showAlert(
-                        title = title,
-                        message = message,
-                        onConfirm = {
-                            bluetoothPermissionsLauncher.launch(bluetoothPermissions)
-                        },
-                    )
-                }
-            }
-        }
 
         try {
             bindMeshService()
@@ -410,11 +265,12 @@ class MainActivity : AppCompatActivity(), Logging {
             }
 
             MainMenuAction.EXPORT_MESSAGES -> {
-                val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    type = "application/csv"
-                    putExtra(Intent.EXTRA_TITLE, "rangetest.csv")
-                }
+                val intent =
+                    Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+                        addCategory(Intent.CATEGORY_OPENABLE)
+                        type = "application/csv"
+                        putExtra(Intent.EXTRA_TITLE, "rangetest.csv")
+                    }
                 createDocumentLauncher.launch(intent)
             }
 
@@ -427,7 +283,7 @@ class MainActivity : AppCompatActivity(), Logging {
             }
 
             MainMenuAction.SHOW_INTRO -> {
-                showAppIntro = true // Show intro again if selected from menu
+                showAppIntro = true
             }
 
             else -> {}
@@ -445,12 +301,13 @@ class MainActivity : AppCompatActivity(), Logging {
     }
 
     private fun chooseThemeDialog() {
-        val styles = mapOf(
-            getString(R.string.dynamic) to MODE_DYNAMIC,
-            getString(R.string.theme_light) to AppCompatDelegate.MODE_NIGHT_NO,
-            getString(R.string.theme_dark) to AppCompatDelegate.MODE_NIGHT_YES,
-            getString(R.string.theme_system) to AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-        )
+        val styles =
+            mapOf(
+                getString(R.string.dynamic) to MODE_DYNAMIC,
+                getString(R.string.theme_light) to AppCompatDelegate.MODE_NIGHT_NO,
+                getString(R.string.theme_dark) to AppCompatDelegate.MODE_NIGHT_YES,
+                getString(R.string.theme_system) to AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM,
+            )
 
         val prefs = UIViewModel.getPreferences(this)
         val theme = prefs.getInt("theme", AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
@@ -458,11 +315,7 @@ class MainActivity : AppCompatActivity(), Logging {
         model.showAlert(
             title = getString(R.string.choose_theme),
             message = "",
-            choices = styles.mapValues { (_, value) ->
-                {
-                    model.setTheme(value)
-                }
-            },
+            choices = styles.mapValues { (_, value) -> { model.setTheme(value) } },
         )
     }
 
@@ -470,16 +323,8 @@ class MainActivity : AppCompatActivity(), Logging {
         val languageTags = LanguageUtils.getLanguageTags(this)
         val lang = LanguageUtils.getLocale()
         debug("Lang from prefs: $lang")
-        val langMap = languageTags.mapValues { (_, value) ->
-            {
-                LanguageUtils.setLocale(value)
-            }
-        }
+        val langMap = languageTags.mapValues { (_, value) -> { LanguageUtils.setLocale(value) } }
 
-        model.showAlert(
-            title = getString(R.string.preferences_language),
-            message = "",
-            choices = langMap,
-        )
+        model.showAlert(title = getString(R.string.preferences_language), message = "", choices = langMap)
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ContextServices.kt
@@ -18,161 +18,58 @@
 package com.geeksville.mesh.android
 
 import android.Manifest
-import android.app.Activity
-import android.app.NotificationManager
-import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.location.LocationManager
-import androidx.core.app.ActivityCompat
+import android.os.Build
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.Fragment
-import com.geeksville.mesh.R
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
-/**
- * @return null on platforms without a BlueTooth driver (i.e. the emulator)
- */
-val Context.bluetoothManager: BluetoothManager?
-    get() = getSystemService(Context.BLUETOOTH_SERVICE).takeIf { hasBluetoothPermission() } as? BluetoothManager?
+/** Checks if the device has a GPS receiver. */
+fun Context.hasGps(): Boolean {
+    val lm = getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+    return lm?.allProviders?.contains(LocationManager.GPS_PROVIDER) == true
+}
 
-val Context.notificationManager: NotificationManager get() = requireNotNull(getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager?)
-
-val Context.locationManager: LocationManager get() = requireNotNull(getSystemService(Context.LOCATION_SERVICE) as? LocationManager?)
-
-/**
- * @return true if the device has a GPS receiver
- */
-fun Context.hasGps(): Boolean = locationManager.allProviders.contains(LocationManager.GPS_PROVIDER)
-
-/**
- * @return true if the device has a GPS receiver and it is disabled (location turned off)
- */
-fun Context.gpsDisabled(): Boolean =
-    if (hasGps()) !locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER) else false
-
-/**
- * @return the text string of the permissions missing
- */
-val Context.permissionMissing: String
-    get() = if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.S) {
-        getString(R.string.permission_missing)
+/** Checks if the device has a GPS receiver and it is currently disabled. */
+fun Context.gpsDisabled(): Boolean {
+    val lm = getSystemService(Context.LOCATION_SERVICE) as? LocationManager ?: return false
+    return if (lm.allProviders.contains(LocationManager.GPS_PROVIDER)) {
+        !lm.isProviderEnabled(LocationManager.GPS_PROVIDER)
     } else {
-        getString(R.string.permission_missing_31)
+        false
     }
+}
 
 /**
- * Checks if any given permissions need to show rationale.
+ * Determines the list of Bluetooth permissions that are currently missing. Internal helper for
+ * [hasBluetoothPermission].
  *
- * @return true if should show UI with rationale before requesting a permission.
- */
-fun Activity.shouldShowRequestPermissionRationale(permissions: Array<String>): Boolean {
-    for (permission in permissions) {
-        if (ActivityCompat.shouldShowRequestPermissionRationale(this, permission)) {
-            return true
-        }
-    }
-    return false
-}
-
-/**
- * Checks if any given permissions need to show rationale.
+ * For Android S (API 31) and above, this includes [Manifest.permission.BLUETOOTH_SCAN] and
+ * [Manifest.permission.BLUETOOTH_CONNECT]. For older versions, it includes [Manifest.permission.ACCESS_FINE_LOCATION]
+ * as it is required for Bluetooth scanning.
  *
- * @return true if should show UI with rationale before requesting a permission.
+ * @return Array of missing Bluetooth permission strings. Empty if all are granted.
  */
-fun Fragment.shouldShowRequestPermissionRationale(permissions: Array<String>): Boolean {
-    for (permission in permissions) {
-        if (shouldShowRequestPermissionRationale(permission)) {
-            return true
-        }
-    }
-    return false
-}
+private fun Context.getBluetoothPermissions(): Array<String> {
+    val requiredPermissions = mutableListOf<String>()
 
-/**
- * Handles whether a rationale dialog should be shown before performing an action.
- */
-fun Context.rationaleDialog(
-    shouldShowRequestPermissionRationale: Boolean = true,
-    title: Int = R.string.required_permissions,
-    rationale: CharSequence = permissionMissing,
-    invokeFun: () -> Unit,
-) {
-    if (!shouldShowRequestPermissionRationale) invokeFun()
-    else MaterialAlertDialogBuilder(this)
-        .setTitle(title)
-        .setMessage(rationale)
-        .setNeutralButton(R.string.cancel) { _, _ ->
-        }
-        .setPositiveButton(R.string.accept) { _, _ ->
-            invokeFun()
-        }
-        .show()
-}
-
-/**
- * return a list of the permissions we don't have
- */
-fun Context.getMissingPermissions(perms: List<String>): Array<String> = perms.filter {
-    ContextCompat.checkSelfPermission(
-        this,
-        it
-    ) != PackageManager.PERMISSION_GRANTED
-}.toTypedArray()
-
-/**
- * Bluetooth permissions (or empty if we already have what we need)
- */
-fun Context.getBluetoothPermissions(): Array<String> {
-    val perms = mutableListOf<String>()
-
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-        perms.add(Manifest.permission.BLUETOOTH_SCAN)
-        perms.add(Manifest.permission.BLUETOOTH_CONNECT)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        requiredPermissions.add(Manifest.permission.BLUETOOTH_SCAN)
+        requiredPermissions.add(Manifest.permission.BLUETOOTH_CONNECT)
     } else {
-        perms.add(Manifest.permission.ACCESS_FINE_LOCATION)
+        // ACCESS_FINE_LOCATION is required for Bluetooth scanning on pre-S devices.
+        requiredPermissions.add(Manifest.permission.ACCESS_FINE_LOCATION)
     }
-    return getMissingPermissions(perms)
+    return requiredPermissions
+        .filter { ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED }
+        .toTypedArray()
 }
 
-/** @return true if the user already has Bluetooth connect permission */
-fun Context.hasBluetoothPermission() = getBluetoothPermissions().isEmpty()
+/** Checks if all necessary Bluetooth permissions have been granted. */
+fun Context.hasBluetoothPermission(): Boolean = getBluetoothPermissions().isEmpty()
 
-/**
- * Camera permission (or empty if we already have what we need)
- */
-fun Context.getCameraPermissions(): Array<String> {
-    val perms = mutableListOf(Manifest.permission.CAMERA)
-
-    return getMissingPermissions(perms)
+/** @return true if the user already has location permission (ACCESS_FINE_LOCATION). */
+fun Context.hasLocationPermission(): Boolean {
+    val perms = listOf(Manifest.permission.ACCESS_FINE_LOCATION)
+    return perms.all { ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED }
 }
-
-/** @return true if the user already has camera permission */
-fun Context.hasCameraPermission() = getCameraPermissions().isEmpty()
-
-/**
- * Location permission (or empty if we already have what we need)
- */
-fun Context.getLocationPermissions(): Array<String> {
-    val perms = mutableListOf(Manifest.permission.ACCESS_FINE_LOCATION)
-
-    return getMissingPermissions(perms)
-}
-
-/** @return true if the user already has location permission */
-fun Context.hasLocationPermission() = getLocationPermissions().isEmpty()
-
-/**
- * Notification permission (or empty if we already have what we need)
- */
-fun Context.getNotificationPermissions(): Array<String> {
-    val perms = mutableListOf<String>()
-    if (android.os.Build.VERSION.SDK_INT >= 33) {
-        perms.add(Manifest.permission.POST_NOTIFICATIONS)
-    }
-
-    return getMissingPermissions(perms)
-}
-
-/** @return true if the user already has notification permission */
-fun Context.hasNotificationPermission() = getNotificationPermissions().isEmpty()

--- a/app/src/main/java/com/geeksville/mesh/model/BluetoothViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/BluetoothViewModel.kt
@@ -18,24 +18,16 @@
 package com.geeksville.mesh.model
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.asLiveData
 import com.geeksville.mesh.repository.bluetooth.BluetoothRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-/**
- * Thin view model which adapts the view layer to the `BluetoothRepository`.
- */
+/** Thin view model which adapts the view layer to the `BluetoothRepository`. */
 @HiltViewModel
-class BluetoothViewModel @Inject constructor(
-    private val bluetoothRepository: BluetoothRepository,
-) : ViewModel() {
-    /**
-     * Called when permissions have been updated.  This causes an explicit refresh of the
-     * bluetooth state.
-     */
+class BluetoothViewModel @Inject constructor(private val bluetoothRepository: BluetoothRepository) : ViewModel() {
+    /** Called when permissions have been updated. This causes an explicit refresh of the bluetooth state. */
     fun permissionsUpdated() = bluetoothRepository.refreshState()
 
-    val enabled = bluetoothRepository.state.map { it.enabled }.asLiveData()
+    val enabled = bluetoothRepository.state.map { it.enabled }
 }

--- a/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
@@ -17,7 +17,6 @@
 
 package com.geeksville.mesh.repository.bluetooth
 
-import android.annotation.SuppressLint
 import android.app.Application
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
@@ -92,7 +91,6 @@ class BluetoothRepository @Inject constructor(
             ?.bluetoothLeScanner
     }
 
-    @SuppressLint("MissingPermission")
     fun scan(): Flow<ScanResult> {
         val filter = ScanFilter.Builder()
             // Samsung doesn't seem to filter properly by service so this can't work
@@ -112,7 +110,6 @@ class BluetoothRepository @Inject constructor(
     @RequiresPermission("android.permission.BLUETOOTH_CONNECT")
     fun createBond(device: BluetoothDevice): Flow<Int> = device.createBond(application)
 
-    @SuppressLint("MissingPermission")
     internal suspend fun updateBluetoothState() {
         val hasPerms = application.hasBluetoothPermission()
         val newState: BluetoothState = bluetoothAdapterLazy.get()?.let { adapter ->

--- a/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
@@ -27,8 +27,8 @@ import android.bluetooth.le.ScanSettings
 import androidx.annotation.RequiresPermission
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
-import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.CoroutineDispatchers
+import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.android.hasBluetoothPermission
 import com.geeksville.mesh.util.registerReceiverCompat
 import kotlinx.coroutines.flow.Flow
@@ -41,22 +41,25 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/**
- * Repository responsible for maintaining and updating the state of Bluetooth availability.
- */
+/** Repository responsible for maintaining and updating the state of Bluetooth availability. */
 @Singleton
-class BluetoothRepository @Inject constructor(
+class BluetoothRepository
+@Inject
+constructor(
     private val application: Application,
     private val bluetoothAdapterLazy: dagger.Lazy<BluetoothAdapter?>,
     private val bluetoothBroadcastReceiverLazy: dagger.Lazy<BluetoothBroadcastReceiver>,
     private val dispatchers: CoroutineDispatchers,
     private val processLifecycle: Lifecycle,
 ) : Logging {
-    private val _state = MutableStateFlow(BluetoothState(
-        // Assume we have permission until we get our initial state update to prevent premature
-        // notifications to the user.
-        hasPermissions = true
-    ))
+    private val _state =
+        MutableStateFlow(
+            BluetoothState(
+                // Assume we have permission until we get our initial state update to prevent premature
+                // notifications to the user.
+                hasPermissions = true,
+            ),
+        )
     val state: StateFlow<BluetoothState> = _state.asStateFlow()
 
     init {
@@ -69,42 +72,35 @@ class BluetoothRepository @Inject constructor(
     }
 
     fun refreshState() {
-        processLifecycle.coroutineScope.launch(dispatchers.default) {
-            updateBluetoothState()
-        }
+        processLifecycle.coroutineScope.launch(dispatchers.default) { updateBluetoothState() }
     }
 
     /** @return true for a valid Bluetooth address, false otherwise */
-    fun isValid(bleAddress: String): Boolean {
-        return BluetoothAdapter.checkBluetoothAddress(bleAddress)
-    }
+    fun isValid(bleAddress: String): Boolean = BluetoothAdapter.checkBluetoothAddress(bleAddress)
 
-    fun getRemoteDevice(address: String): BluetoothDevice? {
-        return bluetoothAdapterLazy.get()
-            ?.takeIf { application.hasBluetoothPermission() && isValid(address) }
-            ?.getRemoteDevice(address)
-    }
+    fun getRemoteDevice(address: String): BluetoothDevice? = bluetoothAdapterLazy
+        .get()
+        ?.takeIf { application.hasBluetoothPermission() && isValid(address) }
+        ?.getRemoteDevice(address)
 
-    private fun getBluetoothLeScanner(): BluetoothLeScanner? {
-        return bluetoothAdapterLazy.get()
-            ?.takeIf { application.hasBluetoothPermission() }
-            ?.bluetoothLeScanner
-    }
+    private fun getBluetoothLeScanner(): BluetoothLeScanner? =
+        bluetoothAdapterLazy.get()?.takeIf { application.hasBluetoothPermission() }?.bluetoothLeScanner
 
     fun scan(): Flow<ScanResult> {
-        val filter = ScanFilter.Builder()
-            // Samsung doesn't seem to filter properly by service so this can't work
-            // see https://stackoverflow.com/questions/57981986/altbeacon-android-beacon-library-not-working-after-device-has-screen-off-for-a-s/57995960#57995960
-            // and https://stackoverflow.com/a/45590493
-            // .setServiceUuid(ParcelUuid(BluetoothInterface.BTM_SERVICE_UUID))
-            .build()
+        val filter =
+            ScanFilter.Builder()
+                // Samsung doesn't seem to filter properly by service so this can't work
+                // see
+                // https://stackoverflow.com/questions/57981986/altbeacon-android-beacon-library-not-working-after-device-has-screen-off-for-a-s/57995960#57995960
+                // and https://stackoverflow.com/a/45590493
+                // .setServiceUuid(ParcelUuid(BluetoothInterface.BTM_SERVICE_UUID))
+                .build()
 
-        val settings = ScanSettings.Builder()
-            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
-            .build()
+        val settings = ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY).build()
 
-        return getBluetoothLeScanner()?.scan(listOf(filter), settings)
-            ?.filter { it.device.name?.matches(Regex(BLE_NAME_PATTERN)) == true } ?: emptyFlow()
+        return getBluetoothLeScanner()?.scan(listOf(filter), settings)?.filter {
+            it.device.name?.matches(Regex(BLE_NAME_PATTERN)) == true
+        } ?: emptyFlow()
     }
 
     @RequiresPermission("android.permission.BLUETOOTH_CONNECT")
@@ -112,17 +108,22 @@ class BluetoothRepository @Inject constructor(
 
     internal suspend fun updateBluetoothState() {
         val hasPerms = application.hasBluetoothPermission()
-        val newState: BluetoothState = bluetoothAdapterLazy.get()?.let { adapter ->
-            val enabled = adapter.isEnabled
-            val bondedDevices = adapter.takeIf { hasPerms }?.bondedDevices ?: emptySet()
+        val newState: BluetoothState =
+            bluetoothAdapterLazy.get()?.let { adapter ->
+                val enabled = adapter.isEnabled
+                val bondedDevices = adapter.takeIf { hasPerms }?.bondedDevices ?: emptySet()
 
-            BluetoothState(
-                hasPermissions = hasPerms,
-                enabled = enabled,
-                bondedDevices = if (!enabled) emptyList()
-                else bondedDevices.filter { it.name?.matches(Regex(BLE_NAME_PATTERN)) == true },
-            )
-        } ?: BluetoothState()
+                BluetoothState(
+                    hasPermissions = hasPerms,
+                    enabled = enabled,
+                    bondedDevices =
+                    if (!enabled) {
+                        emptyList()
+                    } else {
+                        bondedDevices.filter { it.name?.matches(Regex(BLE_NAME_PATTERN)) == true }
+                    },
+                )
+            } ?: BluetoothState()
 
         _state.emit(newState)
         debug("Detected our bluetooth access=$newState")

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -38,16 +38,13 @@ import com.geeksville.mesh.MainActivity
 import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.R
 import com.geeksville.mesh.TelemetryProtos.LocalStats
-import com.geeksville.mesh.android.notificationManager
 import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.navigation.DEEP_LINK_BASE_URI
 import com.geeksville.mesh.service.ReplyReceiver.Companion.KEY_TEXT_REPLY
 import com.geeksville.mesh.util.formatUptime
 
 @Suppress("TooManyFunctions")
-class MeshServiceNotifications(
-    private val context: Context
-) {
+class MeshServiceNotifications(private val context: Context) {
 
     val notificationLightColor = Color.BLUE
 
@@ -56,7 +53,8 @@ class MeshServiceNotifications(
         const val MAX_BATTERY_LEVEL = 100
     }
 
-    private val notificationManager: NotificationManager get() = context.notificationManager
+    private val notificationManager: NotificationManager =
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     // We have two notification channels: one for general service status and another one for messages
     val notifyId = 101
@@ -84,14 +82,11 @@ class MeshServiceNotifications(
         val channelId = "my_service"
         if (notificationManager.getNotificationChannel(channelId) == null) {
             val channelName = context.getString(R.string.meshtastic_service_notifications)
-            val channel = NotificationChannel(
-                channelId,
-                channelName,
-                NotificationManager.IMPORTANCE_MIN
-            ).apply {
-                lightColor = notificationLightColor
-                lockscreenVisibility = Notification.VISIBILITY_PRIVATE
-            }
+            val channel =
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_MIN).apply {
+                    lightColor = notificationLightColor
+                    lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+                }
             notificationManager.createNotificationChannel(channel)
         }
         return channelId
@@ -102,22 +97,19 @@ class MeshServiceNotifications(
         val channelId = "my_messages"
         if (notificationManager.getNotificationChannel(channelId) == null) {
             val channelName = context.getString(R.string.meshtastic_messages_notifications)
-            val channel = NotificationChannel(
-                channelId,
-                channelName,
-                NotificationManager.IMPORTANCE_HIGH
-            ).apply {
-                lightColor = notificationLightColor
-                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-                setShowBadge(true)
-                setSound(
-                    RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                        .build()
-                )
-            }
+            val channel =
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH).apply {
+                    lightColor = notificationLightColor
+                    lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                    setShowBadge(true)
+                    setSound(
+                        RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build(),
+                    )
+                }
             notificationManager.createNotificationChannel(channel)
         }
         return channelId
@@ -128,22 +120,19 @@ class MeshServiceNotifications(
         val channelId = "my_broadcasts"
         if (notificationManager.getNotificationChannel(channelId) == null) {
             val channelName = context.getString(R.string.meshtastic_broadcast_notifications)
-            val channel = NotificationChannel(
-                channelId,
-                channelName,
-                NotificationManager.IMPORTANCE_DEFAULT
-            ).apply {
-                lightColor = notificationLightColor
-                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-                setShowBadge(true)
-                setSound(
-                    RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                        .build()
-                )
-            }
+            val channel =
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_DEFAULT).apply {
+                    lightColor = notificationLightColor
+                    lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                    setShowBadge(true)
+                    setSound(
+                        RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build(),
+                    )
+                }
             notificationManager.createNotificationChannel(channel)
         }
         return channelId
@@ -154,31 +143,31 @@ class MeshServiceNotifications(
         val channelId = "my_alerts"
         if (notificationManager.getNotificationChannel(channelId) == null) {
             val channelName = context.getString(R.string.meshtastic_alerts_notifications)
-            val channel = NotificationChannel(
-                channelId,
-                channelName,
-                NotificationManager.IMPORTANCE_HIGH
-            ).apply {
-                enableLights(true)
-                enableVibration(true)
-                setBypassDnd(true)
-                lightColor = notificationLightColor
-                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-                setShowBadge(true)
-                val alertSoundUri =
-                    (
+            val channel =
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH).apply {
+                    enableLights(true)
+                    enableVibration(true)
+                    setBypassDnd(true)
+                    lightColor = notificationLightColor
+                    lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                    setShowBadge(true)
+                    val alertSoundUri =
+                        (
                             ContentResolver.SCHEME_ANDROID_RESOURCE +
-                                    "://" + context.applicationContext.packageName +
-                                    "/" + R.raw.alert
-                            ).toUri()
-                setSound(
-                    alertSoundUri,
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                        .build()
-                )
-            }
+                                "://" +
+                                context.applicationContext.packageName +
+                                "/" +
+                                R.raw.alert
+                            )
+                            .toUri()
+                    setSound(
+                        alertSoundUri,
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build(),
+                    )
+                }
             notificationManager.createNotificationChannel(channel)
         }
         return channelId
@@ -189,22 +178,19 @@ class MeshServiceNotifications(
         val channelId = "new_nodes"
         if (notificationManager.getNotificationChannel(channelId) == null) {
             val channelName = context.getString(R.string.meshtastic_new_nodes_notifications)
-            val channel = NotificationChannel(
-                channelId,
-                channelName,
-                NotificationManager.IMPORTANCE_HIGH
-            ).apply {
-                lightColor = notificationLightColor
-                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-                setShowBadge(true)
-                setSound(
-                    RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                        .build()
-                )
-            }
+            val channel =
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH).apply {
+                    lightColor = notificationLightColor
+                    lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                    setShowBadge(true)
+                    setSound(
+                        RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build(),
+                    )
+                }
             notificationManager.createNotificationChannel(channel)
         }
         return channelId
@@ -215,22 +201,19 @@ class MeshServiceNotifications(
         val channelId = "low_battery"
         if (notificationManager.getNotificationChannel(channelId) == null) {
             val channelName = context.getString(R.string.meshtastic_low_battery_notifications)
-            val channel = NotificationChannel(
-                channelId,
-                channelName,
-                NotificationManager.IMPORTANCE_HIGH
-            ).apply {
-                lightColor = notificationLightColor
-                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-                setShowBadge(true)
-                setSound(
-                    RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                        .build()
-                )
-            }
+            val channel =
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH).apply {
+                    lightColor = notificationLightColor
+                    lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                    setShowBadge(true)
+                    setSound(
+                        RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build(),
+                    )
+                }
             notificationManager.createNotificationChannel(channel)
         }
         return channelId
@@ -242,25 +225,21 @@ class MeshServiceNotifications(
     private fun createLowBatteryRemoteNotificationChannel(): String {
         val channelId = "low_battery_remote"
         if (notificationManager.getNotificationChannel(channelId) == null) {
-            val channelName =
-                context.getString(R.string.meshtastic_low_battery_temporary_remote_notifications)
-            val channel = NotificationChannel(
-                channelId,
-                channelName,
-                NotificationManager.IMPORTANCE_HIGH
-            ).apply {
-                lightColor = notificationLightColor
-                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-                enableVibration(true)
-                setShowBadge(true)
-                setSound(
-                    RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
-                    AudioAttributes.Builder()
-                        .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                        .build()
-                )
-            }
+            val channelName = context.getString(R.string.meshtastic_low_battery_temporary_remote_notifications)
+            val channel =
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH).apply {
+                    lightColor = notificationLightColor
+                    lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                    enableVibration(true)
+                    setShowBadge(true)
+                    setSound(
+                        RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION),
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build(),
+                    )
+                }
             notificationManager.createNotificationChannel(channel)
         }
         return channelId
@@ -271,15 +250,12 @@ class MeshServiceNotifications(
         val channelId = "client_notifications"
         if (notificationManager.getNotificationChannel(channelId) == null) {
             val channelName = context.getString(R.string.client_notification)
-            val channel = NotificationChannel(
-                channelId,
-                channelName,
-                NotificationManager.IMPORTANCE_HIGH
-            ).apply {
-                lightColor = notificationLightColor
-                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-                setShowBadge(true)
-            }
+            val channel =
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH).apply {
+                    lightColor = notificationLightColor
+                    lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                    setShowBadge(true)
+                }
             notificationManager.createNotificationChannel(channel)
         }
         return channelId
@@ -355,19 +331,23 @@ class MeshServiceNotifications(
         }
     }
 
-    private fun LocalStats?.formatToString(): String = this?.allFields?.mapNotNull { (k, v) ->
-        when (k.name) {
-            "num_online_nodes", "num_total_nodes" -> return@mapNotNull null
-            "uptime_seconds" -> "Uptime: ${formatUptime(v as Int)}"
-            "channel_utilization" -> "ChUtil: %.2f%%".format(v)
-            "air_util_tx" -> "AirUtilTX: %.2f%%".format(v)
-            else ->
-                "${
-                    k.name.replace('_', ' ').split(" ")
-                        .joinToString(" ") { it.replaceFirstChar { char -> char.uppercase() } }
-                }: $v"
+    private fun LocalStats?.formatToString(): String = this?.allFields
+        ?.mapNotNull { (k, v) ->
+            when (k.name) {
+                "num_online_nodes",
+                "num_total_nodes",
+                -> return@mapNotNull null
+                "uptime_seconds" -> "Uptime: ${formatUptime(v as Int)}"
+                "channel_utilization" -> "ChUtil: %.2f%%".format(v)
+                "air_util_tx" -> "AirUtilTX: %.2f%%".format(v)
+                else ->
+                    "${
+                        k.name.replace('_', ' ').split(" ")
+                            .joinToString(" ") { it.replaceFirstChar { char -> char.uppercase() } }
+                    }: $v"
+            }
         }
-    }?.joinToString("\n") ?: "No Local Stats"
+        ?.joinToString("\n") ?: "No Local Stats"
 
     fun updateServiceStateNotification(
         summaryString: String? = null,
@@ -379,8 +359,8 @@ class MeshServiceNotifications(
             createServiceStateNotification(
                 name = summaryString.orEmpty(),
                 message = localStats.formatToString(),
-                nextUpdateAt = currentStatsUpdatedAtMillis?.plus(FIFTEEN_MINUTES_IN_MILLIS)
-            )
+                nextUpdateAt = currentStatsUpdatedAtMillis?.plus(FIFTEEN_MINUTES_IN_MILLIS),
+            ),
         )
     }
 
@@ -391,27 +371,27 @@ class MeshServiceNotifications(
     fun updateMessageNotification(contactKey: String, name: String, message: String, isBroadcast: Boolean) =
         notificationManager.notify(
             contactKey.hashCode(), // show unique notifications,
-            createMessageNotification(contactKey, name, message, isBroadcast)
+            createMessageNotification(contactKey, name, message, isBroadcast),
         )
 
     fun showAlertNotification(contactKey: String, name: String, alert: String) {
         notificationManager.notify(
             name.hashCode(), // show unique notifications,
-            createAlertNotification(contactKey, name, alert)
+            createAlertNotification(contactKey, name, alert),
         )
     }
 
     fun showNewNodeSeenNotification(node: NodeEntity) {
         notificationManager.notify(
             node.num, // show unique notifications
-            createNewNodeSeenNotification(node.user.shortName, node.user.longName)
+            createNewNodeSeenNotification(node.user.shortName, node.user.longName),
         )
     }
 
     fun showOrUpdateLowBatteryNotification(node: NodeEntity, isRemote: Boolean) {
         notificationManager.notify(
             node.num, // show unique notifications
-            createLowBatteryNotification(node, isRemote)
+            createLowBatteryNotification(node, isRemote),
         )
     }
 
@@ -422,9 +402,10 @@ class MeshServiceNotifications(
     fun showClientNotification(notification: MeshProtos.ClientNotification) {
         notificationManager.notify(
             notification.toString().hashCode(), // show unique notifications
-            createClientNotification(context.getString(R.string.client_notification), notification.message)
+            createClientNotification(context.getString(R.string.client_notification), notification.message),
         )
     }
+
     fun clearClientNotification(notification: MeshProtos.ClientNotification) {
         notificationManager.cancel(notification.toString().hashCode())
     }
@@ -433,48 +414,40 @@ class MeshServiceNotifications(
         PendingIntent.getActivity(
             context,
             0,
-            Intent(context, MainActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
-            },
-            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            Intent(context, MainActivity::class.java).apply { flags = Intent.FLAG_ACTIVITY_SINGLE_TOP },
+            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
     }
 
-    private fun createMessageReplyIntent(contactKey: String): Intent {
-        return Intent(context, ReplyReceiver::class.java).apply {
+    private fun createMessageReplyIntent(contactKey: String): Intent =
+        Intent(context, ReplyReceiver::class.java).apply {
             action = ReplyReceiver.REPLY_ACTION
             putExtra(ReplyReceiver.CONTACT_KEY, contactKey)
         }
-    }
 
     private fun createOpenMessageIntent(contactKey: String): PendingIntent {
         val intentFlags = Intent.FLAG_ACTIVITY_SINGLE_TOP
         val deepLink = "$DEEP_LINK_BASE_URI/messages/$contactKey"
-        val deepLinkIntent = Intent(
-            Intent.ACTION_VIEW,
-            deepLink.toUri(),
-            context,
-            MainActivity::class.java
-        ).apply {
-            flags = intentFlags
-        }
+        val deepLinkIntent =
+            Intent(Intent.ACTION_VIEW, deepLink.toUri(), context, MainActivity::class.java).apply {
+                flags = intentFlags
+            }
 
-        val deepLinkPendingIntent: PendingIntent = TaskStackBuilder.create(context).run {
-            addNextIntentWithParentStack(deepLinkIntent)
-            getPendingIntent(0, PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
-        }
+        val deepLinkPendingIntent: PendingIntent =
+            TaskStackBuilder.create(context).run {
+                addNextIntentWithParentStack(deepLinkIntent)
+                getPendingIntent(0, PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+            }
 
         return deepLinkPendingIntent
     }
 
-    private fun commonBuilder(
-        channel: String,
-        contentIntent: PendingIntent? = null
-    ): NotificationCompat.Builder {
-        val builder = NotificationCompat.Builder(context, channel)
-            .setDefaults(NotificationCompat.DEFAULT_ALL)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-            .setContentIntent(contentIntent ?: openAppIntent)
+    private fun commonBuilder(channel: String, contentIntent: PendingIntent? = null): NotificationCompat.Builder {
+        val builder =
+            NotificationCompat.Builder(context, channel)
+                .setDefaults(NotificationCompat.DEFAULT_ALL)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setContentIntent(contentIntent ?: openAppIntent)
 
         builder.setSmallIcon(
             // vector form icons don't work reliably on older androids
@@ -482,16 +455,17 @@ class MeshServiceNotifications(
                 R.drawable.app_icon_novect
             } else {
                 R.drawable.app_icon
-            }
+            },
         )
         return builder
     }
 
     lateinit var serviceNotificationBuilder: NotificationCompat.Builder
+
     fun createServiceStateNotification(
         name: String,
         message: String? = null,
-        nextUpdateAt: Long? = null
+        nextUpdateAt: Long? = null,
     ): Notification {
         if (!::serviceNotificationBuilder.isInitialized) {
             serviceNotificationBuilder = commonBuilder(channelId)
@@ -503,10 +477,7 @@ class MeshServiceNotifications(
             setContentTitle(name)
             message?.let {
                 setContentText(it)
-                setStyle(
-                    NotificationCompat.BigTextStyle()
-                        .bigText(message),
-                )
+                setStyle(NotificationCompat.BigTextStyle().bigText(message))
             }
             nextUpdateAt?.let {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -514,9 +485,7 @@ class MeshServiceNotifications(
                     setUsesChronometer(true)
                     setChronometerCountDown(true)
                 }
-            } ?: {
-                setWhen(System.currentTimeMillis())
-            }
+            } ?: { setWhen(System.currentTimeMillis()) }
             setShowWhen(true)
         }
         return serviceNotificationBuilder.build()
@@ -535,10 +504,11 @@ class MeshServiceNotifications(
         val person = Person.Builder().setName(name).build()
         // Key for the string that's delivered in the action's intent.
         val replyLabel: String = context.getString(R.string.reply)
-        val remoteInput: RemoteInput = RemoteInput.Builder(KEY_TEXT_REPLY).run {
-            setLabel(replyLabel)
-            build()
-        }
+        val remoteInput: RemoteInput =
+            RemoteInput.Builder(KEY_TEXT_REPLY).run {
+                setLabel(replyLabel)
+                build()
+            }
 
         // Build a PendingIntent for the reply action to trigger.
         val replyPendingIntent: PendingIntent =
@@ -546,23 +516,19 @@ class MeshServiceNotifications(
                 context,
                 contactKey.hashCode(),
                 createMessageReplyIntent(contactKey),
-                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
             )
         // Create the reply action and add the remote input.
-        val action: NotificationCompat.Action = NotificationCompat.Action.Builder(
-            android.R.drawable.ic_menu_send,
-            replyLabel,
-            replyPendingIntent
-        ).addRemoteInput(remoteInput).build()
+        val action: NotificationCompat.Action =
+            NotificationCompat.Action.Builder(android.R.drawable.ic_menu_send, replyLabel, replyPendingIntent)
+                .addRemoteInput(remoteInput)
+                .build()
 
         with(messageNotificationBuilder) {
             priority = NotificationCompat.PRIORITY_DEFAULT
             setCategory(Notification.CATEGORY_MESSAGE)
             setAutoCancel(true)
-            setStyle(
-                NotificationCompat.MessagingStyle(person)
-                    .addMessage(message, System.currentTimeMillis(), person)
-            )
+            setStyle(NotificationCompat.MessagingStyle(person).addMessage(message, System.currentTimeMillis(), person))
             addAction(action)
             setWhen(System.currentTimeMillis())
             setShowWhen(true)
@@ -571,29 +537,23 @@ class MeshServiceNotifications(
     }
 
     lateinit var alertNotificationBuilder: NotificationCompat.Builder
-    private fun createAlertNotification(
-        contactKey: String,
-        name: String,
-        alert: String
-    ): Notification {
+
+    private fun createAlertNotification(contactKey: String, name: String, alert: String): Notification {
         if (!::alertNotificationBuilder.isInitialized) {
-            alertNotificationBuilder =
-                commonBuilder(alertChannelId, createOpenMessageIntent(contactKey))
+            alertNotificationBuilder = commonBuilder(alertChannelId, createOpenMessageIntent(contactKey))
         }
         val person = Person.Builder().setName(name).build()
         with(alertNotificationBuilder) {
             priority = NotificationCompat.PRIORITY_HIGH
             setCategory(Notification.CATEGORY_ALARM)
             setAutoCancel(true)
-            setStyle(
-                NotificationCompat.MessagingStyle(person)
-                    .addMessage(alert, System.currentTimeMillis(), person)
-            )
+            setStyle(NotificationCompat.MessagingStyle(person).addMessage(alert, System.currentTimeMillis(), person))
         }
         return alertNotificationBuilder.build()
     }
 
     lateinit var newNodeSeenNotificationBuilder: NotificationCompat.Builder
+
     private fun createNewNodeSeenNotification(name: String, message: String? = null): Notification {
         if (!::newNodeSeenNotificationBuilder.isInitialized) {
             newNodeSeenNotificationBuilder = commonBuilder(newNodeChannelId)
@@ -605,10 +565,7 @@ class MeshServiceNotifications(
             setContentTitle("New Node Seen: $name")
             message?.let {
                 setContentText(it)
-                setStyle(
-                    NotificationCompat.BigTextStyle()
-                        .bigText(message),
-                )
+                setStyle(NotificationCompat.BigTextStyle().bigText(message))
             }
             setWhen(System.currentTimeMillis())
             setShowWhen(true)
@@ -618,18 +575,20 @@ class MeshServiceNotifications(
 
     lateinit var lowBatteryRemoteNotificationBuilder: NotificationCompat.Builder
     lateinit var lowBatteryNotificationBuilder: NotificationCompat.Builder
+
     private fun createLowBatteryNotification(node: NodeEntity, isRemote: Boolean): Notification {
-        val tempNotificationBuilder: NotificationCompat.Builder = if (isRemote) {
-            if (!::lowBatteryRemoteNotificationBuilder.isInitialized) {
-                lowBatteryRemoteNotificationBuilder = commonBuilder(lowBatteryChannelId)
+        val tempNotificationBuilder: NotificationCompat.Builder =
+            if (isRemote) {
+                if (!::lowBatteryRemoteNotificationBuilder.isInitialized) {
+                    lowBatteryRemoteNotificationBuilder = commonBuilder(lowBatteryChannelId)
+                }
+                lowBatteryRemoteNotificationBuilder
+            } else {
+                if (!::lowBatteryNotificationBuilder.isInitialized) {
+                    lowBatteryNotificationBuilder = commonBuilder(lowBatteryRemoteChannelId)
+                }
+                lowBatteryNotificationBuilder
             }
-            lowBatteryRemoteNotificationBuilder
-        } else {
-            if (!::lowBatteryNotificationBuilder.isInitialized) {
-                lowBatteryNotificationBuilder = commonBuilder(lowBatteryRemoteChannelId)
-            }
-            lowBatteryNotificationBuilder
-        }
         with(tempNotificationBuilder) {
             priority = NotificationCompat.PRIORITY_DEFAULT
             setCategory(Notification.CATEGORY_STATUS)
@@ -638,21 +597,12 @@ class MeshServiceNotifications(
             setOnlyAlertOnce(true)
             setWhen(System.currentTimeMillis())
             setProgress(MAX_BATTERY_LEVEL, node.deviceMetrics.batteryLevel, false)
-            setContentTitle(
-                context.getString(R.string.low_battery_title).format(
-                    node.shortName
-                )
-            )
-            val message = context.getString(R.string.low_battery_message).format(
-                node.longName,
-                node.deviceMetrics.batteryLevel
-            )
+            setContentTitle(context.getString(R.string.low_battery_title).format(node.shortName))
+            val message =
+                context.getString(R.string.low_battery_message).format(node.longName, node.deviceMetrics.batteryLevel)
             message.let {
                 setContentText(it)
-                setStyle(
-                    NotificationCompat.BigTextStyle()
-                        .bigText(it),
-                )
+                setStyle(NotificationCompat.BigTextStyle().bigText(it))
             }
         }
         if (isRemote) {
@@ -677,10 +627,7 @@ class MeshServiceNotifications(
             setContentTitle(name)
             message?.let {
                 setContentText(it)
-                setStyle(
-                    NotificationCompat.BigTextStyle()
-                        .bigText(message),
-                )
+                setStyle(NotificationCompat.BigTextStyle().bigText(message))
             }
         }
         return clientNotificationBuilder.build()

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -53,8 +53,7 @@ class MeshServiceNotifications(private val context: Context) {
         const val MAX_BATTERY_LEVEL = 100
     }
 
-    private val notificationManager: NotificationManager
-        =
+    private val notificationManager: NotificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
     // We have two notification channels: one for general service status and another one for messages

--- a/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
@@ -17,97 +17,102 @@
 
 package com.geeksville.mesh.service
 
-import android.bluetooth.*
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.DeadObjectException
 import android.os.Handler
 import android.os.Looper
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
 import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.concurrent.CallbackContinuation
 import com.geeksville.mesh.concurrent.Continuation
 import com.geeksville.mesh.concurrent.SyncContinuation
-import com.geeksville.mesh.android.bluetoothManager
 import com.geeksville.mesh.util.exceptionReporter
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.io.Closeable
-import java.util.*
+import java.util.Random
+import java.util.UUID
 
-
-/// Return a standard BLE 128 bit UUID from the short 16 bit versions
+// / Return a standard BLE 128 bit UUID from the short 16 bit versions
 fun longBLEUUID(hexFour: String): UUID = UUID.fromString("0000$hexFour-0000-1000-8000-00805f9b34fb")
-
 
 /**
  * Uses coroutines to safely access a bluetooth GATT device with a synchronous API
  *
- * The BTLE API on android is dumb.  You can only have one outstanding operation in flight to
- * the device.  If you try to do something when something is pending, the operation just returns
- * false.  You are expected to chain your operations from the results callbacks.
+ * The BTLE API on android is dumb. You can only have one outstanding operation in flight to the device. If you try to
+ * do something when something is pending, the operation just returns false. You are expected to chain your operations
+ * from the results callbacks.
  *
  * This class fixes the API by using coroutines to let you safely do a series of BTLE operations.
  */
 class SafeBluetooth(private val context: Context, private val device: BluetoothDevice) :
-    Logging, Closeable {
+    Logging,
+    Closeable {
 
-    /// Timeout before we declare a bluetooth operation failed (used for synchronous API operations only)
+    // / Timeout before we declare a bluetooth operation failed (used for synchronous API operations only)
     var timeoutMsec = 20 * 1000L
 
-    /// Users can access the GATT directly as needed
-    @Volatile
-    var gatt: BluetoothGatt? = null
+    // / Users can access the GATT directly as needed
+    @Volatile var gatt: BluetoothGatt? = null
 
-    @Volatile
-    var state = BluetoothProfile.STATE_DISCONNECTED
+    @Volatile var state = BluetoothProfile.STATE_DISCONNECTED
 
-    @Volatile
-    private var currentWork: BluetoothContinuation? = null
+    @Volatile private var currentWork: BluetoothContinuation? = null
     private val workQueue = mutableListOf<BluetoothContinuation>()
 
     // Called for reconnection attemps
-    @Volatile
-    private var connectionCallback: ((Result<Unit>) -> Unit)? = null
+    @Volatile private var connectionCallback: ((Result<Unit>) -> Unit)? = null
 
-    @Volatile
-    private var lostConnectCallback: (() -> Unit)? = null
+    @Volatile private var lostConnectCallback: (() -> Unit)? = null
 
-    /// from characteristic UUIDs to the handler function for notfies
+    // / from characteristic UUIDs to the handler function for notfies
     private val notifyHandlers = mutableMapOf<UUID, (BluetoothGattCharacteristic) -> Unit>()
 
     private val serviceScope = CoroutineScope(Dispatchers.IO)
 
-    /**
-     * A BLE status code based error
-     */
+    /** A BLE status code based error */
     class BLEStatusException(val status: Int, msg: String) : BLEException(msg)
 
     // 0x2902 org.bluetooth.descriptor.gatt.client_characteristic_configuration.xml
-    private val configurationDescriptorUUID =
-        longBLEUUID("2902")
+    private val configurationDescriptorUUID = longBLEUUID("2902")
 
     /**
-     * a schedulable bit of bluetooth work, includes both the closure to call to start the operation
-     * and the completion (either async or sync) to call when it completes
+     * a schedulable bit of bluetooth work, includes both the closure to call to start the operation and the completion
+     * (either async or sync) to call when it completes
      */
     private class BluetoothContinuation(
         val tag: String,
         val completion: com.geeksville.mesh.concurrent.Continuation<*>,
         val timeoutMillis: Long = 0, // If we want to timeout this operation at a certain time, use a non zero value
-        private val startWorkFn: () -> Boolean
+        private val startWorkFn: () -> Boolean,
     ) : Logging {
 
-        /// Start running a queued bit of work, return true for success or false for fatal bluetooth error
+        // / Start running a queued bit of work, return true for success or false for fatal bluetooth error
         fun startWork(): Boolean {
             debug("Starting work: $tag")
             return startWorkFn()
         }
 
-        override fun toString(): String {
-            return "Work:$tag"
-        }
+        override fun toString(): String = "Work:$tag"
 
-        /// Connection work items are treated specially
+        // / Connection work items are treated specially
         fun isConnect() = tag == "connect" || tag == "reconnect"
     }
 
@@ -117,213 +122,256 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
      */
     private val mHandler: Handler = Handler(Looper.getMainLooper())
 
+    /**
+     * Attempts an emergency restart of the Bluetooth adapter. This is a workaround for certain BLE stack issues. It
+     * checks for necessary permissions (BLUETOOTH_CONNECT on API 31+, BLUETOOTH_ADMIN on older versions) before
+     * attempting to disable and then re-enable the adapter.
+     */
     fun restartBle() {
         GeeksvilleApplication.analytics.track("ble_restart") // record # of times we needed to use this nasty hack
         errormsg("Doing emergency BLE restart")
-        context.bluetoothManager?.adapter?.let { adp ->
-            if (adp.isEnabled) {
-                adp.disable()
-                // TODO: display some kind of UI about restarting BLE
-                mHandler.postDelayed(object : Runnable {
+
+        val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+        val adapter = bluetoothManager?.adapter
+
+        if (adapter == null) {
+            errormsg("BluetoothAdapter not available for BLE restart.")
+            return
+        }
+
+        val hasPermission =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) ==
+                    PackageManager.PERMISSION_GRANTED
+            } else {
+                ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_ADMIN) ==
+                    PackageManager.PERMISSION_GRANTED
+            }
+
+        if (!hasPermission) {
+            errormsg("Missing Bluetooth permission (CONNECT or ADMIN) for BLE restart.")
+            return
+        }
+
+        if (adapter.isEnabled) {
+            warn("Attempting to disable Bluetooth adapter.")
+            if (!adapter.disable()) {
+                errormsg("adapter.disable() failed.")
+                return
+            }
+            // TODO: display some kind of UI about restarting BLE
+            mHandler.postDelayed(
+                object : Runnable {
+                    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
                     override fun run() {
-                        if (!adp.isEnabled) {
-                            adp.enable()
+                        if (!adapter.isEnabled) {
+                            warn("Attempting to re-enable Bluetooth adapter.")
+                            if (!adapter.enable()) {
+                                errormsg("adapter.enable() failed.")
+                            } else {
+                                info("Bluetooth adapter re-enabled.")
+                            }
                         } else {
+                            // Adapter might have been re-enabled by user or another process, or disable() is async and
+                            // hasn't completed.
+                            // Or, isEnabled check post-disable was too quick.
+                            // If it's still enabled, we retry enabling check later, assuming disable will eventually
+                            // take effect.
+                            warn("Adapter still enabled, retrying enable check soon.")
                             mHandler.postDelayed(this, 2500)
                         }
                     }
-                }, 2500)
+                },
+                2500,
+            )
+        } else {
+            info("Bluetooth adapter already disabled, attempting to enable.")
+            if (!adapter.enable()) {
+                errormsg("adapter.enable() failed while adapter was already disabled.")
+            } else {
+                info("Bluetooth adapter enabled.")
             }
         }
     }
 
+    companion object {
+        private const val STATUS_RELIABLE_WRITE_FAILED = 4403
+        private const val STATUS_TIMEOUT = 4404
+        private const val STATUS_NOSTART = 4405
+        private const val STATUS_SIMFAILURE = 4406
+    }
+
     // Our own custom BLE status codes
-    private val STATUS_RELIABLE_WRITE_FAILED = 4403
-    private val STATUS_TIMEOUT = 4404
-    private val STATUS_NOSTART = 4405
-    private val STATUS_SIMFAILURE = 4406
 
     /**
      * Should we automatically try to reconnect when we lose our connection?
      *
-     * Originally this was true, but over time (now that clients are smarter and need to build
-     * up more state) I see this was a mistake.  Now if the connection drops we just call
-     * the lostConnection callback and the client of this API is responsible for reconnecting.
-     * This also prevents nasty races when sometimes both the upperlayer and this layer decide to reconnect
-     * simultaneously.
+     * Originally this was true, but over time (now that clients are smarter and need to build up more state) I see this
+     * was a mistake. Now if the connection drops we just call the lostConnection callback and the client of this API is
+     * responsible for reconnecting. This also prevents nasty races when sometimes both the upperlayer and this layer
+     * decide to reconnect simultaneously.
      */
     private val autoReconnect = false
 
-    private val gattCallback = object : BluetoothGattCallback() {
+    private val gattCallback =
+        object : BluetoothGattCallback() {
 
-        override fun onConnectionStateChange(
-            g: BluetoothGatt,
-            status: Int,
-            newState: Int
-        ) = exceptionReporter {
-            info("new bluetooth connection state $newState, status $status")
+            @SuppressLint("MissingPermission")
+            override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) = exceptionReporter {
+                info("new bluetooth connection state $newState, status $status")
 
-            when (newState) {
-                BluetoothProfile.STATE_CONNECTED -> {
-                    state =
-                        newState // we only care about connected/disconnected - not the transitional states
+                when (newState) {
+                    BluetoothProfile.STATE_CONNECTED -> {
+                        state = newState // we only care about connected/disconnected - not the transitional states
 
-                    // If autoconnect is on and this connect attempt failed, hopefully some future attempt will succeed
-                    if (status != BluetoothGatt.GATT_SUCCESS && autoConnect) {
-                        errormsg("Connect attempt failed $status, not calling connect completion handler...")
-                    } else
-                        completeWork(status, Unit)
-                }
-                BluetoothProfile.STATE_DISCONNECTED -> {
-                    if (gatt == null) {
-                        errormsg("No gatt: ignoring connection state $newState, status $status")
-                    } else if (isClosing) {
-                        info("Got disconnect because we are shutting down, closing gatt")
-                        gatt = null
-                        g.close() // Finish closing our gatt here
-                    } else {
-                        // cancel any queued ops if we were already connected
-                        val oldstate = state
-                        state = newState
-                        if (oldstate == BluetoothProfile.STATE_CONNECTED) {
-                            info("Lost connection - aborting current work: $currentWork")
-
-                            // If we get a disconnect, just try again otherwise fail all current operations
-                            // Note: if no work is pending (likely) we also just totally teardown and restart the connection, because we won't be
-                            // throwing a lost connection exception to any worker.
-                            if (autoReconnect && (currentWork == null || currentWork?.isConnect() == true))
-                                dropAndReconnect()
-                            else
-                                lostConnection("lost connection")
-                        } else if (status == 133) {
-                            // We were not previously connected and we just failed with our non-auto connection attempt.  Therefore we now need
-                            // to do an autoconnection attempt.  When that attempt succeeds/fails the normal callbacks will be called
-
-                            // Note: To workaround https://issuetracker.google.com/issues/36995652
-                            // Always call BluetoothDevice#connectGatt() with autoConnect=false
-                            // (the race condition does not affect that case). If that connection times out
-                            // you will get a callback with status=133. Then call BluetoothGatt#connect()
-                            // to initiate a background connection.
-                            if (autoConnect) {
-                                warn("Failed on non-auto connect, falling back to auto connect attempt")
-                                closeGatt() // Close the old non-auto connection
-                                lowLevelConnect(true)
-                            }
-                        } else if (status == 147) {
-                            info("got 147, calling lostConnection()")
-                            lostConnection("code 147")
+                        // If autoconnect is on and this connect attempt failed, hopefully some future attempt will
+                        // succeed
+                        if (status != BluetoothGatt.GATT_SUCCESS && autoConnect) {
+                            errormsg("Connect attempt failed $status, not calling connect completion handler...")
+                        } else {
+                            completeWork(status, Unit)
                         }
+                    }
 
-                        if (status == 257) { // mystery error code when phone is hung
-                            //throw Exception("Mystery bluetooth failure - debug me")
-                            restartBle()
+                    BluetoothProfile.STATE_DISCONNECTED -> {
+                        if (gatt == null) {
+                            errormsg("No gatt: ignoring connection state $newState, status $status")
+                        } else if (isClosing) {
+                            info("Got disconnect because we are shutting down, closing gatt")
+                            gatt = null
+                            g.close() // Finish closing our gatt here
+                        } else {
+                            // cancel any queued ops if we were already connected
+                            val oldstate = state
+                            state = newState
+                            if (oldstate == BluetoothProfile.STATE_CONNECTED) {
+                                info("Lost connection - aborting current work: $currentWork")
+
+                                // If we get a disconnect, just try again otherwise fail all current operations
+                                // Note: if no work is pending (likely) we also just totally teardown and restart
+                                // the connection, because we won't be
+                                // throwing a lost connection exception to any worker.
+                                if (autoConnect && (currentWork == null || currentWork?.isConnect() == true)) {
+                                    dropAndReconnect()
+                                } else {
+                                    lostConnection("lost connection")
+                                }
+                            } else if (status == 133) {
+                                // We were not previously connected and we just failed with our non-auto connection
+                                // attempt.  Therefore we now need
+                                // to do an autoconnection attempt.  When that attempt succeeds/fails the normal
+                                // callbacks will be called
+
+                                // Note: To workaround https://issuetracker.google.com/issues/36995652
+                                // Always call BluetoothDevice#connectGatt() with autoConnect=false
+                                // (the race condition does not affect that case). If that connection times out
+                                // you will get a callback with status=133. Then call BluetoothGatt#connect()
+                                // to initiate a background connection.
+                                if (autoConnect) {
+                                    warn("Failed on non-auto connect, falling back to auto connect attempt")
+                                    closeGatt() // Close the old non-auto connection
+                                    lowLevelConnect(true)
+                                }
+                            } else if (status == 147) {
+                                info("got 147, calling lostConnection()")
+                                lostConnection("code 147")
+                            }
+
+                            if (status == 257) { // mystery error code when phone is hung
+                                // throw Exception("Mystery bluetooth failure - debug me")
+                                restartBle()
+                            }
                         }
                     }
                 }
             }
-        }
 
-        override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
-            // For testing lie and claim failure
-            completeWork(status, Unit)
-        }
-
-        override fun onCharacteristicRead(
-            gatt: BluetoothGatt,
-            characteristic: BluetoothGattCharacteristic,
-            status: Int
-        ) {
-            completeWork(status, characteristic)
-        }
-
-        override fun onReliableWriteCompleted(gatt: BluetoothGatt, status: Int) {
-            completeWork(status, Unit)
-        }
-
-        override fun onCharacteristicWrite(
-            gatt: BluetoothGatt,
-            characteristic: BluetoothGattCharacteristic,
-            status: Int
-        ) {
-            val reliable = currentReliableWrite
-            if (reliable != null)
-                if (!characteristic.value.contentEquals(reliable)) {
-                    errormsg("A reliable write failed!")
-                    gatt.abortReliableWrite()
-                    completeWork(
-                        STATUS_RELIABLE_WRITE_FAILED,
-                        characteristic
-                    ) // skanky code to indicate failure
-                } else {
-                    logAssert(gatt.executeReliableWrite())
-                    // After this execute reliable completes - we can continue with normal operations (see onReliableWriteCompleted)
-                }
-            else // Just a standard write - do the normal flow
-                completeWork(status, characteristic)
-        }
-
-        override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
-            // Alas, passing back an Int mtu isn't working and since I don't really care what MTU
-            // the device was willing to let us have I'm just punting and returning Unit
-            if (isSettingMtu)
+            override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+                // For testing lie and claim failure
                 completeWork(status, Unit)
-            else
-                errormsg("Ignoring bogus onMtuChanged")
-        }
+            }
 
-        /**
-         * Callback triggered as a result of a remote characteristic notification.
-         *
-         * @param gatt GATT client the characteristic is associated with
-         * @param characteristic Characteristic that has been updated as a result of a remote
-         * notification event.
-         */
-        override fun onCharacteristicChanged(
-            gatt: BluetoothGatt,
-            characteristic: BluetoothGattCharacteristic
-        ) {
-            val handler = notifyHandlers.get(characteristic.uuid)
-            if (handler == null)
-                warn("Received notification from $characteristic, but no handler registered")
-            else {
-                exceptionReporter {
-                    handler(characteristic)
+            override fun onCharacteristicRead(
+                gatt: BluetoothGatt,
+                characteristic: BluetoothGattCharacteristic,
+                status: Int,
+            ) {
+                completeWork(status, characteristic)
+            }
+
+            override fun onReliableWriteCompleted(gatt: BluetoothGatt, status: Int) {
+                completeWork(status, Unit)
+            }
+
+            @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+            override fun onCharacteristicWrite(
+                gatt: BluetoothGatt,
+                characteristic: BluetoothGattCharacteristic,
+                status: Int,
+            ) {
+                val reliable = currentReliableWrite
+                if (reliable != null) {
+                    if (!characteristic.value.contentEquals(reliable)) {
+                        errormsg("A reliable write failed!")
+                        gatt.abortReliableWrite()
+                        completeWork(STATUS_RELIABLE_WRITE_FAILED, characteristic) // skanky code to indicate failure
+                    } else {
+                        logAssert(gatt.executeReliableWrite())
+                        // After this execute reliable completes - we can continue with normal operations (see
+                        // onReliableWriteCompleted)
+                    }
+                } else { // Just a standard write - do the normal flow
+                    completeWork(status, characteristic)
                 }
             }
-        }
 
-        /**
-         * Callback indicating the result of a descriptor write operation.
-         *
-         * @param gatt GATT client invoked [BluetoothGatt.writeDescriptor]
-         * @param descriptor Descriptor that was writte to the associated remote device.
-         * @param status The result of the write operation [BluetoothGatt.GATT_SUCCESS] if the
-         * operation succeeds.
-         */
-        override fun onDescriptorWrite(
-            gatt: BluetoothGatt,
-            descriptor: BluetoothGattDescriptor,
-            status: Int
-        ) {
-            completeWork(status, descriptor)
-        }
+            override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
+                // Alas, passing back an Int mtu isn't working and since I don't really care what MTU
+                // the device was willing to let us have I'm just punting and returning Unit
+                if (isSettingMtu) {
+                    completeWork(status, Unit)
+                } else {
+                    errormsg("Ignoring bogus onMtuChanged")
+                }
+            }
 
-        /**
-         * Callback reporting the result of a descriptor read operation.
-         *
-         * @param gatt GATT client invoked [BluetoothGatt.readDescriptor]
-         * @param descriptor Descriptor that was read from the associated remote device.
-         * @param status [BluetoothGatt.GATT_SUCCESS] if the read operation was completed
-         * successfully
-         */
-        override fun onDescriptorRead(
-            gatt: BluetoothGatt,
-            descriptor: BluetoothGattDescriptor,
-            status: Int
-        ) {
-            completeWork(status, descriptor)
+            /**
+             * Callback triggered as a result of a remote characteristic notification.
+             *
+             * @param gatt GATT client the characteristic is associated with
+             * @param characteristic Characteristic that has been updated as a result of a remote notification event.
+             */
+            override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
+                val handler = notifyHandlers.get(characteristic.uuid)
+                if (handler == null) {
+                    warn("Received notification from $characteristic, but no handler registered")
+                } else {
+                    exceptionReporter { handler(characteristic) }
+                }
+            }
+
+            /**
+             * Callback indicating the result of a descriptor write operation.
+             *
+             * @param gatt GATT client invoked [BluetoothGatt.writeDescriptor]
+             * @param descriptor Descriptor that was writte to the associated remote device.
+             * @param status The result of the write operation [BluetoothGatt.GATT_SUCCESS] if the operation succeeds.
+             */
+            override fun onDescriptorWrite(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int) {
+                completeWork(status, descriptor)
+            }
+
+            /**
+             * Callback reporting the result of a descriptor read operation.
+             *
+             * @param gatt GATT client invoked [BluetoothGatt.readDescriptor]
+             * @param descriptor Descriptor that was read from the associated remote device.
+             * @param status [BluetoothGatt.GATT_SUCCESS] if the read operation was completed successfully
+             */
+            override fun onDescriptorRead(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int) {
+                completeWork(status, descriptor)
+            }
         }
-    }
 
     // To test loss of BLE faults we can randomly fail a certain % of all work items.  We
     // skip this for "connect" items because the handling for connection failure is special
@@ -334,7 +382,7 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
 
     private var activeTimeout: Job? = null
 
-    /// If we have work we can do, start doing it.
+    // / If we have work we can do, start doing it.
     private fun startNewWork() {
         logAssert(currentWork == null)
 
@@ -343,23 +391,18 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
             currentWork = newWork
 
             if (newWork.timeoutMillis != 0L) {
-
-                activeTimeout = serviceScope.launch {
-                    // debug("Starting failsafe timer ${newWork.timeoutMillis}")
-                    delay(newWork.timeoutMillis)
-                    errormsg("Failsafe BLE timer expired!")
-                    completeWork(
-                        STATUS_TIMEOUT,
-                        Unit
-                    ) // Throw an exception in that work
-                }
+                activeTimeout =
+                    serviceScope.launch {
+                        // debug("Starting failsafe timer ${newWork.timeoutMillis}")
+                        delay(newWork.timeoutMillis)
+                        errormsg("Failsafe BLE timer expired!")
+                        completeWork(STATUS_TIMEOUT, Unit) // Throw an exception in that work
+                    }
             }
 
-            isSettingMtu =
-                false // Most work is not doing MTU stuff, the work that is will re set this flag
+            isSettingMtu = false // Most work is not doing MTU stuff, the work that is will re set this flag
 
-            val failThis =
-                simFailures && !newWork.isConnect() && failRandom.nextInt(100) < failPercent
+            val failThis = simFailures && !newWork.isConnect() && failRandom.nextInt(100) < failPercent
 
             if (failThis) {
                 errormsg("Simulating random work failure!")
@@ -368,42 +411,27 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
                 val started = newWork.startWork()
                 if (!started) {
                     errormsg("Failed to start work, returned error status")
-                    completeWork(
-                        STATUS_NOSTART,
-                        Unit
-                    ) // abandon the current attempt and try for another
+                    completeWork(STATUS_NOSTART, Unit) // abandon the current attempt and try for another
                 }
             }
         }
     }
 
-    private fun <T> queueWork(
-        tag: String,
-        cont: Continuation<T>,
-        timeout: Long,
-        initFn: () -> Boolean
-    ) {
-        val btCont =
-            BluetoothContinuation(
-                tag,
-                cont,
-                timeout,
-                initFn
-            )
+    private fun <T> queueWork(tag: String, cont: Continuation<T>, timeout: Long, initFn: () -> Boolean) {
+        val btCont = BluetoothContinuation(tag, cont, timeout, initFn)
 
         synchronized(workQueue) {
             debug("Enqueuing work: ${btCont.tag}")
             workQueue.add(btCont)
 
             // if we don't have any outstanding operations, run first item in queue
-            if (currentWork == null)
+            if (currentWork == null) {
                 startNewWork()
+            }
         }
     }
 
-    /**
-     * Stop any current work
-     */
+    /** Stop any current work */
     private fun stopCurrentWork() {
         activeTimeout?.let {
             it.cancel()
@@ -412,12 +440,11 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
         currentWork = null
     }
 
-    /**
-     * Called from our big GATT callback, completes the current job and then schedules a new one
-     */
+    /** Called from our big GATT callback, completes the current job and then schedules a new one */
     private fun <T : Any> completeWork(status: Int, res: T) {
         exceptionReporter {
-            // We might unexpectedly fail inside here, but we don't want to pass that exception back up to the bluetooth GATT layer
+            // We might unexpectedly fail inside here, but we don't want to pass that exception back up to the bluetooth
+            // GATT layer
 
             // startup next job in queue before calling the completion handler
             val work =
@@ -432,26 +459,22 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
                     w
                 }
 
-            if (work == null)
+            if (work == null) {
                 warn("wor completed, but we already killed it via failsafetimer? status=$status, res=$res")
-            else {
+            } else {
                 // debug("work ${work.tag} is completed, resuming status=$status, res=$res")
-                if (status != 0)
+                if (status != 0) {
                     work.completion.resumeWithException(
-                        BLEStatusException(
-                            status,
-                            "Bluetooth status=$status while doing ${work.tag}"
-                        )
+                        BLEStatusException(status, "Bluetooth status=$status while doing ${work.tag}"),
                     )
-                else
+                } else {
                     work.completion.resume(Result.success(res) as Result<Nothing>)
+                }
             }
         }
     }
 
-    /**
-     * Something went wrong, abort all queued
-     */
+    /** Something went wrong, abort all queued */
     private fun failAllWork(ex: Exception) {
         synchronized(workQueue) {
             warn("Failing ${workQueue.size} works, because ${ex.message}")
@@ -459,10 +482,7 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
                 try {
                     it.completion.resumeWithException(ex)
                 } catch (ex: Exception) {
-                    errormsg(
-                        "Mystery exception, why were we informed about our own exceptions?",
-                        ex
-                    )
+                    errormsg("Mystery exception, why were we informed about our own exceptions?", ex)
                 }
             }
             workQueue.clear()
@@ -470,7 +490,7 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
         }
     }
 
-    /// helper glue to make sync continuations and then wait for the result
+    // / helper glue to make sync continuations and then wait for the result
     private fun <T> makeSync(wrappedFn: (SyncContinuation<T>) -> Unit): T {
         val cont = SyncContinuation<T>()
         wrappedFn(cont)
@@ -480,28 +500,21 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
     // Is the gatt trying to repeatedly connect as needed?
     private var autoConnect = false
 
-    /// True if the current active connection is auto (possible for this to be false but autoConnect to be true
-    /// if we are in the first non-automated lowLevel connect.
+    // / True if the current active connection is auto (possible for this to be false but autoConnect to be true
+    // / if we are in the first non-automated lowLevel connect.
     private var currentConnectIsAuto = false
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     private fun lowLevelConnect(autoNow: Boolean): BluetoothGatt? {
         currentConnectIsAuto = autoNow
         logAssert(gatt == null)
 
-        val g = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            device.connectGatt(
-                context,
-                autoNow,
-                gattCallback,
-                BluetoothDevice.TRANSPORT_LE
-            )
-        } else {
-            device.connectGatt(
-                context,
-                autoNow,
-                gattCallback
-            )
-        }
+        val g =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                device.connectGatt(context, autoNow, gattCallback, BluetoothDevice.TRANSPORT_LE)
+            } else {
+                device.connectGatt(context, autoNow, gattCallback)
+            }
 
         gatt = g
         return g
@@ -512,16 +525,12 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
     // see https://stackoverflow.com/questions/40156699/which-correct-flag-of-autoconnect-in-connectgatt-of-ble for
     // more info.
     // Otherwise if you pass in false, it will try to connect now and will timeout and fail in 30 seconds.
-    private fun queueConnect(
-        autoConnect: Boolean = false,
-        cont: Continuation<Unit>,
-        timeout: Long = 0
-    ) {
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    private fun queueConnect(autoConnect: Boolean = false, cont: Continuation<Unit>, timeout: Long = 0) {
         this.autoConnect = autoConnect
 
         // assert(gatt == null) this now might be !null with our new reconnect support
         queueWork("connect", cont, timeout) {
-
             // Note: To workaround https://issuetracker.google.com/issues/36995652
             // Always call BluetoothDevice#connectGatt() with autoConnect=false
             // (the race condition does not affect that case). If that connection times out
@@ -535,36 +544,35 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
     /**
      * start a connection attempt.
      *
-     * Note: if autoConnect is true, the callback you provide will be kept around _even after the connection is complete.
-     * If we ever lose the connection, this class will immediately requque the attempt (after canceling
-     * any outstanding queued operations).
+     * Note: if autoConnect is true, the callback you provide will be kept around _even after the connection is
+     * complete. If we ever lose the connection, this class will immediately requque the attempt (after canceling any
+     * outstanding queued operations).
      *
      * So you should expect your callback might be called multiple times, each time to reestablish a new connection.
      */
-    fun asyncConnect(
-        autoConnect: Boolean = false,
-        cb: (Result<Unit>) -> Unit,
-        lostConnectCb: () -> Unit
-    ) {
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun asyncConnect(autoConnect: Boolean = false, cb: (Result<Unit>) -> Unit, lostConnectCb: () -> Unit) {
         logAssert(workQueue.isEmpty())
-        if (currentWork != null)
+        if (currentWork != null) {
             throw AssertionError("currentWork was not null: $currentWork")
+        }
 
         lostConnectCallback = lostConnectCb
-        connectionCallback = if (autoConnect)
-            cb
-        else
-            null
+        connectionCallback =
+            if (autoConnect) {
+                cb
+            } else {
+                null
+            }
         queueConnect(autoConnect, CallbackContinuation(cb))
     }
 
-    /// Restart any previous connect attempts
+    // / Restart any previous connect attempts
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     private fun reconnect() {
         // closeGatt() // Get rid of any old gatt
 
-        connectionCallback?.let { cb ->
-            queueConnect(true, CallbackContinuation(cb))
-        }
+        connectionCallback?.let { cb -> queueConnect(true, CallbackContinuation(cb)) }
     }
 
     private fun lostConnection(reason: String) {
@@ -577,7 +585,7 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
         https://stackoverflow.com/questions/37965337/what-exactly-does-androids-bluetooth-autoconnect-parameter-do?rq=1
 
         closeConnection()
-        */
+         */
         failAllWork(BLEException(reason))
 
         // Cancel any notifications - because when the device comes back it might have forgotten about us
@@ -589,7 +597,8 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
         }
     }
 
-    /// Drop our current connection and then requeue a connect as needed
+    // / Drop our current connection and then requeue a connect as needed
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     private fun dropAndReconnect() {
         lostConnection("lost connection, reconnecting")
 
@@ -599,155 +608,161 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
             debug("queuing a reconnection callback")
             assert(currentWork == null)
 
-            if (!currentConnectIsAuto) { // we must have been running during that 1-time manual connect, switch to auto-mode from now on
+            if (
+                !currentConnectIsAuto
+            ) { // we must have been running during that 1-time manual connect, switch to auto-mode from now on
                 closeGatt() // Close the old non-auto connection
                 lowLevelConnect(true)
             }
 
-            // note - we don't need an init fn (because that would normally redo the connectGatt call - which we don't need)
-            queueWork("reconnect", CallbackContinuation(cb), 0) { -> true }
+            // note - we don't need an init fn (because that would normally redo the connectGatt call - which we don't
+            // need)
+            queueWork("reconnect", CallbackContinuation(cb), 0) { true }
         } else {
             debug("No connectionCallback registered")
         }
     }
 
-    fun connect(autoConnect: Boolean = false) =
-        makeSync<Unit> { queueConnect(autoConnect, it) }
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun connect(autoConnect: Boolean = false) = makeSync<Unit> { queueConnect(autoConnect, it) }
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     private fun queueReadCharacteristic(
         c: BluetoothGattCharacteristic,
-        cont: Continuation<BluetoothGattCharacteristic>, timeout: Long = 0
+        cont: Continuation<BluetoothGattCharacteristic>,
+        timeout: Long = 0,
     ) = queueWork("readC ${c.uuid}", cont, timeout) { gatt!!.readCharacteristic(c) }
 
-    fun asyncReadCharacteristic(
-        c: BluetoothGattCharacteristic,
-        cb: (Result<BluetoothGattCharacteristic>) -> Unit
-    ) = queueReadCharacteristic(c, CallbackContinuation(cb))
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun asyncReadCharacteristic(c: BluetoothGattCharacteristic, cb: (Result<BluetoothGattCharacteristic>) -> Unit) =
+        queueReadCharacteristic(c, CallbackContinuation(cb))
 
-    fun readCharacteristic(
-        c: BluetoothGattCharacteristic,
-        timeout: Long = timeoutMsec
-    ): BluetoothGattCharacteristic =
-        makeSync { queueReadCharacteristic(c, it, timeout) }
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun readCharacteristic(c: BluetoothGattCharacteristic, timeout: Long = timeoutMsec): BluetoothGattCharacteristic =
+        makeSync {
+            queueReadCharacteristic(c, it, timeout)
+        }
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     private fun queueDiscoverServices(cont: Continuation<Unit>, timeout: Long = 0) {
         queueWork("discover", cont, timeout) {
             gatt?.discoverServices()
-                ?: false // throw BLEException("GATT is null") - if we return false here it is probably because the device is being torn down
+                ?: false // throw BLEException("GATT is null") - if we return false here it is probably because the
+            // device is being torn down
         }
     }
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     fun asyncDiscoverServices(cb: (Result<Unit>) -> Unit) {
         queueDiscoverServices(CallbackContinuation(cb))
     }
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     fun discoverServices() = makeSync<Unit> { queueDiscoverServices(it) }
 
-    /**
-     * On some phones we receive bogus mtu gatt callbacks, we need to ignore them if we weren't setting the mtu
-     */
+    /** On some phones we receive bogus mtu gatt callbacks, we need to ignore them if we weren't setting the mtu */
     private var isSettingMtu = false
 
     /**
-     * mtu operations seem to hang sometimes.  To cope with this we have a 5 second timeout before throwing an exception and cancelling the work
+     * mtu operations seem to hang sometimes. To cope with this we have a 5 second timeout before throwing an exception
+     * and cancelling the work
      */
-    private fun queueRequestMtu(
-        len: Int,
-        cont: Continuation<Unit>
-    ) = queueWork("reqMtu", cont, 10 * 1000) {
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    private fun queueRequestMtu(len: Int, cont: Continuation<Unit>) = queueWork("reqMtu", cont, 10 * 1000) {
         isSettingMtu = true
         gatt?.requestMtu(len) ?: false
     }
 
-    fun asyncRequestMtu(
-        len: Int,
-        cb: (Result<Unit>) -> Unit
-    ) {
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun asyncRequestMtu(len: Int, cb: (Result<Unit>) -> Unit) {
         queueRequestMtu(len, CallbackContinuation(cb))
     }
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     fun requestMtu(len: Int): Unit = makeSync { queueRequestMtu(len, it) }
 
     private var currentReliableWrite: ByteArray? = null
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     private fun queueWriteCharacteristic(
         c: BluetoothGattCharacteristic,
         v: ByteArray,
-        cont: Continuation<BluetoothGattCharacteristic>, timeout: Long = 0
+        cont: Continuation<BluetoothGattCharacteristic>,
+        timeout: Long = 0,
     ) = queueWork("writeC ${c.uuid}", cont, timeout) {
         currentReliableWrite = null
         c.value = v
         gatt?.writeCharacteristic(c) ?: false
     }
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     fun asyncWriteCharacteristic(
         c: BluetoothGattCharacteristic,
         v: ByteArray,
-        cb: (Result<BluetoothGattCharacteristic>) -> Unit
+        cb: (Result<BluetoothGattCharacteristic>) -> Unit,
     ) = queueWriteCharacteristic(c, v, CallbackContinuation(cb))
 
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     fun writeCharacteristic(
         c: BluetoothGattCharacteristic,
         v: ByteArray,
-        timeout: Long = timeoutMsec
-    ): BluetoothGattCharacteristic =
-        makeSync { queueWriteCharacteristic(c, v, it, timeout) }
-
-    /** Like write, but we use the extra reliable flow documented here:
-     * https://stackoverflow.com/questions/24485536/what-is-reliable-write-in-ble
-     */
-    private fun queueWriteReliable(
-        c: BluetoothGattCharacteristic,
-        cont: Continuation<Unit>, timeout: Long = 0
-    ) = queueWork("rwriteC ${c.uuid}", cont, timeout) {
-        logAssert(gatt!!.beginReliableWrite())
-        currentReliableWrite = c.value.clone()
-        gatt?.writeCharacteristic(c) ?: false
-    }
-
-    fun asyncWriteReliable(
-        c: BluetoothGattCharacteristic,
-        cb: (Result<Unit>) -> Unit
-    ) = queueWriteReliable(c, CallbackContinuation(cb))
-
-    fun writeReliable(c: BluetoothGattCharacteristic): Unit =
-        makeSync { queueWriteReliable(c, it) }
-
-    private fun queueWriteDescriptor(
-        c: BluetoothGattDescriptor,
-        cont: Continuation<BluetoothGattDescriptor>, timeout: Long = 0
-    ) = queueWork("writeD", cont, timeout) { gatt?.writeDescriptor(c) ?: false }
-
-    fun asyncWriteDescriptor(
-        c: BluetoothGattDescriptor,
-        cb: (Result<BluetoothGattDescriptor>) -> Unit
-    ) = queueWriteDescriptor(c, CallbackContinuation(cb))
+        timeout: Long = timeoutMsec,
+    ): BluetoothGattCharacteristic = makeSync { queueWriteCharacteristic(c, v, it, timeout) }
 
     /**
-     * Some old androids have a bug where calling disconnect doesn't guarantee that the onConnectionStateChange callback gets called
-     * but the only safe way to call gatt.close is from that callback.  So we set a flag once we start closing and then poll
-     * until we see the callback has set gatt to null (indicating the CALLBACK has close the gatt).  If the timeout expires we assume the bug
-     * has occurred, and we manually close the gatt here.
+     * Like write, but we use the extra reliable flow documented here:
+     * https://stackoverflow.com/questions/24485536/what-is-reliable-write-in-ble
+     */
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    private fun queueWriteReliable(c: BluetoothGattCharacteristic, cont: Continuation<Unit>, timeout: Long = 0) =
+        queueWork("rwriteC ${c.uuid}", cont, timeout) {
+            logAssert(gatt!!.beginReliableWrite())
+            currentReliableWrite = c.value.clone()
+            gatt?.writeCharacteristic(c) ?: false
+        }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun asyncWriteReliable(c: BluetoothGattCharacteristic, cb: (Result<Unit>) -> Unit) =
+        queueWriteReliable(c, CallbackContinuation(cb))
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun writeReliable(c: BluetoothGattCharacteristic): Unit = makeSync { queueWriteReliable(c, it) }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    private fun queueWriteDescriptor(
+        c: BluetoothGattDescriptor,
+        cont: Continuation<BluetoothGattDescriptor>,
+        timeout: Long = 0,
+    ) = queueWork("writeD", cont, timeout) { gatt?.writeDescriptor(c) ?: false }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun asyncWriteDescriptor(c: BluetoothGattDescriptor, cb: (Result<BluetoothGattDescriptor>) -> Unit) =
+        queueWriteDescriptor(c, CallbackContinuation(cb))
+
+    /**
+     * Some old androids have a bug where calling disconnect doesn't guarantee that the onConnectionStateChange callback
+     * gets called but the only safe way to call gatt.close is from that callback. So we set a flag once we start
+     * closing and then poll until we see the callback has set gatt to null (indicating the CALLBACK has close the
+     * gatt). If the timeout expires we assume the bug has occurred, and we manually close the gatt here.
      *
-     * Log of typical failure
-     * 06-29 08:47:15.035 29788-30155/com.geeksville.mesh D/BluetoothGatt: cancelOpen() - device: 24:62:AB:F8:40:9A
-    06-29 08:47:15.036 29788-30155/com.geeksville.mesh D/BluetoothGatt: close()
-    06-29 08:47:15.037 29788-30155/com.geeksville.mesh D/BluetoothGatt: unregisterApp() - mClientIf=5
-    06-29 08:47:15.037 29788-29813/com.geeksville.mesh D/BluetoothGatt: onClientConnectionState() - status=0 clientIf=5 device=24:62:AB:F8:40:9A
-    06-29 08:47:15.037 29788-29813/com.geeksville.mesh W/BluetoothGatt: Unhandled exception in callback
-    java.lang.NullPointerException: Attempt to invoke virtual method 'void android.bluetooth.BluetoothGattCallback.onConnectionStateChange(android.bluetooth.BluetoothGatt, int, int)' on a null object reference
-    at android.bluetooth.BluetoothGatt$1.onClientConnectionState(BluetoothGatt.java:182)
-    at android.bluetooth.IBluetoothGattCallback$Stub.onTransact(IBluetoothGattCallback.java:70)
-    at android.os.Binder.execTransact(Binder.java:446)
+     * Log of typical failure 06-29 08:47:15.035 29788-30155/com.geeksville.mesh D/BluetoothGatt: cancelOpen() - device:
+     * 24:62:AB:F8:40:9A 06-29 08:47:15.036 29788-30155/com.geeksville.mesh D/BluetoothGatt: close() 06-29 08:47:15.037
+     * 29788-30155/com.geeksville.mesh D/BluetoothGatt: unregisterApp() - mClientIf=5 06-29 08:47:15.037
+     * 29788-29813/com.geeksville.mesh D/BluetoothGatt: onClientConnectionState() - status=0 clientIf=5
+     * device=24:62:AB:F8:40:9A 06-29 08:47:15.037 29788-29813/com.geeksville.mesh W/BluetoothGatt: Unhandled exception
+     * in callback java.lang.NullPointerException: Attempt to invoke virtual method 'void
+     * android.bluetooth.BluetoothGattCallback.onConnectionStateChange(android.bluetooth.BluetoothGatt, int, int)' on a
+     * null object reference at android.bluetooth.BluetoothGatt$1.onClientConnectionState(BluetoothGatt.java:182) at
+     * android.bluetooth.IBluetoothGattCallback$Stub.onTransact(IBluetoothGattCallback.java:70) at
+     * android.os.Binder.execTransact(Binder.java:446)
      *
      * per https://github.com/don/cordova-plugin-ble-central/issues/473#issuecomment-367687575
      */
-    @Volatile
-    private var isClosing = false
+    @Volatile private var isClosing = false
 
     /** Close just the GATT device but keep our pending callbacks active */
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     fun closeGatt() {
-
         gatt?.let { g ->
             info("Closing our GATT connection")
             isClosing = true
@@ -763,13 +778,13 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
 
                 gatt?.let { g2 ->
                     warn("Android onConnectionStateChange did not run, manually closing")
-                    gatt =
-                        null // clear gat before calling close, bcause close might throw dead object exception
+                    gatt = null // clear gat before calling close, bcause close might throw dead object exception
                     g2.close()
                 }
             } catch (ex: NullPointerException) {
-                // Attempt to invoke virtual method 'com.android.bluetooth.gatt.AdvertiseClient com.android.bluetooth.gatt.AdvertiseManager.getAdvertiseClient(int)' on a null object reference
-                //com.geeksville.mesh.service.SafeBluetooth.closeGatt
+                // Attempt to invoke virtual method 'com.android.bluetooth.gatt.AdvertiseClient
+                // com.android.bluetooth.gatt.AdvertiseManager.getAdvertiseClient(int)' on a null object reference
+                // com.geeksville.mesh.service.SafeBluetooth.closeGatt
                 warn("Ignoring NPE in close - probably buggy Samsung BLE")
             } catch (ex: DeadObjectException) {
                 warn("Ignoring dead object exception, probably bluetooth was just disabled")
@@ -780,11 +795,13 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
     }
 
     /**
-     * Close down any existing connection, any existing calls (including async connects will be
-     * cancelled and you'll need to recall connect to use this againt
+     * Close down any existing connection, any existing calls (including async connects will be cancelled and you'll
+     * need to recall connect to use this againt
      */
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     fun closeConnection() {
-        // Set these to null _before_ calling gatt.disconnect(), because we don't want the old lostConnectCallback to get called
+        // Set these to null _before_ calling gatt.disconnect(), because we don't want the old lostConnectCallback to
+        // get called
         lostConnectCallback = null
         connectionCallback = null
 
@@ -796,34 +813,34 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
         failAllWork(BLEConnectionClosing())
     }
 
-    /**
-     * Close and destroy this SafeBluetooth instance.  You'll need to make a new instance before using it again
-     */
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    /** Close and destroy this SafeBluetooth instance. You'll need to make a new instance before using it again */
     override fun close() {
         closeConnection()
 
         // context.unregisterReceiver(btStateReceiver)
     }
 
-
-    /// asyncronously turn notification on/off for a characteristic
-    fun setNotify(
-        c: BluetoothGattCharacteristic,
-        enable: Boolean,
-        onChanged: (BluetoothGattCharacteristic) -> Unit
-    ) {
+    // / asyncronously turn notification on/off for a characteristic
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    fun setNotify(c: BluetoothGattCharacteristic, enable: Boolean, onChanged: (BluetoothGattCharacteristic) -> Unit) {
         debug("starting setNotify(${c.uuid}, $enable)")
         notifyHandlers[c.uuid] = onChanged
         // c.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
         gatt!!.setCharacteristicNotification(c, enable)
 
         // per https://stackoverflow.com/questions/27068673/subscribe-to-a-ble-gatt-notification-android
-        val descriptor: BluetoothGattDescriptor = c.getDescriptor(configurationDescriptorUUID)
-            ?: throw BLEException("Notify descriptor not found for ${c.uuid}") // This can happen on buggy BLE implementations
+        val descriptor: BluetoothGattDescriptor =
+            c.getDescriptor(configurationDescriptorUUID)
+                ?: throw BLEException(
+                    "Notify descriptor not found for ${c.uuid}",
+                ) // This can happen on buggy BLE implementations
         descriptor.value =
-            if (enable) BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE else BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
-        asyncWriteDescriptor(descriptor) {
-            debug("Notify enable=$enable completed")
-        }
+            if (enable) {
+                BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+            } else {
+                BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE
+            }
+        asyncWriteDescriptor(descriptor) { debug("Notify enable=$enable completed") }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
@@ -17,7 +17,8 @@
 
 package com.geeksville.mesh.ui.connections.components
 
-import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -32,106 +33,139 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.core.app.ActivityCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.geeksville.mesh.R
 import com.geeksville.mesh.android.getBluetoothPermissions
 import com.geeksville.mesh.model.BTScanModel
 import com.geeksville.mesh.service.MeshService
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
 
+/**
+ * Composable that displays a list of Bluetooth Low Energy (BLE) devices and allows scanning.
+ * It handles Bluetooth permissions using `accompanist-permissions`.
+ *
+ * @param connectionState The current connection state of the MeshService.
+ * @param btDevices List of discovered BLE devices.
+ * @param selectedDevice The full address of the currently selected device.
+ * @param scanModel The ViewModel responsible for Bluetooth scanning logic.
+ */
+@OptIn(ExperimentalPermissionsApi::class)
 @Suppress("LongMethod")
 @Composable
 fun BLEDevices(
     connectionState: MeshService.ConnectionState,
     btDevices: List<BTScanModel.DeviceListEntry>,
     selectedDevice: String,
-    showBluetoothRationaleDialog: () -> Unit,
-    requestBluetoothPermission: (Array<String>) -> Unit,
-    scanModel: BTScanModel
+    scanModel: BTScanModel,
 ) {
     val context = LocalContext.current
     val isScanning by scanModel.spinner.collectAsStateWithLifecycle(false)
+
+    // Define permissions needed for Bluetooth scanning based on Android version.
+    val bluetoothPermissions = remember { context.getBluetoothPermissions() }
+
+    val permissionsState = rememberMultiplePermissionsState(bluetoothPermissions)
+
     Text(
         text = stringResource(R.string.bluetooth),
         style = MaterialTheme.typography.titleLarge,
-        modifier = Modifier.padding(vertical = 8.dp)
+        modifier = Modifier.padding(vertical = 8.dp),
     )
-    btDevices.forEach { device ->
-        DeviceListItem(
-            connectionState = connectionState,
-            device = device,
-            selected = device.fullAddress == selectedDevice,
-            onSelect = { scanModel.onSelected(device) },
-            modifier = Modifier
-        )
-    }
-    if (isScanning) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
-            horizontalAlignment = CenterHorizontally
-        ) {
-            CircularProgressIndicator(
-                modifier = Modifier.size(96.dp)
-            )
-            Text(
-                text = stringResource(R.string.scanning),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(vertical = 8.dp)
+
+    if (permissionsState.allPermissionsGranted) {
+        btDevices.forEach { device ->
+            DeviceListItem(
+                connectionState = connectionState,
+                device = device,
+                selected = device.fullAddress == selectedDevice,
+                onSelect = { scanModel.onSelected(device) },
+                modifier = Modifier,
             )
         }
-    } else if (btDevices.filterNot { it.isDisconnect }.isEmpty()) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
-            horizontalAlignment = CenterHorizontally
-        ) {
-            Icon(
-                imageVector = Icons.Default.BluetoothDisabled,
-                contentDescription = stringResource(R.string.no_ble_devices),
-                modifier = Modifier.size(96.dp)
-            )
-            Text(
-                text = stringResource(R.string.no_ble_devices),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(vertical = 8.dp)
-            )
-        }
-    }
-    Button(
-        enabled = !isScanning,
-        modifier = Modifier.fillMaxWidth(),
-        onClick = {
-            val bluetoothPermissions = context.getBluetoothPermissions()
-            if (bluetoothPermissions.isEmpty()) {
-                // If no permissions needed, trigger the scan directly (or via ViewModel)
-                scanModel.startScan()
-            } else {
-                if (bluetoothPermissions.any { permission ->
-                        ActivityCompat.shouldShowRequestPermissionRationale(
-                            context as Activity,
-                            permission
-                        )
-                    }
-                ) {
-                    showBluetoothRationaleDialog()
-                } else {
-                    requestBluetoothPermission(bluetoothPermissions)
-                }
+        if (isScanning) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(96.dp),
+                )
+                Text(
+                    text = stringResource(R.string.scanning),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            }
+        } else if (btDevices.filterNot { it.isDisconnect }.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.BluetoothDisabled,
+                    contentDescription = stringResource(R.string.no_ble_devices),
+                    modifier = Modifier.size(96.dp),
+                )
+                Text(
+                    // Consider a more specific string if no devices are found vs. just not scanning
+                    text = stringResource(R.string.no_ble_devices_found), // Assuming R.string.no_ble_devices_found exists
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
             }
         }
+    } else {
+        // Show a message and a button to grant permissions if not all granted
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            val textToShow = if (permissionsState.shouldShowRationale) {
+                stringResource(R.string.bluetooth_permission_rationale)
+            } else {
+                stringResource(R.string.bluetooth_permission_required_to_scan)
+            }
+            Text(text = textToShow, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+
+    Button(
+        enabled = !isScanning, // Keep disabled during scan
+        modifier = Modifier.fillMaxWidth(),
+        onClick = {
+            if (permissionsState.allPermissionsGranted) {
+                scanModel.startScan()
+            } else {
+                permissionsState.launchMultiplePermissionRequest()
+            }
+        },
     ) {
         Icon(
             imageVector = Icons.Default.Bluetooth,
-            contentDescription = stringResource(R.string.scan)
+            contentDescription = stringResource(R.string.scan_for_bluetooth_devices), // More descriptive
         )
-        Text(stringResource(R.string.scan))
+        Text(
+            if (permissionsState.allPermissionsGranted) {
+                stringResource(R.string.scan)
+            } else {
+                stringResource(R.string.grant_permissions_and_scan) // Assuming R.string.grant_permissions_and_scan exists
+            },
+        )
     }
 }
+

--- a/app/src/main/java/com/geeksville/mesh/ui/intro/AppIntroComponents.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/intro/AppIntroComponents.kt
@@ -17,12 +17,15 @@
 
 package com.geeksville.mesh.ui.intro
 
-import androidx.annotation.DrawableRes
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.annotation.StringRes
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -30,184 +33,520 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.outlined.BatteryAlert
+import androidx.compose.material.icons.outlined.Hub
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.Message
+import androidx.compose.material.icons.outlined.NearMe
+import androidx.compose.material.icons.outlined.Router
+import androidx.compose.material.icons.outlined.SettingsInputAntenna
+import androidx.compose.material.icons.outlined.SpeakerPhone
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import com.geeksville.mesh.R
-import com.geeksville.mesh.ui.common.components.AutoLinkText
-import kotlinx.coroutines.launch
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionState
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.google.accompanist.permissions.rememberPermissionState
 
-// Data class for a slide
-private data class IntroSlide(
-    val title: String,
-    val description: String,
-    @DrawableRes val imageRes: Int,
+/** Sealed class defining type-safe navigation routes for the app introduction flow. */
+sealed class IntroRoute(val route: String) {
+    object Welcome : IntroRoute("welcome")
+
+    object Notifications : IntroRoute("notifications")
+
+    object Location : IntroRoute("location")
+
+    object CriticalAlerts : IntroRoute("critical_alerts")
+}
+
+private const val SETTINGS_TAG = "settings_link_tag"
+
+/**
+ * Data class representing the UI elements for a feature row.
+ *
+ * @param icon The vector asset for the feature icon.
+ * @param titleRes Optional string resource ID for the feature title.
+ * @param subtitleRes String resource ID for the feature subtitle.
+ */
+private data class FeatureUIData(
+    val icon: ImageVector,
+    @StringRes val titleRes: Int? = null,
+    @StringRes val subtitleRes: Int,
 )
 
-@Suppress("LongMethod")
-@OptIn(ExperimentalFoundationApi::class)
+/**
+ * Composable function for the main application introduction screen. This screen guides the user through initial setup
+ * steps like granting permissions.
+ *
+ * @param onDone Callback invoked when the introduction flow is completed.
+ */
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun AppIntroductionScreen(onDone: () -> Unit) {
-    val slides = slides()
-    val pagerState = rememberPagerState(pageCount = { slides.size })
-    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+    val navController = rememberNavController()
+
+    val notificationPermissionState: PermissionState? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            null
+        }
+
+    val locationPermissions =
+        listOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
+    val locationPermissionState = rememberMultiplePermissionsState(permissions = locationPermissions)
+
+    NavHost(navController = navController, startDestination = IntroRoute.Welcome.route) {
+        composable(IntroRoute.Welcome.route) {
+            WelcomeScreen(onGetStarted = { navController.navigate(IntroRoute.Notifications.route) })
+        }
+        composable(IntroRoute.Notifications.route) {
+            val notificationsAlreadyGranted = notificationPermissionState?.status?.isGranted ?: true
+            NotificationsScreen(
+                showNextButton = notificationsAlreadyGranted,
+                onSkip = { navController.navigate(IntroRoute.Location.route) },
+                onConfigure = {
+                    if (notificationsAlreadyGranted) {
+                        navController.navigate(IntroRoute.CriticalAlerts.route)
+                    } else {
+                        notificationPermissionState.launchPermissionRequest()
+                    }
+                },
+            )
+        }
+        composable(IntroRoute.CriticalAlerts.route) {
+            CriticalAlertsScreen(
+                onSkip = { navController.navigate(IntroRoute.Location.route) },
+                onConfigure = {
+                    val intent =
+                        Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {
+                            putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                            putExtra(Settings.EXTRA_CHANNEL_ID, "my_alerts")
+                        }
+                    context.startActivity(intent)
+                    navController.navigate(IntroRoute.Location.route)
+                },
+            )
+        }
+        composable(IntroRoute.Location.route) {
+            val locationAlreadyGranted = locationPermissionState.allPermissionsGranted
+            LocationScreen(
+                showNextButton = locationAlreadyGranted,
+                onSkip = onDone,
+                onConfigure = {
+                    if (locationAlreadyGranted) {
+                        onDone()
+                    } else {
+                        locationPermissionState.launchMultiplePermissionRequest()
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun WelcomeScreen(onGetStarted: () -> Unit) {
+    val features = remember {
+        listOf(
+            FeatureUIData(
+                icon = Icons.Outlined.SettingsInputAntenna,
+                titleRes = R.string.stay_connected_anywhere,
+                subtitleRes = R.string.communicate_off_the_grid,
+            ),
+            FeatureUIData(
+                icon = Icons.Outlined.Hub,
+                titleRes = R.string.create_your_own_networks,
+                subtitleRes = R.string.easily_set_up_private_mesh_networks,
+            ),
+            FeatureUIData(
+                icon = Icons.Outlined.NearMe,
+                titleRes = R.string.track_and_share_locations,
+                subtitleRes = R.string.share_your_location_in_real_time,
+            ),
+        )
+    }
 
     Scaffold(
         bottomBar = {
-            Surface(shadowElevation = 8.dp) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 20.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    if (pagerState.currentPage < slides.size - 1) {
-                        TextButton(onClick = onDone) {
-                            Text(stringResource(id = R.string.app_intro_skip_button))
-                        }
-                    } else {
-                        TextButton(onClick = {
-                            scope.launch {
-                                pagerState.animateScrollToPage(pagerState.currentPage - 1)
-                            }
-                        }) {
-                            Text(stringResource(id = R.string.app_intro_back_button))
-                        }
-                    }
+            IntroBottomBar(
+                onSkip = {}, // No skip on welcome, but could be passed if needed
+                onConfigure = onGetStarted,
+                skipButtonText = "", // Not shown
+                configureButtonText = stringResource(id = R.string.get_started),
+                showSkipButton = false, // Explicitly hide skip for welcome
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+            Modifier.fillMaxSize().padding(innerPadding).padding(16.dp).verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.intro_welcome),
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(R.string.meshtastic),
+                style = MaterialTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+            features.forEach { feature ->
+                FeatureRow(feature = feature)
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
 
-                    PagerIndicator(
-                        slideCount = slides.size,
-                        currentPage = pagerState.currentPage,
-                        modifier = Modifier.weight(1f)
-                    )
+@Composable
+private fun NotificationsScreen(showNextButton: Boolean, onSkip: () -> Unit, onConfigure: () -> Unit) {
+    val context = LocalContext.current
+    val annotatedString =
+        context.createClickableAnnotatedString(
+            fullTextRes = R.string.notification_permissions_description,
+            linkTextRes = R.string.settings,
+            tag = SETTINGS_TAG,
+        )
 
-                    if (pagerState.currentPage < slides.size - 1) {
-                        TextButton(
-                            onClick = {
-                                scope.launch {
-                                    pagerState.animateScrollToPage(pagerState.currentPage + 1)
-                                }
-                            }
-                        ) {
-                            Text(stringResource(id = R.string.app_intro_next_button))
-                        }
-                    } else {
-                        Button(onClick = onDone) {
-                            Text(stringResource(id = R.string.app_intro_done_button))
-                        }
+    val features = remember {
+        listOf(
+            FeatureUIData(
+                icon = Icons.Outlined.Message,
+                titleRes = R.string.incoming_messages,
+                subtitleRes = R.string.notifications_for_channel_and_direct_messages,
+            ),
+            FeatureUIData(
+                icon = Icons.Outlined.SpeakerPhone,
+                titleRes = R.string.new_nodes,
+                subtitleRes = R.string.notifications_for_newly_discovered_nodes,
+            ),
+            FeatureUIData(
+                icon = Icons.Outlined.BatteryAlert,
+                titleRes = R.string.low_battery,
+                subtitleRes = R.string.notifications_for_low_battery_alerts,
+            ),
+        )
+    }
+
+    PermissionScreenLayout(
+        headlineRes = R.string.app_notifications,
+        annotatedDescription = annotatedString,
+        features = features,
+        additionalContent = {
+            Text(
+                text = stringResource(R.string.critical_alerts),
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            FeatureRow(
+                feature =
+                FeatureUIData(icon = Icons.Filled.Notifications, subtitleRes = R.string.critical_alerts_description),
+            )
+        },
+        onSkip = onSkip,
+        onConfigure = onConfigure,
+        configureButtonTextRes = if (showNextButton) R.string.next else R.string.configure_notification_permissions,
+        onAnnotationClick = {
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            intent.data = Uri.fromParts("package", context.packageName, null)
+            context.startActivity(intent)
+        },
+    )
+}
+
+@Composable
+fun CriticalAlertsScreen(onSkip: () -> Unit, onConfigure: () -> Unit) {
+    Scaffold(
+        bottomBar = {
+            IntroBottomBar(
+                onSkip = onSkip,
+                onConfigure = onConfigure,
+                configureButtonText = stringResource(id = R.string.configure_critical_alerts),
+                skipButtonText = stringResource(id = R.string.skip),
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+            Modifier.fillMaxSize().padding(innerPadding).padding(16.dp).verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.critical_alerts),
+                style = MaterialTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.critical_alerts_dnd_request_text),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LocationScreen(showNextButton: Boolean, onSkip: () -> Unit, onConfigure: () -> Unit) {
+    val context = LocalContext.current
+    val annotatedString =
+        context.createClickableAnnotatedString(
+            fullTextRes = R.string.phone_location_description,
+            linkTextRes = R.string.settings,
+            tag = SETTINGS_TAG,
+        )
+
+    val features = remember {
+        listOf(
+            FeatureUIData(
+                icon = Icons.Outlined.LocationOn,
+                titleRes = R.string.share_location,
+                subtitleRes = R.string.share_location_description,
+            ),
+            FeatureUIData(
+                icon = Icons.Outlined.Router,
+                titleRes = R.string.distance_measurements,
+                subtitleRes = R.string.distance_measurements_description,
+            ),
+            FeatureUIData(
+                icon = Icons.Outlined.Router,
+                titleRes = R.string.distance_filters,
+                subtitleRes = R.string.distance_filters_description,
+            ),
+            FeatureUIData(
+                icon = Icons.Outlined.LocationOn,
+                titleRes = R.string.mesh_map_location,
+                subtitleRes = R.string.mesh_map_location_description,
+            ),
+        )
+    }
+
+    PermissionScreenLayout(
+        headlineRes = R.string.phone_location,
+        annotatedDescription = annotatedString,
+        features = features,
+        onSkip = onSkip,
+        onConfigure = onConfigure,
+        configureButtonTextRes = if (showNextButton) R.string.next else R.string.configure_location_permissions,
+        onAnnotationClick = {
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            intent.data = Uri.fromParts("package", context.packageName, null)
+            context.startActivity(intent)
+        },
+    )
+}
+
+/**
+ * A generic layout for screens within the app introduction flow. It typically presents a headline, a descriptive text
+ * (potentially with clickable annotations), a list of features, and standard navigation buttons.
+ *
+ * @param headlineRes String resource for the main headline of the screen.
+ * @param annotatedDescription The [AnnotatedString] for the main descriptive text.
+ * @param features A list of [FeatureUIData] to be displayed using [FeatureRow].
+ * @param additionalContent Optional composable lambda for adding custom content below the features.
+ * @param onSkip Callback for the skip action.
+ * @param onConfigure Callback for the main configure/next action.
+ * @param configureButtonTextRes String resource for the main action button.
+ * @param onAnnotationClick Callback invoked when a tagged annotation within [annotatedDescription] is clicked.
+ */
+@Composable
+private fun PermissionScreenLayout(
+    @StringRes headlineRes: Int,
+    annotatedDescription: AnnotatedString,
+    features: List<FeatureUIData>,
+    additionalContent: (@Composable () -> Unit)? = null,
+    onSkip: () -> Unit,
+    onConfigure: () -> Unit,
+    @StringRes configureButtonTextRes: Int,
+    onAnnotationClick: (String) -> Unit,
+) {
+    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+
+    val pressIndicator =
+        Modifier.pointerInput(Unit) {
+            detectTapGestures { offset ->
+                textLayoutResult?.let { layoutResult ->
+                    val position = layoutResult.getOffsetForPosition(offset)
+                    annotatedDescription.getStringAnnotations(
+                        SETTINGS_TAG,
+                        position,
+                        position,
+                    ).firstOrNull()?.let { annotation ->
+                        onAnnotationClick(annotation.item)
                     }
                 }
             }
         }
-    ) { innerPadding ->
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-        ) { page ->
-            IntroScreenContent(slides[page])
-        }
-    }
-}
 
-@Composable
-private fun slides(): List<IntroSlide> {
-    val slides = listOf(
-        IntroSlide(
-            title = stringResource(R.string.intro_welcome),
-            description = stringResource(R.string.intro_welcome_text),
-            imageRes = R.drawable.app_icon,
-        ),
-        IntroSlide(
-            title = stringResource(R.string.intro_started),
-            description = stringResource(R.string.intro_started_text),
-            imageRes = R.drawable.icon_meanings,
-        ),
-        IntroSlide(
-            title = stringResource(R.string.intro_encryption),
-            description = stringResource(R.string.intro_encryption_text),
-            imageRes = R.drawable.channel_name_image,
-        )
-    )
-    return slides
-}
-
-@Composable
-private fun IntroScreenContent(slide: IntroSlide) {
-    Surface(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            Image(
-                painter = painterResource(id = slide.imageRes),
-                contentDescription = slide.title,
-                modifier = Modifier
-                    .size(200.dp)
-                    .clip(CircleShape),
-                contentScale = ContentScale.Crop,
+    Scaffold(
+        bottomBar = {
+            IntroBottomBar(
+                onSkip = onSkip,
+                onConfigure = onConfigure,
+                configureButtonText = stringResource(id = configureButtonTextRes),
+                skipButtonText = stringResource(id = R.string.skip),
             )
-            Spacer(modifier = Modifier.height(32.dp))
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+            Modifier.fillMaxSize().padding(innerPadding).padding(16.dp).verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
             Text(
-                text = slide.title,
-                style = MaterialTheme.typography.headlineMedium,
-                textAlign = TextAlign.Center
+                text = stringResource(headlineRes),
+                style = MaterialTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center,
             )
             Spacer(modifier = Modifier.height(16.dp))
-            AutoLinkText(
-                text = slide.description,
-                style = MaterialTheme.typography.bodyLarge,
+            Text(
+                text = annotatedDescription,
+                style =
+                MaterialTheme.typography.bodyLarge.copy(
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                ),
+                modifier = Modifier.padding(horizontal = 16.dp).then(pressIndicator),
+                onTextLayout = { textLayoutResult = it },
             )
+            Spacer(modifier = Modifier.height(16.dp))
+            features.forEach { feature ->
+                FeatureRow(feature = feature)
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+            additionalContent?.invoke()
         }
     }
 }
 
+/**
+ * A common bottom bar used across app introduction screens. Provides consistent "Skip" and "Configure" (or "Next")
+ * buttons.
+ *
+ * @param onSkip Callback for the skip action.
+ * @param onConfigure Callback for the main configure/next action.
+ * @param skipButtonText Text for the skip button.
+ * @param configureButtonText Text for the configure/next button.
+ * @param showSkipButton Whether to display the skip button. Defaults to true.
+ */
 @Composable
-fun PagerIndicator(slideCount: Int, currentPage: Int, modifier: Modifier = Modifier) {
-    Row(
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
-    ) {
-        repeat(slideCount) { iteration ->
-            val color =
-                if (currentPage == iteration) {
-                    MaterialTheme.colorScheme.primary
-                } else {
-                    MaterialTheme.colorScheme.onSurface.copy(
-                        alpha = 0.2f
-                    )
-                }
-            Box(
-                modifier = Modifier
-                    .padding(4.dp)
-                    .clip(CircleShape)
-                    .background(color)
-                    .size(12.dp)
+private fun IntroBottomBar(
+    onSkip: () -> Unit,
+    onConfigure: () -> Unit,
+    skipButtonText: String,
+    configureButtonText: String,
+    showSkipButton: Boolean = true,
+) {
+    Surface(shadowElevation = 8.dp) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = if (showSkipButton) Arrangement.SpaceBetween else Arrangement.End,
+        ) {
+            if (showSkipButton) {
+                Button(onClick = onSkip) { Text(skipButtonText) }
+            }
+            Button(onClick = onConfigure) { Text(configureButtonText) }
+        }
+    }
+}
+
+/**
+ * Creates an [AnnotatedString] with a clickable portion.
+ *
+ * @param fullTextRes String resource for the entire text.
+ * @param linkTextRes String resource for the portion of text that should be clickable.
+ * @param tag A tag to identify the annotation.
+ * @return An [AnnotatedString] with the specified portion styled and annotated.
+ */
+@Composable
+private fun Context.createClickableAnnotatedString(
+    @StringRes fullTextRes: Int,
+    @StringRes linkTextRes: Int,
+    tag: String,
+): AnnotatedString {
+    val fullText = stringResource(id = fullTextRes)
+    val linkText = stringResource(id = linkTextRes)
+    val startIndex = fullText.indexOf(linkText)
+
+    return buildAnnotatedString {
+        append(fullText)
+        if (startIndex != -1) {
+            val endIndex = startIndex + linkText.length
+            addStyle(
+                style = SpanStyle(color = MaterialTheme.colorScheme.primary, textDecoration = TextDecoration.Underline),
+                start = startIndex,
+                end = endIndex,
+            )
+            addStringAnnotation(tag = tag, annotation = linkText, start = startIndex, end = endIndex)
+        }
+    }
+}
+
+/**
+ * Displays a row for a feature, including an icon, an optional title, and a subtitle.
+ *
+ * @param feature The [FeatureUIData] containing information for the row.
+ */
+@Composable
+private fun FeatureRow(feature: FeatureUIData) {
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+        Icon(
+            imageVector = feature.icon,
+            contentDescription =
+            feature.titleRes?.let { stringResource(id = it) } ?: stringResource(id = feature.subtitleRes),
+            modifier = Modifier.padding(end = 16.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Column {
+            feature.titleRes?.let { titleRes ->
+                Text(
+                    text = stringResource(id = titleRes),
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                )
+            }
+            Text(
+                text = stringResource(id = feature.subtitleRes),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapView.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapView.kt
@@ -17,9 +17,8 @@
 
 package com.geeksville.mesh.ui.map
 
+import android.Manifest // Added for Accompanist
 import android.content.Context
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -67,10 +66,8 @@ import com.geeksville.mesh.DataPacket
 import com.geeksville.mesh.MeshProtos.Waypoint
 import com.geeksville.mesh.R
 import com.geeksville.mesh.android.BuildUtils.debug
-import com.geeksville.mesh.android.getLocationPermissions
 import com.geeksville.mesh.android.gpsDisabled
 import com.geeksville.mesh.android.hasGps
-import com.geeksville.mesh.android.hasLocationPermission
 import com.geeksville.mesh.copy
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.model.Node
@@ -89,6 +86,8 @@ import com.geeksville.mesh.util.createLatLongGrid
 import com.geeksville.mesh.util.formatAgo
 import com.geeksville.mesh.util.zoomIn
 import com.geeksville.mesh.waypoint
+import com.google.accompanist.permissions.ExperimentalPermissionsApi // Added for Accompanist
+import com.google.accompanist.permissions.rememberMultiplePermissionsState // Added for Accompanist
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.osmdroid.bonuspack.utils.BonusPackHelper.getBitmapFromVectorDrawable
 import org.osmdroid.config.Configuration
@@ -201,6 +200,14 @@ private fun Context.purgeTileSource(onResult: (String) -> Unit) {
     builder.show()
 }
 
+/**
+ * Main composable for displaying the map view, including nodes, waypoints, and user location. It handles user
+ * interactions for map manipulation, filtering, and offline caching.
+ *
+ * @param model The [UIViewModel] providing data and state for the map.
+ * @param navigateToNodeDetails Callback to navigate to the details screen of a selected node.
+ */
+@OptIn(ExperimentalPermissionsApi::class) // Added for Accompanist
 @Suppress("CyclomaticComplexMethod", "LongMethod")
 @Composable
 fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Unit) {
@@ -208,13 +215,11 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
 
     val mapFilterState by model.mapFilterStateFlow.collectAsState()
 
-    // UI Elements
     var cacheEstimate by remember { mutableStateOf("") }
 
     var zoomLevelMin by remember { mutableDoubleStateOf(0.0) }
     var zoomLevelMax by remember { mutableDoubleStateOf(0.0) }
 
-    // Map Elements
     var downloadRegionBoundingBox: BoundingBox? by remember { mutableStateOf(null) }
     var myLocationOverlay: MyLocationNewOverlay? by remember { mutableStateOf(null) }
 
@@ -229,6 +234,11 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
     fun performHapticFeedback() = haptic.performHapticFeedback(HapticFeedbackType.LongPress)
 
     val hasGps = remember { context.hasGps() }
+
+    // Accompanist permissions state for location
+    val locationPermissionsState =
+        rememberMultiplePermissionsState(permissions = listOf(Manifest.permission.ACCESS_FINE_LOCATION))
+    var triggerLocationToggleAfterPermission by remember { mutableStateOf(false) }
 
     fun loadOnlineTileSourceBase(): ITileSource {
         val id = model.mapStyleId
@@ -279,10 +289,13 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
         }
     }
 
-    val requestPermissionAndToggleLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-            if (permissions.entries.all { it.value }) map.toggleMyLocation()
+    // Effect to toggle MyLocation after permission is granted
+    LaunchedEffect(locationPermissionsState.allPermissionsGranted) {
+        if (locationPermissionsState.allPermissionsGranted && triggerLocationToggleAfterPermission) {
+            map.toggleMyLocation()
+            triggerLocationToggleAfterPermission = false
         }
+    }
 
     val nodes by model.filteredNodeList.collectAsStateWithLifecycle()
     val waypoints by model.waypoints.collectAsStateWithLifecycle(emptyMap())
@@ -294,9 +307,9 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
         val ourNode = model.ourNodeInfo.value
         val gpsFormat = model.config.display.gpsFormat.number
         val displayUnits = model.config.display.units
-        val mapFilterState = model.mapFilterStateFlow.value // Access mapFilterState directly
+        val mapFilterStateValue = model.mapFilterStateFlow.value // Access mapFilterState directly
         return nodesWithPosition.mapNotNull { node ->
-            if (mapFilterState.onlyFavorites && !node.isFavorite && !node.equals(ourNode)) {
+            if (mapFilterStateValue.onlyFavorites && !node.isFavorite && !node.equals(ourNode)) {
                 return@mapNotNull null
             }
 
@@ -320,7 +333,7 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
                 position = nodePosition
                 icon = markerIcon
                 setNodeColors(node.colors)
-                if (!mapFilterState.showPrecisionCircle) {
+                if (!mapFilterStateValue.showPrecisionCircle) {
                     setPrecisionBits(0)
                 } else {
                     setPrecisionBits(p.precisionBits)
@@ -388,7 +401,7 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
         val dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
         return waypoints.mapNotNull { waypoint ->
             val pt = waypoint.data.waypoint ?: return@mapNotNull null
-            if (!mapFilterState.showWaypoints) return@mapNotNull null
+            if (!mapFilterState.showWaypoints) return@mapNotNull null // Use collected mapFilterState
             val lock = if (pt.lockedTo != 0) "\uD83D\uDD12" else ""
             val time = dateFormat.format(waypoint.received_time)
             val label = pt.name + " " + formatAgo((waypoint.received_time / 1000).toInt())
@@ -418,7 +431,7 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
                 title = "${pt.name} (${getUsername(waypoint.data.from)}$lock)"
                 snippet = "[$time] ${pt.description}  " + stringResource(R.string.expires) + ": $expireTimeStr"
                 position = GeoPoint(pt.latitudeI * 1e-7, pt.longitudeI * 1e-7)
-                setVisible(false)
+                setVisible(false) // This seems to be always false, was this intended?
                 setOnLongClickListener {
                     showMarkerLongPressDialog(pt.id)
                     true
@@ -430,7 +443,7 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
     LaunchedEffect(showCurrentCacheInfo) {
         if (!showCurrentCacheInfo) return@LaunchedEffect
         model.showSnackbar(R.string.calculating)
-        val cacheManager = CacheManager(map) // Make sure CacheManager has latest from map
+        val cacheManager = CacheManager(map)
         val cacheCapacity = cacheManager.cacheCapacity()
         val currentCacheUsage = cacheManager.currentCacheUsage()
 
@@ -483,7 +496,7 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
             overlays.add(nodeClusterer)
         }
 
-        addCopyright() // Copyright is required for certain map sources
+        addCopyright()
         addScaleBarOverlay(density)
         createLatLongGrid(false)
 
@@ -492,10 +505,9 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
 
     with(map) { UpdateMarkers(onNodesChanged(nodes), onWaypointChanged(waypoints.values), nodeClusterer) }
 
-    /** Creates Box overlay showing what area can be downloaded */
     fun MapView.generateBoxOverlay() {
         overlays.removeAll { it is Polygon }
-        val zoomFactor = 1.3 // zoom difference between view and download area polygon
+        val zoomFactor = 1.3
         zoomLevelMin = minOf(zoomLevelDouble, zoomLevelMax)
         downloadRegionBoundingBox = boundingBox.zoomIn(zoomFactor)
         val polygon =
@@ -528,12 +540,10 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
             val outputName = buildString {
                 append(Configuration.getInstance().osmdroidBasePath.absolutePath)
                 append(File.separator)
-                append("mainFile.sqlite") // TODO: Accept filename input param from user
+                append("mainFile.sqlite")
             }
             val writer = SqliteArchiveTileWriter(outputName)
-            // Make sure cacheManager has latest from map
             val cacheManager = CacheManager(map, writer)
-            // this triggers the download
             cacheManager.downloadAreaAsync(
                 context,
                 boundingBox,
@@ -589,7 +599,6 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
                         map.generateBoxOverlay()
                         dialog.dismiss()
                     }
-
                     2 -> purgeTileSource { model.showSnackbar(it) }
                     else -> dialog.dismiss()
                 }
@@ -606,12 +615,12 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
             AndroidView(
                 factory = {
                     map.apply {
-                        setDestroyMode(false) // keeps map instance alive when in the background
+                        setDestroyMode(false)
                         addMapListener(boxOverlayListener)
                     }
                 },
                 modifier = Modifier.fillMaxSize(),
-                update = { map -> map.drawOverlays() },
+                update = { mapView -> mapView.drawOverlays() }, // Renamed map to mapView to avoid conflict
             )
             if (downloadRegionBoundingBox != null) {
                 CacheLayout(
@@ -645,7 +654,6 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
                             onDismissRequest = { mapFilterExpanded = false },
                             modifier = Modifier.background(MaterialTheme.colorScheme.surface),
                         ) {
-                            // Only Favorites toggle
                             DropdownMenuItem(
                                 text = {
                                     Row(
@@ -714,7 +722,7 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
                                         )
                                         Checkbox(
                                             checked = mapFilterState.showPrecisionCircle,
-                                            onCheckedChange = { enabled -> model.toggleShowPrecisionCircleOnMap() },
+                                            onCheckedChange = { model.toggleShowPrecisionCircleOnMap() },
                                             modifier = Modifier.padding(start = 8.dp),
                                         )
                                     }
@@ -733,10 +741,11 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
                             },
                             contentDescription = stringResource(R.string.toggle_my_position),
                         ) {
-                            if (context.hasLocationPermission()) {
+                            if (locationPermissionsState.allPermissionsGranted) {
                                 map.toggleMyLocation()
                             } else {
-                                requestPermissionAndToggleLauncher.launch(context.getLocationPermissions())
+                                triggerLocationToggleAfterPermission = true
+                                locationPermissionsState.launchMultiplePermissionRequest()
                             }
                         }
                     }
@@ -747,7 +756,7 @@ fun MapView(model: UIViewModel = viewModel(), navigateToNodeDetails: (Int) -> Un
 
     if (showEditWaypointDialog != null) {
         EditWaypointDialog(
-            waypoint = showEditWaypointDialog ?: return,
+            waypoint = showEditWaypointDialog ?: return, // Safe call
             onSendClicked = { waypoint ->
                 debug("User clicked send waypoint ${waypoint.id}")
                 showEditWaypointDialog = null

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/ContactSharing.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/ContactSharing.kt
@@ -17,12 +17,11 @@
 
 package com.geeksville.mesh.ui.sharing
 
-import android.content.pm.PackageManager
+import android.Manifest
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Base64
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -36,11 +35,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
@@ -59,12 +56,14 @@ import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.R
 import com.geeksville.mesh.android.BuildUtils.debug
 import com.geeksville.mesh.android.BuildUtils.errormsg
-import com.geeksville.mesh.android.getCameraPermissions
 import com.geeksville.mesh.model.DeviceVersion
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.common.components.CopyIconButton
 import com.geeksville.mesh.ui.common.components.SimpleAlertDialog
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 import com.google.protobuf.ByteString
 import com.google.protobuf.Descriptors
 import com.google.zxing.BarcodeFormat
@@ -75,6 +74,15 @@ import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import java.net.MalformedURLException
 
+/**
+ * Composable FloatingActionButton to initiate scanning a QR code for adding a contact. Handles camera permission
+ * requests using Accompanist Permissions.
+ *
+ * @param modifier Modifier for this composable.
+ * @param model UIViewModel for interacting with application state.
+ * @param onSharedContactImport Callback invoked when a shared contact is successfully imported.
+ */
+@OptIn(ExperimentalPermissionsApi::class)
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 fun AddContactFAB(
@@ -85,20 +93,22 @@ fun AddContactFAB(
     val context = LocalContext.current
     val contactToImport: AdminProtos.SharedContact? by model.sharedContactRequested.collectAsStateWithLifecycle(null)
 
-    val barcodeLauncher = rememberLauncherForActivityResult(ScanContract()) { result ->
-        if (result.contents != null) {
-            val uri = result.contents.toUri()
-            val sharedContact = try {
-                uri.toSharedContact()
-            } catch (ex: MalformedURLException) {
-                errormsg("URL was malformed: ${ex.message}")
-                null
-            }
-            if (sharedContact != null) {
-                model.setSharedContactRequested(sharedContact)
+    val barcodeLauncher =
+        rememberLauncherForActivityResult(ScanContract()) { result ->
+            if (result.contents != null) {
+                val uri = result.contents.toUri()
+                val sharedContact =
+                    try {
+                        uri.toSharedContact()
+                    } catch (ex: MalformedURLException) {
+                        errormsg("URL was malformed: ${ex.message}")
+                        null
+                    }
+                if (sharedContact != null) {
+                    model.setSharedContactRequested(sharedContact)
+                }
             }
         }
-    }
 
     if (contactToImport != null) {
         val nodeNum = contactToImport?.nodeNum
@@ -109,39 +119,27 @@ fun AddContactFAB(
             text = {
                 Column {
                     if (node != null) {
-                        Text(
-                            text = stringResource(
-                                R.string.import_known_shared_contact_text
-                            )
-                        )
+                        Text(text = stringResource(R.string.import_known_shared_contact_text))
                         if (node.user.publicKey.size() > 0 && node.user.publicKey != contactToImport?.user?.publicKey) {
                             Text(
-                                text = stringResource(
-                                    R.string.public_key_changed
-                                ),
-                                color = MaterialTheme.colorScheme.error
+                                text = stringResource(R.string.public_key_changed),
+                                color = MaterialTheme.colorScheme.error,
                             )
                         }
                         HorizontalDivider()
-                        Text(
-                            text = compareUsers(node.user, contactToImport!!.user)
-                        )
+                        Text(text = compareUsers(node.user, contactToImport!!.user))
                     } else {
-                        Text(
-                            text = userFieldsToString(contactToImport!!.user)
-                        )
+                        Text(text = userFieldsToString(contactToImport!!.user))
                     }
                 }
             },
             dismissText = stringResource(R.string.cancel),
-            onDismiss = {
-                model.setSharedContactRequested(null)
-            },
+            onDismiss = { model.setSharedContactRequested(null) },
             confirmText = stringResource(R.string.import_label),
             onConfirm = {
                 onSharedContactImport(contactToImport!!)
                 model.setSharedContactRequested(null)
-            }
+            },
         )
     }
 
@@ -155,181 +153,136 @@ fun AddContactFAB(
         barcodeLauncher.launch(zxingScan)
     }
 
-    val requestPermissionAndScanLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-            if (permissions.entries.all { it.value }) zxingScan()
-        }
+    val cameraPermissionState = rememberPermissionState(Manifest.permission.CAMERA)
 
-    var showPermissionRationale by remember { mutableStateOf(false) }
-    if (showPermissionRationale) {
-        SimpleAlertDialog(
-            title = R.string.camera_required,
-            text = R.string.why_camera_required,
-            onDismiss = {
-                debug("Camera permission denied")
-                showPermissionRationale = false
-            },
-            onConfirm = {
-                requestPermissionAndScanLauncher.launch(context.getCameraPermissions())
-                showPermissionRationale = false
-            }
-        )
-    }
-    fun requestPermissionAndScan() {
-        showPermissionRationale = true
+    LaunchedEffect(cameraPermissionState.status) {
+        if (cameraPermissionState.status.isGranted) {
+            // If permission was granted as a result of a request, and not initially,
+            // we might want to trigger the scan. However, simple auto-triggering on grant
+            // might not always be desired UX. For now, rely on user re-click if needed.
+        }
     }
 
     FloatingActionButton(
         onClick = {
-            if (context.getCameraPermissions().all {
-                    context.checkSelfPermission(it) == PackageManager.PERMISSION_GRANTED
-                }
-            ) {
+            if (cameraPermissionState.status.isGranted) {
                 zxingScan()
             } else {
-                requestPermissionAndScan()
+                cameraPermissionState.launchPermissionRequest()
             }
         },
-        modifier = modifier.padding(16.dp)
+        modifier = modifier.padding(16.dp),
     ) {
-        Icon(
-            imageVector = Icons.TwoTone.QrCodeScanner,
-            contentDescription = stringResource(R.string.scan_qr_code),
-        )
+        Icon(imageVector = Icons.TwoTone.QrCodeScanner, contentDescription = stringResource(R.string.scan_qr_code))
     }
 }
 
 @Composable
-private fun QrCodeImage(
-    uri: Uri,
-    modifier: Modifier = Modifier,
-) = Image(
-    painter = uri.qrCode
-        ?.let { BitmapPainter(it.asImageBitmap()) }
-        ?: painterResource(id = R.drawable.qrcode),
+private fun QrCodeImage(uri: Uri, modifier: Modifier = Modifier) = Image(
+    painter = uri.qrCode?.let { BitmapPainter(it.asImageBitmap()) } ?: painterResource(id = R.drawable.qrcode),
     contentDescription = stringResource(R.string.qr_code),
     modifier = modifier,
     contentScale = ContentScale.Inside,
 )
 
 @Composable
-private fun SharedContact(
-    contactUri: Uri,
-) {
+private fun SharedContact(contactUri: Uri) {
     Column {
-        QrCodeImage(
-            uri = contactUri,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 4.dp)
-        )
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = contactUri.toString(),
-                modifier = Modifier
-                    .weight(1f)
-            )
-            CopyIconButton(
-                valueToCopy = contactUri.toString(),
-                modifier = Modifier.padding(start = 8.dp)
-            )
+        QrCodeImage(uri = contactUri, modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp))
+        Row(modifier = Modifier.fillMaxWidth().padding(4.dp), verticalAlignment = Alignment.CenterVertically) {
+            Text(text = contactUri.toString(), modifier = Modifier.weight(1f))
+            CopyIconButton(valueToCopy = contactUri.toString(), modifier = Modifier.padding(start = 8.dp))
         }
     }
 }
 
+/**
+ * Displays a dialog with the contact's information as a QR code and URI.
+ *
+ * @param contact The node representing the contact to share. Null if no contact is selected.
+ * @param onDismiss Callback invoked when the dialog is dismissed.
+ */
 @Composable
-fun SharedContactDialog(
-    contact: Node?,
-    onDismiss: () -> Unit,
-) {
+fun SharedContactDialog(contact: Node?, onDismiss: () -> Unit) {
     if (contact == null) return
-    val sharedContact =
-        AdminProtos.SharedContact.newBuilder().setUser(contact.user).setNodeNum(contact.num).build()
+    val sharedContact = AdminProtos.SharedContact.newBuilder().setUser(contact.user).setNodeNum(contact.num).build()
     val uri = sharedContact.getSharedContactUrl()
     SimpleAlertDialog(
         title = R.string.share_contact,
         text = {
             Column {
                 Text(contact.user.longName)
-                SharedContact(
-                    contactUri = uri,
-                )
+                SharedContact(contactUri = uri)
             }
         },
-        onDismiss = onDismiss
+        onDismiss = onDismiss,
     )
 }
 
 @Preview
 @Composable
 private fun ShareContactPreview() {
-    SharedContact(
-        contactUri = "https://example.com".toUri(),
-    )
+    SharedContact(contactUri = "https://example.com".toUri())
 }
 
+/** Bitmap representation of the Uri as a QR code, or null if generation fails. */
 val Uri.qrCode: Bitmap?
-    get() = try {
-        val multiFormatWriter = MultiFormatWriter()
-        val bitMatrix =
-            multiFormatWriter.encode(
-                this.toString(),
-                BarcodeFormat.QR_CODE,
-                BARCODE_PIXEL_SIZE,
-                BARCODE_PIXEL_SIZE
-            )
-        val barcodeEncoder = BarcodeEncoder()
-        barcodeEncoder.createBitmap(bitMatrix)
-    } catch (ex: WriterException) {
-        errormsg("URL was too complex to render as barcode: ${ex.message}")
-        null
-    }
+    get() =
+        try {
+            val multiFormatWriter = MultiFormatWriter()
+            val bitMatrix =
+                multiFormatWriter.encode(this.toString(), BarcodeFormat.QR_CODE, BARCODE_PIXEL_SIZE, BARCODE_PIXEL_SIZE)
+            val barcodeEncoder = BarcodeEncoder()
+            barcodeEncoder.createBitmap(bitMatrix)
+        } catch (ex: WriterException) {
+            errormsg("URL was too complex to render as barcode: ${ex.message}")
+            null
+        }
 
 private const val REQUIRED_MIN_FIRMWARE = "2.6.8"
 private const val BARCODE_PIXEL_SIZE = 960
 private const val MESHTASTIC_HOST = "meshtastic.org"
 private const val CONTACT_SHARE_PATH = "/v/"
+
+/** Prefix for Meshtastic contact sharing URLs. */
 internal const val URL_PREFIX = "https://$MESHTASTIC_HOST$CONTACT_SHARE_PATH#"
 private const val BASE64FLAGS = Base64.URL_SAFE + Base64.NO_WRAP + Base64.NO_PADDING
 private const val CAMERA_ID = 0
 
-fun DeviceVersion.supportsQrCodeSharing(): Boolean =
-    this >= DeviceVersion(REQUIRED_MIN_FIRMWARE)
+/** Checks if the device firmware version supports QR code sharing. */
+fun DeviceVersion.supportsQrCodeSharing(): Boolean = this >= DeviceVersion(REQUIRED_MIN_FIRMWARE)
 
+/**
+ * Converts a URI to a [AdminProtos.SharedContact].
+ *
+ * @throws MalformedURLException if the URI is not a valid Meshtastic contact sharing URL.
+ */
 @Suppress("MagicNumber")
 @Throws(MalformedURLException::class)
 fun Uri.toSharedContact(): AdminProtos.SharedContact {
-    if (fragment.isNullOrBlank() ||
-        !host.equals(MESHTASTIC_HOST, true) ||
-        !path.equals(CONTACT_SHARE_PATH, true)
-    ) {
+    if (fragment.isNullOrBlank() || !host.equals(MESHTASTIC_HOST, true) || !path.equals(CONTACT_SHARE_PATH, true)) {
         throw MalformedURLException("Not a valid Meshtastic URL: ${toString().take(40)}")
     }
-        val url = AdminProtos.SharedContact.parseFrom(Base64.decode(fragment!!, BASE64FLAGS))
-        return url.toBuilder().build()
-    }
+    val url = AdminProtos.SharedContact.parseFrom(Base64.decode(fragment!!, BASE64FLAGS))
+    return url.toBuilder().build()
+}
 
+/** Converts a [AdminProtos.SharedContact] to its corresponding URI representation. */
 fun AdminProtos.SharedContact.getSharedContactUrl(): Uri {
     val bytes = this.toByteArray() ?: ByteArray(0)
     val enc = Base64.encodeToString(bytes, BASE64FLAGS)
     return "$URL_PREFIX$enc".toUri()
 }
 
+/** Compares two [MeshProtos.User] objects and returns a string detailing the differences. */
 fun compareUsers(oldUser: MeshProtos.User, newUser: MeshProtos.User): String {
     val changes = mutableListOf<String>()
 
     // Iterate over all fields in the User message descriptor
     for (fieldDescriptor: Descriptors.FieldDescriptor in MeshProtos.User.getDescriptor().fields) {
         val fieldName = fieldDescriptor.name
-        val oldValue =
-            if (oldUser.hasField(fieldDescriptor)) oldUser.getField(fieldDescriptor) else null
-        val newValue =
-            if (newUser.hasField(fieldDescriptor)) newUser.getField(fieldDescriptor) else null
+        val oldValue = if (oldUser.hasField(fieldDescriptor)) oldUser.getField(fieldDescriptor) else null
+        val newValue = if (newUser.hasField(fieldDescriptor)) newUser.getField(fieldDescriptor) else null
 
         if (oldValue != newValue) {
             val oldValueString = valueToString(oldValue, fieldDescriptor)
@@ -345,6 +298,7 @@ fun compareUsers(oldUser: MeshProtos.User, newUser: MeshProtos.User): String {
     }
 }
 
+/** Converts a [MeshProtos.User] object to a string representation of its fields and values. */
 fun userFieldsToString(user: MeshProtos.User): String {
     val fieldLines = mutableListOf<String>()
 
@@ -352,21 +306,18 @@ fun userFieldsToString(user: MeshProtos.User): String {
         val fieldName = fieldDescriptor.name
         if (user.hasField(fieldDescriptor)) {
             val value = user.getField(fieldDescriptor)
-            val valueString =
-                valueToString(value, fieldDescriptor) // Using the helper from previous example
+            val valueString = valueToString(value, fieldDescriptor) // Using the helper from previous example
             fieldLines.add("$fieldName: $valueString")
         } else if (fieldDescriptor.isRepeated || fieldDescriptor.hasDefaultValue() || fieldDescriptor.isOptional) {
             val defaultValue = fieldDescriptor.defaultValue
-            val valueString = if (fieldDescriptor.isRepeated) {
-                "[]" // Empty list
-            } else if (user.hasField(fieldDescriptor)) {
-                valueToString(
-                user.getField(fieldDescriptor),
-                fieldDescriptor
-            )
-            } else {
-                valueToString(defaultValue, fieldDescriptor)
-            }
+            val valueString =
+                if (fieldDescriptor.isRepeated) {
+                    "[]" // Empty list
+                } else if (user.hasField(fieldDescriptor)) {
+                    valueToString(user.getField(fieldDescriptor), fieldDescriptor)
+                } else {
+                    valueToString(defaultValue, fieldDescriptor)
+                }
 
             fieldLines.add("$fieldName: $valueString")
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -846,4 +846,5 @@
     <string name="configure_critical_alerts">Configure Critical Alerts</string>
     <string name="notification_permissions_description">Meshtastic uses notifications to keep you updated on new messages and other important events. You can update your notification permissions at any time from settings.</string>
     <string name="next">Next</string>
+    <string name="grant_permissions_and_scan">Grant Permissions and Scan</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,7 +246,6 @@
     <string name="reboot">Reboot</string>
     <string name="traceroute">Traceroute</string>
     <string name="intro_show">Show Introduction</string>
-    <string name="intro_welcome">Welcome to Meshtastic</string>
     <string name="intro_welcome_text">Meshtastic is an open-source, off-grid, encrypted communication platform. The Meshtastic radios form a mesh network and communicate using the LoRa protocol to send text messages.</string>
     <string name="intro_started">…Let\'s get started!</string>
     <string name="intro_started_text">Connect your Meshtastic device by using either Bluetooth, Serial or WiFi. \n\nYou can see which devices are compatible at www.meshtastic.org/docs/hardware</string>
@@ -806,4 +805,45 @@
     <string name="latest_alpha_firmware">Latest alpha</string>
     <string name="supported_by_community">Supported by Meshtastic Community</string>
     <string name="firmware_edition">Firmware Edition</string>
+
+    <string name="get_started">Get started</string>
+    <string name="intro_welcome">Welcome to</string>
+    <string name="stay_connected_anywhere">Stay Connected Anywhere</string>
+    <string name="communicate_off_the_grid">Communicate off-the-grid with your friends and community without cell service.</string>
+    <string name="create_your_own_networks">Create Your Own Networks</string>
+    <string name="easily_set_up_private_mesh_networks">Easily set up private mesh networks for secure and reliable communication in remote areas.</string>
+    <string name="track_and_share_locations">Track and Share Locations</string>
+    <string name="share_your_location_in_real_time">Share your location in real-time and keep your group coordinated with integrated GPS features.</string>
+    <string name="app_notifications">App Notifications</string>
+    <string name="send_notifications">Send Notifications</string>
+    <string name="incoming_messages">Incoming Messages</string>
+    <string name="notifications_for_channel_and_direct_messages">Notifications for channel and direct messages.</string>
+    <string name="new_nodes">New Nodes</string>
+    <string name="notifications_for_newly_discovered_nodes">Notifications for newly discovered nodes.</string>
+    <string name="low_battery">Low Battery</string>
+    <string name="notifications_for_low_battery_alerts">Notifications for low battery alerts for the connected device.</string>
+    <string name="critical_alerts_description">Select packets sent as critical will ignore the mute switch and Do Not Disturb settings in the OS notification center.</string>
+    <string name="configure_notification_permissions">Configure notification permissions</string>
+    <string name="phone_location">Phone Location</string>
+    <string name="phone_location_description">Meshtastic uses your phone\'s location to enable a number of features. You can update your location permissions at any time from settings.</string>
+    <string name="share_location">Share Location</string>
+    <string name="share_location_description">Use your phone GPS to send locations to your node to instead of using a hardware GPS on your node.</string>
+    <string name="enable_location_sharing">Enable Location Sharing</string>
+    <string name="distance_measurements">Distance Measurements</string>
+    <string name="distance_measurements_description">Display the distance between your phone and other Meshtastic nodes with positions.</string>
+    <string name="distance_filters">Distance Filters</string>
+    <string name="distance_filters_description">Filter the node list and mesh map based on proximity to your phone.</string>
+    <string name="mesh_map_location">Mesh Map Location</string>
+    <string name="mesh_map_location_description">Enables the blue location dot for your phone in the mesh map.</string>
+    <string name="configure_location_permissions">Configure Location Permissions</string>
+    <string name="skip">Skip</string>
+    <string name="settings">settings</string>
+    <string name="critical_alerts">Critical Alerts</string>
+    <string name="critical_alerts_dnd_request_text">To ensure you receive critical alerts, such as
+        SOS messages, even when your device is in "Do Not Disturb" mode, you need to grant special
+        permission. Please enable this in the notification settings.
+    </string>
+    <string name="configure_critical_alerts">Configure Critical Alerts</string>
+    <string name="notification_permissions_description">Meshtastic uses notifications to keep you updated on new messages and other important events. You can update your notification permissions at any time from settings.</string>
+    <string name="next">Next</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+accompanistPermissions = "0.37.3"
 adaptive = "1.2.0-alpha09"
 adaptive-navigation-suite = "1.3.2"
 agp = "8.11.1"
@@ -50,6 +51,7 @@ zxing-core = "3.5.3"
 spotless = "7.2.1"
 
 [libraries]
+accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
 agp = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 activity = { group = "androidx.activity", name = "activity" }
 actvity-ktx = { group = "androidx.activity", name = "activity-ktx" }


### PR DESCRIPTION
Refreshes Onboarding to be more informative and align with iOS onboarding experience to provide a more unified client experience and context for permissions checks.

Introduces `accompanist-permissions` for compose based permissions checks and request. 
Refactors in app permissions checks and requests to:
-  fire when more contextually appropriate
-  leverage `accompanist-permissions` where possible.


https://github.com/user-attachments/assets/c9c6d82f-f470-44ab-be44-9f1a651b151b


