### PR TITLE
refactor: Switch to `compileOnly` for convention plugins

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -39,22 +39,21 @@ kotlin {
 }
 
 dependencies {
-    implementation(libs.android.gradleApiPlugin)
-    implementation(libs.serialization.gradlePlugin)
-    implementation(libs.android.tools.common)
-    implementation(libs.compose.gradlePlugin)
-    implementation(libs.datadog.gradlePlugin)
-    implementation(libs.detekt.gradlePlugin)
-    implementation(libs.firebase.crashlytics.gradlePlugin)
-    implementation(libs.firebase.performance.gradlePlugin)
-    implementation(libs.google.services.gradlePlugin)
-    implementation(libs.hilt.gradlePlugin)
-    implementation(libs.kotlin.gradlePlugin)
-    implementation(libs.ksp.gradlePlugin)
-    implementation(libs.room.gradlePlugin)
-    implementation(libs.secrets.gradlePlugin)
-    implementation(libs.spotless.gradlePlugin)
-    implementation(libs.truth)
+    compileOnly(libs.android.gradleApiPlugin)
+    compileOnly(libs.serialization.gradlePlugin)
+    compileOnly(libs.android.tools.common)
+    compileOnly(libs.compose.gradlePlugin)
+    compileOnly(libs.datadog.gradlePlugin)
+    compileOnly(libs.detekt.gradlePlugin)
+    compileOnly(libs.firebase.crashlytics.gradlePlugin)
+    compileOnly(libs.google.services.gradlePlugin)
+    compileOnly(libs.hilt.gradlePlugin)
+    compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.ksp.gradlePlugin)
+    compileOnly(libs.room.gradlePlugin)
+    compileOnly(libs.secrets.gradlePlugin)
+    compileOnly(libs.spotless.gradlePlugin)
+    compileOnly(libs.truth)
 }
 
 tasks {

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationFirebaseConventionPlugin.kt
@@ -28,7 +28,6 @@ class AndroidApplicationFirebaseConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply(plugin = libs.findPlugin("firebase-crashlytics").get().get().pluginId)
-            apply(plugin = libs.findPlugin("firebase-perf").get().get().pluginId)
             apply(plugin = libs.findPlugin("google-services").get().get().pluginId)
             extensions.configure<ApplicationExtension> {
                 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,14 +20,25 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.compose) apply false
+    alias(libs.plugins.datadog) apply false
     alias(libs.plugins.devtools.ksp) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
+    alias(libs.plugins.firebase.perf) apply false
+    alias(libs.plugins.google.services) apply false
     alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.room) apply false
+    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ktorfit) apply false
     alias(libs.plugins.protobuf) apply false
+    alias(libs.plugins.secrets) apply false
     alias(libs.plugins.dependency.analysis)
+    alias(libs.plugins.detekt) apply false
     alias(libs.plugins.kover)
+    alias(libs.plugins.spotless) apply false
 }
 
 

--- a/core/analytics/src/google/kotlin/org/meshtastic/core/analytics/platform/GooglePlatformAnalytics.kt
+++ b/core/analytics/src/google/kotlin/org/meshtastic/core/analytics/platform/GooglePlatformAnalytics.kt
@@ -54,7 +54,6 @@ import com.google.firebase.analytics.analytics
 import com.google.firebase.crashlytics.crashlytics
 import com.google.firebase.crashlytics.setCustomKeys
 import com.google.firebase.initialize
-import com.google.firebase.perf.performance
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.opentelemetry.api.GlobalOpenTelemetry
 import kotlinx.coroutines.flow.launchIn
@@ -63,6 +62,8 @@ import org.meshtastic.core.analytics.BuildConfig
 import org.meshtastic.core.analytics.DataPair
 import org.meshtastic.core.prefs.analytics.AnalyticsPrefs
 import timber.log.Timber
+import timber.log.Timber.DebugTree
+import timber.log.Timber.Tree
 import javax.inject.Inject
 
 /**
@@ -101,7 +102,7 @@ constructor(
                 .setBundleWithTraceEnabled(true)
                 .setBundleWithRumEnabled(true)
                 .build()
-        Timber.plant(DatadogTree(datadogLogger), CrashlyticsTree())
+        Timber.plant(DatadogTree(datadogLogger), CrashlyticsTree(), DebugTree())
         // Initial consent state
         updateAnalyticsConsent(analyticsPrefs.analyticsAllowed)
 
@@ -176,7 +177,6 @@ constructor(
         Datadog.setTrackingConsent(if (allowed) TrackingConsent.GRANTED else TrackingConsent.NOT_GRANTED)
         Firebase.crashlytics.isCrashlyticsCollectionEnabled = allowed
         Firebase.analytics.setAnalyticsCollectionEnabled(allowed)
-        Firebase.performance.isPerformanceCollectionEnabled = allowed
 
         if (allowed) {
             Firebase.crashlytics.sendUnsentReports()
@@ -213,7 +213,7 @@ constructor(
     override val isPlatformServicesAvailable: Boolean
         get() = isGooglePlayAvailable && isDatadogAvailable
 
-    private class CrashlyticsTree : Timber.Tree() {
+    private class CrashlyticsTree : Tree() {
         companion object {
             private const val KEY_PRIORITY = "priority"
             private const val KEY_TAG = "tag"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -195,7 +195,7 @@ coroutines = ["kotlinx-coroutines-android", "kotlinx-coroutines-guava"]
 hilt = ["hilt-android", "hilt-navigation-compose"]
 
 # Google
-firebase = ["firebase-analytics", "firebase-crashlytics", "firebase-performance"]
+firebase = ["firebase-analytics", "firebase-crashlytics"]
 maps-compose = ["location-services", "maps-compose", "maps-compose-utils", "maps-compose-widgets"]
 
 # Networking


### PR DESCRIPTION
Switches `build-logic` dependencies from `implementation` to `compileOnly` for faster builds, as these plugins are not needed at runtime. This change required explicitly declaring the plugins in the root `build.gradle.kts`.

Additionally, Firebase Performance monitoring has been removed from the project. This includes removing the plugin, library dependencies, and the related collection logic. A `DebugTree` for Timber has been added in its place for local debugging.
