### PR TITLE
2712  add format types note to custom layers

### DIFF
--- a/app/src/google/java/com/geeksville/mesh/ui/map/components/CustomMapLayersSheet.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/components/CustomMapLayersSheet.kt
@@ -60,6 +60,13 @@ fun CustomMapLayersSheet(
             )
             HorizontalDivider()
         }
+        item {
+            Text(
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 0.dp),
+                text = stringResource(R.string.map_layer_formats),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
 
         if (mapLayers.isEmpty()) {
             item {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -777,6 +777,7 @@
     <string name="map_type_terrain">Terrain</string>
     <string name="map_type_hybrid">Hybrid</string>
     <string name="manage_map_layers">Manage Map Layers</string>
+    <string name="map_layer_formats">Custom layers support .kml or .kmz files.</string>
     <string name="map_layers_title">Map Layers</string>
     <string name="no_map_layers_loaded">No custom layers loaded.</string>
     <string name="add_layer_button">Add Layer</string>


### PR DESCRIPTION
closes #2712 

adds a line to show the compatible formats

<img width="258" height="161" alt="image" src="https://github.com/user-attachments/assets/8a069e3f-006d-4d7f-af71-0513a17eb965" />
