### PR TITLE
ci(workflows): configure git user for release workflows

### DIFF
--- a/.github/workflows/create-internal-release.yml
+++ b/.github/workflows/create-internal-release.yml
@@ -46,6 +46,12 @@ jobs:
           echo "DRY RUN: Would create tag ${{ steps.tag.outputs.internal_tag }} pointing to $(git rev-parse HEAD)"
           git log -5 --oneline
 
+      - name: Configure Git User
+        if: ${{ inputs.dry_run != 'true' }}
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
       - name: Create and Push Tag
         if: ${{ inputs.dry_run != 'true' }}
         run: |

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -171,6 +171,12 @@ jobs:
           echo "Current stage: ${{ steps.current.outputs.current_stage }} -> Target: ${{ steps.decide.outputs.target_stage }}"
           git log -1 --oneline ${{ steps.commit.outputs.commit_sha }}
 
+      - name: Configure Git User
+        if: ${{ inputs.dry_run != 'true' }}
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
       - name: Create & Push Tag
         if: ${{ inputs.dry_run != 'true' }}
         run: |


### PR DESCRIPTION
Configures the git user and email for the `create-internal-release` and `promote-release` workflows before creating and pushing tags. This ensures that the `github-actions[bot]` is correctly attributed as the author of the tags.