### PR TITLE
Fix lint in `Main.kt`

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.recalculateWindowInsets
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
@@ -372,8 +373,8 @@ fun MainScreen(uIViewModel: UIViewModel = hiltViewModel(), scanModel: BTScanMode
             }
         },
     ) {
-        Scaffold(snackbarHost = { SnackbarHost(uIViewModel.snackBarHostState) }) { _ ->
-            Column(modifier = Modifier.fillMaxSize()) {
+        Scaffold(snackbarHost = { SnackbarHost(uIViewModel.snackBarHostState) }) { paddingValues ->
+            Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
                 NavHost(
                     navController = navController,
                     startDestination = NodesRoutes.NodesGraph,


### PR DESCRIPTION
These have been bugging me for a while. Scaffold padding shouldn't really matter in this case, but string res access may actually not behave correctly due to `LocalContext` reads not being invalidated on config changes. `LocalResources` is a better way to access strings in this case.