### PR TITLE
feat(analytics): Integrate _more_ Datadog

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,14 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_secrets:
-    runs-on: ubuntu-latest
-    env:
-        TEST_SECRET: ${{ secrets.TEST_SECRET }}
-    steps:
-      - name: Test Secrets
-        run: |
-          echo "$TEST_SECRET"
 
   build_and_detekt:
     if: github.repository == 'meshtastic/Meshtastic-Android' && github.head_ref != 'scheduled-updates'

--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -9,8 +9,6 @@ on:
         required: false
       DATADOG_CLIENT_TOKEN:
         required: false
-      TEST_SECRET:
-        required: false
     inputs:
       upload_artifacts:
         description: 'Whether to upload build and Detekt artifacts'
@@ -27,10 +25,6 @@ jobs:
       DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
 
     steps:
-      - name: Test Secrets
-        env:
-          TEST_SECRET: ${{ secrets.TEST_SECRET }}
-        run: echo "$TEST_SECRET"
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,7 +126,7 @@ android {
         }
     }
     buildTypes {
-        named("release") {
+        release {
             if (keystoreProperties["storeFile"] != null) {
                 signingConfig = signingConfigs.named("release").get()
             }
@@ -134,7 +134,10 @@ android {
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
-        named("debug") { isPseudoLocalesEnabled = true }
+        debug {
+            isDebuggable = true
+            isPseudoLocalesEnabled = true
+        }
     }
     bundle { language { enableSplit = false } }
     buildFeatures {

--- a/app/src/fdroid/java/com/geeksville/mesh/android/GeeksvilleApplication.kt
+++ b/app/src/fdroid/java/com/geeksville/mesh/android/GeeksvilleApplication.kt
@@ -22,10 +22,14 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.provider.Settings
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.Composable
 import androidx.core.content.edit
+import androidx.navigation.NavHostController
 import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.analytics.AnalyticsProvider
 import com.geeksville.mesh.analytics.NopAnalytics
+import com.geeksville.mesh.android.BuildUtils.debug
+import com.geeksville.mesh.android.BuildUtils.info
 import com.geeksville.mesh.model.DeviceHardware
 import timber.log.Timber
 
@@ -80,4 +84,13 @@ val Context.isGooglePlayAvailable: Boolean
 @Suppress("UnusedParameter")
 fun setAttributes(deviceVersion: String, deviceHardware: DeviceHardware) {
     // No-op for F-Droid version
+    info("Setting attributes: deviceVersion=$deviceVersion, deviceHardware=$deviceHardware")
+}
+
+@Composable
+fun AddNavigationTracking(navController: NavHostController) {
+    // No-op for F-Droid version
+    navController.addOnDestinationChangedListener { _, destination, _ ->
+        debug("Navigation changed to: ${destination.route}")
+    }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -82,6 +82,7 @@ import androidx.navigation.compose.rememberNavController
 import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.R
+import com.geeksville.mesh.android.AddNavigationTracking
 import com.geeksville.mesh.android.BuildUtils.debug
 import com.geeksville.mesh.android.setAttributes
 import com.geeksville.mesh.model.BluetoothViewModel
@@ -158,6 +159,8 @@ fun MainScreen(
             }
         }
     }
+
+    AddNavigationTracking(navController)
 
     if (connectionState.isConnected()) {
         requestChannelSet?.let { newChannelSet -> ScannedQrCodeDialog(uIViewModel, newChannelSet) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,8 +90,10 @@ datastore-preferences = { group = "androidx.datastore", name = "datastore-prefer
 dd-sdk-android-compose = { group = "com.datadoghq", name = "dd-sdk-android-compose", version.ref = "dd-sdk-android" }
 dd-sdk-android-gradle-plugin = { group = "com.datadoghq", name = "dd-sdk-android-gradle-plugin", version.ref = "dd-sdk-android-gradle-plugin" }
 dd-sdk-android-logs = { group = "com.datadoghq", name = "dd-sdk-android-logs", version.ref = "dd-sdk-android" }
+dd-sdk-android-okhttp = { group = "com.datadoghq", name = "dd-sdk-android-okhttp", version.ref = "dd-sdk-android" }
 dd-sdk-android-rum = { group = "com.datadoghq", name = "dd-sdk-android-rum", version.ref = "dd-sdk-android" }
 dd-sdk-android-timber = { group = "com.datadoghq", name = "dd-sdk-android-timber", version.ref = "dd-sdk-android" }
+dd-sdk-android-trace = { group = "com.datadoghq", name = "dd-sdk-android-trace", version.ref = "dd-sdk-android" }
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 emoji2-emojipicker = { group = "androidx.emoji2", name = "emoji2-emojipicker", version.ref = "emoji2" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
@@ -193,7 +195,7 @@ osm = ["osmdroid-android", "osmbonuspack", "mgrs"]
 firebase = ["firebase-analytics", "firebase-crashlytics"]
 
 # Datadog
-datadog = ["dd-sdk-android-compose", "dd-sdk-android-logs", "dd-sdk-android-timber", "dd-sdk-android-rum"]
+datadog = ["dd-sdk-android-compose", "dd-sdk-android-logs", "dd-sdk-android-okhttp", "dd-sdk-android-rum", "dd-sdk-android-timber", "dd-sdk-android-trace"]
 
 # Protobuf
 protobuf = ["protobuf-kotlin"]

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.bundles.hilt)
     implementation(libs.bundles.retrofit)
     implementation(libs.bundles.coil)
+    "googleImplementation"(libs.bundles.datadog)
     ksp(libs.hilt.compiler)
     implementation(libs.kotlinx.serialization.json)
     detektPlugins(libs.detekt.formatting)

--- a/network/src/google/java/com/geeksville/mesh/network/di/ApiModule.kt
+++ b/network/src/google/java/com/geeksville/mesh/network/di/ApiModule.kt
@@ -26,6 +26,8 @@ import coil3.request.crossfade
 import coil3.svg.SvgDecoder
 import coil3.util.DebugLogger
 import coil3.util.Logger
+import com.datadog.android.okhttp.DatadogEventListener
+import com.datadog.android.okhttp.DatadogInterceptor
 import com.geeksville.mesh.network.BuildConfig
 import com.geeksville.mesh.network.retrofit.ApiService
 import dagger.Module
@@ -49,13 +51,17 @@ class ApiModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(): OkHttpClient {
+
         val loggingInterceptor = HttpLoggingInterceptor().apply {
             if (BuildConfig.DEBUG) {
                 setLevel(HttpLoggingInterceptor.Level.BODY)
             }
         }
+        val tracedHosts = listOf("meshtastic.org")
         return OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
+            .addInterceptor(DatadogInterceptor.Builder(tracedHosts).build())
+            .eventListenerFactory(DatadogEventListener.Factory())
             .build()
     }
 


### PR DESCRIPTION
This commit further integrates Datadog into the application for comprehensive analytics and monitoring.

Key changes include:
- Added Datadog SDK dependencies for logs, RUM, trace, and OkHttp integration.
- Configured Datadog in `GeeksvilleApplication.kt` for the Google Play flavor, initializing RUM, Logs, and Trace.
- **Added Datadog navigation tracking for Jetpack Compose.**
- Enabled Datadog Timber tree for logging.
- Integrated Datadog with OkHttp for network request tracing.
- Updated `app/build.gradle.kts` to correctly configure debug and release build types.
- Removed unused test secrets from GitHub Actions workflows.

For the F-Droid flavor, Datadog integration is a no-op, with stubs provided for `setAttributes` and `AddNavigationTracking`.
