### PR TITLE
fix(UI): Apply window insets on welcome screens

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -24,6 +24,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.hardware.usb.UsbManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
@@ -41,7 +42,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalView
 import androidx.core.content.edit
 import androidx.core.net.toUri
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import com.geeksville.mesh.android.BindFailedException
 import com.geeksville.mesh.android.GeeksvilleApplication
@@ -79,6 +79,11 @@ class MainActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // Disable three-button navbar scrim
+            window.setNavigationBarContrastEnforced(false)
+        }
+
         super.onCreate(savedInstanceState)
         val prefs = UIViewModel.getPreferences(this)
         if (savedInstanceState == null) {
@@ -93,7 +98,6 @@ class MainActivity :
             }
         }
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             val theme by model.theme.collectAsState()
             val dynamic = theme == MODE_DYNAMIC

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -22,11 +22,13 @@ import android.app.TaskStackBuilder
 import android.content.Intent
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.graphics.Color
 import android.hardware.usb.UsbManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
@@ -78,7 +80,10 @@ class MainActivity :
     private var showAppIntro by mutableStateOf(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            // Disable three-button navbar scrim on pre-Q devices
+            navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
+        )
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             // Disable three-button navbar scrim
             window.setNavigationBarContrastEnforced(false)

--- a/app/src/main/java/com/geeksville/mesh/ui/intro/IntroBottomBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/intro/IntroBottomBar.kt
@@ -17,15 +17,13 @@
 
 package com.geeksville.mesh.ui.intro
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Button
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
@@ -47,17 +45,13 @@ internal fun IntroBottomBar(
     configureButtonText: String,
     showSkipButton: Boolean = true,
 ) {
-    Surface(shadowElevation = 8.dp) {
-        // Use Surface for elevation as per Material 3 guidelines
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 20.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = if (showSkipButton) Arrangement.SpaceBetween else Arrangement.End,
-        ) {
-            if (showSkipButton) {
-                Button(onClick = onSkip) { Text(skipButtonText) }
-            }
-            Button(onClick = onConfigure) { Text(configureButtonText) }
+    BottomAppBar(contentPadding = PaddingValues(horizontal = 16.dp, vertical = 20.dp)) {
+        if (showSkipButton) {
+            Button(onClick = onSkip) { Text(skipButtonText) }
         }
+
+        Spacer(modifier = Modifier.fillMaxWidth().weight(1f))
+
+        Button(onClick = onConfigure) { Text(configureButtonText) }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/meshtastic/Meshtastic-Android/issues/2723

I leveraged Material 3's `BottomAppBar`  (no custom styling) which provides window inset handling automatically. This does change the appearance slightly, but comments in the affected code gave me the impression that we're adhering to Material. Please let me know if I should revert the appearance changes, and I can update.

|Before (API 36, 3-button nav)|After (API 36, 3-button nav) |After (API 36, gesture nav)|
|-|-|-|
|<img src="https://github.com/user-attachments/assets/23c35ab1-65c2-4605-813c-9b05f4770cd5" width="300"/>|<img src="https://github.com/user-attachments/assets/968bc843-4d8e-44ea-899b-5571818c980c" width="300"/>|<img width="300" alt="image" src="https://github.com/user-attachments/assets/115067f9-9272-40f0-b291-61c7c1479a71" />|



| Before (API 26) | After (API 26) |
|------|-----|
| <img src="https://github.com/user-attachments/assets/0259a9dd-f0a7-436c-8abd-73ff614a46ae" width="300"/> | <img src="https://github.com/user-attachments/assets/c819bc07-3f71-4d33-b184-b201f0f608d4" width="300"/> |
