### PR TITLE
fix(fastlane): Align assemble_beta task with fastlane documentation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,6 +82,6 @@ platform :android do
         "android.injected.version.code" => ENV['VERSION_CODE']
       }
     )
-    return lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+    lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
   end
 end


### PR DESCRIPTION
The assemble_beta task was previously returning the AAB output path directly. This change aligns the task with the Fastlane documentation by assigning the AAB output path to `lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]` without an explicit return. This ensures that the output is available in the lane context for subsequent actions, as expected by Fastlane.