### PR TITLE
feat(settings): add GPS coordinate format setting

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/components/DisplayConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/components/DisplayConfigItemList.kt
@@ -124,16 +124,17 @@ fun DisplayConfigItemList(displayConfig: DisplayConfig, enabled: Boolean, onSave
                 onItemSelected = { displayInput = displayInput.copy { units = it } },
             )
         }
-        item { HorizontalDivider()}
+        item { HorizontalDivider() }
         item {
             DropDownPreference(
                 title = stringResource(R.string.gps_coordinates_format),
                 enabled = enabled,
-                items = DisplayConfig.GpsCoordinateFormat.entries
+                items =
+                DisplayConfig.GpsCoordinateFormat.entries
                     .filter { it != DisplayConfig.GpsCoordinateFormat.UNRECOGNIZED }
                     .map { it to it.name },
                 selectedItem = displayInput.gpsFormat,
-                onItemSelected = { displayInput = displayInput.copy { gpsFormat = it } }
+                onItemSelected = { displayInput = displayInput.copy { gpsFormat = it } },
             )
         }
         item { HorizontalDivider() }


### PR DESCRIPTION
Adds a new dropdown preference in the display settings to allow users to select their preferred GPS coordinate format. The available options are filtered to exclude `UNRECOGNIZED`.



Maybe un-deprecated? #3106 