### PR TITLE
feat(navigation): Navigate back to list view on tab reselection

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -28,19 +28,20 @@ import androidx.navigation.NavHostController
 import com.geeksville.mesh.repository.radio.MeshActivity
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
 import org.jetbrains.compose.resources.getString
 import org.meshtastic.core.analytics.platform.PlatformAnalytics
@@ -131,11 +132,12 @@ constructor(
     val meshActivity: SharedFlow<MeshActivity> =
         radioInterfaceService.meshActivity.shareIn(viewModelScope, SharingStarted.Eagerly, 0)
 
-    private val scrollToTopEventChannel = Channel<ScrollToTopEvent>(capacity = Channel.CONFLATED)
-    val scrollToTopEventFlow: Flow<ScrollToTopEvent> = scrollToTopEventChannel.receiveAsFlow()
+    private val _scrollToTopEventFlow =
+        MutableSharedFlow<ScrollToTopEvent>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val scrollToTopEventFlow: Flow<ScrollToTopEvent> = _scrollToTopEventFlow.asSharedFlow()
 
     fun emitScrollToTopEvent(event: ScrollToTopEvent) {
-        scrollToTopEventChannel.trySend(event)
+        _scrollToTopEventFlow.tryEmit(event)
     }
 
     data class AlertData(

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/AdaptiveContactsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/AdaptiveContactsScreen.kt
@@ -77,6 +77,22 @@ fun AdaptiveContactsScreen(
             navigator.navigateTo(ListDetailPaneScaffoldRole.Detail, initialContactKey)
         }
     }
+
+    LaunchedEffect(scrollToTopEvents) {
+        scrollToTopEvents.collect { event ->
+            if (
+                event is ScrollToTopEvent.ConversationsTabPressed &&
+                navigator.currentDestination?.pane == ListDetailPaneScaffoldRole.Detail
+            ) {
+                if (navigator.canNavigateBack(backNavigationBehavior)) {
+                    navigator.navigateBack(backNavigationBehavior)
+                } else {
+                    navigator.navigateTo(ListDetailPaneScaffoldRole.List)
+                }
+            }
+        }
+    }
+
     ListDetailPaneScaffold(
         directive = navigator.scaffoldDirective,
         value = navigator.scaffoldValue,

--- a/app/src/main/java/com/geeksville/mesh/ui/node/AdaptiveNodeListScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/node/AdaptiveNodeListScreen.kt
@@ -77,6 +77,21 @@ fun AdaptiveNodeListScreen(
         }
     }
 
+    LaunchedEffect(scrollToTopEvents) {
+        scrollToTopEvents.collect { event ->
+            if (
+                event is ScrollToTopEvent.NodesTabPressed &&
+                navigator.currentDestination?.pane == ListDetailPaneScaffoldRole.Detail
+            ) {
+                if (navigator.canNavigateBack(backNavigationBehavior)) {
+                    navigator.navigateBack(backNavigationBehavior)
+                } else {
+                    navigator.navigateTo(ListDetailPaneScaffoldRole.List)
+                }
+            }
+        }
+    }
+
     ListDetailPaneScaffold(
         directive = navigator.scaffoldDirective,
         value = navigator.scaffoldValue,


### PR DESCRIPTION
This commit enhances the user experience in list-detail views by allowing users to navigate back to the list pane when re-selecting the currently active tab.

If the user is viewing a detail screen (e.g., a specific conversation or node details) and taps the corresponding tab in the bottom navigation bar again, the app will now navigate back to the list view for that section. This provides an intuitive way to return to the list without using the back button.

- Implemented a `LaunchedEffect` in `AdaptiveContactsScreen` and `AdaptiveNodeListScreen` to listen for tab reselection events.
- When a `ScrollToTopEvent` for the current tab is received while on a detail pane, it triggers a back navigation to the list pane.
- Updated `UIStateViewModel` to use `MutableSharedFlow` instead of `Channel` for emitting scroll-to-top events, ensuring better event handling.

resolves #3926 