### PR TITLE
refactor(service): improve state management and concurrency in MeshSe…

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -199,6 +199,7 @@ class MeshService :
 
         private const val CONFIG_ONLY_NONCE = 69420
         private const val NODE_INFO_ONLY_NONCE = 69421
+        private const val CONFIG_WAIT_MS = 250L
     }
 
     private var previousSummary: String? = null
@@ -1667,9 +1668,9 @@ class MeshService :
         // we have recieved the response to our ConfigOnly request
         // send a heartbeat, then request NodeInfoOnly to get the nodeDb from the radio
         serviceScope.handledLaunch {
-            delay(250)
+            delay(CONFIG_WAIT_MS)
             radioInterfaceService.keepAlive()
-            delay(250)
+            delay(CONFIG_WAIT_MS)
             sendNodeInfoOnlyRequest()
         }
     }


### PR DESCRIPTION
…rvice

This commit introduces several changes to enhance the robustness and reliability of `MeshService`:

- **Thread Safety for Location and Packet Queue Jobs:** Added `synchronized` blocks around `locationFlow` and `queueJob` modifications to prevent race conditions when starting or stopping these background tasks. This ensures that the jobs are not accessed or modified concurrently by multiple threads.
- **Improved State Reset Logic:**
    - The `resetState` function is now a `suspend` function to allow for asynchronous operations like clearing the NodeDB.
    - `resetState` now explicitly resets in-memory `localConfig`, `moduleConfig`, and `channelSet` to their default instances.
    - Persisted DataStore settings (like `ChannelSet`, `LocalConfig`, `LocalModuleConfig`) are no longer cleared during `resetState`. Only the NodeDB (Room database) is cleared. This prevents accidental loss of user configurations when the device connection changes.
    - `resetState` is now called when the device address changes (`updateLastAddress`), ensuring a clean state when switching between Meshtastic nodes.
    - Removed the redundant `loadSettings()` call from `onCreate()`, as state is now initialized or reset at appropriate times (e.g., when connection changes).
    - Removed the separate `clearDatabases()` function as its functionality is incorporated into `resetState`.
- **Packet Processing Enhancements:**
    - Changed `offlineSentPackets` from `MutableList` to `ConcurrentLinkedQueue` to allow safe concurrent modifications when processing queued packets.
    - Modified `processQueuedPackets` to poll from `offlineSentPackets` in a loop, providing better handling for concurrently added packets.
- **Delayed NodeInfo Request:** Added small delays before sending `keepAlive` and `sendNodeInfoOnlyRequest` after receiving a `ConfigOnly` response. This might help ensure the radio is ready to process subsequent requests.
- **Removed Unnecessary `clearDatabases()` Call:** The explicit call to `clearDatabases()` in `updateLastAddress` was removed as `resetState` now handles this.
