### PR TITLE
Slight tweak to text style on settings detail items for visual clarity

### DIFF
--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SettingsItem.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SettingsItem.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -121,7 +122,10 @@ fun SettingsItemDetail(
             leading = { icon.Icon(iconTint) },
             text = text,
             textColor = textColor,
-            trailing = { trailingText?.let { Text(text = it) } },
+            trailing = { trailingText?.let { Text(
+                text = it,
+                style = MaterialTheme.typography.titleMedium
+            ) } },
         )
     }
 

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SettingsItem.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SettingsItem.kt
@@ -122,10 +122,7 @@ fun SettingsItemDetail(
             leading = { icon.Icon(iconTint) },
             text = text,
             textColor = textColor,
-            trailing = { trailingText?.let { Text(
-                text = it,
-                style = MaterialTheme.typography.titleMedium
-            ) } },
+            trailing = { trailingText?.let { Text(text = it, style = MaterialTheme.typography.titleMedium) } },
         )
     }
 


### PR DESCRIPTION
This is just a slight visual tweak to the style on the node details text on the Node Detail view to make the important data visually stand out more than it currently does.

This class is also reused for the app version string on the Settings view, but it achieves the same effect in that instance as well.
| Before | After |
|------|-----|
|<img width="300" alt="Screenshot_20251005_155401" src="https://github.com/user-attachments/assets/ad172810-00af-4d5f-b614-deb2891e7f64" />|<img width="300" alt="Screenshot_20251005_155436" src="https://github.com/user-attachments/assets/6982634a-74ef-4825-99c9-176652c28c42" />|

