### PR TITLE
add 'ci' to autolabel for repo.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,7 +16,7 @@ enhancement:
  # or files in the .github dir
 repo:
 - any:
-  - head-branch: [repo, Repo, ci, CI]
+  - head-branch: [repo, Repo, REPO, ci, CI]
   - changed-files:
     - any-glob-to-any-file: .github
 


### PR DESCRIPTION
CI and repo both now get repo labels. 