### PR TITLE
feat(model): Make NetworkDeviceHardware robust to unknown JSON keys

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(projects.core.strings)
 
     implementation(libs.androidx.annotation)
+    implementation(libs.kotlinx.serialization.json)
     implementation(libs.timber)
     implementation(libs.zxing.android.embedded) { isTransitive = false }
     implementation(libs.zxing.core)

--- a/core/model/src/main/kotlin/org/meshtastic/core/model/NetworkDeviceHardware.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/NetworkDeviceHardware.kt
@@ -17,10 +17,14 @@
 
 package org.meshtastic.core.model
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
+@JsonIgnoreUnknownKeys
 data class NetworkDeviceHardware(
     @SerialName("activelySupported") val activelySupported: Boolean = false,
     @SerialName("architecture") val architecture: String = "",
@@ -30,9 +34,11 @@ data class NetworkDeviceHardware(
     @SerialName("hwModel") val hwModel: Int = 0,
     @SerialName("hwModelSlug") val hwModelSlug: String = "",
     @SerialName("images") val images: List<String>? = null,
+    @SerialName("key") val key: String? = null,
     @SerialName("partitionScheme") val partitionScheme: String? = null,
     @SerialName("platformioTarget") val platformioTarget: String = "",
     @SerialName("requiresDfu") val requiresDfu: Boolean? = null,
     @SerialName("supportLevel") val supportLevel: Int? = null,
     @SerialName("tags") val tags: List<String>? = null,
+    @SerialName("variant") val variant: String? = null,
 )


### PR DESCRIPTION
This commit enhances the `NetworkDeviceHardware` data class by adding the `@JsonIgnoreUnknownKeys` annotation. This makes JSON deserialization more resilient by preventing crashes if the `devices.json` file contains new, unknown properties.

Additionally, two new nullable fields, `key` and `variant`, have been added to the model to support future device definitions. The `kotlinx-serialization-json` dependency has been included in the `core/model` module to support these changes.