### PR TITLE
ci(release): update artifact paths in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,9 +230,9 @@ jobs:
           name: Release ${{ github.ref_name }}
           generate_release_notes: true
           files: |
-            ./build-artifacts/google/bundle/app-google-release.aab
-            ./build-artifacts/google/apk/app-google-release.apk
-            ./build-artifacts/fdroid/app-fdroid-release.apk
+            ./google/bundle/app-google-release.aab
+            ./google/apk/app-google-release.apk
+            ./fdroid/app-fdroid-release.apk
             ./version_info.txt
           draft: ${{ contains(github.ref_name, '-internal') }}
           prerelease: ${{ contains(github.ref_name, '-internal') || contains(github.ref_name, '-closed') || contains(github.ref_name, '-open') }}


### PR DESCRIPTION
The paths for the release artifacts (AAB and APKs) have been updated to remove the `./build-artifacts/` prefix.