### PR TITLE
chore(ci): remove custom commit message for Crowdin updates

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,6 @@
 pull_request_labels:
   - automation
   - l10n
-commit_message: "[skip ci] Update translations from Crowdin"
 files:
   - source: /*/src/main/res/values/strings.xml
     translation: /%original_path%-%two_letters_code%/strings.xml


### PR DESCRIPTION
Removes the custom commit message "\[skip ci] Update translations from Crowdin" from the Crowdin configuration. This allows Crowdin to use its default commit message for translation updates.