### PR TITLE
Update strings for small meshes.xml

### DIFF
--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -939,7 +939,7 @@
     <string name="device_configuration">Device configuration</string>
     <string name="remotely_administrating">"[Remote] %1$s"</string>
     <string name="device_telemetry_enabled">Send Device Telemetry</string>
-    <string name="device_telemetry_enabled_summary">Enable/Disable the device telemetry module to send metrics to the mesh. These are nominal values. Congested meshes will automatically scale to longer intervals based on number of online nodes. Meshes less than 10 nodes will scale to faster intervals.</string>
+    <string name="device_telemetry_enabled_summary">Enable/Disable the device telemetry module to send metrics to the mesh. These are nominal values. Congested meshes will automatically scale to longer intervals based on number of online nodes.</string>
     <string name="any">Any</string>
     <string name="one_hour">1 Hour</string>
     <string name="eight_hours">8 Hours</string>


### PR DESCRIPTION
 Remove note about more frequent telemetry transmissions when on a small (<10) mesh.
