### PR TITLE
Feat/debug log redaction

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/debug/Debug.kt
@@ -652,6 +652,7 @@ private suspend fun exportAllLogs(context: Context, logs: List<UiMeshLog>) = wit
                             val idx = line.indexOf(':')
                             if (idx != -1) {
                                 outputLine = line.substring(0, idx + 1)
+                                outputLine += "<redacted>"
                             }
                         }
                         writer.write(outputLine)


### PR DESCRIPTION
- Make exportsAll follow the active filters  
- Redact private keys, admin keys, and session keys (in plain text only, the bytestrings remain present) 
- spotless