### PR TITLE
fix(ui): Prevent FAB from obscuring NodeScreen content

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -157,6 +159,7 @@ fun NodeScreen(
                         isConnected = connectionState.isConnected(),
                     )
                 }
+                item { Spacer(modifier = Modifier.height(88.dp)) }
             }
         }
     }


### PR DESCRIPTION
Adds a Spacer to the bottom of the LazyColumn in NodeScreen to ensure that the FloatingActionButton does not hide the last item in the list.
<img width="960" height="615" alt="image" src="https://github.com/user-attachments/assets/ad528c3e-4f1d-481b-836e-ed3f8f7bb757" />
