### PR TITLE
chore(fdroid): Configure F-Droid build variant

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,6 +152,10 @@ android {
             } else {
                 signingConfig = signingConfigs.getByName("debug")
             }
+            productFlavors.getByName("fdroid") {
+                isMinifyEnabled = false
+                isShrinkResources = false
+            }
         }
     }
     bundle { language { enableSplit = false } }
@@ -218,6 +222,21 @@ dependencies {
     implementation(libs.timber)
 
     dokkaPlugin(libs.dokka.android.documentation.plugin)
+}
+
+val googleServiceKeywords = listOf("crashlytics", "google", "datadog")
+tasks.configureEach {
+    if (
+        googleServiceKeywords.any {
+            name.contains(
+                it,
+                ignoreCase = true
+            )
+        } && name.contains("fdroid", ignoreCase = true)
+    ) {
+        project.logger.lifecycle("Disabling task for F-Droid: $name")
+        enabled = false
+    }
 }
 
 dokka {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750
-org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=2g -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
This commit introduces specific configurations for the F-Droid build variant:
- Increases `MaxMetaspaceSize` from 1g to 2g in `gradle.properties`.
- Disables `isMinifyEnabled` and `isShrinkResources` for the `fdroid` product flavor in `app/build.gradle.kts`.
- Adds logic to `app/build.gradle.kts` to disable Gradle tasks containing keywords like "crashlytics", "google", or "datadog" when building for the F-Droid variant.