### PR TITLE
ci: streamline release process and artifact handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
           distribution: 'jetbrains'
 
       - name: Setup Gradle
+        if: contains(github.ref_name, '-internal')
         uses: gradle/actions/setup-gradle@v4
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -105,15 +106,6 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: Generate Changelog for Pre-Releases
-        if: contains(github.ref_name, '-closed') || contains(github.ref_name, '-open')
-        env:
-          APP_VERSION_CODE: ${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }}
-        run: |
-          CHANGELOG_PATH="./fastlane/metadata/android/en-US/changelogs/${APP_VERSION_CODE}.txt"
-          echo "For a detailed list of changes, please see the GitHub release notes:" > $CHANGELOG_PATH
-          echo "https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}" >> $CHANGELOG_PATH
-
       - name: Determine Fastlane Lane
         id: fastlane_lane
         run: |
@@ -135,6 +127,7 @@ jobs:
         run: bundle exec fastlane ${{ steps.fastlane_lane.outputs.lane }}
 
       - name: Upload Google AAB artifact
+        if: contains(github.ref_name, '-internal')
         uses: actions/upload-artifact@v4
         with:
           name: google-aab
@@ -142,6 +135,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Google APK artifact
+        if: contains(github.ref_name, '-internal')
         uses: actions/upload-artifact@v4
         with:
           name: google-apk
@@ -149,6 +143,7 @@ jobs:
           retention-days: 1
 
   release-fdroid:
+    if: contains(github.ref_name, '-internal')
     runs-on: ubuntu-latest
     needs: prepare-build-info
     steps:
@@ -200,41 +195,67 @@ jobs:
           path: app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
           retention-days: 1
 
-  finalize-release:
+  create-github-release:
+    if: contains(github.ref_name, '-internal')
     runs-on: ubuntu-latest
     needs: [release-google, release-fdroid]
     steps:
-      - name: Download Google AAB
-        uses: actions/download-artifact@v5
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: google-aab
-          path: ./google/bundle
-
-      - name: Download Google APK
-        uses: actions/download-artifact@v5
-        with:
-          name: google-apk
-          path: ./google/apk
-
-      - name: Download F-Droid APK
-        uses: actions/download-artifact@v5
-        with:
-          name: fdroid-apk
-          path: ./fdroid
+          path: ./artifacts
 
       - name: Create GitHub Release
-        id: create_gh_release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
           generate_release_notes: true
           files: |
-            ./google/bundle/app-google-release.aab
-            ./google/apk/app-google-release.apk
-            ./fdroid/app-fdroid-release.apk
-            ./version_info.txt
-          draft: ${{ contains(github.ref_name, '-internal') }}
-          prerelease: ${{ contains(github.ref_name, '-internal') || contains(github.ref_name, '-closed') || contains(github.ref_name, '-open') }}
+            ./artifacts/google-aab/app-google-release.aab
+            ./artifacts/google-apk/app-google-release.apk
+            ./artifacts/fdroid-apk/app-fdroid-release.apk
+          draft: true
+          prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-github-release:
+    if: "!contains(github.ref_name, '-internal')"
+    runs-on: ubuntu-latest
+    needs: [prepare-build-info, release-google]
+    steps:
+      - name: Update GitHub Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const internal_tag = `v${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }}-internal`;
+            const current_tag = "${{ github.ref_name }}";
+
+            try {
+              const release = await github.rest.repos.getReleaseByTag({
+                owner,
+                repo,
+                tag: internal_tag,
+              });
+
+              let draft = false;
+              let prerelease = !current_tag.match(/^v\d+\.\d+\.\d+$/); // Not a production tag
+
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: release.data.id,
+                name: `Release ${current_tag}`,
+                draft: draft,
+                prerelease: prerelease,
+              });
+
+              console.log(`Successfully updated release for tag ${internal_tag} to name="Release ${current_tag}", draft=${draft}, prerelease=${prerelease}`);
+            } catch (error) {
+              console.error(`Could not find and update the release for tag ${internal_tag}.`);
+              console.error(error);
+              core.setFailed(`Failed to update the GitHub release.`);
+            }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,12 +36,11 @@ platform :android do
     )
   end
 
-  desc "Deploy a new version to the closed track on Google Play"
+  desc "Promote from internal track to the closed track on Google Play"
   lane :closed do
-    aab_path = build_google_release
     upload_to_play_store(
-      track: 'NewAlpha',
-      aab: aab_path,
+      track: 'internal',
+      track_promote_to: 'NewAlpha',
       release_status: 'completed',
       skip_upload_apk: true,
       skip_upload_metadata: true,
@@ -51,12 +50,11 @@ platform :android do
     )
   end
 
-  desc "Deploy a new version to the open track on Google Play"
+  desc "Promote from closed track to the open track on Google Play"
   lane :open do
-    aab_path = build_google_release
     upload_to_play_store(
-      track: 'beta',
-      aab: aab_path,
+      track: 'NewAlpha',
+      track_promote_to: 'beta',
       release_status: 'draft',
       skip_upload_apk: true,
       skip_upload_metadata: true,
@@ -66,12 +64,11 @@ platform :android do
     )
   end
 
-  desc "Deploy a new version to the production track on Google Play"
+  desc "Promote from open track to the production track on Google Play"
   lane :production do
-    aab_path = build_google_release
     upload_to_play_store(
-      track: 'production',
-      aab: aab_path,
+      track: 'open',
+      track_promote_to: 'production',
       release_status: 'draft',
       skip_upload_apk: true,
       skip_upload_metadata: true,


### PR DESCRIPTION
This commit refactors the GitHub Actions workflow for releases and updates the Fastlane configuration to improve the release process.

The GitHub Actions workflow (`release.yml`) has been modified to:
- Only run Gradle setup, AAB/APK uploads, and F-Droid release jobs for internal builds (tags containing '-internal').
- Consolidate artifact downloading in the `manage-github-release` job.
- Create draft releases for internal builds.
- Update existing internal releases to final release names (e.g., closed, open, production) when corresponding tags are pushed, and mark them as non-draft and pre-release accordingly.
- Remove the separate changelog generation step for pre-releases, relying on GitHub's auto-generated release notes.

The Fastlane configuration (`Fastfile`) has been updated to:
- Change `closed`, `open`, and `production` lanes to promote builds from a previous track (internal -> closed, closed -> open, open -> production) instead of building new AABs for each. This ensures the same artifact moves through the release stages.
