### PR TITLE
ci: add CODECOV_TOKEN to merge-queue workflow

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -28,6 +28,7 @@ jobs:
       upload_artifacts: false
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   check-workflow-status:
     name: Check Workflow Status  # Matches another in pull-request, and is required for merge to main.


### PR DESCRIPTION
This commit adds the `CODECOV_TOKEN` secret to the `merge-queue.yml` GitHub Actions workflow. This is necessary for Codecov to correctly report code coverage metrics for pull requests merged via the merge queue.