### PR TITLE
refactor(service): initialize PacketHandler lazily

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -211,8 +211,14 @@ class MeshService :
         MeshServiceBroadcasts(this, clientPackages) {
             connectionState.also { radioConfigRepository.setConnectionState(it) }
         }
-    private lateinit var packetHandler: PacketHandler
-
+    private val packetHandler: PacketHandler by lazy {
+        PacketHandler(
+            packetRepository = packetRepository,
+            serviceBroadcasts = serviceBroadcasts,
+            radioInterfaceService = radioInterfaceService,
+            meshLogRepository = meshLogRepository,
+        )
+    }
     private val serviceJob = Job()
     private val serviceScope = CoroutineScope(Dispatchers.IO + serviceJob)
     private var connectionState = ConnectionState.DISCONNECTED
@@ -329,14 +335,6 @@ class MeshService :
         radioConfigRepository.serviceAction.onEach(::onServiceAction).launchIn(serviceScope)
 
         loadSettings() // Load our last known node DB
-
-        packetHandler =
-            PacketHandler(
-                packetRepository = packetRepository,
-                serviceBroadcasts = serviceBroadcasts,
-                radioInterfaceService = radioInterfaceService,
-                meshLogRepository = meshLogRepository,
-            )
 
         // the rest of our init will happen once we are in radioConnection.onServiceConnected
     }


### PR DESCRIPTION
This commit changes the initialization of `PacketHandler` in `MeshService` from eager to lazy. This means `PacketHandler` will now be created only when it's first accessed, rather than during the `onCreate` method of the service.

Addresses a race condition picked up by play build scanner.

<img width="716" height="323" alt="image" src="https://github.com/user-attachments/assets/80214178-6483-4897-8ae6-9bdfaa662e24" />
