### PR TITLE
Decouple `SettingsScreen` from `UiViewModel`

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -106,16 +106,16 @@ class MainActivity :
                     SideEffect { AppCompatDelegate.setDefaultNightMode(theme) }
                 }
 
-                val showAppIntro by model.showAppIntro.collectAsStateWithLifecycle()
-                if (showAppIntro) {
+                val appIntroCompleted by model.appIntroCompleted.collectAsStateWithLifecycle()
+                if (appIntroCompleted) {
+                    MainScreen(uIViewModel = model, bluetoothViewModel = bluetoothViewModel)
+                } else {
                     AppIntroductionScreen(
                         onDone = {
                             model.onAppIntroCompleted()
                             (application as GeeksvilleApplication).askToRate(this@MainActivity)
                         },
                     )
-                } else {
-                    MainScreen(uIViewModel = model, bluetoothViewModel = bluetoothViewModel)
                 }
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/android/prefs/UiPrefs.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/prefs/UiPrefs.kt
@@ -33,6 +33,7 @@ interface UiPrefs {
     var theme: Int
     val themeFlow: StateFlow<Int>
     var appIntroCompleted: Boolean
+    val appIntroCompletedFlow: StateFlow<Boolean>
     var hasShownNotPairedWarning: Boolean
     var nodeSortOption: Int
     var includeUnknown: Boolean
@@ -48,12 +49,17 @@ interface UiPrefs {
 }
 
 const val KEY_THEME = "theme"
+const val KEY_APP_INTRO_COMPLETED = "app_intro_completed"
 
 class UiPrefsImpl(private val prefs: SharedPreferences) : UiPrefs {
 
     override var theme: Int by PrefDelegate(prefs, KEY_THEME, AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
     private var _themeFlow = MutableStateFlow(theme)
     override val themeFlow = _themeFlow.asStateFlow()
+
+    override var appIntroCompleted: Boolean by PrefDelegate(prefs, KEY_APP_INTRO_COMPLETED, false)
+    private var _appIntroCompletedFlow = MutableStateFlow(appIntroCompleted)
+    override val appIntroCompletedFlow = _appIntroCompletedFlow.asStateFlow()
 
     // Maps nodeNum to a flow for the for the "provide-location-nodeNum" pref
     private val provideNodeLocationFlows = ConcurrentHashMap<Int, MutableStateFlow<Boolean>>()
@@ -62,6 +68,7 @@ class UiPrefsImpl(private val prefs: SharedPreferences) : UiPrefs {
         SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
             when (key) {
                 KEY_THEME -> _themeFlow.update { theme }
+                KEY_APP_INTRO_COMPLETED -> _appIntroCompletedFlow.update { appIntroCompleted }
                 // Check if the changed key is one of our node location keys
                 else ->
                     provideNodeLocationFlows.keys.forEach { nodeNum ->
@@ -78,7 +85,6 @@ class UiPrefsImpl(private val prefs: SharedPreferences) : UiPrefs {
     }
 
     override var lang: String by PrefDelegate(prefs, "lang", LanguageUtils.SYSTEM_DEFAULT)
-    override var appIntroCompleted: Boolean by PrefDelegate(prefs, "app_intro_completed", false)
     override var hasShownNotPairedWarning: Boolean by PrefDelegate(prefs, "has_shown_not_paired_warning", false)
     override var nodeSortOption: Int by PrefDelegate(prefs, "node-sort-option", NodeSortOption.VIA_FAVORITE.ordinal)
     override var includeUnknown: Boolean by PrefDelegate(prefs, "include-unknown", false)

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -37,7 +37,6 @@ import com.geeksville.mesh.IMeshService
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.LocalOnlyProtos.LocalModuleConfig
 import com.geeksville.mesh.MeshProtos
-import com.geeksville.mesh.Portnums
 import com.geeksville.mesh.Position
 import com.geeksville.mesh.R
 import com.geeksville.mesh.android.Logging
@@ -58,14 +57,12 @@ import com.geeksville.mesh.database.entity.asDeviceVersion
 import com.geeksville.mesh.repository.api.DeviceHardwareRepository
 import com.geeksville.mesh.repository.api.FirmwareReleaseRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
-import com.geeksville.mesh.repository.location.LocationRepository
 import com.geeksville.mesh.repository.radio.MeshActivity
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.service.MeshServiceNotifications
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import com.geeksville.mesh.util.getShortDate
-import com.geeksville.mesh.util.positionToMeter
 import com.geeksville.mesh.util.safeNumber
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -87,14 +84,7 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.io.BufferedWriter
-import java.io.FileNotFoundException
-import java.io.FileWriter
-import java.text.SimpleDateFormat
-import java.util.Locale
 import javax.inject.Inject
-import kotlin.math.roundToInt
 
 // Given a human name, strip out the first letter of the first three words and return that as the
 // initials for
@@ -196,7 +186,6 @@ constructor(
     private val deviceHardwareRepository: DeviceHardwareRepository,
     private val packetRepository: PacketRepository,
     private val quickChatActionRepository: QuickChatActionRepository,
-    private val locationRepository: LocationRepository,
     firmwareReleaseRepository: FirmwareReleaseRepository,
     private val uiPrefs: UiPrefs,
     private val meshServiceNotifications: MeshServiceNotifications,
@@ -811,140 +800,6 @@ constructor(
             meshService?.setRemoteOwner(myNodeNum ?: return, user.toByteArray())
         } catch (ex: RemoteException) {
             errormsg("Can't set username on device, is device offline? ${ex.message}")
-        }
-    }
-
-    /**
-     * Export all persisted packet data to a CSV file at the given URI.
-     *
-     * The CSV will include all packets, or only those matching the given port number if specified. Each row contains:
-     * date, time, sender node number, sender name, sender latitude, sender longitude, receiver latitude, receiver
-     * longitude, receiver elevation, received SNR, distance, hop limit, and payload.
-     *
-     * @param uri The destination URI for the CSV file.
-     * @param filterPortnum If provided, only packets with this port number will be exported.
-     */
-    @Suppress("detekt:CyclomaticComplexMethod", "detekt:LongMethod")
-    fun saveDataCsv(uri: Uri, filterPortnum: Int? = null) {
-        viewModelScope.launch(Dispatchers.Main) {
-            // Extract distances to this device from position messages and put (node,SNR,distance)
-            // in the file_uri
-            val myNodeNum = myNodeNum ?: return@launch
-
-            // Capture the current node value while we're still on main thread
-            val nodes = nodeDB.nodeDBbyNum.value
-
-            val positionToPos: (MeshProtos.Position?) -> Position? = { meshPosition ->
-                meshPosition?.let { Position(it) }.takeIf { it?.isValid() == true }
-            }
-
-            writeToUri(uri) { writer ->
-                val nodePositions = mutableMapOf<Int, MeshProtos.Position?>()
-
-                @Suppress("MaxLineLength")
-                writer.appendLine(
-                    "\"date\",\"time\",\"from\",\"sender name\",\"sender lat\",\"sender long\",\"rx lat\",\"rx long\",\"rx elevation\",\"rx snr\",\"distance\",\"hop limit\",\"payload\"",
-                )
-
-                // Packets are ordered by time, we keep most recent position of
-                // our device in localNodePosition.
-                val dateFormat = SimpleDateFormat("\"yyyy-MM-dd\",\"HH:mm:ss\"", Locale.getDefault())
-                meshLogRepository.getAllLogsInReceiveOrder(Int.MAX_VALUE).first().forEach { packet ->
-                    // If we get a NodeInfo packet, use it to update our position data (if valid)
-                    packet.nodeInfo?.let { nodeInfo ->
-                        positionToPos.invoke(nodeInfo.position)?.let { nodePositions[nodeInfo.num] = nodeInfo.position }
-                    }
-
-                    packet.meshPacket?.let { proto ->
-                        // If the packet contains position data then use it to update, if valid
-                        packet.position?.let { position ->
-                            positionToPos.invoke(position)?.let {
-                                nodePositions[
-                                    proto.from.takeIf { it != 0 } ?: myNodeNum,
-                                ] = position
-                            }
-                        }
-
-                        // packets must have rxSNR, and optionally match the filter given as a param.
-                        if (
-                            (filterPortnum == null || proto.decoded.portnumValue == filterPortnum) &&
-                            proto.rxSnr != 0.0f
-                        ) {
-                            val rxDateTime = dateFormat.format(packet.received_date)
-                            val rxFrom = proto.from.toUInt()
-                            val senderName = nodes[proto.from]?.user?.longName ?: ""
-
-                            // sender lat & long
-                            val senderPosition = nodePositions[proto.from]
-                            val senderPos = positionToPos.invoke(senderPosition)
-                            val senderLat = senderPos?.latitude ?: ""
-                            val senderLong = senderPos?.longitude ?: ""
-
-                            // rx lat, long, and elevation
-                            val rxPosition = nodePositions[myNodeNum]
-                            val rxPos = positionToPos.invoke(rxPosition)
-                            val rxLat = rxPos?.latitude ?: ""
-                            val rxLong = rxPos?.longitude ?: ""
-                            val rxAlt = rxPos?.altitude ?: ""
-                            val rxSnr = proto.rxSnr
-
-                            // Calculate the distance if both positions are valid
-
-                            val dist =
-                                if (senderPos == null || rxPos == null) {
-                                    ""
-                                } else {
-                                    positionToMeter(
-                                        Position(rxPosition!!), // Use rxPosition but only if rxPos was
-                                        // valid
-                                        Position(senderPosition!!), // Use senderPosition but only if
-                                        // senderPos was valid
-                                    )
-                                        .roundToInt()
-                                        .toString()
-                                }
-
-                            val hopLimit = proto.hopLimit
-
-                            val payload =
-                                when {
-                                    proto.decoded.portnumValue !in
-                                        setOf(
-                                            Portnums.PortNum.TEXT_MESSAGE_APP_VALUE,
-                                            Portnums.PortNum.RANGE_TEST_APP_VALUE,
-                                        ) -> "<${proto.decoded.portnum}>"
-
-                                    proto.hasDecoded() -> proto.decoded.payload.toStringUtf8().replace("\"", "\"\"")
-
-                                    proto.hasEncrypted() -> "${proto.encrypted.size()} encrypted bytes"
-                                    else -> ""
-                                }
-
-                            //  date,time,from,sender name,sender lat,sender long,rx lat,rx long,rx
-                            // elevation,rx
-                            // snr,distance,hop limit,payload
-                            @Suppress("MaxLineLength")
-                            writer.appendLine(
-                                "$rxDateTime,\"$rxFrom\",\"$senderName\",\"$senderLat\",\"$senderLong\",\"$rxLat\",\"$rxLong\",\"$rxAlt\",\"$rxSnr\",\"$dist\",\"$hopLimit\",\"$payload\"",
-                            )
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private suspend inline fun writeToUri(uri: Uri, crossinline block: suspend (BufferedWriter) -> Unit) {
-        withContext(Dispatchers.IO) {
-            try {
-                app.contentResolver.openFileDescriptor(uri, "wt")?.use { parcelFileDescriptor ->
-                    FileWriter(parcelFileDescriptor.fileDescriptor).use { fileWriter ->
-                        BufferedWriter(fileWriter).use { writer -> block.invoke(writer) }
-                    }
-                }
-            } catch (ex: FileNotFoundException) {
-                errormsg("Can't write file error: ${ex.message}")
-            }
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -822,19 +822,9 @@ constructor(
         nodeFilterText.value = text
     }
 
-    // region Main menu actions logic
-
-    private val _showAppIntro: MutableStateFlow<Boolean> = MutableStateFlow(!uiPrefs.appIntroCompleted)
-    val showAppIntro: StateFlow<Boolean> = _showAppIntro.asStateFlow()
-
-    fun showAppIntro() {
-        _showAppIntro.update { true }
-    }
-
-    // endregion
+    val appIntroCompleted: StateFlow<Boolean> = uiPrefs.appIntroCompletedFlow
 
     fun onAppIntroCompleted() {
         uiPrefs.appIntroCompleted = true
-        _showAppIntro.update { false }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -192,13 +192,7 @@ constructor(
 ) : ViewModel(),
     Logging {
 
-    private val _theme = MutableStateFlow(uiPrefs.theme)
-    val theme: StateFlow<Int> = _theme.asStateFlow()
-
-    fun setTheme(theme: Int) {
-        _theme.value = theme
-        uiPrefs.theme = theme
-    }
+    val theme: StateFlow<Int> = uiPrefs.themeFlow
 
     private val _lastTraceRouteTime = MutableStateFlow<Long?>(null)
     val lastTraceRouteTime: StateFlow<Long?> = _lastTraceRouteTime.asStateFlow()

--- a/app/src/main/java/com/geeksville/mesh/navigation/SettingsNavigation.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/SettingsNavigation.kt
@@ -57,7 +57,6 @@ import androidx.navigation.navigation
 import com.geeksville.mesh.AdminProtos
 import com.geeksville.mesh.MeshProtos.DeviceMetadata
 import com.geeksville.mesh.R
-import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.debug.DebugScreen
 import com.geeksville.mesh.ui.settings.SettingsScreen
 import com.geeksville.mesh.ui.settings.radio.CleanNodeDatabaseScreen
@@ -90,7 +89,7 @@ fun getNavRouteFrom(routeName: String): Route? =
     ConfigRoute.entries.find { it.name == routeName }?.route ?: ModuleRoute.entries.find { it.name == routeName }?.route
 
 @Suppress("LongMethod")
-fun NavGraphBuilder.settingsGraph(navController: NavHostController, uiViewModel: UIViewModel) {
+fun NavGraphBuilder.settingsGraph(navController: NavHostController) {
     navigation<SettingsRoutes.SettingsGraph>(startDestination = SettingsRoutes.Settings()) {
         composable<SettingsRoutes.Settings>(
             deepLinks = listOf(navDeepLink<SettingsRoutes.Settings>(basePath = "$DEEP_LINK_BASE_URI/settings")),
@@ -98,7 +97,6 @@ fun NavGraphBuilder.settingsGraph(navController: NavHostController, uiViewModel:
             val parentEntry =
                 remember(backStackEntry) { navController.getBackStackEntry(SettingsRoutes.SettingsGraph::class) }
             SettingsScreen(
-                uiViewModel = uiViewModel,
                 viewModel = hiltViewModel(parentEntry),
                 onClickNodeChip = {
                     navController.navigate(NodesRoutes.NodeDetailGraph(it)) {

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -397,7 +397,7 @@ fun MainScreen(
                     mapGraph(navController, uiViewModel = uIViewModel)
                     channelsGraph(navController, uiViewModel = uIViewModel)
                     connectionsGraph(navController, bluetoothViewModel)
-                    settingsGraph(navController, uiViewModel = uIViewModel)
+                    settingsGraph(navController)
                 }
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
@@ -171,6 +171,14 @@ fun SettingsScreen(
         LanguagePickerDialog { showLanguagePickerDialog = false }
     }
 
+    var showThemePickerDialog by remember { mutableStateOf(false) }
+    if (showThemePickerDialog) {
+        ThemePickerDialog(
+            onClickTheme = { settingsViewModel.setTheme(it) },
+            onDismiss = { showThemePickerDialog = false },
+        )
+    }
+
     Scaffold(
         topBar = {
             MainAppBar(
@@ -273,24 +281,12 @@ fun SettingsScreen(
                     showLanguagePickerDialog = true
                 }
 
-                val themeMap = remember {
-                    mapOf(
-                        context.getString(R.string.dynamic) to MODE_DYNAMIC,
-                        context.getString(R.string.theme_light) to AppCompatDelegate.MODE_NIGHT_NO,
-                        context.getString(R.string.theme_dark) to AppCompatDelegate.MODE_NIGHT_YES,
-                        context.getString(R.string.theme_system) to AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM,
-                    )
-                }
                 SettingsItem(
                     text = stringResource(R.string.theme),
                     leadingIcon = Icons.Rounded.FormatPaint,
                     trailingIcon = null,
                 ) {
-                    uiViewModel.showAlert(
-                        title = context.getString(R.string.choose_theme),
-                        message = "",
-                        choices = themeMap.mapValues { (_, value) -> { uiViewModel.setTheme(value) } },
-                    )
+                    showThemePickerDialog = true
                 }
                 val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
 
@@ -397,6 +393,27 @@ private fun LanguagePickerDialog(onDismiss: () -> Unit) {
         title = stringResource(R.string.preferences_language),
         message = "",
         choices = languages,
+        onDismissRequest = onDismiss,
+    )
+}
+
+@Composable
+private fun ThemePickerDialog(onClickTheme: (Int) -> Unit, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val themeMap = remember {
+        mapOf(
+            context.getString(R.string.dynamic) to MODE_DYNAMIC,
+            context.getString(R.string.theme_light) to AppCompatDelegate.MODE_NIGHT_NO,
+            context.getString(R.string.theme_dark) to AppCompatDelegate.MODE_NIGHT_YES,
+            context.getString(R.string.theme_system) to AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM,
+        )
+            .mapValues { (_, value) -> { onClickTheme(value) } }
+    }
+
+    MultipleChoiceAlertDialog(
+        title = stringResource(R.string.choose_theme),
+        message = "",
+        choices = themeMap,
         onDismissRequest = onDismiss,
     )
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
@@ -54,12 +54,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.ClientOnlyProtos.DeviceProfile
 import com.geeksville.mesh.R
-import com.geeksville.mesh.android.BuildUtils.debug
 import com.geeksville.mesh.android.gpsDisabled
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.navigation.getNavRouteFrom
 import com.geeksville.mesh.ui.common.components.MainAppBar
+import com.geeksville.mesh.ui.common.components.MultipleChoiceAlertDialog
 import com.geeksville.mesh.ui.common.components.TitledCard
 import com.geeksville.mesh.ui.common.theme.MODE_DYNAMIC
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
@@ -166,6 +166,11 @@ fun SettingsScreen(
         )
     }
 
+    var showLanguagePickerDialog by remember { mutableStateOf(false) }
+    if (showLanguagePickerDialog) {
+        LanguagePickerDialog { showLanguagePickerDialog = false }
+    }
+
     Scaffold(
         topBar = {
             MainAppBar(
@@ -260,21 +265,12 @@ fun SettingsScreen(
                     settingsViewModel.setProvideLocation(!provideLocation)
                 }
 
-                val languageTags = remember { LanguageUtils.getLanguageTags(context) }
                 SettingsItem(
                     text = stringResource(R.string.preferences_language),
                     leadingIcon = Icons.Rounded.Language,
                     trailingIcon = null,
                 ) {
-                    val lang = LanguageUtils.getLocale()
-                    debug("Lang from prefs: $lang")
-                    val langMap = languageTags.mapValues { (_, value) -> { LanguageUtils.setLocale(value) } }
-
-                    uiViewModel.showAlert(
-                        title = context.getString(R.string.preferences_language),
-                        message = "",
-                        choices = langMap,
-                    )
+                    showLanguagePickerDialog = true
                 }
 
                 val themeMap = remember {
@@ -388,4 +384,19 @@ private fun AppVersionButton(excludedModulesUnlocked: Boolean, onUnlockExcludedM
             }
         }
     }
+}
+
+@Composable
+private fun LanguagePickerDialog(onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val languages = remember {
+        LanguageUtils.getLanguageTags(context).mapValues { (_, value) -> { LanguageUtils.setLocale(value) } }
+    }
+
+    MultipleChoiceAlertDialog(
+        title = stringResource(R.string.preferences_language),
+        message = "",
+        choices = languages,
+        onDismissRequest = onDismiss,
+    )
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
@@ -301,7 +301,7 @@ fun SettingsScreen(
                 val exportRangeTestLauncher =
                     rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
                         if (it.resultCode == RESULT_OK) {
-                            it.data?.data?.let { uri -> uiViewModel.saveDataCsv(uri) }
+                            it.data?.data?.let { uri -> settingsViewModel.saveDataCsv(uri) }
                         }
                     }
                 SettingsItem(
@@ -321,7 +321,7 @@ fun SettingsScreen(
                 val exportDataLauncher =
                     rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
                         if (it.resultCode == RESULT_OK) {
-                            it.data?.data?.let { uri -> uiViewModel.saveDataCsv(uri) }
+                            it.data?.data?.let { uri -> settingsViewModel.saveDataCsv(uri) }
                         }
                     }
                 SettingsItem(

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsScreen.kt
@@ -55,7 +55,6 @@ import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.ClientOnlyProtos.DeviceProfile
 import com.geeksville.mesh.R
 import com.geeksville.mesh.android.gpsDisabled
-import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.navigation.Route
 import com.geeksville.mesh.navigation.getNavRouteFrom
 import com.geeksville.mesh.ui.common.components.MainAppBar
@@ -85,7 +84,6 @@ import kotlin.time.Duration.Companion.seconds
 fun SettingsScreen(
     settingsViewModel: SettingsViewModel = hiltViewModel(),
     viewModel: RadioConfigViewModel = hiltViewModel(),
-    uiViewModel: UIViewModel = hiltViewModel(),
     onClickNodeChip: (Int) -> Unit = {},
     onNavigate: (Route) -> Unit = {},
 ) {
@@ -335,7 +333,7 @@ fun SettingsScreen(
                     leadingIcon = Icons.Rounded.WavingHand,
                     trailingIcon = null,
                 ) {
-                    uiViewModel.showAppIntro()
+                    settingsViewModel.showAppIntro()
                 }
 
                 AppVersionButton(excludedModulesUnlocked) { settingsViewModel.unlockExcludedModules() }

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
@@ -114,6 +114,10 @@ constructor(
         uiPrefs.theme = theme
     }
 
+    fun showAppIntro() {
+        uiPrefs.appIntroCompleted = false
+    }
+
     fun unlockExcludedModules() {
         viewModelScope.launch { _excludedModulesUnlocked.value = true }
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
@@ -17,37 +17,60 @@
 
 package com.geeksville.mesh.ui.settings
 
+import android.app.Application
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.IMeshService
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
+import com.geeksville.mesh.MeshProtos
+import com.geeksville.mesh.Portnums
+import com.geeksville.mesh.Position
+import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.android.prefs.UiPrefs
+import com.geeksville.mesh.database.MeshLogRepository
 import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.database.entity.MyNodeEntity
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
+import com.geeksville.mesh.util.positionToMeter
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.BufferedWriter
+import java.io.FileNotFoundException
+import java.io.FileWriter
+import java.text.SimpleDateFormat
+import java.util.Locale
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 @HiltViewModel
 class SettingsViewModel
 @Inject
 constructor(
+    private val app: Application,
     private val radioConfigRepository: RadioConfigRepository,
     private val nodeRepository: NodeRepository,
+    private val meshLogRepository: MeshLogRepository,
     private val uiPrefs: UiPrefs,
-) : ViewModel() {
+) : ViewModel(),
+    Logging {
     val myNodeInfo: StateFlow<MyNodeEntity?>
         get() = nodeRepository.myNodeInfo
+
+    val myNodeNum
+        get() = myNodeInfo.value?.myNodeNum
 
     val ourNodeInfo: StateFlow<Node?>
         get() = nodeRepository.ourNodeInfo
@@ -84,10 +107,144 @@ constructor(
     val excludedModulesUnlocked: StateFlow<Boolean> = _excludedModulesUnlocked.asStateFlow()
 
     fun setProvideLocation(value: Boolean) {
-        myNodeInfo.value?.myNodeNum?.let { uiPrefs.setShouldProvideNodeLocation(it, value) }
+        myNodeNum?.let { uiPrefs.setShouldProvideNodeLocation(it, value) }
     }
 
     fun unlockExcludedModules() {
         viewModelScope.launch { _excludedModulesUnlocked.value = true }
+    }
+
+    /**
+     * Export all persisted packet data to a CSV file at the given URI.
+     *
+     * The CSV will include all packets, or only those matching the given port number if specified. Each row contains:
+     * date, time, sender node number, sender name, sender latitude, sender longitude, receiver latitude, receiver
+     * longitude, receiver elevation, received SNR, distance, hop limit, and payload.
+     *
+     * @param uri The destination URI for the CSV file.
+     * @param filterPortnum If provided, only packets with this port number will be exported.
+     */
+    @Suppress("detekt:CyclomaticComplexMethod", "detekt:LongMethod")
+    fun saveDataCsv(uri: Uri, filterPortnum: Int? = null) {
+        viewModelScope.launch(Dispatchers.Main) {
+            // Extract distances to this device from position messages and put (node,SNR,distance)
+            // in the file_uri
+            val myNodeNum = myNodeNum ?: return@launch
+
+            // Capture the current node value while we're still on main thread
+            val nodes = nodeRepository.nodeDBbyNum.value
+
+            val positionToPos: (MeshProtos.Position?) -> Position? = { meshPosition ->
+                meshPosition?.let { Position(it) }.takeIf { it?.isValid() == true }
+            }
+
+            writeToUri(uri) { writer ->
+                val nodePositions = mutableMapOf<Int, MeshProtos.Position?>()
+
+                @Suppress("MaxLineLength")
+                writer.appendLine(
+                    "\"date\",\"time\",\"from\",\"sender name\",\"sender lat\",\"sender long\",\"rx lat\",\"rx long\",\"rx elevation\",\"rx snr\",\"distance\",\"hop limit\",\"payload\"",
+                )
+
+                // Packets are ordered by time, we keep most recent position of
+                // our device in localNodePosition.
+                val dateFormat = SimpleDateFormat("\"yyyy-MM-dd\",\"HH:mm:ss\"", Locale.getDefault())
+                meshLogRepository.getAllLogsInReceiveOrder(Int.MAX_VALUE).first().forEach { packet ->
+                    // If we get a NodeInfo packet, use it to update our position data (if valid)
+                    packet.nodeInfo?.let { nodeInfo ->
+                        positionToPos.invoke(nodeInfo.position)?.let { nodePositions[nodeInfo.num] = nodeInfo.position }
+                    }
+
+                    packet.meshPacket?.let { proto ->
+                        // If the packet contains position data then use it to update, if valid
+                        packet.position?.let { position ->
+                            positionToPos.invoke(position)?.let {
+                                nodePositions[
+                                    proto.from.takeIf { it != 0 } ?: myNodeNum,
+                                ] = position
+                            }
+                        }
+
+                        // packets must have rxSNR, and optionally match the filter given as a param.
+                        if (
+                            (filterPortnum == null || proto.decoded.portnumValue == filterPortnum) &&
+                            proto.rxSnr != 0.0f
+                        ) {
+                            val rxDateTime = dateFormat.format(packet.received_date)
+                            val rxFrom = proto.from.toUInt()
+                            val senderName = nodes[proto.from]?.user?.longName ?: ""
+
+                            // sender lat & long
+                            val senderPosition = nodePositions[proto.from]
+                            val senderPos = positionToPos.invoke(senderPosition)
+                            val senderLat = senderPos?.latitude ?: ""
+                            val senderLong = senderPos?.longitude ?: ""
+
+                            // rx lat, long, and elevation
+                            val rxPosition = nodePositions[myNodeNum]
+                            val rxPos = positionToPos.invoke(rxPosition)
+                            val rxLat = rxPos?.latitude ?: ""
+                            val rxLong = rxPos?.longitude ?: ""
+                            val rxAlt = rxPos?.altitude ?: ""
+                            val rxSnr = proto.rxSnr
+
+                            // Calculate the distance if both positions are valid
+
+                            val dist =
+                                if (senderPos == null || rxPos == null) {
+                                    ""
+                                } else {
+                                    positionToMeter(
+                                        Position(rxPosition!!), // Use rxPosition but only if rxPos was
+                                        // valid
+                                        Position(senderPosition!!), // Use senderPosition but only if
+                                        // senderPos was valid
+                                    )
+                                        .roundToInt()
+                                        .toString()
+                                }
+
+                            val hopLimit = proto.hopLimit
+
+                            val payload =
+                                when {
+                                    proto.decoded.portnumValue !in
+                                        setOf(
+                                            Portnums.PortNum.TEXT_MESSAGE_APP_VALUE,
+                                            Portnums.PortNum.RANGE_TEST_APP_VALUE,
+                                        ) -> "<${proto.decoded.portnum}>"
+
+                                    proto.hasDecoded() -> proto.decoded.payload.toStringUtf8().replace("\"", "\"\"")
+
+                                    proto.hasEncrypted() -> "${proto.encrypted.size()} encrypted bytes"
+                                    else -> ""
+                                }
+
+                            //  date,time,from,sender name,sender lat,sender long,rx lat,rx long,rx
+                            // elevation,rx
+                            // snr,distance,hop limit,payload
+                            @Suppress("MaxLineLength")
+                            writer.appendLine(
+                                "$rxDateTime,\"$rxFrom\",\"$senderName\",\"$senderLat\",\"$senderLong\",\"$rxLat\",\"$rxLong\",\"$rxAlt\",\"$rxSnr\",\"$dist\",\"$hopLimit\",\"$payload\"",
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend inline fun writeToUri(uri: Uri, crossinline block: suspend (BufferedWriter) -> Unit) {
+        withContext(Dispatchers.IO) {
+            try {
+                app.contentResolver.openFileDescriptor(uri, "wt")?.use { parcelFileDescriptor ->
+                    FileWriter(parcelFileDescriptor.fileDescriptor).use { fileWriter ->
+                        BufferedWriter(fileWriter).use { writer -> block.invoke(writer) }
+                    }
+                }
+            } catch (ex: FileNotFoundException) {
+                errormsg("Can't write file error: ${ex.message}")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.geeksville.mesh.IMeshService
+import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
+import com.geeksville.mesh.android.prefs.UiPrefs
+import com.geeksville.mesh.database.NodeRepository
+import com.geeksville.mesh.database.entity.MyNodeEntity
+import com.geeksville.mesh.model.Node
+import com.geeksville.mesh.repository.datastore.RadioConfigRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel
+@Inject
+constructor(
+    private val radioConfigRepository: RadioConfigRepository,
+    private val nodeRepository: NodeRepository,
+    private val uiPrefs: UiPrefs,
+) : ViewModel() {
+    val myNodeInfo: StateFlow<MyNodeEntity?>
+        get() = nodeRepository.myNodeInfo
+
+    val ourNodeInfo: StateFlow<Node?>
+        get() = nodeRepository.ourNodeInfo
+
+    val isConnected =
+        radioConfigRepository.connectionState
+            .map { it.isConnected() }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), false)
+
+    val localConfig: StateFlow<LocalConfig> =
+        radioConfigRepository.localConfigFlow.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000L),
+            LocalConfig.getDefaultInstance(),
+        )
+
+    val meshService: IMeshService?
+        get() = radioConfigRepository.meshService
+
+    val provideLocation: StateFlow<Boolean>
+        get() =
+            myNodeInfo
+                .flatMapLatest { myNodeEntity ->
+                    // When myNodeInfo changes, set up emissions for the "provide-location-nodeNum" pref.
+                    if (myNodeEntity == null) {
+                        flowOf(false)
+                    } else {
+                        uiPrefs.shouldProvideNodeLocation(myNodeEntity.myNodeNum)
+                    }
+                }
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    private val _excludedModulesUnlocked = MutableStateFlow(false)
+    val excludedModulesUnlocked: StateFlow<Boolean> = _excludedModulesUnlocked.asStateFlow()
+
+    fun setProvideLocation(value: Boolean) {
+        myNodeInfo.value?.myNodeNum?.let { uiPrefs.setShouldProvideNodeLocation(it, value) }
+    }
+
+    fun unlockExcludedModules() {
+        viewModelScope.launch { _excludedModulesUnlocked.value = true }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
@@ -110,6 +110,10 @@ constructor(
         myNodeNum?.let { uiPrefs.setShouldProvideNodeLocation(it, value) }
     }
 
+    fun setTheme(theme: Int) {
+        uiPrefs.theme = theme
+    }
+
     fun unlockExcludedModules() {
         viewModelScope.launch { _excludedModulesUnlocked.value = true }
     }


### PR DESCRIPTION
Adds a new `SettingsViewModel` to contain Flows/data needed by `SettingsScreen`. Anything no longer used in UiViewModel (i.e. only used by `SettingsScreen`) was removed. There should be no visual changes
