### PR TITLE
Relocate debug panel to Settings nav graph

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NavGraph.kt
@@ -25,14 +25,11 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navDeepLink
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.TopLevelDestination.Companion.isTopLevel
-import com.geeksville.mesh.ui.debug.DebugScreen
 import com.geeksville.mesh.ui.map.MapViewModel
 import kotlinx.serialization.Serializable
 
@@ -47,10 +44,7 @@ const val DEEP_LINK_BASE_URI = "meshtastic://meshtastic"
 
 @Serializable sealed interface Graph : Route
 
-@Serializable
-sealed interface Route {
-    @Serializable data object DebugPanel : Route
-}
+@Serializable sealed interface Route
 
 fun NavDestination.isConfigRoute(): Boolean =
     ConfigRoute.entries.any { hasRoute(it.route::class) } || ModuleRoute.entries.any { hasRoute(it.route::class) }
@@ -80,11 +74,6 @@ fun NavGraph(
         mapGraph(navController, uIViewModel, mapViewModel)
         channelsGraph(navController, uIViewModel)
         connectionsGraph(navController, uIViewModel, bluetoothViewModel)
-        composable<Route.DebugPanel>(
-            deepLinks = listOf(navDeepLink<Route.DebugPanel>(basePath = "$DEEP_LINK_BASE_URI/debug_panel")),
-        ) {
-            DebugScreen()
-        }
         settingsGraph(navController, uIViewModel)
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/navigation/SettingsRoutes.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/SettingsRoutes.kt
@@ -56,6 +56,7 @@ import com.geeksville.mesh.AdminProtos
 import com.geeksville.mesh.MeshProtos.DeviceMetadata
 import com.geeksville.mesh.R
 import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.ui.debug.DebugScreen
 import com.geeksville.mesh.ui.settings.SettingsScreen
 import com.geeksville.mesh.ui.settings.radio.CleanNodeDatabaseScreen
 import com.geeksville.mesh.ui.settings.radio.RadioConfigViewModel
@@ -147,6 +148,8 @@ sealed class SettingsRoutes {
 
     @Serializable data object CleanNodeDb : Route
 
+    @Serializable data object DebugPanel : Route
+
     // endregion
 }
 
@@ -177,6 +180,12 @@ fun NavGraphBuilder.settingsGraph(navController: NavHostController, uiViewModel:
         }
         configRoutesScreens(navController)
         moduleRoutesScreens(navController)
+        composable<SettingsRoutes.DebugPanel>(
+            deepLinks =
+            listOf(navDeepLink<SettingsRoutes.DebugPanel>(basePath = "$DEEP_LINK_BASE_URI/settings/debug_panel")),
+        ) {
+            DebugScreen()
+        }
     }
 }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -351,7 +351,6 @@ fun MainScreen(
                     onAction = { action ->
                         if (action is MainMenuAction) {
                             when (action) {
-                                MainMenuAction.DEBUG -> navController.navigate(Route.DebugPanel)
                                 MainMenuAction.QUICK_CHAT -> navController.navigate(ContactsRoutes.QuickChat)
                                 MainMenuAction.SHOW_INTRO -> uIViewModel.onMainMenuAction(action)
                                 else -> onAction(action)

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
@@ -55,7 +55,6 @@ import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.navigation.ContactsRoutes
 import com.geeksville.mesh.navigation.NodesRoutes
-import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.navigation.SettingsRoutes
 import com.geeksville.mesh.navigation.showLongNameTitle
 import com.geeksville.mesh.ui.TopLevelDestination.Companion.isTopLevel
@@ -88,7 +87,7 @@ fun MainAppBar(
         when {
             currentDestination == null || currentDestination.isTopLevel() -> stringResource(id = R.string.app_name)
 
-            currentDestination.hasRoute<Route.DebugPanel>() -> stringResource(id = R.string.debug_panel)
+            currentDestination.hasRoute<SettingsRoutes.DebugPanel>() -> stringResource(id = R.string.debug_panel)
 
             currentDestination.hasRoute<ContactsRoutes.QuickChat>() -> stringResource(id = R.string.quick_chat)
 
@@ -120,7 +119,7 @@ fun MainAppBar(
                 when {
                     it.isTopLevel() -> MainMenuActions(onAction)
 
-                    currentDestination.hasRoute<Route.DebugPanel>() -> DebugMenuActions()
+                    currentDestination.hasRoute<SettingsRoutes.DebugPanel>() -> DebugMenuActions()
 
                     currentDestination.hasRoute<SettingsRoutes.Settings>() ->
                         RadioConfigMenuActions(viewModel = viewModel)
@@ -206,7 +205,6 @@ private fun TopBarActions(
 }
 
 enum class MainMenuAction(@StringRes val stringRes: Int) {
-    DEBUG(R.string.debug_panel),
     EXPORT_RANGETEST(R.string.save_rangetest),
     SHOW_INTRO(R.string.intro_show),
     QUICK_CHAT(R.string.quick_chat),

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfig.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfig.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Upload
+import androidx.compose.material.icons.rounded.BugReport
 import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -202,6 +203,13 @@ fun RadioConfigItemList(
             text = stringResource(R.string.clean_node_database_title),
             enabled = enabled,
             onClick = { onNavigate(SettingsRoutes.CleanNodeDb) },
+        )
+
+        SettingsItem(
+            text = stringResource(R.string.debug_panel),
+            leadingIcon = Icons.Rounded.BugReport,
+            enabled = enabled,
+            onClick = { onNavigate(SettingsRoutes.DebugPanel) },
         )
     }
 }


### PR DESCRIPTION
Removes debug panel from top-level three-dot menu and places it under Advanced settings.

|Before|After|
|-|-|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/324f53fb-c9c9-4dc2-a2b9-396b01ad4248" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/40ca907e-8c72-45a5-b0e6-73984744eda8" />|