### PR TITLE
chore: Only run dependency submission workflow for the main repository

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   dependency-submission:
     runs-on: ubuntu-latest
+    if: github.repository == 'meshtastic/Meshtastic-Android'
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
Just adding the main repository check to dependency graph submission workflow, so that it won't run on forks by default

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->