### PR TITLE
Migrate node sort prefs to datastore

### DIFF
--- a/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/UiPreferencesDataSource.kt
+++ b/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/UiPreferencesDataSource.kt
@@ -36,6 +36,13 @@ import javax.inject.Singleton
 internal const val KEY_APP_INTRO_COMPLETED = "app_intro_completed"
 internal const val KEY_THEME = "theme"
 
+// Node list filters/sort
+internal const val KEY_NODE_SORT = "node-sort-option"
+internal const val KEY_INCLUDE_UNKNOWN = "include-unknown"
+internal const val KEY_ONLY_ONLINE = "only-online"
+internal const val KEY_ONLY_DIRECT = "only-direct"
+internal const val KEY_SHOW_IGNORED = "show-ignored"
+
 @Singleton
 class UiPreferencesDataSource @Inject constructor(private val dataStore: DataStore<Preferences>) {
 
@@ -46,12 +53,38 @@ class UiPreferencesDataSource @Inject constructor(private val dataStore: DataSto
     // Default value for AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
     val theme: StateFlow<Int> = dataStore.prefStateFlow(key = THEME, default = -1)
 
+    val nodeSort: StateFlow<Int> = dataStore.prefStateFlow(key = NODE_SORT, default = -1)
+    val includeUnknown: StateFlow<Boolean> = dataStore.prefStateFlow(key = INCLUDE_UNKNOWN, default = false)
+    val onlyOnline: StateFlow<Boolean> = dataStore.prefStateFlow(key = ONLY_ONLINE, default = false)
+    val onlyDirect: StateFlow<Boolean> = dataStore.prefStateFlow(key = ONLY_DIRECT, default = false)
+    val showIgnored: StateFlow<Boolean> = dataStore.prefStateFlow(key = SHOW_IGNORED, default = false)
+
     fun setAppIntroCompleted(completed: Boolean) {
         dataStore.setPref(key = APP_INTRO_COMPLETED, value = completed)
     }
 
     fun setTheme(value: Int) {
         dataStore.setPref(key = THEME, value = value)
+    }
+
+    fun setNodeSort(value: Int) {
+        dataStore.setPref(key = NODE_SORT, value = value)
+    }
+
+    fun setIncludeUnknown(value: Boolean) {
+        dataStore.setPref(key = INCLUDE_UNKNOWN, value = value)
+    }
+
+    fun setOnlyOnline(value: Boolean) {
+        dataStore.setPref(key = ONLY_ONLINE, value = value)
+    }
+
+    fun setOnlyDirect(value: Boolean) {
+        dataStore.setPref(key = ONLY_DIRECT, value = value)
+    }
+
+    fun setShowIgnored(value: Boolean) {
+        dataStore.setPref(key = SHOW_IGNORED, value = value)
     }
 
     private fun <T : Any> DataStore<Preferences>.prefStateFlow(key: Preferences.Key<T>, default: T): StateFlow<T> =
@@ -64,5 +97,10 @@ class UiPreferencesDataSource @Inject constructor(private val dataStore: DataSto
     private companion object {
         val APP_INTRO_COMPLETED = booleanPreferencesKey(KEY_APP_INTRO_COMPLETED)
         val THEME = intPreferencesKey(KEY_THEME)
+        val NODE_SORT = intPreferencesKey(KEY_NODE_SORT)
+        val INCLUDE_UNKNOWN = booleanPreferencesKey(KEY_INCLUDE_UNKNOWN)
+        val ONLY_ONLINE = booleanPreferencesKey(KEY_ONLY_ONLINE)
+        val ONLY_DIRECT = booleanPreferencesKey(KEY_ONLY_DIRECT)
+        val SHOW_IGNORED = booleanPreferencesKey(KEY_SHOW_IGNORED)
     }
 }

--- a/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/di/DataStoreModule.kt
@@ -39,6 +39,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import org.meshtastic.core.datastore.KEY_APP_INTRO_COMPLETED
+import org.meshtastic.core.datastore.KEY_INCLUDE_UNKNOWN
+import org.meshtastic.core.datastore.KEY_NODE_SORT
+import org.meshtastic.core.datastore.KEY_ONLY_DIRECT
+import org.meshtastic.core.datastore.KEY_ONLY_ONLINE
+import org.meshtastic.core.datastore.KEY_SHOW_IGNORED
 import org.meshtastic.core.datastore.KEY_THEME
 import org.meshtastic.core.datastore.serializer.ChannelSetSerializer
 import org.meshtastic.core.datastore.serializer.LocalConfigSerializer
@@ -61,7 +66,16 @@ object DataStoreModule {
                 SharedPreferencesMigration(
                     context = appContext,
                     sharedPreferencesName = "ui-prefs",
-                    keysToMigrate = setOf(KEY_APP_INTRO_COMPLETED, KEY_THEME),
+                    keysToMigrate =
+                    setOf(
+                        KEY_APP_INTRO_COMPLETED,
+                        KEY_THEME,
+                        KEY_NODE_SORT,
+                        KEY_INCLUDE_UNKNOWN,
+                        KEY_ONLY_ONLINE,
+                        KEY_ONLY_DIRECT,
+                        KEY_SHOW_IGNORED,
+                    ),
                 ),
             ),
             scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),

--- a/core/prefs/src/main/kotlin/org/meshtastic/core/prefs/ui/UiPrefs.kt
+++ b/core/prefs/src/main/kotlin/org/meshtastic/core/prefs/ui/UiPrefs.kt
@@ -30,12 +30,7 @@ import javax.inject.Singleton
 
 interface UiPrefs {
     var hasShownNotPairedWarning: Boolean
-    var nodeSortOption: Int
-    var includeUnknown: Boolean
     var showDetails: Boolean
-    var onlyOnline: Boolean
-    var onlyDirect: Boolean
-    var showIgnored: Boolean
     var showQuickChat: Boolean
 
     fun shouldProvideNodeLocation(nodeNum: Int): StateFlow<Boolean>
@@ -68,12 +63,7 @@ class UiPrefsImpl @Inject constructor(@UiSharedPreferences private val prefs: Sh
     }
 
     override var hasShownNotPairedWarning: Boolean by PrefDelegate(prefs, "has_shown_not_paired_warning", false)
-    override var nodeSortOption: Int by PrefDelegate(prefs, "node-sort-option", -1)
-    override var includeUnknown: Boolean by PrefDelegate(prefs, "include-unknown", false)
     override var showDetails: Boolean by PrefDelegate(prefs, "show-details", false)
-    override var onlyOnline: Boolean by PrefDelegate(prefs, "only-online", false)
-    override var onlyDirect: Boolean by PrefDelegate(prefs, "only-direct", false)
-    override var showIgnored: Boolean by PrefDelegate(prefs, "show-ignored", false)
     override var showQuickChat: Boolean by PrefDelegate(prefs, "show-quick-chat", false)
 
     override fun shouldProvideNodeLocation(nodeNum: Int): StateFlow<Boolean> = provideNodeLocationFlows


### PR DESCRIPTION
We're already manually converting these to `Flow`. DataStore gives us `Flow` by default.