### PR TITLE
Remove `stringResource()` `id` named argument

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -222,7 +222,7 @@ fun MainScreen(uIViewModel: UIViewModel = hiltViewModel(), scanModel: BTScanMode
                     Text(text = annotateTraceroute(response))
                 }
             },
-            dismissText = stringResource(id = R.string.okay),
+            dismissText = stringResource(R.string.okay),
             onDismiss = { uIViewModel.clearTracerouteResponse() },
         )
     }
@@ -283,7 +283,7 @@ fun MainScreen(uIViewModel: UIViewModel = hiltViewModel(), scanModel: BTScanMode
                                                 ConnectionState.DISCONNECTED -> stringResource(R.string.disconnected)
                                             }
                                         } else {
-                                            stringResource(id = destination.label)
+                                            stringResource(destination.label)
                                         },
                                     )
                                 }
@@ -347,7 +347,7 @@ fun MainScreen(uIViewModel: UIViewModel = hiltViewModel(), scanModel: BTScanMode
                                 ) {
                                     Icon(
                                         imageVector = destination.icon,
-                                        contentDescription = stringResource(id = destination.label),
+                                        contentDescription = stringResource(destination.label),
                                         tint = LocalContentColor.current,
                                     )
                                 }
@@ -357,7 +357,7 @@ fun MainScreen(uIViewModel: UIViewModel = hiltViewModel(), scanModel: BTScanMode
                     selected = isSelected,
                     label = {
                         if (navSuiteType != NavigationSuiteType.ShortNavigationBarCompact) {
-                            Text(stringResource(id = destination.label))
+                            Text(stringResource(destination.label))
                         }
                     },
                     onClick = {

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
@@ -203,7 +203,7 @@ fun ConnectionsScreen(
                                 TitledCard(title = null) {
                                     ListItem(
                                         leadingIcon = Icons.Rounded.Language,
-                                        text = stringResource(id = R.string.set_your_region),
+                                        text = stringResource(R.string.set_your_region),
                                     ) {
                                         isWaiting = true
                                         radioConfigViewModel.setResponseStateLoading(ConfigRoute.LORA)

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
@@ -241,8 +241,8 @@ fun ChannelScreen(
                 channelSet = channels // throw away any edits
                 showResetDialog = false
             },
-            title = { Text(text = stringResource(id = R.string.reset_to_defaults)) },
-            text = { Text(text = stringResource(id = R.string.are_you_sure_change_default)) },
+            title = { Text(text = stringResource(R.string.reset_to_defaults)) },
+            text = { Text(text = stringResource(R.string.are_you_sure_change_default)) },
             confirmButton = {
                 TextButton(
                     onClick = {
@@ -257,7 +257,7 @@ fun ChannelScreen(
                         showResetDialog = false
                     },
                 ) {
-                    Text(text = stringResource(id = R.string.apply))
+                    Text(text = stringResource(R.string.apply))
                 }
             },
             dismissButton = {
@@ -267,7 +267,7 @@ fun ChannelScreen(
                         showResetDialog = false
                     },
                 ) {
-                    Text(text = stringResource(id = R.string.cancel))
+                    Text(text = stringResource(R.string.cancel))
                 }
             },
         )

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/Share.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/Share.kt
@@ -61,7 +61,7 @@ fun ShareScreen(contacts: List<Contact>, onConfirm: (String) -> Unit, onNavigate
     Scaffold(
         topBar = {
             MainAppBar(
-                title = stringResource(id = R.string.share_to),
+                title = stringResource(R.string.share_to),
                 ourNode = null,
                 showNodeChip = false,
                 canNavigateUp = true,
@@ -92,10 +92,7 @@ fun ShareScreen(contacts: List<Contact>, onConfirm: (String) -> Unit, onNavigate
                 modifier = Modifier.fillMaxWidth().padding(24.dp),
                 enabled = selectedContact.isNotEmpty(),
             ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Default.Send,
-                    contentDescription = stringResource(id = R.string.share),
-                )
+                Icon(imageVector = Icons.AutoMirrored.Default.Send, contentDescription = stringResource(R.string.share))
             }
         }
     }

--- a/core/proto/src/main/kotlin/org/meshtastic/core/proto/ProtoExtensions.kt
+++ b/core/proto/src/main/kotlin/org/meshtastic/core/proto/ProtoExtensions.kt
@@ -38,7 +38,7 @@ fun MeshProtos.Position.formatPositionTime(dateFormat: DateFormat): String {
     val isOlderThanSixMonths = time * SECONDS_TO_MILLIS < sixMonthsAgo
     val timeText =
         if (isOlderThanSixMonths) {
-            stringResource(id = org.meshtastic.core.strings.R.string.unknown_age)
+            stringResource(org.meshtastic.core.strings.R.string.unknown_age)
         } else {
             dateFormat.format(time * SECONDS_TO_MILLIS)
         }

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/AlertDialogs.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/AlertDialogs.kt
@@ -72,7 +72,7 @@ fun SimpleAlertDialog(
                 Text(text = message.orEmpty())
             }
         },
-        confirmButton = { TextButton(onClick = onConfirmRequest) { Text(stringResource(id = R.string.okay)) } },
+        confirmButton = { TextButton(onClick = onConfirmRequest) { Text(stringResource(R.string.okay)) } },
     )
 }
 

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/CopyIconButton.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/CopyIconButton.kt
@@ -32,11 +32,7 @@ import kotlinx.coroutines.launch
 import org.meshtastic.core.strings.R
 
 @Composable
-fun CopyIconButton(
-    valueToCopy: String,
-    modifier: Modifier = Modifier,
-    label: String = stringResource(id = R.string.copy),
-) {
+fun CopyIconButton(valueToCopy: String, modifier: Modifier = Modifier, label: String = stringResource(R.string.copy)) {
     val clipboardManager = LocalClipboard.current
     val coroutineScope = rememberCoroutineScope()
     IconButton(

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
@@ -234,7 +234,7 @@ fun EditTextPreference(
                 {
                     Icon(
                         imageVector = Icons.TwoTone.Info,
-                        contentDescription = stringResource(id = R.string.error),
+                        contentDescription = stringResource(R.string.error),
                         tint = MaterialTheme.colorScheme.error,
                     )
                 }

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/IndoorAirQuality.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/IndoorAirQuality.kt
@@ -191,9 +191,7 @@ fun IndoorAirQuality(iaq: Int?, displayMode: IaqDisplayMode = IaqDisplayMode.Pil
                     shape = RoundedCornerShape(16.dp),
                     text = { IAQScale() },
                     confirmButton = {
-                        TextButton(onClick = { isLegendOpen = false }) {
-                            Text(text = stringResource(id = R.string.close))
-                        }
+                        TextButton(onClick = { isLegendOpen = false }) { Text(text = stringResource(R.string.close)) }
                     },
                 )
             }

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicator.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicator.kt
@@ -142,7 +142,7 @@ fun Snr(snr: Float) {
         }
 
     Text(
-        text = "%s %.2fdB".format(stringResource(id = R.string.snr), snr),
+        text = "%s %.2fdB".format(stringResource(R.string.snr), snr),
         color = color,
         style = MaterialTheme.typography.labelSmall,
     )
@@ -159,7 +159,7 @@ fun Rssi(rssi: Int) {
             Quality.BAD.color.invoke()
         }
     Text(
-        text = "%s %ddBm".format(stringResource(id = R.string.rssi), rssi),
+        text = "%s %ddBm".format(stringResource(R.string.rssi), rssi),
         color = color,
         style = MaterialTheme.typography.labelSmall,
     )

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/MainAppBar.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/MainAppBar.kt
@@ -75,7 +75,7 @@ fun MainAppBar(
                 IconButton(onClick = onNavigateUp) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = stringResource(id = R.string.navigate_back),
+                        contentDescription = stringResource(R.string.navigate_back),
                     )
                 }
             }
@@ -85,7 +85,7 @@ fun MainAppBar(
                     Icon(
                         imageVector =
                         ImageVector.vectorResource(id = org.meshtastic.core.ui.R.drawable.ic_meshtastic),
-                        contentDescription = stringResource(id = R.string.application_icon),
+                        contentDescription = stringResource(R.string.application_icon),
                     )
                 }
             }

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/NodeKeyStatusIcon.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/NodeKeyStatusIcon.kt
@@ -174,7 +174,7 @@ private fun KeyStatusDialog(@StringRes title: Int, @StringRes text: Int, key: By
             if (showAll) {
                 Text(stringResource(R.string.show_all_key_title))
             } else {
-                Text(stringResource(id = title))
+                Text(stringResource(title))
             }
         },
         text = {
@@ -182,12 +182,12 @@ private fun KeyStatusDialog(@StringRes title: Int, @StringRes text: Int, key: By
                 AllKeyStates()
             } else {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(text = stringResource(id = text), textAlign = TextAlign.Center)
+                    Text(text = stringResource(text), textAlign = TextAlign.Center)
                     Spacer(Modifier.height(16.dp))
                     if (key != null && title == R.string.encryption_pkc) {
                         val keyString = Base64.encodeToString(key.toByteArray(), Base64.NO_WRAP)
                         Text(
-                            text = stringResource(id = R.string.config_security_public_key) + ":",
+                            text = stringResource(R.string.config_security_public_key) + ":",
                             textAlign = TextAlign.Center,
                         )
                         Spacer(Modifier.height(8.dp))

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/PreferenceFooter.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/PreferenceFooter.kt
@@ -45,9 +45,9 @@ fun PreferenceFooter(
 ) {
     PreferenceFooter(
         enabled = enabled,
-        negativeText = stringResource(id = negativeText),
+        negativeText = stringResource(negativeText),
         onNegativeClicked = onNegativeClicked,
-        positiveText = stringResource(id = positiveText),
+        positiveText = stringResource(positiveText),
         onPositiveClicked = onPositiveClicked,
         modifier = modifier,
     )

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SecurityIcon.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SecurityIcon.kt
@@ -211,11 +211,11 @@ private fun determineSecurityState(
 @Composable
 fun SecurityIcon(
     securityState: SecurityState,
-    baseContentDescription: String = stringResource(id = R.string.security_icon_description),
+    baseContentDescription: String = stringResource(R.string.security_icon_description),
     externalOnClick: (() -> Unit)? = null,
 ) {
     var showHelpDialog by rememberSaveable { mutableStateOf(false) }
-    val fullContentDescription = baseContentDescription + " " + stringResource(id = securityState.descriptionResId)
+    val fullContentDescription = baseContentDescription + " " + stringResource(securityState.descriptionResId)
 
     IconButton(
         onClick = {
@@ -252,7 +252,7 @@ fun SecurityIcon(
     isLowEntropyKey: Boolean,
     isPreciseLocation: Boolean = false,
     isMqttEnabled: Boolean = false,
-    baseContentDescription: String = stringResource(id = R.string.security_icon_description),
+    baseContentDescription: String = stringResource(R.string.security_icon_description),
     externalOnClick: (() -> Unit)? = null,
 ) {
     val securityState = determineSecurityState(isLowEntropyKey, isPreciseLocation, isMqttEnabled)
@@ -285,7 +285,7 @@ val Channel.isMqttEnabled: Boolean
 @Composable
 fun SecurityIcon(
     channel: Channel,
-    baseContentDescription: String = stringResource(id = R.string.security_icon_description),
+    baseContentDescription: String = stringResource(R.string.security_icon_description),
     externalOnClick: (() -> Unit)? = null,
 ) = SecurityIcon(
     isLowEntropyKey = channel.isLowEntropyKey,
@@ -305,7 +305,7 @@ fun SecurityIcon(
 fun SecurityIcon(
     channelSettings: ChannelSettings,
     loraConfig: LoRaConfig,
-    baseContentDescription: String = stringResource(id = R.string.security_icon_description),
+    baseContentDescription: String = stringResource(R.string.security_icon_description),
     externalOnClick: (() -> Unit)? = null,
 ) {
     val channel = Channel(channelSettings, loraConfig)
@@ -331,7 +331,7 @@ fun SecurityIcon(
 fun SecurityIcon(
     channelSet: AppOnlyProtos.ChannelSet,
     channelIndex: Int,
-    baseContentDescription: String = stringResource(id = R.string.security_icon_description),
+    baseContentDescription: String = stringResource(R.string.security_icon_description),
     externalOnClick: (() -> Unit)? = null,
 ) {
     channelSet.getChannel(channelIndex)?.let { channel ->
@@ -357,7 +357,7 @@ fun SecurityIcon(
 fun SecurityIcon(
     channelSet: AppOnlyProtos.ChannelSet,
     channelName: String,
-    baseContentDescription: String = stringResource(id = R.string.security_icon_description),
+    baseContentDescription: String = stringResource(R.string.security_icon_description),
     externalOnClick: (() -> Unit)? = null,
 ) {
     val channelByNameMap =

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SimpleAlertDialog.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SimpleAlertDialog.kt
@@ -51,7 +51,7 @@ fun SimpleAlertDialog(
             modifier = Modifier.padding(horizontal = 16.dp),
             colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
         ) {
-            Text(text = dismissText ?: stringResource(id = R.string.cancel))
+            Text(text = dismissText ?: stringResource(R.string.cancel))
         }
     },
     confirmButton = {
@@ -61,12 +61,12 @@ fun SimpleAlertDialog(
                 modifier = Modifier.padding(horizontal = 16.dp),
                 colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurface),
             ) {
-                Text(text = confirmText ?: stringResource(id = R.string.okay))
+                Text(text = confirmText ?: stringResource(R.string.okay))
             }
         }
     },
     title = {
-        Text(text = stringResource(id = title), modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.Center)
+        Text(text = stringResource(title), modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.Center)
     },
     text = text,
     shape = RoundedCornerShape(16.dp),
@@ -82,9 +82,7 @@ fun SimpleAlertDialog(
     onConfirm = onConfirm,
     onDismiss = onDismiss,
     title = title,
-    text = {
-        Text(text = stringResource(id = text), modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.Center)
-    },
+    text = { Text(text = stringResource(text), modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.Center) },
 )
 
 @Composable

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
@@ -189,7 +189,7 @@ fun ScannedQrCodeDialog(
             ) {
                 item {
                     Text(
-                        text = stringResource(id = R.string.new_channel_rcvd),
+                        text = stringResource(R.string.new_channel_rcvd),
                         modifier = Modifier.padding(20.dp),
                         style = MaterialTheme.typography.titleLarge,
                     )
@@ -261,7 +261,7 @@ fun ScannedQrCodeDialog(
                     ) {
                         TextButton(onClick = { onDismiss() }) {
                             Text(
-                                text = stringResource(id = R.string.cancel),
+                                text = stringResource(R.string.cancel),
                                 color = MaterialTheme.colorScheme.onSurface,
                                 overflow = TextOverflow.Ellipsis,
                                 maxLines = 1,
@@ -277,7 +277,7 @@ fun ScannedQrCodeDialog(
                             enabled = selectedChannelSet.settingsCount in 1..8,
                         ) {
                             Text(
-                                text = stringResource(id = R.string.accept),
+                                text = stringResource(R.string.accept),
                                 color = MaterialTheme.colorScheme.onSurface,
                                 overflow = TextOverflow.Ellipsis,
                                 maxLines = 1,

--- a/feature/intro/src/main/kotlin/org/meshtastic/feature/intro/CriticalAlertsScreen.kt
+++ b/feature/intro/src/main/kotlin/org/meshtastic/feature/intro/CriticalAlertsScreen.kt
@@ -50,8 +50,8 @@ internal fun CriticalAlertsScreen(onSkip: () -> Unit, onConfigure: () -> Unit) {
             IntroBottomBar(
                 onSkip = onSkip,
                 onConfigure = onConfigure,
-                configureButtonText = stringResource(id = R.string.configure_critical_alerts),
-                skipButtonText = stringResource(id = R.string.skip),
+                configureButtonText = stringResource(R.string.configure_critical_alerts),
+                skipButtonText = stringResource(R.string.skip),
             )
         },
     ) { innerPadding ->

--- a/feature/intro/src/main/kotlin/org/meshtastic/feature/intro/IntroUiHelpers.kt
+++ b/feature/intro/src/main/kotlin/org/meshtastic/feature/intro/IntroUiHelpers.kt
@@ -50,20 +50,19 @@ internal fun FeatureRow(feature: FeatureUIData) {
     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
         Icon(
             imageVector = feature.icon,
-            contentDescription =
-            feature.titleRes?.let { stringResource(id = it) } ?: stringResource(id = feature.subtitleRes),
+            contentDescription = feature.titleRes?.let { stringResource(it) } ?: stringResource(feature.subtitleRes),
             modifier = Modifier.padding(end = 16.dp),
             tint = MaterialTheme.colorScheme.primary,
         )
         Column {
             feature.titleRes?.let { titleRes ->
                 Text(
-                    text = stringResource(id = titleRes),
+                    text = stringResource(titleRes),
                     style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
                 )
             }
             Text(
-                text = stringResource(id = feature.subtitleRes),
+                text = stringResource(feature.subtitleRes),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -85,8 +84,8 @@ internal fun Context.createClickableAnnotatedString(
     @StringRes linkTextRes: Int,
     tag: String,
 ): AnnotatedString {
-    val fullText = stringResource(id = fullTextRes)
-    val linkText = stringResource(id = linkTextRes)
+    val fullText = stringResource(fullTextRes)
+    val linkText = stringResource(linkTextRes)
     val startIndex = fullText.indexOf(linkText)
 
     return buildAnnotatedString {

--- a/feature/intro/src/main/kotlin/org/meshtastic/feature/intro/PermissionScreenLayout.kt
+++ b/feature/intro/src/main/kotlin/org/meshtastic/feature/intro/PermissionScreenLayout.kt
@@ -92,8 +92,8 @@ internal fun PermissionScreenLayout(
             IntroBottomBar(
                 onSkip = onSkip,
                 onConfigure = onConfigure,
-                configureButtonText = stringResource(id = configureButtonTextRes),
-                skipButtonText = stringResource(id = R.string.skip),
+                configureButtonText = stringResource(configureButtonTextRes),
+                skipButtonText = stringResource(R.string.skip),
             )
         },
     ) { innerPadding ->

--- a/feature/intro/src/main/kotlin/org/meshtastic/feature/intro/WelcomeScreen.kt
+++ b/feature/intro/src/main/kotlin/org/meshtastic/feature/intro/WelcomeScreen.kt
@@ -75,7 +75,7 @@ internal fun WelcomeScreen(onGetStarted: () -> Unit) {
                 onSkip = {}, // No skip on welcome
                 onConfigure = onGetStarted,
                 skipButtonText = "", // Not shown
-                configureButtonText = stringResource(id = R.string.get_started),
+                configureButtonText = stringResource(R.string.get_started),
                 showSkipButton = false, // Explicitly hide skip for welcome
             )
         },

--- a/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/component/CacheLayout.kt
+++ b/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/component/CacheLayout.kt
@@ -55,7 +55,7 @@ fun CacheLayout(
             .padding(8.dp),
     ) {
         Text(
-            text = stringResource(id = R.string.map_select_download_region),
+            text = stringResource(R.string.map_select_download_region),
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.headlineSmall,
@@ -75,13 +75,10 @@ fun CacheLayout(
             horizontalArrangement = Arrangement.spacedBy(space = 8.dp),
         ) {
             Button(onClick = onCancelDownload, modifier = Modifier.weight(1f)) {
-                Text(text = stringResource(id = R.string.cancel), color = MaterialTheme.colorScheme.onPrimary)
+                Text(text = stringResource(R.string.cancel), color = MaterialTheme.colorScheme.onPrimary)
             }
             Button(onClick = onExecuteJob, modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(id = R.string.map_start_download),
-                    color = MaterialTheme.colorScheme.onPrimary,
-                )
+                Text(text = stringResource(R.string.map_start_download), color = MaterialTheme.colorScheme.onPrimary)
             }
         }
     }

--- a/feature/map/src/google/kotlin/org/meshtastic/feature/map/component/MapControlsOverlay.kt
+++ b/feature/map/src/google/kotlin/org/meshtastic/feature/map/component/MapControlsOverlay.kt
@@ -69,7 +69,7 @@ fun MapControlsOverlay(
             if (isNodeMap) {
                 MapButton(
                     icon = Icons.Outlined.Tune,
-                    contentDescription = stringResource(id = R.string.map_filter),
+                    contentDescription = stringResource(R.string.map_filter),
                     onClick = onToggleMapFilterMenu,
                 )
                 NodeMapFilterDropdown(
@@ -81,7 +81,7 @@ fun MapControlsOverlay(
                 Box {
                     MapButton(
                         icon = Icons.Outlined.Tune,
-                        contentDescription = stringResource(id = R.string.map_filter),
+                        contentDescription = stringResource(R.string.map_filter),
                         onClick = onToggleMapFilterMenu,
                     )
                     MapFilterDropdown(
@@ -95,7 +95,7 @@ fun MapControlsOverlay(
             Box {
                 MapButton(
                     icon = Icons.Outlined.Map,
-                    contentDescription = stringResource(id = R.string.map_tile_source),
+                    contentDescription = stringResource(R.string.map_tile_source),
                     onClick = onToggleMapTypeMenu,
                 )
                 MapTypeDropdown(
@@ -108,7 +108,7 @@ fun MapControlsOverlay(
 
             MapButton(
                 icon = Icons.Outlined.Layers,
-                contentDescription = stringResource(id = R.string.manage_map_layers),
+                contentDescription = stringResource(R.string.manage_map_layers),
                 onClick = onManageLayersClicked,
             )
 
@@ -121,7 +121,7 @@ fun MapControlsOverlay(
                     } else {
                         Icons.Outlined.MyLocation
                     },
-                    contentDescription = stringResource(id = R.string.toggle_my_position),
+                    contentDescription = stringResource(R.string.toggle_my_position),
                     onClick = onToggleLocationTracking,
                 )
             }
@@ -137,7 +137,7 @@ private fun CompassButton(onClick: () -> Unit, bearing: Float, isFollowing: Bool
         modifier = Modifier.rotate(-bearing),
         icon = icon,
         iconTint = MaterialTheme.colorScheme.StatusRed.takeIf { bearing == 0f },
-        contentDescription = stringResource(id = R.string.orient_north),
+        contentDescription = stringResource(R.string.orient_north),
         onClick = onClick,
     )
 }

--- a/feature/map/src/google/kotlin/org/meshtastic/feature/map/component/MapFilterDropdown.kt
+++ b/feature/map/src/google/kotlin/org/meshtastic/feature/map/component/MapFilterDropdown.kt
@@ -50,10 +50,10 @@ internal fun MapFilterDropdown(expanded: Boolean, onDismissRequest: () -> Unit, 
     val mapFilterState by mapViewModel.mapFilterStateFlow.collectAsStateWithLifecycle()
     DropdownMenu(expanded = expanded, onDismissRequest = onDismissRequest) {
         DropdownMenuItem(
-            text = { Text(stringResource(id = R.string.only_favorites)) },
+            text = { Text(stringResource(R.string.only_favorites)) },
             onClick = { mapViewModel.toggleOnlyFavorites() },
             leadingIcon = {
-                Icon(imageVector = Icons.Filled.Star, contentDescription = stringResource(id = R.string.only_favorites))
+                Icon(imageVector = Icons.Filled.Star, contentDescription = stringResource(R.string.only_favorites))
             },
             trailingIcon = {
                 Checkbox(
@@ -63,13 +63,10 @@ internal fun MapFilterDropdown(expanded: Boolean, onDismissRequest: () -> Unit, 
             },
         )
         DropdownMenuItem(
-            text = { Text(stringResource(id = R.string.show_waypoints)) },
+            text = { Text(stringResource(R.string.show_waypoints)) },
             onClick = { mapViewModel.toggleShowWaypointsOnMap() },
             leadingIcon = {
-                Icon(
-                    imageVector = Icons.Filled.Place,
-                    contentDescription = stringResource(id = R.string.show_waypoints),
-                )
+                Icon(imageVector = Icons.Filled.Place, contentDescription = stringResource(R.string.show_waypoints))
             },
             trailingIcon = {
                 Checkbox(
@@ -79,12 +76,12 @@ internal fun MapFilterDropdown(expanded: Boolean, onDismissRequest: () -> Unit, 
             },
         )
         DropdownMenuItem(
-            text = { Text(stringResource(id = R.string.show_precision_circle)) },
+            text = { Text(stringResource(R.string.show_precision_circle)) },
             onClick = { mapViewModel.toggleShowPrecisionCircleOnMap() },
             leadingIcon = {
                 Icon(
                     imageVector = Icons.Outlined.RadioButtonUnchecked, // Placeholder icon
-                    contentDescription = stringResource(id = R.string.show_precision_circle),
+                    contentDescription = stringResource(R.string.show_precision_circle),
                 )
             },
             trailingIcon = {

--- a/feature/map/src/google/kotlin/org/meshtastic/feature/map/component/MapTypeDropdown.kt
+++ b/feature/map/src/google/kotlin/org/meshtastic/feature/map/component/MapTypeDropdown.kt
@@ -46,10 +46,10 @@ internal fun MapTypeDropdown(
 
     val googleMapTypes =
         listOf(
-            stringResource(id = R.string.map_type_normal) to MapType.NORMAL,
-            stringResource(id = R.string.map_type_satellite) to MapType.SATELLITE,
-            stringResource(id = R.string.map_type_terrain) to MapType.TERRAIN,
-            stringResource(id = R.string.map_type_hybrid) to MapType.HYBRID,
+            stringResource(R.string.map_type_normal) to MapType.NORMAL,
+            stringResource(R.string.map_type_satellite) to MapType.SATELLITE,
+            stringResource(R.string.map_type_terrain) to MapType.TERRAIN,
+            stringResource(R.string.map_type_hybrid) to MapType.HYBRID,
         )
 
     DropdownMenu(expanded = expanded, onDismissRequest = onDismissRequest) {

--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -160,7 +160,7 @@ fun MessageScreen(
             Triple(index, id, name)
         }
     val (channelIndex, nodeId, rawChannelName) = channelInfo
-    val unknownChannelText = stringResource(id = R.string.unknown_channel)
+    val unknownChannelText = stringResource(R.string.unknown_channel)
     val channelName = rawChannelName ?: unknownChannelText
 
     val title =
@@ -350,10 +350,7 @@ private fun BoxScope.ScrollToBottomFab(coroutineScope: CoroutineScope, listState
             }
         },
     ) {
-        Icon(
-            imageVector = Icons.Default.ArrowDownward,
-            contentDescription = stringResource(id = R.string.scroll_to_bottom),
-        )
+        Icon(imageVector = Icons.Default.ArrowDownward, contentDescription = stringResource(R.string.scroll_to_bottom))
     }
 }
 
@@ -529,22 +526,19 @@ private fun ActionModeTopBar(selectedCount: Int, onAction: (MessageMenuAction) -
         IconButton(onClick = { onAction(MessageMenuAction.Dismiss) }) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = stringResource(id = R.string.clear_selection),
+                contentDescription = stringResource(R.string.clear_selection),
             )
         }
     },
     actions = {
         IconButton(onClick = { onAction(MessageMenuAction.ClipboardCopy) }) {
-            Icon(imageVector = Icons.Default.ContentCopy, contentDescription = stringResource(id = R.string.copy))
+            Icon(imageVector = Icons.Default.ContentCopy, contentDescription = stringResource(R.string.copy))
         }
         IconButton(onClick = { onAction(MessageMenuAction.Delete) }) {
-            Icon(imageVector = Icons.Default.Delete, contentDescription = stringResource(id = R.string.delete))
+            Icon(imageVector = Icons.Default.Delete, contentDescription = stringResource(R.string.delete))
         }
         IconButton(onClick = { onAction(MessageMenuAction.SelectAll) }) {
-            Icon(
-                imageVector = Icons.Default.SelectAll,
-                contentDescription = stringResource(id = R.string.select_all),
-            )
+            Icon(imageVector = Icons.Default.SelectAll, contentDescription = stringResource(R.string.select_all))
         }
     },
 )
@@ -586,7 +580,7 @@ private fun MessageTopBar(
         IconButton(onClick = onNavigateBack) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = stringResource(id = R.string.navigate_back),
+                contentDescription = stringResource(R.string.navigate_back),
             )
         }
     },
@@ -615,7 +609,7 @@ private fun MessageTopBarActions(
     var expanded by remember { mutableStateOf(false) }
     Box {
         IconButton(onClick = { expanded = true }, enabled = true) {
-            Icon(imageVector = Icons.Default.MoreVert, contentDescription = stringResource(id = R.string.overflow_menu))
+            Icon(imageVector = Icons.Default.MoreVert, contentDescription = stringResource(R.string.overflow_menu))
         }
         OverFlowMenu(
             expanded = expanded,
@@ -662,7 +656,7 @@ private fun OverFlowMenu(
                 },
             )
             DropdownMenuItem(
-                text = { Text(stringResource(id = R.string.quick_chat)) },
+                text = { Text(stringResource(R.string.quick_chat)) },
                 onClick = {
                     onDismiss()
                     onNavigateToQuickChatOptions()
@@ -670,7 +664,7 @@ private fun OverFlowMenu(
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Default.ChatBubbleOutline,
-                        contentDescription = stringResource(id = R.string.quick_chat),
+                        contentDescription = stringResource(R.string.quick_chat),
                     )
                 },
             )
@@ -775,10 +769,7 @@ private fun MessageInput(
         // cursor position and multi-byte characters, likely outside simple inputTransformation.
         trailingIcon = {
             IconButton(onClick = { if (canSend) onSendMessage() }, enabled = canSend) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Default.Send,
-                    contentDescription = stringResource(id = R.string.send),
-                )
+                Icon(imageVector = Icons.AutoMirrored.Default.Send, contentDescription = stringResource(R.string.send))
             }
         },
     )

--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/MessageList.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/MessageList.kt
@@ -73,19 +73,19 @@ fun DeliveryInfo(
     onDismissRequest = onDismiss,
     dismissButton = {
         FilledTonalButton(onClick = onDismiss, modifier = Modifier.padding(horizontal = 16.dp)) {
-            Text(text = stringResource(id = R.string.close))
+            Text(text = stringResource(R.string.close))
         }
     },
     confirmButton = {
         if (resendOption) {
             FilledTonalButton(onClick = onConfirm, modifier = Modifier.padding(horizontal = 16.dp)) {
-                Text(text = stringResource(id = R.string.resend))
+                Text(text = stringResource(R.string.resend))
             }
         }
     },
     title = {
         Text(
-            text = stringResource(id = title),
+            text = stringResource(title),
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.headlineSmall,
@@ -95,7 +95,7 @@ fun DeliveryInfo(
         Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
             text?.let {
                 Text(
-                    text = stringResource(id = it),
+                    text = stringResource(it),
                     textAlign = TextAlign.Center,
                     style = MaterialTheme.typography.bodyMedium,
                 )

--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/QuickChat.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/QuickChat.kt
@@ -98,7 +98,7 @@ fun QuickChatScreen(
     Scaffold(
         topBar = {
             MainAppBar(
-                title = stringResource(id = R.string.quick_chat),
+                title = stringResource(R.string.quick_chat),
                 ourNode = null,
                 showNodeChip = false,
                 canNavigateUp = true,
@@ -137,7 +137,7 @@ fun QuickChatScreen(
                 onClick = { showActionDialog = QuickChatAction(position = actions.size) },
                 modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
             ) {
-                Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(id = R.string.add))
+                Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(R.string.add))
             }
         }
     }
@@ -180,7 +180,7 @@ private fun EditQuickChatDialog(
         text = {
             Column(modifier = Modifier.fillMaxWidth()) {
                 Text(
-                    text = stringResource(id = title),
+                    text = stringResource(title),
                     modifier = Modifier.fillMaxWidth(),
                     style =
                     MaterialTheme.typography.titleLarge.copy(
@@ -204,7 +204,7 @@ private fun EditQuickChatDialog(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 OutlinedTextFieldWithCounter(
-                    label = stringResource(id = R.string.message),
+                    label = stringResource(R.string.message),
                     value = actionInput.message,
                     maxSize = 200,
                     getSize = { it.toByteArray().size + 1 },
@@ -227,7 +227,7 @@ private fun EditQuickChatDialog(
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     if (isInstant) {
-                        Icon(imageVector = icon, contentDescription = stringResource(id = text))
+                        Icon(imageVector = icon, contentDescription = stringResource(text))
                         Spacer(Modifier.width(12.dp))
                     }
 
@@ -328,7 +328,7 @@ private fun QuickChatItem(
                 if (action.mode == QuickChatAction.Mode.Instant) {
                     Icon(
                         imageVector = Icons.Default.FastForward,
-                        contentDescription = stringResource(id = R.string.quick_chat_instant),
+                        contentDescription = stringResource(R.string.quick_chat_instant),
                     )
                 }
             },
@@ -339,12 +339,12 @@ private fun QuickChatItem(
                     IconButton(onClick = { onEdit(action) }, modifier = Modifier.size(48.dp)) {
                         Icon(
                             imageVector = Icons.Default.Edit,
-                            contentDescription = stringResource(id = R.string.quick_chat_edit),
+                            contentDescription = stringResource(R.string.quick_chat_edit),
                         )
                     }
                     Icon(
                         imageVector = Icons.Default.DragHandle,
-                        contentDescription = stringResource(id = R.string.quick_chat),
+                        contentDescription = stringResource(R.string.quick_chat),
                     )
                 }
             },

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/AdministrationSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/AdministrationSection.kt
@@ -54,9 +54,9 @@ fun AdministrationSection(
     onFirmwareSelect: (FirmwareRelease) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    TitledCard(stringResource(id = R.string.administration), modifier = modifier) {
+    TitledCard(stringResource(R.string.administration), modifier = modifier) {
         ListItem(
-            text = stringResource(id = R.string.request_metadata),
+            text = stringResource(R.string.request_metadata),
             leadingIcon = Icons.Default.Memory,
             trailingIcon = null,
             onClick = { onAction(NodeDetailAction.TriggerServiceAction(ServiceAction.GetDeviceMetadata(node.num))) },
@@ -65,7 +65,7 @@ fun AdministrationSection(
         InsetDivider()
 
         ListItem(
-            text = stringResource(id = R.string.remote_admin),
+            text = stringResource(R.string.remote_admin),
             leadingIcon = Icons.Default.Settings,
             enabled = metricsState.isLocal || node.metadata != null,
         ) {

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/DeviceActions.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/DeviceActions.kt
@@ -69,7 +69,7 @@ fun DeviceActions(
     )
     TitledCard(title = stringResource(R.string.actions), modifier = modifier) {
         ListItem(
-            text = stringResource(id = R.string.share_contact),
+            text = stringResource(R.string.share_contact),
             leadingIcon = Icons.Rounded.QrCode2,
             trailingIcon = null,
             onClick = { onAction(NodeDetailAction.ShareContact) },
@@ -102,7 +102,7 @@ fun DeviceActions(
         InsetDivider()
 
         ListItem(
-            text = stringResource(id = R.string.remove),
+            text = stringResource(R.string.remove),
             leadingIcon = Icons.Rounded.Delete,
             trailingIcon = null,
             onClick = { displayRemoveDialog = true },

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/FirmwareReleaseSheetContent.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/FirmwareReleaseSheetContent.kt
@@ -70,9 +70,9 @@ fun FirmwareReleaseSheetContent(firmwareRelease: FirmwareRelease, modifier: Modi
                 },
                 modifier = Modifier.weight(1f),
             ) {
-                Icon(imageVector = Icons.Default.Link, contentDescription = stringResource(id = R.string.view_release))
+                Icon(imageVector = Icons.Default.Link, contentDescription = stringResource(R.string.view_release))
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(text = stringResource(id = R.string.view_release))
+                Text(text = stringResource(R.string.view_release))
             }
             Button(
                 onClick = {
@@ -86,9 +86,9 @@ fun FirmwareReleaseSheetContent(firmwareRelease: FirmwareRelease, modifier: Modi
                 },
                 modifier = Modifier.weight(1f),
             ) {
-                Icon(imageVector = Icons.Default.Download, contentDescription = stringResource(id = R.string.download))
+                Icon(imageVector = Icons.Default.Download, contentDescription = stringResource(R.string.download))
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(text = stringResource(id = R.string.download))
+                Text(text = stringResource(R.string.download))
             }
         }
     }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/MetricsSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/MetricsSection.kt
@@ -55,7 +55,7 @@ fun MetricsSection(
     val nonPositionLogs = availableLogs.filter { it != LogsType.NODE_MAP && it != LogsType.POSITIONS }
 
     if (nonPositionLogs.isNotEmpty()) {
-        TitledCard(title = stringResource(id = R.string.logs), modifier = modifier) {
+        TitledCard(title = stringResource(R.string.logs), modifier = modifier) {
             nonPositionLogs.forEach { type ->
                 ListItem(text = stringResource(type.titleRes), leadingIcon = type.icon) {
                     onAction(NodeDetailAction.Navigate(type.route))

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeDetailsSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeDetailsSection.kt
@@ -57,19 +57,19 @@ fun NodeDetailsSection(node: Node, modifier: Modifier = Modifier) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
                     imageVector = Icons.Default.KeyOff,
-                    contentDescription = stringResource(id = R.string.encryption_error),
+                    contentDescription = stringResource(R.string.encryption_error),
                     tint = Color.Red,
                 )
                 Spacer(Modifier.width(12.dp))
                 Text(
-                    text = stringResource(id = R.string.encryption_error),
+                    text = stringResource(R.string.encryption_error),
                     style = MaterialTheme.typography.titleLarge.copy(color = Color.Red),
                     textAlign = TextAlign.Center,
                 )
             }
             Spacer(Modifier.height(16.dp))
             Text(
-                text = stringResource(id = R.string.encryption_error_text),
+                text = stringResource(R.string.encryption_error_text),
                 style = MaterialTheme.typography.bodyMedium,
                 textAlign = TextAlign.Center,
             )

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeFilterTextField.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeFilterTextField.kt
@@ -114,7 +114,7 @@ fun NodeFilterTextField(
                     .padding(vertical = 16.dp, horizontal = 24.dp),
             ) {
                 Text(
-                    text = stringResource(id = R.string.node_filter_ignored),
+                    text = stringResource(R.string.node_filter_ignored),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.fillMaxWidth(),
@@ -135,20 +135,20 @@ private fun NodeFilterTextField(filterText: String, onTextChange: (String) -> Un
         value = filterText,
         placeholder = {
             Text(
-                text = stringResource(id = R.string.node_filter_placeholder),
+                text = stringResource(R.string.node_filter_placeholder),
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.35F),
             )
         },
         leadingIcon = {
-            Icon(Icons.Default.Search, contentDescription = stringResource(id = R.string.node_filter_placeholder))
+            Icon(Icons.Default.Search, contentDescription = stringResource(R.string.node_filter_placeholder))
         },
         onValueChange = onTextChange,
         trailingIcon = {
             if (filterText.isNotEmpty() || isFocused) {
                 Icon(
                     Icons.Default.Clear,
-                    contentDescription = stringResource(id = R.string.desc_node_filter_clear),
+                    contentDescription = stringResource(R.string.desc_node_filter_clear),
                     modifier =
                     Modifier.clickable {
                         onTextChange("")
@@ -192,7 +192,7 @@ private fun NodeSortButton(
 
         NodeSortOption.entries.forEach { sort ->
             DropdownMenuRadio(
-                text = stringResource(id = sort.stringRes),
+                text = stringResource(sort.stringRes),
                 selected = sort == currentSortOption,
                 onClick = { onSortSelect(sort) },
             )

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
@@ -74,7 +74,7 @@ fun NodeItem(
 ) {
     val isFavorite = remember(thatNode) { thatNode.isFavorite }
     val isIgnored = thatNode.isIgnored
-    val longName = thatNode.user.longName.ifEmpty { stringResource(id = R.string.unknown_username) }
+    val longName = thatNode.user.longName.ifEmpty { stringResource(R.string.unknown_username) }
     val isThisNode = remember(thatNode) { thisNode?.num == thatNode.num }
     val system = remember(distanceUnits) { DisplayConfig.DisplayUnits.forNumber(distanceUnits) }
     val distance =
@@ -165,7 +165,7 @@ fun NodeItem(
                         ElevationInfo(
                             altitude = position.altitude,
                             system = system,
-                            suffix = stringResource(id = R.string.elevation_suffix),
+                            suffix = stringResource(R.string.elevation_suffix),
                             contentColor = contentColor,
                         )
                         val satCount = position.satsInView

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NotesSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NotesSection.kt
@@ -54,7 +54,7 @@ fun NotesSection(node: Node, onSaveNotes: (Int, String) -> Unit, modifier: Modif
                 value = notes,
                 onValueChange = { notes = it },
                 modifier = Modifier.fillMaxWidth().padding(8.dp),
-                placeholder = { Text(stringResource(id = R.string.add_a_note)) },
+                placeholder = { Text(stringResource(R.string.add_a_note)) },
                 trailingIcon = {
                     IconButton(
                         onClick = {
@@ -63,7 +63,7 @@ fun NotesSection(node: Node, onSaveNotes: (Int, String) -> Unit, modifier: Modif
                         },
                         enabled = edited,
                     ) {
-                        Icon(imageVector = Icons.Default.Save, contentDescription = stringResource(id = R.string.save))
+                        Icon(imageVector = Icons.Default.Save, contentDescription = stringResource(R.string.save))
                     }
                 },
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/PositionSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/PositionSection.kt
@@ -76,7 +76,7 @@ fun PositionSection(
 
         // Exchange position action
         ListItem(
-            text = stringResource(id = R.string.exchange_position),
+            text = stringResource(R.string.exchange_position),
             leadingIcon = Icons.Default.LocationOn,
             trailingIcon = null,
             onClick = { onAction(NodeDetailAction.HandleNodeMenuAction(NodeMenuAction.RequestPosition(node))) },

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/RemoteDeviceActions.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/RemoteDeviceActions.kt
@@ -33,7 +33,7 @@ import org.meshtastic.feature.node.model.isEffectivelyUnmessageable
 internal fun RemoteDeviceActions(node: Node, lastTracerouteTime: Long?, onAction: (NodeDetailAction) -> Unit) {
     if (!node.isEffectivelyUnmessageable) {
         ListItem(
-            text = stringResource(id = R.string.direct_message),
+            text = stringResource(R.string.direct_message),
             leadingIcon = Icons.AutoMirrored.TwoTone.Message,
             trailingIcon = null,
             onClick = { onAction(NodeDetailAction.HandleNodeMenuAction(NodeMenuAction.DirectMessage(node))) },
@@ -43,7 +43,7 @@ internal fun RemoteDeviceActions(node: Node, lastTracerouteTime: Long?, onAction
     }
 
     ListItem(
-        text = stringResource(id = R.string.exchange_userinfo),
+        text = stringResource(R.string.exchange_userinfo),
         leadingIcon = Icons.Default.Person,
         trailingIcon = null,
         onClick = { onAction(NodeDetailAction.HandleNodeMenuAction(NodeMenuAction.RequestUserInfo(node))) },

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/TracerouteButton.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/TracerouteButton.kt
@@ -42,7 +42,7 @@ private const val COOL_DOWN_TIME_MS = 30000L
 
 @Composable
 fun TracerouteButton(
-    text: String = stringResource(id = R.string.traceroute),
+    text: String = stringResource(R.string.traceroute),
     lastTracerouteTime: Long?,
     onClick: () -> Unit,
 ) {

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
@@ -140,7 +140,7 @@ private fun TemperatureDisplay(envMetrics: TelemetryProtos.EnvironmentMetrics, e
         if (!temperature.isNaN()) {
             val textFormat = if (environmentDisplayFahrenheit) "%s %.1f°F" else "%s %.1f°C"
             Text(
-                text = textFormat.format(stringResource(id = R.string.temperature), temperature),
+                text = textFormat.format(stringResource(R.string.temperature), temperature),
                 color = MaterialTheme.colorScheme.onSurface,
                 fontSize = MaterialTheme.typography.labelLarge.fontSize,
             )
@@ -161,7 +161,7 @@ private fun HumidityAndBarometricPressureDisplay(envMetrics: TelemetryProtos.Env
             if (hasHumidity) {
                 val humidity = envMetrics.relativeHumidity!!
                 Text(
-                    text = "%s %.2f%%".format(stringResource(id = R.string.humidity), humidity),
+                    text = "%s %.2f%%".format(stringResource(R.string.humidity), humidity),
                     color = MaterialTheme.colorScheme.onSurface,
                     fontSize = MaterialTheme.typography.labelLarge.fontSize,
                     modifier = Modifier.padding(vertical = 0.dp),

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/PositionLog.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/PositionLog.kt
@@ -143,15 +143,15 @@ private fun ActionButtons(
             enabled = clearButtonEnabled,
             colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error),
         ) {
-            Icon(imageVector = Icons.Default.Delete, contentDescription = stringResource(id = R.string.clear))
+            Icon(imageVector = Icons.Default.Delete, contentDescription = stringResource(R.string.clear))
             Spacer(Modifier.width(8.dp))
-            Text(text = stringResource(id = R.string.clear))
+            Text(text = stringResource(R.string.clear))
         }
 
         OutlinedButton(modifier = Modifier.weight(1f), onClick = onSave, enabled = saveButtonEnabled) {
-            Icon(imageVector = Icons.Default.Save, contentDescription = stringResource(id = R.string.save))
+            Icon(imageVector = Icons.Default.Save, contentDescription = stringResource(R.string.save))
             Spacer(Modifier.width(8.dp))
-            Text(text = stringResource(id = R.string.save))
+            Text(text = stringResource(R.string.save))
         }
     }
 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/TracerouteLog.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/TracerouteLog.kt
@@ -185,11 +185,11 @@ private fun DeleteItem(onClick: () -> Unit) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
                     imageVector = Icons.Default.Delete,
-                    contentDescription = stringResource(id = R.string.delete),
+                    contentDescription = stringResource(R.string.delete),
                     tint = MaterialTheme.colorScheme.error,
                 )
                 Spacer(modifier = Modifier.width(12.dp))
-                Text(text = stringResource(id = R.string.delete), color = MaterialTheme.colorScheme.error)
+                Text(text = stringResource(R.string.delete), color = MaterialTheme.colorScheme.error)
             }
         },
     )
@@ -202,7 +202,7 @@ private fun TracerouteItem(icon: ImageVector, text: String, modifier: Modifier =
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Icon(imageVector = icon, contentDescription = stringResource(id = R.string.traceroute))
+            Icon(imageVector = icon, contentDescription = stringResource(R.string.traceroute))
             Spacer(modifier = Modifier.width(8.dp))
             Text(text = text, style = MaterialTheme.typography.bodyLarge)
         }

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
@@ -349,7 +349,7 @@ fun DebugMenuActions(deleteLogs: () -> Unit, modifier: Modifier = Modifier) {
     var showDeleteLogsDialog by remember { mutableStateOf(false) }
 
     IconButton(onClick = { showDeleteLogsDialog = true }, modifier = modifier.padding(4.dp)) {
-        Icon(imageVector = Icons.Default.Delete, contentDescription = stringResource(id = R.string.debug_clear))
+        Icon(imageVector = Icons.Default.Delete, contentDescription = stringResource(R.string.debug_clear))
     }
     if (showDeleteLogsDialog) {
         SimpleAlertDialog(
@@ -426,7 +426,7 @@ private fun DecodedPayloadBlock(
 
     Column(modifier = modifier) {
         Text(
-            text = stringResource(id = R.string.debug_decoded_payload),
+            text = stringResource(R.string.debug_decoded_payload),
             style = commonTextStyle,
             modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
         )
@@ -595,11 +595,11 @@ private fun DebugMenuActionsPreview() {
             IconButton(onClick = { /* Preview only */ }, modifier = Modifier.padding(4.dp)) {
                 Icon(
                     imageVector = Icons.Outlined.FileDownload,
-                    contentDescription = stringResource(id = R.string.debug_logs_export),
+                    contentDescription = stringResource(R.string.debug_logs_export),
                 )
             }
             IconButton(onClick = { /* Preview only */ }, modifier = Modifier.padding(4.dp)) {
-                Icon(imageVector = Icons.Default.Delete, contentDescription = stringResource(id = R.string.debug_clear))
+                Icon(imageVector = Icons.Default.Delete, contentDescription = stringResource(R.string.debug_clear))
             }
         }
     }
@@ -637,7 +637,7 @@ private fun DebugScreenEmptyPreview() {
                                             Text(text = "Filters", style = TextStyle(fontWeight = FontWeight.Bold))
                                             Icon(
                                                 imageVector = Icons.TwoTone.FilterAltOff,
-                                                contentDescription = stringResource(id = R.string.debug_filters),
+                                                contentDescription = stringResource(R.string.debug_filters),
                                             )
                                         }
                                     }

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugFilters.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugFilters.kt
@@ -95,7 +95,7 @@ fun DebugCustomFilterInput(
             },
             enabled = customFilterText.isNotBlank(),
         ) {
-            Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(id = R.string.debug_filter_add))
+            Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(R.string.debug_filter_add))
         }
     }
 }
@@ -144,7 +144,7 @@ internal fun DebugPresetFilters(
                         if (filter in filterTexts) {
                             Icon(
                                 imageVector = Icons.Filled.Done,
-                                contentDescription = stringResource(id = R.string.debug_filter_included),
+                                contentDescription = stringResource(R.string.debug_filter_included),
                             )
                         }
                     },
@@ -181,7 +181,7 @@ internal fun DebugFilterBar(
                         } else {
                             Icons.TwoTone.FilterAltOff
                         },
-                        contentDescription = stringResource(id = R.string.debug_filters),
+                        contentDescription = stringResource(R.string.debug_filters),
                     )
                 }
             }
@@ -256,7 +256,7 @@ internal fun DebugActiveFilters(
                 IconButton(onClick = { onFilterTextsChange(emptyList()) }) {
                     Icon(
                         imageVector = Icons.Default.Clear,
-                        contentDescription = stringResource(id = R.string.debug_filter_clear),
+                        contentDescription = stringResource(R.string.debug_filter_clear),
                     )
                 }
             }

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugSearch.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugSearch.kt
@@ -188,7 +188,7 @@ internal fun DebugSearchState(
                 IconButton(onClick = onExport, modifier = Modifier) {
                     Icon(
                         imageVector = Icons.Outlined.FileDownload,
-                        contentDescription = stringResource(id = R.string.debug_logs_export),
+                        contentDescription = stringResource(R.string.debug_logs_export),
                         modifier = Modifier.size(24.dp),
                     )
                 }

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
@@ -81,7 +81,7 @@ fun ChannelConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     }
 
     ChannelConfigScreen(
-        title = stringResource(id = R.string.channels),
+        title = stringResource(R.string.channels),
         onBack = onBack,
         settingsList = state.channelList,
         loraConfig = state.radioConfig.lora,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/AmbientLightingConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/AmbientLightingConfigItemList.kt
@@ -42,7 +42,7 @@ fun AmbientLightingConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.ambient_lighting),
+        title = stringResource(R.string.ambient_lighting),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/AudioConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/AudioConfigItemList.kt
@@ -44,7 +44,7 @@ fun AudioConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack:
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.audio),
+        title = stringResource(R.string.audio),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/BluetoothConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/BluetoothConfigItemList.kt
@@ -44,7 +44,7 @@ fun BluetoothConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onB
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.bluetooth),
+        title = stringResource(R.string.bluetooth),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/CannedMessageConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/CannedMessageConfigItemList.kt
@@ -52,7 +52,7 @@ fun CannedMessageConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(),
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.canned_message),
+        title = stringResource(R.string.canned_message),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/DetectionSensorConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/DetectionSensorConfigItemList.kt
@@ -53,7 +53,7 @@ fun DetectionSensorConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(
     val context = LocalContext.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.detection_sensor),
+        title = stringResource(R.string.detection_sensor),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/DeviceConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/DeviceConfigItemList.kt
@@ -132,7 +132,7 @@ fun DeviceConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack
     val focusManager = LocalFocusManager.current
     val context = LocalContext.current
     RadioConfigScreenList(
-        title = stringResource(id = R.string.device),
+        title = stringResource(R.string.device),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,
@@ -150,7 +150,7 @@ fun DeviceConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack
                     enabled = state.connected,
                     selectedItem = formState.value.role,
                     onItemSelected = { selectedRole = it },
-                    summary = stringResource(id = formState.value.role.description),
+                    summary = stringResource(formState.value.role.description),
                 )
 
                 HorizontalDivider()
@@ -160,7 +160,7 @@ fun DeviceConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack
                     enabled = state.connected,
                     selectedItem = formState.value.rebroadcastMode,
                     onItemSelected = { formState.value = formState.value.copy { rebroadcastMode = it } },
-                    summary = stringResource(id = formState.value.rebroadcastMode.description),
+                    summary = stringResource(formState.value.rebroadcastMode.description),
                 )
 
                 HorizontalDivider()
@@ -180,7 +180,7 @@ fun DeviceConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack
             TitledCard(title = stringResource(R.string.hardware)) {
                 SwitchPreference(
                     title = stringResource(R.string.double_tap_as_button_press),
-                    summary = stringResource(id = R.string.config_device_doubleTapAsButtonPress_summary),
+                    summary = stringResource(R.string.config_device_doubleTapAsButtonPress_summary),
                     checked = formState.value.doubleTapAsButtonPress,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { doubleTapAsButtonPress = it } },
@@ -191,7 +191,7 @@ fun DeviceConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack
 
                 SwitchPreference(
                     title = stringResource(R.string.triple_click_adhoc_ping),
-                    summary = stringResource(id = R.string.config_device_tripleClickAsAdHocPing_summary),
+                    summary = stringResource(R.string.config_device_tripleClickAsAdHocPing_summary),
                     checked = !formState.value.disableTripleClick,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { disableTripleClick = !it } },
@@ -202,7 +202,7 @@ fun DeviceConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack
 
                 SwitchPreference(
                     title = stringResource(R.string.led_heartbeat),
-                    summary = stringResource(id = R.string.config_device_ledHeartbeatEnabled_summary),
+                    summary = stringResource(R.string.config_device_ledHeartbeatEnabled_summary),
                     checked = !formState.value.ledHeartbeatDisabled,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { ledHeartbeatDisabled = !it } },
@@ -230,7 +230,7 @@ fun DeviceConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack
                 EditTextPreference(
                     title = "",
                     value = formState.value.tzdef,
-                    summary = stringResource(id = R.string.config_device_tzdef_summary),
+                    summary = stringResource(R.string.config_device_tzdef_summary),
                     maxSize = 64, // tzdef max_size:65
                     enabled = state.connected,
                     isError = false,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/DisplayConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/DisplayConfigItemList.kt
@@ -45,7 +45,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
     val context = LocalContext.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.display),
+        title = stringResource(R.string.display),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,
@@ -60,7 +60,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
             TitledCard(title = stringResource(R.string.display_config)) {
                 SwitchPreference(
                     title = stringResource(R.string.always_point_north),
-                    summary = stringResource(id = R.string.config_display_compass_north_top_summary),
+                    summary = stringResource(R.string.config_display_compass_north_top_summary),
                     checked = formState.value.compassNorthTop,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { compassNorthTop = it } },
@@ -78,7 +78,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 HorizontalDivider()
                 SwitchPreference(
                     title = stringResource(R.string.bold_heading),
-                    summary = stringResource(id = R.string.config_display_heading_bold_summary),
+                    summary = stringResource(R.string.config_display_heading_bold_summary),
                     checked = formState.value.headingBold,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { headingBold = it } },
@@ -87,7 +87,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 HorizontalDivider()
                 DropDownPreference(
                     title = stringResource(R.string.display_units),
-                    summary = stringResource(id = R.string.config_display_units_summary),
+                    summary = stringResource(R.string.config_display_units_summary),
                     enabled = state.connected,
                     items =
                     DisplayConfig.DisplayUnits.entries
@@ -104,7 +104,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 val carouselIntervals = remember { IntervalConfiguration.DISPLAY_CAROUSEL.allowedIntervals }
                 DropDownPreference(
                     title = stringResource(R.string.screen_on_for),
-                    summary = stringResource(id = R.string.config_display_screen_on_secs_summary),
+                    summary = stringResource(R.string.config_display_screen_on_secs_summary),
                     enabled = state.connected,
                     items = screenOnIntervals.map { it to it.toDisplayString(context = context) },
                     selectedItem =
@@ -115,7 +115,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 HorizontalDivider()
                 DropDownPreference(
                     title = stringResource(R.string.carousel_interval),
-                    summary = stringResource(id = R.string.config_display_auto_screen_carousel_secs_summary),
+                    summary = stringResource(R.string.config_display_auto_screen_carousel_secs_summary),
                     enabled = state.connected,
                     items = carouselIntervals.map { it to it.toDisplayString(context = context) },
                     selectedItem =
@@ -128,7 +128,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 HorizontalDivider()
                 SwitchPreference(
                     title = stringResource(R.string.wake_on_tap_or_motion),
-                    summary = stringResource(id = R.string.config_display_wake_on_tap_or_motion_summary),
+                    summary = stringResource(R.string.config_display_wake_on_tap_or_motion_summary),
                     checked = formState.value.wakeOnTapOrMotion,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { wakeOnTapOrMotion = it } },
@@ -137,7 +137,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 HorizontalDivider()
                 SwitchPreference(
                     title = stringResource(R.string.flip_screen),
-                    summary = stringResource(id = R.string.config_display_flip_screen_summary),
+                    summary = stringResource(R.string.config_display_flip_screen_summary),
                     checked = formState.value.flipScreen,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { flipScreen = it } },
@@ -146,7 +146,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 HorizontalDivider()
                 DropDownPreference(
                     title = stringResource(R.string.display_mode),
-                    summary = stringResource(id = R.string.config_display_displaymode_summary),
+                    summary = stringResource(R.string.config_display_displaymode_summary),
                     enabled = state.connected,
                     items =
                     DisplayConfig.DisplayMode.entries
@@ -158,7 +158,7 @@ fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 HorizontalDivider()
                 DropDownPreference(
                     title = stringResource(R.string.oled_type),
-                    summary = stringResource(id = R.string.config_display_oled_summary),
+                    summary = stringResource(R.string.config_display_oled_summary),
                     enabled = state.connected,
                     items =
                     DisplayConfig.OledType.entries

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/ExternalNotificationConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/ExternalNotificationConfigItemList.kt
@@ -57,7 +57,7 @@ fun ExternalNotificationConfigScreen(viewModel: RadioConfigViewModel = hiltViewM
     val context = LocalContext.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.external_notification),
+        title = stringResource(R.string.external_notification),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -54,7 +54,7 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.lora),
+        title = stringResource(R.string.lora),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,
@@ -69,7 +69,7 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
             TitledCard(title = stringResource(R.string.options)) {
                 DropDownPreference(
                     title = stringResource(R.string.region_frequency_plan),
-                    summary = stringResource(id = R.string.config_lora_region_summary),
+                    summary = stringResource(R.string.config_lora_region_summary),
                     enabled = state.connected,
                     items = RegionInfo.entries.map { it.regionCode to it.description },
                     selectedItem = formState.value.region,
@@ -87,7 +87,7 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                 if (formState.value.usePreset) {
                     DropDownPreference(
                         title = stringResource(R.string.modem_preset),
-                        summary = stringResource(id = R.string.config_lora_modem_preset_summary),
+                        summary = stringResource(R.string.config_lora_modem_preset_summary),
                         enabled = state.connected && formState.value.usePreset,
                         items = ChannelOption.entries.map { it.modemPreset to stringResource(it.labelRes) },
                         selectedItem = formState.value.modemPreset,
@@ -150,7 +150,7 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                 val hopLimitItems = remember { hopLimits }
                 DropDownPreference(
                     title = stringResource(R.string.hop_limit),
-                    summary = stringResource(id = R.string.config_lora_hop_limit_summary),
+                    summary = stringResource(R.string.config_lora_hop_limit_summary),
                     items = hopLimitItems,
                     selectedItem = formState.value.hopLimit,
                     onItemSelected = { formState.value = formState.value.copy { hopLimit = it } },
@@ -160,7 +160,7 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                 var isFocusedSlot by remember { mutableStateOf(false) }
                 EditTextPreference(
                     title = stringResource(R.string.frequency_slot),
-                    summary = stringResource(id = R.string.config_lora_frequency_slot_summary),
+                    summary = stringResource(R.string.config_lora_frequency_slot_summary),
                     value =
                     if (isFocusedSlot || formState.value.channelNum != 0) {
                         formState.value.channelNum

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
@@ -66,7 +66,7 @@ fun MQTTConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: 
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.mqtt),
+        title = stringResource(R.string.mqtt),
         onBack = onBack,
         configState = formState,
         enabled = state.connected && consentValid,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/NeighborInfoConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/NeighborInfoConfigItemList.kt
@@ -42,7 +42,7 @@ fun NeighborInfoConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), 
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.neighbor_info),
+        title = stringResource(R.string.neighbor_info),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,
@@ -73,7 +73,7 @@ fun NeighborInfoConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), 
                 HorizontalDivider()
                 SwitchPreference(
                     title = stringResource(R.string.transmit_over_lora),
-                    summary = stringResource(id = R.string.config_device_transmitOverLora_summary),
+                    summary = stringResource(R.string.config_device_transmitOverLora_summary),
                     checked = formState.value.transmitOverLora,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { transmitOverLora = it } },

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/NetworkConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/NetworkConfigItemList.kt
@@ -100,7 +100,7 @@ fun NetworkConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.network),
+        title = stringResource(R.string.network),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,
@@ -146,7 +146,7 @@ fun NetworkConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 TitledCard(title = stringResource(R.string.wifi_config)) {
                     SwitchPreference(
                         title = stringResource(R.string.wifi_enabled),
-                        summary = stringResource(id = R.string.config_network_wifi_enabled_summary),
+                        summary = stringResource(R.string.config_network_wifi_enabled_summary),
                         checked = formState.value.wifiEnabled,
                         enabled = state.connected,
                         onCheckedChange = { formState.value = formState.value.copy { wifiEnabled = it } },
@@ -189,7 +189,7 @@ fun NetworkConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 TitledCard(title = stringResource(R.string.ethernet_config)) {
                     SwitchPreference(
                         title = stringResource(R.string.ethernet_enabled),
-                        summary = stringResource(id = R.string.config_network_eth_enabled_summary),
+                        summary = stringResource(R.string.config_network_eth_enabled_summary),
                         checked = formState.value.ethEnabled,
                         enabled = state.connected,
                         onCheckedChange = { formState.value = formState.value.copy { ethEnabled = it } },
@@ -204,7 +204,7 @@ fun NetworkConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBac
                 TitledCard(title = stringResource(R.string.udp_config)) {
                     SwitchPreference(
                         title = stringResource(R.string.udp_enabled),
-                        summary = stringResource(id = R.string.config_network_udp_enabled_summary),
+                        summary = stringResource(R.string.config_network_udp_enabled_summary),
                         checked = formState.value.enabledProtocols == 1,
                         enabled = state.connected,
                         onCheckedChange = {

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PacketResponseStateDialog.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PacketResponseStateDialog.kt
@@ -58,10 +58,10 @@ fun <T> PacketResponseStateDialog(state: ResponseState<T>, onDismiss: () -> Unit
                     if (state.total == state.completed) onComplete()
                 }
                 if (state is ResponseState.Success) {
-                    Text(text = stringResource(id = R.string.delivery_confirmed))
+                    Text(text = stringResource(R.string.delivery_confirmed))
                 }
                 if (state is ResponseState.Error) {
-                    Text(text = stringResource(id = R.string.error), minLines = 2)
+                    Text(text = stringResource(R.string.error), minLines = 2)
                     Text(text = state.error.asString())
                 }
             }

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PaxcounterConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PaxcounterConfigItemList.kt
@@ -48,7 +48,7 @@ fun PaxcounterConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), on
     val context = LocalContext.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.paxcounter),
+        title = stringResource(R.string.paxcounter),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PositionConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PositionConfigItemList.kt
@@ -121,7 +121,7 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
     val focusManager = LocalFocusManager.current
     val context = LocalContext.current
     RadioConfigScreenList(
-        title = stringResource(id = R.string.position),
+        title = stringResource(R.string.position),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,
@@ -147,7 +147,7 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
                 val items = remember { IntervalConfiguration.POSITION_BROADCAST.allowedIntervals }
                 DropDownPreference(
                     title = stringResource(R.string.broadcast_interval),
-                    summary = stringResource(id = R.string.config_position_broadcast_secs_summary),
+                    summary = stringResource(R.string.config_position_broadcast_secs_summary),
                     enabled = state.connected,
                     items = items.map { it to it.toDisplayString(context = context) },
                     selectedItem =
@@ -170,7 +170,7 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
                     DropDownPreference(
                         title = stringResource(R.string.minimum_interval),
                         summary =
-                        stringResource(id = R.string.config_position_broadcast_smart_minimum_interval_secs_summary),
+                        stringResource(R.string.config_position_broadcast_smart_minimum_interval_secs_summary),
                         enabled = state.connected,
                         items = smartItems.map { it to it.toDisplayString(context = context) },
                         selectedItem =
@@ -184,8 +184,7 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
                     HorizontalDivider()
                     EditTextPreference(
                         title = stringResource(R.string.minimum_distance),
-                        summary =
-                        stringResource(id = R.string.config_position_broadcast_smart_minimum_distance_summary),
+                        summary = stringResource(R.string.config_position_broadcast_smart_minimum_distance_summary),
                         value = formState.value.broadcastSmartMinimumDistance,
                         enabled = state.connected,
                         keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
@@ -261,7 +260,7 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
                     val items = remember { IntervalConfiguration.GPS_UPDATE.allowedIntervals }
                     DropDownPreference(
                         title = stringResource(R.string.update_interval),
-                        summary = stringResource(id = R.string.config_position_gps_update_interval_summary),
+                        summary = stringResource(R.string.config_position_gps_update_interval_summary),
                         enabled = state.connected,
                         items = items.map { it to it.toDisplayString(context = context) },
                         selectedItem =
@@ -277,7 +276,7 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
             TitledCard(title = stringResource(R.string.position_flags)) {
                 BitwisePreference(
                     title = stringResource(R.string.position_flags),
-                    summary = stringResource(id = R.string.config_position_flags_summary),
+                    summary = stringResource(R.string.config_position_flags_summary),
                     value = formState.value.positionFlags,
                     enabled = state.connected,
                     items =

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PowerConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PowerConfigItemList.kt
@@ -48,7 +48,7 @@ fun PowerConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack:
     val context = LocalContext.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.power),
+        title = stringResource(R.string.power),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,
@@ -63,7 +63,7 @@ fun PowerConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack:
             TitledCard(title = stringResource(R.string.power_config)) {
                 SwitchPreference(
                     title = stringResource(R.string.enable_power_saving_mode),
-                    summary = stringResource(id = R.string.config_power_is_power_saving_summary),
+                    summary = stringResource(R.string.config_power_is_power_saving_summary),
                     checked = formState.value.isPowerSaving,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { isPowerSaving = it } },

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
@@ -44,7 +44,7 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onB
     val context = LocalContext.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.range_test),
+        title = stringResource(R.string.range_test),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/RemoteHardwareConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/RemoteHardwareConfigItemList.kt
@@ -42,7 +42,7 @@ fun RemoteHardwareConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel()
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.remote_hardware),
+        title = stringResource(R.string.remote_hardware),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/SecurityConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/SecurityConfigItemList.kt
@@ -123,7 +123,7 @@ fun SecurityConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
 
     val focusManager = LocalFocusManager.current
     RadioConfigScreenList(
-        title = stringResource(id = R.string.security),
+        title = stringResource(R.string.security),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,
@@ -138,7 +138,7 @@ fun SecurityConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
             TitledCard(title = stringResource(R.string.direct_message_key)) {
                 EditBase64Preference(
                     title = stringResource(R.string.public_key),
-                    summary = stringResource(id = R.string.config_security_public_key),
+                    summary = stringResource(R.string.config_security_public_key),
                     value = publicKey,
                     enabled = state.connected,
                     readOnly = true,
@@ -153,7 +153,7 @@ fun SecurityConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
                 HorizontalDivider()
                 EditBase64Preference(
                     title = stringResource(R.string.private_key),
-                    summary = stringResource(id = R.string.config_security_private_key),
+                    summary = stringResource(R.string.config_security_private_key),
                     value = formState.value.privateKey,
                     enabled = state.connected,
                     keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
@@ -186,7 +186,7 @@ fun SecurityConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
             TitledCard(title = stringResource(R.string.admin_keys)) {
                 EditListPreference(
                     title = stringResource(R.string.admin_key),
-                    summary = stringResource(id = R.string.config_security_admin_key),
+                    summary = stringResource(R.string.config_security_admin_key),
                     list = formState.value.adminKeyList,
                     maxCount = 3,
                     enabled = state.connected,
@@ -205,7 +205,7 @@ fun SecurityConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
             TitledCard(title = stringResource(R.string.logs)) {
                 SwitchPreference(
                     title = stringResource(R.string.serial_console),
-                    summary = stringResource(id = R.string.config_security_serial_enabled),
+                    summary = stringResource(R.string.config_security_serial_enabled),
                     checked = formState.value.serialEnabled,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { serialEnabled = it } },
@@ -214,7 +214,7 @@ fun SecurityConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
                 HorizontalDivider()
                 SwitchPreference(
                     title = stringResource(R.string.debug_log_api_enabled),
-                    summary = stringResource(id = R.string.config_security_debug_log_api_enabled),
+                    summary = stringResource(R.string.config_security_debug_log_api_enabled),
                     checked = formState.value.debugLogApiEnabled,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { debugLogApiEnabled = it } },
@@ -226,7 +226,7 @@ fun SecurityConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
             TitledCard(title = stringResource(R.string.administration)) {
                 SwitchPreference(
                     title = stringResource(R.string.managed_mode),
-                    summary = stringResource(id = R.string.config_security_is_managed),
+                    summary = stringResource(R.string.config_security_is_managed),
                     checked = formState.value.isManaged,
                     enabled = state.connected && formState.value.adminKeyCount > 0,
                     onCheckedChange = { formState.value = formState.value.copy { isManaged = it } },

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/SerialConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/SerialConfigItemList.kt
@@ -44,7 +44,7 @@ fun SerialConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.serial),
+        title = stringResource(R.string.serial),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/StoreForwardConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/StoreForwardConfigItemList.kt
@@ -42,7 +42,7 @@ fun StoreForwardConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), 
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.store_forward),
+        title = stringResource(R.string.store_forward),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/TelemetryConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/TelemetryConfigItemList.kt
@@ -49,7 +49,7 @@ fun TelemetryConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onB
     val context = LocalContext.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.telemetry),
+        title = stringResource(R.string.telemetry),
         onBack = onBack,
         configState = formState,
         enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/UserConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/UserConfigItemList.kt
@@ -52,7 +52,7 @@ fun UserConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: 
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
-        title = stringResource(id = R.string.user),
+        title = stringResource(R.string.user),
         onBack = onBack,
         configState = formState,
         enabled = state.connected && validNames,


### PR DESCRIPTION
Compose multiplatform's `stringResource()` has the same usage, but its arguments are named differently. This removes `id` (simple find/replace) where it's currently used in order to reduce the diff in https://github.com/meshtastic/Meshtastic-Android/pull/3617