### PR TITLE
feat: Keep screen on during firmware update

### DIFF
--- a/feature/firmware/src/main/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
+++ b/feature/firmware/src/main/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
@@ -74,6 +74,7 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -85,6 +86,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -139,6 +141,17 @@ fun FirmwareUpdateScreen(
         rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
             uri?.let { viewModel.startUpdateFromFile(it) }
         }
+
+    val shouldKeepScreenOn =
+        when (state) {
+            is FirmwareUpdateState.Downloading,
+            is FirmwareUpdateState.Processing,
+            is FirmwareUpdateState.Updating,
+            -> true
+            else -> false
+        }
+
+    KeepScreenOn(shouldKeepScreenOn)
 
     Scaffold(
         modifier = modifier,
@@ -564,5 +577,20 @@ private fun ColumnScope.SuccessState(onDone: () -> Unit) {
     Spacer(Modifier.height(32.dp))
     Button(onClick = onDone, modifier = Modifier.fillMaxWidth().height(56.dp)) {
         Text(stringResource(Res.string.firmware_update_done))
+    }
+}
+
+@Composable
+private fun KeepScreenOn(enabled: Boolean) {
+    val view = LocalView.current
+    DisposableEffect(enabled) {
+        if (enabled) {
+            view.keepScreenOn = true
+        }
+        onDispose {
+            if (enabled) {
+                view.keepScreenOn = false
+            }
+        }
     }
 }


### PR DESCRIPTION
This commit prevents the device screen from turning off during the firmware update process to ensure the user can monitor its progress without interruption.

- Added a `KeepScreenOn` composable that sets the `keepScreenOn` flag on the current `View`.
- The screen is kept on during the `Downloading`, `Processing`, and `Updating` states of the firmware update flow.
- The flag is cleared when the process is complete or the composable is disposed.