### PR TITLE
Start migration away from global top app bar

### DIFF
--- a/app/src/fdroid/java/com/geeksville/mesh/ui/node/NodeMap.kt
+++ b/app/src/fdroid/java/com/geeksville/mesh/ui/node/NodeMap.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
 import com.geeksville.mesh.model.MetricsViewModel
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.map.rememberMapViewWithLifecycle
@@ -40,6 +41,7 @@ private const val DEG_D = 1e-7
 
 @Composable
 fun NodeMapScreen(
+    navController: NavHostController,
     @Suppress("UNUSED_PARAMETER") uiViewModel: UIViewModel = hiltViewModel(),
     viewModel: MetricsViewModel = hiltViewModel(),
 ) {

--- a/app/src/google/java/com/geeksville/mesh/ui/map/MapView.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/MapView.kt
@@ -74,7 +74,6 @@ import com.geeksville.mesh.android.BuildUtils.warn
 import com.geeksville.mesh.copy
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.UIViewModel
-import com.geeksville.mesh.ui.common.components.MainAppBar
 import com.geeksville.mesh.ui.map.components.ClusterItemsListDialog
 import com.geeksville.mesh.ui.map.components.CustomMapLayersSheet
 import com.geeksville.mesh.ui.map.components.CustomTileProviderManagerSheet
@@ -377,20 +376,7 @@ fun MapView(
         }
     }
 
