### PR TITLE
refactor: Improve log export logic for decoded payloads

### DIFF
--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
@@ -380,24 +380,26 @@ private suspend fun exportAllLogsToUri(context: Context, targetUri: Uri, logs: L
                     logs.forEach { log ->
                         writer.write("${log.formattedReceivedDate} [${log.messageType}]\n")
                         writer.write(log.logMessage)
-                        if (!log.decodedPayload.isNullOrBlank()) {
-                            writer.write("\n\nDecoded Payload:\n{")
-                            writer.write("\n")
-                            // Redact Decoded keys.
-                            log.decodedPayload.lineSequence().forEach { line ->
-                                var outputLine = line
-                                val redacted = redactedKeys.firstOrNull { line.contains(it) }
-                                if (redacted != null) {
-                                    val idx = line.indexOf(':')
-                                    if (idx != -1) {
-                                        outputLine = line.substring(0, idx + 1)
-                                        outputLine += "<redacted>"
-                                    }
-                                }
-                                writer.write(outputLine)
+                        log.decodedPayload?.let { decodedPayload ->
+                            if (decodedPayload.isNotBlank()) {
+                                writer.write("\n\nDecoded Payload:\n{")
                                 writer.write("\n")
+                                // Redact Decoded keys.
+                                decodedPayload.lineSequence().forEach { line ->
+                                    var outputLine = line
+                                    val redacted = redactedKeys.firstOrNull { line.contains(it) }
+                                    if (redacted != null) {
+                                        val idx = line.indexOf(':')
+                                        if (idx != -1) {
+                                            outputLine = line.take(idx + 1)
+                                            outputLine += "<redacted>"
+                                        }
+                                    }
+                                    writer.write(outputLine)
+                                    writer.write("\n")
+                                }
+                                writer.write("\n}")
                             }
-                            writer.write("\n}")
                         }
                         writer.write("\n\n")
                     }


### PR DESCRIPTION
This commit refactors the log export functionality to more safely handle the `decodedPayload`.

It replaces a direct check for `isNullOrBlank` with a null-safe `let` block. This prevents potential `NullPointerException`s if the payload is null and improves code clarity and robustness.

hopefully resolves #3662 