### PR TITLE
Relocate proto utils

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/ChannelViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/ChannelViewModel.kt
@@ -29,8 +29,8 @@ import org.meshtastic.core.analytics.DataPair
 import org.meshtastic.core.analytics.platform.PlatformAnalytics
 import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.model.util.toChannelSet
-import org.meshtastic.core.proto.getChannelList
 import org.meshtastic.core.service.ServiceRepository
+import org.meshtastic.core.ui.util.getChannelList
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.proto.AppOnlyProtos
 import org.meshtastic.proto.ChannelProtos

--- a/core/proto/build.gradle.kts
+++ b/core/proto/build.gradle.kts
@@ -14,24 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
-/*
- * Copyright (c) 2025 Meshtastic LLC
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 plugins {
     alias(libs.plugins.meshtastic.android.library)
     alias(libs.plugins.meshtastic.android.library.compose)
@@ -54,9 +36,6 @@ protobuf {
 }
 
 dependencies {
-    implementation(projects.core.strings)
-
-    implementation(libs.timber)
     // This needs to be API for consuming modules
     api(libs.protobuf.kotlin)
 }

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
@@ -23,8 +23,8 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import org.meshtastic.core.data.repository.RadioConfigRepository
-import org.meshtastic.core.proto.getChannelList
 import org.meshtastic.core.service.ServiceRepository
+import org.meshtastic.core.ui.util.getChannelList
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.proto.AppOnlyProtos
 import org.meshtastic.proto.ChannelProtos

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.meshtastic.core.proto
+package org.meshtastic.core.ui.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource

--- a/feature/map/src/google/kotlin/org/meshtastic/feature/map/MapView.kt
+++ b/feature/map/src/google/kotlin/org/meshtastic/feature/map/MapView.kt
@@ -96,8 +96,8 @@ import org.meshtastic.core.model.util.metersIn
 import org.meshtastic.core.model.util.mpsToKmph
 import org.meshtastic.core.model.util.mpsToMph
 import org.meshtastic.core.model.util.toString
-import org.meshtastic.core.proto.formatPositionTime
 import org.meshtastic.core.ui.component.NodeChip
+import org.meshtastic.core.ui.util.formatPositionTime
 import org.meshtastic.feature.map.component.ClusterItemsListDialog
 import org.meshtastic.feature.map.component.CustomMapLayersSheet
 import org.meshtastic.feature.map.component.CustomTileProviderManagerSheet

--- a/feature/map/src/main/kotlin/org/meshtastic/feature/map/node/NodeMapViewModel.kt
+++ b/feature/map/src/main/kotlin/org/meshtastic/feature/map/node/NodeMapViewModel.kt
@@ -32,7 +32,7 @@ import org.meshtastic.core.data.repository.MeshLogRepository
 import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.navigation.NodesRoutes
 import org.meshtastic.core.prefs.map.MapPrefs
-import org.meshtastic.core.proto.toPosition
+import org.meshtastic.core.ui.util.toPosition
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.feature.map.model.CustomTileSource
 import org.meshtastic.proto.MeshProtos.Position

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/HardwareModelExtensions.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/HardwareModelExtensions.kt
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.meshtastic.core.proto
+package org.meshtastic.feature.node.metrics
 
 import org.meshtastic.proto.MeshProtos
 import timber.log.Timber
@@ -36,17 +36,4 @@ fun MeshProtos.HardwareModel.safeNumber(fallbackValue: Int = -1): Int = try {
 } catch (e: IllegalArgumentException) {
     Timber.w("Unknown hardware model enum value: $this, using fallback value: $fallbackValue")
     fallbackValue
-}
-
-/**
- * Checks if the hardware model is a known/supported value.
- *
- * @return true if the hardware model is known and supported, false otherwise
- */
-@Suppress("detekt:SwallowedException")
-fun MeshProtos.HardwareModel.isKnown(): Boolean = try {
-    this.number
-    true
-} catch (e: IllegalArgumentException) {
-    false
 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
@@ -48,10 +48,9 @@ import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.navigation.NodesRoutes
-import org.meshtastic.core.proto.safeNumber
-import org.meshtastic.core.proto.toPosition
 import org.meshtastic.core.service.ServiceAction
 import org.meshtastic.core.service.ServiceRepository
+import org.meshtastic.core.ui.util.toPosition
 import org.meshtastic.feature.node.model.MetricsState
 import org.meshtastic.feature.node.model.TimeFrame
 import org.meshtastic.proto.MeshProtos

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/PositionLog.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/PositionLog.kt
@@ -64,9 +64,9 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.meshtastic.core.model.util.metersIn
 import org.meshtastic.core.model.util.toString
-import org.meshtastic.core.proto.formatPositionTime
 import org.meshtastic.core.ui.component.MainAppBar
 import org.meshtastic.core.ui.theme.AppTheme
+import org.meshtastic.core.ui.util.formatPositionTime
 import org.meshtastic.proto.ConfigProtos.Config.DisplayConfig.DisplayUnits
 import org.meshtastic.proto.MeshProtos
 import java.text.DateFormat

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -59,10 +59,10 @@ import org.meshtastic.core.model.util.toChannelSet
 import org.meshtastic.core.navigation.SettingsRoutes
 import org.meshtastic.core.prefs.analytics.AnalyticsPrefs
 import org.meshtastic.core.prefs.map.MapConsentPrefs
-import org.meshtastic.core.proto.getChannelList
 import org.meshtastic.core.service.ConnectionState
 import org.meshtastic.core.service.IMeshService
 import org.meshtastic.core.service.ServiceRepository
+import org.meshtastic.core.ui.util.getChannelList
 import org.meshtastic.feature.settings.navigation.ConfigRoute
 import org.meshtastic.feature.settings.navigation.ModuleRoute
 import org.meshtastic.feature.settings.util.UiText


### PR DESCRIPTION
Moves a few proto utils out of `:core:proto` so it doesn't need to to rely on Android dependencies.