-    Scaffold(
-        topBar = {
-            MainAppBar(
-                title = stringResource(R.string.map),
-                ourNode = ourNodeInfo,
-                isConnected = isConnected,
-                showNodeChip = ourNodeInfo != null && isConnected,
-                canNavigateUp = false,
-                onNavigateUp = {},
-                actions = {},
-                onAction = {},
-            )
-        },
-    ) { paddingValues ->
+    Scaffold { paddingValues ->
         Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
             GoogleMap(
                 mapColorScheme = mapColorScheme,

--- a/app/src/google/java/com/geeksville/mesh/ui/map/MapView.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/MapView.kt
@@ -74,6 +74,7 @@ import com.geeksville.mesh.android.BuildUtils.warn
 import com.geeksville.mesh.copy
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.ui.common.components.MainAppBar
 import com.geeksville.mesh.ui.map.components.ClusterItemsListDialog
 import com.geeksville.mesh.ui.map.components.CustomMapLayersSheet
 import com.geeksville.mesh.ui.map.components.CustomTileProviderManagerSheet
@@ -376,7 +377,20 @@ fun MapView(
         }
     }
 
-    Scaffold { paddingValues ->
+    Scaffold(
+        topBar = {
+            MainAppBar(
+                title = stringResource(R.string.map),
+                ourNode = ourNodeInfo,
+                isConnected = isConnected,
+                showNodeChip = ourNodeInfo != null && isConnected,
+                canNavigateUp = false,
+                onNavigateUp = {},
+                actions = {},
+                onAction = {},
+            )
+        },
+    ) { paddingValues ->
         Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
             GoogleMap(
                 mapColorScheme = mapColorScheme,

--- a/app/src/google/java/com/geeksville/mesh/ui/node/NodeMap.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/node/NodeMap.kt
@@ -17,20 +17,56 @@
 
 package com.geeksville.mesh.ui.node
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
 import com.geeksville.mesh.model.MetricsViewModel
 import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.ui.common.components.MainAppBar
 import com.geeksville.mesh.ui.map.MapView
 
 const val DEG_D = 1e-7
 
 @Composable
-fun NodeMapScreen(uiViewModel: UIViewModel, metricsViewModel: MetricsViewModel = hiltViewModel()) {
+fun NodeMapScreen(
+    navController: NavHostController,
+    uiViewModel: UIViewModel,
+    metricsViewModel: MetricsViewModel = hiltViewModel(),
+) {
     val state by metricsViewModel.state.collectAsState()
     val positions = state.positionLogs
     val destNum = state.node?.num
-    MapView(uiViewModel = uiViewModel, focusedNodeNum = destNum, nodeTrack = positions, navigateToNodeDetails = {})
+    val ourNodeInfo by uiViewModel.ourNodeInfo.collectAsStateWithLifecycle()
+    val isConnected by uiViewModel.isConnectedStateFlow.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            MainAppBar(
+                title = state.node?.user?.longName ?: "",
+                ourNode = ourNodeInfo,
+                isConnected = isConnected,
+                showNodeChip = false,
+                canNavigateUp = true,
+                onNavigateUp = navController::navigateUp,
+                actions = {},
+                onAction = {},
+            )
+        },
+    ) { paddingValues ->
+        Box(modifier = Modifier.padding(paddingValues)) {
+            MapView(
+                uiViewModel = uiViewModel,
+                focusedNodeNum = destNum,
+                nodeTrack = positions,
+                navigateToNodeDetails = {},
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/geeksville/mesh/navigation/ConnectionsNavigation.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/ConnectionsNavigation.kt
@@ -42,6 +42,12 @@ fun NavGraphBuilder.connectionsGraph(navController: NavHostController, bluetooth
             ConnectionsScreen(
                 bluetoothViewModel = bluetoothViewModel,
                 radioConfigViewModel = hiltViewModel(parentEntry),
+                onClickNodeChip = {
+                    navController.navigate(NodesRoutes.NodeDetailGraph(it)) {
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
                 onNavigateToSettings = { navController.navigate(SettingsRoutes.Settings()) },
                 onNavigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
                 onConfigNavigate = { route -> navController.navigate(route) },

--- a/app/src/main/java/com/geeksville/mesh/navigation/ContactsNavigation.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/ContactsNavigation.kt
@@ -37,6 +37,12 @@ fun NavGraphBuilder.contactsGraph(navController: NavHostController, uiViewModel:
         ) {
             ContactsScreen(
                 uiViewModel,
+                onClickNodeChip = {
+                    navController.navigate(NodesRoutes.NodeDetailGraph(it)) {
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
                 onNavigateToMessages = { navController.navigate(ContactsRoutes.Messages(it)) },
                 onNavigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
                 onNavigateToShare = { navController.navigate(ChannelsRoutes.ChannelsGraph) },

--- a/app/src/main/java/com/geeksville/mesh/navigation/MapNavigation.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/MapNavigation.kt
@@ -17,18 +17,58 @@
 
 package com.geeksville.mesh.navigation
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
+import com.geeksville.mesh.R
 import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.ui.common.components.MainAppBar
 import com.geeksville.mesh.ui.map.MapView
+import com.geeksville.mesh.ui.node.components.NodeMenuAction
 
 fun NavGraphBuilder.mapGraph(navController: NavHostController, uiViewModel: UIViewModel) {
     composable<MapRoutes.Map>(deepLinks = listOf(navDeepLink<MapRoutes.Map>(basePath = "$DEEP_LINK_BASE_URI/map"))) {
-        MapView(
-            uiViewModel = uiViewModel,
-            navigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
-        )
+        val ourNodeInfo by uiViewModel.ourNodeInfo.collectAsStateWithLifecycle()
+        val isConnected by uiViewModel.isConnectedStateFlow.collectAsStateWithLifecycle()
+
+        Scaffold(
+            topBar = {
+                MainAppBar(
+                    title = stringResource(R.string.map),
+                    ourNode = ourNodeInfo,
+                    isConnected = isConnected,
+                    showNodeChip = ourNodeInfo != null && isConnected,
+                    canNavigateUp = false,
+                    onNavigateUp = {},
+                    actions = {},
+                    onAction = { action ->
+                        when (action) {
+                            is NodeMenuAction.MoreDetails -> {
+                                navController.navigate(NodesRoutes.NodeDetailGraph(action.node.num)) {
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            }
+                            else -> {}
+                        }
+                    },
+                )
+            },
+        ) { paddingValues ->
+            Box(modifier = Modifier.padding(paddingValues)) {
+                MapView(
+                    uiViewModel = uiViewModel,
+                    navigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/navigation/NodesNavigation.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/NodesNavigation.kt
@@ -183,7 +183,12 @@ private inline fun <reified R : Route> NavGraphBuilder.addNodeDetailScreenCompos
     navController: NavHostController,
     uiViewModel: UIViewModel,
     routeInfo: NodeDetailRoute,
-    crossinline screenContent: @Composable (metricsViewModel: MetricsViewModel, passedUiViewModel: UIViewModel) -> Unit,
+    crossinline screenContent:
+    @Composable (
+        navController: NavHostController,
+        metricsViewModel: MetricsViewModel,
+        passedUiViewModel: UIViewModel,
+    ) -> Unit,
 ) {
     composable<R>(
         deepLinks =
@@ -195,7 +200,7 @@ private inline fun <reified R : Route> NavGraphBuilder.addNodeDetailScreenCompos
         val parentGraphBackStackEntry =
             remember(backStackEntry) { navController.getBackStackEntry(NodesRoutes.NodeDetailGraph::class) }
         val metricsViewModel = hiltViewModel<MetricsViewModel>(parentGraphBackStackEntry)
-        screenContent(metricsViewModel, uiViewModel)
+        screenContent(navController, metricsViewModel, uiViewModel)
     }
 }
 
@@ -203,60 +208,65 @@ enum class NodeDetailRoute(
     @StringRes val title: Int,
     val route: Route,
     val icon: ImageVector?,
-    val screenComposable: @Composable (metricsViewModel: MetricsViewModel, uiViewModel: UIViewModel) -> Unit,
+    val screenComposable:
+    @Composable (
+        navController: NavHostController,
+        metricsViewModel: MetricsViewModel,
+        uiViewModel: UIViewModel,
+    ) -> Unit,
 ) {
     DEVICE(
         R.string.device,
         NodeDetailRoutes.DeviceMetrics,
         Icons.Default.Router,
-        { metricsVM, _ -> DeviceMetricsScreen(metricsVM) },
+        { _, metricsVM, _ -> DeviceMetricsScreen(metricsVM) },
     ),
     NODE_MAP(
         R.string.node_map,
         NodeDetailRoutes.NodeMap,
         Icons.Default.LocationOn,
-        { metricsVM, uiVM -> NodeMapScreen(uiVM, metricsVM) },
+        { navController, metricsVM, uiVM -> NodeMapScreen(navController, uiVM, metricsVM) },
     ),
     POSITION_LOG(
         R.string.position_log,
         NodeDetailRoutes.PositionLog,
         Icons.Default.LocationOn,
-        { metricsVM, _ -> PositionLogScreen(metricsVM) },
+        { _, metricsVM, _ -> PositionLogScreen(metricsVM) },
     ),
     ENVIRONMENT(
         R.string.environment,
         NodeDetailRoutes.EnvironmentMetrics,
         Icons.Default.LightMode,
-        { metricsVM, _ -> EnvironmentMetricsScreen(metricsVM) },
+        { _, metricsVM, _ -> EnvironmentMetricsScreen(metricsVM) },
     ),
     SIGNAL(
         R.string.signal,
         NodeDetailRoutes.SignalMetrics,
         Icons.Default.CellTower,
-        { metricsVM, _ -> SignalMetricsScreen(metricsVM) },
+        { _, metricsVM, _ -> SignalMetricsScreen(metricsVM) },
     ),
     TRACEROUTE(
         R.string.traceroute,
         NodeDetailRoutes.TracerouteLog,
         Icons.Default.PermScanWifi,
-        { metricsVM, _ -> TracerouteLogScreen(viewModel = metricsVM) },
+        { _, metricsVM, _ -> TracerouteLogScreen(viewModel = metricsVM) },
     ),
     POWER(
         R.string.power,
         NodeDetailRoutes.PowerMetrics,
         Icons.Default.Power,
-        { metricsVM, _ -> PowerMetricsScreen(metricsVM) },
+        { _, metricsVM, _ -> PowerMetricsScreen(metricsVM) },
     ),
     HOST(
         R.string.host,
         NodeDetailRoutes.HostMetricsLog,
         Icons.Default.Memory,
-        { metricsVM, _ -> HostMetricsLogScreen(metricsVM) },
+        { _, metricsVM, _ -> HostMetricsLogScreen(metricsVM) },
     ),
     PAX(
         R.string.pax,
         NodeDetailRoutes.PaxMetrics,
         Icons.Default.People,
-        { metricsVM, _ -> PaxMetricsScreen(metricsVM) },
+        { _, metricsVM, _ -> PaxMetricsScreen(metricsVM) },
     ),
 }

--- a/app/src/main/java/com/geeksville/mesh/navigation/SettingsNavigation.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/SettingsNavigation.kt
@@ -97,7 +97,16 @@ fun NavGraphBuilder.settingsGraph(navController: NavHostController, uiViewModel:
         ) { backStackEntry ->
             val parentEntry =
                 remember(backStackEntry) { navController.getBackStackEntry(SettingsRoutes.SettingsGraph::class) }
-            SettingsScreen(uiViewModel = uiViewModel, viewModel = hiltViewModel(parentEntry)) {
+            SettingsScreen(
+                uiViewModel = uiViewModel,
+                viewModel = hiltViewModel(parentEntry),
+                onClickNodeChip = {
+                    navController.navigate(NodesRoutes.NodeDetailGraph(it)) {
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+            ) {
                 navController.navigate(it) { popUpTo(SettingsRoutes.Settings()) { inclusive = false } }
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -22,6 +22,7 @@ package com.geeksville.mesh.ui
 import android.Manifest
 import android.os.Build
 import androidx.annotation.StringRes
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
@@ -135,7 +136,6 @@ enum class TopLevelDestination(@StringRes val label: Int, val icon: ImageVector,
             NodesRoutes.Nodes::class,
             MapRoutes.Map::class,
             ConnectionsRoutes.Connections::class,
-            SettingsRoutes.Settings::class,
         )
             .any { this.hasRoute(it) }
 
@@ -349,26 +349,33 @@ fun MainScreen(
                 if (sharedContact != null) {
                     SharedContactDialog(contact = sharedContact, onDismiss = { sharedContact = null })
                 }
-                MainAppBar(
-                    viewModel = uIViewModel,
-                    navController = navController,
-                    onAction = { action ->
-                        when (action) {
-                            is NodeMenuAction.MoreDetails -> {
-                                navController.navigate(
-                                    NodesRoutes.NodeDetailGraph(action.node.num),
-                                    {
-                                        launchSingleTop = true
-                                        restoreState = true
-                                    },
-                                )
-                            }
 
-                            is NodeMenuAction.Share -> sharedContact = action.node
-                            else -> {}
-                        }
-                    },
-                )
+                fun NavDestination.hasGlobalAppBar(): Boolean =
+                    // List of screens to exclude from having the global app bar
+                    listOf<KClass<out Route>>(SettingsRoutes.Settings::class).none { this.hasRoute(it) }
+
+                AnimatedVisibility(visible = currentDestination?.hasGlobalAppBar() ?: true) {
+                    MainAppBar(
+                        viewModel = uIViewModel,
+                        navController = navController,
+                        onAction = { action ->
+                            when (action) {
+                                is NodeMenuAction.MoreDetails -> {
+                                    navController.navigate(
+                                        NodesRoutes.NodeDetailGraph(action.node.num),
+                                        {
+                                            launchSingleTop = true
+                                            restoreState = true
+                                        },
+                                    )
+                                }
+
+                                is NodeMenuAction.Share -> sharedContact = action.node
+                                else -> {}
+                            }
+                        },
+                    )
+                }
 
                 NavHost(
                     navController = navController,

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -88,6 +88,7 @@ import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.navigation.ConnectionsRoutes
 import com.geeksville.mesh.navigation.ContactsRoutes
 import com.geeksville.mesh.navigation.MapRoutes
+import com.geeksville.mesh.navigation.NodeDetailRoutes
 import com.geeksville.mesh.navigation.NodesRoutes
 import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.navigation.SettingsRoutes
@@ -356,6 +357,7 @@ fun MainScreen(
                         ConnectionsRoutes.Connections::class,
                         ContactsRoutes.Contacts::class,
                         MapRoutes.Map::class,
+                        NodeDetailRoutes.NodeMap::class,
                         NodesRoutes.Nodes::class,
                         SettingsRoutes.Settings::class,
                     )

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -359,6 +359,7 @@ fun MainScreen(
                         MapRoutes.Map::class,
                         NodeDetailRoutes.NodeMap::class,
                         NodesRoutes.Nodes::class,
+                        NodesRoutes.NodeDetail::class,
                         SettingsRoutes.Settings::class,
                     )
                         .none { this.hasRoute(it) }

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -352,7 +352,9 @@ fun MainScreen(
 
                 fun NavDestination.hasGlobalAppBar(): Boolean =
                     // List of screens to exclude from having the global app bar
-                    listOf<KClass<out Route>>(SettingsRoutes.Settings::class).none { this.hasRoute(it) }
+                    listOf(ConnectionsRoutes.Connections::class, SettingsRoutes.Settings::class).none {
+                        this.hasRoute(it)
+                    }
 
                 AnimatedVisibility(visible = currentDestination?.hasGlobalAppBar() ?: true) {
                     MainAppBar(

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -355,6 +355,7 @@ fun MainScreen(
                     listOf(
                         ConnectionsRoutes.Connections::class,
                         ContactsRoutes.Contacts::class,
+                        MapRoutes.Map::class,
                         NodesRoutes.Nodes::class,
                         SettingsRoutes.Settings::class,
                     )

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -354,6 +354,7 @@ fun MainScreen(
                     // List of screens to exclude from having the global app bar
                     listOf(
                         ConnectionsRoutes.Connections::class,
+                        ContactsRoutes.Contacts::class,
                         NodesRoutes.Nodes::class,
                         SettingsRoutes.Settings::class,
                     )

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -352,9 +352,12 @@ fun MainScreen(
 
                 fun NavDestination.hasGlobalAppBar(): Boolean =
                     // List of screens to exclude from having the global app bar
-                    listOf(ConnectionsRoutes.Connections::class, SettingsRoutes.Settings::class).none {
-                        this.hasRoute(it)
-                    }
+                    listOf(
+                        ConnectionsRoutes.Connections::class,
+                        NodesRoutes.Nodes::class,
+                        SettingsRoutes.Settings::class,
+                    )
+                        .none { this.hasRoute(it) }
 
                 AnimatedVisibility(visible = currentDestination?.hasGlobalAppBar() ?: true) {
                     MainAppBar(

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
@@ -75,8 +75,6 @@ fun MainAppBar(
     }
 
     val longTitle by viewModel.title.collectAsStateWithLifecycle("")
-    val onlineNodeCount by viewModel.onlineNodeCount.collectAsStateWithLifecycle(0)
-    val totalNodeCount by viewModel.totalNodeCount.collectAsStateWithLifecycle(0)
     val ourNode by viewModel.ourNodeInfo.collectAsStateWithLifecycle()
     val isConnected by viewModel.isConnectedStateFlow.collectAsStateWithLifecycle(false)
 
@@ -95,17 +93,10 @@ fun MainAppBar(
             else -> stringResource(id = R.string.app_name)
         }
 
-    val subtitle =
-        if (currentDestination?.hasRoute<NodesRoutes.Nodes>() == true) {
-            stringResource(R.string.node_count_template, onlineNodeCount, totalNodeCount)
-        } else {
-            null
-        }
-
     MainAppBar(
         modifier = modifier,
         title = title,
-        subtitle = subtitle,
+        subtitle = null,
         canNavigateUp = navController.previousBackStackEntry != null && currentDestination?.isTopLevel() == false,
         ourNode = ourNode,
         isConnected = isConnected,

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
@@ -125,7 +125,7 @@ fun MainAppBar(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
-private fun MainAppBar(
+fun MainAppBar(
     modifier: Modifier = Modifier,
     title: String,
     subtitle: String? = null,

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
@@ -74,11 +74,11 @@ import com.geeksville.mesh.ui.common.components.MainAppBar
 import com.geeksville.mesh.ui.common.components.TitledCard
 import com.geeksville.mesh.ui.connections.components.BLEDevices
 import com.geeksville.mesh.ui.connections.components.ConnectionsSegmentedBar
-import com.geeksville.mesh.ui.connections.components.CurrentlyConnectedCard
+import com.geeksville.mesh.ui.connections.components.CurrentlyConnectedInfo
 import com.geeksville.mesh.ui.connections.components.NetworkDevices
 import com.geeksville.mesh.ui.connections.components.UsbDevices
-import com.geeksville.mesh.ui.settings.components.SettingsItem
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
+import com.geeksville.mesh.ui.settings.components.SettingsItem
 import com.geeksville.mesh.ui.settings.radio.RadioConfigViewModel
 import com.geeksville.mesh.ui.settings.radio.components.PacketResponseStateDialog
 import com.geeksville.mesh.ui.sharing.SharedContactDialog
@@ -219,19 +219,15 @@ fun ConnectionsScreen(
                     ) {
                         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                             ourNode?.let { node ->
-                                Text(
-                                    stringResource(R.string.connected_device),
-                                    modifier = Modifier.padding(horizontal = 16.dp),
-                                    style = MaterialTheme.typography.titleLarge,
-                                )
-
-                                CurrentlyConnectedCard(
-                                    node = node,
-                                    onNavigateToNodeDetails = onNavigateToNodeDetails,
-                                    onSetShowSharedContact = { showSharedContact = it },
-                                    onNavigateToSettings = onNavigateToSettings,
-                                    onClickDisconnect = { scanModel.disconnect() },
-                                )
+                                TitledCard(title = stringResource(R.string.connected_device)) {
+                                    CurrentlyConnectedInfo(
+                                        node = node,
+                                        onNavigateToNodeDetails = onNavigateToNodeDetails,
+                                        onSetShowSharedContact = { showSharedContact = it },
+                                        onNavigateToSettings = onNavigateToSettings,
+                                        onClickDisconnect = { scanModel.disconnect() },
+                                    )
+                                }
                             }
 
                             if (regionUnset && selectedDevice != "m") {
@@ -249,11 +245,14 @@ fun ConnectionsScreen(
                     }
 
                     var selectedDeviceType by remember { mutableStateOf(DeviceType.BLE) }
-                    LaunchedEffect(selectedDevice) {
-                        DeviceType.fromAddress(selectedDevice)?.let { type -> selectedDeviceType = type }
-                    }
+                    LaunchedEffect(Unit) { DeviceType.fromAddress(selectedDevice)?.let { selectedDeviceType = it } }
 
-                    ConnectionsSegmentedBar(modifier = Modifier.fillMaxWidth()) { selectedDeviceType = it }
+                    ConnectionsSegmentedBar(
+                        selectedDeviceType = selectedDeviceType,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        selectedDeviceType = it
+                    }
 
                     Spacer(modifier = Modifier.height(4.dp))
 

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
@@ -72,6 +72,7 @@ import com.geeksville.mesh.ui.connections.components.ConnectionsSegmentedBar
 import com.geeksville.mesh.ui.connections.components.CurrentlyConnectedCard
 import com.geeksville.mesh.ui.connections.components.NetworkDevices
 import com.geeksville.mesh.ui.connections.components.UsbDevices
+import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import com.geeksville.mesh.ui.settings.radio.RadioConfigViewModel
 import com.geeksville.mesh.ui.settings.radio.components.PacketResponseStateDialog
 import com.geeksville.mesh.ui.sharing.SharedContactDialog
@@ -97,6 +98,7 @@ fun ConnectionsScreen(
     scanModel: BTScanModel = hiltViewModel(),
     bluetoothViewModel: BluetoothViewModel = hiltViewModel(),
     radioConfigViewModel: RadioConfigViewModel = hiltViewModel(),
+    onClickNodeChip: (Int) -> Unit,
     onNavigateToSettings: () -> Unit,
     onNavigateToNodeDetails: (Int) -> Unit,
     onConfigNavigate: (Route) -> Unit,
@@ -188,7 +190,12 @@ fun ConnectionsScreen(
                 canNavigateUp = false,
                 onNavigateUp = {},
                 actions = {},
-                onAction = {},
+                onAction = { action ->
+                    when (action) {
+                        is NodeMenuAction.MoreDetails -> onClickNodeChip(action.node.num)
+                        else -> {}
+                    }
+                },
             )
         },
     ) { paddingValues ->

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/ConnectionsSegmentedBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/ConnectionsSegmentedBar.kt
@@ -28,10 +28,6 @@ import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -43,19 +39,18 @@ import com.geeksville.mesh.ui.connections.DeviceType
 
 @Suppress("LambdaParameterEventTrailing")
 @Composable
-fun ConnectionsSegmentedBar(modifier: Modifier = Modifier, onClickDeviceType: (DeviceType) -> Unit) {
-    var selectedItem by remember { mutableStateOf(Item.BLUETOOTH) }
-
+fun ConnectionsSegmentedBar(
+    selectedDeviceType: DeviceType,
+    modifier: Modifier = Modifier,
+    onClickDeviceType: (DeviceType) -> Unit,
+) {
     SingleChoiceSegmentedButtonRow(modifier = modifier) {
         Item.entries.forEachIndexed { index, item ->
             val text = stringResource(item.textRes)
             SegmentedButton(
                 shape = SegmentedButtonDefaults.itemShape(index, Item.entries.size),
-                onClick = {
-                    selectedItem = item
-                    onClickDeviceType(item.deviceType)
-                },
-                selected = item == selectedItem,
+                onClick = { onClickDeviceType(item.deviceType) },
+                selected = item.deviceType == selectedDeviceType,
                 icon = { Icon(imageVector = item.imageVector, contentDescription = text) },
                 label = { Text(text = text, maxLines = 1, overflow = TextOverflow.Ellipsis) },
             )
@@ -72,5 +67,5 @@ private enum class Item(val imageVector: ImageVector, @StringRes val textRes: In
 @Preview(showBackground = true)
 @Composable
 private fun ConnectionsSegmentedBarPreview() {
-    AppTheme { ConnectionsSegmentedBar {} }
+    AppTheme { ConnectionsSegmentedBar(selectedDeviceType = DeviceType.BLE) {} }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedInfo.kt
@@ -27,7 +27,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -53,71 +52,69 @@ import com.geeksville.mesh.ui.node.components.NodeChip
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 
 @Composable
-fun CurrentlyConnectedCard(
+fun CurrentlyConnectedInfo(
     node: Node,
-    modifier: Modifier = Modifier,
     onNavigateToNodeDetails: (Int) -> Unit,
     onSetShowSharedContact: (Node) -> Unit,
     onNavigateToSettings: () -> Unit,
     onClickDisconnect: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    Card(modifier = modifier) {
-        Column {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    NodeChip(
-                        node = node,
-                        isThisNode = true,
-                        isConnected = true,
-                        onAction = { action ->
-                            when (action) {
-                                is NodeMenuAction.MoreDetails -> onNavigateToNodeDetails(node.num)
-
-                                is NodeMenuAction.Share -> onSetShowSharedContact(node)
-                                else -> {}
-                            }
-                        },
-                    )
-
-                    MaterialBatteryInfo(level = node.batteryLevel)
-                }
-
-                Column(modifier = Modifier.weight(1f, fill = true)) {
-                    Text(text = node.user.longName, style = MaterialTheme.typography.titleMedium)
-
-                    node.metadata?.firmwareVersion?.let { firmwareVersion ->
-                        Text(
-                            text = stringResource(R.string.firmware_version, firmwareVersion),
-                            style = MaterialTheme.typography.bodySmall,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                }
-
-                IconButton(enabled = true, onClick = onNavigateToSettings) {
-                    Icon(
-                        imageVector = Icons.Default.Settings,
-                        contentDescription = stringResource(id = R.string.radio_configuration),
-                    )
-                }
-            }
-
-            Button(
-                shape = RectangleShape,
-                modifier = Modifier.fillMaxWidth().height(40.dp),
-                colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.StatusRed,
-                    contentColor = Color.White,
-                ),
-                onClick = onClickDisconnect,
+    Column(modifier = modifier) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Text(stringResource(R.string.disconnect))
+                NodeChip(
+                    node = node,
+                    isThisNode = true,
+                    isConnected = true,
+                    onAction = { action ->
+                        when (action) {
+                            is NodeMenuAction.MoreDetails -> onNavigateToNodeDetails(node.num)
+
+                            is NodeMenuAction.Share -> onSetShowSharedContact(node)
+                            else -> {}
+                        }
+                    },
+                )
+
+                MaterialBatteryInfo(level = node.batteryLevel)
             }
+
+            Column(modifier = Modifier.weight(1f, fill = true)) {
+                Text(text = node.user.longName, style = MaterialTheme.typography.titleMedium)
+
+                node.metadata?.firmwareVersion?.let { firmwareVersion ->
+                    Text(
+                        text = stringResource(R.string.firmware_version, firmwareVersion),
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+
+            IconButton(enabled = true, onClick = onNavigateToSettings) {
+                Icon(
+                    imageVector = Icons.Default.Settings,
+                    contentDescription = stringResource(id = R.string.radio_configuration),
+                )
+            }
+        }
+
+        Button(
+            shape = RectangleShape,
+            modifier = Modifier.fillMaxWidth().height(40.dp),
+            colors =
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.StatusRed,
+                contentColor = Color.White,
+            ),
+            onClick = onClickDisconnect,
+        ) {
+            Text(stringResource(R.string.disconnect))
         }
     }
 }
@@ -125,9 +122,9 @@ fun CurrentlyConnectedCard(
 @Suppress("MagicNumber")
 @PreviewLightDark
 @Composable
-private fun CurrentlyConnectedCardPreview() {
+private fun CurrentlyConnectedInfoPreview() {
     AppTheme {
-        CurrentlyConnectedCard(
+        CurrentlyConnectedInfo(
             node =
             Node(
                 num = 13444,

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/UsbDevices.kt
@@ -57,7 +57,7 @@ private fun UsbDevices(
             EmptyStateContent(imageVector = Icons.Rounded.UsbOff, text = stringResource(R.string.no_usb_devices))
 
         else ->
-            TitledCard(title = "") {
+            TitledCard(title = null) {
                 usbDevices.forEach { device ->
                     DeviceListItem(
                         connected =

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/Contacts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/Contacts.kt
@@ -66,6 +66,7 @@ import com.geeksville.mesh.R
 import com.geeksville.mesh.model.Contact
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.common.components.MainAppBar
+import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -73,6 +74,7 @@ import java.util.concurrent.TimeUnit
 @Composable
 fun ContactsScreen(
     uiViewModel: UIViewModel = hiltViewModel(),
+    onClickNodeChip: (Int) -> Unit = {},
     onNavigateToMessages: (String) -> Unit = {},
     onNavigateToNodeDetails: (Int) -> Unit = {},
     onNavigateToShare: () -> Unit,
@@ -148,7 +150,12 @@ fun ContactsScreen(
                 canNavigateUp = false,
                 onNavigateUp = {},
                 actions = {},
-                onAction = {},
+                onAction = { action ->
+                    when (action) {
+                        is NodeMenuAction.MoreDetails -> onClickNodeChip(action.node.num)
+                        else -> {}
+                    }
+                },
             )
         },
         floatingActionButton = {

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeScreen.kt
@@ -42,14 +42,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.geeksville.mesh.DataPacket
+import com.geeksville.mesh.R
 import com.geeksville.mesh.model.DeviceVersion
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.service.ConnectionState
+import com.geeksville.mesh.ui.common.components.MainAppBar
 import com.geeksville.mesh.ui.common.components.rememberTimeTickWithLifecycle
 import com.geeksville.mesh.ui.node.components.NodeFilterTextField
 import com.geeksville.mesh.ui.node.components.NodeItem
@@ -70,6 +73,8 @@ fun NodeScreen(
 
     val nodes by model.nodeList.collectAsStateWithLifecycle()
     val ourNode by model.ourNodeInfo.collectAsStateWithLifecycle()
+    val onlineNodeCount by model.onlineNodeCount.collectAsStateWithLifecycle(0)
+    val totalNodeCount by model.totalNodeCount.collectAsStateWithLifecycle(0)
     val unfilteredNodes by model.unfilteredNodeList.collectAsStateWithLifecycle()
     val ignoredNodeCount = unfilteredNodes.count { it.isIgnored }
 
@@ -85,6 +90,19 @@ fun NodeScreen(
 
     val isScrollInProgress by remember { derivedStateOf { listState.isScrollInProgress } }
     Scaffold(
+        topBar = {
+            MainAppBar(
+                title = stringResource(R.string.nodes),
+                subtitle = stringResource(R.string.node_count_template, onlineNodeCount, totalNodeCount),
+                ourNode = ourNode,
+                isConnected = connectionState.isConnected(),
+                showNodeChip = false,
+                canNavigateUp = false,
+                onNavigateUp = {},
+                actions = {},
+                onAction = {},
+            )
+        },
         floatingActionButton = {
             val firmwareVersion = DeviceVersion(ourNode?.metadata?.firmwareVersion ?: "0.0.0")
             val shareCapable = firmwareVersion.supportsQrCodeSharing()

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
@@ -63,6 +63,7 @@ import com.geeksville.mesh.navigation.getNavRouteFrom
 import com.geeksville.mesh.ui.common.components.MainAppBar
 import com.geeksville.mesh.ui.common.components.TitledCard
 import com.geeksville.mesh.ui.common.theme.MODE_DYNAMIC
+import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import com.geeksville.mesh.ui.settings.components.SettingsItem
 import com.geeksville.mesh.ui.settings.components.SettingsItemDetail
 import com.geeksville.mesh.ui.settings.components.SettingsItemSwitch
@@ -85,6 +86,7 @@ import kotlin.time.Duration.Companion.seconds
 fun SettingsScreen(
     viewModel: RadioConfigViewModel = hiltViewModel(),
     uiViewModel: UIViewModel = hiltViewModel(),
+    onClickNodeChip: (Int) -> Unit = {},
     onNavigate: (Route) -> Unit = {},
 ) {
     val excludedModulesUnlocked by uiViewModel.excludedModulesUnlocked.collectAsStateWithLifecycle()
@@ -174,7 +176,12 @@ fun SettingsScreen(
                 canNavigateUp = false,
                 onNavigateUp = {},
                 actions = {},
-                onAction = {},
+                onAction = { action ->
+                    when (action) {
+                        is NodeMenuAction.MoreDetails -> onClickNodeChip(action.node.num)
+                        else -> {}
+                    }
+                },
             )
         },
     ) { paddingValues ->

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
@@ -170,7 +170,7 @@ fun SettingsScreen(
                 title = stringResource(R.string.bottom_nav_settings),
                 ourNode = ourNode,
                 isConnected = isConnected,
-                showNodeChip = true,
+                showNodeChip = ourNode != null && isConnected,
                 canNavigateUp = false,
                 onNavigateUp = {},
                 actions = {},


### PR DESCRIPTION
Removes global top app bar in favor of local ones for the following screens. A new extension function `NavDestination.hasGlobalAppBar()` was added to `Main.kt` to exclude screens from global top app bar usage to support incremental migration. There are no visual changes. This should unblock https://github.com/meshtastic/Meshtastic-Android/pull/3010.
- `ConnectionsRoutes.Connections`
- `ContactsRoutes.Contacts`
- `MapRoutes.Map`
- `NodeDetailRoutes.NodeMap`
- `NodesRoutes.Nodes`
- `NodesRoutes.NodeDetail`
- `SettingsRoutes.Settings`

[Screen_recording_20250917_164852.webm](https://github.com/user-attachments/assets/27400e6b-a545-4a11-a04f-38eb55f92a20)