### PR TITLE
Allow using custom tile server via HTTP

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,7 +105,8 @@
         android:supportsRtl="true"
         android:hardwareAccelerated="true"
         android:theme="@style/SplashTheme"
-        android:localeConfig="@xml/locales_config">
+        android:localeConfig="@xml/locales_config"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <!-- Default crash collection and analytics off until we (possibly) turn it on in application.onCreate -->
         <meta-data

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system"/>
+        </trust-anchors>
+    </base-config>
+
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
Online maps prevent Meshtastic app to be used with no internet connection. The recent app version allows adding custom tile servers. So in order to make it autonomous you can spin up a local tile server on your Android device and point the Meshtastic app to fetch tiles from localhost.
Problem with this approach is that the map component only allows HTTPS schema to be used. And making your local tile server working with HTTP is not a trivial task, mainly due to the self signed certificates.
This PR adds network configuration that will allow the app to use HTTP for localhost only.
With this you can spin up a tiny tile server and use it as a map tile source without any internet connection