### PR TITLE
fix(locale): correct typo in Dutch locale code

### DIFF
--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -23,7 +23,7 @@
     <locale android:name="ja-JP"/>
     <locale android:name="ko-KR"/>
     <locale android:name="lt-LT"/>
-    <locale android:name.="nl-NL"/>
+    <locale android:name="nl-NL"/>
     <locale android:name="nb-NO"/>
     <locale android:name="pl-PL"/>
     <locale android:name="pt-BR"/>


### PR DESCRIPTION
The Dutch locale code was incorrectly specified as `nl-NL.` and has been corrected to `nl-NL`.