### PR TITLE
chore: configure Crowdin integration

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
 
   build_and_detekt:
-    if: github.repository == 'meshtastic/Meshtastic-Android' && github.head_ref != 'scheduled-updates'
+    if: github.repository == 'meshtastic/Meshtastic-Android' && github.head_ref != 'scheduled-updates' && github.head.ref != `l10n_main`
     uses: ./.github/workflows/reusable-android-build.yml
     secrets: inherit
 
   androidTest:
     # Assuming androidTest should also only run for the main repository
-    if: github.repository == 'meshtastic/Meshtastic-Android' && github.head_ref != 'scheduled-updates'
+    if: github.repository == 'meshtastic/Meshtastic-Android' && github.head_ref != 'scheduled-updates' && github.head.ref != `l10n_main`
     uses: ./.github/workflows/reusable-android-test.yml
     with:
       api_levels: '[35]' # Run only on API 35 for PRs

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,7 @@
+pull_request_labels:
+  - automation
+  - l10n
+commit_message: "[skip ci] Update translations from Crowdin"
 files:
   - source: /*/src/main/res/values/strings.xml
     translation: /%original_path%-%two_letters_code%/strings.xml


### PR DESCRIPTION
This commit updates the `crowdin.yml` configuration file.

The following changes were made:
- Added labels for pull requests created by Crowdin: `automation` and `l10n`.
- Defined a commit message for translation updates: `Update translations from Crowdin` and adds the skip.
- modified the GitHub Actions workflow file `pull-request.yml`
to prevent the `build_and_detekt` and `androidTest` jobs from running
when changes are pushed to the `l10n_main` branch. This is in addition
to the existing condition that prevents these jobs from running on the
`scheduled-updates` branch