### PR TITLE
Decouple mesh service bind from `MainActivity`

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -44,14 +44,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalView
 import androidx.core.content.edit
 import androidx.core.net.toUri
-import com.geeksville.mesh.android.BindFailedException
 import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.navigation.DEEP_LINK_BASE_URI
-import com.geeksville.mesh.service.MeshService
-import com.geeksville.mesh.service.startService
 import com.geeksville.mesh.ui.MainMenuAction
 import com.geeksville.mesh.ui.MainScreen
 import com.geeksville.mesh.ui.common.theme.AppTheme
@@ -70,6 +67,7 @@ class MainActivity :
     private val bluetoothViewModel: BluetoothViewModel by viewModels()
     private val model: UIViewModel by viewModels()
 
+    // This is aware of the Activity lifecycle and handles binding to the mesh service.
     @Inject internal lateinit var meshServiceClient: MeshServiceClient
 
     private var showAppIntro by mutableStateOf(false)
@@ -217,27 +215,6 @@ class MainActivity :
                 it.data?.data?.let { file_uri -> model.saveRangetestCSV(file_uri) }
             }
         }
-
-    private fun bindMeshService() {
-        debug("Binding to mesh service!")
-        try {
-            MeshService.startService(this)
-        } catch (ex: Exception) {
-            errormsg("Failed to start service from activity - but ignoring because bind will work ${ex.message}")
-        }
-
-        meshServiceClient.connect(this, MeshService.createIntent(), BIND_AUTO_CREATE + BIND_ABOVE_CLIENT)
-    }
-
-    override fun onStart() {
-        super.onStart()
-
-        try {
-            bindMeshService()
-        } catch (ex: BindFailedException) {
-            errormsg("Bind of MeshService failed${ex.message}")
-        }
-    }
 
     private fun showSettingsPage() {
         createSettingsIntent().send()

--- a/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
+++ b/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
@@ -59,6 +59,8 @@ constructor(
         lifecycleOwner.lifecycle.addObserver(this)
     }
 
+    //region ServiceClient overrides
+
     override fun onConnected(service: IMeshService) {
         serviceSetupJob?.cancel()
         serviceSetupJob =
@@ -72,6 +74,10 @@ constructor(
         serviceSetupJob?.cancel()
         serviceRepository.setMeshService(null)
     }
+
+    //endregion
+
+    //region DefaultLifecycleObserver overrides
 
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
@@ -91,6 +97,8 @@ constructor(
         owner.lifecycle.removeObserver(this)
         debug("Removed self as LifecycleObserver to $lifecycleOwner")
     }
+
+    //endregion
 
     private fun bindMeshService() {
         debug("Binding to mesh service!")

--- a/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
+++ b/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh
+
+import android.app.Activity
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.geeksville.mesh.android.ServiceClient
+import com.geeksville.mesh.concurrent.handledLaunch
+import com.geeksville.mesh.service.ServiceRepository
+import dagger.hilt.android.scopes.ActivityScoped
+import kotlinx.coroutines.Job
+import javax.inject.Inject
+
+@ActivityScoped
+class MeshServiceClient
+@Inject
+constructor(
+    /**
+     * Activity is injected here instead of LifecycleOwner because ApplicationModule defines its own LifecycleOwner
+     * which overrides the default binding for @ActivityScoped. The solution to this is to add a qualifier to the
+     * LifecycleOwner provider in ApplicationModule.
+     */
+    activity: Activity,
+    private val serviceRepository: ServiceRepository,
+) : ServiceClient<IMeshService>(IMeshService.Stub::asInterface) {
+
+    // TODO Use the default binding for @AcitvityScoped
+    private val lifecycleOwner: LifecycleOwner = activity as LifecycleOwner
+
+    // TODO Inject this for ease of testing
+    private var serviceSetupJob: Job? = null
+
+    override fun onConnected(service: IMeshService) {
+        serviceSetupJob?.cancel()
+        serviceSetupJob =
+            lifecycleOwner.lifecycleScope.handledLaunch {
+                serviceRepository.setMeshService(service)
+                debug("connected to mesh service, connectionState=${serviceRepository.connectionState.value}")
+            }
+    }
+
+    override fun onDisconnected() {
+        serviceSetupJob?.cancel()
+        serviceRepository.setMeshService(null)
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
+++ b/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
@@ -100,6 +100,7 @@ constructor(
 
     // endregion
 
+    @Suppress("TooGenericExceptionCaught")
     private fun bindMeshService() {
         debug("Binding to mesh service!")
         try {

--- a/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
+++ b/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
@@ -18,33 +18,46 @@
 package com.geeksville.mesh
 
 import android.app.Activity
+import androidx.appcompat.app.AppCompatActivity.BIND_ABOVE_CLIENT
+import androidx.appcompat.app.AppCompatActivity.BIND_AUTO_CREATE
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import com.geeksville.mesh.android.BindFailedException
 import com.geeksville.mesh.android.ServiceClient
 import com.geeksville.mesh.concurrent.handledLaunch
+import com.geeksville.mesh.service.MeshService
 import com.geeksville.mesh.service.ServiceRepository
+import com.geeksville.mesh.service.startService
 import dagger.hilt.android.scopes.ActivityScoped
 import kotlinx.coroutines.Job
 import javax.inject.Inject
 
+/** A Activity-lifecycle-aware [ServiceClient] that binds [MeshService] once the Activity is started. */
 @ActivityScoped
 class MeshServiceClient
 @Inject
 constructor(
     /**
-     * Activity is injected here instead of LifecycleOwner because ApplicationModule defines its own LifecycleOwner
-     * which overrides the default binding for @ActivityScoped. The solution to this is to add a qualifier to the
-     * LifecycleOwner provider in ApplicationModule.
+     * Ideally, this would be broken up into Context and LifecycleOwner. However, ApplicationModule defines its own
+     * LifecycleOwner which overrides the default binding for @ActivityScoped. The solution to this is to add a
+     * qualifier to the LifecycleOwner provider in ApplicationModule.
      */
-    activity: Activity,
+    private val activity: Activity,
     private val serviceRepository: ServiceRepository,
-) : ServiceClient<IMeshService>(IMeshService.Stub::asInterface) {
+) : ServiceClient<IMeshService>(IMeshService.Stub::asInterface),
+    DefaultLifecycleObserver {
 
-    // TODO Use the default binding for @AcitvityScoped
+    // TODO Use the default binding for @ActivityScoped
     private val lifecycleOwner: LifecycleOwner = activity as LifecycleOwner
 
     // TODO Inject this for ease of testing
     private var serviceSetupJob: Job? = null
+
+    init {
+        debug("Adding self as LifecycleObserver for $lifecycleOwner")
+        lifecycleOwner.lifecycle.addObserver(this)
+    }
 
     override fun onConnected(service: IMeshService) {
         serviceSetupJob?.cancel()
@@ -58,5 +71,35 @@ constructor(
     override fun onDisconnected() {
         serviceSetupJob?.cancel()
         serviceRepository.setMeshService(null)
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        debug("Lifecycle: ON_START")
+
+        try {
+            bindMeshService()
+        } catch (ex: BindFailedException) {
+            errormsg("Bind of MeshService failed${ex.message}")
+        }
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        debug("Lifecycle: ON_DESTROY")
+
+        owner.lifecycle.removeObserver(this)
+        debug("Removed self as LifecycleObserver to $lifecycleOwner")
+    }
+
+    private fun bindMeshService() {
+        debug("Binding to mesh service!")
+        try {
+            MeshService.startService(activity)
+        } catch (ex: Exception) {
+            errormsg("Failed to start service from activity - but ignoring because bind will work ${ex.message}")
+        }
+
+        connect(activity, MeshService.createIntent(), BIND_AUTO_CREATE + BIND_ABOVE_CLIENT)
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
+++ b/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
@@ -59,7 +59,7 @@ constructor(
         lifecycleOwner.lifecycle.addObserver(this)
     }
 
-    //region ServiceClient overrides
+    // region ServiceClient overrides
 
     override fun onConnected(service: IMeshService) {
         serviceSetupJob?.cancel()
@@ -75,9 +75,9 @@ constructor(
         serviceRepository.setMeshService(null)
     }
 
-    //endregion
+    // endregion
 
-    //region DefaultLifecycleObserver overrides
+    // region DefaultLifecycleObserver overrides
 
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
@@ -86,7 +86,7 @@ constructor(
         try {
             bindMeshService()
         } catch (ex: BindFailedException) {
-            errormsg("Bind of MeshService failed${ex.message}")
+            errormsg("Bind of MeshService failed: ${ex.message}")
         }
     }
 
@@ -98,14 +98,14 @@ constructor(
         debug("Removed self as LifecycleObserver to $lifecycleOwner")
     }
 
-    //endregion
+    // endregion
 
     private fun bindMeshService() {
         debug("Binding to mesh service!")
         try {
             MeshService.startService(activity)
         } catch (ex: Exception) {
-            errormsg("Failed to start service from activity - but ignoring because bind will work ${ex.message}")
+            errormsg("Failed to start service from activity - but ignoring because bind will work: ${ex.message}")
         }
 
         connect(activity, MeshService.createIntent(), BIND_AUTO_CREATE + BIND_ABOVE_CLIENT)


### PR DESCRIPTION
I took a stab at decoupling the `MeshService` bind logic from `MainActivity`. This is a refactor, and no behavior change is expected. `MainActivity` is now injected with a `MeshServiceClient` that observes the Activity lifecycle and handles binding `MeshService`.

There is one minor issue that I called out in the comments. `MeshServiceClient` cannot be injected with the default `LifecycleOwner` binding for `@ActivityScoped` due to a global `LifecycleOwner` provided in `ApplicationModule` taking precedence. The current workaround is to inject `Activity` (not ideal) and cast to `LifecycleOwner`. Qualifying the provider in `ApplicationModule` solves this issue, but would add a ton of scope to this PR.