### PR TITLE
ci: Use `tag_name` input in release and promote workflows

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.base_version }}
+          tag_name: ${{ inputs.tag_name }}
           name: ${{ inputs.tag_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})
           generate_release_notes: true
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Create or Update GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.base_version }}
+          tag_name: ${{ inputs.tag_name }}
           name: ${{ inputs.tag_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})
           generate_release_notes: true
           files: ./artifacts/*/*


### PR DESCRIPTION
The `base_version` input is incorrect for the `softprops/action-gh-release` action. This commit updates the `release.yml` and `promote.yml` workflows to use the correct `tag_name` input for specifying the release tag.