### PR TITLE
fix(build): disable more analytics tasks for F-Droid builds

### DIFF
--- a/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
@@ -58,12 +58,12 @@ class AnalyticsConventionPlugin : Plugin<Project> {
             }
 
             // Disable Analytics tasks for non-google flavors
-            val analyticsKeywords = listOf("crashlytics", "google", "datadog")
+            val analyticsKeywords = listOf("crashlytics", "google", "datadog","buildId")
             tasks.configureEach {
                 val taskName = name.lowercase()
-                val isAnalyticsTask = analyticsKeywords.any { taskName.contains(it) }
+                val isAnalyticsTask = analyticsKeywords.any { taskName.contains(it, ignoreCase = true) }
 
-                if (isAnalyticsTask && taskName.contains("fdroid")) {
+                if (isAnalyticsTask && taskName.contains("fdroid", ignoreCase = true)) {
                     logger.lifecycle("AnalyticsConventionPlugin: Disabling task $name")
                     enabled = false
                 }


### PR DESCRIPTION
Expanded the list of keywords used to identify and disable analytics-related tasks for the `fdroid` build flavor.

The keyword "buildId" has been added, and the matching logic is now case-insensitive.

---
AnalyticsConventionPlugin: Disabling task processFdroidDebugGoogleServices
AnalyticsConventionPlugin: Disabling task injectCrashlyticsVersionControlInfoFdroidDebug
AnalyticsConventionPlugin: Disabling task injectCrashlyticsMappingFileIdFdroidDebug
AnalyticsConventionPlugin: Disabling task processFdroidReleaseGoogleServices
AnalyticsConventionPlugin: Disabling task injectCrashlyticsVersionControlInfoFdroidRelease
AnalyticsConventionPlugin: Disabling task injectCrashlyticsMappingFileIdFdroidRelease
AnalyticsConventionPlugin: Disabling task uploadCrashlyticsMappingFileFdroidRelease
***AnalyticsConventionPlugin: Disabling task generateBuildIdFdroidRelease***

Hopefully resolves #3231 (maybe this time?)