### PR TITLE
feat: Add contentColor parameter to info components

### DIFF
--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicator.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicator.kt
@@ -109,7 +109,7 @@ fun SnrAndRssi(snr: Float, rssi: Int) {
 
 /** Displays a human readable description and icon representing the signal quality. */
 @Composable
-fun LoraSignalIndicator(snr: Float, rssi: Int) {
+fun LoraSignalIndicator(snr: Float, rssi: Int, contentColor: Color = MaterialTheme.colorScheme.onSurface) {
     val quality = determineSignalQuality(snr, rssi)
     Column(
         verticalArrangement = Arrangement.Center,
@@ -125,6 +125,7 @@ fun LoraSignalIndicator(snr: Float, rssi: Int) {
         Text(
             text = "${stringResource(R.string.signal)} ${stringResource(quality.nameRes)}",
             style = MaterialTheme.typography.labelSmall,
+            color = contentColor,
         )
     }
 }

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/MaterialBatteryInfo.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/MaterialBatteryInfo.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -51,7 +52,12 @@ private const val SIZE_ICON = 20
 
 @Suppress("MagicNumber", "LongMethod")
 @Composable
-fun MaterialBatteryInfo(modifier: Modifier = Modifier, level: Int?, voltage: Float? = null) {
+fun MaterialBatteryInfo(
+    modifier: Modifier = Modifier,
+    level: Int?,
+    voltage: Float? = null,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
     val levelString = FORMAT.format(level)
 
     Row(
@@ -63,22 +69,18 @@ fun MaterialBatteryInfo(modifier: Modifier = Modifier, level: Int?, voltage: Flo
             Icon(
                 modifier = Modifier.size(SIZE_ICON.dp),
                 imageVector = MeshtasticIcons.BatteryUnknown,
-                tint = MaterialTheme.colorScheme.onSurface,
+                tint = contentColor,
                 contentDescription = stringResource(R.string.unknown),
             )
         } else if (level > 100) {
             Icon(
                 modifier = Modifier.size(SIZE_ICON.dp).rotate(90f),
                 imageVector = Icons.Rounded.Power,
-                tint = MaterialTheme.colorScheme.onSurface,
+                tint = contentColor,
                 contentDescription = levelString,
             )
 
-            Text(
-                text = "PWD",
-                color = MaterialTheme.colorScheme.onSurface,
-                style = MaterialTheme.typography.labelMedium,
-            )
+            Text(text = "PWD", color = contentColor, style = MaterialTheme.typography.labelMedium)
         } else {
             // Map battery percentage to color
             val fillColor =
@@ -108,24 +110,16 @@ fun MaterialBatteryInfo(modifier: Modifier = Modifier, level: Int?, voltage: Flo
                     )
                 },
                 imageVector = MeshtasticIcons.BatteryEmpty,
-                tint = MaterialTheme.colorScheme.onSurface,
+                tint = contentColor,
                 contentDescription = levelString,
             )
 
-            Text(
-                text = levelString,
-                color = MaterialTheme.colorScheme.onSurface,
-                style = MaterialTheme.typography.labelMedium,
-            )
+            Text(text = levelString, color = contentColor, style = MaterialTheme.typography.labelMedium)
         }
         voltage
             ?.takeIf { it > 0 }
             ?.let {
-                Text(
-                    text = "%.2fV".format(it),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    style = MaterialTheme.typography.labelMedium,
-                )
+                Text(text = "%.2fV".format(it), color = contentColor, style = MaterialTheme.typography.labelMedium)
             }
     }
 }

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SignalInfo.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SignalInfo.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -42,7 +43,12 @@ const val MAX_VALID_RSSI = 0
 
 @Suppress("LongMethod")
 @Composable
-fun SignalInfo(modifier: Modifier = Modifier, node: Node, isThisNode: Boolean) {
+fun SignalInfo(
+    modifier: Modifier = Modifier,
+    node: Node,
+    isThisNode: Boolean,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
     val text =
         if (isThisNode) {
             stringResource(R.string.channel_air_util)
@@ -72,7 +78,7 @@ fun SignalInfo(modifier: Modifier = Modifier, node: Node, isThisNode: Boolean) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (text.isNotEmpty()) {
-            Text(text = text, color = MaterialTheme.colorScheme.onSurface, style = MaterialTheme.typography.labelSmall)
+            Text(text = text, color = contentColor, style = MaterialTheme.typography.labelSmall)
         }
         /* We only know the Signal Quality from direct nodes aka 0 hop. */
         if (node.hopsAway <= 0) {
@@ -98,7 +104,7 @@ fun SignalInfo(modifier: Modifier = Modifier, node: Node, isThisNode: Boolean) {
                     Text(
                         text = "${stringResource(R.string.signal)} ${stringResource(quality.nameRes)}",
                         style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = contentColor,
                         maxLines = 1,
                     )
                 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/DistanceInfo.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/DistanceInfo.kt
@@ -19,20 +19,27 @@ package org.meshtastic.feature.node.component
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.SocialDistance
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import org.meshtastic.core.strings.R
 import org.meshtastic.core.ui.theme.AppTheme
 
 @Composable
-fun DistanceInfo(distance: String, modifier: Modifier = Modifier) {
+fun DistanceInfo(
+    distance: String,
+    modifier: Modifier = Modifier,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
     IconInfo(
         modifier = modifier,
         icon = Icons.Rounded.SocialDistance,
         contentDescription = stringResource(R.string.distance),
         text = distance,
+        contentColor = contentColor,
     )
 }
 

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/ElevationInfo.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/ElevationInfo.kt
@@ -20,6 +20,7 @@ package org.meshtastic.feature.node.component
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.geeksville.mesh.ConfigProtos.Config.DisplayConfig.DisplayUnits
@@ -35,12 +36,14 @@ fun ElevationInfo(
     altitude: Int,
     system: DisplayUnits,
     suffix: String = stringResource(R.string.elevation_suffix),
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
 ) {
     IconInfo(
         modifier = modifier,
         icon = MeshtasticIcons.Elevation,
         contentDescription = stringResource(R.string.altitude),
         text = altitude.metersIn(system).toString(system) + " " + suffix,
+        contentColor = contentColor,
     )
 }
 

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/IconInfo.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/IconInfo.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -40,6 +41,7 @@ fun IconInfo(
     contentDescription: String,
     modifier: Modifier = Modifier,
     text: String? = null,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
     content: @Composable () -> Unit = {},
 ) {
     Row(
@@ -51,11 +53,9 @@ fun IconInfo(
             modifier = Modifier.size(SIZE_ICON.dp),
             imageVector = icon,
             contentDescription = contentDescription,
-            tint = MaterialTheme.colorScheme.onSurface,
+            tint = contentColor,
         )
-        text?.let {
-            Text(text = it, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurface)
-        }
+        text?.let { Text(text = it, style = MaterialTheme.typography.labelMedium, color = contentColor) }
         content()
     }
 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/LastHeardInfo.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/LastHeardInfo.kt
@@ -17,8 +17,10 @@
 
 package org.meshtastic.feature.node.component
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -28,12 +30,18 @@ import org.meshtastic.core.ui.R
 import org.meshtastic.core.ui.theme.AppTheme
 
 @Composable
-fun LastHeardInfo(modifier: Modifier = Modifier, lastHeard: Int, currentTimeMillis: Long) {
+fun LastHeardInfo(
+    modifier: Modifier = Modifier,
+    lastHeard: Int,
+    currentTimeMillis: Long,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
     IconInfo(
         modifier = modifier,
         icon = ImageVector.vectorResource(id = R.drawable.ic_antenna_24),
         contentDescription = stringResource(org.meshtastic.core.strings.R.string.node_sort_last_heard),
         text = formatAgo(lastHeard, currentTimeMillis),
+        contentColor = contentColor,
     )
 }
 

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
@@ -95,9 +94,9 @@ fun NodeItem(
 
     val style =
         if (thatNode.isUnknownUser) {
-            LocalTextStyle.current.copy(fontStyle = FontStyle.Italic)
+            FontStyle.Italic
         } else {
-            LocalTextStyle.current
+            FontStyle.Normal
         }
 
     val unmessageable =
@@ -125,14 +124,15 @@ fun NodeItem(
                 Text(
                     modifier = Modifier.weight(1f),
                     text = longName,
-                    style =
-                    MaterialTheme.typography.titleMediumEmphasized.copy(
-                        color = MaterialTheme.colorScheme.onSurface,
-                    ),
+                    style = MaterialTheme.typography.titleMediumEmphasized.copy(fontStyle = style),
                     textDecoration = TextDecoration.LineThrough.takeIf { isIgnored },
                     softWrap = true,
                 )
-                LastHeardInfo(lastHeard = thatNode.lastHeard, currentTimeMillis = currentTimeMillis)
+                LastHeardInfo(
+                    lastHeard = thatNode.lastHeard,
+                    currentTimeMillis = currentTimeMillis,
+                    contentColor = contentColor,
+                )
                 NodeStatusIcons(
                     isThisNode = isThisNode,
                     isFavorite = isFavorite,
@@ -148,23 +148,28 @@ fun NodeItem(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                MaterialBatteryInfo(level = thatNode.batteryLevel, voltage = thatNode.voltage)
+                MaterialBatteryInfo(
+                    level = thatNode.batteryLevel,
+                    voltage = thatNode.voltage,
+                    contentColor = contentColor,
+                )
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     if (distance != null) {
-                        DistanceInfo(distance = distance)
+                        DistanceInfo(distance = distance, contentColor = contentColor)
                     }
                     thatNode.validPosition?.let { position ->
                         ElevationInfo(
                             altitude = position.altitude,
                             system = system,
                             suffix = stringResource(id = R.string.elevation_suffix),
+                            contentColor = contentColor,
                         )
                         val satCount = position.satsInView
                         if (satCount > 0) {
-                            SatelliteCountInfo(satCount = satCount)
+                            SatelliteCountInfo(satCount = satCount, contentColor = contentColor)
                         }
                     }
                 }
@@ -175,7 +180,7 @@ fun NodeItem(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 itemVerticalAlignment = Alignment.CenterVertically,
             ) {
-                SignalInfo(node = thatNode, isThisNode = isThisNode)
+                SignalInfo(node = thatNode, isThisNode = isThisNode, contentColor = contentColor)
             }
             val telemetryStrings = thatNode.getTelemetryStrings(tempInFahrenheit)
 
@@ -183,11 +188,7 @@ fun NodeItem(
                 Spacer(modifier = Modifier.height(2.dp))
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                     telemetryStrings.forEach { telemetryString ->
-                        Text(
-                            text = telemetryString,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            style = MaterialTheme.typography.bodySmall,
-                        )
+                        Text(text = telemetryString, style = MaterialTheme.typography.bodySmall, color = contentColor)
                     }
                 }
             }
@@ -199,12 +200,9 @@ fun NodeItem(
             ) {
                 val labelStyle =
                     if (thatNode.isUnknownUser) {
-                        MaterialTheme.typography.labelSmall.copy(
-                            fontStyle = FontStyle.Italic,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
+                        MaterialTheme.typography.labelSmall.copy(fontStyle = FontStyle.Italic)
                     } else {
-                        MaterialTheme.typography.labelSmall.copy(color = MaterialTheme.colorScheme.onSurface)
+                        MaterialTheme.typography.labelSmall
                     }
                 Text(text = thatNode.user.hwModel.name, style = labelStyle)
                 Text(text = thatNode.user.role.name, style = labelStyle)

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/SatelliteCountInfo.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/SatelliteCountInfo.kt
@@ -19,19 +19,26 @@ package org.meshtastic.feature.node.component
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.SatelliteAlt
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import org.meshtastic.core.ui.theme.AppTheme
 
 @Composable
-fun SatelliteCountInfo(modifier: Modifier = Modifier, satCount: Int) {
+fun SatelliteCountInfo(
+    modifier: Modifier = Modifier,
+    satCount: Int,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
     IconInfo(
         modifier = modifier,
         icon = Icons.TwoTone.SatelliteAlt,
         contentDescription = stringResource(org.meshtastic.core.strings.R.string.sats),
         text = "$satCount",
+        contentColor = contentColor,
     )
 }
 


### PR DESCRIPTION
This commit introduces a `contentColor` parameter to various info-related composable functions to allow for more flexible color theming.

The following components have been updated to accept and utilize the new `contentColor` parameter:

- `IconInfo`
- `MaterialBatteryInfo`
- `SignalInfo`
- `LoraSignalIndicator`
- `DistanceInfo`
- `ElevationInfo`
- `LastHeardInfo`
- `SatelliteCountInfo`

The `NodeItem` composable has also been updated to pass the appropriate `contentColor` to these components, ensuring a consistent look and feel.