### PR TITLE
strip line breaks from display

### DIFF
--- a/app/src/google/java/com/geeksville/mesh/ui/map/components/WaypointMarkers.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/components/WaypointMarkers.kt
@@ -52,8 +52,8 @@ fun WaypointMarkers(
                 } else {
                     unicodeEmojiToBitmapProvider(waypoint.icon)
                 },
-                title = waypoint.name,
-                snippet = waypoint.description,
+                title = waypoint.name.replace('\n', ' ').replace('\b', ' '),
+                snippet = waypoint.description.replace('\n', ' ').replace('\b', ' '),
                 visible = true,
                 onInfoWindowClick = {
                     if (waypoint.lockedTo == 0 || waypoint.lockedTo == myNodeNum || !isConnected) {


### PR DESCRIPTION
closes #2803 

Now displays all content. 

Strips /b and /n at display, and replaces with ' '.

The line breaks are sneaking in through another interface, we don't have them on the keyboard for out editor