### PR TITLE
fix: Update ignored status in nodeDB on toggle

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1968,6 +1968,7 @@ class MeshService : Service() {
                 }
             },
         )
+        updateNodeInfo(node.num) { it.isIgnored = !node.isIgnored }
     }
 
     private fun sendReaction(reaction: ServiceAction.Reaction) = toRemoteExceptions {


### PR DESCRIPTION
When a node's ignored status is toggled, this change ensures that the corresponding entry in the nodeDB is also updated to reflect the new state.