### PR TITLE
Add elevation to places where LatLong is listed.

### DIFF
--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/compass/CompassUiState.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/compass/CompassUiState.kt
@@ -45,4 +45,5 @@ data class CompassUiState(
     val isAligned: Boolean = false,
     val hasTargetPosition: Boolean = true,
     val displayUnits: DisplayUnits = DisplayUnits.METRIC,
+    val targetAltitude: Int? = null,
 )

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/compass/CompassViewModel.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/compass/CompassViewModel.kt
@@ -87,6 +87,7 @@ constructor(
                 hasTargetPosition = targetPos != null,
                 displayUnits = displayUnits,
                 positionTimeSec = targetPositionTimeSec,
+                targetAltitude = node.validPosition?.altitude,
             )
         }
 

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/LinkedCoordinatesItem.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/LinkedCoordinatesItem.kt
@@ -37,29 +37,38 @@ import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.model.util.GPSFormat
 import org.meshtastic.core.model.util.formatAgo
+import org.meshtastic.core.model.util.metersIn
+import org.meshtastic.core.model.util.toString
 import org.meshtastic.core.strings.Res
+import org.meshtastic.core.strings.elevation_suffix
 import org.meshtastic.core.strings.last_position_update
 import org.meshtastic.core.ui.component.BasicListItem
 import org.meshtastic.core.ui.component.icon
 import org.meshtastic.core.ui.theme.AppTheme
 import org.meshtastic.core.ui.util.showToast
+import org.meshtastic.proto.ConfigProtos.Config.DisplayConfig.DisplayUnits
 import timber.log.Timber
 import java.net.URLEncoder
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun LinkedCoordinatesItem(node: Node) {
+fun LinkedCoordinatesItem(node: Node, displayUnits: DisplayUnits = DisplayUnits.METRIC) {
     val context = LocalContext.current
     val clipboard: Clipboard = LocalClipboard.current
     val coroutineScope = rememberCoroutineScope()
 
     val ago = formatAgo(node.position.time)
     val coordinates = GPSFormat.toDec(node.latitude, node.longitude)
+    val elevationText =
+        node.validPosition?.altitude?.let { altitude ->
+            val suffix = stringResource(Res.string.elevation_suffix)
+            " • ${altitude.metersIn(displayUnits).toString(displayUnits)} $suffix"
+        } ?: ""
 
     BasicListItem(
         text = stringResource(Res.string.last_position_update),
         leadingIcon = Icons.Default.LocationOn,
-        supportingText = "$ago • $coordinates",
+        supportingText = "$ago • $coordinates$elevationText",
         trailingContent = Icons.AutoMirrored.Rounded.KeyboardArrowRight.icon(),
         onClick = {
             val label = URLEncoder.encode(node.user.longName, "utf-8")

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/PositionSection.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/PositionSection.kt
@@ -93,7 +93,7 @@ fun PositionSection(
 
             if (hasValidPosition) {
                 PositionMap(node, distance)
-                LinkedCoordinatesItem(node)
+                LinkedCoordinatesItem(node, metricsState.displayUnits)
                 Spacer(Modifier.height(8.dp))
             }
 


### PR DESCRIPTION
Add altitude to Latlong entries on node details and compass. 

Have tried to minimise impacts for those for whom it's not essential info, but having to flick back to the node list page to get an altitude is infuriating. 

![Screenshot_20251227-204921.Moto App Launcher.png](https://github.com/user-attachments/assets/ae56395d-430d-4866-b26f-f8cd9fbe5329)

![Screenshot_20251227-204911.Moto App Launcher.png](https://github.com/user-attachments/assets/cbcf96f8-1a28-4644-a26e-bd8baad77d0b)


