### PR TITLE
move debug export to using URI

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,9 @@
     <string name="debug_panel">Debug Panel</string>
     <string name="debug_decoded_payload">Decoded Payload:</string>
     <string name="debug_logs_export">Export Logs</string>
+    <string name="debug_export_cancelled">Export canceled</string>
+    <string name="debug_export_success">%1$d logs exported</string>
+    <string name="debug_export_failed">Failed to write log file: %1$s</string>
     <string name="debug_filters">Filters</string>
     <string name="debug_active_filters">Active filters</string>
     <string name="debug_default_search">Search in logs…</string>


### PR DESCRIPTION
closes #2990 

- Uses the current methods to select a file to export
- same defaults 
- shouldn't get a permission failure. 