### PR TITLE
ci(release): trigger release workflow from promotion and internal builds

### DIFF
--- a/.github/workflows/create-internal-release.yml
+++ b/.github/workflows/create-internal-release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   create-internal-tag:
@@ -60,9 +61,33 @@ jobs:
           git push origin "$TAG"
           echo "Created and pushed $TAG"
 
+      - name: Trigger Release Workflow for Tag
+        if: ${{ inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG='${{ steps.tag.outputs.internal_tag }}'
+          echo "Dispatching release workflow for $TAG"
+          for i in {1..5}; do
+            if gh api \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              repos/${{ github.repository }}/actions/workflows/release.yml/dispatches \
+              -f ref="$TAG"; then
+              echo "Triggered release workflow for $TAG"
+              break
+            fi
+            echo "Retry $i/5 in 5s..."
+            sleep 5
+          done
+
       - name: Output Summary
         run: |
           echo "### Internal Tag Created" >> $GITHUB_STEP_SUMMARY
           echo "Tag: ${{ steps.tag.outputs.internal_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "Base Version: ${{ inputs.base_version }}" >> $GITHUB_STEP_SUMMARY
           echo "Dry Run: ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.dry_run }}" != "true" ]; then
+            echo "Release workflow dispatched for tag ${{ steps.tag.outputs.internal_tag }}" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   promote:
@@ -186,6 +187,27 @@ jobs:
           git push origin "$TAG"
           echo "Created and pushed $TAG"
 
+      - name: Trigger Release Workflow for Tag
+        if: ${{ inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG='${{ steps.tag.outputs.new_tag }}'
+          echo "Dispatching release workflow for $TAG"
+          for i in {1..5}; do
+            if gh api \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              repos/${{ github.repository }}/actions/workflows/release.yml/dispatches \
+              -f ref="$TAG"; then
+              echo "Triggered release workflow for $TAG"
+              break
+            fi
+            echo "Retry $i/5 in 5s..."
+            sleep 5
+          done
+
       - name: Promotion Summary
         run: |
           echo "### Promotion Tag Created" >> $GITHUB_STEP_SUMMARY
@@ -194,3 +216,6 @@ jobs:
           echo "Target Stage: ${{ steps.decide.outputs.target_stage }}" >> $GITHUB_STEP_SUMMARY
           echo "New Tag: ${{ steps.tag.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "Dry Run: ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.dry_run }}" != "true" ]; then
+            echo "Release workflow dispatched for tag ${{ steps.tag.outputs.new_tag }}" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Extract VERSION_CODE_OFFSET from config.properties
         id: get_version_code_offset
         run: |
-          OFFSET=$(grep '^VERSION_CODE_OFFSET=' config.properties | cut-d'=' -f2)
+          OFFSET=$(grep '^VERSION_CODE_OFFSET=' config.properties | cut -d'=' -f2)
           echo "VERSION_CODE_OFFSET=$OFFSET" >> $GITHUB_OUTPUT
 
       - name: Calculate Version Code from Git Commit Count
@@ -276,29 +276,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine Release Properties for Promotion
-        if: "!contains(github.ref_name, '-internal')"
-        id: release_properties
-        run: |
-          TAG_NAME="${{ github.ref_name }}"
-          if [[ "$TAG_NAME" == *"-closed"* ]]; then
-            echo "draft=false" >> $GITHUB_OUTPUT
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-          elif [[ "$TAG_NAME" == *"-open"* ]]; then
-            echo "draft=false" >> $GITHUB_OUTPUT
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-          else
-            echo "draft=false" >> $GITHUB_OUTPUT
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Promote GitHub Release
         if: "!contains(github.ref_name, '-internal')"
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.prepare-build-info.outputs.BASE_TAG }}
           name: ${{ github.ref_name }}
-          draft: ${{ steps.release_properties.outputs.draft }}
-          prerelease: ${{ steps.release_properties.outputs.prerelease }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-closed') || contains(github.ref_name, '-open') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit modifies the CI/CD workflows to automatically trigger the `release.yml` workflow after a new tag is created by either the `promote-release.yml` or `create-internal-release.yml` workflows. This is achieved by dispatching a `workflow_dispatch` event to the release workflow.

Key changes include:
- Adding the `actions: write` permission to `promote-release.yml` and `create-internal-release.yml` to allow them to trigger other workflows.
- Introducing a new step in both workflows that uses the `gh api` to dispatch the `release.yml` workflow, passing the newly created tag as the `ref`. This step includes a retry mechanism.
- Updating the summary output in both workflows to indicate that the release workflow has been dispatched.

Additionally, a minor fix is included in `release.yml` to correct a shell command syntax error by adding a space in `cut -d'='`. Another fix ensures boolean conversion for `draft` and `prerelease` inputs in the `create-release` step.