### PR TITLE
feat(bluetooth): expose and display bluetooth signal strength (RSSI)

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -325,6 +325,7 @@ class MeshService :
         serviceScope.handledLaunch { radioInterfaceService.connect() }
         radioInterfaceService.connectionState.onEach(::onRadioConnectionState).launchIn(serviceScope)
         radioInterfaceService.receivedData.onEach(::onReceiveFromRadio).launchIn(serviceScope)
+        radioInterfaceService.bluetoothRssi.onEach { serviceRepository.setBluetoothRssi(it) }.launchIn(serviceScope)
         radioConfigRepository.localConfigFlow.onEach { localConfig = it }.launchIn(serviceScope)
         radioConfigRepository.moduleConfigFlow.onEach { moduleConfig = it }.launchIn(serviceScope)
         radioConfigRepository.channelSetFlow.onEach { channelSet = it }.launchIn(serviceScope)

--- a/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
@@ -46,8 +46,17 @@ class ServiceRepository @Inject constructor() : Logging {
     val connectionState: StateFlow<ConnectionState>
         get() = _connectionState
 
-    fun setConnectionState(connectionState: ConnectionState) {
+    fun setConnectionState(connectionState: ConnectionState){
         _connectionState.value = connectionState
+    }
+
+    // Current bluetooth link RSSI (dBm). Null if not connected or not a bluetooth interface.
+    private val _bluetoothRssi = MutableStateFlow<Int?>(null)
+    val bluetoothRssi: StateFlow<Int?>
+        get() = _bluetoothRssi
+
+    fun setBluetoothRssi(rssi: Int?) {
+        _bluetoothRssi.value = rssi
     }
 
     private val _clientNotification = MutableStateFlow<MeshProtos.ClientNotification?>(null)

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Language
+import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -120,6 +121,7 @@ fun ConnectionsScreen(
     val selectedDevice by scanModel.selectedNotNullFlow.collectAsStateWithLifecycle()
     val bluetoothState by connectionsViewModel.bluetoothState.collectAsStateWithLifecycle()
     val regionUnset = config.lora.region == ConfigProtos.Config.LoRaConfig.RegionCode.UNSET
+    val bluetoothRssi by connectionsViewModel.bluetoothRssi.collectAsStateWithLifecycle()
 
     val bleDevices by scanModel.bleDevicesForUi.collectAsStateWithLifecycle()
     val discoveredTcpDevices by scanModel.discoveredTcpDevicesForUi.collectAsStateWithLifecycle()
@@ -224,6 +226,7 @@ fun ConnectionsScreen(
                                         onSetShowSharedContact = { showSharedContact = it },
                                         onNavigateToSettings = onNavigateToSettings,
                                         onClickDisconnect = { scanModel.disconnect() },
+                                        bluetoothRssi = bluetoothRssi,
                                     )
                                 }
                             }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsViewModel.kt
@@ -60,6 +60,9 @@ constructor(
 
     val bluetoothState = bluetoothRepository.state
 
+    // Newly added: bluetooth RSSI stream (dBm, null if unavailable)
+    val bluetoothRssi = serviceRepository.bluetoothRssi
+
     private val _hasShownNotPairedWarning = MutableStateFlow(uiPrefs.hasShownNotPairedWarning)
     val hasShownNotPairedWarning: StateFlow<Boolean> = _hasShownNotPairedWarning.asStateFlow()
 

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedInfo.kt
@@ -20,6 +20,7 @@ package com.geeksville.mesh.ui.connections.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -27,6 +28,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -54,6 +57,7 @@ import org.meshtastic.core.ui.theme.StatusColors.StatusRed
 @Composable
 fun CurrentlyConnectedInfo(
     node: Node,
+    bluetoothRssi: Int? = null,
     onNavigateToNodeDetails: (Int) -> Unit,
     onSetShowSharedContact: (Node) -> Unit,
     onNavigateToSettings: () -> Unit,
@@ -92,6 +96,14 @@ fun CurrentlyConnectedInfo(
                         style = MaterialTheme.typography.bodySmall,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                if (bluetoothRssi != null) {
+                    HorizontalDivider()
+                    Text(
+                        text =
+                            stringResource(R.string.bluetooth_signal_strength_fmt, bluetoothRssi),
+                        style = MaterialTheme.typography.bodySmall,
                     )
                 }
             }

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -918,4 +918,5 @@
     <string name="one_day">24 Hours</string>
     <string name="two_days">48 Hours</string>
     <string name="last_heard_filter_label">Filter by Last Heard time: %s</string>
+    <string name="bluetooth_signal_strength_fmt">Bluetooth signal: %1$d dBm</string>
 </resources>


### PR DESCRIPTION
This commit introduces the ability to read and display the Bluetooth signal strength (RSSI) for connected devices.

Key changes include:

*   **ServiceRepository & RadioInterfaceService:** Added StateFlows to hold and expose the current Bluetooth RSSI.
*   **SafeBluetooth:** Implemented `onReadRemoteRssi` callback and added methods (`queueReadRemoteRssi`, `asyncReadRemoteRssi`, `readRemoteRssi`) to read the remote RSSI.
*   **BluetoothInterface:**
    *   Added an `rssiFlow` to emit RSSI updates.
    *   Implemented `startRssiPolling` and `stopRssiPolling` methods to periodically read and update the RSSI value when connected, and clear it on disconnect.
*   **ConnectionsViewModel:** Exposes the `bluetoothRssi` StateFlow from `ServiceRepository`.
*   **MeshService:** Collects `bluetoothRssi` from `RadioInterfaceService` and updates `ServiceRepository`.
*   **UI (CurrentlyConnectedInfo & ConnectionsScreen):**
    *   The "Currently Connected" card now displays the Bluetooth signal strength in dBm when available.
    *   Added a new string resource `bluetooth_signal_strength_fmt` for formatting the display.
*   **Resource strings:** Added a new string `bluetooth_signal_strength_fmt` for displaying the RSSI value.
<img width="960" height="351" alt="image" src="https://github.com/user-attachments/assets/0a80d8d0-53f5-42e6-aed9-f470ed8b37ea" />
