### PR TITLE
feat(bluetooth): Request location permission for BLE scan pre S

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/BLEDevices.kt
@@ -19,6 +19,7 @@ package com.geeksville.mesh.ui.connections.components
 
 import android.Manifest
 import android.content.Intent
+import android.os.Build
 import android.provider.Settings.ACTION_BLUETOOTH_SETTINGS
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -94,7 +95,11 @@ fun BLEDevices(
 
     // Define permissions needed for Bluetooth scanning based on Android version.
     val bluetoothPermissionsList = remember {
-        listOf(Manifest.permission.BLUETOOTH_SCAN, Manifest.permission.BLUETOOTH_CONNECT)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            listOf(Manifest.permission.BLUETOOTH_SCAN, Manifest.permission.BLUETOOTH_CONNECT)
+        } else {
+            listOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
     }
 
     val context = LocalContext.current


### PR DESCRIPTION
On Android versions prior to SDK 31 (Android S), `ACCESS_FINE_LOCATION` permission is required to perform a Bluetooth LE scan. This commit adds a conditional check for the device's SDK version.

- If the SDK version is S (31) or higher, it requests `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT`.
- If the SDK version is lower, it requests `ACCESS_FINE_LOCATION`.

This ensures the app has the necessary permissions to scan for BLE devices across different Android versions.