### PR TITLE
chore(ci): generate changelog on pushes to main

### DIFF
--- a/.github/workflows/main-push-changelog.yml
+++ b/.github/workflows/main-push-changelog.yml
@@ -1,0 +1,55 @@
+name: Main Push Changelog
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: main-push-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main-push-changelog:
+    name: Generate main push changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine last production tag
+        id: last_prod_tag
+        run: |
+          # Find the most recent tag that looks like a production release (vX.Y.Z)
+          TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-creatordate | head -n 1)
+          echo "Found last production tag: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog from last production tag to current
+        if: steps.last_prod_tag.outputs.tag != ''
+        uses: mikepenz/release-changelog-builder-action@v5
+        id: changelog
+        with:
+          configuration: .github/release.yml
+          fromTag: ${{ steps.last_prod_tag.outputs.tag }}
+          toTag: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print main push summary
+        run: |
+          echo "Pushed to main"
+          echo "SHA: $GITHUB_SHA"
+          echo "Actor: $GITHUB_ACTOR"
+          echo "Ref: $GITHUB_REF"
+          echo ""
+          if [ "${{ steps.last_prod_tag.outputs.tag }}" != "" ]; then
+            echo "Changelog since last production tag (${{ steps.last_prod_tag.outputs.tag }})":
+            echo "----------------------------------------"
+            echo "${{ steps.changelog.outputs.changelog }}"
+          else
+            echo "No production tag (vX.Y.Z) found. Skipping changelog generation."
+          fi
+

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,14 +1,6 @@
 name: Android CI (PR)
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**.md"
-      - ".idea/**"
-      - ".gitignore"
-      - ".gitmodules"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automatically generate a changelog on every push to the `main` branch.

- Adds the `main-push-changelog.yml` workflow, which triggers on pushes to `main`.
- The workflow identifies the most recent production tag (e.g., `vX.Y.Z`).
- It then generates and prints a summary of all changes committed since that tag.
- Removes the `push` trigger from the `pull-request.yml` workflow to avoid redundant runs, dedicating it solely to pull requests.