### PR TITLE
chore(analytics): Disable Google services for F-Droid builds

### DIFF
--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -43,6 +43,17 @@ dependencies {
     googleImplementation(libs.bundles.datadog)
 }
 
+val googleServiceKeywords = listOf("crashlytics", "google", "datadog")
+
+tasks.configureEach {
+    if (
+        googleServiceKeywords.any { name.contains(it, ignoreCase = true) } && name.contains("fdroid", ignoreCase = true)
+    ) {
+        project.logger.lifecycle("Disabling task for F-Droid: $name")
+        enabled = false
+    }
+}
+
 android {
     buildFeatures { buildConfig = true }
     namespace = "org.meshtastic.core.analytics"


### PR DESCRIPTION
This commit introduces a mechanism to disable tasks related to Google services (Crashlytics, Google services, Datadog) when building the F-Droid flavor. This is achieved by checking task names for specific keywords and disabling them if they match and the build is for F-Droid.