### PR TITLE
Repo - drop completeness check for feature requests

### DIFF
--- a/.github/workflows/models_completeness.yml
+++ b/.github/workflows/models_completeness.yml
@@ -3,6 +3,10 @@ name: Issue Completeness Check
 on:
   issues:
     types: [opened]
+    filters:
+      - if: >
+          !contains(github.event.issue.labels.*.name, 'enhancement') &&
+          !contains(github.event.issue.title, 'Feature Request')
 
 permissions:
   issues: write


### PR DESCRIPTION
We don't care about completeness for Feature requests, or at least not in the same way.
