### PR TITLE
Fix Bluetooth reconnection logic

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/SafeBluetooth.kt
@@ -557,8 +557,12 @@ class SafeBluetooth(private val context: Context, private val device: BluetoothD
     @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     fun asyncConnect(autoConnect: Boolean = false, cb: (Result<Unit>) -> Unit, lostConnectCb: () -> Unit) {
         logAssert(workQueue.isEmpty())
+
+        // If there's already connection work in progress, clear it before starting new connection
+        // This can happen during reconnection where previous connection work wasn't properly cleared
         if (currentWork != null) {
-            throw AssertionError("currentWork was not null: $currentWork")
+            warn("Found existing work during asyncConnect: $currentWork - clearing it")
+            synchronized(workQueue) { stopCurrentWork() }
         }
 
         lostConnectCallback = lostConnectCb


### PR DESCRIPTION
When attempting to reconnect to an out of range or turned off device I sometimes get an exception due to currentWork being scheduled still. This PR fixes that by calling stopCurrentWork to ensure this pending operation is canceled before we attempt to reconnect.