### PR TITLE
refactor(analytics): Only plant DebugTree in debug builds

### DIFF
--- a/core/analytics/src/google/kotlin/org/meshtastic/core/analytics/platform/GooglePlatformAnalytics.kt
+++ b/core/analytics/src/google/kotlin/org/meshtastic/core/analytics/platform/GooglePlatformAnalytics.kt
@@ -102,7 +102,15 @@ constructor(
                 .setBundleWithTraceEnabled(true)
                 .setBundleWithRumEnabled(true)
                 .build()
-        Timber.plant(DatadogTree(datadogLogger), CrashlyticsTree(), DebugTree())
+        buildList {
+            add(DatadogTree(datadogLogger))
+            add(CrashlyticsTree())
+            if (BuildConfig.DEBUG) {
+                add(DebugTree())
+            }
+        }
+            .forEach(Timber::plant)
+
         // Initial consent state
         updateAnalyticsConsent(analyticsPrefs.analyticsAllowed)
 


### PR DESCRIPTION
The `DebugTree` for Timber logging will now only be planted when the application is built in `DEBUG` mode. This is achieved by conditionally adding it to the list of trees to be planted based on the `BuildConfig.DEBUG` flag.