### PR TITLE
fix(nodes): Correctly filter ignored nodes

### DIFF
--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
@@ -107,9 +107,7 @@ constructor(
                     )
                     .map { list ->
                         list
-                            .filter { node ->
-                                node.isIgnored == filter.showIgnored
-                            }
+                            .filter { node -> node.isIgnored == filter.showIgnored }
                             .filter { node ->
                                 if (filter.excludeInfrastructure) {
                                     val role = node.user.role


### PR DESCRIPTION
The filter for showing or hiding ignored nodes was not working as intended. This commit corrects the logic to properly filter the node list based on the `showIgnored` flag.

Previously, the filter was `filter.showIgnored || !it.isIgnored`, which would always show non-ignored nodes, regardless of the filter setting.

The new logic, `node.isIgnored == filter.showIgnored`, correctly displays only ignored nodes when `showIgnored` is true, and only non-ignored nodes when it is false.

resolves #3881 