### PR TITLE
ci: upload Android test results to Codecov

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,6 +34,7 @@ jobs:
       # upload_artifacts defaults to true, so no need to explicitly set
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           
   check-workflow-status:
     name: Check Workflow Status

--- a/.github/workflows/reusable-android-test.yml
+++ b/.github/workflows/reusable-android-test.yml
@@ -16,6 +16,8 @@ on:
     secrets:
       GRADLE_ENCRYPTION_KEY:
         required: false
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   androidTest:
@@ -64,6 +66,11 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           script: ./gradlew :app:connectedFdroidDebugAndroidTest :app:connectedGoogleDebugAndroidTest --configuration-cache --scan && ( killall -INT crashpad_handler || true )
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload Test Results
         if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This commit introduces the necessary changes to upload Android test results to Codecov.

The `pull-request.yml` workflow is updated to include the `CODECOV_TOKEN` secret.

The `reusable-android-test.yml` workflow is updated to:
- Require the `CODECOV_TOKEN` secret.
- Add a new step to upload test results to Codecov using the `codecov/test-results-action@v1` action. This step runs if the workflow is not cancelled.
