### PR TITLE
feat: Mark database models and protobufs as stable

### DIFF
--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -3,3 +3,8 @@
 // For more information, check https://developer.android.com/jetpack/compose/performance/stability/fix#configuration-file
 
 
+org.meshtastic.core.database.model.Node
+org.meshtastic.core.database.model.Message
+org.meshtastic.core.database.entity.Reaction
+org.meshtastic.proto.**
+com.google.protobuf.ByteString


### PR DESCRIPTION
Mark several classes as stable for the Jetpack Compose compiler to enable optimizations. This includes Node and Message models, the Reaction entity, all Meshtastic protobuf-generated classes, and Google's ByteString.