### PR TITLE
ci(release): use correct promote action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,18 +264,20 @@ jobs:
             echo "track=production" >> $GITHUB_OUTPUT
             echo "from_track=beta" >> $GITHUB_OUTPUT
             echo "action=promote" >> $GITHUB_OUTPUT
+            echo "user_fraction=0.1" >> $GITHUB_OUTPUT
           fi
 
       - name: Attempt to Promote on Google Play
         id: promote
         if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && steps.play_action.outputs.action == 'promote'
-        uses: r0adkll/upload-google-play@v1.1.3
+        uses: kevin-david/promote-play-release@v1
         continue-on-error: true
         with:
-          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
-          packageName: com.geeksville.mesh
-          track: ${{ steps.play_action.outputs.track }}
-          fromTrack: ${{ steps.play_action.outputs.from_track }}
+          service-account-json-raw: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+          package-name: com.geeksville.mesh
+          to-track: ${{ steps.play_action.outputs.track }}
+          from-track: ${{ steps.play_action.outputs.from_track }}
+          user-fraction: ${{ steps.play_action.outputs.user_fraction }}
 
       - name: Upload to Google Play
         if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && (steps.play_action.outputs.action == 'upload' || steps.promote.outcome == 'failure')


### PR DESCRIPTION
This commit updates the Google Play release workflow. It changes the promotion step to use a different GitHub Action, `kevin-david/promote-play-release@v1`, replacing `r0adkll/upload-google-play@v1.1.3`.

The key change is the introduction of a staged rollout. When a beta version is promoted to production, it will now initially roll out to 10% of users.

The input parameters for the GitHub Action have been updated to reflect the new action's requirements:
- `serviceAccountJsonPlainText` is now `service-account-json-raw`
- `packageName` is now `package-name`
- `track` is now `to-track`
- `fromTrack` is now `from-track`
- A new input `user-fraction` has been added and set to the output of the `play_action` step, which is 0.1 for promotions.