### PR TITLE
`ConnectionsScreen` available BLE devices

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
@@ -118,7 +118,7 @@ fun ConnectionsScreen(
     val regionUnset = config.lora.region == ConfigProtos.Config.LoRaConfig.RegionCode.UNSET
     val bluetoothRssi by connectionsViewModel.bluetoothRssi.collectAsStateWithLifecycle()
 
-    val bleDevices by scanModel.bleDevicesForUi.collectAsStateWithLifecycle()
+    val bondedBleDevices by scanModel.bleDevicesForUi.collectAsStateWithLifecycle()
     val discoveredTcpDevices by scanModel.discoveredTcpDevicesForUi.collectAsStateWithLifecycle()
     val recentTcpDevices by scanModel.recentTcpDevicesForUi.collectAsStateWithLifecycle()
     val usbDevices by scanModel.usbDevicesForUi.collectAsStateWithLifecycle()
@@ -245,7 +245,7 @@ fun ConnectionsScreen(
                             DeviceType.BLE -> {
                                 BLEDevices(
                                     connectionState = connectionState,
-                                    btDevices = bleDevices,
+                                    bondedDevices = bondedBleDevices,
                                     selectedDevice = selectedDevice,
                                     scanModel = scanModel,
                                     bluetoothEnabled = bluetoothState.enabled,
@@ -280,7 +280,7 @@ fun ConnectionsScreen(
                         val showWarningNotPaired =
                             !connectionState.isConnected() &&
                                 !hasShownNotPairedWarning &&
-                                bleDevices.none { it is DeviceListEntry.Ble && it.bonded }
+                                bondedBleDevices.none { it is DeviceListEntry.Ble && it.bonded }
                         if (showWarningNotPaired) {
                             Text(
                                 text = stringResource(R.string.warning_not_paired),

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
@@ -25,23 +25,18 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Language
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -49,14 +44,12 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.geeksville.mesh.ConfigProtos
@@ -119,6 +112,7 @@ fun ConnectionsScreen(
     val bluetoothRssi by connectionsViewModel.bluetoothRssi.collectAsStateWithLifecycle()
 
     val bondedBleDevices by scanModel.bleDevicesForUi.collectAsStateWithLifecycle()
+    val scannedBleDevices by scanModel.scanResult.observeAsState(emptyMap())
     val discoveredTcpDevices by scanModel.discoveredTcpDevicesForUi.collectAsStateWithLifecycle()
     val recentTcpDevices by scanModel.recentTcpDevicesForUi.collectAsStateWithLifecycle()
     val usbDevices by scanModel.usbDevicesForUi.collectAsStateWithLifecycle()
@@ -150,15 +144,6 @@ fun ConnectionsScreen(
             delay(SCAN_PERIOD)
             scanModel.stopScan()
         }
-    }
-
-    // State for the device scan dialog
-    var showScanDialog by remember { mutableStateOf(false) }
-    val scanResults by scanModel.scanResult.observeAsState(emptyMap())
-
-    // Observe scan results to show the dialog
-    if (scanResults.isNotEmpty()) {
-        showScanDialog = true
     }
 
     LaunchedEffect(connectionState, regionUnset) {
@@ -246,6 +231,10 @@ fun ConnectionsScreen(
                                 BLEDevices(
                                     connectionState = connectionState,
                                     bondedDevices = bondedBleDevices,
+                                    availableDevices =
+                                    scannedBleDevices.values.toList().filterNot { available ->
+                                        bondedBleDevices.any { it.address == available.address }
+                                    },
                                     selectedDevice = selectedDevice,
                                     scanModel = scanModel,
                                     bluetoothEnabled = bluetoothState.enabled,
@@ -291,55 +280,6 @@ fun ConnectionsScreen(
                             Spacer(modifier = Modifier.height(16.dp))
 
                             LaunchedEffect(Unit) { connectionsViewModel.suppressNoPairedWarning() }
-                        }
-                    }
-                }
-
-                // Compose Device Scan Dialog
-                if (showScanDialog) {
-                    Dialog(
-                        onDismissRequest = {
-                            showScanDialog = false
-                            scanModel.clearScanResults()
-                        },
-                    ) {
-                        Surface(shape = MaterialTheme.shapes.medium) {
-                            Column(modifier = Modifier.padding(16.dp)) {
-                                Text(
-                                    text = "Select a Bluetooth device",
-                                    style = MaterialTheme.typography.titleLarge,
-                                    modifier = Modifier.padding(bottom = 16.dp),
-                                )
-                                Column(modifier = Modifier.selectableGroup()) {
-                                    scanResults.values.forEach { device ->
-                                        Row(
-                                            modifier =
-                                            Modifier.fillMaxWidth()
-                                                .selectable(
-                                                    selected = false, // No pre-selection in this dialog
-                                                    onClick = {
-                                                        scanModel.onSelected(device)
-                                                        scanModel.clearScanResults()
-                                                        showScanDialog = false
-                                                    },
-                                                )
-                                                .padding(vertical = 8.dp),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                        ) {
-                                            Text(text = device.name)
-                                        }
-                                    }
-                                }
-                                Spacer(modifier = Modifier.height(16.dp))
-                                TextButton(
-                                    onClick = {
-                                        scanModel.clearScanResults()
-                                        showScanDialog = false
-                                    },
-                                ) {
-                                    Text(stringResource(R.string.cancel))
-                                }
-                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
@@ -69,7 +69,7 @@ import org.meshtastic.core.ui.component.TitledCard
 @Composable
 fun BLEDevices(
     connectionState: ConnectionState,
-    btDevices: List<DeviceListEntry>,
+    bondedDevices: List<DeviceListEntry>,
     selectedDevice: String,
     scanModel: BTScanModel,
     bluetoothEnabled: Boolean,
@@ -153,7 +153,7 @@ fun BLEDevices(
                         }
                     }
 
-                    if (btDevices.isEmpty()) {
+                    if (bondedDevices.isEmpty()) {
                         EmptyStateContent(
                             imageVector = Icons.Rounded.BluetoothDisabled,
                             text =
@@ -166,7 +166,7 @@ fun BLEDevices(
                         )
                     } else {
                         TitledCard(title = stringResource(R.string.bluetooth_paired_devices)) {
-                            btDevices.forEach { device ->
+                            bondedDevices.forEach { device ->
                                 val connected =
                                     connectionState == ConnectionState.CONNECTED && device.fullAddress == selectedDevice
                                 DeviceListItem(

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -821,7 +821,8 @@
     <string name="no_pax_metrics_logs">No PAX metrics logs available.</string>
     <string name="wifi_devices">WiFi Devices</string>
     <string name="ble_devices">BLE Devices</string>
-    <string name="bluetooth_paired_devices">Paired Devices</string>
+    <string name="bluetooth_paired_devices">Paired devices</string>
+    <string name="bluetooth_available_devices">Available devices</string>
     <string name="connected_device">Connected Device</string>
 
     <string name="routing_error_rate_limit_exceeded">Rate Limit Exceeded. Please try again later.</string>


### PR DESCRIPTION
Previously, results of a bluetooth scan were listed in a dialog without filtering out paired devices. This is a bit noisy, especially when the device list in the dialog matches the already displayed "Paired devices" section.

This PR removes the dialog in favor of a "Available devices" section on `ConnectionsScreen`. This section displays the same list of scanned bluetooth devices, but with the bonded devices filtered out.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/c70eb477-1cf6-49dd-aced-a687fd119904"/>|<video src="https://github.com/user-attachments/assets/38c17826-f29e-4460-87f6-6e1e6d09011a"/>|