### PR TITLE
fix(contact-import): streamline shared contact handling 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -166,10 +166,11 @@
             </intent-filter>
 
             <intent-filter android:autoVerify="true">
-                <!-- The QR codes to share channel settings are shared as meshtastic URLS
+                <!-- The QR codes to share channel settings and contacts are shared as meshtastic URLS
 
                 an approximate example:
                 https://meshtastic.org/e/YXNkZnF3ZXJhc2RmcXdlcmFzZGZxd2Vy
+                https://meshtastic.org/v/#CNar9vwDEi0KCSEzZjgyOTVkNhIPV2F0ZXJmYWxsIDIg4piGGgPimaciBu2eP4KV1igJOAI
                 -->
                 <action android:name="android.intent.action.VIEW" />
 

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -630,7 +630,7 @@ constructor(
         get() = _sharedContactRequested.asStateFlow()
 
     fun setSharedContactRequested(sharedContact: AdminProtos.SharedContact?) {
-        viewModelScope.launch { _sharedContactRequested.value = sharedContact }
+        _sharedContactRequested.value = sharedContact
     }
 
     fun addSharedContact(sharedContact: AdminProtos.SharedContact) =

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/ContactSharing.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/ContactSharing.kt
@@ -89,7 +89,7 @@ fun AddContactFAB(
     model: UIViewModel = hiltViewModel(),
     onSharedContactImport: (AdminProtos.SharedContact) -> Unit = {},
 ) {
-    val contactToImport: AdminProtos.SharedContact? by model.sharedContactRequested.collectAsStateWithLifecycle(null)
+    val scannedContact: AdminProtos.SharedContact? by model.sharedContactRequested.collectAsStateWithLifecycle(null)
 
     val barcodeLauncher =
         rememberLauncherForActivityResult(ScanContract()) { result ->
@@ -108,8 +108,8 @@ fun AddContactFAB(
             }
         }
 
-    if (contactToImport != null) {
-        val nodeNum = contactToImport?.nodeNum
+    scannedContact?.let{ contactToImport ->
+        val nodeNum = scannedContact?.nodeNum
         val nodes by model.unfilteredNodeList.collectAsState()
         val node = nodes.find { it.num == nodeNum }
         SimpleAlertDialog(
@@ -118,16 +118,16 @@ fun AddContactFAB(
                 Column {
                     if (node != null) {
                         Text(text = stringResource(R.string.import_known_shared_contact_text))
-                        if (node.user.publicKey.size() > 0 && node.user.publicKey != contactToImport?.user?.publicKey) {
+                        if (node.user.publicKey.size() > 0 && node.user.publicKey != contactToImport.user?.publicKey) {
                             Text(
                                 text = stringResource(R.string.public_key_changed),
                                 color = MaterialTheme.colorScheme.error,
                             )
                         }
                         HorizontalDivider()
-                        Text(text = compareUsers(node.user, contactToImport!!.user))
+                        Text(text = compareUsers(node.user, contactToImport.user))
                     } else {
-                        Text(text = userFieldsToString(contactToImport!!.user))
+                        Text(text = userFieldsToString(contactToImport.user))
                     }
                 }
             },
@@ -135,7 +135,7 @@ fun AddContactFAB(
             onDismiss = { model.setSharedContactRequested(null) },
             confirmText = stringResource(R.string.import_label),
             onConfirm = {
-                onSharedContactImport(contactToImport!!)
+                onSharedContactImport(contactToImport)
                 model.setSharedContactRequested(null)
             },
         )
@@ -155,9 +155,7 @@ fun AddContactFAB(
 
     LaunchedEffect(cameraPermissionState.status) {
         if (cameraPermissionState.status.isGranted) {
-            // If permission was granted as a result of a request, and not initially,
-            // we might want to trigger the scan. However, simple auto-triggering on grant
-            // might not always be desired UX. For now, rely on user re-click if needed.
+            zxingScan()
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/ContactSharing.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/ContactSharing.kt
@@ -108,7 +108,7 @@ fun AddContactFAB(
             }
         }
 
-    scannedContact?.let{ contactToImport ->
+    scannedContact?.let { contactToImport ->
         val nodeNum = scannedContact?.nodeNum
         val nodes by model.unfilteredNodeList.collectAsState()
         val node = nodes.find { it.num == nodeNum }


### PR DESCRIPTION
fixes #2804

The `setSharedContactRequested` function was updated to set the `_sharedContactRequested.value` directly instead of launching a coroutine on the `viewModelScope`. This ensures that the value is set on the main thread, which is necessary for UI updates.

Additionally:
-  the AndroidManifest.xml was updated to include a new intent filter for handling shared contact QR codes. 
- trigger qr scan after successful permission grant instead of making user tap scan button again.