### PR TITLE
#2650 - make the catch all on the labeler less generic

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -76,11 +76,12 @@ body:
   - type: markdown
     attributes:
       value: |
-
         ### Relevant log output
-        <details>
-
-        <summary>Expand Logs ... </summary>
+        <!--
+          uncomment this section to fold logs
+          <details>
+          <summary>Expand Logs ... </summary>
+        -->
   - type: textarea
     id: logs
     attributes:
@@ -90,7 +91,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        </details>
+        <!--
+          </details>
+        -->
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,9 +20,9 @@ repo:
   - changed-files:
     - any-glob-to-any-file: .github
 
- # Add 'bug' label to any PR where the head branch name contains `fix` or `bug`
+ # Add 'bug' label to any PR where the head branch name contains `fix` or `bug` as the prefix.
 bugfix:
-  - head-branch: [fix, bug, Fix, FIX, Bug, BUG]
+  - head-branch: [^fix, ^bug, ^Fix, ^FIX, ^Bug, ^BUG]
 
 # our fallback - bug except repo, feat, or automated pipelines
 # bug_fallthrough:


### PR DESCRIPTION
closes #2650

- Move the code folding in the bug form behind comments 
   -  we can still edit and uncomment it for ones where it's useful (ie. big logs) 
- Make the catchall on the labeler only function when it's the first word, to stop double labeling a lot of things. 
 

_We could enforce branch rules:  `[ fix/#[0-9]**,  feat/#[0-9]**, repo/#[0-9]** ]` would be my preference, but I'm happy with whatever._ 