### PR TITLE
feat(messaging): Add double-tap to react with 👍

### DIFF
--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/MessageListPaged.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/MessageListPaged.kt
@@ -253,6 +253,7 @@ private fun LazyItemScope.renderPagedChatMessageRow(
             state.selectedIds.toggle(message.uuid)
             haptics.performHapticFeedback(HapticFeedbackType.LongPress)
         },
+        onDoubleClick = { if (!inSelectionMode) handlers.onSendReaction("👍", message.packetId) },
         onClickChip = handlers.onClickChip,
         onStatusClick = { onShowStatusDialog(message) },
         onReply = { handlers.onReply(message) },

--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
@@ -80,6 +80,7 @@ internal fun MessageItem(
     emojis: List<Reaction> = emptyList(),
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = {},
+    onDoubleClick: () -> Unit = {},
     onClickChip: (Node) -> Unit = {},
     onStatusClick: () -> Unit = {},
     onNavigateToOriginalMessage: (Int) -> Unit = {},
@@ -120,7 +121,7 @@ internal fun MessageItem(
                     start = if (!message.fromLocal) 0.dp else 16.dp,
                     end = if (message.fromLocal) 0.dp else 16.dp,
                 )
-                .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+                .combinedClickable(onClick = onClick, onLongClick = onLongClick, onDoubleClick = onDoubleClick)
                 .then(messageModifier),
             colors = cardColors,
         ) {


### PR DESCRIPTION
This commit introduces a new quick-reaction feature, allowing users to send a "👍" reaction by double-tapping a message.

- Added an `onDoubleClick` handler to `MessageItem`.
- Implemented the double-tap gesture in `MessageListPaged` to trigger `onSendReaction` when not in selection mode.
