### PR TITLE
Tweak settings footer button style/visibility

### DIFF
--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -186,7 +186,7 @@
     <string name="analytics_okay">Allow analytics and crash reporting.</string>
     <string name="accept">Accept</string>
     <string name="cancel">Cancel</string>
-    <string name="discard_changes">Discard changes</string>
+    <string name="discard_changes">Discard</string>
     <string name="save_changes">Save</string>
     <string name="new_channel_rcvd">New Channel URL received</string>
     <string name="permission_missing">Meshtastic needs location permissions enabled to find new devices via Bluetooth. You can disable when not in use.</string>

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/PreferenceFooter.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/PreferenceFooter.kt
@@ -23,8 +23,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -63,14 +63,22 @@ fun PreferenceFooter(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier.fillMaxWidth().padding(16.dp),
+        modifier = modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        OutlinedButton(modifier = Modifier.height(48.dp).weight(1f), onClick = onNegativeClicked) {
+        ElevatedButton(
+            modifier = Modifier.height(48.dp).weight(1f),
+            colors = ButtonDefaults.filledTonalButtonColors(),
+            onClick = onNegativeClicked,
+        ) {
             Text(text = negativeText)
         }
-        Button(modifier = Modifier.height(48.dp).weight(1f), enabled = enabled, onClick = onPositiveClicked) {
+        ElevatedButton(
+            modifier = Modifier.height(48.dp).weight(1f),
+            colors = ButtonDefaults.buttonColors(),
+            onClick = { if (enabled) onPositiveClicked() },
+        ) {
             Text(text = positiveText)
         }
     }

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/RadioConfigScreenList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/RadioConfigScreenList.kt
@@ -17,14 +17,24 @@
 
 package org.meshtastic.feature.settings.radio.component
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -65,24 +75,44 @@ fun <T : MessageLite> RadioConfigScreenList(
             )
         },
     ) { innerPadding ->
-        Column(modifier = Modifier.padding(innerPadding)) {
-            LazyColumn(modifier = Modifier.fillMaxSize().weight(1f), contentPadding = PaddingValues(16.dp)) {
+        val showFooterButtons = configState.isDirty
+
+        Box(modifier = Modifier.padding(innerPadding)) {
+            LazyColumn(modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(16.dp)) {
                 content()
+
+                item {
+                    AnimatedVisibility(
+                        visible = showFooterButtons,
+                        modifier = Modifier.align(Alignment.BottomCenter),
+                        enter = expandIn(),
+                        exit = shrinkOut(),
+                    ) {
+                        Spacer(modifier = Modifier.height(64.dp))
+                    }
+                }
             }
 
-            PreferenceFooter(
-                enabled = enabled && configState.isDirty,
-                negativeText = stringResource(R.string.discard_changes),
-                onNegativeClicked = {
-                    focusManager.clearFocus()
-                    configState.reset()
-                },
-                positiveText = stringResource(R.string.save_changes),
-                onPositiveClicked = {
-                    focusManager.clearFocus()
-                    onSave(configState.value)
-                },
-            )
+            AnimatedVisibility(
+                visible = showFooterButtons,
+                modifier = Modifier.align(Alignment.BottomCenter),
+                enter = fadeIn() + slideInVertically(initialOffsetY = { it }),
+                exit = fadeOut() + slideOutVertically(targetOffsetY = { it }),
+            ) {
+                PreferenceFooter(
+                    enabled = enabled && configState.isDirty,
+                    negativeText = stringResource(R.string.discard_changes),
+                    onNegativeClicked = {
+                        focusManager.clearFocus()
+                        configState.reset()
+                    },
+                    positiveText = stringResource(R.string.save_changes),
+                    onPositiveClicked = {
+                        focusManager.clearFocus()
+                        onSave(configState.value)
+                    },
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Tweaks footer buttons to improve scrollable visibility. Before, they were always visible taking up vertical space, even when disabled.
- Hides settings footer buttons when config has not changed
- Footer buttons are superimposed on scrollable content when visible. Buttons are elevated and tinted for primary/secondary action. Container is transparent.

| Before | After |
|------|-----|
|<video src="https://github.com/user-attachments/assets/3411a3ba-610e-484b-aee1-316ed4f32a6e"/>|<video src="https://github.com/user-attachments/assets/6948d22b-ca84-49e8-88c5-9adf0b238e79"/>|