### PR TITLE
ci(workflows): Preserve hierarchy when uploading sources to Crowdin

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: 'true'
 
       - name: Update firmware releases list
         run: |
@@ -79,7 +81,7 @@ jobs:
       - name: Create Pull Request if changes occurred
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |
             chore: Scheduled updates (Firmware, Hardware, Translations)
 


### PR DESCRIPTION
This change adds the `--preserve-hierarchy` argument to the Crowdin upload sources step in the `scheduled-updates` workflow. This ensures that the directory structure of the source files is maintained when they are uploaded to Crowdin.

