### PR TITLE
ci(release): add GOOGLE_MAPS_API_KEY to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
           KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
           DATADOG_APPLICATION_ID: ${{ secrets.DATADOG_APPLICATION_ID }}
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4


### PR DESCRIPTION
This commit adds the `GOOGLE_MAPS_API_KEY` secret to the release workflow. This key is necessary for building the release version of the app that includes Google Maps functionality.