### PR TITLE
feat(ui): display app version in connections screen

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -20,14 +20,11 @@ package com.geeksville.mesh
 import android.app.PendingIntent
 import android.app.TaskStackBuilder
 import android.content.Intent
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
 import android.graphics.Color
 import android.hardware.usb.UsbManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -56,7 +53,6 @@ import com.geeksville.mesh.ui.common.theme.MODE_DYNAMIC
 import com.geeksville.mesh.ui.intro.AppIntroductionScreen
 import com.geeksville.mesh.ui.sharing.toSharedContact
 import com.geeksville.mesh.util.LanguageUtils
-import com.geeksville.mesh.util.getPackageInfoCompat
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -221,10 +217,6 @@ class MainActivity :
 
     private fun onMainMenuAction(action: MainMenuAction) {
         when (action) {
-            MainMenuAction.ABOUT -> {
-                getVersionInfo()
-            }
-
             MainMenuAction.EXPORT_RANGETEST -> {
                 val intent =
                     Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
@@ -244,16 +236,6 @@ class MainActivity :
             }
 
             else -> warn("Unexpected action: $action")
-        }
-    }
-
-    private fun getVersionInfo() {
-        try {
-            val packageInfo: PackageInfo = packageManager.getPackageInfoCompat(packageName, 0)
-            val versionName = packageInfo.versionName
-            Toast.makeText(this, versionName, Toast.LENGTH_LONG).show()
-        } catch (e: PackageManager.NameNotFoundException) {
-            errormsg("Can not find the version: ${e.message}")
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
@@ -214,7 +214,6 @@ enum class MainMenuAction(@StringRes val stringRes: Int) {
     LANGUAGE(R.string.preferences_language),
     SHOW_INTRO(R.string.intro_show),
     QUICK_CHAT(R.string.quick_chat),
-    ABOUT(R.string.about),
 }
 
 @Composable

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/Connections.kt
@@ -25,6 +25,7 @@ import android.net.InetAddresses
 import android.os.Build
 import android.util.Patterns
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -81,6 +82,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.ConfigProtos
 import com.geeksville.mesh.R
 import com.geeksville.mesh.android.BuildUtils.debug
@@ -559,12 +561,14 @@ fun ConnectionsScreen(
         }
 
         Box(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
-            Text(
-                text = scanStatusText.orEmpty(),
-                fontSize = 10.sp,
-                textAlign = TextAlign.End,
+            Row(
                 modifier = Modifier.fillMaxWidth(),
-            )
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(text = BuildConfig.VERSION_NAME, fontSize = 10.sp, textAlign = TextAlign.Start)
+                Text(text = scanStatusText.orEmpty(), fontSize = 10.sp, textAlign = TextAlign.End)
+            }
         }
     }
 }


### PR DESCRIPTION
Removes the "About" item from the main menu and displays the app's version name at the bottom of the Connections screen.

The version name is now shown on the left side of the bottom bar, while the scan status text remains on the right side.

<img width="1280" height="2856" alt="Screenshot_20250825_130340" src="https://github.com/user-attachments/assets/11a4f804-9aef-4b51-aea5-1b5d8982cc71" />
