### PR TITLE
chore(build): prioritize injected version properties

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,9 +59,13 @@ android {
         applicationId = Configs.APPLICATION_ID
         minSdk = Configs.MIN_SDK
         targetSdk = Configs.TARGET_SDK
-        // Prioritize ENV, then fallback to git commit count for versionCode
-        versionCode = (System.getenv("VERSION_CODE") ?: gitVersionProvider.get()).toInt()
-        versionName = System.getenv("VERSION_NAME") ?: Configs.VERSION_NAME_BASE
+        // Prioritize injected props, then ENV, then fallback to git commit count
+        versionCode = (project.findProperty("android.injected.version.code")?.toString()?.toInt()
+            ?: System.getenv("VERSION_CODE")?.toInt()
+            ?: gitVersionProvider.get().toInt())
+        versionName = (project.findProperty("android.injected.version.name")?.toString()
+            ?: System.getenv("VERSION_NAME")
+            ?: Configs.VERSION_NAME_BASE)
         testInstrumentationRunner = "com.geeksville.mesh.TestRunner"
         buildConfigField("String", "MIN_FW_VERSION", "\"${Configs.MIN_FW_VERSION}\"")
         buildConfigField("String", "ABS_MIN_FW_VERSION", "\"${Configs.ABS_MIN_FW_VERSION}\"")


### PR DESCRIPTION
This commit updates the build script to prioritize version code and version name values injected via project properties (`android.injected.version.code` and `android.injected.version.name`).

If these properties are not found, the script falls back to environment variables (`VERSION_CODE` and `VERSION_NAME`), and finally to a git-commit-count-based version code and a default version name (`Configs.VERSION_NAME_BASE`) if neither injected properties nor environment variables are available.
