### PR TITLE
fix: Add delays around heartbeat on connection

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -208,6 +208,8 @@ class MeshService : Service() {
         // Two-stage config flow nonces to avoid stale BLE packets, mirroring Meshtastic-Apple
         private const val DEFAULT_CONFIG_ONLY_NONCE = 69420
         private const val DEFAULT_NODE_INFO_NONCE = 69421
+
+        private const val HEARTBEAT_INTERVAL = 25L
     }
 
     private val serviceJob = Job()
@@ -1779,9 +1781,9 @@ class MeshService : Service() {
         }
         // Keep BLE awake and allow the firmware to settle before the node-info stage.
         serviceScope.handledLaunch {
-            delay(25)
+            delay(HEARTBEAT_INTERVAL)
             sendHeartbeat()
-            delay(25)
+            delay(HEARTBEAT_INTERVAL)
             startNodeInfoOnly()
         }
     }


### PR DESCRIPTION
This commit introduces small delays before and after sending the initial heartbeat when a device connects. This is intended to improve reliability by allowing the device firmware some time to settle.