### PR TITLE
Make Nodes screen the root of the nav graph

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -74,7 +74,7 @@ fun NavGraph(
     mapViewModel: MapViewModel = hiltViewModel(),
     navController: NavHostController = rememberNavController(),
 ) {
-    NavHost(navController = navController, startDestination = ConnectionsRoutes.ConnectionsGraph, modifier = modifier) {
+    NavHost(navController = navController, startDestination = NodesRoutes.NodesGraph, modifier = modifier) {
         contactsGraph(navController, uIViewModel)
         nodesGraph(navController, uIViewModel)
         mapGraph(navController, uIViewModel, mapViewModel)


### PR DESCRIPTION
This causes the app to land on the Nodes screen on launch instead of the Connections screen. Based on discussions in Discord.