### PR TITLE
ci(release): refactor release workflow to be callable

### DIFF
--- a/.github/workflows/create-or-promote-release.yml
+++ b/.github/workflows/create-or-promote-release.yml
@@ -1,0 +1,67 @@
+name: Create or Promote Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Base version for the release (e.g., 2.3.0)'
+        required: true
+      channel:
+        description: 'The channel to create a release for or promote to'
+        required: true
+        type: choice
+        options:
+          - internal
+          - closed
+          - open
+          - production
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.calculate_new_tag.outputs.new_tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Calculate new release tag
+        id: calculate_new_tag
+        run: |
+          BASE_VERSION="${{ inputs.version }}"
+          CHANNEL="${{ inputs.channel }}"
+
+          if [[ "$CHANNEL" == "production" ]]; then
+            # Production tags are simple, without a channel or increment
+            NEW_TAG="v${BASE_VERSION}"
+          else
+            # Pre-release channels get an incrementing number
+            LATEST_TAG=$(git tag --list "v${BASE_VERSION}-${CHANNEL}.*" --sort=-v:refname | head -n 1)
+            
+            if [ -z "$LATEST_TAG" ]; then
+              INCREMENT=1
+            else
+              INCREMENT=$(echo "$LATEST_TAG" | sed -n "s/.*-${CHANNEL}\.\([0-9]*\)/\1/p" | awk '{print $1+1}')
+            fi
+            
+            NEW_TAG="v${BASE_VERSION}-${CHANNEL}.${INCREMENT}"
+          fi
+          
+          echo "Calculated new tag: $NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Create and push new tag
+        run: |
+          git tag ${{ steps.calculate_new_tag.outputs.new_tag }}
+          git push origin ${{ steps.calculate_new_tag.outputs.new_tag }}
+  
+  call-release-workflow:
+    needs: create-tag
+    uses: ./.github/workflows/release.yml@main
+    with:
+      tag_name: ${{ needs.create-tag.outputs.new_tag }}
+      release_type: ${{ inputs.channel == 'internal' && 'internal' || 'promotion' }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,38 @@
 name: Make Release
 
 on:
-  workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag_name:
+        description: 'The tag that triggered the release'
+        required: true
+        type: string
+      release_type:
+        description: 'Type of release (internal or promotion)'
+        required: true
+        type: string
+    secrets:
+      GSERVICES:
+        required: true
+      KEYSTORE:
+        required: true
+      KEYSTORE_FILENAME:
+        required: true
+      KEYSTORE_PROPERTIES:
+        required: true
+      DATADOG_APPLICATION_ID:
+        required: true
+      DATADOG_CLIENT_TOKEN:
+        required: true
+      GOOGLE_MAPS_API_KEY:
+        required: true
+      GOOGLE_PLAY_JSON_KEY:
+        required: true
+      GRADLE_ENCRYPTION_KEY:
+        required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.tag_name }}
   cancel-in-progress: true
 
 permissions:
@@ -26,6 +51,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
+          ref: ${{ inputs.tag_name }}
           fetch-depth: 0
           submodules: 'recursive'
       - name: Set up JDK 21
@@ -43,7 +69,7 @@ jobs:
 
       - name: Determine Version Name from Tag
         id: get_version_name
-        run: echo "APP_VERSION_NAME=$(echo ${GITHUB_REF_NAME#v} | sed 's/-.*//')" >> $GITHUB_OUTPUT
+        run: echo "APP_VERSION_NAME=$(echo ${{ inputs.tag_name }} | sed 's/-.*//' | sed 's/v//')" >> $GITHUB_OUTPUT
 
       - name: Extract VERSION_CODE_OFFSET from config.properties
         id: get_version_code_offset
@@ -59,7 +85,6 @@ jobs:
           VERSION_CODE=$((COMMIT_COUNT + OFFSET))
           echo "versionCode=$VERSION_CODE" >> $GITHUB_OUTPUT
         shell: bash
-        # This matches the reproducible versionCode strategy: versionCode = git commit count + offset
 
   release-google:
     runs-on: ubuntu-latest
@@ -68,6 +93,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
+          ref: ${{ inputs.tag_name }}
           fetch-depth: 0
           submodules: 'recursive'
       - name: Set up JDK 21
@@ -76,7 +102,6 @@ jobs:
           java-version: '21'
           distribution: 'jetbrains'
       - name: Setup Gradle
-        if: contains(github.ref_name, '-internal')
         uses: gradle/actions/setup-gradle@v5
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -95,7 +120,7 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
         run: |
