### PR TITLE
#2932: Add radiation to enviroment metrics log

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/metrics/EnvironmentMetrics.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/metrics/EnvironmentMetrics.kt
@@ -356,7 +356,7 @@ private fun EnvironmentMetricsContent(telemetry: Telemetry, environmentDisplayFa
     }
 }
 
-@file:Suppress("MagicNumber") // preview data
+@Suppress("MagicNumber") // preview data
 @Preview(showBackground = true)
 @Composable
 private fun PreviewEnvironmentMetricsContent() {


### PR DESCRIPTION
closes #2932 

add radiation to the env logs. 

- General cleanup so all elements use the same params. 
- reduce emply space, 
- group elements together
- add preview. 

Fullly populated: 
<img width="313" height="170" alt="image" src="https://github.com/user-attachments/assets/afc0f06c-1e06-4b3a-a29c-ffe653e1469c" />
