### PR TITLE
fix(locale): handle null locale tags and use forLanguageTag

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -420,7 +420,7 @@ private fun VersionChecks(viewModel: UIViewModel) {
     LaunchedEffect(connectionState, myNodeInfo) {
         if (connectionState == ConnectionState.CONNECTED) {
             myNodeInfo?.let { info ->
-                val isOld = info.minAppVersion > BuildConfig.VERSION_CODE
+                val isOld = info.minAppVersion > BuildConfig.VERSION_CODE && BuildConfig.DEBUG.not()
                 if (isOld) {
                     viewModel.showAlert(
                         context.getString(R.string.app_too_old),

--- a/app/src/main/java/com/geeksville/mesh/util/LanguageUtils.kt
+++ b/app/src/main/java/com/geeksville/mesh/util/LanguageUtils.kt
@@ -57,7 +57,7 @@ object LanguageUtils : Logging {
             context.resources.getXml(R.xml.locales_config).use {
                 while (it.eventType != XmlPullParser.END_DOCUMENT) {
                     if (it.eventType == XmlPullParser.START_TAG && it.name == "locale") {
-                        languageTags += it.getAttributeValue(0)
+                        it.getAttributeValue(0)?.let { tag -> languageTags += tag }
                     }
                     it.next()
                 }
@@ -66,7 +66,7 @@ object LanguageUtils : Logging {
             errormsg("Error parsing locale_config.xml ${e.message}")
         }
         return languageTags.associateBy { tag ->
-            val loc = Locale(tag)
+            val loc = Locale.forLanguageTag(tag)
             when (tag) {
                 SYSTEM_DEFAULT -> context.getString(R.string.preferences_system_default)
                 "fr-HT" -> context.getString(R.string.fr_HT)


### PR DESCRIPTION
- In LanguageUtils.kt, ensure that null locale tags from `locales_config.xml` are not added to the list of language tags.
- Use `Locale.forLanguageTag(tag)` instead of `Locale(tag)` for creating Locale objects to ensure correct parsing of language tags, including those with regional variants like "fr-HT".
- In Main.kt, modify the firmware update alert to only show for non-debug builds when the app version is older than the minimum required by the firmware.
