### PR TITLE
refactor(repository)!: improve api caching and error handling

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -264,7 +264,11 @@ constructor(
                     val deviceHardware =
                         actualNode.user.hwModel.number.let { deviceHardwareRepository.getDeviceHardwareByModel(it) }
                     _state.update { state ->
-                        state.copy(node = actualNode, isLocal = destNum == ourNode, deviceHardware = deviceHardware)
+                        state.copy(
+                            node = actualNode,
+                            isLocal = destNum == ourNode,
+                            deviceHardware = deviceHardware.getOrNull(),
+                        )
                     }
                 }
                 .launchIn(viewModelScope)

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -230,7 +230,9 @@ constructor(
     val deviceHardware: StateFlow<DeviceHardware?> =
         ourNodeInfo
             .mapNotNull { nodeInfo ->
-                nodeInfo?.user?.hwModel?.let { deviceHardwareRepository.getDeviceHardwareByModel(it.number) }
+                nodeInfo?.user?.hwModel?.let {
+                    deviceHardwareRepository.getDeviceHardwareByModel(it.number).getOrNull()
+                }
             }
             .stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(5_000), initialValue = null)
 


### PR DESCRIPTION
This commit refactors the `FirmwareReleaseRepository` and `DeviceHardwareRepository` to enhance caching logic and error handling.

**FirmwareReleaseRepository Changes:**
- Implements a "cache-then-network" strategy for `stableRelease` and `alphaRelease` flows.
  - Immediately emits cached data.
  - If the cache is stale or a refresh is forced, fetches from the remote API.
  - Falls back to bundled JSON if the remote fetch fails.
  - Caches all release types (stable, alpha) in a single operation when updating from sources.
- Introduces `isStale()` extension function for `FirmwareReleaseEntity`.
- Sets cache expiration to 1 hour.

**DeviceHardwareRepository Changes:**
- `getDeviceHardwareByModel` now returns a `Result<DeviceHardware?>`.
- Implements a cache-aside pattern with fallback:
  1. Checks for a fresh local cache entry.
  2. Fetches from the remote API if the cache is stale or refresh is forced.
  3. Uses stale cached data if the remote fetch fails.
  4. Falls back to bundled JSON if the cache is empty.
- Introduces `isStale()` extension function for `DeviceHardwareEntity`.
- Sets cache expiration to 1 day.

**Other Changes:**
- `MetricsViewModel`: Updates to use `getOrNull()` when accessing `deviceHardware` from the repository's `Result`.
- `UIState`: Updates to use `getOrNull()` when accessing `deviceHardware` from the repository's `Result`.

BREAKING CHANGE: The `DeviceHardwareRepository.getDeviceHardwareByModel` method now returns `Result<DeviceHardware?>` instead of `DeviceHardware?`. Consumers need to update their code to handle the `Result` type, for example by using `getOrNull()` or `fold()`.
