### PR TITLE
fix(ci): improve release workflow and proguard setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,13 @@ jobs:
           path: app/build/outputs/apk/google/release/app-google-release.apk
           retention-days: 1
 
+      - name: Upload Mapping File
+        uses: actions/upload-artifact@v4
+        with:
+          name: mapping
+          path: app/build/outputs/mapping/googleRelease/mapping.txt
+          retention-days: 1
+
   publish-release:
     runs-on: ubuntu-latest
     needs: [prepare-build-info, build-fdroid, build-google]
@@ -194,11 +201,16 @@ jobs:
           name: google-apk
           path: ./build-artifacts/google/apk
 
+      - name: Download Mapping File
+        uses: actions/download-artifact@v5
+        with:
+          name: mapping
+          path: ./build-artifacts/google/mapping
+
       - name: Generate Changelog
         id: generate_changelog
         uses: mikepenz/release-changelog-builder-action@v5
         with:
-          configuration: ".github/changelog-config.json"
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           ignorePreReleases: true
@@ -211,8 +223,7 @@ jobs:
         if: steps.generate_changelog.outputs.changelog != ''
         run: |
           mkdir -p play_store_release_notes/en-US
-          echo "${{ steps.generate_changelog.outputs.changelog }}" > play_store_release_notes/en-US/default.txt
-          echo "${{ steps.generate_changelog.outputs.changelog }}" > changelog.txt # Also create a root changelog.txt for GitHub release
+          echo "${{ steps.generate_changelog.outputs.changelog }}" > whatsnew/whatsnew-en-US/default.txt
 
       - name: Create version_info.txt
         run: |
@@ -225,7 +236,7 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
-          body: ${{ steps.generate_changelog.outputs.changelog }}
+          generate_release_notes: true
           files: |
             ./build-artifacts/google/bundle/app-google-release.aab
             ./build-artifacts/google/apk/app-google-release.apk
@@ -269,5 +280,6 @@ jobs:
           packageName: com.geeksville.mesh
           releaseFiles: ./build-artifacts/google/bundle/app-google-release.aab
           track: ${{ steps.get_track.outputs.track }}
-          status: 'draft'
-          whatsNewDirectory: ./play_store_release_notes/en-US/
+          status: ${{ steps.get_track.outputs.track == 'internal' && 'complete' || 'draft' }}
+          whatsNewDirectory: /whatsnew/
+          mappingFile: ./build-artifacts/google/mapping/mapping.txt

--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -85,14 +85,6 @@ jobs:
           path: app/build/outputs/apk/google/debug/app-google-debug.apk
           retention-days: 14
 
-      - name: Attest Build Provenance
-        if: ${{ inputs.upload_artifacts && github.ref_name == 'main' && github.repository == 'meshtastic/Meshtastic-Android' }}
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: |
-            app/build/outputs/apk/google/debug/app-google-debug.apk
-            app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
-
       - name: Upload reports
         if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@v4

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,7 +14,7 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
@@ -27,9 +27,6 @@
 # eclipse.paho.client
 -keep class org.eclipse.paho.client.mqttv3.logging.JSR47Logger { *; }
 
-# ormlite
--dontwarn com.j256.ormlite.**
-
 # OkHttp
 -dontwarn okhttp3.internal.platform.**
 -dontwarn org.conscrypt.**
@@ -37,7 +34,6 @@
 -dontwarn org.openjsse.**
 
 # ?
--dontwarn java.awt.image.**
 -dontwarn java.lang.reflect.**
 -dontwarn com.google.errorprone.annotations.**
 


### PR DESCRIPTION
This commit introduces several changes to the CI release workflow and Proguard configuration.

The Proguard rules have been updated to:
- Keep SourceFile and LineNumberTable attributes for better debugging.
- Remove outdated `dontwarn` rules for ormlite and java.awt.image.

The `reusable-android-build.yml` workflow has been updated to remove the `Attest Build Provenance` step for debug builds.

The `release.yml` workflow has been significantly improved:
- Added a step to upload the mapping file for Google Play Console.
- The changelog generation now uses the default GitHub action configuration.
- Release notes for the Play Store are now placed in the `whatsnew/whatsnew-en-US/` directory.
- GitHub release notes will now be automatically generated.
- The Play Store upload step now includes the mapping file and sets the status to 'complete' for internal tracks.