### PR TITLE
ci(release): promote from NewAlpha to beta for open builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
             echo "user_fraction=1.0" >> $GITHUB_OUTPUT
           elif [[ "$TAG_NAME" == *"-open"* ]]; then
             echo "track=beta" >> $GITHUB_OUTPUT
-            echo "from_track=alpha" >> $GITHUB_OUTPUT
+            echo "from_track=NewAlpha" >> $GITHUB_OUTPUT
             echo "action=promote" >> $GITHUB_OUTPUT
             echo "user_fraction=1.0" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
This commit updates the release workflow to promote open builds from the `NewAlpha` track to the `beta` track, instead of from `alpha`.