### PR TITLE
feat(notifications): hide message sensitive content on lockscreen

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -295,6 +295,7 @@ class MeshServiceNotifications(private val context: Context) {
             .setCategory(Notification.CATEGORY_MESSAGE)
             .setAutoCancel(true)
             .setStyle(style)
+            .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
             .setWhen(System.currentTimeMillis())
             .setShowWhen(true)
 


### PR DESCRIPTION
**Description**
This commit adds hiding of sensitive message content on the lock screen.

**Changes**
	• Applied [Notification.VISIBILITY_PRIVATE](https://developer.android.com/reference/android/app/Notification#VISIBILITY_PRIVATE) to message notifications.

Issue
Resolves [meshtastic/Meshtastic-Android#2681](https://github.com/meshtastic/Meshtastic-Android/issues/2681)

| Before | After |
|--------|-------|
| <img width="300" alt="Screenshot_20250813_063101" src="https://github.com/user-attachments/assets/973ed9ea-9428-4908-9d2a-f6d0538e5252"/> | <img width="300" alt="Screenshot_20250813_063147" src="https://github.com/user-attachments/assets/3bffb14d-1b01-4150-8ae0-333c8f310417"/> |