### PR TITLE
Fix add qr acting like replace instead of add

### DIFF
--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
@@ -115,22 +115,21 @@ fun ScannedQrCodeDialog(
         remember(channelSet) { mutableStateListOf(elements = Array(size = channelSet.settingsCount, init = { true })) }
 
     val selectedChannelSet =
-    if (shouldReplace) {
-        channelSet.copy {
-            val result = settings.filterIndexed { i, _ -> channelSelections.getOrNull(i) == true }
-            settings.clear()
-            settings.addAll(result)
-        }
-    } else {
-        channelSet.copy {
-            // When adding (not replacing), include all previous channels + selected new channels
-            val selectedNewChannels = incoming.settingsList.filterIndexed { i, _ ->
-                channelSelections.getOrNull(i) == true
+        if (shouldReplace) {
+            channelSet.copy {
+                val result = settings.filterIndexed { i, _ -> channelSelections.getOrNull(i) == true }
+                settings.clear()
+                settings.addAll(result)
             }
-            settings.clear()
-            settings.addAll(channels.settingsList + selectedNewChannels)
+        } else {
+            channelSet.copy {
+                // When adding (not replacing), include all previous channels + selected new channels
+                val selectedNewChannels =
+                    incoming.settingsList.filterIndexed { i, _ -> channelSelections.getOrNull(i) == true }
+                settings.clear()
+                settings.addAll(channels.settingsList + selectedNewChannels)
+            }
         }
-    }
 
     // Compute LoRa configuration changes when in replace mode
     val loraChanges =


### PR DESCRIPTION
Closes #3464 ?? 
 
There was a major bug that made a add channel actually replace all channels instead. The only thing that worked correctly was add would not override the lora settings.

This is what happened when I would share just one channel from iOS to Android
<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/413e3cc1-86b2-4c2b-8ef1-048e9ea9495c" />

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/5e3d62cd-c651-4d17-899b-e313d96aa539" />
