### PR TITLE
feat(map): add last heard filter for map nodes

### DIFF
--- a/app/src/google/java/com/geeksville/mesh/ui/map/MapView.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/MapView.kt
@@ -304,8 +304,8 @@ fun MapView(
         allNodes
             .filter { node -> !mapFilterState.onlyFavorites || node.isFavorite || node.num == ourNodeInfo?.num }
             .filter { node ->
-                mapFilterState.lastHeardFilter == 0L ||
-                    (System.currentTimeMillis() / 1000 - node.lastHeard) <= mapFilterState.lastHeardFilter ||
+                mapFilterState.lastHeardFilter.seconds == 0L ||
+                    (System.currentTimeMillis() / 1000 - node.lastHeard) <= mapFilterState.lastHeardFilter.seconds ||
                     node.num == ourNodeInfo?.num
             }
 

--- a/app/src/google/java/com/geeksville/mesh/ui/map/MapView.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/MapView.kt
@@ -301,11 +301,13 @@ fun MapView(
     val displayableWaypoints = waypoints.values.mapNotNull { it.data.waypoint }
 
     val filteredNodes =
-        if (mapFilterState.onlyFavorites) {
-            allNodes.filter { it.isFavorite || it.num == ourNodeInfo?.num }
-        } else {
-            allNodes
-        }
+        allNodes
+            .filter { node -> !mapFilterState.onlyFavorites || node.isFavorite || node.num == ourNodeInfo?.num }
+            .filter { node ->
+                mapFilterState.lastHeardFilter == 0L ||
+                    (System.currentTimeMillis() / 1000 - node.lastHeard) <= mapFilterState.lastHeardFilter ||
+                    node.num == ourNodeInfo?.num
+            }
 
     val nodeClusterItems =
         filteredNodes.map { node ->

--- a/app/src/google/java/com/geeksville/mesh/ui/map/components/MapFilterDropdown.kt
+++ b/app/src/google/java/com/geeksville/mesh/ui/map/components/MapFilterDropdown.kt
@@ -17,6 +17,7 @@
 
 package com.geeksville.mesh.ui.map.components
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Place
@@ -24,14 +25,20 @@ import androidx.compose.material.icons.outlined.RadioButtonUnchecked
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.geeksville.mesh.ui.map.MapViewModel
 import org.meshtastic.core.strings.R
+import java.util.concurrent.TimeUnit
 
 @Composable
 internal fun MapFilterDropdown(expanded: Boolean, onDismissRequest: () -> Unit, mapViewModel: MapViewModel) {
@@ -85,5 +92,37 @@ internal fun MapFilterDropdown(expanded: Boolean, onDismissRequest: () -> Unit, 
                 )
             },
         )
+        HorizontalDivider()
+        Text(
+            text = stringResource(R.string.last_heard_filter),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            style = MaterialTheme.typography.labelLarge,
+        )
+        mapViewModel.lastHeardFilterOptions.forEach { seconds ->
+            val text =
+                when (seconds) {
+                    0L -> stringResource(R.string.any)
+                    TimeUnit.HOURS.toSeconds(1) -> stringResource(R.string.one_hour)
+                    TimeUnit.HOURS.toSeconds(8) -> stringResource(R.string.eight_hours)
+                    TimeUnit.DAYS.toSeconds(1) -> stringResource(R.string.one_day)
+                    else -> seconds.toString()
+                }
+            DropdownMenuItem(
+                text = { Text(text) },
+                onClick = {
+                    mapViewModel.setLastHeardFilter(seconds)
+                    onDismissRequest()
+                },
+                trailingIcon = {
+                    RadioButton(
+                        selected = mapFilterState.lastHeardFilter == seconds,
+                        onClick = {
+                            mapViewModel.setLastHeardFilter(seconds)
+                            onDismissRequest()
+                        },
+                    )
+                },
+            )
+        }
     }
 }

--- a/core/prefs/src/main/kotlin/org/meshtastic/core/prefs/map/MapPrefs.kt
+++ b/core/prefs/src/main/kotlin/org/meshtastic/core/prefs/map/MapPrefs.kt
@@ -29,6 +29,7 @@ interface MapPrefs {
     var showOnlyFavorites: Boolean
     var showWaypointsOnMap: Boolean
     var showPrecisionCircleOnMap: Boolean
+    var lastHeardFilter: Long
 }
 
 @Singleton
@@ -37,4 +38,5 @@ class MapPrefsImpl @Inject constructor(@MapSharedPreferences prefs: SharedPrefer
     override var showOnlyFavorites: Boolean by PrefDelegate(prefs, "show_only_favorites", false)
     override var showWaypointsOnMap: Boolean by PrefDelegate(prefs, "show_waypoints", true)
     override var showPrecisionCircleOnMap: Boolean by PrefDelegate(prefs, "show_precision_circle", true)
+    override var lastHeardFilter: Long by PrefDelegate(prefs, "last_heard_filter", 0L)
 }

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -905,5 +905,6 @@
     <string name="one_hour">1 Hour</string>
     <string name="eight_hours">8 Hours</string>
     <string name="one_day">24 Hours</string>
-    <string name="last_heard_filter">Filter by Last Heard time</string>
+    <string name="two_days">48 Hours</string>
+    <string name="last_heard_filter_label">Filter by Last Heard time: %s</string>
 </resources>

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -901,4 +901,9 @@
     <string name="remotely_administrating">"[Remote] %1$s"</string>
     <string name="device_telemetry_enabled">Send Device Telemetry</string>
     <string name="device_telemetry_enabled_summary">Enable/Disable the device telemetry module to send metrics to the mesh</string>
+    <string name="any">Any</string>
+    <string name="one_hour">1 Hour</string>
+    <string name="eight_hours">8 Hours</string>
+    <string name="one_day">24 Hours</string>
+    <string name="last_heard_filter">Filter by Last Heard time</string>
 </resources>


### PR DESCRIPTION
This commit introduces a "last heard" filter to the map, allowing users to filter nodes based on when they were last heard from.

The filter options include "Any", "1 Hour", "8 Hours", "24 Hours", and "48 Hours".

This change includes:
- Adding a `lastHeardFilter` preference to `MapPrefs`.
- Updating the `MapFilterDropdown` to include options for the last heard filter.
- Modifying `BaseMapViewModel` to handle the new filter state and logic.
- Updating `MapView` to apply the last heard filter to displayed nodes.
- Adding new string resources for the filter options.

<img width="1087" height="961" alt="image" src="https://github.com/user-attachments/assets/8a96563f-b12b-4168-bce1-9d5142ba5c1a" />

