### PR TITLE
Decouple `MainAppBar` from `UiViewModel`

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -242,13 +242,6 @@ constructor(
         _currentAlert.value = null
     }
 
-    private val _title = MutableStateFlow("")
-    val title: StateFlow<String> = _title.asStateFlow()
-
-    fun setTitle(title: String) {
-        viewModelScope.launch { _title.value = title }
-    }
-
     val meshService: IMeshService?
         get() = serviceRepository.meshService
 

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -120,7 +120,6 @@ import org.meshtastic.core.ui.icon.Nodes
 import org.meshtastic.core.ui.icon.Settings
 import org.meshtastic.core.ui.theme.StatusColors.StatusBlue
 import org.meshtastic.core.ui.theme.StatusColors.StatusGreen
-import kotlin.reflect.KClass
 
 enum class TopLevelDestination(@StringRes val label: Int, val icon: ImageVector, val route: Route) {
     Conversations(R.string.conversations, MeshtasticIcons.Conversations, ContactsRoutes.ContactsGraph),
@@ -131,13 +130,6 @@ enum class TopLevelDestination(@StringRes val label: Int, val icon: ImageVector,
     ;
 
     companion object {
-        fun NavDestination.isTopLevel(): Boolean = listOf<KClass<out Route>>(
-            ContactsRoutes.Contacts::class,
-            MapRoutes.Map::class,
-            ConnectionsRoutes.Connections::class,
-        )
-            .any { this.hasRoute(it) }
-
         fun fromNavDestination(destination: NavDestination?): TopLevelDestination? =
             entries.find { dest -> destination?.hierarchy?.any { it.hasRoute(dest.route::class) } == true }
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -374,10 +374,11 @@ fun MainScreen(uIViewModel: UIViewModel = hiltViewModel(), scanModel: BTScanMode
                     )
                         .none { this.hasRoute(it) }
 
+                val ourNodeInfo by uIViewModel.ourNodeInfo.collectAsStateWithLifecycle()
                 AnimatedVisibility(visible = currentDestination?.hasGlobalAppBar() ?: false) {
                     MainAppBar(
-                        viewModel = uIViewModel,
                         navController = navController,
+                        ourNode = ourNodeInfo,
                         isConnected = connectionState.isConnected(),
                         onAction = { action ->
                             when (action) {

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -378,6 +378,7 @@ fun MainScreen(uIViewModel: UIViewModel = hiltViewModel(), scanModel: BTScanMode
                     MainAppBar(
                         viewModel = uIViewModel,
                         navController = navController,
+                        isConnected = connectionState.isConnected(),
                         onAction = { action ->
                             when (action) {
                                 is NodeMenuAction.MoreDetails -> {

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
@@ -42,20 +42,16 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.geeksville.mesh.model.UIViewModel
-import com.geeksville.mesh.navigation.isConfigRoute
-import com.geeksville.mesh.navigation.isNodeDetailRoute
 import com.geeksville.mesh.ui.TopLevelDestination.Companion.isTopLevel
 import com.geeksville.mesh.ui.debug.DebugMenuActions
 import com.geeksville.mesh.ui.node.components.NodeChip
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.navigation.ContactsRoutes
-import org.meshtastic.core.navigation.NodesRoutes
 import org.meshtastic.core.navigation.SettingsRoutes
 import org.meshtastic.core.strings.R
 import org.meshtastic.core.ui.theme.AppTheme
@@ -74,7 +70,6 @@ fun MainAppBar(
         return
     }
 
-    val longTitle by viewModel.title.collectAsStateWithLifecycle("")
     val ourNode by viewModel.ourNodeInfo.collectAsStateWithLifecycle()
     val isConnected by viewModel.isConnectedStateFlow.collectAsStateWithLifecycle(false)
 
@@ -87,8 +82,6 @@ fun MainAppBar(
             currentDestination.hasRoute<ContactsRoutes.QuickChat>() -> stringResource(id = R.string.quick_chat)
 
             currentDestination.hasRoute<ContactsRoutes.Share>() -> stringResource(id = R.string.share_to)
-
-            currentDestination.showLongNameTitle() -> longTitle
 
             else -> stringResource(id = R.string.app_name)
         }
@@ -170,14 +163,6 @@ fun MainAppBar(
         },
     )
 }
-
-fun NavDestination.showLongNameTitle(): Boolean = !this.isTopLevel() &&
-    (
-        this.hasRoute<SettingsRoutes.Settings>() ||
-            this.hasRoute<NodesRoutes.NodeDetail>() ||
-            this.isConfigRoute() ||
-            this.isNodeDetailRoute()
-        )
 
 @Composable
 private fun TopBarActions(

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
@@ -46,7 +46,6 @@ import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.geeksville.mesh.model.UIViewModel
-import com.geeksville.mesh.ui.TopLevelDestination.Companion.isTopLevel
 import com.geeksville.mesh.ui.debug.DebugMenuActions
 import com.geeksville.mesh.ui.node.components.NodeChip
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
@@ -75,7 +74,7 @@ fun MainAppBar(
 
     val title: String =
         when {
-            currentDestination == null || currentDestination.isTopLevel() -> stringResource(id = R.string.app_name)
+            currentDestination == null -> ""
 
             currentDestination.hasRoute<SettingsRoutes.DebugPanel>() -> stringResource(id = R.string.debug_panel)
 
@@ -83,17 +82,17 @@ fun MainAppBar(
 
             currentDestination.hasRoute<ContactsRoutes.Share>() -> stringResource(id = R.string.share_to)
 
-            else -> stringResource(id = R.string.app_name)
+            else -> ""
         }
 
     MainAppBar(
         modifier = modifier,
         title = title,
         subtitle = null,
-        canNavigateUp = navController.previousBackStackEntry != null && currentDestination?.isTopLevel() == false,
+        canNavigateUp = navController.previousBackStackEntry != null,
         ourNode = ourNode,
         isConnected = isConnected,
-        showNodeChip = ourNode != null && currentDestination?.isTopLevel() == true && isConnected,
+        showNodeChip = false,
         onNavigateUp = navController::navigateUp,
         actions = {
             currentDestination?.let {

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
@@ -40,12 +40,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.debug.DebugMenuActions
 import com.geeksville.mesh.ui.node.components.NodeChip
 import com.geeksville.mesh.ui.node.components.NodeMenuAction
@@ -59,8 +56,8 @@ import org.meshtastic.core.ui.theme.AppTheme
 @Composable
 fun MainAppBar(
     modifier: Modifier = Modifier,
-    viewModel: UIViewModel = hiltViewModel(),
     navController: NavHostController,
+    ourNode: Node?,
     isConnected: Boolean,
     onAction: (NodeMenuAction) -> Unit,
 ) {
@@ -69,8 +66,6 @@ fun MainAppBar(
     if (currentDestination?.hasRoute<ContactsRoutes.Messages>() == true) {
         return
     }
-
-    val ourNode by viewModel.ourNodeInfo.collectAsStateWithLifecycle()
 
     val title: String =
         when {

--- a/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/common/components/MainAppBar.kt
@@ -61,6 +61,7 @@ fun MainAppBar(
     modifier: Modifier = Modifier,
     viewModel: UIViewModel = hiltViewModel(),
     navController: NavHostController,
+    isConnected: Boolean,
     onAction: (NodeMenuAction) -> Unit,
 ) {
     val backStackEntry by navController.currentBackStackEntryAsState()
@@ -70,7 +71,6 @@ fun MainAppBar(
     }
 
     val ourNode by viewModel.ourNodeInfo.collectAsStateWithLifecycle()
-    val isConnected by viewModel.isConnectedStateFlow.collectAsStateWithLifecycle(false)
 
     val title: String =
         when {


### PR DESCRIPTION
Also cleans up some of the logic surrounding top-level screens, as they all employ their own instance of `MainAppBar`.