### PR TITLE
fix: skip default nodeinfo upsert in handleReceivedUser for live packets

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -993,8 +993,8 @@ class MeshService : Service() {
     }
 
     /**
-     * Check if a User is a default/placeholder from firmware (node was evicted and re-created)
-     * and whether we should preserve existing user data instead of overwriting it.
+     * Check if a User is a default/placeholder from firmware (node was evicted and re-created) and whether we should
+     * preserve existing user data instead of overwriting it.
      */
     private fun shouldPreserveExistingUser(existing: MeshProtos.User, incoming: MeshProtos.User): Boolean {
         val isDefaultName = incoming.longName.matches(Regex("^Meshtastic [0-9a-fA-F]{4}$"))
@@ -1025,7 +1025,7 @@ class MeshService : Service() {
                 Timber.d(
                     "Preserving existing user data for node $fromNum: " +
                         "kept='${it.user.longName}' (hwModel=${it.user.hwModel}), " +
-                        "skipped default='${p.longName}' (hwModel=UNSET)"
+                        "skipped default='${p.longName}' (hwModel=UNSET)",
                 )
                 // Still update channel and verification status
                 it.channel = channel


### PR DESCRIPTION
Extends the fix from commit 552097888 to also protect handleReceivedUser(), which processes live NODEINFO_APP packets from the mesh.

The original fix only protected installNodeInfo() (initial device sync), but live NodeInfo packets were still overwriting user data through handleReceivedUser() without any protection against default names.

Changes:
- Extract duplicate logic into shouldPreserveExistingUser() helper function
- Apply same protection to handleReceivedUser() for live packet handling
- Refactor installNodeInfo() to use shared helper, eliminating duplication

This ensures that when firmware's NodeDB evicts a node and later re-creates it with default info ("Meshtastic XXXX", hwModel=UNSET), the app detects this in both code paths and preserves existing user data instead of overwriting it.

Fixes issue where user names were still being reset to defaults despite the original fix