### PR TITLE
fix: Change fallback node name format

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -102,7 +102,7 @@ constructor(
     private fun createFallbackNode(nodeNum: Int): Node {
         val userId = DataPacket.nodeNumToDefaultId(nodeNum)
         val safeUserId = userId.padStart(DEFAULT_ID_SUFFIX_LENGTH, '0').takeLast(DEFAULT_ID_SUFFIX_LENGTH)
-        val longName = app.getString(R.string.fallback_node_name, safeUserId)
+        val longName = app.getString(R.string.fallback_node_name) + "  $safeUserId"
         val defaultUser =
             MeshProtos.User.newBuilder()
                 .setId(userId)

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
 
     <string name="default_mqtt_address" translatable="false">mqtt.meshtastic.org</string>
 
-    <string name="fallback_node_name">Meshtastic %s</string>
+    <string name="fallback_node_name">Meshtastic</string>
     <string name="node_filter_placeholder">Filter</string>
     <string name="desc_node_filter_clear">clear node filter</string>
     <string name="node_filter_title">Filter by</string>


### PR DESCRIPTION
Removes the string formatting argument from the `fallback_node_name` string resource. The node's unique ID is now appended directly in the code, providing more flexibility in formatting.

addresses: https://console.firebase.google.com/u/0/project/meshutil/crashlytics/app/android:com.geeksville.mesh/issues/51118c6f75d470f9794c5bd2c7c092e7