### PR TITLE
feat(build)!: apply Datadog and Firebase plugins only to google flavor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,12 +25,10 @@ plugins {
     alias(libs.plugins.meshtastic.android.application)
     alias(libs.plugins.meshtastic.android.application.flavors)
     alias(libs.plugins.meshtastic.android.application.compose)
-    alias(libs.plugins.meshtastic.android.application.firebase)
     alias(libs.plugins.meshtastic.hilt)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
     alias(libs.plugins.devtools.ksp)
-    alias(libs.plugins.datadog)
     alias(libs.plugins.secrets)
     alias(libs.plugins.dokka)
     alias(libs.plugins.kover)
@@ -131,6 +129,13 @@ android {
             ),
         )
         ndk { abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64") }
+
+        dependenciesInfo {
+            // Disables dependency metadata when building APKs (for IzzyOnDroid/F-Droid)
+            includeInApk = false
+            // Disables dependency metadata when building Android App Bundles (for Google Play)
+            includeInBundle = false
+        }
     }
 
     // Configure existing product flavors (defined by convention plugin)

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     compileOnly(libs.compose.gradlePlugin)
     compileOnly(libs.detekt.gradle)
     compileOnly(libs.firebase.crashlytics.gradlePlugin)
+    compileOnly(libs.firebase.performance.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.ksp.gradlePlugin)
     compileOnly(libs.room.gradlePlugin)
