### PR TITLE
ci(github-actions): move release environment to correct workflow

### DIFF
--- a/.github/workflows/create-internal-release.yml
+++ b/.github/workflows/create-internal-release.yml
@@ -17,7 +17,6 @@ permissions:
 jobs:
   create-internal-tag:
     runs-on: ubuntu-latest
-    environment: Release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -27,7 +27,6 @@ permissions:
 jobs:
   promote:
     runs-on: ubuntu-latest
-    environment: Release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   prepare-build-info:
     runs-on: ubuntu-latest
+    environment: Release
     outputs:
       APP_VERSION_NAME: ${{ steps.get_version_name.outputs.APP_VERSION_NAME }}
       APP_VERSION_CODE: ${{ steps.calculate_version_code.outputs.versionCode }}


### PR DESCRIPTION
The `Release` environment, which may contain secrets or require specific protection rules, was incorrectly applied to the `create-internal-release` and `promote-release` workflows. It is now correctly applied only to the `release` workflow's `prepare-build-info` job, which requires access to this environment.

The environment has been removed from the `create-internal-tag` job in the `create-internal-release.yml` workflow and the `promote` job in the `promote-release.yml` workflow.