### PR TITLE
refactor(build-logic): Apply kotlinx-serialization plugin for compose

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/geeksville/mesh/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/com/geeksville/mesh/buildlogic/AndroidCompose.kt
@@ -1,17 +1,18 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright (c) 2025 Meshtastic LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package com.geeksville.mesh.buildlogic
@@ -33,6 +34,9 @@ internal fun Project.configureAndroidCompose(
         buildFeatures {
             compose = true
         }
+
+        //needed for navigation3
+        pluginManager.apply(libs.findPlugin("meshtastic-kotlinx-serialization").get().get().pluginId)
 
         dependencies {
             val bom = libs.findLibrary("androidx-compose-bom").get()


### PR DESCRIPTION
Applies the `meshtastic-kotlinx-serialization` plugin within the `AndroidCompose` convention plugin. This is required for navigation3 functionality. The copyright header was also updated to the project standard.