### PR TITLE
Redundant methods in `RadioConfigRepository`

### DIFF
--- a/app/src/fdroid/java/com/geeksville/mesh/ui/map/MapViewModel.kt
+++ b/app/src/fdroid/java/com/geeksville/mesh/ui/map/MapViewModel.kt
@@ -19,7 +19,7 @@ package com.geeksville.mesh.ui.map
 
 import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.database.PacketRepository
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
+import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.meshtastic.core.prefs.map.MapPrefs
 import javax.inject.Inject
@@ -31,8 +31,8 @@ constructor(
     mapPrefs: MapPrefs,
     packetRepository: PacketRepository,
     nodeRepository: NodeRepository,
-    radioConfigRepository: RadioConfigRepository,
-) : BaseMapViewModel(mapPrefs, nodeRepository, packetRepository, radioConfigRepository) {
+    serviceRepository: ServiceRepository,
+) : BaseMapViewModel(mapPrefs, nodeRepository, packetRepository, serviceRepository) {
 
     var mapStyleId: Int
         get() = mapPrefs.mapStyle

--- a/app/src/google/java/com/geeksville/mesh/ui/map/MapViewModel.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/MapViewModel.kt
@@ -26,6 +26,7 @@ import com.geeksville.mesh.android.BuildUtils.debug
 import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.database.PacketRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
+import com.geeksville.mesh.service.ServiceRepository
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.TileProvider
 import com.google.android.gms.maps.model.UrlTileProvider
@@ -85,8 +86,9 @@ constructor(
     nodeRepository: NodeRepository,
     packetRepository: PacketRepository,
     radioConfigRepository: RadioConfigRepository,
+    serviceRepository: ServiceRepository,
     private val customTileProviderRepository: CustomTileProviderRepository,
-) : BaseMapViewModel(mapPrefs, nodeRepository, packetRepository, radioConfigRepository) {
+) : BaseMapViewModel(mapPrefs, nodeRepository, packetRepository, serviceRepository) {
 
     private val _errorFlow = MutableSharedFlow<String>()
     val errorFlow: SharedFlow<String> = _errorFlow.asSharedFlow()

--- a/app/src/main/java/com/geeksville/mesh/model/DebugViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/DebugViewModel.kt
@@ -28,7 +28,7 @@ import com.geeksville.mesh.StoreAndForwardProtos
 import com.geeksville.mesh.TelemetryProtos
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.database.MeshLogRepository
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
+import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.ui.debug.FilterMode
 import com.google.protobuf.InvalidProtocolBufferException
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -202,7 +202,7 @@ class DebugViewModel
 @Inject
 constructor(
     private val meshLogRepository: MeshLogRepository,
-    private val radioConfigRepository: RadioConfigRepository,
+    private val nodeRepository: NodeRepository,
 ) : ViewModel(),
     Logging {
 
@@ -345,7 +345,7 @@ constructor(
     val presetFilters: List<String>
         get() = buildList {
             // Our address if available
-            radioConfigRepository.myNodeInfo.value?.myNodeNum?.let { add("!%08x".format(it)) }
+            nodeRepository.myNodeInfo.value?.myNodeNum?.let { add("!%08x".format(it)) }
             // broadcast
             add("!ffffffff")
             // decoded

--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -41,6 +41,7 @@ import com.geeksville.mesh.repository.api.DeviceHardwareRepository
 import com.geeksville.mesh.repository.api.FirmwareReleaseRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceAction
+import com.geeksville.mesh.service.ServiceRepository
 import com.geeksville.mesh.util.safeNumber
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -204,7 +205,8 @@ constructor(
     private val app: Application,
     private val dispatchers: CoroutineDispatchers,
     private val meshLogRepository: MeshLogRepository,
-    private val radioConfigRepository: RadioConfigRepository,
+    radioConfigRepository: RadioConfigRepository,
+    private val serviceRepository: ServiceRepository,
     private val nodeRepository: NodeRepository,
     private val deviceHardwareRepository: DeviceHardwareRepository,
     private val firmwareReleaseRepository: FirmwareReleaseRepository,
@@ -246,7 +248,7 @@ constructor(
         destNum?.let { meshLogRepository.deleteLogs(it, PortNum.POSITION_APP_VALUE) }
     }
 
-    fun onServiceAction(action: ServiceAction) = viewModelScope.launch { radioConfigRepository.onServiceAction(action) }
+    fun onServiceAction(action: ServiceAction) = viewModelScope.launch { serviceRepository.onServiceAction(action) }
 
     private val _state = MutableStateFlow(MetricsState.Empty)
     val state: StateFlow<MetricsState> = _state

--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -36,6 +36,7 @@ import com.geeksville.mesh.Portnums.PortNum
 import com.geeksville.mesh.TelemetryProtos.Telemetry
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.database.MeshLogRepository
+import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.repository.api.DeviceHardwareRepository
 import com.geeksville.mesh.repository.api.FirmwareReleaseRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
@@ -204,6 +205,7 @@ constructor(
     private val dispatchers: CoroutineDispatchers,
     private val meshLogRepository: MeshLogRepository,
     private val radioConfigRepository: RadioConfigRepository,
+    private val nodeRepository: NodeRepository,
     private val deviceHardwareRepository: DeviceHardwareRepository,
     private val firmwareReleaseRepository: FirmwareReleaseRepository,
     private val mapPrefs: MapPrefs,
@@ -233,7 +235,7 @@ constructor(
         return Node(num = nodeNum, user = defaultUser)
     }
 
-    fun getUser(nodeNum: Int) = radioConfigRepository.getUser(nodeNum)
+    fun getUser(nodeNum: Int) = nodeRepository.getUser(nodeNum)
 
     val tileSource
         get() = CustomTileSource.getTileSource(mapPrefs.mapStyle)
@@ -257,7 +259,7 @@ constructor(
 
     init {
         if (destNum != null) {
-            radioConfigRepository.nodeDBbyNum
+            nodeRepository.nodeDBbyNum
                 .mapLatest { nodes -> nodes[destNum] to nodes.keys.firstOrNull() }
                 .distinctUntilChanged()
                 .onEach { (node, ourNode) ->

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -53,6 +53,7 @@ import com.geeksville.mesh.repository.radio.MeshActivity
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.service.MeshServiceNotifications
 import com.geeksville.mesh.service.ServiceAction
+import com.geeksville.mesh.service.ServiceRepository
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import com.geeksville.mesh.util.safeNumber
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -185,6 +186,7 @@ constructor(
     private val app: Application,
     private val nodeDB: NodeRepository,
     private val radioConfigRepository: RadioConfigRepository,
+    private val serviceRepository: ServiceRepository,
     radioInterfaceService: RadioInterfaceService,
     private val meshLogRepository: MeshLogRepository,
     private val deviceHardwareRepository: DeviceHardwareRepository,
@@ -215,10 +217,10 @@ constructor(
             }
             .stateIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(5_000), initialValue = null)
 
-    val clientNotification: StateFlow<MeshProtos.ClientNotification?> = radioConfigRepository.clientNotification
+    val clientNotification: StateFlow<MeshProtos.ClientNotification?> = serviceRepository.clientNotification
 
     fun clearClientNotification(notification: MeshProtos.ClientNotification) {
-        radioConfigRepository.clearClientNotification()
+        serviceRepository.clearClientNotification()
         meshServiceNotifications.clearClientNotification(notification)
     }
 
@@ -275,7 +277,7 @@ constructor(
     }
 
     val meshService: IMeshService?
-        get() = radioConfigRepository.meshService
+        get() = serviceRepository.meshService
 
     private val localConfig = MutableStateFlow<LocalConfig>(LocalConfig.getDefaultInstance())
 
@@ -447,13 +449,13 @@ constructor(
     }
 
     init {
-        radioConfigRepository.errorMessage
+        serviceRepository.errorMessage
             .filterNotNull()
             .onEach {
                 showAlert(
                     title = app.getString(R.string.client_notification),
                     message = it,
-                    onConfirm = { radioConfigRepository.clearErrorMessage() },
+                    onConfirm = { serviceRepository.clearErrorMessage() },
                     dismissable = false,
                 )
             }
@@ -590,9 +592,8 @@ constructor(
         }
     }
 
-    fun sendReaction(emoji: String, replyId: Int, contactKey: String) = viewModelScope.launch {
-        radioConfigRepository.onServiceAction(ServiceAction.Reaction(emoji, replyId, contactKey))
-    }
+    fun sendReaction(emoji: String, replyId: Int, contactKey: String) =
+        viewModelScope.launch { serviceRepository.onServiceAction(ServiceAction.Reaction(emoji, replyId, contactKey)) }
 
     private val _sharedContactRequested: MutableStateFlow<AdminProtos.SharedContact?> = MutableStateFlow(null)
     val sharedContactRequested: StateFlow<AdminProtos.SharedContact?>
@@ -603,7 +604,7 @@ constructor(
     }
 
     fun addSharedContact(sharedContact: AdminProtos.SharedContact) =
-        viewModelScope.launch { radioConfigRepository.onServiceAction(ServiceAction.AddSharedContact(sharedContact)) }
+        viewModelScope.launch { serviceRepository.onServiceAction(ServiceAction.AddSharedContact(sharedContact)) }
 
     fun requestTraceroute(destNum: Int) {
         info("Requesting traceroute for '$destNum'")
@@ -663,10 +664,10 @@ constructor(
 
     // Connection state to our radio device
     val connectionState
-        get() = radioConfigRepository.connectionState
+        get() = serviceRepository.connectionState
 
     val isConnectedStateFlow =
-        radioConfigRepository.connectionState
+        serviceRepository.connectionState
             .map { it.isConnected() }
             .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
@@ -701,7 +702,7 @@ constructor(
 
     fun favoriteNode(node: Node) = viewModelScope.launch {
         try {
-            radioConfigRepository.onServiceAction(ServiceAction.Favorite(node))
+            serviceRepository.onServiceAction(ServiceAction.Favorite(node))
         } catch (ex: RemoteException) {
             errormsg("Favorite node error:", ex)
         }
@@ -709,7 +710,7 @@ constructor(
 
     fun ignoreNode(node: Node) = viewModelScope.launch {
         try {
-            radioConfigRepository.onServiceAction(ServiceAction.Ignore(node))
+            serviceRepository.onServiceAction(ServiceAction.Ignore(node))
         } catch (ex: RemoteException) {
             errormsg("Ignore node error:", ex)
         }
@@ -817,7 +818,7 @@ constructor(
     }
 
     val tracerouteResponse: LiveData<String?>
-        get() = radioConfigRepository.tracerouteResponse.asLiveData()
+        get() = serviceRepository.tracerouteResponse.asLiveData()
 
     fun clearTracerouteResponse() {
         radioConfigRepository.clearTracerouteResponse()

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -821,7 +821,7 @@ constructor(
         get() = serviceRepository.tracerouteResponse.asLiveData()
 
     fun clearTracerouteResponse() {
-        serviceRepository.setTracerouteResponse(null)
+        serviceRepository.clearTracerouteResponse()
     }
 
     fun setNodeFilterText(text: String) {

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -821,7 +821,7 @@ constructor(
         get() = serviceRepository.tracerouteResponse.asLiveData()
 
     fun clearTracerouteResponse() {
-        radioConfigRepository.clearTracerouteResponse()
+        serviceRepository.setTracerouteResponse(null)
     }
 
     fun setNodeFilterText(text: String) {

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -22,23 +22,15 @@ import com.geeksville.mesh.ChannelProtos.Channel
 import com.geeksville.mesh.ChannelProtos.ChannelSettings
 import com.geeksville.mesh.ClientOnlyProtos.DeviceProfile
 import com.geeksville.mesh.ConfigProtos.Config
-import com.geeksville.mesh.IMeshService
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.LocalOnlyProtos.LocalModuleConfig
-import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.MeshProtos.DeviceMetadata
-import com.geeksville.mesh.MeshProtos.MeshPacket
 import com.geeksville.mesh.ModuleConfigProtos.ModuleConfig
 import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.deviceProfile
 import com.geeksville.mesh.model.getChannelUrl
-import com.geeksville.mesh.service.ConnectionState
-import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.service.ServiceRepository
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import org.meshtastic.core.database.entity.MetadataEntity
@@ -60,14 +52,6 @@ constructor(
     private val localConfigDataSource: LocalConfigDataSource,
     private val moduleConfigDataSource: ModuleConfigDataSource,
 ) {
-    val meshService: IMeshService?
-        get() = serviceRepository.meshService
-
-    // Connection state to our radio device
-    val connectionState
-        get() = serviceRepository.connectionState
-
-    fun setConnectionState(state: ConnectionState) = serviceRepository.setConnectionState(state)
 
     suspend fun getNodeDBbyNum() = nodeDB.getNodeDBbyNum().first()
 
@@ -154,44 +138,6 @@ constructor(
                 }
             }
         }
-
-    val clientNotification = serviceRepository.clientNotification
-
-    fun setClientNotification(notification: MeshProtos.ClientNotification?) {
-        serviceRepository.setClientNotification(notification)
-    }
-
-    fun clearClientNotification() {
-        serviceRepository.clearClientNotification()
-    }
-
-    val errorMessage: StateFlow<String?>
-        get() = serviceRepository.errorMessage
-
-    fun setErrorMessage(text: String) {
-        serviceRepository.setErrorMessage(text)
-    }
-
-    fun clearErrorMessage() {
-        serviceRepository.clearErrorMessage()
-    }
-
-    fun setStatusMessage(text: String) {
-        serviceRepository.setStatusMessage(text)
-    }
-
-    val meshPacketFlow: SharedFlow<MeshPacket>
-        get() = serviceRepository.meshPacketFlow
-
-    suspend fun emitMeshPacket(packet: MeshPacket) = coroutineScope { serviceRepository.emitMeshPacket(packet) }
-
-    val serviceAction: Flow<ServiceAction>
-        get() = serviceRepository.serviceAction
-
-    suspend fun onServiceAction(action: ServiceAction) = coroutineScope { serviceRepository.onServiceAction(action) }
-
-    val tracerouteResponse: StateFlow<String?>
-        get() = serviceRepository.tracerouteResponse
 
     fun setTracerouteResponse(value: String?) {
         serviceRepository.setTracerouteResponse(value)

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -42,9 +42,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import org.meshtastic.core.database.entity.MetadataEntity
-import org.meshtastic.core.database.entity.MyNodeEntity
-import org.meshtastic.core.database.entity.NodeEntity
-import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.datastore.ChannelSetDataSource
 import org.meshtastic.core.datastore.LocalConfigDataSource
 import org.meshtastic.core.datastore.ModuleConfigDataSource
@@ -72,38 +69,10 @@ constructor(
 
     fun setConnectionState(state: ConnectionState) = serviceRepository.setConnectionState(state)
 
-    /** Flow representing the unique userId of our node. */
-    val myId: StateFlow<String?>
-        get() = nodeDB.myId
-
-    /** Flow representing the [MyNodeEntity] database. */
-    val myNodeInfo: StateFlow<MyNodeEntity?>
-        get() = nodeDB.myNodeInfo
-
-    /** Flow representing the [Node] database. */
-    val nodeDBbyNum: StateFlow<Map<Int, Node>>
-        get() = nodeDB.nodeDBbyNum
-
-    fun getUser(nodeNum: Int) = nodeDB.getUser(nodeNum)
-
     suspend fun getNodeDBbyNum() = nodeDB.getNodeDBbyNum().first()
-
-    suspend fun upsert(node: NodeEntity) = nodeDB.upsert(node)
-
-    suspend fun installMyNodeInfo(mi: MyNodeEntity) {
-        nodeDB.installMyNodeInfo(mi)
-    }
-
-    suspend fun installNodeDb(nodes: List<NodeEntity>) {
-        nodeDB.installNodeDb(nodes)
-    }
 
     suspend fun insertMetadata(fromNum: Int, metadata: DeviceMetadata) {
         nodeDB.insertMetadata(MetadataEntity(fromNum, metadata))
-    }
-
-    suspend fun clearNodeDB() {
-        nodeDB.clearNodeDB()
     }
 
     /** Flow representing the [ChannelSet] data store. */

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -24,15 +24,12 @@ import com.geeksville.mesh.ClientOnlyProtos.DeviceProfile
 import com.geeksville.mesh.ConfigProtos.Config
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.LocalOnlyProtos.LocalModuleConfig
-import com.geeksville.mesh.MeshProtos.DeviceMetadata
 import com.geeksville.mesh.ModuleConfigProtos.ModuleConfig
 import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.deviceProfile
 import com.geeksville.mesh.model.getChannelUrl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
-import org.meshtastic.core.database.entity.MetadataEntity
 import org.meshtastic.core.datastore.ChannelSetDataSource
 import org.meshtastic.core.datastore.LocalConfigDataSource
 import org.meshtastic.core.datastore.ModuleConfigDataSource
@@ -50,12 +47,6 @@ constructor(
     private val localConfigDataSource: LocalConfigDataSource,
     private val moduleConfigDataSource: ModuleConfigDataSource,
 ) {
-
-    suspend fun getNodeDBbyNum() = nodeDB.getNodeDBbyNum().first()
-
-    suspend fun insertMetadata(fromNum: Int, metadata: DeviceMetadata) {
-        nodeDB.insertMetadata(MetadataEntity(fromNum, metadata))
-    }
 
     /** Flow representing the [ChannelSet] data store. */
     val channelSetFlow: Flow<ChannelSet> = channelSetDataSource.channelSetFlow

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -29,7 +29,6 @@ import com.geeksville.mesh.ModuleConfigProtos.ModuleConfig
 import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.deviceProfile
 import com.geeksville.mesh.model.getChannelUrl
-import com.geeksville.mesh.service.ServiceRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -46,7 +45,6 @@ import javax.inject.Inject
 class RadioConfigRepository
 @Inject
 constructor(
-    private val serviceRepository: ServiceRepository,
     private val nodeDB: NodeRepository,
     private val channelSetDataSource: ChannelSetDataSource,
     private val localConfigDataSource: LocalConfigDataSource,
@@ -138,12 +136,4 @@ constructor(
                 }
             }
         }
-
-    fun setTracerouteResponse(value: String?) {
-        serviceRepository.setTracerouteResponse(value)
-    }
-
-    fun clearTracerouteResponse() {
-        setTracerouteResponse(null)
-    }
 }

--- a/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
@@ -19,6 +19,7 @@ package com.geeksville.mesh.repository.network
 
 import com.geeksville.mesh.MeshProtos.MqttClientProxyMessage
 import com.geeksville.mesh.android.Logging
+import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.model.subscribeList
 import com.geeksville.mesh.mqttClientProxyMessage
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
@@ -44,7 +45,12 @@ import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 
 @Singleton
-class MQTTRepository @Inject constructor(private val radioConfigRepository: RadioConfigRepository) : Logging {
+class MQTTRepository
+@Inject
+constructor(
+    private val radioConfigRepository: RadioConfigRepository,
+    private val nodeRepository: NodeRepository,
+) : Logging {
 
     companion object {
         /**
@@ -73,7 +79,7 @@ class MQTTRepository @Inject constructor(private val radioConfigRepository: Radi
     }
 
     val proxyMessageFlow: Flow<MqttClientProxyMessage> = callbackFlow {
-        val ownerId = "MeshtasticAndroidMqttProxy-${radioConfigRepository.myId.value ?: generateClientId()}"
+        val ownerId = "MeshtasticAndroidMqttProxy-${nodeRepository.myId.value ?: generateClientId()}"
         val channelSet = radioConfigRepository.channelSetFlow.first()
         val mqttConfig = radioConfigRepository.moduleConfigFlow.first().mqtt
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -889,7 +889,7 @@ class MeshService :
                                 } else {
                                     full
                                 }
-                            radioConfigRepository.setTracerouteResponse(response)
+                            serviceRepository.setTracerouteResponse(response)
                         }
                     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsViewModel.kt
@@ -23,6 +23,7 @@ import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.repository.bluetooth.BluetoothRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
+import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -39,6 +40,7 @@ class ConnectionsViewModel
 @Inject
 constructor(
     radioConfigRepository: RadioConfigRepository,
+    serviceRepository: ServiceRepository,
     nodeRepository: NodeRepository,
     bluetoothRepository: BluetoothRepository,
     private val uiPrefs: UiPrefs,
@@ -50,7 +52,7 @@ constructor(
             LocalConfig.getDefaultInstance(),
         )
 
-    val connectionState = radioConfigRepository.connectionState
+    val connectionState = serviceRepository.connectionState
 
     val myNodeInfo: StateFlow<MyNodeEntity?> = nodeRepository.myNodeInfo
 

--- a/app/src/main/java/com/geeksville/mesh/ui/map/BaseMapViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/BaseMapViewModel.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.database.PacketRepository
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
+import com.geeksville.mesh.service.ServiceRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -38,7 +38,7 @@ abstract class BaseMapViewModel(
     protected val mapPrefs: MapPrefs,
     nodeRepository: NodeRepository,
     packetRepository: PacketRepository,
-    radioConfigRepository: RadioConfigRepository,
+    serviceRepository: ServiceRepository,
 ) : ViewModel() {
 
     val nodes: StateFlow<List<Node>> =
@@ -72,7 +72,7 @@ abstract class BaseMapViewModel(
     val ourNodeInfo: StateFlow<Node?> = nodeRepository.ourNodeInfo
 
     val isConnected =
-        radioConfigRepository.connectionState
+        serviceRepository.connectionState
             .map { it.isConnected() }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
@@ -29,6 +29,7 @@ import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.database.MeshLogRepository
 import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
+import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,7 +63,8 @@ class SettingsViewModel
 @Inject
 constructor(
     private val app: Application,
-    private val radioConfigRepository: RadioConfigRepository,
+    radioConfigRepository: RadioConfigRepository,
+    private val serviceRepository: ServiceRepository,
     private val nodeRepository: NodeRepository,
     private val meshLogRepository: MeshLogRepository,
     private val uiPrefs: UiPrefs,
@@ -77,7 +79,7 @@ constructor(
     val ourNodeInfo: StateFlow<Node?> = nodeRepository.ourNodeInfo
 
     val isConnected =
-        radioConfigRepository.connectionState
+        serviceRepository.connectionState
             .map { it.isConnected() }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000L), false)
 
@@ -89,7 +91,7 @@ constructor(
         )
 
     val meshService: IMeshService?
-        get() = radioConfigRepository.meshService
+        get() = serviceRepository.meshService
 
     val provideLocation: StateFlow<Boolean> =
         myNodeInfo

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
@@ -58,6 +58,7 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
+@Suppress("LongParameterList")
 @HiltViewModel
 class SettingsViewModel
 @Inject

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/CleanNodeDatabaseViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/CleanNodeDatabaseViewModel.kt
@@ -20,7 +20,7 @@ package com.geeksville.mesh.ui.settings.radio
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.database.NodeRepository
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
+import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -41,7 +41,7 @@ class CleanNodeDatabaseViewModel
 @Inject
 constructor(
     private val nodeRepository: NodeRepository,
-    private val radioConfigRepository: RadioConfigRepository,
+    private val serviceRepository: ServiceRepository,
 ) : ViewModel() {
     private val _olderThanDays = MutableStateFlow(30f)
     val olderThanDays = _olderThanDays.asStateFlow()
@@ -110,7 +110,7 @@ constructor(
             if (nodeNums.isNotEmpty()) {
                 nodeRepository.deleteNodes(nodeNums)
 
-                val service = radioConfigRepository.meshService
+                val service = serviceRepository.meshService
                 if (service != null) {
                     for (nodeNum in nodeNums) {
                         service.removeByNodenum(service.packetId, nodeNum)

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
@@ -100,6 +100,7 @@ data class RadioConfigState(
     val analyticsEnabled: Boolean = false,
 )
 
+@Suppress("LongParameterList")
 @HiltViewModel
 class RadioConfigViewModel
 @Inject

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
@@ -45,6 +45,7 @@ import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.android.isAnalyticsAvailable
 import com.geeksville.mesh.config
+import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.deviceProfile
 import com.geeksville.mesh.model.getChannelList
 import com.geeksville.mesh.model.toChannelSet
@@ -105,6 +106,7 @@ constructor(
     savedStateHandle: SavedStateHandle,
     private val app: Application,
     private val radioConfigRepository: RadioConfigRepository,
+    private val nodeRepository: NodeRepository,
     private val locationRepository: LocationRepository,
     private val mapConsentPrefs: MapConsentPrefs,
     private val analyticsPrefs: AnalyticsPrefs,
@@ -137,7 +139,7 @@ constructor(
     }
 
     init {
-        radioConfigRepository.nodeDBbyNum
+        nodeRepository.nodeDBbyNum
             .mapLatest { nodes -> nodes[destNum] ?: nodes.values.firstOrNull() }
             .distinctUntilChanged()
             .onEach {
@@ -158,7 +160,7 @@ constructor(
         }
             .launchIn(viewModelScope)
 
-        radioConfigRepository.myNodeInfo
+        nodeRepository.myNodeInfo
             .onEach { ni ->
                 _radioConfigState.update { it.copy(isLocal = destNum == null || destNum == ni?.myNodeNum) }
             }
@@ -170,7 +172,7 @@ constructor(
     }
 
     private val myNodeInfo: StateFlow<MyNodeEntity?>
-        get() = radioConfigRepository.myNodeInfo
+        get() = nodeRepository.myNodeInfo
 
     val myNodeNum
         get() = myNodeInfo.value?.myNodeNum
@@ -342,7 +344,7 @@ constructor(
             "Request factory reset error",
         )
         if (destNum == myNodeNum) {
-            viewModelScope.launch { radioConfigRepository.clearNodeDB() }
+            viewModelScope.launch { nodeRepository.clearNodeDB() }
         }
     }
 
@@ -353,7 +355,7 @@ constructor(
             "Request NodeDB reset error",
         )
         if (destNum == myNodeNum) {
-            viewModelScope.launch { radioConfigRepository.clearNodeDB() }
+            viewModelScope.launch { nodeRepository.clearNodeDB() }
         }
     }
 


### PR DESCRIPTION
`RadioConfigRepository` contains a lot of methods that simply call through to another repository class. Remove these in favor of injecting those repositories directly.