### PR TITLE
chore(deps): group meshtastic protobuf updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,7 +25,9 @@
       "matchPackageNames": [
         "https://github.com/meshtastic/protobufs.git"
       ],
-      "changelogUrl": "https://github.com/meshtastic/protobufs/compare/{{currentDigest}}...{{newDigest}}"
+      "changelogUrl": "https://github.com/meshtastic/protobufs/compare/{{currentDigest}}...{{newDigest}}",
+      "groupName": "Meshtastic Protobufs",
+      "groupSlug": "meshtastic-protobufs"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
This change groups updates to the Meshtastic protobufs dependency in Renovate configuration. This will result in a single pull request for all protobuf updates, rather than individual pull requests for each update.