### PR TITLE
Less state held by `MeshService`

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceConnectionStateHolder.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceConnectionStateHolder.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.service
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MeshServiceConnectionStateHolder @Inject constructor() {
+    private var connectionState = ConnectionState.DISCONNECTED
+
+    fun setState(state: ConnectionState) {
+        connectionState = state
+    }
+
+    fun getState() = connectionState
+}


### PR DESCRIPTION
Moves `MeshService.connectionState` to `MeshServiceConnectionStateHolder` so it can be injected into `PacketHandler` and `MeshServiceBroadcasts` where it is also used.

I'm not sure how `MeshService.connectionState` differs from `ServiceRepository.connectionState` and `RadioInterfaceService.connectionState`, but these appear to be 3 distinct instances of `connectionState` (something this PR does not aim to solve).