### PR TITLE
ci(github-actions): add Release environment to workflows

### DIFF
--- a/.github/workflows/create-internal-release.yml
+++ b/.github/workflows/create-internal-release.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   create-internal-tag:
     runs-on: ubuntu-latest
+    environment: Release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    environment: Release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -188,4 +189,3 @@ jobs:
           echo "Target Stage: ${{ steps.decide.outputs.target_stage }}" >> $GITHUB_STEP_SUMMARY
           echo "New Tag: ${{ steps.tag.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "Dry Run: ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
-


### PR DESCRIPTION
Adds the `Release` environment to the `create-internal-release` and `promote-release` GitHub Actions workflows.

This change ensures that these jobs are run within the context of the defined `Release` environment, to restrict it's usage.
