### PR TITLE
build: centralize repository declarations in settings.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     alias(libs.plugins.devtools.ksp)
     alias(libs.plugins.detekt)
     alias(libs.plugins.datadog)
-    alias(libs.plugins.secrets.gradle.plugin)
+    alias(libs.plugins.secrets)
     alias(libs.plugins.spotless)
 }
 
@@ -292,8 +292,6 @@ ksp {
     //    arg("room.generateKotlin", "true")
     arg("room.schemaLocation", "$projectDir/schemas")
 }
-
-repositories { maven { url = uri("https://jitpack.io") } }
 
 detekt {
     config.setFrom("../config/detekt/detekt.yml")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,37 +15,21 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath(libs.agp)
-        classpath(libs.kotlin.gradle.plugin)
-        classpath(libs.kotlin.serialization)
-        classpath(libs.google.services)
-        classpath(libs.firebase.crashlytics.gradle)
-        classpath(libs.secrets.gradle.plugin)
-        classpath(libs.protobuf.gradle.plugin)
-        classpath(libs.hilt.android.gradle.plugin)
-        classpath(libs.secrets.gradle.plugin)
-        classpath(libs.dd.sdk.android.gradle.plugin)
-    }
-}
-
 plugins {
-    alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.devtools.ksp) apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
     alias(libs.plugins.compose) apply false
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url = uri("https://jitpack.io") }
-    }
+    alias(libs.plugins.datadog) apply false
+    alias(libs.plugins.devtools.ksp) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.secrets) apply false
 }
 
 tasks.register<Delete>("clean") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,6 @@ spotless = "7.2.1"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanistPermissions" }
-agp = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 activity = { group = "androidx.activity", name = "activity" }
 actvity-ktx = { group = "androidx.activity", name = "activity-ktx" }
 activity-compose = { group = "androidx.activity", name = "activity-compose" }
@@ -88,7 +87,6 @@ core-splashscreen = { group = "androidx.core", name = "core-splashscreen", versi
 datastore = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 dd-sdk-android-compose = { group = "com.datadoghq", name = "dd-sdk-android-compose", version.ref = "dd-sdk-android" }
-dd-sdk-android-gradle-plugin = { group = "com.datadoghq", name = "dd-sdk-android-gradle-plugin", version.ref = "dd-sdk-android-gradle-plugin" }
 dd-sdk-android-logs = { group = "com.datadoghq", name = "dd-sdk-android-logs", version.ref = "dd-sdk-android" }
 dd-sdk-android-okhttp = { group = "com.datadoghq", name = "dd-sdk-android-okhttp", version.ref = "dd-sdk-android" }
 dd-sdk-android-rum = { group = "com.datadoghq", name = "dd-sdk-android-rum", version.ref = "dd-sdk-android" }
@@ -103,16 +101,11 @@ ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junit-
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
-firebase-crashlytics-gradle = { group = "com.google.firebase", name = "firebase-crashlytics-gradle", version.ref = "crashlytics" }
-google-services = { group = "com.google.gms", name = "google-services", version.ref = "google-services" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
-hilt-android-gradle-plugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
-kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin-serialization = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines-android" }
 kotlinx-coroutines-guava = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-guava", version.ref = "kotlinx-coroutines-android" }
@@ -141,7 +134,6 @@ org-eclipse-paho-client-mqttv3 = { group = "org.eclipse.paho", name = "org.eclip
 osmbonuspack = { group = "com.github.MKergall", name = "osmbonuspack", version.ref = "osmbonuspack" }
 osmdroid-android = { group = "org.osmdroid", name = "osmdroid-android", version.ref = "osmdroid-android" }
 osmdroid-geopackage = { group = "org.osmdroid", name = "osmdroid-geopackage", version.ref = "osmdroid-android" }
-protobuf-gradle-plugin = { group = "com.google.protobuf", name = "protobuf-gradle-plugin", version.ref = "protobuf-gradle-plugin" }
 protobuf-kotlin = { group = "com.google.protobuf", name = "protobuf-kotlin", version.ref = "protobuf-kotlin" }
 protobuf-protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protobuf-kotlin" }
 retrofit2 = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
@@ -150,7 +142,6 @@ room-compiler = { group = "androidx.room", name = "room-compiler", version.ref =
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
-secrets-gradle-plugin = { group = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", name = "secrets-gradle-plugin", version.ref = "secrets-gradle-plugin" }
 streamsupport-minifuture = { group = "net.sourceforge.streamsupport", name = "streamsupport-minifuture", version.ref = "streamsupport-minifuture" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 usb-serial-android = { group = "com.github.mik3y", name = "usb-serial-for-android", version.ref = "usb-serial-android" }
@@ -214,20 +205,19 @@ retrofit = ["retrofit2", "retrofit2-kotlin-serialization", "okhttp3", "okhttp3-l
 coil = ["coil", "coil-network-core", "coil-network-okhttp", "coil-svg"]
 
 [plugins]
-android-application = { id = "com.android.application" }
-android-library = { id = "com.android.library" }
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
 compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-datadog = { id = "com.datadoghq.dd-sdk-android-gradle-plugin"}
+datadog = { id = "com.datadoghq.dd-sdk-android-gradle-plugin", version.ref = "dd-sdk-android-gradle-plugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "devtools-ksp" }
-hilt = { id = "com.google.dagger.hilt.android" }
-kotlin-android = { id = "org.jetbrains.kotlin.android" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics" , version.ref = "crashlytics" }
+google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
+hilt = { id = "com.google.dagger.hilt.android" , version.ref = "hilt" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization" }
-protobuf = { id = "com.google.protobuf" }
-google-services = { id = "com.google.gms.google-services" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics" }
-secrets-gradle-plugin = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin"}
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobuf-gradle-plugin" }
+secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets-gradle-plugin" }
 spotless = { id = "com.diffplug.spotless", version .ref= "spotless" }
-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        gradlePluginPortal()
         maven { url = uri("https://jitpack.io") }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.maven
+
 /*
  * Copyright (c) 2025 Meshtastic LLC
  *
@@ -17,6 +19,26 @@
 
 include(":app", ":network", ":mesh_service_example")
 rootProject.name = "Meshtastic Android"
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver") version "1.0.0"


### PR DESCRIPTION
This commit centralizes all repository declarations into the `settings.gradle.kts` file.

The `pluginManagement` and `dependencyResolutionManagement` blocks in `settings.gradle.kts` now define the repositories (google, mavenCentral, gradlePluginPortal, jitpack.io) for the entire project.

Consequently, `buildscript` and `allprojects` repository blocks have been removed from the root `build.gradle.kts`. Individual repository declarations have also been removed from module-level `build.gradle.kts` files (e.g., `app/build.gradle.kts`).

Plugin and library declarations in `gradle/libs.versions.toml` have been updated to remove explicit group and name for plugins, as these are now resolved via the centralized repository configuration and plugin aliases. Version references have been added to plugin aliases where they were previously inferred from classpath dependencies.