### PR TITLE
refactor(coroutines): Use SupervisorJobs

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -31,7 +31,7 @@ import com.geeksville.mesh.util.ignoreException
 import com.geeksville.mesh.util.toRemoteExceptions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -105,7 +105,7 @@ constructor(
     val mockInterfaceAddress: String by lazy { toInterfaceAddress(InterfaceId.MOCK, "") }
 
     /** We recreate this scope each time we stop an interface */
-    var serviceScope = CoroutineScope(Dispatchers.IO + Job())
+    var serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     private var radioIf: IRadioInterface = NopInterface("")
 
@@ -298,7 +298,7 @@ constructor(
 
         // cancel any old jobs and get ready for the new ones
         serviceScope.cancel("stopping interface")
-        serviceScope = CoroutineScope(Dispatchers.IO + Job())
+        serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
         if (logSends) {
             sentPacketsLog.close()


### PR DESCRIPTION
This refactors  DataStore and Radio coroutine scope management to improve robustness and efficiency.

In `RadioInterfaceService`, the `serviceScope` now uses a `SupervisorJob` instead of a `Job`. This prevents the failure of one child coroutine from canceling the entire scope, which is critical when the service starts a new interface.

In `DataStoreModule`, a single `CoroutineScope` with a `SupervisorJob` is now provided as a singleton (`@DataStoreScope`). This shared scope is injected into all DataStore providers, eliminating the creation of a new scope for each DataStore instance. This reduces resource overhead and centralizes scope management for data persistence operations.