### PR TITLE
chore: Use repeatOnLifecycle for lifecycle-aware coroutine launch

### DIFF
--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/NodeRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/NodeRepository.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.data.repository
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -29,6 +30,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.data.datasource.NodeInfoReadDataSource
 import org.meshtastic.core.data.datasource.NodeInfoWriteDataSource
@@ -56,8 +58,10 @@ constructor(
 ) {
     init {
         // Backfill denormalized name columns for existing nodes on startup
-        processLifecycle.coroutineScope.launchWhenCreated {
-            withContext(dispatchers.io) { nodeInfoWriteDataSource.backfillDenormalizedNames() }
+        processLifecycle.coroutineScope.launch {
+            processLifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
+                withContext(dispatchers.io) { nodeInfoWriteDataSource.backfillDenormalizedNames() }
+            }
         }
     }
 


### PR DESCRIPTION
This commit updates the `NodeRepository` to use `repeatOnLifecycle` instead of the deprecated `launchWhenCreated`. This ensures that the coroutine for backfilling denormalized node names is launched when the lifecycle is at least `CREATED` and is automatically cancelled when the lifecycle is `DESTROYED`, preventing potential resource leaks.