### PR TITLE
fix(service): set node time after config completion

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -199,7 +199,7 @@ class MeshService :
 
         private const val CONFIG_ONLY_NONCE = 69420
         private const val NODE_INFO_ONLY_NONCE = 69421
-        private const val CONFIG_WAIT_MS = 250L
+        private const val CONFIG_WAIT_MS = 50L
     }
 
     private var previousSummary: String? = null
@@ -1750,9 +1750,6 @@ class MeshService :
         processQueuedPackets() // send any packets that were queued up
         startMqttClientProxy()
         serviceBroadcasts.broadcastConnection()
-        packetHandler.sendToRadio(newMeshPacketTo(myNodeNum).buildAdminPacket { setTimeOnly = currentSecond() }) {
-            connectionState
-        }
         sendAnalytics()
         reportConnection()
     }
@@ -1824,6 +1821,11 @@ class MeshService :
 
             sendAnalytics()
             onNodeDBChanged()
+        }
+        packetHandler.sendToRadio(newMeshPacketTo(myNodeNum).buildAdminPacket {
+            setTimeOnly = currentSecond()
+        }) {
+            connectionState
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1822,9 +1822,7 @@ class MeshService :
             sendAnalytics()
             onNodeDBChanged()
         }
-        packetHandler.sendToRadio(newMeshPacketTo(myNodeNum).buildAdminPacket {
-            setTimeOnly = currentSecond()
-        }) {
+        packetHandler.sendToRadio(newMeshPacketTo(myNodeNum).buildAdminPacket { setTimeOnly = currentSecond() }) {
             connectionState
         }
     }


### PR DESCRIPTION
The node time was previously set before the configuration was complete. This change moves the time setting operation to after the configuration flow finishes, ensuring the node has the correct time after it's fully configured.

Additionally, the `CONFIG_WAIT_MS` constant was reduced from 250L to 50L.

This one could use some extra hands-on, connection switching testing.