### PR TITLE
fix: Explicitly set Crowdin project type to Android

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,3 +8,4 @@ files:
     content_segmentation: 0
     escape_quotes: 0
     escape_special_characters: 0
+    type: android


### PR DESCRIPTION
Specifies the `type` as `android` in the `crowdin.yml` configuration file.