### PR TITLE
fix: Allow BLE reconnection after connection drop

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -315,7 +315,7 @@ constructor(
      * @return true if the device changed, false if no change
      */
     private fun setBondedDeviceAddress(address: String?): Boolean =
-        if (getBondedDeviceAddress() == address && isStarted) {
+        if (getBondedDeviceAddress() == address && isStarted && _connectionState.value == ConnectionState.CONNECTED) {
             Timber.w("Ignoring setBondedDevice ${address.anonymize}, because we are already using that device")
             false
         } else {


### PR DESCRIPTION
# Summary

Fixes critical bug where the app refused to reconnect to Meshtastic nodes via BLE after connection drops, requiring users to toggle Android Bluetooth settings to recover.

## Problem

Users experienced persistent reconnection failures after BLE connection loss:
- Error: `Ignoring setBondedDevice ...:E4, because we are already using that device`
- Only workaround: Toggle Android Bluetooth off/on to reset state
- Affected users with intermittent connections and device sleep scenarios

## Root Cause

`RadioInterfaceService.setBondedDeviceAddress()` only checked the `isStarted` boolean flag to determine if reconnection should be allowed. This flag remained `true` even after GATT connection loss, causing the service to incorrectly believe it was still connected.

**Connection Loss Flow:**
1. GATT connection drops (device sleep, out of range, etc.)
2. BluetoothInterface detects via `lostConnectCb` callback
3. Calls `service.onDisconnect(false)` → sets `_connectionState = DEVICE_SLEEP`
4. **BUT**: `isStarted` remains `true`
5. User attempts reconnection → refused because `isStarted == true`

## Solution

Added connection state verification to the reconnection check:

```kotlin
// Before:
if (getBondedDeviceAddress() == address && isStarted) {
    // Refuse connection
}

// After:
if (getBondedDeviceAddress() == address && 
    isStarted && 
    _connectionState.value == ConnectionState.CONNECTED) {
    // Refuse connection
}
```

Now only refuses reconnection if **actually connected** (CONNECTED state), not just when the interface is started.

## Files Modified

**app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt:318**
- Single line change: Added `&& _connectionState.value == ConnectionState.CONNECTED` condition
- Minimal change for maximum correctness

## Testing

**Test Scenarios:**
- ✅ Normal connection when disconnected → Connects successfully
- ✅ Duplicate connection when already connected → Refuses (warning logged)
- ✅ Reconnection after connection drop → Connects successfully (bug fix)
- ✅ Reconnection after device sleep → Connects successfully (bug fix)
- ✅ No BLE toggle required after connection loss

**Verified on:**
- Physical device with Meshtastic node
- Tested connection drop scenarios
- Confirmed seamless reconnection without manual BLE toggle

## Impact

- **User Impact**: Seamless reconnection without manual BLE toggle
- **Code Impact**: Minimal - single condition added, leverages existing state
- **Regression Risk**: Low - only affects reconnection logic, doesn't change connection flow

## Breaking Changes

None. This is a bug fix with no API changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>