### PR TITLE
fix(bluetooth): Check for permissions before accessing bonded devices

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
@@ -160,11 +160,13 @@ constructor(
         Timber.d("Detected our bluetooth access=$newState")
     }
 
-    private fun getBondedAppPeripherals(enabled: Boolean): List<Peripheral> = if (enabled) {
-        centralManager.getBondedPeripherals().filter(::isMatchingPeripheral)
-    } else {
-        emptyList()
-    }
+    @SuppressLint("MissingPermission")
+    private fun getBondedAppPeripherals(enabled: Boolean): List<Peripheral> =
+        if (enabled && application.hasBluetoothPermission()) {
+            centralManager.getBondedPeripherals().filter(::isMatchingPeripheral)
+        } else {
+            emptyList()
+        }
 
     /** Checks if a peripheral is one of ours, either by its advertised name or by the services it provides. */
     @OptIn(ExperimentalUuidApi::class)


### PR DESCRIPTION
resolves #3719

This addresses a potential crash by ensuring Bluetooth permissions are checked before attempting to access bonded peripherals.

Specifically, `getBondedAppPeripherals` now verifies `hasBluetoothPermission()` before retrieving the list of bonded devices.

Additionally, a toast notification has been added to inform the user when necessary permissions are missing for a Bluetooth scan.