### PR TITLE
ci(release): Cache build artifacts to speed up release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,13 +61,22 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
+      - name: Restore F-Droid APK from cache
+        id: cache-restore-fdroid
+        uses: actions/cache@v4
+        with:
+          path: app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
+          key: build-artifacts-fdroid-${{ github.sha }}
+
       - name: Set up JDK 21
+        if: steps.cache-restore-fdroid.outputs.cache-hit != 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'jetbrains'
 
       - name: Setup Gradle
+        if: steps.cache-restore-fdroid.outputs.cache-hit != 'true'
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -76,6 +85,7 @@ jobs:
           build-scan-terms-of-use-agree: 'yes'
 
       - name: Load Fdroid secrets
+        if: steps.cache-restore-fdroid.outputs.cache-hit != 'true'
         run: |
           echo $KEYSTORE | base64 -di > ./app/$KEYSTORE_FILENAME
           echo "$KEYSTORE_PROPERTIES" > ./keystore.properties
@@ -85,6 +95,7 @@ jobs:
           KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
 
       - name: Build F-Droid Release APK
+        if: steps.cache-restore-fdroid.outputs.cache-hit != 'true'
         run: |
           ./gradlew :app:assembleFdroidRelease --parallel --continue --scan
         env:
@@ -108,13 +119,25 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
+      - name: Restore build artifacts from cache
+        id: cache-restore-google
+        uses: actions/cache@v4
+        with:
+          path: |
+            app/build/outputs/bundle/googleRelease/app-google-release.aab
+            app/build/outputs/apk/google/release/app-google-release.apk
+            app/build/outputs/mapping/googleRelease/mapping.txt
+          key: build-artifacts-google-${{ github.sha }}
+
       - name: Set up JDK 21
+        if: steps.cache-restore-google.outputs.cache-hit != 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'jetbrains'
 
       - name: Setup Gradle
+        if: steps.cache-restore-google.outputs.cache-hit != 'true'
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -123,6 +146,7 @@ jobs:
           build-scan-terms-of-use-agree: 'yes'
 
       - name: Load Google secrets
+        if: steps.cache-restore-google.outputs.cache-hit != 'true'
         env:
           GSERVICES: ${{ secrets.GSERVICES }}
           KEYSTORE: ${{ secrets.KEYSTORE }}
@@ -141,6 +165,7 @@ jobs:
           echo "MAPS_API_KEY=$GOOGLE_MAPS_API_KEY" >> ./secrets.properties
 
       - name: Build Google Release Artifacts (AAB and APK)
+        if: steps.cache-restore-google.outputs.cache-hit != 'true'
         run: |
           ./gradlew :app:bundleGoogleRelease :app:assembleGoogleRelease --parallel --continue --scan
         env:

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -5,8 +5,8 @@ zzThis document outlines the steps for releasing a new version of the Meshtastic
 **Note on Automation:** The `release.yml` GitHub Action is primarily triggered by **pushing a Git tag** matching the pattern `v*` (e.g., `v1.2.3`, `v1.2.3-open.1`). It can also be manually triggered via `workflow_dispatch` from the GitHub Actions UI (select the desired branch/tag/commit).
 
 The workflow automatically:
-*   Determines version information (version name from the tag, version code via a script).
-*   Builds F-Droid (APK) and Google (AAB, APK) artifacts in parallel.
+*   Determines version information from the tag.
+*   Builds F-Droid (APK) and Google (AAB, APK) artifacts. If artifacts for the same commit SHA have been built before, it will use the cached artifacts instead of rebuilding.
 *   Generates a changelog.
 *   Creates a **draft GitHub Release**. The release is marked as a "pre-release" if the tag name contains `-internal`, `-closed`, or `-open`.
 *   Attaches build artifacts, `version_info.txt`, and `changelog.txt` to the draft GitHub Release.


### PR DESCRIPTION
This change introduces caching for build artifacts (APK, AAB, mapping files) in the `release.yml` GitHub Actions workflow.

If artifacts for the current commit SHA already exist in the cache, the workflow will skip the corresponding build steps (JDK setup, Gradle setup, secret loading, and the actual build command). This significantly speeds up the release process when re-running the workflow for the same commit, for example, if a previous run failed during a later step like changelog generation or GitHub Release creation.

The `RELEASE_PROCESS.md` has been updated to reflect this new caching behavior.
