### PR TITLE
feat(db): introduce transactional config installation

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/database/NodeRepository.kt
@@ -118,16 +118,8 @@ constructor(
 
     suspend fun upsert(node: NodeEntity) = withContext(dispatchers.io) { nodeInfoDao.upsert(node) }
 
-    suspend fun installMyNodeInfo(mi: MyNodeEntity) = withContext(dispatchers.io) {
-        nodeInfoDao.clearMyNodeInfo()
-        nodeInfoDao.setMyNodeInfo(mi)
-        nodeInfoDao.clearNodeInfo()
-    }
-
-    suspend fun installNodeDb(nodes: List<NodeEntity>) = withContext(dispatchers.io) {
-        nodeInfoDao.clearNodeInfo()
-        nodeInfoDao.putAll(nodes)
-    }
+    suspend fun installConfig(mi: MyNodeEntity, nodes: List<NodeEntity>) =
+        withContext(dispatchers.io) { nodeInfoDao.installConfig(mi, nodes) }
 
     suspend fun clearNodeDB() = withContext(dispatchers.io) { nodeInfoDao.clearNodeInfo() }
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -214,7 +214,6 @@ class MeshService :
         val absoluteMinDeviceVersion = DeviceVersion(BuildConfig.ABS_MIN_FW_VERSION)
 
         private var configNonce = 1
-        private const val CONFIG_WAIT_MS = 250L
     }
 
     private var previousSummary: String? = null

--- a/core/database/src/main/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
+++ b/core/database/src/main/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
@@ -221,4 +221,11 @@ interface NodeInfoDao {
 
     @Query("UPDATE nodes SET notes = :notes WHERE num = :num")
     fun setNodeNotes(num: Int, notes: String)
+
+    @Transaction
+    fun installConfig(mi: MyNodeEntity, nodes: List<NodeEntity>) {
+        clearMyNodeInfo()
+        setMyNodeInfo(mi)
+        nodes.forEach { upsert(it) }
+    }
 }

--- a/core/database/src/main/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
+++ b/core/database/src/main/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
@@ -226,6 +226,6 @@ interface NodeInfoDao {
     fun installConfig(mi: MyNodeEntity, nodes: List<NodeEntity>) {
         clearMyNodeInfo()
         setMyNodeInfo(mi)
-        nodes.forEach { upsert(it) }
+        putAll(nodes.map { getVerifiedNodeForUpsert(it) })
     }
 }

--- a/core/prefs/src/main/kotlin/org/meshtastic/core/prefs/mesh/MeshPrefs.kt
+++ b/core/prefs/src/main/kotlin/org/meshtastic/core/prefs/mesh/MeshPrefs.kt
@@ -34,7 +34,7 @@ interface MeshPrefs {
 
 @Singleton
 class MeshPrefsImpl @Inject constructor(@MeshSharedPreferences private val prefs: SharedPreferences) : MeshPrefs {
-    override var deviceAddress: String? by NullableStringPrefDelegate(prefs, "device_address", null)
+    override var deviceAddress: String? by NullableStringPrefDelegate(prefs, "device_address", NO_DEVICE_SELECTED)
 
     override fun shouldProvideNodeLocation(nodeNum: Int?): Boolean =
         prefs.getBoolean(provideLocationKey(nodeNum), false)
@@ -45,3 +45,5 @@ class MeshPrefsImpl @Inject constructor(@MeshSharedPreferences private val prefs
 
     private fun provideLocationKey(nodeNum: Int?) = "provide-location-$nodeNum"
 }
+
+private const val NO_DEVICE_SELECTED = "n"


### PR DESCRIPTION
Replaces separate calls for installing MyNodeInfo and the node database with a single transactional `installConfig` operation in the DAO. This ensures atomicity when updating the local node configuration from the device.

Refactors the `MeshService` to use this new transactional method and removes the now-redundant individual installation functions from `NodeRepository`.

Additionally, this commit simplifies the device address handling logic in `MeshService` by removing the local `StateFlow` and relying directly on `MeshPrefs`.