### PR TITLE
feat(fastlane): return AAB path from build lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,5 +82,6 @@ platform :android do
         "android.injected.version.code" => ENV['VERSION_CODE']
       }
     )
+    return lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
   end
 end


### PR DESCRIPTION
The `internal_build` lane now returns the path to the generated AAB file. This allows other lanes or scripts to easily access the build artifact.