### PR TITLE
Move some repo classes to `:core:data`

### DIFF
--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -124,8 +124,6 @@
     <ID>MagicNumber:BluetoothInterface.kt$BluetoothInterface$1000</ID>
     <ID>MagicNumber:BluetoothInterface.kt$BluetoothInterface$500</ID>
     <ID>MagicNumber:BluetoothInterface.kt$BluetoothInterface$512</ID>
-    <ID>MagicNumber:ChannelSet.kt$40</ID>
-    <ID>MagicNumber:ChannelSet.kt$960</ID>
     <ID>MagicNumber:Contacts.kt$7</ID>
     <ID>MagicNumber:Contacts.kt$8</ID>
     <ID>MagicNumber:Debug.kt$3</ID>
@@ -150,7 +148,6 @@
     <ID>MagicNumber:MetricsViewModel.kt$MetricsViewModel$1000L</ID>
     <ID>MagicNumber:MetricsViewModel.kt$MetricsViewModel$1e-5</ID>
     <ID>MagicNumber:MetricsViewModel.kt$MetricsViewModel$1e-7</ID>
-    <ID>MagicNumber:PacketRepository.kt$PacketRepository$500</ID>
     <ID>MagicNumber:PacketResponseStateDialog.kt$100</ID>
     <ID>MagicNumber:PowerConfigItemList.kt$3600</ID>
     <ID>MagicNumber:ProbeTableProvider.kt$ProbeTableProvider$21972</ID>
@@ -355,7 +352,6 @@
     <ID>SpacingAroundKeyword:Exceptions.kt$if</ID>
     <ID>SpacingAroundKeyword:Exceptions.kt$when</ID>
     <ID>SwallowedException:BluetoothInterface.kt$BluetoothInterface$ex: CancellationException</ID>
-    <ID>SwallowedException:ChannelSet.kt$ex: Throwable</ID>
     <ID>SwallowedException:Exceptions.kt$ex: Throwable</ID>
     <ID>SwallowedException:MeshService.kt$MeshService$ex: BLEException</ID>
     <ID>SwallowedException:MeshService.kt$MeshService$ex: CancellationException</ID>
@@ -366,7 +362,6 @@
     <ID>SwallowedException:TCPInterface.kt$TCPInterface$ex: SocketTimeoutException</ID>
     <ID>TooGenericExceptionCaught:BTScanModel.kt$BTScanModel$ex: Throwable</ID>
     <ID>TooGenericExceptionCaught:BluetoothInterface.kt$BluetoothInterface$ex: Exception</ID>
-    <ID>TooGenericExceptionCaught:ChannelSet.kt$ex: Throwable</ID>
     <ID>TooGenericExceptionCaught:Exceptions.kt$ex: Throwable</ID>
     <ID>TooGenericExceptionCaught:LanguageUtils.kt$LanguageUtils$e: Exception</ID>
     <ID>TooGenericExceptionCaught:LocationRepository.kt$LocationRepository$e: Exception</ID>
@@ -391,7 +386,6 @@
     <ID>TooManyFunctions:MessageViewModel.kt$MessageViewModel : ViewModel</ID>
     <ID>TooManyFunctions:NodeDetail.kt$com.geeksville.mesh.ui.node.NodeDetail.kt</ID>
     <ID>TooManyFunctions:NodesViewModel.kt$NodesViewModel : ViewModel</ID>
-    <ID>TooManyFunctions:PacketRepository.kt$PacketRepository</ID>
     <ID>TooManyFunctions:RadioConfigViewModel.kt$RadioConfigViewModel : ViewModelLogging</ID>
     <ID>TooManyFunctions:RadioInterfaceService.kt$RadioInterfaceService : Logging</ID>
     <ID>TooManyFunctions:SafeBluetooth.kt$SafeBluetooth : LoggingCloseable</ID>

--- a/app/src/androidTest/java/com/geeksville/mesh/ChannelSetTest.kt
+++ b/app/src/androidTest/java/com/geeksville/mesh/ChannelSetTest.kt
@@ -18,21 +18,20 @@
 package com.geeksville.mesh
 
 import android.net.Uri
