### PR TITLE
ci: check workflow status on scheduled updates

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -106,3 +106,16 @@ jobs:
             l10n
             firmware
             hardware
+
+  check-workflow-status:
+    name: Check Workflow Status
+    runs-on: ubuntu-latest
+    needs:
+        - update_assets,
+    if: always()
+    steps:
+      - name: Check Workflow Status
+        if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')"
+        run: |
+          echo "One of the dependent jobs failed or was cancelled. Failing the workflow."
+          exit 1


### PR DESCRIPTION
This adds a `check-workflow-status` job to the `scheduled-updates.yml` workflow.

The new job ensures that the entire workflow run will be marked as failed if any of the preceding jobs (`update_assets`) fail or are cancelled.
