### PR TITLE
feat(build): Add distinct names for debug builds

### DIFF
--- a/app/src/fdroidDebug/res/values/strings.xml
+++ b/app/src/fdroidDebug/res/values/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+     Copyright (c) 2025 Meshtastic LLC
+
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation, either version 3 of the License, or
+     (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License
+     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<resources>
+    <string name="app_name" translatable="false">Fdroid Debug</string>
+</resources>

--- a/app/src/googleDebug/res/values/strings.xml
+++ b/app/src/googleDebug/res/values/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+     Copyright (c) 2025 Meshtastic LLC
+
+     This program is free software: you can redistribute it and/or modify
+     it under the terms of the GNU General Public License as published by
+     the Free Software Foundation, either version 3 of the License, or
+     (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful,
+     but WITHOUT ANY WARRANTY; without even the implied warranty of
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+     GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License
+     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<resources>
+    <string name="app_name" translatable="false">Google Debug</string>
+</resources>


### PR DESCRIPTION
Thi introduces separate `strings.xml` files for `googleDebug` and `fdroidDebug` build variants.

By setting the `app_name` string resource in each variant, the installed application will now have a distinct name ("Google Debug" or "Fdroid Debug"), making it easier to differentiate between them on a device.
