### PR TITLE
fix(service): increase config wait time

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -201,7 +201,7 @@ class MeshService :
 
         private const val CONFIG_ONLY_NONCE = 69420
         private const val NODE_INFO_ONLY_NONCE = 69421
-        private const val CONFIG_WAIT_MS = 50L
+        private const val CONFIG_WAIT_MS = 250L
     }
 
     private var previousSummary: String? = null


### PR DESCRIPTION
Increased the `CONFIG_WAIT_MS` constant from 50L to 250L. This should improve the reliability of configuration changes by allowing more time for the operation to complete.

This reverts a change that introduced some instability.