### PR TITLE
fix: message list paged lifecycle resulting in notifications being cleared

### DIFF
--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/MessageListPaged.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/MessageListPaged.kt
@@ -298,10 +298,7 @@ private fun AutoScrollToBottomPaged(
     }
 }
 
-private fun findFirstVisibleUnreadMessage(
-    messages: LazyPagingItems<Message>,
-    visibleIndex: Int,
-): Message? {
+private fun findFirstVisibleUnreadMessage(messages: LazyPagingItems<Message>, visibleIndex: Int): Message? {
     val firstVisibleUnreadIndex =
         (visibleIndex until messages.itemCount).firstOrNull { i ->
             val msg = messages[i]
@@ -377,9 +374,7 @@ private fun UpdateUnreadCountPaged(
                     // will batch-mark all older messages via SQL: WHERE received_time <= timestamp
                     if (lastUnreadIndex != null && index <= lastUnreadIndex) {
                         val firstVisibleUnread = findFirstVisibleUnreadMessage(messages, index)
-                        firstVisibleUnread?.let {
-                            currentOnUnreadChange(it.uuid, it.receivedTime)
-                        }
+                        firstVisibleUnread?.let { currentOnUnreadChange(it.uuid, it.receivedTime) }
                     }
                 }
             }


### PR DESCRIPTION
### Summary

Fixes a bug where message notifications were being cleared after 3 seconds even when the app was backgrounded or the screen was locked. The unread debounce timer now only marks messages as read and clears notifications when the message thread is actually visible to the user. This was introduced during my pagination work.

**Problem:** When a user left a message thread open and locked their screen or backgrounded the app, incoming message notifications would automatically disappear after 3 seconds due to the unread debounce continuing to run in the background.

**Solution:** Added lifecycle awareness to the UpdateUnreadCountPaged composable. The debounce now:
  - Pauses when the screen is locked or app is backgrounded (ON_PAUSE)
  - Restarts fresh when the user returns to the screen (ON_RESUME)
  - Only clears notifications after 3 seconds of the message thread being actively visible