### PR TITLE
fix(strings): correct settings interval templating

### DIFF
--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -1021,14 +1021,14 @@
     <string name="interval_always_on">Always On</string>
     <plurals name="plurals_seconds">
         <item quantity="one">1 second</item>
-        <item quantity="other">%d seconds</item>
+        <item quantity="other">%1$d seconds</item>
     </plurals>
     <plurals name="plurals_minutes">
         <item quantity="one">1 minute</item>
-        <item quantity="other">%d minutes</item>
+        <item quantity="other">%1$d minutes</item>
     </plurals>
     <plurals name="plurals_hours">
         <item quantity="one">1 hour</item>
-        <item quantity="other">%d hours</item>
+        <item quantity="other">%1$d hours</item>
     </plurals>
 </resources>


### PR DESCRIPTION
The `%d` format specifier in plural resources has been changed to `%1$d`. This ensures that the integer argument is correctly referenced, preventing potential formatting errors or crashes on some Android versions.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/37e7bf7e-55fc-4f75-b466-99fccbaefa6d" />
