### PR TITLE
fix: correctly check for local or pre-db-update reaction via RSSI == 0

### DIFF
--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/Reaction.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/Reaction.kt
@@ -152,7 +152,7 @@ internal fun ReactionDialog(reactions: List<Reaction>, onDismiss: () -> Unit = {
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        val isLocalOrPreDbUpdateReaction = (reaction.snr == 0.0f)
+                        val isLocalOrPreDbUpdateReaction = (reaction.rssi == 0)
                         if (!isLocalOrPreDbUpdateReaction) {
                             if (reaction.hopsAway == 0) {
                                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {


### PR DESCRIPTION
SNR == 0 can possibly be observed for remote messages, while RSSI == 0 (also default value) cannot.

This is a follow-up fix for https://github.com/meshtastic/Meshtastic-Android/pull/3964.
