### PR TITLE
fix: Multiple bugs - settings text fields, dropdowns, missing override duty cycle, and MQTT icon display

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -721,6 +721,7 @@ class MeshService : Service() {
             rssi = packet.rxRssi,
             replyId = data.replyId,
             relayNode = packet.relayNode,
+            viaMqtt = packet.viaMqtt,
         )
     }
 

--- a/core/database/src/main/kotlin/org/meshtastic/core/database/entity/Packet.kt
+++ b/core/database/src/main/kotlin/org/meshtastic/core/database/entity/Packet.kt
@@ -52,7 +52,7 @@ data class PacketEntity(
             packetId = packetId,
             emojis = reactions.toReaction(getNode),
             replyId = data.replyId,
-            viaMqtt = node.viaMqtt,
+            viaMqtt = data.viaMqtt,
             relayNode = data.relayNode,
             relays = data.relays,
         )

--- a/core/model/src/main/kotlin/org/meshtastic/core/model/DataPacket.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/DataPacket.kt
@@ -63,6 +63,7 @@ data class DataPacket(
     var replyId: Int? = null, // If this is a reply to a previous message, this is the ID of that message
     var relayNode: Int? = null,
     var relays: Int = 0,
+    var viaMqtt: Boolean = false, // True if this packet passed via MQTT somewhere along its path
 ) : Parcelable {
 
     /** If there was an error with this message, this string describes what was wrong. */

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
@@ -163,6 +163,7 @@ fun EditTextPreference(
     onValueChanged: (Double) -> Unit,
     modifier: Modifier = Modifier,
     summary: String? = null,
+    onFocusChanged: (FocusState) -> Unit = {},
 ) {
     var valueState by remember(value) { mutableStateOf(value.toString()) }
     val decimalSeparators = setOf('.', ',', '٫', '、', '·') // set of possible decimal separators
@@ -185,7 +186,7 @@ fun EditTextPreference(
                 }
             }
         },
-        onFocusChanged = {},
+        onFocusChanged = onFocusChanged,
         modifier = modifier,
     )
 }

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/CannedMessageConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/CannedMessageConfigItemList.kt
@@ -72,6 +72,8 @@ fun CannedMessageConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(),
         enabled = state.connected,
         responseState = state.responseState,
         onDismissPacketResponse = viewModel::clearPacketResponse,
