### PR TITLE
Add SnackBarHost

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -20,7 +20,9 @@ package com.geeksville.mesh.model
 import android.app.Application
 import android.net.Uri
 import android.os.RemoteException
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
@@ -455,11 +457,25 @@ constructor(
 
     fun getUser(userId: String?) = nodeDB.getUser(userId ?: DataPacket.ID_BROADCAST)
 
-    private val snackBarHostState = SnackbarHostState()
+    val snackBarHostState = SnackbarHostState()
 
     fun showSnackBar(text: Int) = showSnackBar(app.getString(text))
 
-    fun showSnackBar(text: String) = viewModelScope.launch { snackBarHostState.showSnackbar(text) }
+    fun showSnackBar(
+        text: String,
+        actionLabel: String? = null,
+        withDismissAction: Boolean = false,
+        duration: SnackbarDuration = if (actionLabel == null) SnackbarDuration.Short else SnackbarDuration.Indefinite,
+        onActionPerformed: (() -> Unit) = {},
+        onDismissed: (() -> Unit) = {},
+    ) = viewModelScope.launch {
+        snackBarHostState.showSnackbar(text, actionLabel, withDismissAction, duration).run {
+            when (this) {
+                SnackbarResult.ActionPerformed -> onActionPerformed()
+                SnackbarResult.Dismissed -> onDismissed()
+            }
+        }
+    }
 
     init {
         radioConfigRepository.errorMessage

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -46,6 +46,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
@@ -330,48 +332,50 @@ fun MainScreen(
             }
         },
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            var sharedContact: Node? by remember { mutableStateOf(null) }
-            if (sharedContact != null) {
-                SharedContactDialog(contact = sharedContact, onDismiss = { sharedContact = null })
-            }
-            MainAppBar(
-                viewModel = uIViewModel,
-                isManaged = localConfig.security.isManaged,
-                navController = navController,
-                onAction = { action ->
-                    if (action is MainMenuAction) {
-                        when (action) {
-                            MainMenuAction.DEBUG -> navController.navigate(Route.DebugPanel)
-                            MainMenuAction.RADIO_CONFIG -> navController.navigate(RadioConfigRoutes.RadioConfig())
-                            MainMenuAction.QUICK_CHAT -> navController.navigate(ContactsRoutes.QuickChat)
-                            MainMenuAction.SHOW_INTRO -> uIViewModel.onMainMenuAction(action)
-                            else -> onAction(action)
-                        }
-                    } else if (action is NodeMenuAction) {
-                        when (action) {
-                            is NodeMenuAction.MoreDetails -> {
-                                navController.navigate(
-                                    NodesRoutes.NodeDetailGraph(action.node.num),
-                                    {
-                                        launchSingleTop = true
-                                        restoreState = true
-                                    },
-                                )
+        Scaffold(snackbarHost = { SnackbarHost(uIViewModel.snackBarHostState) }) { _ ->
+            Column(modifier = Modifier.fillMaxSize()) {
+                var sharedContact: Node? by remember { mutableStateOf(null) }
+                if (sharedContact != null) {
+                    SharedContactDialog(contact = sharedContact, onDismiss = { sharedContact = null })
+                }
+                MainAppBar(
+                    viewModel = uIViewModel,
+                    isManaged = localConfig.security.isManaged,
+                    navController = navController,
+                    onAction = { action ->
+                        if (action is MainMenuAction) {
+                            when (action) {
+                                MainMenuAction.DEBUG -> navController.navigate(Route.DebugPanel)
+                                MainMenuAction.RADIO_CONFIG -> navController.navigate(RadioConfigRoutes.RadioConfig())
+                                MainMenuAction.QUICK_CHAT -> navController.navigate(ContactsRoutes.QuickChat)
+                                MainMenuAction.SHOW_INTRO -> uIViewModel.onMainMenuAction(action)
+                                else -> onAction(action)
                             }
+                        } else if (action is NodeMenuAction) {
+                            when (action) {
+                                is NodeMenuAction.MoreDetails -> {
+                                    navController.navigate(
+                                        NodesRoutes.NodeDetailGraph(action.node.num),
+                                        {
+                                            launchSingleTop = true
+                                            restoreState = true
+                                        },
+                                    )
+                                }
 
-                            is NodeMenuAction.Share -> sharedContact = action.node
-                            else -> {}
+                                is NodeMenuAction.Share -> sharedContact = action.node
+                                else -> {}
+                            }
                         }
-                    }
-                },
-            )
-            NavGraph(
-                modifier = Modifier.fillMaxSize().recalculateWindowInsets().safeDrawingPadding().imePadding(),
-                uIViewModel = uIViewModel,
-                bluetoothViewModel = bluetoothViewModel,
-                navController = navController,
-            )
+                    },
+                )
+                NavGraph(
+                    modifier = Modifier.fillMaxSize().recalculateWindowInsets().safeDrawingPadding().imePadding(),
+                    uIViewModel = uIViewModel,
+                    bluetoothViewModel = bluetoothViewModel,
+                    navController = navController,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Not sure if this was intentional, but there is currently no `SnackbarHost` being set, meaning none of the snackbars actually get handle or shown. `NavigationSuiteScaffold` doesn't appear to have one, so I've wrapped the entire app UI in a simple `Scaffold`.