### PR TITLE
feat: Always Display voltage

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedInfo.kt
@@ -62,7 +62,7 @@ fun CurrentlyConnectedInfo(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            MaterialBatteryInfo(level = node.batteryLevel)
+            MaterialBatteryInfo(level = node.batteryLevel, voltage = node.voltage)
             if (bluetoothRssi != null) {
                 MaterialBluetoothSignalInfo(rssi = bluetoothRssi)
             }

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/MaterialBatteryInfo.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/MaterialBatteryInfo.kt
@@ -68,7 +68,9 @@ fun MaterialBatteryInfo(modifier: Modifier = Modifier, level: Int?, voltage: Flo
             )
         } else if (level > 100) {
             Icon(
-                modifier = Modifier.size(SIZE_ICON.dp).rotate(90f),
+                modifier = Modifier
+                    .size(SIZE_ICON.dp)
+                    .rotate(90f),
                 imageVector = Icons.Rounded.Power,
                 tint = MaterialTheme.colorScheme.onSurface,
                 contentDescription = levelString,
@@ -90,23 +92,25 @@ fun MaterialBatteryInfo(modifier: Modifier = Modifier, level: Int?, voltage: Flo
 
             Icon(
                 modifier =
-                Modifier.size(SIZE_ICON.dp).drawBehind {
-                    val insetVertical = size.height * .28f
-                    val insetLeft = size.width * .11f
-                    val insetRight = size.width * .22f
+                    Modifier
+                        .size(SIZE_ICON.dp)
+                        .drawBehind {
+                            val insetVertical = size.height * .28f
+                            val insetLeft = size.width * .11f
+                            val insetRight = size.width * .22f
 
-                    val availableWidth = size.width - (insetLeft + insetRight)
-                    val availableHeight = size.height - (insetVertical * 2)
+                            val availableWidth = size.width - (insetLeft + insetRight)
+                            val availableHeight = size.height - (insetVertical * 2)
 
-                    // Fill (grow from left to right)
-                    val fillWidth = availableWidth * (level / 100f)
+                            // Fill (grow from left to right)
+                            val fillWidth = availableWidth * (level / 100f)
 
-                    drawRect(
-                        color = fillColor,
-                        topLeft = Offset(insetLeft, insetVertical),
-                        size = Size(fillWidth, availableHeight),
-                    )
-                },
+                            drawRect(
+                                color = fillColor,
+                                topLeft = Offset(insetLeft, insetVertical),
+                                size = Size(fillWidth, availableHeight),
+                            )
+                        },
                 imageVector = MeshtasticIcons.BatteryEmpty,
                 tint = MaterialTheme.colorScheme.onSurface,
                 contentDescription = levelString,
@@ -117,13 +121,13 @@ fun MaterialBatteryInfo(modifier: Modifier = Modifier, level: Int?, voltage: Flo
                 color = MaterialTheme.colorScheme.onSurface,
                 style = MaterialTheme.typography.labelMedium,
             )
-            voltage?.let {
-                Text(
-                    text = "%.2fV".format(it),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    style = MaterialTheme.typography.labelMedium,
-                )
-            }
+        }
+        voltage?.takeIf { it > 0 }?.let {
+            Text(
+                text = "%.2fV".format(it),
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.labelMedium,
+            )
         }
     }
 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
@@ -78,7 +78,9 @@ fun NodeItem(
     val isThisNode = remember(thatNode) { thisNode?.num == thatNode.num }
     val system = remember(distanceUnits) { DisplayConfig.DisplayUnits.forNumber(distanceUnits) }
     val distance =
-        remember(thisNode, thatNode) { thisNode?.distance(thatNode)?.takeIf { it > 0 }?.toDistanceString(system) }
+        remember(thisNode, thatNode) {
+            thisNode?.distance(thatNode)?.takeIf { it > 0 }?.toDistanceString(system)
+        }
 
     var contentColor = MaterialTheme.colorScheme.onSurface
     val cardColors =
@@ -90,7 +92,8 @@ fun NodeItem(
             ?.let {
                 val containerColor = Color(it).copy(alpha = 0.2f)
                 contentColor = contentColorFor(containerColor)
-                CardDefaults.cardColors().copy(containerColor = containerColor, contentColor = contentColor)
+                CardDefaults.cardColors()
+                    .copy(containerColor = containerColor, contentColor = contentColor)
             } ?: (CardDefaults.cardColors())
 
     val style =
@@ -108,12 +111,23 @@ fun NodeItem(
             }
         }
 
-    Card(modifier = modifier.fillMaxWidth().defaultMinSize(minHeight = 80.dp), colors = cardColors) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 80.dp),
+        colors = cardColors
+    ) {
         Column(
             modifier =
-            Modifier.combinedClickable(onClick = onClick, onLongClick = onLongClick).fillMaxWidth().padding(8.dp),
+                Modifier
+                    .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+                    .fillMaxWidth()
+                    .padding(8.dp),
         ) {
-            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 NodeChip(node = thatNode)
 
                 NodeKeyStatusIcon(
@@ -126,9 +140,9 @@ fun NodeItem(
                     modifier = Modifier.weight(1f),
                     text = longName,
                     style =
-                    MaterialTheme.typography.titleMediumEmphasized.copy(
-                        color = MaterialTheme.colorScheme.onSurface,
-                    ),
+                        MaterialTheme.typography.titleMediumEmphasized.copy(
+                            color = MaterialTheme.colorScheme.onSurface,
+                        ),
                     textDecoration = TextDecoration.LineThrough.takeIf { isIgnored },
                     softWrap = true,
                 )
@@ -181,7 +195,10 @@ fun NodeItem(
 
             if (telemetryStrings.isNotEmpty()) {
                 Spacer(modifier = Modifier.height(2.dp))
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
                     telemetryStrings.forEach { telemetryString ->
                         Text(
                             text = telemetryString,
@@ -220,7 +237,13 @@ fun NodeInfoSimplePreview() {
     AppTheme {
         val thisNode = NodePreviewParameterProvider().values.first()
         val thatNode = NodePreviewParameterProvider().values.last()
-        NodeItem(thisNode = thisNode, thatNode = thatNode, 0, true, currentTimeMillis = System.currentTimeMillis())
+        NodeItem(
+            thisNode = thisNode,
+            thatNode = thatNode,
+            0,
+            true,
+            currentTimeMillis = System.currentTimeMillis()
+        )
     }
 }
 


### PR DESCRIPTION
Adds the voltage next to the battery level indicator on the connection screen and in the node list. The voltage is only shown when a valid > 0 value is available.
<img width="1344" height="425" alt="image" src="https://github.com/user-attachments/assets/a87a8511-b71c-4ff9-b597-9058562c7b1e" />