+        additionalDirtyCheck = { messagesInput != messages },
+        onDiscard = { messagesInput = messages },
         onSave = {
             if (messagesInput != messages) {
                 viewModel.setCannedMessages(messagesInput)

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/ExternalNotificationConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/ExternalNotificationConfigItemList.kt
@@ -130,6 +130,8 @@ fun ExternalNotificationConfigScreen(
         enabled = state.connected,
         responseState = state.responseState,
         onDismissPacketResponse = viewModel::clearPacketResponse,
+        additionalDirtyCheck = { ringtoneInput != ringtone },
+        onDiscard = { ringtoneInput = ringtone },
         onSave = {
             if (ringtoneInput != ringtone) {
                 viewModel.setRingtone(ringtoneInput)
@@ -259,7 +261,7 @@ fun ExternalNotificationConfigScreen(
                 DropDownPreference(
                     title = stringResource(Res.string.output_duration_milliseconds),
                     items = outputItems.map { it.value to it.toDisplayString() },
-                    selectedItem = formState.value.outputMs,
+                    selectedItem = formState.value.outputMs.toLong(),
                     enabled = state.connected,
                     onItemSelected = { formState.value = formState.value.copy { outputMs = it.toInt() } },
                 )
@@ -268,7 +270,7 @@ fun ExternalNotificationConfigScreen(
                 DropDownPreference(
                     title = stringResource(Res.string.nag_timeout_seconds),
                     items = nagItems.map { it.value to it.toDisplayString() },
-                    selectedItem = formState.value.nagTimeout,
+                    selectedItem = formState.value.nagTimeout.toLong(),
                     enabled = state.connected,
                     onItemSelected = { formState.value = formState.value.copy { nagTimeout = it.toInt() } },
                 )

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -47,6 +47,7 @@ import org.meshtastic.core.strings.lora
 import org.meshtastic.core.strings.modem_preset
 import org.meshtastic.core.strings.ok_to_mqtt
 import org.meshtastic.core.strings.options
+import org.meshtastic.core.strings.override_duty_cycle
 import org.meshtastic.core.strings.override_frequency_mhz
 import org.meshtastic.core.strings.pa_fan_disabled
 import org.meshtastic.core.strings.region_frequency_plan
@@ -166,6 +167,14 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     checked = formState.value.txEnabled,
                     enabled = state.connected,
                     onCheckedChange = { formState.value = formState.value.copy { txEnabled = it } },
+                    containerColor = CardDefaults.cardColors().containerColor,
+                )
+                HorizontalDivider()
+                SwitchPreference(
+                    title = stringResource(Res.string.override_duty_cycle),
+                    checked = formState.value.overrideDutyCycle,
+                    enabled = state.connected,
+                    onCheckedChange = { formState.value = formState.value.copy { overrideDutyCycle = it } },
                     containerColor = CardDefaults.cardColors().containerColor,
                 )
                 HorizontalDivider()

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PositionConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/PositionConfigItemList.kt
@@ -149,6 +149,8 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
         enabled = state.connected,
         responseState = state.responseState,
         onDismissPacketResponse = viewModel::clearPacketResponse,
+        additionalDirtyCheck = { locationInput != currentPosition },
+        onDiscard = { locationInput = currentPosition },
         onSave = {
             if (formState.value.fixedPosition) {
                 if (locationInput != currentPosition) {
@@ -233,9 +235,9 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
                         value = locationInput.latitude,
                         enabled = state.connected,
                         keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-                        onValueChanged = { value ->
-                            if (value >= -90 && value <= 90.0) {
-                                locationInput = locationInput.copy(latitude = value)
+                        onValueChanged = { lat: Double ->
+                            if (lat >= -90 && lat <= 90.0) {
+                                locationInput = locationInput.copy(latitude = lat)
                             }
                         },
                     )
@@ -245,9 +247,9 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
                         value = locationInput.longitude,
                         enabled = state.connected,
                         keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-                        onValueChanged = { value ->
-                            if (value >= -180 && value <= 180.0) {
-                                locationInput = locationInput.copy(longitude = value)
+                        onValueChanged = { lon: Double ->
+                            if (lon >= -180 && lon <= 180.0) {
+                                locationInput = locationInput.copy(longitude = lon)
                             }
                         },
                     )
@@ -257,7 +259,7 @@ fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBa
                         value = locationInput.altitude,
                         enabled = state.connected,
                         keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-                        onValueChanged = { value -> locationInput = locationInput.copy(altitude = value) },
+                        onValueChanged = { alt: Int -> locationInput = locationInput.copy(altitude = alt) },
                     )
                     HorizontalDivider()
                     TextButton(


### PR DESCRIPTION
**Text field save buttons:**
  - Add additionalDirtyCheck parameter to RadioConfigScreenList for tracking state changes outside the main ConfigState
  - Track changes to Position coordinates, External Notification ringtone, and Canned Messages separately from main config state
  - Move save/discard buttons inside LazyColumn to prevent overlapping content
  - Add onDiscard callback to reset additional state
  - Add onFocusChanged parameter to EditTextPreference Double overload

**Dropdown type mismatches:**
  - Fix External Notification "Nag Timeout" dropdown showing blank by converting Int to Long (.toLong()) to match dropdown item types
  - Fix External Notification "Output Duration" dropdown same issue
  - Both fields are uint32 in protobuf, dropdowns use Long values

**Missing LoRa setting:**
  - Add missing "Override Duty Cycle" checkbox to LoRa config between txEnabled and hopLimit fields
  - Field existed in protobuf and translations but was omitted from UI

**MQTT cloud icon display:**
  - Fix MQTT cloud icon not displaying correctly for messages via MQTT
  - Add viaMqtt field to DataPacket model to store packet's via_mqtt flag
  - Map packet.viaMqtt in MeshService.toDataPacket() from protobuf
  - Use data.viaMqtt instead of node.viaMqtt in Packet.toMessage()
  - Icon now shows when the specific message traveled via MQTT, not just when we've ever heard from that node via MQTT
  
  Closes #3434 
  Closes #3324
  Closes #3548
  Closes #3567 