### PR TITLE
feat(analytics): enable datadog user interaction tracking

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import com.datadog.gradle.plugin.InstrumentationMode
 import io.gitlab.arturbosch.detekt.Detekt
 import java.io.FileInputStream
 import java.util.Properties
@@ -175,9 +176,7 @@ secrets {
 }
 
 datadog {
-    // compose instrumentation is broken for kotlin 2.2.x - see:
-    // https://github.com/DataDog/dd-sdk-android-gradle-plugin/issues/407
-    //  composeInstrumentation = InstrumentationMode.AUTO
+    composeInstrumentation = InstrumentationMode.AUTO
 }
 
 // per protobuf-gradle-plugin docs, this is recommended for android

--- a/app/src/google/java/com/geeksville/mesh/android/GeeksvilleApplication.kt
+++ b/app/src/google/java/com/geeksville/mesh/android/GeeksvilleApplication.kt
@@ -176,9 +176,7 @@ abstract class GeeksvilleApplication :
                 .trackFrustrations(true)
                 .trackLongTasks()
                 .trackNonFatalAnrs(true)
-                // Re-enable tracking when auto instrumentation available. See note in `app/build.gradle`
-                .disableUserInteractionTracking()
-                // .trackUserInteractions()
+                .trackUserInteractions()
                 .enableComposeActionTracking()
                 .build()
         Rum.enable(rumConfiguration)


### PR DESCRIPTION
Enables Datadog's user interaction tracking and automatic compose instrumentation. This was previously disabled due to a bug with Kotlin 2.2.x that has since been resolved.