-          rm -f ./app/google-services.json # Ensure clean state
+          rm -f ./app/google-services.json
           echo $GSERVICES > ./app/google-services.json
           echo $KEYSTORE | base64 -di > ./app/$KEYSTORE_FILENAME
           echo "$KEYSTORE_PROPERTIES" > ./keystore.properties
@@ -113,12 +138,11 @@ jobs:
       - name: Determine Fastlane Lane
         id: fastlane_lane
         run: |
-          TAG_NAME="${{ github.ref_name }}"
-          if [[ "$TAG_NAME" == *"-internal"* ]]; then
+          if [[ "${{ inputs.tag_name }}" == *"-internal"* ]]; then
             echo "lane=internal" >> $GITHUB_OUTPUT
-          elif [[ "$TAG_NAME" == *"-closed"* ]]; then
+          elif [[ "${{ inputs.tag_name }}" == *"-closed"* ]]; then
             echo "lane=closed" >> $GITHUB_OUTPUT
-          elif [[ "$TAG_NAME" == *"-open"* ]]; then
+          elif [[ "${{ inputs.tag_name }}" == *"-open"* ]]; then
             echo "lane=open" >> $GITHUB_OUTPUT
           else
             echo "lane=production" >> $GITHUB_OUTPUT
@@ -131,7 +155,6 @@ jobs:
         run: bundle exec fastlane ${{ steps.fastlane_lane.outputs.lane }}
 
       - name: Upload Google AAB artifact
-        if: contains(github.ref_name, '-internal')
         uses: actions/upload-artifact@v4
         with:
           name: google-aab
@@ -139,7 +162,6 @@ jobs:
           retention-days: 1
 
       - name: Upload Google APK artifact
-        if: contains(github.ref_name, '-internal')
         uses: actions/upload-artifact@v4
         with:
           name: google-apk
@@ -147,7 +169,6 @@ jobs:
           retention-days: 1
 
       - name: Attest Google artifacts provenance
-        if: contains(github.ref_name, '-internal')
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: |
@@ -155,13 +176,13 @@ jobs:
             app/build/outputs/apk/google/release/app-google-release.apk
 
   release-fdroid:
-    if: contains(github.ref_name, '-internal')
     runs-on: ubuntu-latest
     needs: prepare-build-info
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
+          ref: ${{ inputs.tag_name }}
           fetch-depth: 0
           submodules: 'recursive'
       - name: Set up JDK 21
@@ -210,41 +231,25 @@ jobs:
         with:
           subject-path: app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
 
-  create-internal-release:
+  github-release:
     runs-on: ubuntu-latest
     needs: [prepare-build-info, release-google, release-fdroid]
-    if: contains(github.ref_name, '-internal')
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v5
         with:
           path: ./artifacts
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }}
-          name: ${{ github.ref_name }}
-          generate_release_notes: true
-          files: ./artifacts/*/*
-          draft: true
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  promote-release:
-    runs-on: ubuntu-latest
-    needs: [prepare-build-info, release-google]
-    if: "!contains(github.ref_name, '-internal')"
-    steps:
       - name: Determine Release Properties
         id: release_properties
         run: |
-          TAG_NAME="${{ github.ref_name }}"
-          if [[ "$TAG_NAME" == *"-closed"* ]]; then
+          if [[ "${{ inputs.release_type }}" == "internal" ]]; then
+            echo "draft=true" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.tag_name }}" == *"-closed"* ]]; then
             echo "draft=false" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT
-          elif [[ "$TAG_NAME" == *"-open"* ]]; then
+          elif [[ "${{ inputs.tag_name }}" == *"-open"* ]]; then
             echo "draft=false" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT
           else
@@ -252,12 +257,12 @@ jobs:
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Update GitHub Release
+      - name: Create or Update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }}
-          name: ${{ github.ref_name }}
+          tag_name: ${{ inputs.tag_name }}
+          name: ${{ inputs.tag_name }}
+          generate_release_notes: true
+          files: ./artifacts/*/*
           draft: ${{ steps.release_properties.outputs.draft }}
           prerelease: ${{ steps.release_properties.outputs.prerelease }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit refactors the release process to improve automation and simplify manual steps.

The main `release.yml` workflow is converted into a reusable, callable workflow. This workflow now takes `tag_name` and `release_type` as inputs, removing its dependency on direct tag pushes. It now handles building, signing, and deploying for all release channels consistently.

A new `create-or-promote-release.yml` workflow is introduced. This user-facing workflow is triggered manually via `workflow_dispatch` and orchestrates the entire release process. It takes a base version and a target channel (internal, closed, open, production) as input, automatically calculates and pushes the correct semantic tag, and then calls the reusable `release.yml` workflow.

The release documentation in `RELEASE_PROCESS.md` has been updated to reflect this new, simplified, and fully automated process.