### PR TITLE
Node list molecule

### DIFF
--- a/feature/node/build.gradle.kts
+++ b/feature/node/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.markdown.renderer.android)
     implementation(libs.markdown.renderer.m3)
     implementation(libs.markdown.renderer)
+    implementation(libs.molecule)
 
     googleImplementation(libs.location.services)
     googleImplementation(libs.maps.compose)

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeFilterTextField.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeFilterTextField.kt
@@ -75,30 +75,30 @@ import org.meshtastic.core.strings.node_filter_title
 import org.meshtastic.core.strings.node_sort_button
 import org.meshtastic.core.strings.node_sort_title
 import org.meshtastic.core.ui.theme.AppTheme
+import org.meshtastic.feature.node.list.NodeFilterState
 
 @Suppress("LongParameterList")
 @Composable
 fun NodeFilterTextField(
     modifier: Modifier = Modifier,
-    filterText: String,
+    filterState: NodeFilterState,
     onTextChange: (String) -> Unit,
     currentSortOption: NodeSortOption,
     onSortSelect: (NodeSortOption) -> Unit,
-    includeUnknown: Boolean,
     onToggleIncludeUnknown: () -> Unit,
-    excludeInfrastructure: Boolean,
     onToggleExcludeInfrastructure: () -> Unit,
-    onlyOnline: Boolean,
     onToggleOnlyOnline: () -> Unit,
-    onlyDirect: Boolean,
     onToggleOnlyDirect: () -> Unit,
-    showIgnored: Boolean,
     onToggleShowIgnored: () -> Unit,
     ignoredNodeCount: Int,
 ) {
     Column(modifier = modifier.background(MaterialTheme.colorScheme.background)) {
         Row {
-            NodeFilterTextField(filterText = filterText, onTextChange = onTextChange, modifier = Modifier.weight(1f))
+            NodeFilterTextField(
+                filterText = filterState.filterText,
+                onTextChange = onTextChange,
+                modifier = Modifier.weight(1f),
+            )
 
             NodeSortButton(
                 modifier = Modifier.align(Alignment.CenterVertically),
@@ -106,21 +106,21 @@ fun NodeFilterTextField(
                 onSortSelect = onSortSelect,
                 toggles =
                 NodeFilterToggles(
-                    includeUnknown = includeUnknown,
+                    includeUnknown = filterState.includeUnknown,
                     onToggleIncludeUnknown = onToggleIncludeUnknown,
-                    excludeInfrastructure = excludeInfrastructure,
+                    excludeInfrastructure = filterState.excludeInfrastructure,
                     onToggleExcludeInfrastructure = onToggleExcludeInfrastructure,
-                    onlyOnline = onlyOnline,
+                    onlyOnline = filterState.onlyOnline,
                     onToggleOnlyOnline = onToggleOnlyOnline,
-                    onlyDirect = onlyDirect,
+                    onlyDirect = filterState.onlyDirect,
                     onToggleOnlyDirect = onToggleOnlyDirect,
-                    showIgnored = showIgnored,
+                    showIgnored = filterState.showIgnored,
                     onToggleShowIgnored = onToggleShowIgnored,
                     ignoredNodeCount = ignoredNodeCount,
                 ),
             )
         }
-        if (showIgnored) {
+        if (filterState.showIgnored) {
             Box(
                 modifier =
                 Modifier.fillMaxWidth()
@@ -303,19 +303,14 @@ private fun DropdownMenuCheck(
 private fun NodeFilterTextFieldPreview() {
     AppTheme {
         NodeFilterTextField(
-            filterText = "Filter text",
+            filterState = NodeFilterState(),
             onTextChange = {},
             currentSortOption = NodeSortOption.LAST_HEARD,
             onSortSelect = {},
-            includeUnknown = false,
             onToggleIncludeUnknown = {},
-            excludeInfrastructure = false,
             onToggleExcludeInfrastructure = {},
-            onlyOnline = false,
             onToggleOnlyOnline = {},
-            onlyDirect = false,
             onToggleOnlyDirect = {},
-            showIgnored = false,
             onToggleShowIgnored = {},
             ignoredNodeCount = 0,
         )

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -153,21 +153,16 @@ fun NodeListScreen(
                             .graphicsLayer(alpha = animatedAlpha)
                             .background(MaterialTheme.colorScheme.surfaceDim)
                             .padding(8.dp),
-                        filterText = state.filter.filterText,
+                        filterState = state.filter,
                         onTextChange = { viewModel.setFilterText(it) },
                         currentSortOption = state.sort,
                         onSortSelect = viewModel::setSortOption,
-                        includeUnknown = state.filter.includeUnknown,
                         onToggleIncludeUnknown = { viewModel.nodeFilterPreferences.toggleIncludeUnknown() },
-                        excludeInfrastructure = state.filter.excludeInfrastructure,
                         onToggleExcludeInfrastructure = {
                             viewModel.nodeFilterPreferences.toggleExcludeInfrastructure()
                         },
-                        onlyOnline = state.filter.onlyOnline,
                         onToggleOnlyOnline = { viewModel.nodeFilterPreferences.toggleOnlyOnline() },
-                        onlyDirect = state.filter.onlyDirect,
                         onToggleOnlyDirect = { viewModel.nodeFilterPreferences.toggleOnlyDirect() },
-                        showIgnored = state.filter.showIgnored,
                         onToggleShowIgnored = { viewModel.nodeFilterPreferences.toggleShowIgnored() },
                         ignoredNodeCount = state.ignoredNodeCount,
                     )

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -96,9 +96,6 @@ fun NodeListScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
-    val unfilteredNodes by viewModel.unfilteredNodeList.collectAsStateWithLifecycle()
-    val ignoredNodeCount = unfilteredNodes.count { it.isIgnored }
-
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
 
@@ -172,7 +169,7 @@ fun NodeListScreen(
                         onToggleOnlyDirect = { viewModel.nodeFilterPreferences.toggleOnlyDirect() },
                         showIgnored = state.filter.showIgnored,
                         onToggleShowIgnored = { viewModel.nodeFilterPreferences.toggleShowIgnored() },
-                        ignoredNodeCount = ignoredNodeCount,
+                        ignoredNodeCount = state.ignoredNodeCount,
                     )
                 }
 

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -154,7 +154,6 @@ fun NodeListScreen(
                             .background(MaterialTheme.colorScheme.surfaceDim)
                             .padding(8.dp),
                         filterState = state.filter,
-                        onTextChange = { viewModel.setFilterText(it) },
                         currentSortOption = state.sort,
                         onSortSelect = viewModel::setSortOption,
                         onToggleIncludeUnknown = { viewModel.nodeFilterPreferences.toggleIncludeUnknown() },

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -94,7 +94,7 @@ fun NodeListScreen(
     scrollToTopEvents: Flow<ScrollToTopEvent>? = null,
     activeNodeId: Int? = null,
 ) {
-    val state by viewModel.nodesUiState.collectAsStateWithLifecycle()
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     val nodes by viewModel.nodeList.collectAsStateWithLifecycle()
     val ourNode by viewModel.ourNodeInfo.collectAsStateWithLifecycle()
@@ -161,7 +161,7 @@ fun NodeListScreen(
                             .background(MaterialTheme.colorScheme.surfaceDim)
                             .padding(8.dp),
                         filterText = state.filter.filterText,
-                        onTextChange = { viewModel.nodeFilterText = it },
+                        onTextChange = { viewModel.setFilterText(it) },
                         currentSortOption = state.sort,
                         onSortSelect = viewModel::setSortOption,
                         includeUnknown = state.filter.includeUnknown,

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
@@ -17,6 +17,7 @@
 
 package org.meshtastic.feature.node.list
 
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -61,7 +62,7 @@ constructor(
     private val _sharedContactRequested: MutableStateFlow<AdminProtos.SharedContact?> = MutableStateFlow(null)
     val sharedContactRequested = _sharedContactRequested.asStateFlow()
 
-    private val filterText = savedStateHandle.getStateFlow(KEY_FILTER_TEXT, "")
+    private val filterText = mutableStateOf(TextFieldState())
 
     private val moleculeScope = CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
     val uiState: StateFlow<NodesUiState> by
@@ -71,7 +72,6 @@ constructor(
                 val onlineNodeCount by nodeRepository.onlineNodeCount.collectAsState(0)
                 val totalNodeCount by nodeRepository.totalNodeCount.collectAsState(0)
                 val connectionState by serviceRepository.connectionState.collectAsState()
-                val filterText by filterText
                 val includeUnknown by nodeFilterPreferences.includeUnknown.collectAsState()
                 val excludeInfrastructure by nodeFilterPreferences.excludeInfrastructure.collectAsState()
                 val onlyOnline by nodeFilterPreferences.onlyOnline.collectAsState()
@@ -81,7 +81,7 @@ constructor(
 
                 val filter =
                     NodeFilterState(
-                        filterText = filterText,
+                        filterText = filterText.value,
                         includeUnknown = includeUnknown,
                         excludeInfrastructure = excludeInfrastructure,
                         onlyOnline = onlyOnline,
@@ -97,7 +97,7 @@ constructor(
                     nodeRepository
                         .getNodes(
                             sort = sort,
-                            filter = filter.filterText,
+                            filter = filter.filterText.text.toString(),
                             includeUnknown = filter.includeUnknown,
                             onlyOnline = filter.onlyOnline,
                             onlyDirect = filter.onlyDirect,
@@ -138,10 +138,6 @@ constructor(
             }
         }
 
-    fun setFilterText(filterText: String) {
-        savedStateHandle[KEY_FILTER_TEXT] = value
-    }
-
     fun setSortOption(sort: NodeSortOption) {
         nodeFilterPreferences.setNodeSort(sort)
     }
@@ -175,7 +171,7 @@ data class NodesUiState(
 )
 
 data class NodeFilterState(
-    val filterText: String = "",
+    val filterText: TextFieldState = TextFieldState(),
     val includeUnknown: Boolean = false,
     val excludeInfrastructure: Boolean = false,
     val onlyOnline: Boolean = false,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,6 +146,7 @@ markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-
 markdown-renderer-android = { module = "com.mikepenz:multiplatform-markdown-renderer-android", version.ref = "markdownRenderer" }
 material = { module = "com.google.android.material:material", version = "1.13.0" }
 mgrs = { module = "mil.nga:mgrs", version = "2.1.3" }
+molecule = { module = "app.cash.molecule:molecule-runtime", version = "2.2.0" }
 nordic = { module = "no.nordicsemi.kotlin.ble:client-android", version = "2.0.0-alpha12" }
 nordic-dfu = { module = "no.nordicsemi.android:dfu", version = "2.10.1" }
 org-eclipse-paho-client-mqttv3 = { module = "org.eclipse.paho:org.eclipse.paho.client.mqttv3", version = "1.2.5" }


### PR DESCRIPTION
This branch is a couple weeks old, so rebasing had a bunch on conflicts which haven't been addressed yet. Figured I'd throw a draft up here before fixing for some visibility and to see if other folks like this pattern.

This PR introduces [Molecule ](https://github.com/cashapp/molecule) to `NodeListViewModel` to clean up its Flow combination logic. This circumvents the arg count limitations of `Flow.combine()` while maintaining type safety when combining many Flows. Instead of using the `Flow.combine()` operator, Molecule allows us to collect the needed flows in a VM-level Composable, then construct the desired emission which is still exposed to the UI as a Flow.