### PR TITLE
fix(crowdin): correct update_option typo and update workflow

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -83,6 +83,7 @@ jobs:
           push_translations: false
           push_sources: false
           localization_branch_name: ${{ github.ref_name }}
+          export_only_approved: false
           # skip_ref_checkout: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/crowdin/crowdin.yml
+++ b/config/crowdin/crowdin.yml
@@ -30,7 +30,7 @@
       "sr-Latn": "b+sr+Latn",
     },
     "cleanup_mode": true,
-    "update_option:": "update_as_unapproved",
+    "update_option": "update_as_unapproved",
     "escape_quotes": 2,
     "escape_special_characters": 1,
     "type": "android",


### PR DESCRIPTION
The `update_option:` key in `config/crowdin/crowdin.yml` had an extraneous colon. This commit removes the colon.

Additionally, the `scheduled-updates.yml` GitHub workflow was updated to set `export_only_approved` to `false`.

hopefully closes #2689 