### PR TITLE
chore(crowdin): Remove `preserve_hierarchy` option

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,4 +6,3 @@ files:
     escape_quotes: 0
     escape_special_characters: 0
     type: android
-    preserve_hierarchy: true


### PR DESCRIPTION
The `preserve_hierarchy: true` configuration has been removed from the `crowdin.yml` file. This change simplifies the configuration by relying on the default behavior for file structure.
