### PR TITLE
Exchange Position was sending exact position when channel settings were different

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -235,7 +235,6 @@ class MeshService : Service() {
         private const val MAX_EARLY_PACKET_BUFFER = 128
         private const val PRECISE_POSITION_BITS = 32
 
-
         @VisibleForTesting
         internal fun buildStoreForwardHistoryRequest(
             lastRequest: Int,
@@ -2509,7 +2508,8 @@ class MeshService : Service() {
                 if (destNum != myNodeNum) {
                     val provideLocation = meshPrefs.shouldProvideNodeLocation(myNodeNum)
                     val channel = nodeDBbyNodeNum[destNum]?.channel ?: 0
-                    val precision = this@MeshService.channelSet.settingsList.getOrNull(channel)?.moduleSettings?.positionPrecision ?: 0
+                    val channelSettingsList = this@MeshService.channelSet.settingsList
+                    val precision = channelSettingsList.getOrNull(channel)?.moduleSettings?.positionPrecision ?: 0
 
                     // default meshPosition to empty in case precision is 0 and this channel is not supposed to
                     // broadcast positions
@@ -2517,12 +2517,10 @@ class MeshService : Service() {
                     val currentPosition =
                         when {
                             provideLocation && position.isValid() -> position
-                            else ->
-                                nodeDBbyNodeNum[myNodeNum]?.position?.let { Position(it) }?.takeIf { it.isValid() }
+                            else -> nodeDBbyNodeNum[myNodeNum]?.position?.let { Position(it) }?.takeIf { it.isValid() }
                         }
 
                     if (precision > 0 && currentPosition != null) {
-
                         var latitude = Position.degI(currentPosition.latitude)
                         var longitude = Position.degI(currentPosition.longitude)
 
@@ -2541,10 +2539,10 @@ class MeshService : Service() {
                         meshPosition = position {
                             latitudeI = latitude
                             longitudeI = longitude
-                        altitude = currentPosition.altitude
-                        time = currentSecond()
+                            altitude = currentPosition.altitude
+                            time = currentSecond()
                             precisionBits = precision
-                    }
+                        }
                     }
 
                     packetHandler.sendToRadio(


### PR DESCRIPTION
There was an issue I noticed with the Exchange Position functionality where it would send my exact position to the mesh when my position was disabled or when the precision was modified. I hadn't opened an issue as I already discovered where this is happening.

## The issue
In the android app when the user activated the Exchange Position button, a POSITION_APP packet is generated and sent by the android app. This is different from the firmware which would have sent an imprecise position based on the precision setting of that channel or would not include position if disabled on the channel.

I replicated how the firmware generates POSITION_APP packets to ensure that this functions similarly.

## Testing
After making the change I built and ran the app on my phone, connected to a node and set the primary channel precision to 13.
<img width="621" height="1331" alt="image" src="https://github.com/user-attachments/assets/1a1582d7-8b45-43c4-8855-64e336367fc4" />
You can see that the position app with precision 13 was sent and I also received a response from the destination.

I then sent the request with position disabled on my primary channel.
<img width="621" height="1331" alt="image" src="https://github.com/user-attachments/assets/664a3a70-57ac-40e5-a09d-5e752156418e" />

You can see that the request was sent without the position and a response was received.

I ran the unit tests via android studio and ran the other gradle commands required by the contribution guide.
