### PR TITLE
ci: Enable Renovate for Bundler

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,9 @@
   "git-submodules": {
     "enabled": true
   },
+  "bundler": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
This enables Renovate to manage dependencies for Bundler.