@@ -80,6 +81,10 @@ gradlePlugin {
         register("androidFirebase") {
             id = libs.plugins.meshtastic.android.application.firebase.get().pluginId
             implementationClass = "AndroidApplicationFirebaseConventionPlugin"
+        }
+        register("androidDatadog") {
+            id = libs.plugins.meshtastic.android.application.datadog.get().pluginId
+            implementationClass = "AndroidApplicationDatadogConventionPlugin"
         }
         register("androidLibraryCompose") {
             id = libs.plugins.meshtastic.android.library.compose.get().pluginId

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationDatadogConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationDatadogConventionPlugin.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.geeksville.mesh.buildlogic.libs
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+
+
+/**
+ * Convention plugin to apply and configure Datadog for Android applications.
+ * This plugin should only be applied to variants that require Datadog integration (e.g., 'google' flavor).
+ */
+class AndroidApplicationDatadogConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            extensions.configure<ApplicationExtension> {
+                apply(plugin = libs.findPlugin("datadog").get().get().pluginId)
+                dependencies {
+                    "googleImplementation"(libs.findBundle("datadog").get())
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseConventionPlugin.kt
@@ -16,7 +16,6 @@
  */
 
 import com.android.build.api.dsl.ApplicationExtension
-import com.geeksville.mesh.buildlogic.MeshtasticFlavor
 import com.geeksville.mesh.buildlogic.libs
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
 import org.gradle.api.Plugin
@@ -29,13 +28,14 @@ import org.gradle.kotlin.dsl.exclude
 class AndroidApplicationFirebaseConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            apply(plugin = "com.google.gms.google-services")
-            apply(plugin = "com.google.firebase.crashlytics")
-
+            apply(plugin = libs.findPlugin("firebase-crashlytics").get().get().pluginId)
+            apply(plugin = libs.findPlugin("firebase-perf").get().get().pluginId)
+            apply(plugin = libs.findPlugin("google-services").get().get().pluginId)
+            extensions.configure<ApplicationExtension> {
                 dependencies {
                     val bom = libs.findLibrary("firebase-bom").get()
-                    "implementation"(platform(bom))
-                    "implementation"(libs.findBundle("firebase").get()) {
+                    "googleImplementation"(platform(bom))
+                    "googleImplementation"(libs.findBundle("firebase").get()) {
                         /*
                         Exclusion of protobuf / protolite dependencies is necessary as the
                         datastore-proto brings in protobuf dependencies. These are the source of truth
@@ -45,9 +45,13 @@ class AndroidApplicationFirebaseConventionPlugin : Plugin<Project> {
                         exclude(group = "com.google.protobuf", module = "protobuf-java")
                         exclude(group = "com.google.protobuf", module = "protobuf-kotlin")
                         exclude(group = "com.google.protobuf", module = "protobuf-javalite")
-                        exclude(group = "com.google.firebase", module = "protolite-well-known-types")
+                        exclude(
+                            group = "com.google.firebase",
+                            module = "protolite-well-known-types"
+                        )
                     }
                 }
+            }
 
             extensions.configure<ApplicationExtension> {
                 buildTypes.configureEach {

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationFlavorsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationFlavorsConventionPlugin.kt
@@ -16,10 +16,12 @@
  */
 
 import com.android.build.api.dsl.ApplicationExtension
+import com.geeksville.mesh.buildlogic.MeshtasticFlavor
 import com.geeksville.mesh.buildlogic.configureFlavors
 import com.geeksville.mesh.buildlogic.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.exclude
@@ -29,17 +31,28 @@ class AndroidApplicationFlavorsConventionPlugin : Plugin<Project> {
         with(target) {
             extensions.configure<ApplicationExtension> {
                 configureFlavors(this)
-                dependencies {
-                    // F-Droid specific dependencies
-                    "fdroidImplementation"(libs.findBundle("osm").get())
-                    "fdroidImplementation"(libs.findLibrary("osmdroid-geopackage").get()) {
-                        exclude(group = "com.j256.ormlite")
+                productFlavors {
+                    all {
+                        if (name == MeshtasticFlavor.google.name) {
+                            apply(plugin = "meshtastic.android.application.firebase")
+                            apply(plugin = "meshtastic.android.application.datadog")
+                            dependencies {
+                                // Google specific dependencies
+                                "googleImplementation"(libs.findBundle("maps-compose").get())
+                                "googleImplementation"(libs.findLibrary("awesome-app-rating").get())
+                            }
+                        } else if (name == MeshtasticFlavor.fdroid.name) {
+                            dependencies {
+                                // F-Droid specific dependencies
+                                "fdroidImplementation"(libs.findBundle("osm").get())
+                                "fdroidImplementation"(
+                                    libs.findLibrary("osmdroid-geopackage").get()
+                                ) {
+                                    exclude(group = "com.j256.ormlite")
+                                }
+                            }
+                        }
                     }
-
-                    // Google specific dependencies
-                    "googleImplementation"(libs.findBundle("maps-compose").get())
-                    "googleImplementation"(libs.findLibrary("awesome-app-rating").get())
-                    "googleImplementation"(libs.findBundle("datadog").get())
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -251,6 +251,7 @@ spotless = { id = "com.diffplug.spotless", version = "8.0.0" }
 # Meshtastic
 meshtastic-android-application = { id = "meshtastic.android.application" }
 meshtastic-android-application-compose = { id = "meshtastic.android.application.compose" }
+meshtastic-android-application-datadog = { id = "meshtastic.android.application.datadog" }
 meshtastic-android-application-firebase = { id = "meshtastic.android.application.firebase" }
 meshtastic-android-application-flavors = { id = "meshtastic.android.application.flavors" }
 meshtastic-android-library = { id = "meshtastic.android.library" }


### PR DESCRIPTION
This change introduces a new `AndroidApplicationDatadogConventionPlugin` and modifies the `AndroidApplicationFirebaseConventionPlugin` and `AndroidApplicationFlavorsConventionPlugin`.

The Datadog and Firebase plugins, along with their respective dependencies, are now conditionally applied only to the 'google' product flavor. This is achieved by moving the plugin application and dependency declarations into the flavor configuration block within `AndroidApplicationFlavorsConventionPlugin`.

Additionally, dependency metadata inclusion in APKs and App Bundles has been disabled in `app/build.gradle.kts`.

BREAKING CHANGE: The Datadog and Firebase plugins are no longer applied by default to all flavors. They are now specifically applied to the 'google' flavor. This might affect builds if other flavors were implicitly relying on these plugins or their dependencies.

This to address post-modularization alignment with fdroid/izzydroid build requirements as noted in #3231 .