### PR TITLE
fix #2062:  Remap channels when rearranged

### DIFF
--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/PacketRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/PacketRepository.kt
@@ -29,6 +29,7 @@ import org.meshtastic.core.database.entity.ReactionEntity
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
+import org.meshtastic.proto.ChannelProtos.ChannelSettings
 import org.meshtastic.proto.Portnums.PortNum
 import javax.inject.Inject
 
@@ -103,4 +104,7 @@ class PacketRepository @Inject constructor(private val packetDaoLazy: Lazy<Packe
     suspend fun insertReaction(reaction: ReactionEntity) = withContext(Dispatchers.IO) { packetDao.insert(reaction) }
 
     suspend fun clearPacketDB() = withContext(Dispatchers.IO) { packetDao.deleteAll() }
+
+    suspend fun migrateChannelsByPSK(oldSettings: List<ChannelSettings>, newSettings: List<ChannelSettings>) =
+        packetDao.migrateChannelsByPSK(oldSettings, newSettings)
 }

--- a/core/database/src/main/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
+++ b/core/database/src/main/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
@@ -30,6 +30,7 @@ import org.meshtastic.core.database.entity.PacketEntity
 import org.meshtastic.core.database.entity.ReactionEntity
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
+import org.meshtastic.proto.ChannelProtos.ChannelSettings
 
 @Suppress("TooManyFunctions")
 @Dao
@@ -240,4 +241,29 @@ interface PacketDao {
 
     @Query("DELETE FROM packet")
     suspend fun deleteAll()
+
+    /**
+     * One-time migration: Remap all message DataPacket.channel indices to new mapping using PSK after a channel
+     * reorder. For each Packet (with port_num = 1), finds the old PSK then sets the channel index to the matching
+     * newSettings index. Skips if PSKs do not match or are missing.
+     */
+    @Transaction
+    suspend fun migrateChannelsByPSK(oldSettings: List<ChannelSettings>, newSettings: List<ChannelSettings>) {
+        val pskToNewIndex = newSettings.mapIndexed { idx, ch -> ch.psk to idx }.toMap()
+        val allPackets = getAllUserPacketsForMigration()
+        for (packet in allPackets) {
+            val oldIndex = packet.data.channel
+            val oldPSK = oldSettings.getOrNull(oldIndex)?.psk
+            val newIndex = if (oldPSK != null) pskToNewIndex[oldPSK] else null
+            if (oldPSK != null && newIndex != null && oldIndex != newIndex) {
+                // Rebuild contact_key with the new index, keeping the rest unchanged
+                val oldKeySuffix = packet.contact_key.drop(1) // removes only the channelIndex prefix
+                val newContactKey = "$newIndex$oldKeySuffix"
+                update(packet.copy(contact_key = newContactKey, data = packet.data.copy(channel = newIndex)))
+            }
+        }
+    }
+
+    @Query("SELECT * FROM packet WHERE port_num = 1")
+    suspend fun getAllUserPacketsForMigration(): List<Packet>
 }

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import org.meshtastic.core.data.repository.LocationRepository
 import org.meshtastic.core.data.repository.NodeRepository
+import org.meshtastic.core.data.repository.PacketRepository
 import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.model.Node
@@ -106,6 +107,7 @@ constructor(
     savedStateHandle: SavedStateHandle,
     private val app: Application,
     private val radioConfigRepository: RadioConfigRepository,
+    private val packetRepository: PacketRepository,
     private val serviceRepository: ServiceRepository,
     private val nodeRepository: NodeRepository,
     private val locationRepository: LocationRepository,
@@ -245,7 +247,12 @@ constructor(
         val destNum = destNode.value?.num ?: return
         getChannelList(new, old).forEach { setRemoteChannel(destNum, it) }
 
-        if (destNum == myNodeNum) viewModelScope.launch { radioConfigRepository.replaceAllSettings(new) }
+        if (destNum == myNodeNum) {
+            viewModelScope.launch {
+                packetRepository.migrateChannelsByPSK(old, new)
+                radioConfigRepository.replaceAllSettings(new)
+            }
+        }
         _radioConfigState.update { it.copy(channelList = new) }
     }
 


### PR DESCRIPTION
Closes #2062 

When a change of order is triggered by the app, we remap the existing messages. 

This may not play nicely when something else changes the channel map, but there's not much we can do about that.
