### PR TITLE
Fix google build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,6 +140,13 @@ android {
     // Configure existing product flavors (defined by convention plugin)
     // with their dynamic version names.
     productFlavors {
+        all {
+            if (name == "google") {
+                apply(plugin = libs.plugins.google.services.get().pluginId)
+                apply(plugin = libs.plugins.firebase.crashlytics.get().pluginId)
+            }
+        }
+
         named("google") { versionName = "${defaultConfig.versionName} (${defaultConfig.versionCode}) google" }
         named("fdroid") { versionName = "${defaultConfig.versionName} (${defaultConfig.versionCode}) fdroid" }
     }


### PR DESCRIPTION
Fixes startup crash in the Google app flavor. Re-adds the Google Services and Crashlytics plugins that were removed in https://github.com/meshtastic/Meshtastic-Android/pull/3365.