### PR TITLE
fix/2542 pair up the power metric icons

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -997,7 +997,8 @@ private fun EnvironmentMetrics(
  * Displays environmental metrics for a node, including temperature, humidity, pressure, and other sensor data.
  *
  * WARNING: All metrics must be added in pairs (e.g., voltage and current for each channel) due to the display logic,
- * which arranges metrics in columns of two. If an odd number of metrics is provided, the UI may not display as intended.
+ * which arranges metrics in columns of two. If an odd number of metrics is provided, the UI may not display as
+ * intended.
  */
 @Composable
 private fun PowerMetrics(node: Node) {
@@ -1028,11 +1029,7 @@ private fun PowerMetrics(node: Node) {
         metrics.chunked(2).forEach { rowMetrics ->
             Column {
                 rowMetrics.forEach { metric ->
-                    InfoCard(
-                        icon = metric.icon,
-                        text = stringResource(metric.label),
-                        value = metric.value,
-                    )
+                    InfoCard(icon = metric.icon, text = stringResource(metric.label), value = metric.value)
                 }
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -993,6 +993,12 @@ private fun EnvironmentMetrics(
     }
 }
 
+/**
+ * Displays environmental metrics for a node, including temperature, humidity, pressure, and other sensor data.
+ *
+ * WARNING: All metrics must be added in pairs (e.g., voltage and current for each channel) due to the display logic,
+ * which arranges metrics in columns of two. If an odd number of metrics is provided, the UI may not display as intended.
+ */
 @Composable
 private fun PowerMetrics(node: Node) {
     val metrics =
@@ -1019,8 +1025,16 @@ private fun PowerMetrics(node: Node) {
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalArrangement = Arrangement.SpaceEvenly,
     ) {
-        metrics.forEach { metric ->
-            InfoCard(icon = metric.icon, text = stringResource(metric.label), value = metric.value)
+        metrics.chunked(2).forEach { rowMetrics ->
+            Column {
+                rowMetrics.forEach { metric ->
+                    InfoCard(
+                        icon = metric.icon,
+                        text = stringResource(metric.label),
+                        value = metric.value,
+                    )
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
closes #2542
Fix regression in power metrics - ensure that they are displayed in pairs with the other data of the channel. 