-import com.geeksville.mesh.model.getChannelUrl
-import com.geeksville.mesh.model.primaryChannel
-import com.geeksville.mesh.model.toChannelSet
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.meshtastic.core.model.util.getChannelUrl
+import org.meshtastic.core.model.util.primaryChannel
+import org.meshtastic.core.model.util.toChannelSet
 
 @HiltAndroidTest
 class ChannelSetTest {
 
-    @get:Rule
-    var hiltRule = HiltAndroidRule(this)
+    @get:Rule var hiltRule = HiltAndroidRule(this)
 
     @Before
     fun init() {

--- a/app/src/androidTest/java/com/geeksville/mesh/ChannelTest.kt
+++ b/app/src/androidTest/java/com/geeksville/mesh/ChannelTest.kt
@@ -18,14 +18,14 @@
 package com.geeksville.mesh
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.geeksville.mesh.model.URL_PREFIX
-import com.geeksville.mesh.model.getChannelUrl
-import com.geeksville.mesh.model.toChannelSet
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.meshtastic.core.model.Channel
 import org.meshtastic.core.model.numChannels
+import org.meshtastic.core.model.util.URL_PREFIX
+import org.meshtastic.core.model.util.getChannelUrl
+import org.meshtastic.core.model.util.toChannelSet
 
 @RunWith(AndroidJUnit4::class)
 class ChannelTest {

--- a/app/src/fdroid/java/com/geeksville/mesh/ui/map/MapViewModel.kt
+++ b/app/src/fdroid/java/com/geeksville/mesh/ui/map/MapViewModel.kt
@@ -19,13 +19,13 @@ package com.geeksville.mesh.ui.map
 
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
-import com.geeksville.mesh.database.NodeRepository
-import com.geeksville.mesh.database.PacketRepository
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
+import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.PacketRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.prefs.map.MapPrefs
 import javax.inject.Inject

--- a/app/src/google/java/com/geeksville/mesh/ui/map/MapViewModel.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/MapViewModel.kt
@@ -23,7 +23,6 @@ import androidx.core.net.toFile
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.ConfigProtos
 import com.geeksville.mesh.android.BuildUtils.debug
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceRepository
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.TileProvider
@@ -52,6 +51,7 @@ import org.meshtastic.core.data.model.CustomTileProviderConfig
 import org.meshtastic.core.data.repository.CustomTileProviderRepository
 import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.data.repository.PacketRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.datastore.UiPreferencesDataSource
 import org.meshtastic.core.prefs.map.GoogleMapsPrefs
 import org.meshtastic.core.prefs.map.MapPrefs

--- a/app/src/google/java/com/geeksville/mesh/ui/map/MapViewModel.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/MapViewModel.kt
@@ -23,8 +23,6 @@ import androidx.core.net.toFile
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.ConfigProtos
 import com.geeksville.mesh.android.BuildUtils.debug
-import com.geeksville.mesh.database.NodeRepository
-import com.geeksville.mesh.database.PacketRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceRepository
 import com.google.android.gms.maps.GoogleMap
@@ -52,6 +50,8 @@ import kotlinx.serialization.Serializable
 import org.json.JSONObject
 import org.meshtastic.core.data.model.CustomTileProviderConfig
 import org.meshtastic.core.data.repository.CustomTileProviderRepository
+import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.PacketRepository
 import org.meshtastic.core.datastore.UiPreferencesDataSource
 import org.meshtastic.core.prefs.map.GoogleMapsPrefs
 import org.meshtastic.core.prefs.map.MapPrefs

--- a/app/src/main/java/com/geeksville/mesh/model/DebugViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/DebugViewModel.kt
@@ -27,8 +27,6 @@ import com.geeksville.mesh.Portnums.PortNum
 import com.geeksville.mesh.StoreAndForwardProtos
 import com.geeksville.mesh.TelemetryProtos
 import com.geeksville.mesh.android.Logging
-import com.geeksville.mesh.database.MeshLogRepository
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.ui.debug.FilterMode
 import com.google.protobuf.InvalidProtocolBufferException
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -44,6 +42,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.meshtastic.core.data.repository.MeshLogRepository
+import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.database.entity.MeshLog
 import java.text.DateFormat
 import java.util.Date

--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -35,9 +35,6 @@ import com.geeksville.mesh.Portnums
 import com.geeksville.mesh.Portnums.PortNum
 import com.geeksville.mesh.TelemetryProtos.Telemetry
 import com.geeksville.mesh.android.Logging
-import com.geeksville.mesh.repository.api.DeviceHardwareRepository
-import com.geeksville.mesh.repository.api.FirmwareReleaseRepository
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.service.ServiceRepository
 import com.geeksville.mesh.util.safeNumber
@@ -56,8 +53,11 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.meshtastic.core.data.repository.DeviceHardwareRepository
+import org.meshtastic.core.data.repository.FirmwareReleaseRepository
 import org.meshtastic.core.data.repository.MeshLogRepository
 import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.MeshLog
 import org.meshtastic.core.database.model.Node

--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -35,8 +35,6 @@ import com.geeksville.mesh.Portnums
 import com.geeksville.mesh.Portnums.PortNum
 import com.geeksville.mesh.TelemetryProtos.Telemetry
 import com.geeksville.mesh.android.Logging
-import com.geeksville.mesh.database.MeshLogRepository
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.repository.api.DeviceHardwareRepository
 import com.geeksville.mesh.repository.api.FirmwareReleaseRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
@@ -58,6 +56,8 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.meshtastic.core.data.repository.MeshLogRepository
+import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.MeshLog
 import org.meshtastic.core.database.model.Node

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -42,10 +42,6 @@ import com.geeksville.mesh.channelSet
 import com.geeksville.mesh.channelSettings
 import com.geeksville.mesh.config
 import com.geeksville.mesh.copy
-import com.geeksville.mesh.database.MeshLogRepository
-import com.geeksville.mesh.database.NodeRepository
-import com.geeksville.mesh.database.PacketRepository
-import com.geeksville.mesh.database.QuickChatActionRepository
 import com.geeksville.mesh.repository.api.DeviceHardwareRepository
 import com.geeksville.mesh.repository.api.FirmwareReleaseRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
@@ -70,6 +66,10 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.meshtastic.core.data.repository.MeshLogRepository
+import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.PacketRepository
+import org.meshtastic.core.data.repository.QuickChatActionRepository
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.entity.Packet
 import org.meshtastic.core.database.entity.QuickChatAction

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -78,7 +78,9 @@ import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.datastore.UiPreferencesDataSource
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.DeviceHardware
+import org.meshtastic.core.model.util.getChannel
 import org.meshtastic.core.model.util.getShortDate
+import org.meshtastic.core.model.util.toChannelSet
 import org.meshtastic.core.strings.R
 import javax.inject.Inject
 

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -42,9 +42,6 @@ import com.geeksville.mesh.channelSet
 import com.geeksville.mesh.channelSettings
 import com.geeksville.mesh.config
 import com.geeksville.mesh.copy
-import com.geeksville.mesh.repository.api.DeviceHardwareRepository
-import com.geeksville.mesh.repository.api.FirmwareReleaseRepository
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.repository.radio.MeshActivity
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import com.geeksville.mesh.service.MeshServiceNotifications
@@ -66,10 +63,13 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.meshtastic.core.data.repository.DeviceHardwareRepository
+import org.meshtastic.core.data.repository.FirmwareReleaseRepository
 import org.meshtastic.core.data.repository.MeshLogRepository
 import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.data.repository.PacketRepository
 import org.meshtastic.core.data.repository.QuickChatActionRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.entity.Packet
 import org.meshtastic.core.database.entity.QuickChatAction

--- a/app/src/main/java/com/geeksville/mesh/repository/api/DeviceHardwareRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/api/DeviceHardwareRepository.kt
@@ -21,6 +21,8 @@ import com.geeksville.mesh.android.BuildUtils.debug
 import com.geeksville.mesh.android.BuildUtils.warn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.meshtastic.core.data.datasource.DeviceHardwareJsonDataSource
+import org.meshtastic.core.data.datasource.DeviceHardwareLocalDataSource
 import org.meshtastic.core.database.entity.DeviceHardwareEntity
 import org.meshtastic.core.database.entity.asExternalModel
 import org.meshtastic.core.model.DeviceHardware

--- a/app/src/main/java/com/geeksville/mesh/repository/api/FirmwareReleaseRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/api/FirmwareReleaseRepository.kt
@@ -21,6 +21,8 @@ import com.geeksville.mesh.android.BuildUtils.debug
 import com.geeksville.mesh.android.BuildUtils.warn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import org.meshtastic.core.data.datasource.FirmwareReleaseJsonDataSource
+import org.meshtastic.core.data.datasource.FirmwareReleaseLocalDataSource
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.FirmwareReleaseEntity
 import org.meshtastic.core.database.entity.FirmwareReleaseType

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -26,13 +26,13 @@ import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.LocalOnlyProtos.LocalModuleConfig
 import com.geeksville.mesh.ModuleConfigProtos.ModuleConfig
 import com.geeksville.mesh.deviceProfile
-import com.geeksville.mesh.model.getChannelUrl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.datastore.ChannelSetDataSource
 import org.meshtastic.core.datastore.LocalConfigDataSource
 import org.meshtastic.core.datastore.ModuleConfigDataSource
+import org.meshtastic.core.model.util.getChannelUrl
 import javax.inject.Inject
 
 /**

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -25,11 +25,11 @@ import com.geeksville.mesh.ConfigProtos.Config
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.LocalOnlyProtos.LocalModuleConfig
 import com.geeksville.mesh.ModuleConfigProtos.ModuleConfig
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.deviceProfile
 import com.geeksville.mesh.model.getChannelUrl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.datastore.ChannelSetDataSource
 import org.meshtastic.core.datastore.LocalConfigDataSource
 import org.meshtastic.core.datastore.ModuleConfigDataSource

--- a/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
@@ -20,7 +20,6 @@ package com.geeksville.mesh.repository.network
 import com.geeksville.mesh.MeshProtos.MqttClientProxyMessage
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.mqttClientProxyMessage
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.util.ignoreException
 import com.google.protobuf.ByteString
 import kotlinx.coroutines.channels.awaitClose
@@ -36,6 +35,7 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions
 import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.model.util.subscribeList
 import java.net.URI
 import java.security.SecureRandom

--- a/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
@@ -19,7 +19,6 @@ package com.geeksville.mesh.repository.network
 
 import com.geeksville.mesh.MeshProtos.MqttClientProxyMessage
 import com.geeksville.mesh.android.Logging
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.model.subscribeList
 import com.geeksville.mesh.mqttClientProxyMessage
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
@@ -37,6 +36,7 @@ import org.eclipse.paho.client.mqttv3.MqttCallbackExtended
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions
 import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
+import org.meshtastic.core.data.repository.NodeRepository
 import java.net.URI
 import java.security.SecureRandom
 import javax.inject.Inject

--- a/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
@@ -19,7 +19,6 @@ package com.geeksville.mesh.repository.network
 
 import com.geeksville.mesh.MeshProtos.MqttClientProxyMessage
 import com.geeksville.mesh.android.Logging
-import com.geeksville.mesh.model.subscribeList
 import com.geeksville.mesh.mqttClientProxyMessage
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.util.ignoreException
@@ -37,6 +36,7 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions
 import org.eclipse.paho.client.mqttv3.MqttMessage
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence
 import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.model.util.subscribeList
 import java.net.URI
 import java.security.SecureRandom
 import javax.inject.Inject

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -57,7 +57,6 @@ import com.geeksville.mesh.copy
 import com.geeksville.mesh.fromRadio
 import com.geeksville.mesh.model.NO_DEVICE_SELECTED
 import com.geeksville.mesh.position
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.repository.location.LocationRepository
 import com.geeksville.mesh.repository.network.MQTTRepository
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
@@ -83,6 +82,7 @@ import kotlinx.coroutines.flow.onEach
 import org.meshtastic.core.data.repository.MeshLogRepository
 import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.data.repository.PacketRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.database.entity.MeshLog
 import org.meshtastic.core.database.entity.MetadataEntity
 import org.meshtastic.core.database.entity.MyNodeEntity

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -54,9 +54,6 @@ import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.android.hasLocationPermission
 import com.geeksville.mesh.concurrent.handledLaunch
 import com.geeksville.mesh.copy
-import com.geeksville.mesh.database.MeshLogRepository
-import com.geeksville.mesh.database.NodeRepository
-import com.geeksville.mesh.database.PacketRepository
 import com.geeksville.mesh.fromRadio
 import com.geeksville.mesh.model.NO_DEVICE_SELECTED
 import com.geeksville.mesh.position
@@ -83,6 +80,9 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import org.meshtastic.core.data.repository.MeshLogRepository
+import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.PacketRepository
 import org.meshtastic.core.database.entity.MeshLog
 import org.meshtastic.core.database.entity.MetadataEntity
 import org.meshtastic.core.database.entity.MyNodeEntity

--- a/app/src/main/java/com/geeksville/mesh/service/PacketHandler.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/PacketHandler.kt
@@ -24,8 +24,6 @@ import com.geeksville.mesh.android.BuildUtils.debug
 import com.geeksville.mesh.android.BuildUtils.errormsg
 import com.geeksville.mesh.android.BuildUtils.info
 import com.geeksville.mesh.concurrent.handledLaunch
-import com.geeksville.mesh.database.MeshLogRepository
-import com.geeksville.mesh.database.PacketRepository
 import com.geeksville.mesh.fromRadio
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import dagger.Lazy
@@ -35,6 +33,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
+import org.meshtastic.core.data.repository.MeshLogRepository
+import org.meshtastic.core.data.repository.PacketRepository
 import org.meshtastic.core.database.entity.MeshLog
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/SecurityIcon.kt
@@ -63,8 +63,8 @@ import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.AppOnlyProtos
 import com.geeksville.mesh.ChannelProtos.ChannelSettings
 import com.geeksville.mesh.ConfigProtos.Config.LoRaConfig
-import com.geeksville.mesh.model.getChannel
 import org.meshtastic.core.model.Channel
+import org.meshtastic.core.model.util.getChannel
 import org.meshtastic.core.strings.R
 import org.meshtastic.core.ui.theme.StatusColors.StatusGreen
 import org.meshtastic.core.ui.theme.StatusColors.StatusRed

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsViewModel.kt
@@ -20,7 +20,6 @@ package com.geeksville.mesh.ui.connections
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.repository.bluetooth.BluetoothRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceRepository
@@ -30,6 +29,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
+import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.prefs.ui.UiPrefs

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsViewModel.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.repository.bluetooth.BluetoothRepository
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,6 +29,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.prefs.ui.UiPrefs

--- a/app/src/main/java/com/geeksville/mesh/ui/map/BaseMapViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/BaseMapViewModel.kt
@@ -21,8 +21,6 @@ import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.MeshProtos
-import com.geeksville.mesh.database.NodeRepository
-import com.geeksville.mesh.database.PacketRepository
 import com.geeksville.mesh.service.ServiceRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,6 +31,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.PacketRepository
 import org.meshtastic.core.database.entity.Packet
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.model.DataPacket

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -95,7 +95,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.geeksville.mesh.AppOnlyProtos
-import com.geeksville.mesh.model.getChannel
 import com.geeksville.mesh.ui.common.components.SecurityIcon
 import com.geeksville.mesh.ui.node.components.NodeKeyStatusIcon
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
@@ -106,6 +105,7 @@ import org.meshtastic.core.database.entity.QuickChatAction
 import org.meshtastic.core.database.model.Message
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.model.DataPacket
+import org.meshtastic.core.model.util.getChannel
 import org.meshtastic.core.strings.R
 import org.meshtastic.core.ui.theme.AppTheme
 import java.nio.charset.StandardCharsets

--- a/app/src/main/java/com/geeksville/mesh/ui/message/MessageViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/MessageViewModel.kt
@@ -21,7 +21,6 @@ import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.channelSet
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.MeshServiceNotifications
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.service.ServiceRepository
@@ -40,6 +39,7 @@ import kotlinx.coroutines.launch
 import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.data.repository.PacketRepository
 import org.meshtastic.core.data.repository.QuickChatActionRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.database.model.Message
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.model.DataPacket

--- a/app/src/main/java/com/geeksville/mesh/ui/message/MessageViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/MessageViewModel.kt
@@ -21,9 +21,6 @@ import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.channelSet
-import com.geeksville.mesh.database.NodeRepository
-import com.geeksville.mesh.database.PacketRepository
-import com.geeksville.mesh.database.QuickChatActionRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.MeshServiceNotifications
 import com.geeksville.mesh.service.ServiceAction
@@ -40,6 +37,9 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.PacketRepository
+import org.meshtastic.core.data.repository.QuickChatActionRepository
 import org.meshtastic.core.database.model.Message
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.model.DataPacket

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetailViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodeDetailViewModel.kt
@@ -20,7 +20,6 @@ package com.geeksville.mesh.ui.node
 import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.service.ServiceRepository
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
@@ -30,6 +29,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.model.Position
 import timber.log.Timber

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodesViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodesViewModel.kt
@@ -21,7 +21,6 @@ import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.AdminProtos
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.service.ServiceRepository
@@ -38,6 +37,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.database.model.NodeSortOption
 import org.meshtastic.core.model.Position

--- a/app/src/main/java/com/geeksville/mesh/ui/node/NodesViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/NodesViewModel.kt
@@ -21,7 +21,6 @@ import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.geeksville.mesh.AdminProtos
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceAction
 import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -38,6 +37,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.database.model.NodeSortOption
 import org.meshtastic.core.model.Position

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
@@ -26,8 +26,6 @@ import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.Portnums
 import com.geeksville.mesh.android.Logging
-import com.geeksville.mesh.database.MeshLogRepository
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -44,6 +42,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.meshtastic.core.data.repository.MeshLogRepository
+import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.datastore.UiPreferencesDataSource

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/SettingsViewModel.kt
@@ -26,7 +26,6 @@ import com.geeksville.mesh.LocalOnlyProtos.LocalConfig
 import com.geeksville.mesh.MeshProtos
 import com.geeksville.mesh.Portnums
 import com.geeksville.mesh.android.Logging
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -44,6 +43,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.data.repository.MeshLogRepository
 import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.datastore.UiPreferencesDataSource

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/CleanNodeDatabaseViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/CleanNodeDatabaseViewModel.kt
@@ -19,12 +19,12 @@ package com.geeksville.mesh.ui.settings.radio
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.service.ServiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.database.entity.NodeEntity
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.days

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
@@ -47,7 +47,6 @@ import com.geeksville.mesh.android.isAnalyticsAvailable
 import com.geeksville.mesh.config
 import com.geeksville.mesh.deviceProfile
 import com.geeksville.mesh.model.getChannelList
-import com.geeksville.mesh.model.toChannelSet
 import com.geeksville.mesh.moduleConfig
 import com.geeksville.mesh.navigation.ConfigRoute
 import com.geeksville.mesh.navigation.ModuleRoute
@@ -76,6 +75,7 @@ import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.database.model.getStringResFrom
 import org.meshtastic.core.model.Position
+import org.meshtastic.core.model.util.toChannelSet
 import org.meshtastic.core.navigation.SettingsRoutes
 import org.meshtastic.core.prefs.analytics.AnalyticsPrefs
 import org.meshtastic.core.prefs.map.MapConsentPrefs

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
@@ -45,7 +45,6 @@ import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.android.Logging
 import com.geeksville.mesh.android.isAnalyticsAvailable
 import com.geeksville.mesh.config
-import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.deviceProfile
 import com.geeksville.mesh.model.getChannelList
 import com.geeksville.mesh.model.toChannelSet
@@ -72,6 +71,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.database.model.getStringResFrom

--- a/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/settings/radio/RadioConfigViewModel.kt
@@ -50,7 +50,6 @@ import com.geeksville.mesh.model.getChannelList
 import com.geeksville.mesh.moduleConfig
 import com.geeksville.mesh.navigation.ConfigRoute
 import com.geeksville.mesh.navigation.ModuleRoute
-import com.geeksville.mesh.repository.datastore.RadioConfigRepository
 import com.geeksville.mesh.repository.location.LocationRepository
 import com.geeksville.mesh.service.ConnectionState
 import com.geeksville.mesh.service.ServiceRepository
@@ -71,6 +70,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.database.model.getStringResFrom

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
@@ -96,9 +96,6 @@ import com.geeksville.mesh.android.GeeksvilleApplication
 import com.geeksville.mesh.channelSet
 import com.geeksville.mesh.copy
 import com.geeksville.mesh.model.UIViewModel
-import com.geeksville.mesh.model.getChannelUrl
-import com.geeksville.mesh.model.qrCode
-import com.geeksville.mesh.model.toChannelSet
 import com.geeksville.mesh.navigation.ConfigRoute
 import com.geeksville.mesh.navigation.getNavRouteFrom
 import com.geeksville.mesh.service.ConnectionState
@@ -112,6 +109,9 @@ import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import kotlinx.coroutines.launch
 import org.meshtastic.core.model.Channel
+import org.meshtastic.core.model.util.getChannelUrl
+import org.meshtastic.core.model.util.qrCode
+import org.meshtastic.core.model.util.toChannelSet
 import org.meshtastic.core.navigation.Route
 import org.meshtastic.core.strings.R
 import org.meshtastic.core.ui.component.AdaptiveTwoPane

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -26,6 +26,7 @@ android { namespace = "org.meshtastic.core.data" }
 
 dependencies {
     implementation(projects.core.database)
+    implementation(projects.core.datastore)
     implementation(projects.core.di)
     implementation(projects.core.model)
     implementation(projects.core.prefs)

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(projects.core.datastore)
     implementation(projects.core.di)
     implementation(projects.core.model)
+    implementation(projects.core.network)
     implementation(projects.core.prefs)
     implementation(projects.core.proto)
 

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -25,8 +25,11 @@ plugins {
 android { namespace = "org.meshtastic.core.data" }
 
 dependencies {
+    implementation(projects.core.database)
     implementation(projects.core.di)
+    implementation(projects.core.model)
     implementation(projects.core.prefs)
+    implementation(projects.core.proto)
 
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)

--- a/core/data/detekt-baseline.xml
+++ b/core/data/detekt-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MagicNumber:PacketRepository.kt$PacketRepository$500</ID>
+    <ID>TooManyFunctions:PacketRepository.kt$PacketRepository</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareJsonDataSource.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareJsonDataSource.kt
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.geeksville.mesh.repository.api
+package org.meshtastic.core.data.datasource
 
 import android.app.Application
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
@@ -15,8 +15,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.geeksville.mesh.repository.api
+package org.meshtastic.core.data.datasource
 
+import dagger.Lazy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.database.dao.DeviceHardwareDao
@@ -25,11 +26,7 @@ import org.meshtastic.core.database.entity.asEntity
 import org.meshtastic.core.model.NetworkDeviceHardware
 import javax.inject.Inject
 
-class DeviceHardwareLocalDataSource
-@Inject
-constructor(
-    private val deviceHardwareDaoLazy: dagger.Lazy<DeviceHardwareDao>,
-) {
+class DeviceHardwareLocalDataSource @Inject constructor(private val deviceHardwareDaoLazy: Lazy<DeviceHardwareDao>) {
     private val deviceHardwareDao by lazy { deviceHardwareDaoLazy.get() }
 
     suspend fun insertAllDeviceHardware(deviceHardware: List<NetworkDeviceHardware>) = withContext(Dispatchers.IO) {

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseJsonDataSource.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseJsonDataSource.kt
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.geeksville.mesh.repository.api
+package org.meshtastic.core.data.datasource
 
 import android.app.Application
 import kotlinx.serialization.ExperimentalSerializationApi

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.geeksville.mesh.repository.api
+package org.meshtastic.core.data.datasource
 
 import dagger.Lazy
 import kotlinx.coroutines.Dispatchers

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/PacketRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/PacketRepository.kt
@@ -15,9 +15,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.geeksville.mesh.database
+package org.meshtastic.core.data.repository
 
 import com.geeksville.mesh.Portnums.PortNum
+import dagger.Lazy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapLatest
@@ -31,7 +32,7 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import javax.inject.Inject
 
-class PacketRepository @Inject constructor(private val packetDaoLazy: dagger.Lazy<PacketDao>) {
+class PacketRepository @Inject constructor(private val packetDaoLazy: Lazy<PacketDao>) {
     private val packetDao by lazy { packetDaoLazy.get() }
 
     fun getWaypoints(): Flow<List<Packet>> = packetDao.getAllPackets(PortNum.WAYPOINT_APP_VALUE)

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/QuickChatActionRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/QuickChatActionRepository.kt
@@ -15,31 +15,33 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.geeksville.mesh.database
+package org.meshtastic.core.data.repository
 
-import com.geeksville.mesh.CoroutineDispatchers
+import dagger.Lazy
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.database.dao.QuickChatActionDao
 import org.meshtastic.core.database.entity.QuickChatAction
+import org.meshtastic.core.di.annotation.IoDispatcher
 import javax.inject.Inject
 
 class QuickChatActionRepository
 @Inject
 constructor(
-    private val quickChatDaoLazy: dagger.Lazy<QuickChatActionDao>,
-    private val dispatchers: CoroutineDispatchers,
+    private val quickChatDaoLazy: Lazy<QuickChatActionDao>,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) {
     private val quickChatActionDao by lazy { quickChatDaoLazy.get() }
 
-    fun getAllActions() = quickChatActionDao.getAll().flowOn(dispatchers.io)
+    fun getAllActions() = quickChatActionDao.getAll().flowOn(ioDispatcher)
 
-    suspend fun upsert(action: QuickChatAction) = withContext(dispatchers.io) { quickChatActionDao.upsert(action) }
+    suspend fun upsert(action: QuickChatAction) = withContext(ioDispatcher) { quickChatActionDao.upsert(action) }
 
-    suspend fun deleteAll() = withContext(dispatchers.io) { quickChatActionDao.deleteAll() }
+    suspend fun deleteAll() = withContext(ioDispatcher) { quickChatActionDao.deleteAll() }
 
-    suspend fun delete(action: QuickChatAction) = withContext(dispatchers.io) { quickChatActionDao.delete(action) }
+    suspend fun delete(action: QuickChatAction) = withContext(ioDispatcher) { quickChatActionDao.delete(action) }
 
     suspend fun setItemPosition(uuid: Long, newPos: Int) =
-        withContext(dispatchers.io) { quickChatActionDao.updateActionPosition(uuid, newPos) }
+        withContext(ioDispatcher) { quickChatActionDao.updateActionPosition(uuid, newPos) }
 }

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/RadioConfigRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/RadioConfigRepository.kt
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.geeksville.mesh.repository.datastore
+package org.meshtastic.core.data.repository
 
 import com.geeksville.mesh.AppOnlyProtos.ChannelSet
 import com.geeksville.mesh.ChannelProtos.Channel
@@ -28,7 +28,6 @@ import com.geeksville.mesh.ModuleConfigProtos.ModuleConfig
 import com.geeksville.mesh.deviceProfile
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.datastore.ChannelSetDataSource
 import org.meshtastic.core.datastore.LocalConfigDataSource
 import org.meshtastic.core.datastore.ModuleConfigDataSource

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -34,4 +34,6 @@ dependencies {
     implementation(projects.core.proto)
     implementation(projects.core.strings)
     implementation(libs.timber)
+    implementation(libs.zxing.android.embedded) { isTransitive = false }
+    implementation(libs.zxing.core)
 }

--- a/core/model/detekt-baseline.xml
+++ b/core/model/detekt-baseline.xml
@@ -26,5 +26,9 @@
     <ID>MagicNumber:ChannelOption.kt$ChannelOption.SHORT_FAST$.250f</ID>
     <ID>MagicNumber:ChannelOption.kt$ChannelOption.SHORT_SLOW$.250f</ID>
     <ID>MagicNumber:ChannelOption.kt$ChannelOption.VERY_LONG_SLOW$.0625f</ID>
+    <ID>MagicNumber:ChannelSet.kt$40</ID>
+    <ID>MagicNumber:ChannelSet.kt$960</ID>
+    <ID>SwallowedException:ChannelSet.kt$ex: Throwable</ID>
+    <ID>TooGenericExceptionCaught:ChannelSet.kt$ex: Throwable</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/core/model/src/main/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
@@ -15,23 +15,23 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.geeksville.mesh.model
+package org.meshtastic.core.model.util
 
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Base64
 import com.geeksville.mesh.AppOnlyProtos.ChannelSet
-import com.geeksville.mesh.android.BuildUtils.errormsg
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.MultiFormatWriter
 import com.journeyapps.barcodescanner.BarcodeEncoder
 import org.meshtastic.core.model.Channel
+import timber.log.Timber
 import java.net.MalformedURLException
 import kotlin.jvm.Throws
 
 private const val MESHTASTIC_HOST = "meshtastic.org"
 private const val CHANNEL_PATH = "/e/"
-internal const val URL_PREFIX = "https://$MESHTASTIC_HOST$CHANNEL_PATH"
+const val URL_PREFIX = "https://$MESHTASTIC_HOST$CHANNEL_PATH"
 private const val BASE64FLAGS = Base64.URL_SAFE + Base64.NO_WRAP + Base64.NO_PADDING
 
 /**
@@ -86,6 +86,6 @@ fun ChannelSet.qrCode(shouldAdd: Boolean): Bitmap? = try {
     val barcodeEncoder = BarcodeEncoder()
     barcodeEncoder.createBitmap(bitMatrix)
 } catch (ex: Throwable) {
-    errormsg("URL was too complex to render as barcode")
+    Timber.e("URL was too complex to render as barcode")
     null
 }


### PR DESCRIPTION
Moves the following repository classes to `:core:data`:
- `MeshLogRepository`
- `NodeRepository`
- `RadioConfigRepository`
- `PacketRepository`
- `QuickChatActionRepository`
- `DeviceHardwareRepository`
- `FirmwareReleaseRepository`