### PR TITLE
feat(navigation): Implement adaptive list-detail for contacts and nodes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -219,6 +219,8 @@ dependencies {
     implementation(projects.feature.firmware)
 
     implementation(libs.androidx.compose.material3.adaptive)
+    implementation(libs.androidx.compose.material3.adaptive.layout)
+    implementation(libs.androidx.compose.material3.adaptive.navigation)
     implementation(libs.androidx.compose.material3.navigationSuite)
     implementation(libs.material)
     implementation(libs.androidx.compose.material3)

--- a/app/src/main/java/com/geeksville/mesh/navigation/ContactsNavigation.kt
+++ b/app/src/main/java/com/geeksville/mesh/navigation/ContactsNavigation.kt
@@ -23,15 +23,12 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
 import androidx.navigation.navigation
 import androidx.navigation.toRoute
-import com.geeksville.mesh.ui.contact.ContactsScreen
+import com.geeksville.mesh.ui.contact.AdaptiveContactsScreen
 import com.geeksville.mesh.ui.sharing.ShareScreen
 import kotlinx.coroutines.flow.Flow
-import org.meshtastic.core.navigation.ChannelsRoutes
 import org.meshtastic.core.navigation.ContactsRoutes
 import org.meshtastic.core.navigation.DEEP_LINK_BASE_URI
-import org.meshtastic.core.navigation.NodesRoutes
 import org.meshtastic.core.ui.component.ScrollToTopEvent
-import org.meshtastic.feature.messaging.MessageScreen
 import org.meshtastic.feature.messaging.QuickChatScreen
 
 @Suppress("LongMethod")
@@ -40,18 +37,7 @@ fun NavGraphBuilder.contactsGraph(navController: NavHostController, scrollToTopE
         composable<ContactsRoutes.Contacts>(
             deepLinks = listOf(navDeepLink<ContactsRoutes.Contacts>(basePath = "$DEEP_LINK_BASE_URI/contacts")),
         ) {
-            ContactsScreen(
-                onClickNodeChip = {
-                    navController.navigate(NodesRoutes.NodeDetailGraph(it)) {
-                        launchSingleTop = true
-                        restoreState = true
-                    }
-                },
-                onNavigateToMessages = { navController.navigate(ContactsRoutes.Messages(it)) },
-                onNavigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
-                onNavigateToShare = { navController.navigate(ChannelsRoutes.ChannelsGraph) },
-                scrollToTopEvents = scrollToTopEvents,
-            )
+            AdaptiveContactsScreen(navController = navController, scrollToTopEvents = scrollToTopEvents)
         }
         composable<ContactsRoutes.Messages>(
             deepLinks =
@@ -63,13 +49,11 @@ fun NavGraphBuilder.contactsGraph(navController: NavHostController, scrollToTopE
             ),
         ) { backStackEntry ->
             val args = backStackEntry.toRoute<ContactsRoutes.Messages>()
-            MessageScreen(
-                contactKey = args.contactKey,
-                message = args.message,
-                navigateToMessages = { navController.navigate(ContactsRoutes.Messages(it)) },
-                navigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
-                navigateToQuickChatOptions = { navController.navigate(ContactsRoutes.QuickChat) },
-                onNavigateBack = navController::navigateUp,
+            AdaptiveContactsScreen(
+                navController = navController,
+                scrollToTopEvents = scrollToTopEvents,
+                initialContactKey = args.contactKey,
+                initialMessage = args.message,
             )
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/AdaptiveContactsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/AdaptiveContactsScreen.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.ui.contact
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.navigation.ChannelsRoutes
+import org.meshtastic.core.navigation.ContactsRoutes
+import org.meshtastic.core.navigation.NodesRoutes
+import org.meshtastic.core.strings.Res
+import org.meshtastic.core.strings.conversations
+import org.meshtastic.core.ui.component.ScrollToTopEvent
+import org.meshtastic.core.ui.icon.Conversations
+import org.meshtastic.core.ui.icon.MeshtasticIcons
+import org.meshtastic.feature.messaging.MessageScreen
+
+@Suppress("LongMethod")
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+fun AdaptiveContactsScreen(
+    navController: NavHostController,
+    scrollToTopEvents: Flow<ScrollToTopEvent>,
+    initialContactKey: String? = null,
+    initialMessage: String = "",
+) {
+    val navigator = rememberListDetailPaneScaffoldNavigator<String>()
+    val scope = rememberCoroutineScope()
+
+    BackHandler(navigator.canNavigateBack()) { scope.launch { navigator.navigateBack() } }
+
+    LaunchedEffect(initialContactKey) {
+        if (initialContactKey != null) {
+            navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, initialContactKey)
+        }
+    }
+
+    ListDetailPaneScaffold(
+        directive = navigator.scaffoldDirective,
+        value = navigator.scaffoldValue,
+        listPane = {
+            AnimatedPane {
+                ContactsScreen(
+                    onNavigateToShare = { navController.navigate(ChannelsRoutes.ChannelsGraph) },
+                    onClickNodeChip = {
+                        navController.navigate(NodesRoutes.NodeDetailGraph(it)) {
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
+                    onNavigateToMessages = { contactKey ->
+                        scope.launch { navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, contactKey) }
+                    },
+                    onNavigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
+                    scrollToTopEvents = scrollToTopEvents,
+                    activeContactKey = navigator.currentDestination?.contentKey,
+                )
+            }
+        },
+        detailPane = {
+            AnimatedPane {
+                val contactKey = navigator.currentDestination?.contentKey
+
+                if (contactKey != null) {
+                    MessageScreen(
+                        contactKey = contactKey,
+                        message = if (contactKey == initialContactKey) initialMessage else "",
+                        navigateToMessages = { newContactKey ->
+                            scope.launch { navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, newContactKey) }
+                        },
+                        navigateToNodeDetails = { navController.navigate(NodesRoutes.NodeDetailGraph(it)) },
+                        navigateToQuickChatOptions = { navController.navigate(ContactsRoutes.QuickChat) },
+                        onNavigateBack = {
+                            if (navigator.canNavigateBack()) {
+                                scope.launch { navigator.navigateBack() }
+                            } else {
+                                navController.navigateUp()
+                            }
+                        },
+                    )
+                } else {
+                    PlaceholderScreen()
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun PlaceholderScreen() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+            Icon(
+                imageVector = MeshtasticIcons.Conversations,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(Res.string.conversations),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/ContactItem.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.automirrored.twotone.VolumeOff
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -67,20 +68,39 @@ fun ContactItem(
     contact: Contact,
     selected: Boolean,
     modifier: Modifier = Modifier,
+    isActive: Boolean = false,
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = {},
     onNodeChipClick: () -> Unit = {},
     channels: AppOnlyProtos.ChannelSet? = null,
 ) = with(contact) {
+    val isOutlined = !selected && !isActive
+
+    val colors =
+        if (isOutlined) {
+            CardDefaults.outlinedCardColors(containerColor = Color.Transparent)
+        } else {
+            val containerColor = if (selected) Color.Gray else MaterialTheme.colorScheme.surfaceVariant
+            CardDefaults.cardColors(containerColor = containerColor)
+        }
+
+    val border =
+        if (isOutlined) {
+            CardDefaults.outlinedCardBorder()
+        } else {
+            null
+        }
+
     Card(
         modifier =
         modifier
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)
-            .background(color = if (selected) Color.Gray else MaterialTheme.colorScheme.background)
             .fillMaxWidth()
             .padding(horizontal = 8.dp, vertical = 4.dp)
             .semantics { contentDescription = shortName },
         shape = RoundedCornerShape(12.dp),
+        colors = colors,
+        border = border,
     ) {
         Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
             ContactHeader(contact = contact, channels = channels, onNodeChipClick = onNodeChipClick)

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/Contacts.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/Contacts.kt
@@ -112,6 +112,7 @@ fun ContactsScreen(
     onNavigateToMessages: (String) -> Unit = {},
     onNavigateToNodeDetails: (Int) -> Unit = {},
     scrollToTopEvents: Flow<ScrollToTopEvent>? = null,
+    activeContactKey: String? = null,
 ) {
     val connectionState by viewModel.connectionState.collectAsStateWithLifecycle()
     val ourNode by viewModel.ourNodeInfo.collectAsStateWithLifecycle()
@@ -252,6 +253,7 @@ fun ContactsScreen(
                 contacts = pagedContacts,
                 channelPlaceholders = channelPlaceholders,
                 selectedList = selectedContactKeys,
+                activeContactKey = activeContactKey,
                 onClick = onContactClick,
                 onLongClick = onContactLongClick,
                 onNodeChipClick = onNodeChipClick,
@@ -473,6 +475,7 @@ private fun ContactListViewPaged(
     contacts: LazyPagingItems<Contact>,
     channelPlaceholders: List<Contact>,
     selectedList: List<String>,
+    activeContactKey: String?,
     onClick: (Contact) -> Unit,
     onLongClick: (Contact) -> Unit,
     onNodeChipClick: (Contact) -> Unit,
@@ -493,6 +496,7 @@ private fun ContactListViewPaged(
         contacts = contacts,
         visiblePlaceholders = visiblePlaceholders,
         selectedList = selectedList,
+        activeContactKey = activeContactKey,
         onClick = onClick,
         onLongClick = onLongClick,
         onNodeChipClick = onNodeChipClick,
@@ -508,6 +512,7 @@ private fun ContactListContentInternal(
     contacts: LazyPagingItems<Contact>,
     visiblePlaceholders: List<Contact>,
     selectedList: List<String>,
+    activeContactKey: String?,
     onClick: (Contact) -> Unit,
     onLongClick: (Contact) -> Unit,
     onNodeChipClick: (Contact) -> Unit,
@@ -520,6 +525,7 @@ private fun ContactListContentInternal(
         contactListPlaceholdersItems(
             visiblePlaceholders = visiblePlaceholders,
             selectedList = selectedList,
+            activeContactKey = activeContactKey,
             onClick = onClick,
             onLongClick = onLongClick,
             onNodeChipClick = onNodeChipClick,
@@ -530,6 +536,7 @@ private fun ContactListContentInternal(
         contactListPagedItems(
             contacts = contacts,
             selectedList = selectedList,
+            activeContactKey = activeContactKey,
             onClick = onClick,
             onLongClick = onLongClick,
             onNodeChipClick = onNodeChipClick,
@@ -544,6 +551,7 @@ private fun ContactListContentInternal(
 private fun LazyListScope.contactListPlaceholdersItems(
     visiblePlaceholders: List<Contact>,
     selectedList: List<String>,
+    activeContactKey: String?,
     onClick: (Contact) -> Unit,
     onLongClick: (Contact) -> Unit,
     onNodeChipClick: (Contact) -> Unit,
@@ -556,10 +564,12 @@ private fun LazyListScope.contactListPlaceholdersItems(
     ) { index ->
         val placeholder = visiblePlaceholders[index]
         val selected by remember { derivedStateOf { selectedList.contains(placeholder.contactKey) } }
+        val isActive = remember(placeholder.contactKey, activeContactKey) { placeholder.contactKey == activeContactKey }
 
         ContactItem(
             contact = placeholder,
             selected = selected,
+            isActive = isActive,
             onClick = { onClick(placeholder) },
             onLongClick = {
                 onLongClick(placeholder)
@@ -574,6 +584,7 @@ private fun LazyListScope.contactListPlaceholdersItems(
 private fun LazyListScope.contactListPagedItems(
     contacts: LazyPagingItems<Contact>,
     selectedList: List<String>,
+    activeContactKey: String?,
     onClick: (Contact) -> Unit,
     onLongClick: (Contact) -> Unit,
     onNodeChipClick: (Contact) -> Unit,
@@ -590,10 +601,12 @@ private fun LazyListScope.contactListPagedItems(
         val contact = contacts[index]
         if (contact != null) {
             val selected by remember { derivedStateOf { selectedList.contains(contact.contactKey) } }
+            val isActive = remember(contact.contactKey, activeContactKey) { contact.contactKey == activeContactKey }
 
             ContactItem(
                 contact = contact,
                 selected = selected,
+                isActive = isActive,
                 onClick = { onClick(contact) },
                 onLongClick = {
                     onLongClick(contact)

--- a/app/src/main/java/com/geeksville/mesh/ui/node/AdaptiveNodeListScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/AdaptiveNodeListScreen.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.ui.node
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.navigation.Route
+import org.meshtastic.core.strings.Res
+import org.meshtastic.core.strings.nodes
+import org.meshtastic.core.ui.component.ScrollToTopEvent
+import org.meshtastic.core.ui.icon.MeshtasticIcons
+import org.meshtastic.core.ui.icon.Nodes
+import org.meshtastic.feature.node.detail.NodeDetailScreen
+import org.meshtastic.feature.node.list.NodeListScreen
+
+@Suppress("LongMethod")
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+fun AdaptiveNodeListScreen(
+    navController: NavHostController,
+    scrollToTopEvents: Flow<ScrollToTopEvent>,
+    initialNodeId: Int? = null,
+    onNavigateToMessages: (String) -> Unit = {},
+) {
+    val navigator = rememberListDetailPaneScaffoldNavigator<Int>()
+    val scope = rememberCoroutineScope()
+
+    val isDetailActive = navigator.currentDestination?.contentKey != null
+
+    BackHandler(enabled = isDetailActive) {
+        scope.launch {
+            if (navigator.canNavigateBack()) {
+                navigator.navigateBack()
+            } else {
+                navigator.navigateTo(ListDetailPaneScaffoldRole.List, null)
+            }
+        }
+    }
+
+    LaunchedEffect(initialNodeId) {
+        if (initialNodeId != null) {
+            navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, initialNodeId)
+        }
+    }
+
+    ListDetailPaneScaffold(
+        directive = navigator.scaffoldDirective,
+        value = navigator.scaffoldValue,
+        listPane = {
+            AnimatedPane {
+                NodeListScreen(
+                    navigateToNodeDetails = { nodeId ->
+                        scope.launch { navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, nodeId) }
+                    },
+                    scrollToTopEvents = scrollToTopEvents,
+                    activeNodeId = navigator.currentDestination?.contentKey,
+                )
+            }
+        },
+        detailPane = {
+            AnimatedPane {
+                val nodeId = navigator.currentDestination?.contentKey
+                if (nodeId != null) {
+                    NodeDetailScreenWrapper(
+                        nodeId = nodeId,
+                        navigateToMessages = onNavigateToMessages,
+                        onNavigate = { route -> navController.navigate(route) },
+                        onNavigateUp = { scope.launch { navigator.navigateTo(ListDetailPaneScaffoldRole.List, null) } },
+                    )
+                } else {
+                    PlaceholderScreen()
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun NodeDetailScreenWrapper(
+    nodeId: Int,
+    navigateToMessages: (String) -> Unit,
+    onNavigate: (Route) -> Unit,
+    onNavigateUp: () -> Unit,
+) {
+    NodeDetailScreen(
+        onNavigateUp = onNavigateUp,
+        navigateToMessages = navigateToMessages,
+        onNavigate = onNavigate,
+        overrideNodeId = nodeId,
+    )
+}
+
+@Composable
+private fun PlaceholderScreen() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+            Icon(
+                imageVector = MeshtasticIcons.Nodes,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(Res.string.nodes),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/core/navigation/src/main/kotlin/org/meshtastic/core/navigation/Routes.kt
+++ b/core/navigation/src/main/kotlin/org/meshtastic/core/navigation/Routes.kt
@@ -64,23 +64,23 @@ object NodesRoutes {
 }
 
 object NodeDetailRoutes {
-    @Serializable data object DeviceMetrics : Route
+    @Serializable data class DeviceMetrics(val destNum: Int) : Route
 
-    @Serializable data object NodeMap : Route
+    @Serializable data class NodeMap(val destNum: Int) : Route
 
-    @Serializable data object PositionLog : Route
+    @Serializable data class PositionLog(val destNum: Int) : Route
 
-    @Serializable data object EnvironmentMetrics : Route
+    @Serializable data class EnvironmentMetrics(val destNum: Int) : Route
 
-    @Serializable data object SignalMetrics : Route
+    @Serializable data class SignalMetrics(val destNum: Int) : Route
 
-    @Serializable data object PowerMetrics : Route
+    @Serializable data class PowerMetrics(val destNum: Int) : Route
 
-    @Serializable data object TracerouteLog : Route
+    @Serializable data class TracerouteLog(val destNum: Int) : Route
 
-    @Serializable data object HostMetricsLog : Route
+    @Serializable data class HostMetricsLog(val destNum: Int) : Route
 
-    @Serializable data object PaxMetrics : Route
+    @Serializable data class PaxMetrics(val destNum: Int) : Route
 }
 
 object SettingsRoutes {

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/MetricsSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/MetricsSection.kt
@@ -61,7 +61,7 @@ fun MetricsSection(
         TitledCard(title = stringResource(Res.string.logs), modifier = modifier) {
             nonPositionLogs.forEach { type ->
                 ListItem(text = stringResource(type.titleRes), leadingIcon = type.icon) {
-                    onAction(NodeDetailAction.Navigate(type.route))
+                    onAction(NodeDetailAction.Navigate(type.routeFactory(node.num)))
                 }
             }
         }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
@@ -61,6 +61,9 @@ import org.meshtastic.core.ui.component.preview.NodePreviewParameterProvider
 import org.meshtastic.core.ui.theme.AppTheme
 import org.meshtastic.proto.ConfigProtos.Config.DisplayConfig
 
+private const val ACTIVE_ALPHA = 0.5f
+private const val INACTIVE_ALPHA = 0.2f
+
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
@@ -74,6 +77,7 @@ fun NodeItem(
     onLongClick: (() -> Unit)? = null,
     currentTimeMillis: Long,
     connectionState: ConnectionState,
+    isActive: Boolean = false,
 ) {
     val isFavorite = remember(thatNode) { thatNode.isFavorite }
     val isIgnored = thatNode.isIgnored
@@ -91,7 +95,8 @@ fun NodeItem(
             thatNode.colors.second
         }
             ?.let {
-                val containerColor = Color(it).copy(alpha = 0.2f)
+                val alpha = if (isActive) ACTIVE_ALPHA else INACTIVE_ALPHA
+                val containerColor = Color(it).copy(alpha = alpha)
                 contentColor = contentColorFor(containerColor)
                 CardDefaults.cardColors().copy(containerColor = containerColor, contentColor = contentColor)
             } ?: (CardDefaults.cardColors())

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/PositionSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/PositionSection.kt
@@ -90,7 +90,7 @@ fun PositionSection(
             InsetDivider()
 
             ListItem(text = stringResource(LogsType.NODE_MAP.titleRes), leadingIcon = LogsType.NODE_MAP.icon) {
-                onAction(NodeDetailAction.Navigate(LogsType.NODE_MAP.route))
+                onAction(NodeDetailAction.Navigate(LogsType.NODE_MAP.routeFactory(node.num)))
             }
         }
 
@@ -99,7 +99,7 @@ fun PositionSection(
             InsetDivider()
 
             ListItem(text = stringResource(LogsType.POSITIONS.titleRes), leadingIcon = LogsType.POSITIONS.icon) {
-                onAction(NodeDetailAction.Navigate(LogsType.POSITIONS.route))
+                onAction(NodeDetailAction.Navigate(LogsType.POSITIONS.routeFactory(node.num)))
             }
         }
     }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailScreen.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -48,7 +49,14 @@ fun NodeDetailScreen(
     navigateToMessages: (String) -> Unit = {},
     onNavigate: (Route) -> Unit = {},
     onNavigateUp: () -> Unit = {},
+    overrideNodeId: Int? = null,
 ) {
+    LaunchedEffect(overrideNodeId) {
+        if (overrideNodeId != null) {
+            viewModel.setNodeId(overrideNodeId)
+        }
+    }
+
     val state by viewModel.state.collectAsStateWithLifecycle()
     val environmentState by viewModel.environmentState.collectAsStateWithLifecycle()
     val lastTracerouteTime by nodeDetailViewModel.lastTraceRouteTime.collectAsStateWithLifecycle()

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeFilterPreferences.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeFilterPreferences.kt
@@ -17,6 +17,8 @@
 
 package org.meshtastic.feature.node.list
 
+import kotlinx.coroutines.flow.map
+import org.meshtastic.core.database.model.NodeSortOption
 import org.meshtastic.core.datastore.UiPreferencesDataSource
 import javax.inject.Inject
 
@@ -26,6 +28,13 @@ class NodeFilterPreferences @Inject constructor(private val uiPreferencesDataSou
     val onlyOnline = uiPreferencesDataSource.onlyOnline
     val onlyDirect = uiPreferencesDataSource.onlyDirect
     val showIgnored = uiPreferencesDataSource.showIgnored
+
+    val nodeSortOption =
+        uiPreferencesDataSource.nodeSort.map { NodeSortOption.entries.getOrElse(it) { NodeSortOption.VIA_FAVORITE } }
+
+    fun setNodeSort(option: NodeSortOption) {
+        uiPreferencesDataSource.setNodeSort(option.ordinal)
+    }
 
     fun toggleIncludeUnknown() {
         uiPreferencesDataSource.setIncludeUnknown(!includeUnknown.value)

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -91,6 +91,7 @@ fun NodeListScreen(
     navigateToNodeDetails: (Int) -> Unit,
     viewModel: NodeListViewModel = hiltViewModel(),
     scrollToTopEvents: Flow<ScrollToTopEvent>? = null,
+    activeNodeId: Int? = null,
 ) {
     val state by viewModel.nodesUiState.collectAsStateWithLifecycle()
 
@@ -208,6 +209,8 @@ fun NodeListScreen(
                                 null
                             }
 
+                        val isActive = remember(activeNodeId, node.num) { activeNodeId == node.num }
+
                         NodeItem(
                             modifier = Modifier.animateItem(),
                             thisNode = ourNode,
@@ -218,6 +221,7 @@ fun NodeListScreen(
                             onLongClick = longClick,
                             currentTimeMillis = currentTimeMillis,
                             connectionState = connectionState,
+                            isActive = isActive,
                         )
                         val isThisNode = remember(node) { ourNode?.num == node.num }
                         if (!isThisNode) {

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/model/LogsType.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/model/LogsType.kt
@@ -42,14 +42,14 @@ import org.meshtastic.core.strings.power_metrics_log
 import org.meshtastic.core.strings.sig_metrics_log
 import org.meshtastic.core.strings.traceroute_log
 
-enum class LogsType(val titleRes: StringResource, val icon: ImageVector, val route: Route) {
-    DEVICE(Res.string.device_metrics_log, Icons.Default.ChargingStation, NodeDetailRoutes.DeviceMetrics),
-    NODE_MAP(Res.string.node_map, Icons.Default.Map, NodeDetailRoutes.NodeMap),
-    POSITIONS(Res.string.position_log, Icons.Default.LocationOn, NodeDetailRoutes.PositionLog),
-    ENVIRONMENT(Res.string.env_metrics_log, Icons.Default.Thermostat, NodeDetailRoutes.EnvironmentMetrics),
-    SIGNAL(Res.string.sig_metrics_log, Icons.Default.SignalCellularAlt, NodeDetailRoutes.SignalMetrics),
-    POWER(Res.string.power_metrics_log, Icons.Default.Power, NodeDetailRoutes.PowerMetrics),
-    TRACEROUTE(Res.string.traceroute_log, Icons.Default.Route, NodeDetailRoutes.TracerouteLog),
-    HOST(Res.string.host_metrics_log, Icons.Default.Memory, NodeDetailRoutes.HostMetricsLog),
-    PAX(Res.string.pax_metrics_log, Icons.Default.People, NodeDetailRoutes.PaxMetrics),
+enum class LogsType(val titleRes: StringResource, val icon: ImageVector, val routeFactory: (Int) -> Route) {
+    DEVICE(Res.string.device_metrics_log, Icons.Default.ChargingStation, { NodeDetailRoutes.DeviceMetrics(it) }),
+    NODE_MAP(Res.string.node_map, Icons.Default.Map, { NodeDetailRoutes.NodeMap(it) }),
+    POSITIONS(Res.string.position_log, Icons.Default.LocationOn, { NodeDetailRoutes.PositionLog(it) }),
+    ENVIRONMENT(Res.string.env_metrics_log, Icons.Default.Thermostat, { NodeDetailRoutes.EnvironmentMetrics(it) }),
+    SIGNAL(Res.string.sig_metrics_log, Icons.Default.SignalCellularAlt, { NodeDetailRoutes.SignalMetrics(it) }),
+    POWER(Res.string.power_metrics_log, Icons.Default.Power, { NodeDetailRoutes.PowerMetrics(it) }),
+    TRACEROUTE(Res.string.traceroute_log, Icons.Default.Route, { NodeDetailRoutes.TracerouteLog(it) }),
+    HOST(Res.string.host_metrics_log, Icons.Default.Memory, { NodeDetailRoutes.HostMetricsLog(it) }),
+    PAX(Res.string.pax_metrics_log, Icons.Default.People, { NodeDetailRoutes.PaxMetrics(it) }),
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,6 +76,8 @@ androidx-compose-material-iconsExtended = { module = "androidx.compose.material:
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-material3-navigationSuite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite" }
 androidx-compose-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "androidxComposeMaterial3Adaptive" }
+androidx-compose-material3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout", version.ref = "androidxComposeMaterial3Adaptive" }
+androidx-compose-material3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "androidxComposeMaterial3Adaptive" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "androidxTracing" }


### PR DESCRIPTION
Introduces `ListDetailPaneScaffold` from Material 3 Adaptive to create adaptive layouts for the Contacts and Nodes screens, providing a two-pane view on larger screens.

- Added `AdaptiveContactsScreen` to display a contact list and message view side-by-side.
- Added `AdaptiveNodeListScreen` to show a node list and node details concurrently.
- Updated `ContactsNavigation` and `NodesNavigation` to use these new adaptive screens.
- Refactored `MetricsViewModel` to dynamically update its `nodeId` and re-initialize data flows when the selected node changes in the UI.
- Passed `destNum` to `NodeDetailRoutes` to ensure metrics screens display data for the correct node.
- Added a visual indicator for the currently active item in both the contact and node lists.
- Included necessary Material 3 Adaptive dependencies (`adaptive-layout`, `adaptive-navigation`).

<img width="600" alt="image" src="https://github.com/user-attachments/assets/d81ac858-d895-494e-87cb-512bf1b8e2fc" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6a70d406-46dd-4e53-ba0d-f147d051a3c3" />

