### PR TITLE
add times to traceroute displays.

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -84,7 +84,7 @@ data class MetricsState(
     val powerMetrics: List<Telemetry> = emptyList(),
     val hostMetrics: List<Telemetry> = emptyList(),
     val tracerouteRequests: List<MeshLog> = emptyList(),
-    val tracerouteResults: List<MeshPacket> = emptyList(),
+    val tracerouteResults: List<MeshLog> = emptyList(),
     val positionLogs: List<Position> = emptyList(),
     val deviceHardware: DeviceHardware? = null,
     val isLocalDevice: Boolean = false,
@@ -321,7 +321,7 @@ constructor(
 
             combine(
                 meshLogRepository.getLogsFrom(nodeNum = 0, PortNum.TRACEROUTE_APP_VALUE),
-                meshLogRepository.getMeshPacketsFrom(destNum, PortNum.TRACEROUTE_APP_VALUE),
+                meshLogRepository.getLogsFrom(destNum ?: 0, PortNum.TRACEROUTE_APP_VALUE),
             ) { request, response ->
                 _state.update { state ->
                     state.copy(

--- a/app/src/main/java/com/geeksville/mesh/model/RouteDiscovery.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/RouteDiscovery.kt
@@ -22,48 +22,51 @@ import com.geeksville.mesh.MeshProtos.RouteDiscovery
 import com.geeksville.mesh.Portnums
 
 val MeshProtos.MeshPacket.fullRouteDiscovery: RouteDiscovery?
-    get() = with(decoded) {
-        if (hasDecoded() && !wantResponse && portnum == Portnums.PortNum.TRACEROUTE_APP) {
-            runCatching { RouteDiscovery.parseFrom(payload).toBuilder() }.getOrNull()?.apply {
-                val fullRoute = listOf(to) + routeList + from
-                clearRoute()
-                addAllRoute(fullRoute)
+    get() =
+        with(decoded) {
+            if (hasDecoded() && !wantResponse && portnum == Portnums.PortNum.TRACEROUTE_APP) {
+                runCatching { RouteDiscovery.parseFrom(payload).toBuilder() }
+                    .getOrNull()
+                    ?.apply {
+                        val fullRoute = listOf(to) + routeList + from
+                        clearRoute()
+                        addAllRoute(fullRoute)
 
-                val fullRouteBack = listOf(from) + routeBackList + to
-                clearRouteBack()
-                if (hopStart > 0 && snrBackCount > 0) { // otherwise back route is invalid
-                    addAllRouteBack(fullRouteBack)
-                }
-            }?.build()
-        } else {
-            null
+                        val fullRouteBack = listOf(from) + routeBackList + to
+                        clearRouteBack()
+                        if (hopStart > 0 && snrBackCount > 0) { // otherwise back route is invalid
+                            addAllRouteBack(fullRouteBack)
+                        }
+                    }
+                    ?.build()
+            } else {
+                null
+            }
         }
-    }
 
 @Suppress("MagicNumber")
 private fun formatTraceroutePath(nodesList: List<String>, snrList: List<Int>): String {
     // nodesList should include both origin and destination nodes
     // origin will not have an SNR value, but destination should
-    val snrStr = if (snrList.size == nodesList.size - 1) {
-        snrList
-    } else {
-        // use unknown SNR for entire route if snrList has invalid size
-        List(nodesList.size - 1) { -128 }
-    }.map { snr ->
-        val str = if (snr == -128) "?" else "${snr / 4f}"
-        "⇊ $str dB"
-    }
+    val snrStr =
+        if (snrList.size == nodesList.size - 1) {
+            snrList
+        } else {
+            // use unknown SNR for entire route if snrList has invalid size
+            List(nodesList.size - 1) { -128 }
+        }
+            .map { snr ->
+                val str = if (snr == -128) "?" else "${snr / 4f}"
+                "⇊ $str dB"
+            }
 
-    return nodesList.map { userName ->
-        "■ $userName"
-    }.flatMapIndexed { i, nodeStr ->
-        if (i == 0) listOf(nodeStr) else listOf(snrStr[i - 1], nodeStr)
-    }.joinToString("\n")
+    return nodesList
+        .map { userName -> "■ $userName" }
+        .flatMapIndexed { i, nodeStr -> if (i == 0) listOf(nodeStr) else listOf(snrStr[i - 1], nodeStr) }
+        .joinToString("\n")
 }
 
-private fun RouteDiscovery.getTracerouteResponse(
-    getUser: (nodeNum: Int) -> String,
-): String = buildString {
+private fun RouteDiscovery.getTracerouteResponse(getUser: (nodeNum: Int) -> String): String = buildString {
     if (routeList.isNotEmpty()) {
         append("Route traced toward destination:\n\n")
         append(formatTraceroutePath(routeList.map(getUser), snrTowardsList))
@@ -75,6 +78,10 @@ private fun RouteDiscovery.getTracerouteResponse(
     }
 }
 
-fun MeshProtos.MeshPacket.getTracerouteResponse(
-    getUser: (nodeNum: Int) -> String,
-): String? = fullRouteDiscovery?.getTracerouteResponse(getUser)
+fun MeshProtos.MeshPacket.getTracerouteResponse(getUser: (nodeNum: Int) -> String): String? =
+    fullRouteDiscovery?.getTracerouteResponse(getUser)
+
+/** Returns a traceroute response string only when the result is complete (both directions). */
+fun MeshProtos.MeshPacket.getFullTracerouteResponse(getUser: (nodeNum: Int) -> String): String? = fullRouteDiscovery
+    ?.takeIf { it.routeList.isNotEmpty() && it.routeBackList.isNotEmpty() }
+    ?.getTracerouteResponse(getUser)


### PR DESCRIPTION
closes #2896 

- add elapsed time to traceroutes. 
- calculated from packet times, so doesn't need changes to db 
- 