### PR TITLE
`NodeDetail` list items

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -362,7 +363,10 @@ private fun NodeDetailList(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         if (metricsState.deviceHardware != null) {
-            TitledCard(title = stringResource(R.string.device)) { DeviceDetailsContent(metricsState) }
+            TitledCard(title = stringResource(R.string.device)) {
+                Spacer(modifier = Modifier.height(16.dp))
+                DeviceDetailsContent(metricsState)
+            }
         }
 
         TitledCard(title = stringResource(R.string.details)) {
@@ -635,21 +639,24 @@ private fun RemoteDeviceActions(node: Node, lastTracerouteTime: Long?, onAction:
 }
 
 @Composable
-private fun DeviceDetailsContent(state: MetricsState) {
+private fun ColumnScope.DeviceDetailsContent(state: MetricsState) {
     val node = state.node ?: return
     val deviceHardware = state.deviceHardware ?: return
     val hwModelName = deviceHardware.displayName
     val isSupported = deviceHardware.activelySupported
     Box(
         modifier =
-        Modifier.size(100.dp)
-            .padding(4.dp)
+        Modifier.align(Alignment.CenterHorizontally)
+            .size(100.dp)
             .clip(CircleShape)
             .background(color = Color(node.colors.second).copy(alpha = .5f), shape = CircleShape),
         contentAlignment = Alignment.Center,
     ) {
         DeviceHardwareImage(deviceHardware, Modifier.fillMaxSize())
     }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
     SettingsItemDetail(
         text = stringResource(R.string.hardware),
         icon = Icons.Default.Router,

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -24,7 +24,6 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,7 +37,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -70,7 +68,6 @@ import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Router
 import androidx.compose.material.icons.filled.Scale
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SignalCellularAlt
 import androidx.compose.material.icons.filled.SocialDistance
 import androidx.compose.material.icons.filled.Speed
@@ -82,6 +79,8 @@ import androidx.compose.material.icons.filled.Work
 import androidx.compose.material.icons.outlined.Navigation
 import androidx.compose.material.icons.outlined.NoCell
 import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.QrCode2
 import androidx.compose.material.icons.twotone.Person
 import androidx.compose.material.icons.twotone.Verified
 import androidx.compose.material3.Button
@@ -95,7 +94,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ProgressIndicatorDefaults
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -116,7 +114,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -155,6 +152,7 @@ import com.geeksville.mesh.ui.common.theme.StatusColors.StatusYellow
 import com.geeksville.mesh.ui.node.components.NodeActionDialogs
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import com.geeksville.mesh.ui.settings.components.SettingsItem
+import com.geeksville.mesh.ui.settings.components.SettingsItemSwitch
 import com.geeksville.mesh.ui.sharing.SharedContactDialog
 import com.geeksville.mesh.util.UnitConversions
 import com.geeksville.mesh.util.UnitConversions.toTempString
@@ -410,10 +408,10 @@ private fun MetricsSection(
     }
 
     if (availableLogs.isNotEmpty()) {
-        TitledCard(title = stringResource(id = R.string.logs)) {
+        TitledCard(title = stringResource(id = R.string.logs), modifier = Modifier.padding(top = 16.dp)) {
             LogsType.entries.forEach { type ->
                 if (availableLogs.contains(type)) {
-                    SettingsItem(text = stringResource(type.titleRes), leadingIcon = type.icon, enabled = true) {
+                    SettingsItem(text = stringResource(type.titleRes), leadingIcon = type.icon) {
                         onAction(NodeDetailAction.Navigate(type.route))
                     }
                 }
@@ -434,7 +432,6 @@ private fun AdministrationSection(
             text = stringResource(id = R.string.request_metadata),
             leadingIcon = Icons.Default.Memory,
             trailingIcon = null,
-            enabled = true,
             onClick = { onAction(NodeDetailAction.TriggerServiceAction(ServiceAction.GetDeviceMetadata(node.num))) },
         )
         SettingsItem(
@@ -589,35 +586,34 @@ private fun DeviceActions(
         },
         onAction = { onAction(NodeDetailAction.HandleNodeMenuAction(it)) },
     )
-    PreferenceCategory(text = stringResource(R.string.actions)) {
-        NodeActionButton(
-            title = stringResource(id = R.string.share_contact),
-            icon = Icons.Default.Share,
-            enabled = true,
+    TitledCard(title = stringResource(R.string.actions), modifier = Modifier.padding(top = 16.dp)) {
+        SettingsItem(
+            text = stringResource(id = R.string.share_contact),
+            leadingIcon = Icons.Rounded.QrCode2,
+            trailingIcon = null,
             onClick = { onAction(NodeDetailAction.ShareContact) },
         )
         if (!isLocal) {
             RemoteDeviceActions(node = node, lastTracerouteTime = lastTracerouteTime, onAction = onAction)
         }
-        NodeActionSwitch(
-            title = stringResource(R.string.favorite),
-            icon = if (node.isFavorite) Icons.Default.Star else Icons.Default.StarBorder,
-            iconTint = if (node.isFavorite) Color.Yellow else LocalContentColor.current,
-            enabled = true,
+        SettingsItemSwitch(
+            text = stringResource(R.string.favorite),
+            leadingIcon = if (node.isFavorite) Icons.Default.Star else Icons.Default.StarBorder,
+            leadingIconTint = if (node.isFavorite) Color.Yellow else LocalContentColor.current,
             checked = node.isFavorite,
             onClick = { displayFavoriteDialog = true },
         )
-        NodeActionSwitch(
-            title = stringResource(R.string.ignore),
-            icon = if (node.isIgnored) Icons.AutoMirrored.Outlined.VolumeMute else Icons.AutoMirrored.Default.VolumeUp,
-            enabled = true,
+        SettingsItemSwitch(
+            text = stringResource(R.string.ignore),
+            leadingIcon =
+            if (node.isIgnored) Icons.AutoMirrored.Outlined.VolumeMute else Icons.AutoMirrored.Default.VolumeUp,
             checked = node.isIgnored,
             onClick = { displayIgnoreDialog = true },
         )
-        NodeActionButton(
-            title = stringResource(id = R.string.remove),
-            icon = Icons.Default.Delete,
-            enabled = true,
+        SettingsItem(
+            text = stringResource(id = R.string.remove),
+            leadingIcon = Icons.Rounded.Delete,
+            trailingIcon = null,
             onClick = { displayRemoveDialog = true },
         )
     }
@@ -626,23 +622,23 @@ private fun DeviceActions(
 @Composable
 private fun RemoteDeviceActions(node: Node, lastTracerouteTime: Long?, onAction: (NodeDetailAction) -> Unit) {
     if (!node.isEffectivelyUnmessageable) {
-        NodeActionButton(
-            title = stringResource(id = R.string.direct_message),
-            icon = Icons.AutoMirrored.TwoTone.Message,
-            enabled = true,
+        SettingsItem(
+            text = stringResource(id = R.string.direct_message),
+            leadingIcon = Icons.AutoMirrored.TwoTone.Message,
+            trailingIcon = null,
             onClick = { onAction(NodeDetailAction.HandleNodeMenuAction(NodeMenuAction.DirectMessage(node))) },
         )
     }
-    NodeActionButton(
-        title = stringResource(id = R.string.exchange_position),
-        icon = Icons.Default.LocationOn,
-        enabled = true,
+    SettingsItem(
+        text = stringResource(id = R.string.exchange_position),
+        leadingIcon = Icons.Default.LocationOn,
+        trailingIcon = null,
         onClick = { onAction(NodeDetailAction.HandleNodeMenuAction(NodeMenuAction.RequestPosition(node))) },
     )
-    NodeActionButton(
-        title = stringResource(id = R.string.exchange_userinfo),
-        icon = Icons.Default.Person,
-        enabled = true,
+    SettingsItem(
+        text = stringResource(id = R.string.exchange_userinfo),
+        leadingIcon = Icons.Default.Person,
+        trailingIcon = null,
         onClick = { onAction(NodeDetailAction.HandleNodeMenuAction(NodeMenuAction.RequestUserInfo(node))) },
     )
     TracerouteActionButton(
@@ -1112,45 +1108,6 @@ fun NodeActionButton(
                 Spacer(modifier = Modifier.width(8.dp))
             }
             Text(text = title, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
-        }
-    }
-}
-
-@Composable
-fun NodeActionSwitch(
-    title: String,
-    enabled: Boolean,
-    checked: Boolean,
-    icon: ImageVector? = null,
-    iconTint: Color? = null,
-    onClick: () -> Unit,
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    Card(
-        modifier =
-        Modifier.fillMaxWidth()
-            .padding(vertical = 4.dp)
-            .height(48.dp)
-            .toggleable(value = checked, enabled = enabled, role = Role.Switch, onValueChange = { onClick() }),
-        shape = MaterialTheme.shapes.large,
-        interactionSource = interactionSource,
-        onClick = onClick,
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 16.dp),
-        ) {
-            if (icon != null) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = title,
-                    modifier = Modifier.size(24.dp),
-                    tint = iconTint ?: LocalContentColor.current,
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-            }
-            Text(text = title, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
-            Switch(checked = checked, onCheckedChange = null)
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -145,6 +145,7 @@ import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.navigation.SettingsRoutes
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.ui.common.components.PreferenceCategory
+import com.geeksville.mesh.ui.common.components.TitledCard
 import com.geeksville.mesh.ui.common.preview.NodePreviewParameterProvider
 import com.geeksville.mesh.ui.common.theme.AppTheme
 import com.geeksville.mesh.ui.common.theme.StatusColors.StatusGreen
@@ -153,6 +154,7 @@ import com.geeksville.mesh.ui.common.theme.StatusColors.StatusRed
 import com.geeksville.mesh.ui.common.theme.StatusColors.StatusYellow
 import com.geeksville.mesh.ui.node.components.NodeActionDialogs
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
+import com.geeksville.mesh.ui.settings.components.SettingsItem
 import com.geeksville.mesh.ui.settings.radio.NavCard
 import com.geeksville.mesh.ui.sharing.SharedContactDialog
 import com.geeksville.mesh.util.UnitConversions
@@ -409,10 +411,10 @@ private fun MetricsSection(
     }
 
     if (availableLogs.isNotEmpty()) {
-        PreferenceCategory(stringResource(id = R.string.logs)) {
+        TitledCard(title = stringResource(id = R.string.logs)) {
             LogsType.entries.forEach { type ->
                 if (availableLogs.contains(type)) {
-                    NavCard(title = stringResource(type.titleRes), icon = type.icon, enabled = true) {
+                    SettingsItem(text = stringResource(type.titleRes), leadingIcon = type.icon, enabled = true) {
                         onAction(NodeDetailAction.Navigate(type.route))
                     }
                 }

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetail.kt
@@ -155,7 +155,6 @@ import com.geeksville.mesh.ui.common.theme.StatusColors.StatusYellow
 import com.geeksville.mesh.ui.node.components.NodeActionDialogs
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import com.geeksville.mesh.ui.settings.components.SettingsItem
-import com.geeksville.mesh.ui.settings.radio.NavCard
 import com.geeksville.mesh.ui.sharing.SharedContactDialog
 import com.geeksville.mesh.util.UnitConversions
 import com.geeksville.mesh.util.UnitConversions.toTempString
@@ -430,16 +429,17 @@ private fun AdministrationSection(
     onAction: (NodeDetailAction) -> Unit,
     onFirmwareSelected: (FirmwareRelease) -> Unit,
 ) {
-    PreferenceCategory(stringResource(id = R.string.administration)) {
-        NodeActionButton(
-            title = stringResource(id = R.string.request_metadata),
-            icon = Icons.Default.Memory,
+    TitledCard(stringResource(id = R.string.administration), modifier = Modifier.padding(top = 16.dp)) {
+        SettingsItem(
+            text = stringResource(id = R.string.request_metadata),
+            leadingIcon = Icons.Default.Memory,
+            trailingIcon = null,
             enabled = true,
             onClick = { onAction(NodeDetailAction.TriggerServiceAction(ServiceAction.GetDeviceMetadata(node.num))) },
         )
-        NavCard(
-            title = stringResource(id = R.string.remote_admin),
-            icon = Icons.Default.Settings,
+        SettingsItem(
+            text = stringResource(id = R.string.remote_admin),
+            leadingIcon = Icons.Default.Settings,
             enabled = metricsState.isLocal || node.metadata != null,
         ) {
             onAction(NodeDetailAction.Navigate(SettingsRoutes.Settings(node.num)))

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/components/SettingsItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/components/SettingsItem.kt
@@ -17,20 +17,22 @@
 
 package com.geeksville.mesh.ui.settings.components
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.rounded.Android
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -44,35 +46,69 @@ import com.geeksville.mesh.ui.common.theme.AppTheme
 @Composable
 fun SettingsItem(
     text: String,
-    enabled: Boolean,
+    enabled: Boolean = true,
     leadingIcon: ImageVector? = null,
+    leadingIconTint: Color = LocalContentColor.current,
     trailingIcon: ImageVector? = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+    trailingIconTint: Color = LocalContentColor.current,
     onClick: () -> Unit,
 ) {
+    ClickableWrapper(enabled = enabled, onClick = onClick) {
+        Content(
+            leading = { leadingIcon.Icon(leadingIconTint) },
+            text = text,
+            trailing = { trailingIcon.Icon(trailingIconTint) },
+        )
+    }
+}
+
+@Composable
+fun SettingsItemSwitch(
+    checked: Boolean,
+    text: String,
+    enabled: Boolean = true,
+    leadingIcon: ImageVector? = null,
+    leadingIconTint: Color = LocalContentColor.current,
+    onClick: () -> Unit,
+) {
+    ClickableWrapper(enabled = enabled, onClick = onClick) {
+        Content(
+            leading = { leadingIcon.Icon(leadingIconTint) },
+            text = text,
+            trailing = { Switch(checked = checked, enabled = enabled, onCheckedChange = null) },
+        )
+    }
+}
+
+/** A clickable Card wrapper used for all clickable settings items. */
+@Composable
+private fun ClickableWrapper(enabled: Boolean, onClick: () -> Unit, content: @Composable ColumnScope.() -> Unit) {
     Card(
         onClick = onClick,
         enabled = enabled,
-        colors = CardDefaults.cardColors(
-            containerColor = Color.Transparent,
-            disabledContainerColor = Color.Transparent,
-        ),
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 16.dp),
-        ) {
-            leadingIcon?.let {
-                Icon(imageVector = it, contentDescription = text, modifier = Modifier.size(24.dp))
-                Spacer(modifier = Modifier.width(16.dp))
-            }
-            Text(text = text, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
+        colors =
+        CardDefaults.cardColors(containerColor = Color.Transparent, disabledContainerColor = Color.Transparent),
+        content = content,
+    )
+}
 
-            trailingIcon?.let {
-                Icon(imageVector = it, contentDescription = null, modifier = Modifier.wrapContentSize())
-            }
-        }
+/** The row content to display for a settings item. */
+@Composable
+private fun Content(leading: @Composable () -> Unit, text: String, trailing: @Composable RowScope.() -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 16.dp),
+    ) {
+        leading()
+        Text(text = text, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
+        trailing()
     }
 }
+
+@Composable
+private fun ImageVector?.Icon(tint: Color = LocalContentColor.current) =
+    this?.let { Icon(imageVector = it, contentDescription = null, modifier = Modifier.size(24.dp), tint = tint) }
 
 @Preview(showBackground = true)
 @Composable
@@ -84,4 +120,10 @@ private fun SettingsItemPreview() {
 @Composable
 private fun SettingsItemDisabledPreview() {
     AppTheme { SettingsItem(text = "Text", leadingIcon = Icons.Rounded.Android, enabled = false) {} }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsItemSwitchPreview() {
+    AppTheme { SettingsItemSwitch(text = "Text", leadingIcon = Icons.Rounded.Android, checked = true) {} }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/components/SettingsItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/components/SettingsItem.kt
@@ -18,12 +18,15 @@
 package com.geeksville.mesh.ui.settings.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.rounded.Android
@@ -43,6 +46,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.ui.common.theme.AppTheme
 
+/** A clickable settings button item. */
 @Composable
 fun SettingsItem(
     text: String,
@@ -62,6 +66,7 @@ fun SettingsItem(
     }
 }
 
+/** A toggleable settings switch item. */
 @Composable
 fun SettingsItemSwitch(
     checked: Boolean,
@@ -77,6 +82,27 @@ fun SettingsItemSwitch(
             text = text,
             trailing = { Switch(checked = checked, enabled = enabled, onCheckedChange = null) },
         )
+    }
+}
+
+/** A settings detail item. */
+@Composable
+fun SettingsItemDetail(
+    text: String,
+    icon: ImageVector? = null,
+    iconTint: Color = LocalContentColor.current,
+    trailingText: String? = null,
+    enabled: Boolean = true,
+    onClick: (() -> Unit)? = null,
+) {
+    val content: @Composable ColumnScope.() -> Unit = {
+        Content(leading = { icon.Icon(iconTint) }, text = text, trailing = { trailingText?.let { Text(text = it) } })
+    }
+
+    if (onClick != null) {
+        ClickableWrapper(enabled = enabled, onClick = onClick, content = content)
+    } else {
+        Column(content = content)
     }
 }
 
@@ -101,7 +127,8 @@ private fun Content(leading: @Composable () -> Unit, text: String, trailing: @Co
         modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp, horizontal = 16.dp),
     ) {
         leading()
-        Text(text = text, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
+        Text(text = text, style = MaterialTheme.typography.bodyLarge, modifier = Modifier.wrapContentWidth())
+        Spacer(modifier = Modifier.weight(1f))
         trailing()
     }
 }
@@ -126,4 +153,10 @@ private fun SettingsItemDisabledPreview() {
 @Composable
 private fun SettingsItemSwitchPreview() {
     AppTheme { SettingsItemSwitch(text = "Text", leadingIcon = Icons.Rounded.Android, checked = true) {} }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsItemDetailPreview() {
+    AppTheme { SettingsItemDetail(text = "Text 1", icon = Icons.Rounded.Android, trailingText = "Text2") }
 }


### PR DESCRIPTION
Extract reusable components from `NodeDetail`, so they can be used in other parts of the app. Apply existing `TitledCard` used in Connections.


<video width="400" src="https://github.com/user-attachments/assets/50189a3b-52ad-47b7-ab2d-41b0de9fba5e" />

