### PR TITLE
feat(service): handle DeviceUIConfig and FileInfo packets

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -36,6 +36,7 @@ import com.geeksville.mesh.ChannelProtos
 import com.geeksville.mesh.ConfigProtos
 import com.geeksville.mesh.CoroutineDispatchers
 import com.geeksville.mesh.DataPacket
+import com.geeksville.mesh.DeviceUIProtos
 import com.geeksville.mesh.IMeshService
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.LocalOnlyProtos.LocalModuleConfig
@@ -1479,6 +1480,10 @@ class MeshService :
                     handleClientNotification(proto.clientNotification)
                 }
 
+                MeshProtos.FromRadio.DEVICEUICONFIG_FIELD_NUMBER -> handleDevicUiConfig(proto.deviceuiConfig)
+
+                MeshProtos.FromRadio.FILEINFO_FIELD_NUMBER -> handleFileInfo(proto.fileInfo)
+
                 else -> errormsg("Unexpected FromRadio variant")
             }
         } catch (ex: InvalidProtocolBufferException) {
@@ -1687,6 +1692,32 @@ class MeshService :
             radioConfigRepository.clearLocalConfig()
             radioConfigRepository.clearLocalModuleConfig()
         }
+    }
+
+    private fun handleDevicUiConfig(deviceuiConfig: DeviceUIProtos.DeviceUIConfig) {
+        debug("Received DeviceUIConfig ${deviceuiConfig.toOneLineString()}")
+        val packetToSave =
+            MeshLog(
+                uuid = UUID.randomUUID().toString(),
+                message_type = "DeviceUIConfig",
+                received_date = System.currentTimeMillis(),
+                raw_message = deviceuiConfig.toString(),
+                fromRadio = fromRadio { this.deviceuiConfig = deviceuiConfig },
+            )
+        insertMeshLog(packetToSave)
+    }
+
+    private fun handleFileInfo(fileInfo: MeshProtos.FileInfo) {
+        debug("Received FileInfo ${fileInfo.toOneLineString()}")
+        val packetToSave =
+            MeshLog(
+                uuid = UUID.randomUUID().toString(),
+                message_type = "FileInfo",
+                received_date = System.currentTimeMillis(),
+                raw_message = fileInfo.toString(),
+                fromRadio = fromRadio { this.fileInfo = fileInfo },
+            )
+        insertMeshLog(packetToSave)
     }
 
     /** Update our DeviceMetadata */


### PR DESCRIPTION
This commit introduces handling for two new packet types received from the radio: `DeviceUIConfig` and `FileInfo` - mitigating the "Unexpected FromRadio variant" error in the logs

When these packets are received:
- They are logged with a debug message.
- A `MeshLog` entry is created with the relevant information.
- The `MeshLog` entry is inserted into the database.

- [x] check on whether we actually need to do anything with these other than log them

chatted w/ garth on vc, tl;dr - no we don't need to do anything special w/ these right now.

 we could leverage the FileInfo to pull the rangetest csv file directly from the device. (currently generating our own from inapp debug logs)