### PR TITLE
chore(ci): remove release environment from prepare-build-info job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ permissions:
 jobs:
   prepare-build-info:
     runs-on: ubuntu-latest
-    environment: Release
     outputs:
       APP_VERSION_NAME: ${{ steps.get_version_name.outputs.APP_VERSION_NAME }}
       APP_VERSION_CODE: ${{ steps.calculate_version_code.outputs.versionCode }}


### PR DESCRIPTION
The `prepare-build-info` job in the release workflow does not require any secrets and can run without the "Release" environment context. This change removes the unnecessary environment configuration.