### PR TITLE
feat(ci): Use `gh release edit` to retag releases

### DIFF
--- a/.github/workflows/create-or-promote-release.yml
+++ b/.github/workflows/create-or-promote-release.yml
@@ -98,15 +98,18 @@ jobs:
 
       - name: Create and push new tag
         if: ${{ !inputs.dry_run && inputs.channel == 'internal' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git tag ${{ steps.calculate_tags.outputs.tag_to_process }}
           git push origin ${{ steps.calculate_tags.outputs.tag_to_process }}
 
       - name: Create and push final tag
         if: ${{ !inputs.dry_run && inputs.channel != 'internal' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git tag ${{ steps.calculate_tags.outputs.final_tag }} ${{ steps.calculate_tags.outputs.tag_to_process }}
-          git push origin ${{ steps.calculate_tags.outputs.final_tag }}
+          gh release edit ${{ steps.calculate_tags.outputs.tag_to_process }} --tag ${{ steps.calculate_tags.outputs.final_tag }} --title "${{ steps.calculate_tags.outputs.release_name }}"
 
   call-release-workflow:
     if: ${{ !inputs.dry_run && inputs.channel == 'internal' }}


### PR DESCRIPTION
Instead of creating a new annotated tag and pushing it, this change uses the `gh release edit` command to update the tag of an existing release. This simplifies the process of promoting a release from one channel (e.g., 'internal') to another by directly retagging it.

The `GH_TOKEN` environment variable is now explicitly set for the steps that interact with the repository.