### PR TITLE
ci(release): improve Google Play release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Determine Version Name from Tag
         id: get_version_name
-        run: echo "APP_VERSION_NAME=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: echo "APP_VERSION_NAME=$(echo ${GITHUB_REF_NAME#v} | sed 's/-.*//')" >> $GITHUB_OUTPUT
 
       - name: Calculate Version Code
         id: calculate_version_code
@@ -245,28 +245,46 @@ jobs:
             ./build-artifacts/google/apk/app-google-release.apk
             ./build-artifacts/fdroid/app-fdroid-release.apk
 
-      - name: Determine Play Store Track
-        id: get_track
+      - name: Determine Play Store Action
+        id: play_action
         run: |
           TAG_NAME="${{ github.ref_name }}"
           if [[ "$TAG_NAME" == *"-internal"* ]]; then
             echo "track=internal" >> $GITHUB_OUTPUT
+            echo "action=upload" >> $GITHUB_OUTPUT
           elif [[ "$TAG_NAME" == *"-closed"* ]]; then
             echo "track=NewAlpha" >> $GITHUB_OUTPUT
+            echo "from_track=internal" >> $GITHUB_OUTPUT
+            echo "action=promote" >> $GITHUB_OUTPUT
           elif [[ "$TAG_NAME" == *"-open"* ]]; then
             echo "track=beta" >> $GITHUB_OUTPUT
+            echo "from_track=alpha" >> $GITHUB_OUTPUT
+            echo "action=promote" >> $GITHUB_OUTPUT
           else
             echo "track=production" >> $GITHUB_OUTPUT
+            echo "from_track=beta" >> $GITHUB_OUTPUT
+            echo "action=promote" >> $GITHUB_OUTPUT
           fi
 
-      - name: Upload AAB to Google Play
-        if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      - name: Attempt to Promote on Google Play
+        id: promote
+        if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && steps.play_action.outputs.action == 'promote'
+        uses: r0adkll/upload-google-play@v1.1.3
+        continue-on-error: true
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+          packageName: com.geeksville.mesh
+          track: ${{ steps.play_action.outputs.track }}
+          fromTrack: ${{ steps.play_action.outputs.from_track }}
+
+      - name: Upload to Google Play
+        if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && (steps.play_action.outputs.action == 'upload' || steps.promote.outcome == 'failure')
         uses: r0adkll/upload-google-play@v1.1.3
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
           packageName: com.geeksville.mesh
           releaseFiles: ./build-artifacts/google/bundle/app-google-release.aab
-          track: ${{ steps.get_track.outputs.track }}
-          status: ${{ steps.get_track.outputs.track == 'internal' && 'completed' || 'draft' }}
+          track: ${{ steps.play_action.outputs.track }}
+          status: ${{ steps.play_action.outputs.track == 'internal' && 'completed' || 'draft' }}
           whatsNewDirectory: ./whatsnew/
           mappingFile: ./build-artifacts/google/mapping/mapping.txt


### PR DESCRIPTION
This commit refines the Google Play release process within the GitHub Actions workflow.

Key changes include:

-   **Version Name Extraction:** The version name derived from the Git tag now correctly handles suffixes (e.g., "-internal", "-beta") by removing them, ensuring a clean version name like "1.2.3" instead of "1.2.3-beta".
-   **Play Store Action Determination:** The workflow now distinguishes between uploading a new build and promoting an existing one.
    -   Tags with "-internal" will directly upload to the "internal" track.
    -   Tags with "-closed" will attempt to promote from "internal" to "NewAlpha".
    -   Tags with "-open" will attempt to promote from "alpha" to "beta".
    -   Regular tags (no suffix) will attempt to promote from "beta" to "production".
-   **Conditional Promotion and Upload:**
    -   The workflow first attempts to promote a build if the tag indicates a promotion action.
    -   If the promotion fails (e.g., the build doesn't exist in the `from_track`), or if the action is explicitly "upload" (for internal builds), it proceeds to upload the new AAB.
    -   The `status` for uploaded builds is set to "completed" for the "internal" track and "draft" for others, allowing for manual review before full rollout.