### PR TITLE
refactor(navigation)!: Make contacts screen a list/detail view

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceNotifications.kt
@@ -377,7 +377,7 @@ class MeshServiceNotifications(private val context: Context) {
     }
 
     private fun createOpenMessageIntent(contactKey: String): PendingIntent {
-        val deepLinkUri = "$DEEP_LINK_BASE_URI/messages/$contactKey".toUri()
+        val deepLinkUri = "$DEEP_LINK_BASE_URI/messages?contactKey=$contactKey".toUri()
         val deepLinkIntent =
             Intent(Intent.ACTION_VIEW, deepLinkUri, context, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -93,7 +93,7 @@ import com.geeksville.mesh.navigation.SettingsRoutes
 import com.geeksville.mesh.repository.radio.MeshActivity
 import com.geeksville.mesh.service.ConnectionState
 import com.geeksville.mesh.service.MeshService
-import com.geeksville.mesh.ui.common.components.MainAppBar
+import com.geeksville.mesh.ui.common.components.GlobalAppBar
 import com.geeksville.mesh.ui.common.components.MultipleChoiceAlertDialog
 import com.geeksville.mesh.ui.common.components.ScannedQrCodeDialog
 import com.geeksville.mesh.ui.common.components.SimpleAlertDialog
@@ -116,7 +116,7 @@ import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
 enum class TopLevelDestination(@StringRes val label: Int, val icon: ImageVector, val route: Route) {
-    Conversations(R.string.conversations, MeshtasticIcons.Conversations, ContactsRoutes.ContactsGraph),
+    Conversations(R.string.conversations, MeshtasticIcons.Conversations, ContactsRoutes.Messages()),
     Nodes(R.string.nodes, MeshtasticIcons.Nodes, NodesRoutes.NodesGraph),
     Map(R.string.map, MeshtasticIcons.Map, MapRoutes.Map),
     Settings(R.string.bottom_nav_settings, MeshtasticIcons.Settings, SettingsRoutes.SettingsGraph()),
@@ -125,7 +125,7 @@ enum class TopLevelDestination(@StringRes val label: Int, val icon: ImageVector,
 
     companion object {
         fun NavDestination.isTopLevel(): Boolean = listOf<KClass<out Route>>(
-            ContactsRoutes.Contacts::class,
+            ContactsRoutes.Messages::class,
             NodesRoutes.Nodes::class,
             MapRoutes.Map::class,
             ConnectionsRoutes.Connections::class,
@@ -343,7 +343,7 @@ fun MainScreen(
                 if (sharedContact != null) {
                     SharedContactDialog(contact = sharedContact, onDismiss = { sharedContact = null })
                 }
-                MainAppBar(
+                GlobalAppBar(
                     viewModel = uIViewModel,
                     navController = navController,
                     onAction = { action ->

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
@@ -60,7 +60,7 @@ import com.geeksville.mesh.ui.node.components.NodeMenuAction
 
 @Suppress("CyclomaticComplexMethod")
 @Composable
-fun MainAppBar(
+fun GlobalAppBar(
     modifier: Modifier = Modifier,
     viewModel: UIViewModel = hiltViewModel(),
     navController: NavHostController,
@@ -123,7 +123,7 @@ fun MainAppBar(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
-private fun MainAppBar(
+fun MainAppBar(
     modifier: Modifier = Modifier,
     title: String,
     subtitle: String? = null,


### PR DESCRIPTION
The contacts screen has been refactored to use a list/detail pattern. The `ContactsScreen` composable has been replaced with `Contacts` and now manages the display of both the list of conversations and the detail view for a selected conversation using `NavigableListDetailPaneScaffold`.

The `ContactsRoutes.Contacts` route has been removed and `ContactsRoutes.Messages` is now the entry point for the contacts graph. The `MessageScreen` is now displayed in the detail pane.

The `MainAppBar` composable has been renamed to `GlobalAppBar` and the previously private `MainAppBar` component is now public.

Deep link URI for messages has been updated to use query parameters.

<img width="300" alt="Screenshot_20250906_230214" src="https://github.com/user-attachments/assets/db2b5c7b-c688-4392-9330-bb40c5feec5d" />
