### PR TITLE
feat(ci): Configure staged rollouts for Android releases

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -90,6 +90,7 @@ jobs:
           package-name: 'com.geeksville.mesh'
           from-track: 'internal'
           to-track: ${{ inputs.channel == 'closed' && 'NewAlpha' || (inputs.channel == 'open' && 'beta' || 'production') }}
+          user-fraction: ${{ inputs.channel == 'production' && '0.1' || (inputs.channel == 'open' && '0.5') || '1.0' }}
 
   update-github-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change introduces the `user-fraction` parameter to the Android promotion workflow. It enables staged rollouts to a percentage of users based on the target channel:

- 10% for production
- 50% for open testing (beta)
- 100% for closed testing (NewAlpha)