### PR TITLE
refactor(map): replace VerticalFloatingToolbar with Horizontal

### DIFF
--- a/app/src/google/java/com/geeksville/mesh/ui/map/components/MapControlsOverlay.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/components/MapControlsOverlay.kt
@@ -26,8 +26,7 @@ import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material.icons.outlined.MyLocation
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FloatingToolbarScrollBehavior
-import androidx.compose.material3.VerticalFloatingToolbar
+import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -48,19 +47,17 @@ fun MapControlsOverlay(
     onManageLayersClicked: () -> Unit,
     onManageCustomTileProvidersClicked: () -> Unit, // New parameter
     showFilterButton: Boolean,
-    scrollBehavior: FloatingToolbarScrollBehavior,
     // Location tracking parameters
     hasLocationPermission: Boolean = false,
     isLocationTrackingEnabled: Boolean = false,
     onToggleLocationTracking: () -> Unit = {},
     onOrientNorth: () -> Unit = {},
 ) {
-    VerticalFloatingToolbar(
+    HorizontalFloatingToolbar(
         modifier = modifier,
         expanded = true,
         leadingContent = {},
         trailingContent = {},
-        scrollBehavior = scrollBehavior,
         content = {
             if (showFilterButton) {
                 Box {


### PR DESCRIPTION
The `MapControlsOverlay` now uses a `HorizontalFloatingToolbar` instead of a `VerticalFloatingToolbar`. This changes the layout and appearance of the map controls. The `scrollBehavior` parameter has been removed as it is no longer needed. The toolbar is now aligned to the top center of the screen.
