### PR TITLE
chore(ci): Use CROWDIN_GITHUB_TOKEN for scheduled updates PR

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Create Pull Request if changes occurred
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.AUTOMATION_PAT }}
+          token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
           commit-message: |
             chore: Scheduled updates (Firmware, Hardware, Translations)
 


### PR DESCRIPTION
This commit updates the `scheduled-updates.yml` workflow to use the `CROWDIN_GITHUB_TOKEN` secret instead of `AUTOMATION_PAT` for creating pull requests.
