### PR TITLE
Add location sharing feature to messaging for users who are mapping out mesh coverage.  Safer than typing 'at landmark' 'at roadname

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,7 @@ if (configPropertiesFile.exists()) {
 }
 
 android {
-    namespace = configProperties.getProperty("APPLICATION_ID")
+    namespace = "com.geeksville.mesh"  // Keep original namespace for BuildConfig/R
     compileSdk = configProperties.getProperty("COMPILE_SDK").toInt()
 
     signingConfigs {

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/ContactsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/ContactsViewModel.kt
@@ -97,7 +97,9 @@ constructor(
                     shortName = if (toBroadcast) "${data.channel}" else shortName,
                     longName = longName,
                     lastMessageTime = getShortDate(data.time),
-                    lastMessageText = if (fromLocal) data.text else "$shortName: ${data.text}",
+                    lastMessageText = stripMarkdownLinks(
+                        if (fromLocal) data.text else "$shortName: ${data.text}"
+                    ),
                     unreadCount = packetRepository.getUnreadCount(contactKey),
                     messageCount = packetRepository.getMessageCount(contactKey),
                     isMuted = settings[contactKey]?.isMuted == true,
@@ -122,4 +124,12 @@ constructor(
         viewModelScope.launch(Dispatchers.IO) { packetRepository.setMuteUntil(contacts, until) }
 
     private fun getUser(userId: String?) = nodeRepository.getUser(userId ?: DataPacket.ID_BROADCAST)
+
+    /**
+     * Strips markdown link syntax [text](url) from a string, keeping only the display text.
+     * This is used for message previews to show clean text instead of raw markdown.
+     */
+    private fun stripMarkdownLinks(text: String?): String? {
+        return text?.replace("\\[([^\\]]+)\\]\\([^)]+\\)".toRegex(), "$1")
+    }
 }


### PR DESCRIPTION
This allows users to press a single button as they travel, when sending to LongFast or their Private Share channel, so they have a log of message received status and a clickable location link in each message to show on a map where the test happened.

This commit adds a location sharing button to the QuickChat menu that allows users to share their current GPS coordinates (from the Meshtastic node) as a clickable Google Maps link in conversations.

Features:
- Added location pin (📍) button to QuickChat menu in messaging interface
- Coordinates are displayed with 4 decimal places (~11m precision) for readability
- Link contains full 7 decimal places (~1.1cm precision) for accuracy
- Markdown link support in AutoLinkText component for clean display
- Message previews show shortened coordinates without markdown syntax

Changes:
- Modified AutoLinkText.kt to support markdown-style links [text](url)
- Updated Message.kt to add location action to QuickChat with current node position
- Added stripMarkdownLinks() to ContactsViewModel.kt for clean message previews
- Updated app/build.gradle.kts namespace configuration

The location data comes from the Meshtastic node's GPS (or phone GPS if shared with the node), ensuring the shared location reflects the node's actual position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

![conversation](https://github.com/user-attachments/assets/61352978-1f5c-4ce2-a360-66b575a0f754)
