### PR TITLE
ci(release): Remove build caching and set user fraction for promotions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,22 +61,13 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: Restore F-Droid APK from cache
-        id: cache-restore-fdroid
-        uses: actions/cache@v4
-        with:
-          path: app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
-          key: build-artifacts-fdroid-${{ github.sha }}
-
       - name: Set up JDK 21
-        if: steps.cache-restore-fdroid.outputs.cache-hit != 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'jetbrains'
 
       - name: Setup Gradle
-        if: steps.cache-restore-fdroid.outputs.cache-hit != 'true'
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -85,7 +76,6 @@ jobs:
           build-scan-terms-of-use-agree: 'yes'
 
       - name: Load Fdroid secrets
-        if: steps.cache-restore-fdroid.outputs.cache-hit != 'true'
         run: |
           echo $KEYSTORE | base64 -di > ./app/$KEYSTORE_FILENAME
           echo "$KEYSTORE_PROPERTIES" > ./keystore.properties
@@ -95,7 +85,6 @@ jobs:
           KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
 
       - name: Build F-Droid Release APK
-        if: steps.cache-restore-fdroid.outputs.cache-hit != 'true'
         run: |
           ./gradlew :app:assembleFdroidRelease --parallel --continue --scan
         env:
@@ -119,25 +108,13 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: Restore build artifacts from cache
-        id: cache-restore-google
-        uses: actions/cache@v4
-        with:
-          path: |
-            app/build/outputs/bundle/googleRelease/app-google-release.aab
-            app/build/outputs/apk/google/release/app-google-release.apk
-            app/build/outputs/mapping/googleRelease/mapping.txt
-          key: build-artifacts-google-${{ github.sha }}
-
       - name: Set up JDK 21
-        if: steps.cache-restore-google.outputs.cache-hit != 'true'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'jetbrains'
 
       - name: Setup Gradle
-        if: steps.cache-restore-google.outputs.cache-hit != 'true'
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -146,7 +123,6 @@ jobs:
           build-scan-terms-of-use-agree: 'yes'
 
       - name: Load Google secrets
-        if: steps.cache-restore-google.outputs.cache-hit != 'true'
         env:
           GSERVICES: ${{ secrets.GSERVICES }}
           KEYSTORE: ${{ secrets.KEYSTORE }}
@@ -165,7 +141,6 @@ jobs:
           echo "MAPS_API_KEY=$GOOGLE_MAPS_API_KEY" >> ./secrets.properties
 
       - name: Build Google Release Artifacts (AAB and APK)
-        if: steps.cache-restore-google.outputs.cache-hit != 'true'
         run: |
           ./gradlew :app:bundleGoogleRelease :app:assembleGoogleRelease --parallel --continue --scan
         env:
@@ -281,10 +256,12 @@ jobs:
             echo "track=NewAlpha" >> $GITHUB_OUTPUT
             echo "from_track=internal" >> $GITHUB_OUTPUT
             echo "action=promote" >> $GITHUB_OUTPUT
+            echo "user_fraction=1.0" >> $GITHUB_OUTPUT
           elif [[ "$TAG_NAME" == *"-open"* ]]; then
             echo "track=beta" >> $GITHUB_OUTPUT
             echo "from_track=alpha" >> $GITHUB_OUTPUT
             echo "action=promote" >> $GITHUB_OUTPUT
+            echo "user_fraction=1.0" >> $GITHUB_OUTPUT
           else
             echo "track=production" >> $GITHUB_OUTPUT
             echo "from_track=beta" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Removes the caching steps for F-Droid and Google Play builds in the release workflow. This ensures that builds are always performed fresh.

Additionally, this change sets the `user_fraction` to `1.0` for promotions to Alpha and Beta tracks, ensuring new releases are rolled out to all users in those tracks.