### PR TITLE
fix: Clear packet database alongside node database

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1990,6 +1990,9 @@ class MeshService : Service() {
         Timber.d("Clearing nodeDB")
         discardNodeDB()
         nodeRepository.clearNodeDB()
+
+        Timber.d("Clearing packetDB")
+        packetRepository.get().clearPacketDB()
     }
 
     private fun updateLastAddress(deviceAddr: String?) {

--- a/core/database/src/main/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
+++ b/core/database/src/main/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
@@ -249,8 +249,21 @@ interface PacketDao {
 
     @Upsert suspend fun insert(reaction: ReactionEntity)
 
+    @Transaction
+    suspend fun deleteAll() {
+        deleteAllPackets()
+        deleteAllReactions()
+        deleteAllContactSettings()
+    }
+
     @Query("DELETE FROM packet")
-    suspend fun deleteAll()
+    suspend fun deleteAllPackets()
+
+    @Query("DELETE FROM reactions")
+    suspend fun deleteAllReactions()
+
+    @Query("DELETE FROM contact_settings")
+    suspend fun deleteAllContactSettings()
 
     /**
      * One-time migration: Remap all message DataPacket.channel indices to new mapping using PSK after a channel


### PR DESCRIPTION
When switching nodes, does a more thorough cleanup job.