### PR TITLE
Feat/2586 pr labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+
+# - [ ] need to look at branch / title.     waiting on https://github.com/actions/labeler/pull/866
+# - [x] and an else. 
+
+
+# Add 'enhancement' label to any PR where the head branch name starts with `feat` or has a `feat` section in the name
+enhancement:
+ - head-branch: ['/feat/i']
+
+ # Add 'repo' label to any PR where the head branch name starts with `repo` or has a `repo` section in the name
+ # or files in the .github dir
+repo:
+- any:
+  - head-branch: ['/repo/i']
+  - changed-files:
+    - any-glob-to-any-file: '.github'
+
+ # Add 'bug' label to any PR where the head branch name starts with `fix` or has a `fix` section in the name
+bug:
+  - head-branch: ['/fix/i']
+
+# our fallback - bug except repo, feat, or automated pipelines
+bug:
+  - head-branch: ['^((?!feat).)*$', '^((?!repo).)*$', '^((?!renovate).)*$', '^((?!scheduled).)*$']
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,31 @@
+# Auto Labeler rulse using https://github.com/actions/labeler
+#
 
-# - [ ] need to look at branch / title.     waiting on https://github.com/actions/labeler/pull/866
-# - [x] and an else. 
+# 'fix' in title/branch -> bug
+# 'feat' in title/branch -> enhancement
+# 'repo' in title/branch OR changes to ~/.github/ -> repo
+# 'bug_fallthrough' for everything else except auto 
+#
+# - [ ] need to look at title.     waiting on https://github.com/actions/labeler/pull/866
 
-
-# Add 'enhancement' label to any PR where the head branch name starts with `feat` or has a `feat` section in the name
+# Add 'enhancement' label to any PR where the head branch name contains `feat`
 enhancement:
- - head-branch: ['/feat/i']
+ - head-branch: ['feat']
 
- # Add 'repo' label to any PR where the head branch name starts with `repo` or has a `repo` section in the name
+ # Add 'repo' label to any PR where the head branch name contains `repo` 
  # or files in the .github dir
 repo:
 - any:
-  - head-branch: ['/repo/i']
+  - head-branch: ['repo']
   - changed-files:
     - any-glob-to-any-file: '.github'
 
- # Add 'bug' label to any PR where the head branch name starts with `fix` or has a `fix` section in the name
+ # Add 'bug' label to any PR where the head branch name contains `fix` or `bug`
 bug:
-  - head-branch: ['/fix/i']
+  - head-branch: ['fix', 'bug']
 
 # our fallback - bug except repo, feat, or automated pipelines
 bug_fallthrough:
+- all:
   - head-branch: ['^((?!feat).)*$', '^((?!repo).)*$', '^((?!renovate).)*$', '^((?!scheduled).)*$']
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,6 +20,6 @@ bug:
   - head-branch: ['/fix/i']
 
 # our fallback - bug except repo, feat, or automated pipelines
-bug:
+bug_fallthrough:
   - head-branch: ['^((?!feat).)*$', '^((?!repo).)*$', '^((?!renovate).)*$', '^((?!scheduled).)*$']
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,11 +21,11 @@ repo:
     - any-glob-to-any-file: '.github'
 
  # Add 'bug' label to any PR where the head branch name contains `fix` or `bug`
-bug:
+bugfix:
   - head-branch: ['fix', 'bug']
 
 # our fallback - bug except repo, feat, or automated pipelines
-bug_fallthrough:
-- all:
-  - head-branch: ['^((?!feat).)*$', '^((?!repo).)*$', '^((?!renovate).)*$', '^((?!scheduled).)*$']
+# bug_fallthrough:
+# - all:
+#   - head-branch: ['^((?!feat).)*$', '^((?!repo).)*$', '^((?!renovate).)*$', '^((?!scheduled).)*$']
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,7 @@ changelog:
           - dependencies
           - repo
           - automation
+          - release
 
     - title: 👷Dependencies
       labels:
@@ -30,3 +31,4 @@ changelog:
     - title: 🤖Automated
       labels:
         - automation
+        - release

--- a/.github/workflows/pr_enforce_labels.yml
+++ b/.github/workflows/pr_enforce_labels.yml
@@ -1,0 +1,24 @@
+name: Check PR Labels
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  check-label:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check for PR labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(label => label.name);
+            const requiredLabels = ['bugfix', 'enhancement', 'automation', 'dependencies', 'repo', 'release'];
+            const hasRequiredLabel = labels.some(label => requiredLabels.includes(label));
+            if (!hasRequiredLabel) {
+              core.setFailed(`PR must have at least one of the following labels before it can be merged: ${requiredLabels.join(', ')}.`);
+            }

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - id: label-the-PR
+      uses: actions/labeler@v5

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -1,6 +1,8 @@
 name: "Pull Request Labeler"
 on:
 - pull_request_target
+# Do not execute arbitary code on this workflow. 
+# See warnings at https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target
 
 jobs:
   labeler:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,10 @@ jobs:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
   check-workflow-status:
-    name: Check Workflow Status # Matches another in merge-queue, and is required.
+    name: Check Workflow Status
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     needs:
       [
@@ -47,3 +50,4 @@ jobs:
           }
           exit_on_result "build_and_detekt" "${{ needs.build_and_detekt.result }}"
           exit_on_result "androidTest" "${{ needs.androidTest.result }}"
+      - uses: actions/labeler@v5

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - test_PR
 
 concurrency:
   group: build-pr-${{ github.ref }}
@@ -30,9 +29,6 @@ jobs:
 
   check-workflow-status:
     name: Check Workflow Status
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     needs:
       [
@@ -51,4 +47,3 @@ jobs:
           }
           exit_on_result "build_and_detekt" "${{ needs.build_and_detekt.result }}"
           exit_on_result "androidTest" "${{ needs.androidTest.result }}"
-      - uses: actions/labeler@v5

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - test_PR
 
 concurrency:
   group: build-pr-${{ github.ref }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,12 @@ Comprehensive testing helps prevent regressions and ensures a stable experience 
 
 ## Pull Requests
 
+- branches should start with:
+    - bugfix
+    - enhancement
+    - dependencies
+    - repo
+    - reserved (release, automation)
 - Ensure your branch is up to date with the latest `main` branch before submitting a PR.
 - Provide a meaningful title and description for your PR.
 - Inlude information on how to test and/or replicate if it is not obvious.


### PR DESCRIPTION
- Add an autolabeler on creation of MRs. 
- Makes generation of release changelogs smoother

closes #2586 

tested at https://github.com/DaneEvans/sandbox/pull/4

- [x] All labels used need to be created manually 
- [x] Would do well paired with rules 
- [x] Doco should be updated

@jamesarich  I'm open to ideas wrt changing the labels and rules here. 
For the most part I've reused the GH defaults, and the same ones we have, but I'm certainly not averse to making some new ones.  
Firmware has a check-labels Action, which could be added to our merge checks, and uses 'bugfix' among others. Aligning with them may be a good idea. And make the fallthrough unecessary. 
```
  const requiredLabels = ['bugfix', 'enhancement', 'hardware-support', 'dependencies', 'submodules', 'github_actions', 'trunk'];
```


