### PR TITLE
ci(release): include version code in GitHub release name

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -84,7 +84,7 @@ jobs:
     needs: [ prepare-build-info ]
     steps:
       - name: Promote to next channel
-        uses: kevin-david/promote-play-release@v1
+        uses: kevin-david/promote-play-release@v1.2.0
         with:
           service-account-json-raw: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
           package-name: 'com.geeksville.mesh'
@@ -99,7 +99,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.base_version }}
-          name: ${{ inputs.tag_name }}
+          name: ${{ inputs.tag_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})
           generate_release_notes: true
           draft: false
           prerelease: ${{ inputs.channel != 'production' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.base_version }}
-          name: ${{ inputs.tag_name }}
+          name: ${{ inputs.tag_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})
           generate_release_notes: true
           files: ./artifacts/*/*
           draft: true


### PR DESCRIPTION
The GitHub release name for both draft releases and promotions will now include the application version code in parentheses, following the tag name.

This provides more immediate context about the specific build directly in the release title. The `promote-play-release` action version is also updated.