### PR TITLE
refactor: Comment out debug applicationId overrides

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -173,15 +173,16 @@ secrets {
 
 // workaround for https://github.com/google/ksp/issues/1590
 androidComponents {
-    onVariants(selector().all()) { variant ->
-        if (variant.name == "fdroidDebug") {
-            variant.applicationId = "com.geeksville.mesh.fdroid.debug"
-        }
-
-        if (variant.name == "googleDebug") {
-            variant.applicationId = "com.geeksville.mesh.google.debug"
-        }
-    }
+    /** Disabling until this works w/ bluetooth */
+    //    onVariants(selector().all()) { variant ->
+    //        if (variant.name == "fdroidDebug") {
+    //            variant.applicationId = "com.geeksville.mesh.fdroid.debug"
+    //        }
+    //
+    //        if (variant.name == "googleDebug") {
+    //            variant.applicationId = "com.geeksville.mesh.google.debug"
+    //        }
+    //    }
     onVariants(selector().withBuildType("release")) { variant ->
         if (variant.flavorName == "google") {
             val variantNameCapped = variant.name.replaceFirstChar { it.uppercase() }


### PR DESCRIPTION
The workaround for unique debug `applicationId`s is temporarily disabled by commenting out the `onVariants` block that sets them for the `fdroidDebug` and `googleDebug` build variants.

Disabling until this is functional w/ all connection types.