### PR TITLE
feat: Enable minification and add ProGuard rules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,10 +158,9 @@ android {
             } else {
                 signingConfig = signingConfigs.getByName("debug")
             }
-            productFlavors.getByName("fdroid") {
-                isMinifyEnabled = false
-                isShrinkResources = false
-            }
+            isMinifyEnabled = true
+            isShrinkResources = true
+            isDebuggable = false
         }
     }
     bundle { language { enableSplit = false } }

--- a/core/model/consumer-rules.pro
+++ b/core/model/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class org.meshtastic.core.model.DataPacket
+-keep class org.meshtastic.core.model.DataPacket$CREATOR

--- a/core/proto/consumer-rules.pro
+++ b/core/proto/consumer-rules.pro
@@ -1,0 +1,6 @@
+-keep class org.meshtastic.proto.MeshProtos$DeviceMetadata
+-keep class org.meshtastic.proto.MeshProtos$FromRadio
+-keep class org.meshtastic.proto.MeshProtos$Position
+-keep class org.meshtastic.proto.MeshProtos$User
+-keep class org.meshtastic.proto.PaxcountProtos$Paxcount
+-keep class org.meshtastic.proto.TelemetryProtos$Telemetry


### PR DESCRIPTION
This enables minification and resource shrinking for release builds to reduce the app's size.

It also introduces ProGuard consumer rules for the `core/model` and `core/proto` modules to prevent necessary classes from being obfuscated or removed during the build process.