### PR TITLE
feat(navigation): Add deep links to other screens

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -162,11 +162,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
-                <data android:scheme="meshtastic" />
-                <data android:host="meshtastic" />
-                <data android:pathPrefix="/messages" />
-                <data android:pathPrefix="/share" />
-                <data android:pathPrefix="/settings" />
+                <data android:scheme="meshtastic" android:host="meshtastic" />
             </intent-filter>
 
             <intent-filter android:autoVerify="true">

--- a/app/src/main/java/com/geeksville/mesh/navigation/ContactsRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/ContactsRoutes.kt
@@ -17,6 +17,7 @@
 
 package com.geeksville.mesh.navigation
 
+import android.content.Intent
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -44,7 +45,15 @@ sealed class ContactsRoutes {
 
 fun NavGraphBuilder.contactsGraph(navController: NavHostController, uiViewModel: UIViewModel) {
     navigation<ContactsRoutes.ContactsGraph>(startDestination = ContactsRoutes.Contacts) {
-        composable<ContactsRoutes.Contacts> {
+        composable<ContactsRoutes.Contacts>(
+            deepLinks =
+            listOf(
+                navDeepLink {
+                    uriPattern = "$DEEP_LINK_BASE_URI/contacts"
+                    action = Intent.ACTION_VIEW
+                },
+            ),
+        ) {
             ContactsScreen(
                 uiViewModel,
                 onNavigateToMessages = { navController.navigate(ContactsRoutes.Messages(it)) },
@@ -56,7 +65,7 @@ fun NavGraphBuilder.contactsGraph(navController: NavHostController, uiViewModel:
             listOf(
                 navDeepLink {
                     uriPattern = "$DEEP_LINK_BASE_URI/messages/{contactKey}?message={message}"
-                    action = "android.intent.action.VIEW"
+                    action = Intent.ACTION_VIEW
                 },
             ),
         ) { backStackEntry ->
@@ -77,7 +86,7 @@ fun NavGraphBuilder.contactsGraph(navController: NavHostController, uiViewModel:
         listOf(
             navDeepLink {
                 uriPattern = "$DEEP_LINK_BASE_URI/share?message={message}"
-                action = "android.intent.action.VIEW"
+                action = Intent.ACTION_VIEW
             },
         ),
     ) { backStackEntry ->
@@ -88,5 +97,15 @@ fun NavGraphBuilder.contactsGraph(navController: NavHostController, uiViewModel:
             }
         }
     }
-    composable<ContactsRoutes.QuickChat> { QuickChatScreen() }
+    composable<ContactsRoutes.QuickChat>(
+        deepLinks =
+        listOf(
+            navDeepLink {
+                uriPattern = "$DEEP_LINK_BASE_URI/quick_chat"
+                action = Intent.ACTION_VIEW
+            },
+        ),
+    ) {
+        QuickChatScreen()
+    }
 }

--- a/app/src/main/java/com/geeksville/mesh/navigation/MapRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/MapRoutes.kt
@@ -17,9 +17,11 @@
 
 package com.geeksville.mesh.navigation
 
+import android.content.Intent
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.map.MapView
 import com.geeksville.mesh.ui.map.MapViewModel
@@ -30,7 +32,15 @@ sealed class MapRoutes {
 }
 
 fun NavGraphBuilder.mapGraph(navController: NavHostController, uiViewModel: UIViewModel, mapViewModel: MapViewModel) {
-    composable<MapRoutes.Map> {
+    composable<MapRoutes.Map>(
+        deepLinks =
+        listOf(
+            navDeepLink {
+                uriPattern = "$DEEP_LINK_BASE_URI/map"
+                action = Intent.ACTION_VIEW
+            },
+        ),
+    ) {
         MapView(
             uiViewModel = uiViewModel,
             mapViewModel = mapViewModel,

--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -17,6 +17,7 @@
 
 package com.geeksville.mesh.navigation
 
+import android.content.Intent
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -27,6 +28,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navDeepLink
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
@@ -79,7 +81,17 @@ fun NavGraph(
         mapGraph(navController, uIViewModel, mapViewModel)
         channelsGraph(navController, uIViewModel)
         connectionsGraph(navController, uIViewModel, bluetoothViewModel)
-        composable<Route.DebugPanel> { DebugScreen() }
+        composable<Route.DebugPanel>(
+            deepLinks =
+            listOf(
+                navDeepLink {
+                    uriPattern = "$DEEP_LINK_BASE_URI/debug_panel"
+                    action = Intent.ACTION_VIEW
+                },
+            ),
+        ) {
+            DebugScreen()
+        }
         radioConfigGraph(navController, uIViewModel)
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/navigation/RadioConfigRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/RadioConfigRoutes.kt
@@ -17,6 +17,7 @@
 
 package com.geeksville.mesh.navigation
 
+import android.content.Intent
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Forward
@@ -48,6 +49,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import androidx.navigation.navigation
 import com.geeksville.mesh.MeshProtos.DeviceMetadata
 import com.geeksville.mesh.R
@@ -138,7 +140,19 @@ fun getNavRouteFrom(routeName: String): Route? =
 
 fun NavGraphBuilder.radioConfigGraph(navController: NavHostController, uiViewModel: UIViewModel) {
     navigation<RadioConfigRoutes.RadioConfigGraph>(startDestination = RadioConfigRoutes.RadioConfig()) {
-        composable<RadioConfigRoutes.RadioConfig> { backStackEntry ->
+        composable<RadioConfigRoutes.RadioConfig>(
+            deepLinks =
+            listOf(
+                navDeepLink {
+                    uriPattern = "$DEEP_LINK_BASE_URI/radio_config/{destNum}"
+                    action = Intent.ACTION_VIEW
+                },
+                navDeepLink {
+                    uriPattern = "$DEEP_LINK_BASE_URI/radio_config"
+                    action = Intent.ACTION_VIEW
+                },
+            ),
+        ) { backStackEntry ->
             val parentEntry =
                 remember(backStackEntry) {
                     val parentRoute = backStackEntry.destination.parent!!.route!!
@@ -148,7 +162,17 @@ fun NavGraphBuilder.radioConfigGraph(navController: NavHostController, uiViewMod
                 navController.navigate(it) { popUpTo(RadioConfigRoutes.RadioConfig()) { inclusive = false } }
             }
         }
-        composable<RadioConfigRoutes.CleanNodeDb> { CleanNodeDatabaseScreen() }
+        composable<RadioConfigRoutes.CleanNodeDb>(
+            deepLinks =
+            listOf(
+                navDeepLink {
+                    uriPattern = "$DEEP_LINK_BASE_URI/radio_config/clean_node_db"
+                    action = Intent.ACTION_VIEW
+                },
+            ),
+        ) {
+            CleanNodeDatabaseScreen()
+        }
         configRoutes(navController)
         moduleRoutes(navController)
     }
@@ -156,7 +180,21 @@ fun NavGraphBuilder.radioConfigGraph(navController: NavHostController, uiViewMod
 
 private fun NavGraphBuilder.configRoutes(navController: NavHostController) {
     ConfigRoute.entries.forEach { configRoute ->
-        composable(configRoute.route::class) { backStackEntry ->
+        val pathSegment = configRoute.name.lowercase()
+        composable(
+            route = configRoute.route::class,
+            deepLinks =
+            listOf(
+                navDeepLink {
+                    uriPattern = "$DEEP_LINK_BASE_URI/radio_config/{destNum}/$pathSegment"
+                    action = Intent.ACTION_VIEW
+                },
+                navDeepLink {
+                    uriPattern = "$DEEP_LINK_BASE_URI/radio_config/$pathSegment"
+                    action = Intent.ACTION_VIEW
+                },
+            ),
+        ) { backStackEntry ->
             val parentEntry =
                 remember(backStackEntry) {
                     val parentRoute = backStackEntry.destination.parent!!.route!!
@@ -181,7 +219,21 @@ private fun NavGraphBuilder.configRoutes(navController: NavHostController) {
 @Suppress("CyclomaticComplexMethod")
 private fun NavGraphBuilder.moduleRoutes(navController: NavHostController) {
     ModuleRoute.entries.forEach { moduleRoute ->
-        composable(moduleRoute.route::class) { backStackEntry ->
+        val pathSegment = moduleRoute.name.lowercase()
+        composable(
+            route = moduleRoute.route::class,
+            deepLinks =
+            listOf(
+                navDeepLink {
+                    uriPattern = "$DEEP_LINK_BASE_URI/radio_config/{destNum}/$pathSegment"
+                    action = Intent.ACTION_VIEW
+                },
+                navDeepLink {
+                    uriPattern = "$DEEP_LINK_BASE_URI/radio_config/$pathSegment"
+                    action = Intent.ACTION_VIEW
+                },
+            ),
+        ) { backStackEntry ->
             val parentEntry =
                 remember(backStackEntry) {
                     val parentRoute = backStackEntry.destination.parent!!.route!!
@@ -191,20 +243,15 @@ private fun NavGraphBuilder.moduleRoutes(navController: NavHostController) {
                 ModuleRoute.MQTT -> MQTTConfigScreen(hiltViewModel(parentEntry))
                 ModuleRoute.SERIAL -> SerialConfigScreen(hiltViewModel(parentEntry))
                 ModuleRoute.EXT_NOTIFICATION -> ExternalNotificationConfigScreen(hiltViewModel(parentEntry))
-
                 ModuleRoute.STORE_FORWARD -> StoreForwardConfigScreen(hiltViewModel(parentEntry))
                 ModuleRoute.RANGE_TEST -> RangeTestConfigScreen(hiltViewModel(parentEntry))
                 ModuleRoute.TELEMETRY -> TelemetryConfigScreen(hiltViewModel(parentEntry))
                 ModuleRoute.CANNED_MESSAGE -> CannedMessageConfigScreen(hiltViewModel(parentEntry))
-
                 ModuleRoute.AUDIO -> AudioConfigScreen(hiltViewModel(parentEntry))
                 ModuleRoute.REMOTE_HARDWARE -> RemoteHardwareConfigScreen(hiltViewModel(parentEntry))
-
                 ModuleRoute.NEIGHBOR_INFO -> NeighborInfoConfigScreen(hiltViewModel(parentEntry))
                 ModuleRoute.AMBIENT_LIGHTING -> AmbientLightingConfigScreen(hiltViewModel(parentEntry))
-
                 ModuleRoute.DETECTION_SENSOR -> DetectionSensorConfigScreen(hiltViewModel(parentEntry))
-
                 ModuleRoute.PAXCOUNTER -> PaxcounterConfigScreen(hiltViewModel(parentEntry))
             }
         }


### PR DESCRIPTION
This commit introduces deep link support for all screens within the application. This allows users (and developers) to navigate directly to specific screens via URLs.

The following screens now support deep linking:
- Nodes
- Node Detail (and its sub-screens like Device Metrics, Node Map, etc.)
- Map
- Contacts
- Messages
- Share Message
- Quick Chat
- Channels
- Radio Configuration (and its sub-screens like LoRa, MQTT, etc.)
- Debug Panel

The `Intent.ACTION_VIEW` is used for all deep links.

Also updates manifest to consolidate filter intents.