### PR TITLE
Clean up Connections UI, fix some friction with Bluetooth

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -52,7 +52,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
@@ -60,7 +59,6 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -71,6 +69,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -100,6 +99,7 @@ import com.geeksville.mesh.navigation.RadioConfigRoutes
 import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.navigation.getNavRouteFrom
 import com.geeksville.mesh.service.ConnectionState
+import com.geeksville.mesh.ui.common.components.SwitchPreference
 import com.geeksville.mesh.ui.connections.components.BLEDevices
 import com.geeksville.mesh.ui.connections.components.CurrentlyConnectedCard
 import com.geeksville.mesh.ui.connections.components.NetworkDevices
@@ -271,36 +271,13 @@ fun ConnectionsScreen(
                         Spacer(modifier = Modifier.height(16.dp))
 
                         Card {
-                            Row(
-                                modifier =
-                                Modifier.fillMaxWidth()
-                                    .toggleable(
-                                        value = provideLocation,
-                                        onValueChange = { checked -> uiViewModel.setProvideLocation(checked) },
-                                        enabled = !isGpsDisabled,
-                                    )
-                                    .minimumInteractiveComponentSize()
-                                    .padding(horizontal = 16.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Checkbox(
-                                    // Checked state driven by receivingLocationUpdates for visual feedback
-                                    // but toggle action drives provideLocation
-                                    checked = receivingLocationUpdates,
-                                    onCheckedChange = null, // Toggleable handles the change
-                                    enabled = !isGpsDisabled, // Disable if GPS is disabled
-                                )
-                                Text(
-                                    text = stringResource(R.string.provide_location_to_mesh),
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    modifier = Modifier.padding(start = 16.dp),
-                                )
-                            }
-
-                            if (scanning) {
-                                Spacer(modifier = Modifier.height(16.dp))
-                                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                            }
+                            SwitchPreference(
+                                title = stringResource(R.string.provide_location_to_mesh),
+                                checked = provideLocation,
+                                enabled = !isGpsDisabled,
+                                onCheckedChange = { checked -> uiViewModel.setProvideLocation(checked) },
+                                containerColor = Color.Transparent,
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -27,6 +27,7 @@ import android.util.Patterns
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -38,6 +39,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.Usb
@@ -76,6 +78,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -238,160 +241,161 @@ fun ConnectionsScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
-        Column(modifier = Modifier.fillMaxSize().padding(start = 16.dp, end = 16.dp, bottom = 16.dp)) {
-            val isConnected by uiViewModel.isConnectedStateFlow.collectAsState(false)
-            val ourNode by uiViewModel.ourNodeInfo.collectAsState()
+    Column(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize().weight(1f)) {
+            Column(
+                modifier = Modifier.fillMaxSize().verticalScroll(scrollState).height(IntrinsicSize.Max).padding(16.dp),
+            ) {
+                val isConnected by uiViewModel.isConnectedStateFlow.collectAsState(false)
+                val ourNode by uiViewModel.ourNodeInfo.collectAsState()
 
-            AnimatedVisibility(visible = isConnected, modifier = Modifier.padding(bottom = 16.dp)) {
-                Column {
-                    ourNode?.let { node ->
-                        Text(
-                            stringResource(R.string.connected_device),
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                            style = MaterialTheme.typography.titleLarge,
-                        )
-
-                        Spacer(modifier = Modifier.height(8.dp))
-
-                        CurrentlyConnectedCard(
-                            node = node,
-                            onNavigateToNodeDetails = onNavigateToNodeDetails,
-                            onSetShowSharedContact = { showSharedContact = it },
-                            onNavigateToRadioConfig = onNavigateToRadioConfig,
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Card {
-                        Row(
-                            modifier =
-                            Modifier.fillMaxWidth()
-                                .toggleable(
-                                    value = provideLocation,
-                                    onValueChange = { checked -> uiViewModel.setProvideLocation(checked) },
-                                    enabled = !isGpsDisabled,
-                                )
-                                .minimumInteractiveComponentSize()
-                                .padding(horizontal = 16.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Checkbox(
-                                // Checked state driven by receivingLocationUpdates for visual feedback
-                                // but toggle action drives provideLocation
-                                checked = receivingLocationUpdates,
-                                onCheckedChange = null, // Toggleable handles the change
-                                enabled = !isGpsDisabled, // Disable if GPS is disabled
-                            )
+                AnimatedVisibility(visible = isConnected, modifier = Modifier.padding(bottom = 16.dp)) {
+                    Column {
+                        ourNode?.let { node ->
                             Text(
-                                text = stringResource(R.string.provide_location_to_mesh),
-                                style = MaterialTheme.typography.bodyLarge,
-                                modifier = Modifier.padding(start = 16.dp),
+                                stringResource(R.string.connected_device),
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                                style = MaterialTheme.typography.titleLarge,
+                            )
+
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            CurrentlyConnectedCard(
+                                node = node,
+                                onNavigateToNodeDetails = onNavigateToNodeDetails,
+                                onSetShowSharedContact = { showSharedContact = it },
+                                onNavigateToRadioConfig = onNavigateToRadioConfig,
                             )
                         }
 
-                        if (scanning) {
-                            Spacer(modifier = Modifier.height(16.dp))
-                            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        Card {
+                            Row(
+                                modifier =
+                                Modifier.fillMaxWidth()
+                                    .toggleable(
+                                        value = provideLocation,
+                                        onValueChange = { checked -> uiViewModel.setProvideLocation(checked) },
+                                        enabled = !isGpsDisabled,
+                                    )
+                                    .minimumInteractiveComponentSize()
+                                    .padding(horizontal = 16.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Checkbox(
+                                    // Checked state driven by receivingLocationUpdates for visual feedback
+                                    // but toggle action drives provideLocation
+                                    checked = receivingLocationUpdates,
+                                    onCheckedChange = null, // Toggleable handles the change
+                                    enabled = !isGpsDisabled, // Disable if GPS is disabled
+                                )
+                                Text(
+                                    text = stringResource(R.string.provide_location_to_mesh),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier.padding(start = 16.dp),
+                                )
+                            }
+
+                            if (scanning) {
+                                Spacer(modifier = Modifier.height(16.dp))
+                                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                            }
                         }
                     }
                 }
-            }
 
-            val setRegionText = stringResource(id = R.string.set_your_region)
-            val actionText = stringResource(id = R.string.action_go)
-            LaunchedEffect(isConnected && regionUnset && selectedDevice != "m") {
-                if (isConnected && regionUnset && selectedDevice != "m") {
-                    uiViewModel.showSnackBar(
-                        text = setRegionText,
-                        actionLabel = actionText,
-                        onActionPerformed = {
-                            isWaiting = true
-                            radioConfigViewModel.setResponseStateLoading(ConfigRoute.LORA)
+                val setRegionText = stringResource(id = R.string.set_your_region)
+                val actionText = stringResource(id = R.string.action_go)
+                LaunchedEffect(isConnected && regionUnset && selectedDevice != "m") {
+                    if (isConnected && regionUnset && selectedDevice != "m") {
+                        uiViewModel.showSnackBar(
+                            text = setRegionText,
+                            actionLabel = actionText,
+                            onActionPerformed = {
+                                isWaiting = true
+                                radioConfigViewModel.setResponseStateLoading(ConfigRoute.LORA)
+                            },
+                        )
+                    }
+                }
+
+                var selectedDeviceType by remember { mutableStateOf(DeviceType.BLE) }
+                LaunchedEffect(selectedDevice) {
+                    DeviceType.fromAddress(selectedDevice)?.let { type -> selectedDeviceType = type }
+                }
+
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    SegmentedButton(
+                        shape = SegmentedButtonDefaults.itemShape(DeviceType.BLE.ordinal, DeviceType.entries.size),
+                        onClick = { selectedDeviceType = DeviceType.BLE },
+                        selected = (selectedDeviceType == DeviceType.BLE),
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Rounded.Bluetooth,
+                                contentDescription = stringResource(id = R.string.bluetooth),
+                                // modifier = Modifier.padding(end = 8.dp), // Add padding to separate icon from text
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(id = R.string.bluetooth),
+                                maxLines = 1,
+                                softWrap = true,
+                                // textAlign = TextAlign.Center,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                    )
+                    SegmentedButton(
+                        shape = SegmentedButtonDefaults.itemShape(DeviceType.TCP.ordinal, DeviceType.entries.size),
+                        onClick = { selectedDeviceType = DeviceType.TCP },
+                        selected = (selectedDeviceType == DeviceType.TCP),
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Rounded.Wifi,
+                                contentDescription = stringResource(id = R.string.network),
+                                modifier = Modifier.padding(end = 8.dp), // Add padding to separate icon from text
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(id = R.string.network),
+                                modifier = Modifier.padding(top = 2.dp),
+                                maxLines = 1,
+                                softWrap = true,
+                                textAlign = TextAlign.Center,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        },
+                    )
+                    SegmentedButton(
+                        shape = SegmentedButtonDefaults.itemShape(DeviceType.USB.ordinal, DeviceType.entries.size),
+                        onClick = { selectedDeviceType = DeviceType.USB },
+                        selected = (selectedDeviceType == DeviceType.USB),
+                        icon = {
+                            Icon(
+                                imageVector = Icons.Rounded.Usb,
+                                contentDescription = stringResource(id = R.string.serial),
+                                modifier = Modifier.padding(end = 8.dp), // Add padding to separate icon from text
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(id = R.string.serial),
+                                modifier = Modifier.padding(top = 2.dp),
+                                maxLines = 1,
+                                softWrap = true,
+                                textAlign = TextAlign.Center,
+                                overflow = TextOverflow.Ellipsis,
+                            )
                         },
                     )
                 }
-            }
 
-            var selectedDeviceType by remember { mutableStateOf(DeviceType.BLE) }
-            LaunchedEffect(selectedDevice) {
-                DeviceType.fromAddress(selectedDevice)?.let { type -> selectedDeviceType = type }
-            }
+                Spacer(modifier = Modifier.height(4.dp))
 
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                SegmentedButton(
-                    shape = SegmentedButtonDefaults.itemShape(DeviceType.BLE.ordinal, DeviceType.entries.size),
-                    onClick = { selectedDeviceType = DeviceType.BLE },
-                    selected = (selectedDeviceType == DeviceType.BLE),
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Rounded.Bluetooth,
-                            contentDescription = stringResource(id = R.string.bluetooth),
-                            modifier = Modifier.padding(end = 8.dp), // Add padding to separate icon from text
-                        )
-                    },
-                    label = {
-                        Text(
-                            text = stringResource(id = R.string.bluetooth),
-                            modifier = Modifier.padding(top = 2.dp),
-                            maxLines = 1,
-                            softWrap = true,
-                            textAlign = TextAlign.Center,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    },
-                )
-                SegmentedButton(
-                    shape = SegmentedButtonDefaults.itemShape(DeviceType.TCP.ordinal, DeviceType.entries.size),
-                    onClick = { selectedDeviceType = DeviceType.TCP },
-                    selected = (selectedDeviceType == DeviceType.TCP),
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Rounded.Wifi,
-                            contentDescription = stringResource(id = R.string.network),
-                            modifier = Modifier.padding(end = 8.dp), // Add padding to separate icon from text
-                        )
-                    },
-                    label = {
-                        Text(
-                            text = stringResource(id = R.string.network),
-                            modifier = Modifier.padding(top = 2.dp),
-                            maxLines = 1,
-                            softWrap = true,
-                            textAlign = TextAlign.Center,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    },
-                )
-                SegmentedButton(
-                    shape = SegmentedButtonDefaults.itemShape(DeviceType.USB.ordinal, DeviceType.entries.size),
-                    onClick = { selectedDeviceType = DeviceType.USB },
-                    selected = (selectedDeviceType == DeviceType.USB),
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Rounded.Usb,
-                            contentDescription = stringResource(id = R.string.serial),
-                            modifier = Modifier.padding(end = 8.dp), // Add padding to separate icon from text
-                        )
-                    },
-                    label = {
-                        Text(
-                            text = stringResource(id = R.string.serial),
-                            modifier = Modifier.padding(top = 2.dp),
-                            maxLines = 1,
-                            softWrap = true,
-                            textAlign = TextAlign.Center,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    },
-                )
-            }
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            Column(modifier = Modifier.fillMaxSize()) {
-                Box(modifier = Modifier.fillMaxSize().weight(1f)) {
+                Column(modifier = Modifier.fillMaxSize()) {
                     when (selectedDeviceType) {
                         DeviceType.BLE -> {
                             BLEDevices(
@@ -422,153 +426,166 @@ fun ConnectionsScreen(
                             )
                         }
                     }
-                }
 
-                LaunchedEffect(ourNode) {
-                    if (ourNode != null) {
-                        uiViewModel.refreshProvideLocation()
+                    LaunchedEffect(ourNode) {
+                        if (ourNode != null) {
+                            uiViewModel.refreshProvideLocation()
+                        }
                     }
-                }
 
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Warning Not Paired
-                val hasShownNotPairedWarning by uiViewModel.hasShownNotPairedWarning.collectAsStateWithLifecycle()
-                val showWarningNotPaired =
-                    !isConnected &&
-                        !hasShownNotPairedWarning &&
-                        bleDevices.none { it is DeviceListEntry.Ble && it.bonded }
-                if (showWarningNotPaired) {
-                    Text(
-                        text = stringResource(R.string.warning_not_paired),
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                    )
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    LaunchedEffect(Unit) { uiViewModel.suppressNoPairedWarning() }
-                }
-
-                // Analytics Okay Checkbox
-
-                val isGooglePlayAvailable = context.isGooglePlayAvailable
-                val isAnalyticsAllowed = app.isAnalyticsAllowed && isGooglePlayAvailable
-                if (isGooglePlayAvailable) {
-                    var loading by remember { mutableStateOf(false) }
-                    LaunchedEffect(isAnalyticsAllowed) { loading = false }
-                    Row(
-                        modifier =
-                        Modifier.fillMaxWidth()
-                            .toggleable(
-                                value = isAnalyticsAllowed,
-                                onValueChange = {
-                                    debug("User changed analytics to $it")
-                                    app.isAnalyticsAllowed = it
-                                    loading = true
-                                },
-                                role = Role.Checkbox,
-                                enabled = isGooglePlayAvailable && !loading,
-                            )
-                            .padding(horizontal = 16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Checkbox(enabled = isGooglePlayAvailable, checked = isAnalyticsAllowed, onCheckedChange = null)
+                    // Warning Not Paired
+                    val hasShownNotPairedWarning by uiViewModel.hasShownNotPairedWarning.collectAsStateWithLifecycle()
+                    val showWarningNotPaired =
+                        !isConnected &&
+                            !hasShownNotPairedWarning &&
+                            bleDevices.none { it is DeviceListEntry.Ble && it.bonded }
+                    if (showWarningNotPaired) {
                         Text(
-                            text = stringResource(R.string.analytics_okay),
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(start = 16.dp),
+                            text = stringResource(R.string.warning_not_paired),
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(horizontal = 16.dp),
                         )
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        LaunchedEffect(Unit) { uiViewModel.suppressNoPairedWarning() }
                     }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    // Report Bug Button
-                    Button(
-                        onClick = { showReportBugDialog = true }, // Set state to show Report Bug dialog
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                        enabled = isAnalyticsAllowed,
-                    ) {
-                        Text(stringResource(R.string.report_bug))
+
+                    // Analytics Okay Checkbox
+
+                    val isGooglePlayAvailable = context.isGooglePlayAvailable
+                    val isAnalyticsAllowed = app.isAnalyticsAllowed && isGooglePlayAvailable
+                    if (isGooglePlayAvailable) {
+                        var loading by remember { mutableStateOf(false) }
+                        LaunchedEffect(isAnalyticsAllowed) { loading = false }
+                        Row(
+                            modifier =
+                            Modifier.fillMaxWidth()
+                                .toggleable(
+                                    value = isAnalyticsAllowed,
+                                    onValueChange = {
+                                        debug("User changed analytics to $it")
+                                        app.isAnalyticsAllowed = it
+                                        loading = true
+                                    },
+                                    role = Role.Checkbox,
+                                    enabled = isGooglePlayAvailable && !loading,
+                                )
+                                .padding(horizontal = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Checkbox(
+                                enabled = isGooglePlayAvailable,
+                                checked = isAnalyticsAllowed,
+                                onCheckedChange = null,
+                            )
+                            Text(
+                                text = stringResource(R.string.analytics_okay),
+                                style = MaterialTheme.typography.bodyLarge,
+                                modifier = Modifier.padding(start = 16.dp),
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(16.dp))
+                        // Report Bug Button
+                        Button(
+                            onClick = { showReportBugDialog = true }, // Set state to show Report Bug dialog
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                            enabled = isAnalyticsAllowed,
+                        ) {
+                            Text(stringResource(R.string.report_bug))
+                        }
                     }
                 }
             }
-        }
 
-        // Compose Device Scan Dialog
-        if (showScanDialog) {
-            Dialog(
-                onDismissRequest = {
-                    showScanDialog = false
-                    scanModel.clearScanResults()
-                },
-            ) {
-                Surface(shape = MaterialTheme.shapes.medium) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Text(
-                            text = "Select a Bluetooth device",
-                            style = MaterialTheme.typography.titleLarge,
-                            modifier = Modifier.padding(bottom = 16.dp),
-                        )
-                        Column(modifier = Modifier.selectableGroup()) {
-                            scanResults.values.forEach { device ->
-                                Row(
-                                    modifier =
-                                    Modifier.fillMaxWidth()
-                                        .selectable(
-                                            selected = false, // No pre-selection in this dialog
-                                            onClick = {
-                                                scanModel.onSelected(device)
-                                                scanModel.clearScanResults()
-                                                showScanDialog = false
-                                            },
-                                        )
-                                        .padding(vertical = 8.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    Text(text = device.name)
+            // Compose Device Scan Dialog
+            if (showScanDialog) {
+                Dialog(
+                    onDismissRequest = {
+                        showScanDialog = false
+                        scanModel.clearScanResults()
+                    },
+                ) {
+                    Surface(shape = MaterialTheme.shapes.medium) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text(
+                                text = "Select a Bluetooth device",
+                                style = MaterialTheme.typography.titleLarge,
+                                modifier = Modifier.padding(bottom = 16.dp),
+                            )
+                            Column(modifier = Modifier.selectableGroup()) {
+                                scanResults.values.forEach { device ->
+                                    Row(
+                                        modifier =
+                                        Modifier.fillMaxWidth()
+                                            .selectable(
+                                                selected = false, // No pre-selection in this dialog
+                                                onClick = {
+                                                    scanModel.onSelected(device)
+                                                    scanModel.clearScanResults()
+                                                    showScanDialog = false
+                                                },
+                                            )
+                                            .padding(vertical = 8.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Text(text = device.name)
+                                    }
                                 }
                             }
+                            Spacer(modifier = Modifier.height(16.dp))
+                            TextButton(
+                                onClick = {
+                                    scanModel.clearScanResults()
+                                    showScanDialog = false
+                                },
+                            ) {
+                                Text(stringResource(R.string.cancel))
+                            }
                         }
-                        Spacer(modifier = Modifier.height(16.dp))
-                        TextButton(
+                    }
+                }
+            }
+
+            // Compose Report Bug Dialog
+            if (showReportBugDialog) {
+                AlertDialog(
+                    onDismissRequest = { showReportBugDialog = false },
+                    title = { Text(stringResource(R.string.report_a_bug)) },
+                    text = { Text(stringResource(R.string.report_bug_text)) },
+                    confirmButton = {
+                        Button(
                             onClick = {
-                                scanModel.clearScanResults()
-                                showScanDialog = false
+                                showReportBugDialog = false
+                                reportError("Clicked Report A Bug")
+                                uiViewModel.showSnackBar("Bug report sent!")
+                            },
+                        ) {
+                            Text(stringResource(R.string.report))
+                        }
+                    },
+                    dismissButton = {
+                        Button(
+                            onClick = {
+                                showReportBugDialog = false
+                                debug("Decided not to report a bug")
                             },
                         ) {
                             Text(stringResource(R.string.cancel))
                         }
-                    }
-                }
+                    },
+                )
             }
         }
 
-        // Compose Report Bug Dialog
-        if (showReportBugDialog) {
-            AlertDialog(
-                onDismissRequest = { showReportBugDialog = false },
-                title = { Text(stringResource(R.string.report_a_bug)) },
-                text = { Text(stringResource(R.string.report_bug_text)) },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            showReportBugDialog = false
-                            reportError("Clicked Report A Bug")
-                            uiViewModel.showSnackBar("Bug report sent!")
-                        },
-                    ) {
-                        Text(stringResource(R.string.report))
-                    }
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            showReportBugDialog = false
-                            debug("Decided not to report a bug")
-                        },
-                    ) {
-                        Text(stringResource(R.string.cancel))
-                    }
-                },
+        Box(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+            Text(
+                text = scanStatusText.orEmpty(),
+                fontSize = 10.sp,
+                textAlign = TextAlign.End,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -265,6 +265,7 @@ fun ConnectionsScreen(
                                 onNavigateToNodeDetails = onNavigateToNodeDetails,
                                 onSetShowSharedContact = { showSharedContact = it },
                                 onNavigateToRadioConfig = onNavigateToRadioConfig,
+                                onClickDisconnect = { scanModel.disconnect() },
                             )
                         }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
@@ -153,7 +153,7 @@ fun BLEDevices(
                         }
                     }
 
-                    if (btDevices.filterNot { it is DeviceListEntry.Disconnect }.isEmpty()) {
+                    if (btDevices.isEmpty()) {
                         EmptyStateContent(
                             imageVector = Icons.Rounded.BluetoothDisabled,
                             text =

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
@@ -23,25 +23,20 @@ import android.os.Build
 import android.provider.Settings.ACTION_BLUETOOTH_SETTINGS
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BluetoothDisabled
 import androidx.compose.material.icons.rounded.BluetoothDisabled
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -49,10 +44,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.geeksville.mesh.R
@@ -171,15 +164,7 @@ fun BLEDevices(
                     } else {
                         Spacer(modifier = Modifier.height(8.dp))
 
-                        Text(
-                            stringResource(R.string.bluetooth_paired_devices),
-                            modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
-                            style = MaterialTheme.typography.titleLarge,
-                        )
-
-                        Spacer(modifier = Modifier.height(8.dp))
-
-                        Card {
+                        TitledCard(title = stringResource(R.string.bluetooth_paired_devices)) {
                             btDevices.forEach { device ->
                                 DeviceListItem(
                                     connectionState = connectionState,
@@ -213,30 +198,6 @@ fun BLEDevices(
                 },
             )
         }
-    }
-}
-
-@Composable
-private fun EmptyStateContent(
-    imageVector: ImageVector? = null,
-    text: String,
-    actionButton: @Composable (() -> Unit)? = null,
-) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        imageVector?.let { Icon(imageVector = imageVector, contentDescription = text, modifier = Modifier.size(96.dp)) }
-
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.padding(vertical = 8.dp),
-            textAlign = TextAlign.Center,
-        )
-
-        actionButton?.invoke()
     }
 }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
@@ -23,12 +23,11 @@ import android.os.Build
 import android.provider.Settings.ACTION_BLUETOOTH_SETTINGS
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BluetoothDisabled
@@ -107,7 +106,11 @@ fun BLEDevices(
             // checkPermissionsAndScan(permissionsState, scanModel, bluetoothEnabled)
         }
 
-    Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
         if (permissionsState.allPermissionsGranted) {
             when {
                 !bluetoothEnabled -> {
@@ -162,8 +165,6 @@ fun BLEDevices(
                             actionButton = scanButton,
                         )
                     } else {
-                        Spacer(modifier = Modifier.height(8.dp))
-
                         TitledCard(title = stringResource(R.string.bluetooth_paired_devices)) {
                             btDevices.forEach { device ->
                                 DeviceListItem(
@@ -175,8 +176,6 @@ fun BLEDevices(
                                 )
                             }
                         }
-
-                        Spacer(modifier = Modifier.weight(1f, true))
 
                         scanButton()
                     }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.BluetoothDisabled
 import androidx.compose.material.icons.rounded.BluetoothDisabled
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Button
@@ -65,7 +64,7 @@ import com.google.accompanist.permissions.rememberMultiplePermissionsState
  * @param scanModel The ViewModel responsible for Bluetooth scanning logic.
  */
 @OptIn(ExperimentalPermissionsApi::class)
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 fun BLEDevices(
     connectionState: ConnectionState,
@@ -167,10 +166,11 @@ fun BLEDevices(
                     } else {
                         TitledCard(title = stringResource(R.string.bluetooth_paired_devices)) {
                             btDevices.forEach { device ->
+                                val connected =
+                                    connectionState == ConnectionState.CONNECTED && device.fullAddress == selectedDevice
                                 DeviceListItem(
-                                    connectionState = connectionState,
+                                    connected = connected,
                                     device = device,
-                                    selected = device.fullAddress == selectedDevice,
                                     onSelect = { scanModel.onSelected(device) },
                                     modifier = Modifier,
                                 )

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedCard.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedCard.kt
@@ -20,9 +20,13 @@ package com.geeksville.mesh.ui.connections.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -31,6 +35,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -42,6 +48,7 @@ import com.geeksville.mesh.TelemetryProtos
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.ui.common.components.MaterialBatteryInfo
 import com.geeksville.mesh.ui.common.theme.AppTheme
+import com.geeksville.mesh.ui.common.theme.StatusColors.StatusRed
 import com.geeksville.mesh.ui.node.components.NodeChip
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 
@@ -52,11 +59,15 @@ fun CurrentlyConnectedCard(
     onNavigateToNodeDetails: (Int) -> Unit,
     onSetShowSharedContact: (Node) -> Unit,
     onNavigateToRadioConfig: () -> Unit,
+    onClickDisconnect: () -> Unit,
 ) {
     Card(modifier = modifier) {
-        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Column {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
                     NodeChip(
                         node = node,
                         isThisNode = true,
@@ -94,6 +105,19 @@ fun CurrentlyConnectedCard(
                     )
                 }
             }
+
+            Button(
+                shape = RectangleShape,
+                modifier = Modifier.fillMaxWidth().height(40.dp),
+                colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.StatusRed,
+                    contentColor = Color.White,
+                ),
+                onClick = onClickDisconnect,
+            ) {
+                Text(stringResource(R.string.disconnect))
+            }
         }
     }
 }
@@ -119,6 +143,7 @@ private fun CurrentlyConnectedCardPreview() {
             onNavigateToNodeDetails = {},
             onSetShowSharedContact = {},
             onNavigateToRadioConfig = {},
+            onClickDisconnect = {},
         )
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedCard.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedCard.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.ui.connections.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.geeksville.mesh.MeshProtos
+import com.geeksville.mesh.PaxcountProtos
+import com.geeksville.mesh.R
+import com.geeksville.mesh.TelemetryProtos
+import com.geeksville.mesh.model.Node
+import com.geeksville.mesh.ui.common.components.MaterialBatteryInfo
+import com.geeksville.mesh.ui.common.theme.AppTheme
+import com.geeksville.mesh.ui.node.components.NodeChip
+import com.geeksville.mesh.ui.node.components.NodeMenuAction
+
+@Composable
+fun CurrentlyConnectedCard(
+    node: Node,
+    modifier: Modifier = Modifier,
+    onNavigateToNodeDetails: (Int) -> Unit,
+    onSetShowSharedContact: (Node) -> Unit,
+    onNavigateToRadioConfig: () -> Unit,
+) {
+    Card(modifier = modifier) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    NodeChip(
+                        node = node,
+                        isThisNode = true,
+                        isConnected = true,
+                        onAction = { action ->
+                            when (action) {
+                                is NodeMenuAction.MoreDetails -> onNavigateToNodeDetails(node.num)
+
+                                is NodeMenuAction.Share -> onSetShowSharedContact(node)
+                                else -> {}
+                            }
+                        },
+                    )
+
+                    MaterialBatteryInfo(level = node.batteryLevel)
+                }
+
+                Column(modifier = Modifier.weight(1f, fill = true)) {
+                    Text(text = node.user.longName, style = MaterialTheme.typography.titleMedium)
+
+                    node.metadata?.firmwareVersion?.let { firmwareVersion ->
+                        Text(
+                            text = stringResource(R.string.firmware_version, firmwareVersion),
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+
+                IconButton(enabled = true, onClick = onNavigateToRadioConfig) {
+                    Icon(
+                        imageVector = Icons.Default.Settings,
+                        contentDescription = stringResource(id = R.string.radio_configuration),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Suppress("MagicNumber")
+@PreviewLightDark
+@Composable
+private fun CurrentlyConnectedCardPreview() {
+    AppTheme {
+        CurrentlyConnectedCard(
+            node =
+            Node(
+                num = 13444,
+                user = MeshProtos.User.newBuilder().setShortName("\uD83E\uDEE0").setLongName("John Doe").build(),
+                isIgnored = false,
+                paxcounter = PaxcountProtos.Paxcount.newBuilder().setBle(10).setWifi(5).build(),
+                environmentMetrics =
+                TelemetryProtos.EnvironmentMetrics.newBuilder()
+                    .setTemperature(25f)
+                    .setRelativeHumidity(60f)
+                    .build(),
+            ),
+            onNavigateToNodeDetails = {},
+            onSetShowSharedContact = {},
+            onNavigateToRadioConfig = {},
+        )
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
@@ -23,24 +23,25 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.Cancel
-import androidx.compose.material.icons.filled.CloudDone
-import androidx.compose.material.icons.filled.CloudOff
-import androidx.compose.material.icons.filled.CloudQueue
 import androidx.compose.material.icons.filled.Usb
 import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Bluetooth
+import androidx.compose.material.icons.rounded.Cancel
+import androidx.compose.material.icons.rounded.Usb
+import androidx.compose.material.icons.rounded.Wifi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.DeviceListEntry
 import com.geeksville.mesh.service.ConnectionState
-import com.geeksville.mesh.ui.common.theme.StatusColors.StatusGreen
-import com.geeksville.mesh.ui.common.theme.StatusColors.StatusRed
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
@@ -53,11 +54,11 @@ fun DeviceListItem(
 ) {
     val icon =
         when (device) {
-            is DeviceListEntry.Ble -> Icons.Default.Bluetooth
-            is DeviceListEntry.Usb -> Icons.Default.Usb
-            is DeviceListEntry.Tcp -> Icons.Default.Wifi
-            is DeviceListEntry.Disconnect -> Icons.Default.Cancel
-            is DeviceListEntry.Mock -> Icons.Default.Add
+            is DeviceListEntry.Ble -> Icons.Rounded.Bluetooth
+            is DeviceListEntry.Usb -> Icons.Rounded.Usb
+            is DeviceListEntry.Tcp -> Icons.Rounded.Wifi
+            is DeviceListEntry.Disconnect -> Icons.Rounded.Cancel
+            is DeviceListEntry.Mock -> Icons.Rounded.Add
         }
 
     val contentDescription =
@@ -69,39 +70,6 @@ fun DeviceListItem(
             is DeviceListEntry.Mock -> stringResource(R.string.add)
         }
 
-    val colors =
-        when {
-            selected && device is DeviceListEntry.Disconnect -> {
-                ListItemDefaults.colors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                    headlineColor = MaterialTheme.colorScheme.onErrorContainer,
-                    leadingIconColor = MaterialTheme.colorScheme.onErrorContainer,
-                    supportingColor = MaterialTheme.colorScheme.onErrorContainer,
-                    trailingIconColor = MaterialTheme.colorScheme.onErrorContainer,
-                )
-            }
-
-            selected -> { // Standard selection for other device types
-                ListItemDefaults.colors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    headlineColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    leadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    trailingIconColor =
-                    when (connectionState) {
-                        ConnectionState.CONNECTED -> MaterialTheme.colorScheme.StatusGreen
-                        ConnectionState.DISCONNECTED -> MaterialTheme.colorScheme.StatusRed
-                        else ->
-                            MaterialTheme.colorScheme
-                                .onPrimaryContainer // Fallback for other states (e.g. connecting)
-                    },
-                )
-            }
-
-            else -> {
-                ListItemDefaults.colors()
-            }
-        }
-
     val useSelectable = modifier == Modifier
     ListItem(
         modifier =
@@ -111,12 +79,7 @@ fun DeviceListItem(
             modifier.fillMaxWidth()
         },
         headlineContent = { Text(device.name) },
-        leadingContent = {
-            Icon(
-                icon, // icon is already CloudOff if device.isDisconnect
-                contentDescription,
-            )
-        },
+        leadingContent = { Icon(icon, contentDescription) },
         supportingContent = {
             if (device is DeviceListEntry.Tcp) {
                 Text(device.address)
@@ -124,16 +87,11 @@ fun DeviceListItem(
         },
         trailingContent = {
             if (device is DeviceListEntry.Disconnect) {
-                Icon(imageVector = Icons.Default.CloudOff, contentDescription = stringResource(R.string.disconnect))
-            } else if (connectionState == ConnectionState.CONNECTED) {
-                Icon(imageVector = Icons.Default.CloudDone, contentDescription = stringResource(R.string.connected))
+                RadioButton(selected = connectionState == ConnectionState.DISCONNECTED, onClick = null)
             } else {
-                Icon(
-                    imageVector = Icons.Default.CloudQueue,
-                    contentDescription = stringResource(R.string.not_connected),
-                )
+                RadioButton(selected = connectionState == ConnectionState.CONNECTED, onClick = null)
             }
         },
-        colors = colors,
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
     )
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
@@ -20,14 +20,8 @@ package com.geeksville.mesh.ui.connections.components
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Bluetooth
-import androidx.compose.material.icons.filled.Cancel
-import androidx.compose.material.icons.filled.Usb
-import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Bluetooth
-import androidx.compose.material.icons.rounded.Cancel
 import androidx.compose.material.icons.rounded.Usb
 import androidx.compose.material.icons.rounded.Wifi
 import androidx.compose.material3.Icon
@@ -57,7 +51,6 @@ fun DeviceListItem(
             is DeviceListEntry.Ble -> Icons.Rounded.Bluetooth
             is DeviceListEntry.Usb -> Icons.Rounded.Usb
             is DeviceListEntry.Tcp -> Icons.Rounded.Wifi
-            is DeviceListEntry.Disconnect -> Icons.Rounded.Cancel
             is DeviceListEntry.Mock -> Icons.Rounded.Add
         }
 
@@ -66,7 +59,6 @@ fun DeviceListItem(
             is DeviceListEntry.Ble -> stringResource(R.string.bluetooth)
             is DeviceListEntry.Usb -> stringResource(R.string.serial)
             is DeviceListEntry.Tcp -> stringResource(R.string.network)
-            is DeviceListEntry.Disconnect -> stringResource(R.string.disconnect)
             is DeviceListEntry.Mock -> stringResource(R.string.add)
         }
 
@@ -85,13 +77,7 @@ fun DeviceListItem(
                 Text(device.address)
             }
         },
-        trailingContent = {
-            if (device is DeviceListEntry.Disconnect) {
-                RadioButton(selected = connectionState == ConnectionState.DISCONNECTED, onClick = null)
-            } else {
-                RadioButton(selected = connectionState == ConnectionState.CONNECTED, onClick = null)
-            }
-        },
+        trailingContent = { RadioButton(selected = connectionState == ConnectionState.CONNECTED, onClick = null) },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
     )
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
@@ -77,7 +77,9 @@ fun DeviceListItem(
                 Text(device.address)
             }
         },
-        trailingContent = { RadioButton(selected = connectionState == ConnectionState.CONNECTED, onClick = null) },
+        trailingContent = {
+            RadioButton(selected = connectionState == ConnectionState.CONNECTED && selected, onClick = null)
+        },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
     )
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/DeviceListItem.kt
@@ -17,11 +17,12 @@
 
 package com.geeksville.mesh.ui.connections.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Bluetooth
+import androidx.compose.material.icons.rounded.BluetoothConnected
 import androidx.compose.material.icons.rounded.Usb
 import androidx.compose.material.icons.rounded.Wifi
 import androidx.compose.material3.Icon
@@ -35,20 +36,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.DeviceListEntry
-import com.geeksville.mesh.service.ConnectionState
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
-fun DeviceListItem(
-    connectionState: ConnectionState,
-    device: DeviceListEntry,
-    selected: Boolean,
-    onSelect: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
+fun DeviceListItem(connected: Boolean, device: DeviceListEntry, onSelect: () -> Unit, modifier: Modifier = Modifier) {
     val icon =
         when (device) {
-            is DeviceListEntry.Ble -> Icons.Rounded.Bluetooth
+            is DeviceListEntry.Ble ->
+                if (connected) {
+                    Icons.Rounded.BluetoothConnected
+                } else {
+                    Icons.Rounded.Bluetooth
+                }
             is DeviceListEntry.Usb -> Icons.Rounded.Usb
             is DeviceListEntry.Tcp -> Icons.Rounded.Wifi
             is DeviceListEntry.Mock -> Icons.Rounded.Add
@@ -66,7 +65,7 @@ fun DeviceListItem(
     ListItem(
         modifier =
         if (useSelectable) {
-            modifier.fillMaxWidth().selectable(selected = selected, onClick = onSelect)
+            modifier.fillMaxWidth().clickable(onClick = onSelect)
         } else {
             modifier.fillMaxWidth()
         },
@@ -77,9 +76,7 @@ fun DeviceListItem(
                 Text(device.address)
             }
         },
-        trailingContent = {
-            RadioButton(selected = connectionState == ConnectionState.CONNECTED && selected, onClick = null)
-        },
+        trailingContent = { RadioButton(selected = connected, onClick = null) },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
     )
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/EmptyStateContent.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/EmptyStateContent.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.ui.connections.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.BluetoothDisabled
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.geeksville.mesh.ui.common.theme.AppTheme
+
+@Composable
+fun EmptyStateContent(imageVector: ImageVector? = null, text: String, actionButton: @Composable (() -> Unit)? = null) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        imageVector?.let { Icon(imageVector = imageVector, contentDescription = text, modifier = Modifier.size(96.dp)) }
+
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(vertical = 8.dp),
+            textAlign = TextAlign.Center,
+        )
+
+        actionButton?.invoke()
+    }
+}
+
+@PreviewLightDark
+@Composable
+fun EmptyStateContentPreview() {
+    AppTheme {
+        Surface {
+            EmptyStateContent(imageVector = Icons.Rounded.BluetoothDisabled, text = "No devices found") {
+                Button(onClick = {}) { Text("Button") }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
@@ -120,9 +120,10 @@ fun NetworkDevices(
                     TitledCard(title = stringResource(R.string.recent_network_devices)) {
                         recentNetworkDevices.forEach { device ->
                             DeviceListItem(
-                                connectionState,
-                                device,
-                                device.fullAddress == selectedDevice,
+                                connected =
+                                connectionState == ConnectionState.CONNECTED &&
+                                    device.fullAddress == selectedDevice,
+                                device = device,
                                 onSelect = { scanModel.onSelected(device) },
                                 modifier =
                                 Modifier.combinedClickable(
@@ -141,9 +142,10 @@ fun NetworkDevices(
                     TitledCard(title = stringResource(R.string.discovered_network_devices)) {
                         discoveredNetworkDevices.forEach { device ->
                             DeviceListItem(
-                                connectionState,
-                                device,
-                                device.fullAddress == selectedDevice,
+                                connected =
+                                connectionState == ConnectionState.CONNECTED &&
+                                    device.fullAddress == selectedDevice,
+                                device = device,
                                 onSelect = { scanModel.onSelected(device) },
                             )
                         }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
@@ -168,6 +168,7 @@ private fun AddDeviceDialog(
 
     val scope = rememberCoroutineScope()
 
+    @Suppress("MagicNumber")
     ModalBottomSheet(onDismissRequest = onHideDialog, sheetState = sheetState) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -179,6 +180,7 @@ private fun AddDeviceDialog(
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal, imeAction = ImeAction.Next),
                     modifier = Modifier.weight(.7f),
                 )
+
                 OutlinedTextField(
                     state = portState,
                     labelPosition = TextFieldLabelPosition.Above(),

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
@@ -17,47 +17,50 @@
 
 package com.geeksville.mesh.ui.connections.components
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.WifiFind
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Wifi
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldLabelPosition
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.BTScanModel
 import com.geeksville.mesh.model.DeviceListEntry
 import com.geeksville.mesh.repository.network.NetworkRepository
 import com.geeksville.mesh.service.ConnectionState
+import com.geeksville.mesh.ui.common.theme.AppTheme
 import com.geeksville.mesh.ui.connections.isIPAddress
+import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Suppress("MagicNumber", "LongMethod")
 @Composable
 fun NetworkDevices(
@@ -67,138 +70,199 @@ fun NetworkDevices(
     selectedDevice: String,
     scanModel: BTScanModel,
 ) {
-    val manualIpAddress = rememberTextFieldState("")
-    val manualIpPort = rememberTextFieldState(NetworkRepository.Companion.SERVICE_PORT.toString())
+    val searchDialogState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    var showSearchDialog by remember { mutableStateOf(false) }
     var showDeleteDialog by remember { mutableStateOf(false) }
+
     var deviceToDelete by remember { mutableStateOf<DeviceListEntry?>(null) }
-    Text(
-        text = stringResource(R.string.network),
-        style = MaterialTheme.typography.titleLarge,
-        modifier = Modifier.padding(vertical = 8.dp),
-    )
-    DeviceListItem(
-        connectionState = connectionState,
-        device = scanModel.disconnectDevice,
-        selected = scanModel.disconnectDevice.fullAddress == selectedDevice,
-        onSelect = { scanModel.onSelected(scanModel.disconnectDevice) },
-    )
-    if (discoveredNetworkDevices.isNotEmpty()) {
-        Text(
-            text = stringResource(R.string.discovered_network_devices),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(vertical = 8.dp),
-        )
-        discoveredNetworkDevices.forEach { device ->
-            DeviceListItem(
-                connectionState,
-                device,
-                device.fullAddress == selectedDevice,
-                onSelect = { scanModel.onSelected(device) },
-            )
-        }
-    }
-    if (recentNetworkDevices.isNotEmpty()) {
-        Text(
-            text = stringResource(R.string.recent_network_devices),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(vertical = 8.dp),
-        )
-        recentNetworkDevices.forEach { device ->
-            DeviceListItem(
-                connectionState,
-                device,
-                device.fullAddress == selectedDevice,
-                onSelect = { scanModel.onSelected(device) },
-                modifier =
-                Modifier.combinedClickable(
-                    onClick = { scanModel.onSelected(device) },
-                    onLongClick = {
-                        deviceToDelete = device
-                        showDeleteDialog = true
-                    },
-                ),
-            )
-        }
-    }
-    if (showDeleteDialog && deviceToDelete != null) {
-        AlertDialog(
-            onDismissRequest = { showDeleteDialog = false },
-            title = { Text(stringResource(R.string.delete)) },
-            text = { Text(stringResource(R.string.confirm_delete_node)) },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        scanModel.removeRecentAddress(deviceToDelete!!.fullAddress)
-                        showDeleteDialog = false
-                    },
-                ) {
-                    Text(stringResource(R.string.delete))
-                }
-            },
-            dismissButton = {
-                Button(onClick = { showDeleteDialog = false }) { Text(stringResource(R.string.cancel)) }
+
+    if (showSearchDialog) {
+        AddDeviceDialog(
+            searchDialogState,
+            onHideDialog = { showSearchDialog = false },
+            onClickAdd = { ipAddress, fullAddress ->
+                scanModel.onSelected(DeviceListEntry.Tcp(ipAddress, fullAddress))
+                showSearchDialog = false
             },
         )
     }
-    if (discoveredNetworkDevices.isEmpty() && recentNetworkDevices.isEmpty()) {
-        Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalAlignment = CenterHorizontally) {
-            Icon(
-                imageVector = Icons.Default.WifiFind,
-                contentDescription = stringResource(R.string.no_network_devices),
-                modifier = Modifier.size(96.dp),
-            )
-            Text(
-                text = stringResource(R.string.no_network_devices),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(vertical = 8.dp),
+
+    if (showDeleteDialog) {
+        deviceToDelete?.let {
+            ConfirmDeleteDialog(
+                it.fullAddress,
+                onHideDialog = { showDeleteDialog = false },
+                onConfirm = { deviceFullAddress -> scanModel.removeRecentAddress(deviceFullAddress) },
             )
         }
     }
 
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(8.dp),
-        verticalAlignment = Alignment.Companion.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp, CenterHorizontally),
-    ) {
-        OutlinedTextField(
-            state = manualIpAddress,
-            lineLimits = TextFieldLineLimits.SingleLine,
-            label = { Text(stringResource(R.string.ip_address)) },
-            keyboardOptions =
-            KeyboardOptions(keyboardType = KeyboardType.Companion.Decimal, imeAction = ImeAction.Next),
-            modifier = Modifier.weight(.7f, fill = false), // Fill 70% of the space
-        )
-        OutlinedTextField(
-            state = manualIpPort,
-            placeholder = { Text(NetworkRepository.SERVICE_PORT.toString()) },
-            lineLimits = TextFieldLineLimits.SingleLine,
-            label = { Text(stringResource(R.string.ip_port)) },
-            keyboardOptions =
-            KeyboardOptions(keyboardType = KeyboardType.Companion.Decimal, imeAction = ImeAction.Done),
-            modifier = Modifier.weight(.3f, fill = false), // Fill remaining space
-        )
-        IconButton(
-            onClick = {
-                if (manualIpAddress.text.toString().isIPAddress()) {
-                    val fullAddress =
-                        "t" +
-                            if (
-                                manualIpPort.text.isNotEmpty() &&
-                                manualIpPort.text.toString().toInt() != NetworkRepository.SERVICE_PORT
-                            ) {
-                                "${manualIpAddress.text}:${manualIpPort.text}"
-                            } else {
-                                manualIpAddress.text.toString()
-                            }
-                    scanModel.onSelected(DeviceListEntry.Tcp(manualIpAddress.text.toString(), fullAddress))
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+        val addButton: @Composable () -> Unit = {
+            Button(onClick = { showSearchDialog = true }) {
+                Icon(imageVector = Icons.Rounded.Add, contentDescription = stringResource(R.string.add_network_device))
+                Text(stringResource(R.string.add_network_device))
+            }
+        }
+
+        when {
+            discoveredNetworkDevices.isEmpty() && recentNetworkDevices.isEmpty() -> {
+                EmptyStateContent(
+                    imageVector = Icons.Rounded.Wifi,
+                    text = stringResource(R.string.no_network_devices),
+                    actionButton = addButton,
+                )
+            }
+
+            else -> {
+                if (recentNetworkDevices.isNotEmpty()) {
+                    TitledCard(title = stringResource(R.string.recent_network_devices)) {
+                        recentNetworkDevices.forEach { device ->
+                            DeviceListItem(
+                                connectionState,
+                                device,
+                                device.fullAddress == selectedDevice,
+                                onSelect = { scanModel.onSelected(device) },
+                                modifier =
+                                Modifier.combinedClickable(
+                                    onClick = { scanModel.onSelected(device) },
+                                    onLongClick = {
+                                        deviceToDelete = device
+                                        showDeleteDialog = true
+                                    },
+                                ),
+                            )
+                        }
+                    }
                 }
-            },
-        ) {
-            Icon(
-                imageVector = Icons.Default.WifiFind,
-                contentDescription = stringResource(R.string.add),
-                modifier = Modifier.size(32.dp),
-            )
+
+                if (discoveredNetworkDevices.isNotEmpty()) {
+                    TitledCard(title = stringResource(R.string.discovered_network_devices)) {
+                        discoveredNetworkDevices.forEach { device ->
+                            DeviceListItem(
+                                connectionState,
+                                device,
+                                device.fullAddress == selectedDevice,
+                                onSelect = { scanModel.onSelected(device) },
+                            )
+                        }
+                    }
+                }
+
+                addButton()
+            }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddDeviceDialog(
+    sheetState: SheetState,
+    onHideDialog: () -> Unit,
+    onClickAdd: (ipAddress: String, fullAddress: String) -> Unit,
+) {
+    val ipState = rememberTextFieldState("")
+    val portState = rememberTextFieldState(NetworkRepository.SERVICE_PORT.toString())
+
+    val scope = rememberCoroutineScope()
+
+    ModalBottomSheet(onDismissRequest = onHideDialog, sheetState = sheetState) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    state = ipState,
+                    labelPosition = TextFieldLabelPosition.Above(),
+                    lineLimits = TextFieldLineLimits.SingleLine,
+                    label = { Text(stringResource(R.string.ip_address)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal, imeAction = ImeAction.Next),
+                    modifier = Modifier.weight(.7f),
+                )
+                OutlinedTextField(
+                    state = portState,
+                    labelPosition = TextFieldLabelPosition.Above(),
+                    placeholder = { Text(NetworkRepository.SERVICE_PORT.toString()) },
+                    lineLimits = TextFieldLineLimits.SingleLine,
+                    label = { Text(stringResource(R.string.ip_port)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal, imeAction = ImeAction.Done),
+                    modifier = Modifier.weight(.3f),
+                )
+            }
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(modifier = Modifier.weight(1f), onClick = { onHideDialog() }) {
+                    Text(stringResource(R.string.cancel))
+                }
+
+                Button(
+                    modifier = Modifier.weight(1f),
+                    onClick = {
+                        val ipAddress = ipState.text.toString()
+                        if (ipAddress.isIPAddress()) {
+                            val portString = portState.text.toString()
+
+                            val combinedString =
+                                if (portString.isNotEmpty() && portString.toInt() != NetworkRepository.SERVICE_PORT) {
+                                    "$ipAddress:$portString"
+                                } else {
+                                    ipAddress
+                                }
+
+                            onClickAdd(ipState.text.toString(), "t$combinedString")
+
+                            scope
+                                .launch { sheetState.hide() }
+                                .invokeOnCompletion {
+                                    if (!sheetState.isVisible) {
+                                        onHideDialog()
+                                    }
+                                }
+                        }
+                    },
+                ) {
+                    Text(stringResource(R.string.add_network_device))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConfirmDeleteDialog(
+    fullAddressToDelete: String,
+    onHideDialog: () -> Unit,
+    onConfirm: (deviceFullAddress: String) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onHideDialog,
+        title = { Text(stringResource(R.string.delete)) },
+        text = { Text(stringResource(R.string.confirm_delete_node)) },
+        confirmButton = {
+            Button(
+                onClick = {
+                    onConfirm(fullAddressToDelete)
+                    onHideDialog()
+                },
+            ) {
+                Text(stringResource(R.string.delete))
+            }
+        },
+        dismissButton = { Button(onClick = { onHideDialog() }) { Text(stringResource(R.string.cancel)) } },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewLightDark
+@Composable
+private fun SearchDialogPreview() {
+    AppTheme {
+        AddDeviceDialog(sheetState = rememberModalBottomSheetState(), onHideDialog = {}, onClickAdd = { _, _ -> })
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ConfirmDeleteDialogPreview() {
+    AppTheme { ConfirmDeleteDialog(fullAddressToDelete = "", onHideDialog = {}, onConfirm = {}) }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/TitledCard.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/TitledCard.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.ui.connections.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.geeksville.mesh.ui.common.theme.AppTheme
+
+@Composable
+fun TitledCard(title: String, content: @Composable ColumnScope.() -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            title,
+            modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
+            style = MaterialTheme.typography.titleLarge,
+        )
+
+        Card(content = content)
+    }
+}
+
+@PreviewLightDark
+@Composable
+fun TitledCardPreview() {
+    AppTheme { Surface { TitledCard(title = "Title") { Box(modifier = Modifier.fillMaxWidth().height(100.dp)) {} } } }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
@@ -59,9 +59,9 @@ private fun UsbDevices(
             TitledCard(title = "") {
                 usbDevices.forEach { device ->
                     DeviceListItem(
-                        connectionState = connectionState,
+                        connected =
+                        connectionState == ConnectionState.CONNECTED && device.fullAddress == selectedDevice,
                         device = device,
-                        selected = device.fullAddress == selectedDevice,
                         onSelect = { onDeviceSelected(device) },
                         modifier = Modifier,
                     )

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
@@ -52,7 +52,7 @@ private fun UsbDevices(
     onDeviceSelected: (DeviceListEntry) -> Unit,
 ) {
     when {
-        usbDevices.filterNot { it is DeviceListEntry.Disconnect || it is DeviceListEntry.Mock }.isEmpty() ->
+        usbDevices.isEmpty() ->
             EmptyStateContent(imageVector = Icons.Rounded.UsbOff, text = stringResource(R.string.no_usb_devices))
 
         else ->

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
@@ -17,24 +17,17 @@
 
 package com.geeksville.mesh.ui.connections.components
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.UsbOff
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.material.icons.rounded.UsbOff
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.BTScanModel
 import com.geeksville.mesh.model.DeviceListEntry
 import com.geeksville.mesh.service.ConnectionState
+import com.geeksville.mesh.ui.common.theme.AppTheme
 
 @Composable
 fun UsbDevices(
@@ -43,32 +36,49 @@ fun UsbDevices(
     selectedDevice: String,
     scanModel: BTScanModel,
 ) {
-    Text(
-        text = stringResource(R.string.serial),
-        style = MaterialTheme.typography.titleLarge,
-        modifier = Modifier.padding(vertical = 8.dp),
+    UsbDevices(
+        connectionState = connectionState,
+        usbDevices = usbDevices,
+        selectedDevice = selectedDevice,
+        onDeviceSelected = scanModel::onSelected,
     )
-    usbDevices.forEach { device ->
-        DeviceListItem(
-            connectionState = connectionState,
-            device = device,
-            selected = device.fullAddress == selectedDevice,
-            onSelect = { scanModel.onSelected(device) },
-            modifier = Modifier,
-        )
+}
+
+@Composable
+private fun UsbDevices(
+    connectionState: ConnectionState,
+    usbDevices: List<DeviceListEntry>,
+    selectedDevice: String,
+    onDeviceSelected: (DeviceListEntry) -> Unit,
+) {
+    when {
+        usbDevices.filterNot { it is DeviceListEntry.Disconnect || it is DeviceListEntry.Mock }.isEmpty() ->
+            EmptyStateContent(imageVector = Icons.Rounded.UsbOff, text = stringResource(R.string.no_usb_devices))
+
+        else ->
+            TitledCard(title = "") {
+                usbDevices.forEach { device ->
+                    DeviceListItem(
+                        connectionState = connectionState,
+                        device = device,
+                        selected = device.fullAddress == selectedDevice,
+                        onSelect = { onDeviceSelected(device) },
+                        modifier = Modifier,
+                    )
+                }
+            }
     }
-    if (usbDevices.filterNot { it is DeviceListEntry.Disconnect || it is DeviceListEntry.Mock }.isEmpty()) {
-        Column(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalAlignment = CenterHorizontally) {
-            Icon(
-                imageVector = Icons.Default.UsbOff,
-                contentDescription = stringResource(R.string.no_usb_devices),
-                modifier = Modifier.size(96.dp),
-            )
-            Text(
-                text = stringResource(R.string.no_usb_devices),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(vertical = 8.dp),
-            )
-        }
+}
+
+@PreviewLightDark
+@Composable
+private fun UsbDevicesPreview() {
+    AppTheme {
+        UsbDevices(
+            connectionState = ConnectionState.CONNECTED,
+            usbDevices = emptyList(),
+            selectedDevice = "",
+            onDeviceSelected = {},
+        )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,7 +105,7 @@
     <string name="cancel">Cancel</string>
     <string name="clear_changes">Clear changes</string>
     <string name="new_channel_rcvd">New Channel URL received</string>
-    <string name="permission_missing">Meshtastic needs location permission and location must be turned on to find new devices via Bluetooth. You can turn it off again afterwards.</string>
+    <string name="permission_missing">Meshtastic needs location permissions enabled to find new devices via Bluetooth. You can disable when not in use.</string>
     <string name="report_bug">Report Bug</string>
     <string name="report_a_bug">Report a bug</string>
     <string name="report_bug_text">Are you sure you want to report a bug? After reporting, please post in https://github.com/orgs/meshtastic/discussions so we can match up the report with what you found.</string>
@@ -201,8 +201,10 @@
     <string name="quick_chat_show">Show quick chat menu</string>
     <string name="quick_chat_hide">Hide quick chat menu</string>
     <string name="factory_reset">Factory reset</string>
-    <string name="bluetooth_disabled">Bluetooth disabled</string>
-    <string name="permission_missing_31">Meshtastic needs Nearby devices permission to find and connect to devices via Bluetooth. You can turn it off when not in use.</string>
+    <string name="bluetooth_disabled">Bluetooth is disabled. Please enable it in your device settings.</string>
+    <string name="open_settings">Open settings</string>
+    <string name="firmware_version">Firmware version: %1$s</string>
+    <string name="permission_missing_31">Meshtastic needs \"Nearby devices\" permissions enabled to find and connect to devices via Bluetooth. You can disable when not in use.</string>
     <string name="direct_message">Direct Message</string>
     <string name="nodedb_reset">NodeDB reset</string>
     <string name="delivery_confirmed">Delivery confirmed</string>
@@ -652,7 +654,8 @@
     <string name="node_count_template">(%1$d online / %2$d total)</string>
     <string name="react">React</string>
     <string name="disconnect">Disconnect</string>
-    <string name="no_ble_devices">No Bluetooth devices found.</string>
+    <string name="scanning_bluetooth">Scanning for Bluetooth devices…</string>
+    <string name="no_ble_devices">No paired Bluetooth devices.</string>
     <string name="no_network_devices">No Network devices found.</string>
     <string name="no_usb_devices">No USB Serial devices found.</string>
     <string name="scroll_to_bottom">Scroll to bottom</string>
@@ -709,6 +712,9 @@
     <string name="no_pax_metrics_logs">No PAX metrics logs available.</string>
     <string name="wifi_devices">WiFi Devices</string>
     <string name="ble_devices">BLE Devices</string>
+    <string name="bluetooth_paired_devices">Paired Devices</string>
+    <string name="connected_device">Connected Device</string>
+    <string name="action_go">Go</string>
 
     <string name="routing_error_rate_limit_exceeded">Rate Limit Exceeded. Please try again later.</string>
     <string name="view_release">View Release</string>
@@ -759,7 +765,7 @@
     <string name="configure_critical_alerts">Configure Critical Alerts</string>
     <string name="notification_permissions_description">Meshtastic uses notifications to keep you updated on new messages and other important events. You can update your notification permissions at any time from settings.</string>
     <string name="next">Next</string>
-    <string name="grant_permissions_and_scan">Grant Permissions and Scan</string>
+    <string name="grant_permissions">Grant Permissions</string>
     <string name="nodes_queued_for_deletion">%d nodes queued for deletion:</string>
     <string name="clean_node_database_description">Caution: This removes nodes from in-app and on-device databases.\nSelections are additive.</string>
     <string name="connecting_to_device">Connecting to device</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
     <string name="save_rangetest">Export rangetest.csv</string>
     <string name="reset">Reset</string>
     <string name="scan">Scan</string>
+    <string name="add_network_device">Add</string>
     <string name="are_you_sure_change_default">Are you sure you want to change to the default channel?</string>
     <string name="reset_to_defaults">Reset to defaults</string>
     <string name="apply">Apply</string>


### PR DESCRIPTION
Cleans up the display of the connections screen, while leaving existing functionality intact. I've handled a couple more bluetooth edge cases, including launching the device bluetooth settings screen when disabled.

Pretty large diff, so I'd appreciate some help reviewing that everything still works. I only have a bluetooth radio, so that's all I've really been able to test, but the bulk of these changes are just UI updates. Network and serial device components were pretty straightforward - nothing of note there.

|Bluetooth before|Bluetooth after|
|-|-|
|<video src="https://github.com/user-attachments/assets/ec5b5189-69e6-483c-ae50-33fb8d658a09"/>|<video src="https://github.com/user-attachments/assets/1171efd6-c187-4956-a0e7-f8bf80e62952"/>|

|TCP before|TCP after|
|-|-|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/475f001b-452e-4389-b220-41c9f3aa0ad7" />|<video src="https://github.com/user-attachments/assets/76931fba-6785-4c1d-8bde-a7bb6dd2b5d9"/>|