### PR TITLE
Add Types to the templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: Bug Report
 description: File a bug report.
 title: "[Bug]: "
 labels: ["bug"]
+type: [Bug]
 projects: ["meshtastic/Meshtastic-Android"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,9 +1,9 @@
 name: Bug Report
 description: File a bug report.
 title: "[Bug]: "
-labels: ["bug"]
-type: [Bug]
-projects: ["meshtastic/Meshtastic-Android"]
+labels: [bug]
+type: Bug
+projects: [meshtastic/Meshtastic-Android]
 body:
   - type: markdown
     attributes:
@@ -23,7 +23,7 @@ body:
       label: What happened?
       description: Also tell us, what did you expect to happen?
       placeholder: Tell us what you see!
-      value: "A bug happened!"
+      value: A bug happened!
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: Feature Request
 description: File a request for new feature or functionality.
 title: "[Feature Request]: "
 labels: ["enhancement"]
+type: [Feature]
 projects: ["meshtastic/Meshtastic-Android"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,9 +1,9 @@
 name: Feature Request
 description: File a request for new feature or functionality.
 title: "[Feature Request]: "
-labels: ["enhancement"]
-type: [Feature]
-projects: ["meshtastic/Meshtastic-Android"]
+labels: [enhancement]
+type: Feature
+projects: [meshtastic/Meshtastic-Android]
 body:
   - type: markdown
     attributes:
@@ -23,7 +23,7 @@ body:
       label: Tell us your idea.
       description: Tell us what you'd like the app to do. Give as much detail as you can.
       placeholder: Your idea
-      value: "I'd like the app to..."
+      value: I'd like the app to...
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Add Types to new issues, 

GH Issues now have types., and labels. 
PR's only have labels.

Types are mutually exclusive, and organisation managed.
I don't know if they'll prove useful, and we can reduce our labels to MRs + escalation / clarity, or whether they'll offer no value



