### PR TITLE
refactor(build): simplify lint, spotless, and detekt configurations

### DIFF
--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -69,7 +69,7 @@ jobs:
           echo "datadogApplicationId=$DATADOG_APPLICATION_ID" >> ./secrets.properties
           echo "datadogClientToken=$DATADOG_CLIENT_TOKEN" >> ./secrets.properties
       - name: Run Spotless, Detekt, Build, Lint, and Local Tests
-        run: ./gradlew :app:spotlessCheck :app:detekt :app:lintFdroidDebug :app:lintGoogleDebug :app:assembleDebug koverXmlReport --configuration-cache --scan
+        run: ./gradlew spotlessCheck detekt lintDebug :app:assembleDebug koverXmlReport --configuration-cache --scan
         env:
           VERSION_CODE: ${{ env.VERSION_CODE }}
 

--- a/build-logic/convention/src/main/kotlin/AndroidLintConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLintConventionPlugin.kt
@@ -22,7 +22,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import java.io.File
 
 class AndroidLintConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -49,6 +48,4 @@ private fun Lint.configure(project: Project) {
     checkDependencies = true
     abortOnError = false
     disable += "GradleDependency"
-    sarifOutput = File("${project.layout.buildDirectory}/reports/lint/lint-results.sarif")
-    xmlOutput = File("${project.layout.buildDirectory}/reports/lint/lint-results.xml")
 }

--- a/build-logic/convention/src/main/kotlin/DetektConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DetektConventionPlugin.kt
@@ -1,4 +1,5 @@
 import com.geeksville.mesh.buildlogic.configureDetekt
+import com.geeksville.mesh.buildlogic.configureKotlinJvm
 import com.geeksville.mesh.buildlogic.libs
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Plugin
@@ -9,6 +10,7 @@ import org.gradle.kotlin.dsl.getByType
 class DetektConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
+            configureKotlinJvm()
             apply(plugin = libs.findPlugin("detekt").get().get().pluginId)
             val extension = extensions.getByType<DetektExtension>()
             configureDetekt(extension)

--- a/build-logic/convention/src/main/kotlin/SpotlessConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/SpotlessConventionPlugin.kt
@@ -1,4 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
+import com.geeksville.mesh.buildlogic.configureKotlinJvm
 import com.geeksville.mesh.buildlogic.configureSpotless
 import com.geeksville.mesh.buildlogic.libs
 import org.gradle.api.Plugin
@@ -9,6 +10,7 @@ import org.gradle.kotlin.dsl.getByType
 class SpotlessConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
+            configureKotlinJvm()
             apply(plugin = libs.findPlugin("spotless").get().get().pluginId)
             val extension = extensions.getByType<SpotlessExtension>()
             configureSpotless(extension)

--- a/mesh_service_example/src/main/kotlin/com/geeksville/mesh/util/Extensions.kt
+++ b/mesh_service_example/src/main/kotlin/com/geeksville/mesh/util/Extensions.kt
@@ -21,20 +21,16 @@ import android.widget.EditText
 import com.geeksville.mesh.ConfigProtos
 
 /**
- * When printing strings to logs sometimes we want to print useful debugging information about users
- * or positions.  But we don't want to leak things like usernames or locations.  So this function
- * if given a string, will return a string which is a maximum of three characters long, taken from the tail
- * of the string.  Which should effectively hide real usernames and locations,
- * but still let us see if values were zero, empty or different.
+ * When printing strings to logs sometimes we want to print useful debugging information about users or positions. But
+ * we don't want to leak things like usernames or locations. So this function if given a string, will return a string
+ * which is a maximum of three characters long, taken from the tail of the string. Which should effectively hide real
+ * usernames and locations, but still let us see if values were zero, empty or different.
  */
 val Any?.anonymize: String
     get() = this.anonymize()
 
-/**
- * A version of anonymize that allows passing in a custom minimum length
- */
-fun Any?.anonymize(maxLen: Int = 3) =
-    if (this != null) ("..." + this.toString().takeLast(maxLen)) else "null"
+/** A version of anonymize that allows passing in a custom minimum length */
+fun Any?.anonymize(maxLen: Int = 3) = if (this != null) ("..." + this.toString().takeLast(maxLen)) else "null"
 
 // A toString that makes sure all newlines are removed (for nice logging).
 fun Any.toOneLineString() = this.toString().replace('\n', ' ')
@@ -66,7 +62,6 @@ fun formatAgo(lastSeenUnix: Int, currentTimeMillis: Long = System.currentTimeMil
 // Allows usage like email.onEditorAction(EditorInfo.IME_ACTION_NEXT, { confirm() })
 fun EditText.onEditorAction(actionId: Int, func: () -> Unit) {
     setOnEditorActionListener { _, receivedActionId, _ ->
-
         if (actionId == receivedActionId) {
             func()
         }


### PR DESCRIPTION
This commit refactors the build logic for lint, spotless, and detekt.

- Lint:
    - Removed explicit SARIF and XML output file configurations as these are default locations.
- Spotless & Detekt:
    - Applied `configureKotlinJvm()` to simplify Kotlin JVM setup.
- GitHub Actions:
    - Updated the Android build workflow to run lint, spotless, and detekt at the project root level instead of specifically for the `:app` module. This ensures these checks are run for all modules.
- Code Style:
    - Minor KDoc and code formatting updates in `Extensions.kt`.

