### PR TITLE
refactor(bluetooth): exponential backoff for BLE reconnects

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
@@ -107,7 +107,7 @@ constructor(
     Logging {
 
     companion object {
-        // / this service UUID is publicly visible for scanning
+        // this service UUID is publicly visible for scanning
         val BTM_SERVICE_UUID: UUID = UUID.fromString("6ba1b218-15a8-461f-9fa8-5dcae273eafd")
 
         val BTM_FROMRADIO_CHARACTER: UUID = UUID.fromString("2c55e69e-4993-11ed-b878-0242ac120002")

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
@@ -121,7 +121,7 @@ constructor(
         @Volatile var safe: SafeBluetooth? = null
     }
 
-    // / Our BLE device
+    // Our BLE device
     val device
         get() =
             (safe ?: throw RadioNotConnectedException("No SafeBluetooth")).gatt

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
@@ -349,7 +349,7 @@ constructor(
                             debug("Discovered services!")
                             delay(
                                 1000,
-                            ) // android BLE is buggy and needs a 500ms sleep before calling getChracteristic, or you
+                            ) // android BLE is buggy and needs a 1000ms sleep before calling getChracteristic, or you
                             // might get back null
 
                             /* if (isFirstTime) {

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/BluetoothInterface.kt
@@ -127,7 +127,7 @@ constructor(
             (safe ?: throw RadioNotConnectedException("No SafeBluetooth")).gatt
                 ?: throw RadioNotConnectedException("No GATT")
 
-    // / Our service - note - it is possible to get back a null response for getService if the device services haven't
+    // Our service - note - it is possible to get back a null response for getService if the device services haven't
     // yet been found
     private val bservice
         get(): BluetoothGattService =


### PR DESCRIPTION
An attempt at making the bluetooth connection more reliable - this allows more time for recovery when buggy or intermittent.

**NEEDS TESTING**

This change introduces an exponential backoff mechanism for Bluetooth Low Energy (BLE) reconnection attempts. When a BLE connection drops or fails to establish, the system will now wait for an increasing amount of time before retrying. This approach aims to improve connection stability and reduce unnecessary strain on the BLE stack, especially in environments with intermittent connectivity.

The initial backoff delay is 1 second, and it doubles with each subsequent failed attempt, up to a maximum of 64 seconds (after 6 attempts). The reconnect attempt counter is reset upon a successful connection.

Additionally, this commit includes a refactoring of the `SafeBluetooth.closeConnection()` method. It now uses `runBlocking` with `withTimeoutOrNull` to wait for the `onConnectionStateChange` callback after calling `disconnect()`. This provides a more robust way to ensure the GATT object is properly handled during disconnection, preventing potential "DeadObjectException" errors.
