### PR TITLE
Turn on/off position or device telemetry

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/components/PositionConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/components/PositionConfigItemList.kt
@@ -124,7 +124,6 @@ fun PositionConfigItemList(
         }
     var locationInput by rememberSaveable { mutableStateOf(location) }
     var positionInput by rememberSaveable { mutableStateOf(positionConfig) }
-    val maxInt32 = 2147483647
     val defaultBroadcastSecs: Int = 900
 
     LaunchedEffect(phoneLocation) {
@@ -148,21 +147,21 @@ fun PositionConfigItemList(
         item { PreferenceCategory(text = stringResource(R.string.position_config)) }
         item {
             SwitchPreference(
-                title = "Broadcast Position",
-                checked = positionInput.positionBroadcastSecs < maxInt32,
+                title = stringResource(R.string.broadcast_position),
+                checked = positionInput.positionBroadcastSecs < Int.MAX_VALUE,
                 enabled = enabled,
                 onCheckedChange = { isChecked ->
                     positionInput =
                         positionInput.copy {
                             positionBroadcastSecs =
                                 if (isChecked) {
-                                    if (positionBroadcastSecs >= maxInt32) {
+                                    if (positionBroadcastSecs >= Int.MAX_VALUE) {
                                         defaultBroadcastSecs
                                     } else {
                                         positionBroadcastSecs
                                     }
                                 } else {
-                                    maxInt32
+                                    Int.MAX_VALUE
                                 }
                         }
                 },
@@ -172,14 +171,14 @@ fun PositionConfigItemList(
             EditTextPreference(
                 title = stringResource(R.string.position_broadcast_interval_seconds),
                 value = positionInput.positionBroadcastSecs,
-                enabled = enabled && positionInput.positionBroadcastSecs < maxInt32,
+                enabled = enabled && positionInput.positionBroadcastSecs < Int.MAX_VALUE,
                 keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                 onValueChanged = {
                     positionInput =
                         positionInput.copy {
                             positionBroadcastSecs = it
-                            if (it >= maxInt32) {
-                                positionBroadcastSecs = maxInt32
+                            if (it >= Int.MAX_VALUE) {
+                                positionBroadcastSecs = Int.MAX_VALUE
                             }
                         }
                 },

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/components/TelemetryConfigItemList.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/components/TelemetryConfigItemList.kt
@@ -69,7 +69,6 @@ fun TelemetryConfigItemList(
 ) {
     val focusManager = LocalFocusManager.current
     var telemetryInput by rememberSaveable { mutableStateOf(telemetryConfig) }
-    val maxInt32 = 2147483647
     val defaultBroadcastSecs: Int = 1800
 
     LazyColumn(modifier = Modifier.fillMaxSize()) {
@@ -77,17 +76,21 @@ fun TelemetryConfigItemList(
 
         item {
             SwitchPreference(
-                title = "Broadcast Device Metrics",
-                checked = telemetryInput.deviceUpdateInterval < maxInt32,
+                title = stringResource(R.string.broadcast_device_metrics),
+                checked = telemetryInput.deviceUpdateInterval < Int.MAX_VALUE,
                 enabled = enabled,
                 onCheckedChange = { isChecked ->
                     telemetryInput =
                         telemetryInput.copy {
                             deviceUpdateInterval =
                                 if (isChecked) {
-                                    if (deviceUpdateInterval >= maxInt32) defaultBroadcastSecs else deviceUpdateInterval
+                                    if (deviceUpdateInterval >= Int.MAX_VALUE) {
+                                        defaultBroadcastSecs
+                                    } else {
+                                        deviceUpdateInterval
+                                    }
                                 } else {
-                                    maxInt32
+                                    Int.MAX_VALUE
                                 }
                         }
                 },
@@ -98,15 +101,15 @@ fun TelemetryConfigItemList(
             EditTextPreference(
                 title = stringResource(R.string.device_metrics_update_interval_seconds),
                 value = telemetryInput.deviceUpdateInterval,
-                enabled = enabled && telemetryInput.deviceUpdateInterval < maxInt32,
+                enabled = enabled && telemetryInput.deviceUpdateInterval < Int.MAX_VALUE,
                 keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                 onValueChanged = {
                     telemetryInput =
                         telemetryInput.copy {
                             deviceUpdateInterval = it
                             // Update broadcast toggle based on interval value
-                            if (it >= maxInt32) {
-                                deviceUpdateInterval = maxInt32
+                            if (it >= Int.MAX_VALUE) {
+                                deviceUpdateInterval = Int.MAX_VALUE
                             }
                         }
                 },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -818,4 +818,6 @@
     <string name="downlink_feature_description">Messages from a public internet gateway are forwarded to the local mesh. Due to the zero-hop policy, traffic from the default MQTT server will not propagate further than this device.</string>
     <string name="icon_meanings">Icon Meanings</string>
     <string name="secondary_channel_position_feature">Disabling position on the primary channel allows periodic position broadcasts on the first secondary channel with the position enabled, otherwise manual position request required.</string>
+    <string name="broadcast_position">Broadcast Position</string>
+    <string name="broadcast_device_metrics">Broadcast Device Metrics</string>
 </resources>


### PR DESCRIPTION
By default, telemetry is now disabled in firmware, so it will not be displayed; instead, it should be displayed in its own toggle.

You can now more easily turn off the position or telemetry broadcast functionality with the flip of a switch.


https://github.com/user-attachments/assets/96e17001-2ccf-4b24-846d-f9b743886811


https://github.com/user-attachments/assets/02b21fd0-1cbb-4f54-bf44-19b5631ca99b


