### PR TITLE
feat(logging): Replace Timber with Kermit for multiplatform logging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -232,7 +232,7 @@ dependencies {
     implementation(libs.usb.serial.android)
     implementation(libs.androidx.work.runtime.ktx)
     implementation(libs.accompanist.permissions)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 
     implementation(libs.nordic)
 

--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -5,11 +5,6 @@
     <ID>CommentSpacing:BLEException.kt$BLEConnectionClosing$/// Our interface is being shut down</ID>
     <ID>CommentSpacing:Constants.kt$/// a bool true means we expect this condition to continue until, false means device might come back</ID>
     <ID>CommentSpacing:Coroutines.kt$/// Wrap launch with an exception handler, FIXME, move into a utility lib</ID>
-    <ID>ComposableParamOrder:Channel.kt$ChannelScreen</ID>
-    <ID>ComposableParamOrder:Channel.kt$EditChannelUrl</ID>
-    <ID>ComposableParamOrder:ConnectionsNavIcon.kt$ConnectionsNavIcon</ID>
-    <ID>ComposableParamOrder:EmptyStateContent.kt$EmptyStateContent</ID>
-    <ID>ComposableParamOrder:Share.kt$ShareScreen</ID>
     <ID>CyclomaticComplexMethod:BleError.kt$BleError.Companion$fun from(exception: Throwable): BleError</ID>
     <ID>CyclomaticComplexMethod:MeshService.kt$MeshService$private fun handleReceivedData(packet: MeshPacket)</ID>
     <ID>CyclomaticComplexMethod:SettingsNavigation.kt$@Suppress("LongMethod") fun NavGraphBuilder.settingsGraph(navController: NavHostController)</ID>
@@ -32,10 +27,9 @@
     <ID>FinalNewline:SerialInterfaceFactory.kt$com.geeksville.mesh.repository.radio.SerialInterfaceFactory.kt</ID>
     <ID>FinalNewline:TCPInterfaceFactory.kt$com.geeksville.mesh.repository.radio.TCPInterfaceFactory.kt</ID>
     <ID>FinalNewline:UsbRepositoryModule.kt$com.geeksville.mesh.repository.usb.UsbRepositoryModule.kt</ID>
-    <ID>LambdaParameterEventTrailing:Channel.kt$onConfirm</ID>
-    <ID>LambdaParameterInRestartableEffect:Channel.kt$onConfirm</ID>
     <ID>LargeClass:MeshService.kt$MeshService : Service</ID>
     <ID>LongMethod:MeshService.kt$MeshService$private fun handleReceivedData(packet: MeshPacket)</ID>
+    <ID>LongMethod:TCPInterface.kt$TCPInterface$private suspend fun startConnect()</ID>
     <ID>MagicNumber:Contacts.kt$7</ID>
     <ID>MagicNumber:Contacts.kt$8</ID>
     <ID>MagicNumber:MQTTRepository.kt$MQTTRepository$512</ID>
@@ -60,27 +54,15 @@
     <ID>MagicNumber:StreamInterface.kt$StreamInterface$4</ID>
     <ID>MagicNumber:StreamInterface.kt$StreamInterface$8</ID>
     <ID>MagicNumber:TCPInterface.kt$TCPInterface$1000</ID>
-    <ID>MagicNumber:TCPInterface.kt$TCPInterface$180</ID>
-    <ID>MagicNumber:TCPInterface.kt$TCPInterface$500</ID>
     <ID>MagicNumber:UIState.kt$4</ID>
     <ID>MaxLineLength:MeshService.kt$MeshService$"Config complete id mismatch: received=$configCompleteId expected one of [$configOnlyNonce,$nodeInfoNonce]"</ID>
+    <ID>MaxLineLength:MeshService.kt$MeshService$"Neighbor info response filtered: ToUs=$isAddressedToUs, isRecentRequest=$isRecentRequest"</ID>
     <ID>MaxLineLength:MeshService.kt$MeshService$"setOwner Id: $id longName: ${longName.anonymize} shortName: $shortName isLicensed: $isLicensed isUnmessagable: $isUnmessagable"</ID>
     <ID>MaxLineLength:MeshService.kt$MeshService.&lt;no name provided&gt;$"sendData dest=${p.to}, id=${p.id} &lt;- ${bytes.size} bytes (connectionState=${connectionStateHolder.connectionState.value})"</ID>
     <ID>MaxLineLength:NordicBleInterface.kt$NordicBleInterface$"[$address] Found fromNum: ${fromNumCharacteristic?.uuid}, ${fromNumCharacteristic?.instanceId}"</ID>
     <ID>MaxLineLength:NordicBleInterface.kt$NordicBleInterface$"[$address] Found fromRadio: ${fromRadioCharacteristic?.uuid}, ${fromRadioCharacteristic?.instanceId}"</ID>
     <ID>MaxLineLength:NordicBleInterface.kt$NordicBleInterface$"[$address] Found logRadio: ${logRadioCharacteristic?.uuid}, ${logRadioCharacteristic?.instanceId}"</ID>
     <ID>MaxLineLength:NordicBleInterface.kt$NordicBleInterface$"[$address] Found toRadio: ${toRadioCharacteristic?.uuid}, ${toRadioCharacteristic?.instanceId}"</ID>
-    <ID>ModifierClickableOrder:Channel.kt$clickable(onClick = onClick)</ID>
-    <ID>ModifierMissing:BLEDevices.kt$BLEDevices</ID>
-    <ID>ModifierMissing:Channel.kt$ChannelScreen</ID>
-    <ID>ModifierMissing:Contacts.kt$ContactListView</ID>
-    <ID>ModifierMissing:Contacts.kt$ContactsScreen</ID>
-    <ID>ModifierMissing:Contacts.kt$SelectionToolbar</ID>
-    <ID>ModifierMissing:EmptyStateContent.kt$EmptyStateContent</ID>
-    <ID>ModifierMissing:Main.kt$MainScreen</ID>
-    <ID>ModifierMissing:NetworkDevices.kt$NetworkDevices</ID>
-    <ID>ModifierMissing:Share.kt$ShareScreen</ID>
-    <ID>MutableStateAutoboxing:Contacts.kt$mutableStateOf(2)</ID>
     <ID>NestedBlockDepth:MeshService.kt$MeshService$private fun handleReceivedAdmin(fromNodeNum: Int, a: AdminProtos.AdminMessage)</ID>
     <ID>NestedBlockDepth:MeshService.kt$MeshService$private fun handleReceivedData(packet: MeshPacket)</ID>
     <ID>NewLineAtEndOfFile:BLEException.kt$com.geeksville.mesh.service.BLEException.kt</ID>
@@ -106,11 +88,6 @@
     <ID>NoEmptyClassBody:DebugLogFile.kt$BinaryLogFile${ }</ID>
     <ID>NoSemicolons:DateUtils.kt$DateUtils$;</ID>
     <ID>OptionalAbstractKeyword:SyncContinuation.kt$Continuation$abstract</ID>
-    <ID>ParameterNaming:Contacts.kt$onDeleteSelected</ID>
-    <ID>ParameterNaming:Contacts.kt$onMuteSelected</ID>
-    <ID>ParameterNaming:UsbDevices.kt$onDeviceSelected</ID>
-    <ID>PreviewPublic:Channel.kt$ModemPresetInfoPreview</ID>
-    <ID>PreviewPublic:EmptyStateContent.kt$EmptyStateContentPreview</ID>
     <ID>RethrowCaughtException:SyncContinuation.kt$Continuation$throw ex</ID>
     <ID>SwallowedException:Exceptions.kt$ex: Throwable</ID>
     <ID>SwallowedException:NsdManager.kt$ex: IllegalArgumentException</ID>
@@ -138,6 +115,5 @@
     <ID>TooManyFunctions:UIState.kt$UIViewModel : ViewModel</ID>
     <ID>TopLevelPropertyNaming:Constants.kt$const val prefix = "com.geeksville.mesh"</ID>
     <ID>UtilityClassWithPublicConstructor:NetworkRepositoryModule.kt$NetworkRepositoryModule</ID>
-    <ID>ViewModelForwarding:Main.kt$VersionChecks(uIViewModel)</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -40,6 +40,7 @@ import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.MainScreen
 import dagger.hilt.android.AndroidEntryPoint
@@ -53,7 +54,6 @@ import org.meshtastic.core.ui.theme.AppTheme
 import org.meshtastic.core.ui.theme.MODE_DYNAMIC
 import org.meshtastic.core.ui.util.showToast
 import org.meshtastic.feature.intro.AppIntroductionScreen
-import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -118,27 +118,27 @@ class MainActivity : AppCompatActivity() {
         when (appLinkAction) {
             Intent.ACTION_VIEW -> {
                 appLinkData?.let {
-                    Timber.d("App link data: $it")
+                    Logger.d { "App link data: $it" }
                     if (it.path?.startsWith("/e/") == true || it.path?.startsWith("/E/") == true) {
-                        Timber.d("App link data is a channel set")
+                        Logger.d { "App link data is a channel set" }
                         model.requestChannelUrl(
                             url = it,
                             onFailure = { lifecycleScope.launch { showToast(Res.string.channel_invalid) } },
                         )
                     } else if (it.path?.startsWith("/v/") == true || it.path?.startsWith("/V/") == true) {
-                        Timber.d("App link data is a shared contact")
+                        Logger.d { "App link data is a shared contact" }
                         model.setSharedContactRequested(
                             url = it,
                             onFailure = { lifecycleScope.launch { showToast(Res.string.contact_invalid) } },
                         )
                     } else {
-                        Timber.d("App link data is not a channel set")
+                        Logger.d { "App link data is not a channel set" }
                     }
                 }
             }
 
             UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
-                Timber.d("USB device attached")
+                Logger.d { "USB device attached" }
                 showSettingsPage()
             }
 
@@ -152,7 +152,7 @@ class MainActivity : AppCompatActivity() {
             }
 
             else -> {
-                Timber.w("Unexpected action $appLinkAction")
+                Logger.w { "Unexpected action $appLinkAction" }
             }
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
+++ b/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
@@ -23,6 +23,7 @@ import androidx.appcompat.app.AppCompatActivity.BIND_AUTO_CREATE
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.android.BindFailedException
 import com.geeksville.mesh.android.ServiceClient
 import com.geeksville.mesh.concurrent.SequentialJob
@@ -32,7 +33,6 @@ import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
 import org.meshtastic.core.service.IMeshService
 import org.meshtastic.core.service.ServiceRepository
-import timber.log.Timber
 import javax.inject.Inject
 
 /** A Activity-lifecycle-aware [ServiceClient] that binds [MeshService] once the Activity is started. */
@@ -49,7 +49,7 @@ constructor(
     private val lifecycleOwner: LifecycleOwner = context as LifecycleOwner
 
     init {
-        Timber.d("Adding self as LifecycleObserver for $lifecycleOwner")
+        Logger.d { "Adding self as LifecycleObserver for $lifecycleOwner" }
         lifecycleOwner.lifecycle.addObserver(this)
     }
 
@@ -58,7 +58,7 @@ constructor(
     override fun onConnected(service: IMeshService) {
         serviceSetupJob.launch(lifecycleOwner.lifecycleScope) {
             serviceRepository.setMeshService(service)
-            Timber.d("connected to mesh service, connectionState=${serviceRepository.connectionState.value}")
+            Logger.d { "connected to mesh service, connectionState=${serviceRepository.connectionState.value}" }
         }
     }
 
@@ -73,32 +73,32 @@ constructor(
 
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
-        Timber.d("Lifecycle: ON_START")
+        Logger.d { "Lifecycle: ON_START" }
 
         try {
             bindMeshService()
         } catch (ex: BindFailedException) {
-            Timber.e("Bind of MeshService failed: ${ex.message}")
+            Logger.e { "Bind of MeshService failed: ${ex.message}" }
         }
     }
 
     override fun onDestroy(owner: LifecycleOwner) {
         super.onDestroy(owner)
-        Timber.d("Lifecycle: ON_DESTROY")
+        Logger.d { "Lifecycle: ON_DESTROY" }
 
         owner.lifecycle.removeObserver(this)
-        Timber.d("Removed self as LifecycleObserver to $lifecycleOwner")
+        Logger.d { "Removed self as LifecycleObserver to $lifecycleOwner" }
     }
 
     // endregion
 
     @Suppress("TooGenericExceptionCaught")
     private fun bindMeshService() {
-        Timber.d("Binding to mesh service!")
+        Logger.d { "Binding to mesh service!" }
         try {
             MeshService.startService(context)
         } catch (ex: Exception) {
-            Timber.e("Failed to start service from activity - but ignoring because bind will work: ${ex.message}")
+            Logger.e { "Failed to start service from activity - but ignoring because bind will work: ${ex.message}" }
         }
 
         connect(context, MeshService.createIntent(context), BIND_AUTO_CREATE + BIND_ABOVE_CLIENT)

--- a/app/src/main/java/com/geeksville/mesh/MeshUtilApplication.kt
+++ b/app/src/main/java/com/geeksville/mesh/MeshUtilApplication.kt
@@ -18,6 +18,7 @@
 package com.geeksville.mesh
 
 import android.app.Application
+import co.touchlab.kermit.Logger
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -28,7 +29,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.meshtastic.core.database.DatabaseManager
 import org.meshtastic.core.prefs.mesh.MeshPrefs
-import timber.log.Timber
 
 /**
  * The main application class for Meshtastic.
@@ -61,7 +61,7 @@ interface AppEntryPoint {
 fun logAssert(executeReliableWrite: Boolean) {
     if (!executeReliableWrite) {
         val ex = AssertionError("Assertion failed")
-        Timber.e(ex)
+        Logger.e(ex) { "logAssert" }
         throw ex
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/android/ServiceClient.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ServiceClient.kt
@@ -23,10 +23,9 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
 import android.os.IInterface
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.util.exceptionReporter
-import timber.log.Timber
 import java.io.Closeable
-import java.lang.IllegalArgumentException
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -73,14 +72,14 @@ open class ServiceClient<T : IInterface>(private val stubFactory: (IBinder) -> T
                 // Some phones seem to ahve a race where if you unbind and quickly rebind bindService returns false.
                 // Try
                 // a short sleep to see if that helps
-                Timber.e("Needed to use the second bind attempt hack")
+                Logger.e { "Needed to use the second bind attempt hack" }
                 Thread.sleep(500) // was 200ms, but received an autobug from a Galaxy Note4, android 6.0.1
                 if (!c.bindService(intent, connection, flags)) {
                     throw BindFailedException()
                 }
             }
         } else {
-            Timber.w("Ignoring rebind attempt for service")
+            Logger.w { "Ignoring rebind attempt for service" }
         }
     }
 
@@ -90,7 +89,7 @@ open class ServiceClient<T : IInterface>(private val stubFactory: (IBinder) -> T
             context?.unbindService(connection)
         } catch (ex: IllegalArgumentException) {
             // Autobugs show this can generate an illegal arg exception for "service not registered" during reinstall?
-            Timber.w("Ignoring error in ServiceClient.close, probably harmless")
+            Logger.w { "Ignoring error in ServiceClient.close, probably harmless" }
         }
         serviceP = null
         context = null
@@ -116,7 +115,7 @@ open class ServiceClient<T : IInterface>(private val stubFactory: (IBinder) -> T
                     // If we start to close a service, it seems that there is a possibility a onServiceConnected event
                     // is the queue
                     // for us.  Be careful not to process that stale event
-                    Timber.w("A service connected while we were closing it, ignoring")
+                    Logger.w { "A service connected while we were closing it, ignoring" }
                 }
             }
 

--- a/app/src/main/java/com/geeksville/mesh/concurrent/DeferredExecution.kt
+++ b/app/src/main/java/com/geeksville/mesh/concurrent/DeferredExecution.kt
@@ -17,7 +17,7 @@
 
 package com.geeksville.mesh.concurrent
 
-import timber.log.Timber
+import co.touchlab.kermit.Logger
 
 /**
  * Sometimes when starting services we face situations where messages come in that require computation but we can't do
@@ -36,7 +36,7 @@ class DeferredExecution {
 
     // / run all work in the queue and clear it to be ready to accept new work
     fun run() {
-        Timber.d("Running deferred execution numjobs=${queue.size}")
+        Logger.d { "Running deferred execution numjobs=${queue.size}" }
         queue.forEach { it() }
         queue.clear()
     }

--- a/app/src/main/java/com/geeksville/mesh/concurrent/SyncContinuation.kt
+++ b/app/src/main/java/com/geeksville/mesh/concurrent/SyncContinuation.kt
@@ -27,7 +27,7 @@ interface Continuation<in T> {
     fun resumeWithException(ex: Throwable) = try {
         resume(Result.failure(ex))
     } catch (ex: Throwable) {
-        // Timber.e("Ignoring $ex while resuming, because we are the ones who threw it")
+        // Logger.e { "Ignoring $ex while resuming because we are the ones who threw it" }
         throw ex
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.repository.radio.MeshActivity
 import com.geeksville.mesh.repository.radio.RadioInterfaceService
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -67,7 +68,6 @@ import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.proto.AdminProtos
 import org.meshtastic.proto.AppOnlyProtos
 import org.meshtastic.proto.MeshProtos
-import timber.log.Timber
 import javax.inject.Inject
 
 // Given a human name, strip out the first letter of the first three words and return that as the
@@ -212,7 +212,7 @@ constructor(
             }
             .launchIn(viewModelScope)
 
-        Timber.d("ViewModel created")
+        Logger.d { "ViewModel created" }
     }
 
     private val _sharedContactRequested: MutableStateFlow<AdminProtos.SharedContact?> = MutableStateFlow(null)
@@ -222,7 +222,7 @@ constructor(
     fun setSharedContactRequested(url: Uri, onFailure: () -> Unit) {
         runCatching { _sharedContactRequested.value = url.toSharedContact() }
             .onFailure { ex ->
-                Timber.e(ex, "Shared contact error")
+                Logger.e(ex) { "Shared contact error" }
                 onFailure()
             }
     }
@@ -243,7 +243,7 @@ constructor(
     fun requestChannelUrl(url: Uri, onFailure: () -> Unit) =
         runCatching { _requestChannelSet.value = url.toChannelSet() }
             .onFailure { ex ->
-                Timber.e(ex, "Channel url error")
+                Logger.e(ex) { "Channel url error" }
                 onFailure()
             }
 
@@ -256,7 +256,7 @@ constructor(
 
     override fun onCleared() {
         super.onCleared()
-        Timber.d("ViewModel cleared")
+        Logger.d { "ViewModel cleared" }
     }
 
     val tracerouteResponse: LiveData<TracerouteResponse?>

--- a/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/bluetooth/BluetoothRepository.kt
@@ -22,6 +22,7 @@ import android.app.Application
 import android.bluetooth.BluetoothAdapter
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.repository.radio.BleConstants.BLE_NAME_PATTERN
 import com.geeksville.mesh.repository.radio.BleConstants.BTM_SERVICE_UUID
 import com.geeksville.mesh.util.registerReceiverCompat
@@ -42,7 +43,6 @@ import no.nordicsemi.kotlin.ble.core.Manager
 import org.meshtastic.core.common.hasBluetoothPermission
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.di.ProcessLifecycle
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.seconds
@@ -112,7 +112,7 @@ constructor(
                     .onStart { _isScanning.value = true }
                     .onCompletion { _isScanning.value = false }
                     .catch { ex ->
-                        Timber.w(ex, "Bluetooth scan failed")
+                        Logger.w(ex) { "Bluetooth scan failed" }
                         _isScanning.value = false
                     }
                     .collect { peripheral ->
@@ -158,7 +158,7 @@ constructor(
             )
 
         _state.emit(newState)
-        Timber.d("Detected our bluetooth access=$newState")
+        Logger.d { "Detected our bluetooth access=$newState" }
     }
 
     @SuppressLint("MissingPermission")

--- a/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/network/MQTTRepository.kt
@@ -17,6 +17,7 @@
 
 package com.geeksville.mesh.repository.network
 
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.util.ignoreException
 import com.google.protobuf.ByteString
 import kotlinx.coroutines.channels.awaitClose
@@ -36,7 +37,6 @@ import org.meshtastic.core.data.repository.RadioConfigRepository
 import org.meshtastic.core.model.util.subscribeList
 import org.meshtastic.proto.MeshProtos.MqttClientProxyMessage
 import org.meshtastic.proto.mqttClientProxyMessage
-import timber.log.Timber
 import java.net.URI
 import java.security.SecureRandom
 import javax.inject.Inject
@@ -70,7 +70,7 @@ constructor(
     private var mqttClient: MqttAsyncClient? = null
 
     fun disconnect() {
-        Timber.i("MQTT Disconnected")
+        Logger.i { "MQTT Disconnected" }
         mqttClient?.apply {
             ignoreException { disconnect() }
             close(true)
@@ -110,7 +110,7 @@ constructor(
         val callback =
             object : MqttCallbackExtended {
                 override fun connectComplete(reconnect: Boolean, serverURI: String) {
-                    Timber.i("MQTT connectComplete: $serverURI reconnect: $reconnect")
+                    Logger.i { "MQTT connectComplete: $serverURI reconnect: $reconnect" }
                     channelSet.subscribeList
                         .ifEmpty {
                             return
@@ -123,7 +123,7 @@ constructor(
                 }
 
                 override fun connectionLost(cause: Throwable) {
-                    Timber.i("MQTT connectionLost cause: $cause")
+                    Logger.i { "MQTT connectionLost cause: $cause" }
                     if (cause is IllegalArgumentException) close(cause)
                 }
 
@@ -138,7 +138,7 @@ constructor(
                 }
 
                 override fun deliveryComplete(token: IMqttDeliveryToken?) {
-                    Timber.i("MQTT deliveryComplete messageId: ${token?.messageId}")
+                    Logger.i { "MQTT deliveryComplete messageId: ${token?.messageId}" }
                 }
             }
 
@@ -161,15 +161,15 @@ constructor(
 
     private fun subscribe(topic: String) {
         mqttClient?.subscribe(topic, DEFAULT_QOS)
-        Timber.i("MQTT Subscribed to topic: $topic")
+        Logger.i { "MQTT Subscribed to topic: $topic" }
     }
 
     fun publish(topic: String, data: ByteArray, retained: Boolean) {
         try {
             val token = mqttClient?.publish(topic, data, DEFAULT_QOS, retained)
-            Timber.i("MQTT Publish messageId: ${token?.messageId}")
+            Logger.i { "MQTT Publish messageId: ${token?.messageId}" }
         } catch (ex: Exception) {
-            Timber.e("MQTT Publish error: ${ex.message}")
+            Logger.e { "MQTT Publish error: ${ex.message}" }
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/repository/network/NsdManager.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/network/NsdManager.kt
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.Build
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asExecutor
@@ -30,7 +31,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.suspendCancellableCoroutine
-import timber.log.Timber
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.coroutines.resume
 
@@ -54,22 +54,22 @@ private fun NsdManager.discoverServices(
             }
 
             override fun onDiscoveryStarted(serviceType: String) {
-                Timber.d("NSD Service discovery started")
+                Logger.d { "NSD Service discovery started" }
             }
 
             override fun onDiscoveryStopped(serviceType: String) {
-                Timber.d("NSD Service discovery stopped")
+                Logger.d { "NSD Service discovery stopped" }
                 close()
             }
 
             override fun onServiceFound(serviceInfo: NsdServiceInfo) {
-                Timber.d("NSD Service found: $serviceInfo")
+                Logger.d { "NSD Service found: $serviceInfo" }
                 serviceList += serviceInfo
                 trySend(serviceList)
             }
 
             override fun onServiceLost(serviceInfo: NsdServiceInfo) {
-                Timber.d("NSD Service lost: $serviceInfo")
+                Logger.d { "NSD Service lost: $serviceInfo" }
                 serviceList.removeAll { it.serviceName == serviceInfo.serviceName }
                 trySend(serviceList)
             }
@@ -102,7 +102,7 @@ private suspend fun NsdManager.resolveService(serviceInfo: NsdServiceInfo): NsdS
                             try {
                                 unregisterServiceInfoCallback(this)
                             } catch (e: IllegalArgumentException) {
-                                Timber.w(e, "Already unregistered")
+                                Logger.w(e) { "Already unregistered" }
                             }
                         }
                     }
@@ -112,7 +112,7 @@ private suspend fun NsdManager.resolveService(serviceInfo: NsdServiceInfo): NsdS
                         try {
                             unregisterServiceInfoCallback(this)
                         } catch (e: IllegalArgumentException) {
-                            Timber.w(e, "Already unregistered")
+                            Logger.w(e) { "Already unregistered" }
                         }
                     }
 
@@ -125,7 +125,7 @@ private suspend fun NsdManager.resolveService(serviceInfo: NsdServiceInfo): NsdS
                 try {
                     unregisterServiceInfoCallback(callback)
                 } catch (e: IllegalArgumentException) {
-                    Timber.w(e, "Already unregistered")
+                    Logger.w(e) { "Already unregistered" }
                 }
             }
         } else {

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/MockInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/MockInterface.kt
@@ -17,6 +17,7 @@
 
 package com.geeksville.mesh.repository.radio
 
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.concurrent.handledLaunch
 import com.geeksville.mesh.model.getInitials
 import com.google.protobuf.ByteString
@@ -38,7 +39,6 @@ import org.meshtastic.proto.config
 import org.meshtastic.proto.deviceMetadata
 import org.meshtastic.proto.fromRadio
 import org.meshtastic.proto.queueStatus
-import timber.log.Timber
 import kotlin.random.Random
 
 private val defaultLoRaConfig =
@@ -71,7 +71,7 @@ constructor(
     private val packetIdSequence = generateSequence { currentPacketId++ }.iterator()
 
     init {
-        Timber.i("Starting the mock interface")
+        Logger.i { "Starting the mock interface" }
         service.onConnect() // Tell clients they can use the API
     }
 
@@ -86,7 +86,7 @@ constructor(
             data != null && data.portnum == Portnums.PortNum.ADMIN_APP ->
                 handleAdminPacket(pr, AdminProtos.AdminMessage.parseFrom(data.payload))
             pr.hasPacket() && pr.packet.wantAck -> sendFakeAck(pr)
-            else -> Timber.i("Ignoring data sent to mock interface $pr")
+            else -> Logger.i { "Ignoring data sent to mock interface $pr" }
         }
     }
 
@@ -108,12 +108,12 @@ constructor(
                     }
                 }
 
-            else -> Timber.i("Ignoring admin sent to mock interface $d")
+            else -> Logger.i { "Ignoring admin sent to mock interface $d" }
         }
     }
 
     override fun close() {
-        Timber.i("Closing the mock interface")
+        Logger.i { "Closing the mock interface" }
     }
 
     // / Generate a fake text message from a node
@@ -297,7 +297,7 @@ constructor(
     }
 
     private fun sendConfigResponse(configId: Int) {
-        Timber.d("Sending mock config response")
+        Logger.d { "Sending mock config response" }
 
         // / Generate a fake node info entry
         @Suppress("MagicNumber")

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/NordicBleInterfaceSpec.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/NordicBleInterfaceSpec.kt
@@ -17,9 +17,9 @@
 
 package com.geeksville.mesh.repository.radio
 
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.repository.bluetooth.BluetoothRepository
 import org.meshtastic.core.model.util.anonymize
-import timber.log.Timber
 import javax.inject.Inject
 
 /** Bluetooth backend implementation. */
@@ -35,7 +35,7 @@ constructor(
     override fun addressValid(rest: String): Boolean {
         val allPaired = bluetoothRepository.state.value.bondedDevices.map { it.address }.toSet()
         return if (!allPaired.contains(rest)) {
-            Timber.w("Ignoring stale bond to ${rest.anonymize}")
+            Logger.w { "Ignoring stale bond to ${rest.anonymize}" }
             false
         } else {
             true

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/StreamInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/StreamInterface.kt
@@ -17,7 +17,7 @@
 
 package com.geeksville.mesh.repository.radio
 
-import timber.log.Timber
+import co.touchlab.kermit.Logger
 
 /**
  * An interface that assumes we are talking to a meshtastic device over some sort of stream connection (serial or TCP
@@ -41,7 +41,7 @@ abstract class StreamInterface(protected val service: RadioInterfaceService) : I
     private var packetLen = 0
 
     override fun close() {
-        Timber.d("Closing stream for good")
+        Logger.d { "Closing stream for good" }
         onDeviceDisconnect(true)
     }
 
@@ -90,7 +90,7 @@ abstract class StreamInterface(protected val service: RadioInterfaceService) : I
         when (val c = b.toInt().toChar()) {
             '\r' -> {} // ignore
             '\n' -> {
-                Timber.d("DeviceLog: $debugLineBuf")
+                Logger.d { "DeviceLog: $debugLineBuf" }
                 debugLineBuf.clear()
             }
             else -> debugLineBuf.append(c)
@@ -104,7 +104,7 @@ abstract class StreamInterface(protected val service: RadioInterfaceService) : I
         var nextPtr = ptr + 1
 
         fun lostSync() {
-            Timber.e("Lost protocol sync")
+            Logger.e { "Lost protocol sync" }
             nextPtr = 0
         }
 

--- a/app/src/main/java/com/geeksville/mesh/repository/usb/SerialConnectionImpl.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/usb/SerialConnectionImpl.kt
@@ -18,11 +18,11 @@
 package com.geeksville.mesh.repository.usb
 
 import android.hardware.usb.UsbManager
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.util.ignoreException
 import com.hoho.android.usbserial.driver.UsbSerialDriver
 import com.hoho.android.usbserial.driver.UsbSerialPort
 import com.hoho.android.usbserial.util.SerialInputOutputManager
-import timber.log.Timber
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -40,7 +40,7 @@ internal class SerialConnectionImpl(
 
     override fun sendBytes(bytes: ByteArray) {
         ioRef.get()?.let {
-            Timber.d("writing ${bytes.size} byte(s)")
+            Logger.d { "writing ${bytes.size} byte(s }" }
             it.writeAsync(bytes)
         }
     }
@@ -54,7 +54,7 @@ internal class SerialConnectionImpl(
 
             // Allow a short amount of time for the manager to quit (so the port can be cleanly closed)
             if (waitForStopped) {
-                Timber.d("Waiting for USB manager to stop...")
+                Logger.d { "Waiting for USB manager to stop..." }
                 closedLatch.await(1, TimeUnit.SECONDS)
             }
         }
@@ -80,7 +80,7 @@ internal class SerialConnectionImpl(
         port.dtr = true
         port.rts = true
 
-        Timber.d("Starting serial reader thread")
+        Logger.d { "Starting serial reader thread" }
         val io =
             SerialInputOutputManager(
                 port,

--- a/app/src/main/java/com/geeksville/mesh/repository/usb/UsbBroadcastReceiver.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/usb/UsbBroadcastReceiver.kt
@@ -23,9 +23,9 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.util.exceptionReporter
 import com.geeksville.mesh.util.getParcelableExtraCompat
-import timber.log.Timber
 import javax.inject.Inject
 
 /** A helper class to call onChanged when bluetooth is enabled or disabled or when permissions are changed. */
@@ -44,15 +44,15 @@ class UsbBroadcastReceiver @Inject constructor(private val usbRepository: UsbRep
 
         when (intent.action) {
             UsbManager.ACTION_USB_DEVICE_DETACHED -> {
-                Timber.d("USB device '$deviceName' was detached")
+                Logger.d { "USB device '$deviceName' was detached" }
                 usbRepository.refreshState()
             }
             UsbManager.ACTION_USB_DEVICE_ATTACHED -> {
-                Timber.d("USB device '$deviceName' was attached")
+                Logger.d { "USB device '$deviceName' was attached" }
                 usbRepository.refreshState()
             }
             UsbManager.EXTRA_PERMISSION_GRANTED -> {
-                Timber.d("USB device '$deviceName' was granted permission")
+                Logger.d { "USB device '$deviceName' was granted permission" }
                 usbRepository.refreshState()
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceBroadcasts.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceBroadcasts.kt
@@ -20,13 +20,13 @@ package com.geeksville.mesh.service
 import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
+import co.touchlab.kermit.Logger
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.NodeInfo
 import org.meshtastic.core.model.util.toPIIString
 import org.meshtastic.core.service.ServiceRepository
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -51,7 +51,7 @@ constructor(
     }
 
     fun broadcastNodeChange(info: NodeInfo) {
-        Timber.d("Broadcasting node change ${info.user?.toPIIString()}")
+        Logger.d { "Broadcasting node change ${info.user?.toPIIString()}" }
         val intent = Intent(MeshService.ACTION_NODE_CHANGE).putExtra(EXTRA_NODEINFO, info)
         explicitBroadcast(intent)
     }
@@ -60,10 +60,10 @@ constructor(
 
     fun broadcastMessageStatus(id: Int, status: MessageStatus?) {
         if (id == 0) {
-            Timber.d("Ignoring anonymous packet status")
+            Logger.d { "Ignoring anonymous packet status" }
         } else {
             // Do not log, contains PII possibly
-            // MeshService.Timber.d("Broadcasting message status $p")
+            // MeshService.Logger.d { "Broadcasting message status $p" }
             val intent =
                 Intent(MeshService.ACTION_MESSAGE_STATUS).apply {
                     putExtra(EXTRA_PACKET_ID, id)

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceStarter.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceStarter.kt
@@ -20,8 +20,8 @@ package com.geeksville.mesh.service
 import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context
 import android.os.Build
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.BuildConfig
-import timber.log.Timber
 
 // / Helper function to start running our service
 fun MeshService.Companion.startService(context: Context) {
@@ -33,14 +33,14 @@ fun MeshService.Companion.startService(context: Context) {
     // Before binding we want to explicitly create - so the service stays alive forever (so it can keep
     // listening for the bluetooth packets arriving from the radio. And when they arrive forward them
     // to Signal or whatever.
-    Timber.i("Trying to start service debug=${BuildConfig.DEBUG}")
+    Logger.i { "Trying to start service debug=${BuildConfig.DEBUG}" }
 
     val intent = createIntent(context)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         try {
             context.startForegroundService(intent)
         } catch (ex: ForegroundServiceStartNotAllowedException) {
-            Timber.e("Unable to start service: ${ex.message}")
+            Logger.e { "Unable to start service: ${ex.message}" }
         }
     } else {
         context.startForegroundService(intent)

--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -77,7 +77,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -88,6 +87,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.BuildConfig
 import com.geeksville.mesh.model.BTScanModel
 import com.geeksville.mesh.model.UIViewModel
@@ -157,7 +157,6 @@ import org.meshtastic.core.ui.theme.StatusColors.StatusBlue
 import org.meshtastic.core.ui.theme.StatusColors.StatusGreen
 import org.meshtastic.feature.node.metrics.annotateTraceroute
 import org.meshtastic.proto.MeshProtos
-import timber.log.Timber
 
 enum class TopLevelDestination(val label: StringResource, val icon: ImageVector, val route: Route) {
     Conversations(Res.string.conversations, MeshtasticIcons.Conversations, ContactsRoutes.ContactsGraph),
@@ -610,7 +609,7 @@ private fun VersionChecks(viewModel: UIViewModel) {
     LaunchedEffect(connectionState, firmwareEdition) {
         if (connectionState == ConnectionState.Connected) {
             firmwareEdition?.let { edition ->
-                Timber.d("FirmwareEdition: ${edition.name}")
+                Logger.d { "FirmwareEdition: ${edition.name}" }
                 when (edition) {
                     MeshProtos.FirmwareEdition.VANILLA -> {
                         // Handle any specific logic for VANILLA firmware edition if needed
@@ -627,21 +626,21 @@ private fun VersionChecks(viewModel: UIViewModel) {
     // Check if the device is running an old app version or firmware version
     LaunchedEffect(connectionState, myNodeInfo) {
         if (connectionState == ConnectionState.Connected) {
-            Timber.i(
+            Logger.i {
                 "[FW_CHECK] Connection state: $connectionState, " +
                     "myNodeInfo: ${if (myNodeInfo != null) "present" else "null"}, " +
-                    "firmwareVersion: ${myFirmwareVersion ?: "null"}",
-            )
+                    "firmwareVersion: ${myFirmwareVersion ?: "null"}"
+            }
 
             myNodeInfo?.let { info ->
                 val isOld = info.minAppVersion > BuildConfig.VERSION_CODE && BuildConfig.DEBUG.not()
-                Timber.d(
+                Logger.d {
                     "[FW_CHECK] App version check - minAppVersion: ${info.minAppVersion}, " +
-                        "currentVersion: ${BuildConfig.VERSION_CODE}, isOld: $isOld",
-                )
+                        "currentVersion: ${BuildConfig.VERSION_CODE}, isOld: $isOld"
+                }
 
                 if (isOld) {
-                    Timber.w("[FW_CHECK] App too old - showing update prompt")
+                    Logger.w { "[FW_CHECK] App too old - showing update prompt" }
                     viewModel.showAlert(
                         getString(Res.string.app_too_old),
                         getString(Res.string.must_update),
@@ -654,18 +653,18 @@ private fun VersionChecks(viewModel: UIViewModel) {
                 } else {
                     myFirmwareVersion?.let { fwVersion ->
                         val curVer = DeviceVersion(fwVersion)
-                        Timber.i(
+                        Logger.i {
                             "[FW_CHECK] Firmware version comparison - " +
                                 "device: $curVer (raw: $fwVersion), " +
                                 "absoluteMin: ${MeshService.absoluteMinDeviceVersion}, " +
-                                "min: ${MeshService.minDeviceVersion}",
-                        )
+                                "min: ${MeshService.minDeviceVersion}"
+                        }
 
                         if (curVer < MeshService.absoluteMinDeviceVersion) {
-                            Timber.w(
+                            Logger.w {
                                 "[FW_CHECK] Firmware too old - " +
-                                    "device: $curVer < absoluteMin: ${MeshService.absoluteMinDeviceVersion}",
-                            )
+                                    "device: $curVer < absoluteMin: ${MeshService.absoluteMinDeviceVersion}"
+                            }
                             val title = getString(Res.string.firmware_too_old)
                             val message = getString(Res.string.firmware_old)
                             viewModel.showAlert(
@@ -678,21 +677,21 @@ private fun VersionChecks(viewModel: UIViewModel) {
                                 },
                             )
                         } else if (curVer < MeshService.minDeviceVersion) {
-                            Timber.w(
+                            Logger.w {
                                 "[FW_CHECK] Firmware should update - " +
-                                    "device: $curVer < min: ${MeshService.minDeviceVersion}",
-                            )
+                                    "device: $curVer < min: ${MeshService.minDeviceVersion}"
+                            }
                             val title = getString(Res.string.should_update_firmware)
                             val message = getString(Res.string.should_update, latestStableFirmwareRelease.asString)
                             viewModel.showAlert(title = title, message = message, dismissable = false, onConfirm = {})
                         } else {
-                            Timber.i("[FW_CHECK] Firmware version OK - device: $curVer meets requirements")
+                            Logger.i { "[FW_CHECK] Firmware version OK - device: $curVer meets requirements" }
                         }
-                    } ?: run { Timber.w("[FW_CHECK] Firmware version is null despite myNodeInfo being present") }
+                    } ?: run { Logger.w { "[FW_CHECK] Firmware version is null despite myNodeInfo being present" } }
                 }
-            } ?: run { Timber.d("[FW_CHECK] myNodeInfo is null, skipping firmware check") }
+            } ?: run { Logger.d { "[FW_CHECK] myNodeInfo is null, skipping firmware check" } }
         } else {
-            Timber.d("[FW_CHECK] Not connected (state: $connectionState), skipping firmware check")
+            Logger.d { "[FW_CHECK] Not connected (state: $connectionState), skipping firmware check" }
         }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/CurrentlyConnectedInfo.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import co.touchlab.kermit.Logger
 import com.geeksville.mesh.model.DeviceListEntry
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
@@ -58,7 +59,6 @@ import org.meshtastic.core.ui.theme.StatusColors.StatusRed
 import org.meshtastic.proto.MeshProtos
 import org.meshtastic.proto.PaxcountProtos
 import org.meshtastic.proto.TelemetryProtos
-import timber.log.Timber
 import kotlin.time.Duration.Companion.seconds
 
 private const val RSSI_DELAY = 10
@@ -81,13 +81,13 @@ fun CurrentlyConnectedInfo(
                     rssi = withTimeout(RSSI_TIMEOUT.seconds) { bleDevice.peripheral.readRssi() }
                     delay(RSSI_DELAY.seconds)
                 } catch (e: PeripheralNotConnectedException) {
-                    Timber.e(e, "Failed to read RSSI ${e.message}")
+                    Logger.e(e) { "Failed to read RSSI ${e.message}" }
                     break
                 } catch (e: OperationFailedException) {
-                    Timber.e(e, "Failed to read RSSI ${e.message}")
+                    Logger.e(e) { "Failed to read RSSI ${e.message}" }
                     break
                 } catch (e: SecurityException) {
-                    Timber.e(e, "Failed to read RSSI ${e.message}")
+                    Logger.e(e) { "Failed to read RSSI ${e.message}" }
                     break
                 }
             }

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/Channel.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.touchlab.kermit.Logger
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
@@ -133,7 +134,6 @@ import org.meshtastic.proto.ChannelProtos
 import org.meshtastic.proto.ConfigProtos
 import org.meshtastic.proto.channelSet
 import org.meshtastic.proto.copy
-import timber.log.Timber
 
 /**
  * Composable screen for managing and sharing Meshtastic channels. Allows users to view, edit, and share channel
@@ -209,7 +209,7 @@ fun ChannelScreen(
         }
 
     fun zxingScan() {
-        Timber.d("Starting zxing QR code scanner")
+        Logger.d { "Starting zxing QR code scanner" }
         val zxingScan = ScanOptions()
         zxingScan.setCameraId(0)
         zxingScan.setPrompt("")
@@ -236,7 +236,7 @@ fun ChannelScreen(
             viewModel.setChannels(newChannelSet)
             // Since we are writing to DeviceConfig, that will trigger the rest of the GUI update (QR code etc)
         } catch (ex: RemoteException) {
-            Timber.e(ex, "ignoring channel problem")
+            Logger.e(ex) { "ignoring channel problem" }
 
             channelSet = channels // Throw away user edits
 
@@ -264,7 +264,7 @@ fun ChannelScreen(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        Timber.d("Switching back to default channel")
+                        Logger.d { "Switching back to default channel" }
                         installSettings(
                             Channel.default.settings,
                             Channel.default.loraConfig.copy {

--- a/app/src/main/java/com/geeksville/mesh/ui/sharing/ChannelViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/sharing/ChannelViewModel.kt
@@ -21,6 +21,7 @@ import android.net.Uri
 import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -39,7 +40,6 @@ import org.meshtastic.proto.LocalOnlyProtos.LocalConfig
 import org.meshtastic.proto.channelSet
 import org.meshtastic.proto.config
 import org.meshtastic.proto.copy
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -80,7 +80,7 @@ constructor(
 
     fun requestChannelUrl(url: Uri, onError: () -> Unit) = runCatching { _requestChannelSet.value = url.toChannelSet() }
         .onFailure { ex ->
-            Timber.e(ex, "Channel url error")
+            Logger.e(ex) { "Channel url error" }
             onError()
         }
 
@@ -101,7 +101,7 @@ constructor(
         try {
             serviceRepository.meshService?.setChannel(channel.toByteArray())
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Set channel error")
+            Logger.e(ex) { "Set channel error" }
         }
     }
 
@@ -110,7 +110,7 @@ constructor(
         try {
             serviceRepository.meshService?.setConfig(config.toByteArray())
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Set config error")
+            Logger.e(ex) { "Set config error" }
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/util/Exceptions.kt
+++ b/app/src/main/java/com/geeksville/mesh/util/Exceptions.kt
@@ -19,7 +19,7 @@ package com.geeksville.mesh.util
 
 import android.os.RemoteException
 import android.util.Log
-import timber.log.Timber
+import co.touchlab.kermit.Logger
 
 object Exceptions {
     // / Set in Application.onCreate
@@ -31,10 +31,9 @@ object Exceptions {
      * After reporting return
      */
     fun report(exception: Throwable, tag: String? = null, message: String? = null) {
-        Timber.e(
-            exception,
-            "Exceptions.report: $tag $message",
-        ) // print the message to the log _before_ telling the crash reporter
+        Logger.e(exception) {
+            "Exceptions.report: $tag $message"
+        } // print the message to the log _before_ telling the crash reporter
         reporter?.let { r -> r(exception, tag, message) }
     }
 }
@@ -58,7 +57,7 @@ fun ignoreException(silent: Boolean = false, inner: () -> Unit) {
         inner()
     } catch (ex: Throwable) {
         // DO NOT THROW users expect we have fully handled/discarded the exception
-        if (!silent) Timber.e("ignoring exception", ex)
+        if (!silent) Logger.e(ex) { "ignoring exception" }
     }
 }
 

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.navigation.runtime)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 
     googleApi(libs.dd.sdk.android.compose)
     googleApi(libs.dd.sdk.android.logs)

--- a/core/analytics/src/fdroid/kotlin/org/meshtastic/core/analytics/platform/FdroidPlatformAnalytics.kt
+++ b/core/analytics/src/fdroid/kotlin/org/meshtastic/core/analytics/platform/FdroidPlatformAnalytics.kt
@@ -19,9 +19,10 @@ package org.meshtastic.core.analytics.platform
 
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
 import org.meshtastic.core.analytics.BuildConfig
 import org.meshtastic.core.analytics.DataPair
-import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -34,16 +35,17 @@ class FdroidPlatformAnalytics @Inject constructor() : PlatformAnalytics {
         // In debug builds we attach a DebugTree for convenient local logging, but
         // release builds rely on system logging only.
         if (BuildConfig.DEBUG) {
-            Timber.plant(Timber.DebugTree())
-            Timber.i("F-Droid platform no-op analytics initialized (DebugTree planted).")
+            Logger.setMinSeverity(Severity.Debug)
+            Logger.i { "F-Droid platform no-op analytics initialized (Debug mode }." }
         } else {
-            Timber.i("F-Droid platform no-op analytics initialized.")
+            Logger.setMinSeverity(Severity.Info)
+            Logger.i { "F-Droid platform no-op analytics initialized." }
         }
     }
 
     override fun setDeviceAttributes(firmwareVersion: String, model: String) {
         // No-op for F-Droid
-        Timber.d("Set device attributes called: firmwareVersion=$firmwareVersion, deviceHardware=$model")
+        Logger.d { "Set device attributes called: firmwareVersion=$firmwareVersion, deviceHardware=$model" }
     }
 
     @Composable
@@ -51,7 +53,7 @@ class FdroidPlatformAnalytics @Inject constructor() : PlatformAnalytics {
         // No-op for F-Droid, but we can log navigation if needed for debugging
         if (BuildConfig.DEBUG) {
             navController.addOnDestinationChangedListener { _, destination, _ ->
-                Timber.d("Navigation changed to: ${destination.route}")
+                Logger.d { "Navigation changed to: ${destination.route}" }
             }
         }
     }
@@ -60,6 +62,6 @@ class FdroidPlatformAnalytics @Inject constructor() : PlatformAnalytics {
         get() = false
 
     override fun track(event: String, vararg properties: DataPair) {
-        Timber.d("Track called: event=$event, properties=${properties.toList()}")
+        Logger.d { "Track called: event=$event, properties=${properties.toList()}" }
     }
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -61,5 +61,5 @@ dependencies {
     implementation(libs.androidx.core.location.altitude)
     implementation(libs.androidx.paging.common)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 }

--- a/core/data/detekt-baseline.xml
+++ b/core/data/detekt-baseline.xml
@@ -6,6 +6,11 @@
     <ID>MagicNumber:LocationRepository.kt$LocationRepository$30</ID>
     <ID>MagicNumber:LocationRepository.kt$LocationRepository$31</ID>
     <ID>MagicNumber:PacketRepository.kt$PacketRepository$500</ID>
+    <ID>MaxLineLength:DeviceHardwareRepository.kt$DeviceHardwareRepository$"DeviceHardwareRepository: applying quirk: requiresBootloaderUpgradeForOta=${quirk.requiresBootloaderUpgradeForOta}, infoUrl=${quirk.infoUrl}"</ID>
+    <ID>MaxLineLength:DeviceHardwareRepository.kt$DeviceHardwareRepository$"DeviceHardwareRepository: cache ${if (staleEntity == null) "empty" else "incomplete"} for hwModel=$hwModel, falling back to bundled JSON asset"</ID>
+    <ID>MaxLineLength:DeviceHardwareRepository.kt$DeviceHardwareRepository$"DeviceHardwareRepository: failed to load device hardware from bundled JSON for hwModel=$hwModel"</ID>
+    <ID>MaxLineLength:DeviceHardwareRepository.kt$DeviceHardwareRepository$"DeviceHardwareRepository: lookup after JSON load for hwModel=$hwModel ${if (base != null) "succeeded" else "returned null"}"</ID>
+    <ID>MaxLineLength:DeviceHardwareRepository.kt$DeviceHardwareRepository$"DeviceHardwareRepository: lookup after remote fetch for hwModel=$hwModel ${if (fromDb != null) "succeeded" else "returned null"}"</ID>
     <ID>TooGenericExceptionCaught:LocationRepository.kt$LocationRepository$e: Exception</ID>
     <ID>TooManyFunctions:PacketRepository.kt$PacketRepository</ID>
   </CurrentIssues>

--- a/core/data/src/google/kotlin/org/meshtastic/core/data/repository/CustomTileProviderRepository.kt
+++ b/core/data/src/google/kotlin/org/meshtastic/core/data/repository/CustomTileProviderRepository.kt
@@ -17,6 +17,7 @@
 
 package org.meshtastic.core.data.repository
 
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,10 +27,8 @@ import kotlinx.serialization.json.Json
 import org.meshtastic.core.data.model.CustomTileProviderConfig
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.prefs.map.MapTileProviderPrefs
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.collections.plus
 
 interface CustomTileProviderRepository {
     fun getCustomTileProviders(): Flow<List<CustomTileProviderConfig>>
@@ -88,7 +87,7 @@ constructor(
             try {
                 customTileProvidersStateFlow.value = json.decodeFromString<List<CustomTileProviderConfig>>(jsonString)
             } catch (e: SerializationException) {
-                Timber.e(e, "Error deserializing tile providers")
+                Logger.e(e) { "Error deserializing tile providers" }
                 customTileProvidersStateFlow.value = emptyList()
             }
         } else {
@@ -102,7 +101,7 @@ constructor(
                 val jsonString = json.encodeToString(providers)
                 mapTileProviderPrefs.customTileProviders = jsonString
             } catch (e: SerializationException) {
-                Timber.e(e, "Error serializing tile providers")
+                Logger.e(e) { "Error serializing tile providers" }
             }
         }
     }

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/BootloaderOtaQuirksJsonDataSource.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/BootloaderOtaQuirksJsonDataSource.kt
@@ -18,12 +18,12 @@
 package org.meshtastic.core.data.datasource
 
 import android.app.Application
+import co.touchlab.kermit.Logger
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import org.meshtastic.core.model.BootloaderOtaQuirk
-import timber.log.Timber
 import javax.inject.Inject
 
 class BootloaderOtaQuirksJsonDataSource @Inject constructor(private val application: Application) {
@@ -32,7 +32,7 @@ class BootloaderOtaQuirksJsonDataSource @Inject constructor(private val applicat
         val inputStream = application.assets.open("device_bootloader_ota_quirks.json")
         inputStream.use { Json.decodeFromStream<ListWrapper>(it).devices }
     }
-        .onFailure { e -> Timber.w(e, "Failed to load device_bootloader_ota_quirks.json") }
+        .onFailure { e -> Logger.w(e) { "Failed to load device_bootloader_ota_quirks.json" } }
         .getOrDefault(emptyList())
 
     @Serializable private data class ListWrapper(val devices: List<BootloaderOtaQuirk> = emptyList())

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/LocationRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/LocationRepository.kt
@@ -27,6 +27,7 @@ import androidx.core.location.LocationListenerCompat
 import androidx.core.location.LocationManagerCompat
 import androidx.core.location.LocationRequestCompat
 import androidx.core.location.altitude.AltitudeConverterCompat
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.channels.awaitClose
@@ -34,7 +35,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import org.meshtastic.core.analytics.platform.PlatformAnalytics
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -68,7 +68,7 @@ constructor(
                 try {
                     AltitudeConverterCompat.addMslAltitudeToLocation(context, location)
                 } catch (e: Exception) {
-                    Timber.e(e, "addMslAltitudeToLocation() failed")
+                    Logger.e(e) { "addMslAltitudeToLocation() failed" }
                 }
             }
             // info("New location: $location")
@@ -85,9 +85,9 @@ constructor(
             }
         }
 
-        Timber.i(
-            "Starting location updates with $providerList intervalMs=${intervalMs}ms and minDistanceM=${minDistanceM}m",
-        )
+        Logger.i {
+            "Starting location updates with $providerList intervalMs=${intervalMs}ms and minDistanceM=${minDistanceM}m"
+        }
         _receivingLocationUpdates.value = true
         analytics.track("location_start") // Figure out how many users needed to use the phone GPS
 
@@ -106,7 +106,7 @@ constructor(
         }
 
         awaitClose {
-            Timber.i("Stopping location requests")
+            Logger.i { "Stopping location requests" }
             _receivingLocationUpdates.value = false
             analytics.track("location_stop")
 

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 
     implementation(libs.androidx.room.paging)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 
     ksp(libs.androidx.room.compiler)
 

--- a/core/database/src/main/kotlin/org/meshtastic/core/database/Converters.kt
+++ b/core/database/src/main/kotlin/org/meshtastic/core/database/Converters.kt
@@ -18,6 +18,7 @@
 package org.meshtastic.core.database
 
 import androidx.room.TypeConverter
+import co.touchlab.kermit.Logger
 import com.google.protobuf.ByteString
 import com.google.protobuf.InvalidProtocolBufferException
 import kotlinx.serialization.json.Json
@@ -25,7 +26,6 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.proto.MeshProtos
 import org.meshtastic.proto.PaxcountProtos
 import org.meshtastic.proto.TelemetryProtos
-import timber.log.Timber
 
 @Suppress("TooManyFunctions")
 class Converters {
@@ -45,7 +45,7 @@ class Converters {
     fun bytesToFromRadio(bytes: ByteArray): MeshProtos.FromRadio = try {
         MeshProtos.FromRadio.parseFrom(bytes)
     } catch (ex: InvalidProtocolBufferException) {
-        Timber.e(ex, "bytesToFromRadio TypeConverter error")
+        Logger.e(ex) { "bytesToFromRadio TypeConverter error" }
         MeshProtos.FromRadio.getDefaultInstance()
     }
 
@@ -55,7 +55,7 @@ class Converters {
     fun bytesToUser(bytes: ByteArray): MeshProtos.User = try {
         MeshProtos.User.parseFrom(bytes)
     } catch (ex: InvalidProtocolBufferException) {
-        Timber.e(ex, "bytesToUser TypeConverter error")
+        Logger.e(ex) { "bytesToUser TypeConverter error" }
         MeshProtos.User.getDefaultInstance()
     }
 
@@ -65,7 +65,7 @@ class Converters {
     fun bytesToPosition(bytes: ByteArray): MeshProtos.Position = try {
         MeshProtos.Position.parseFrom(bytes)
     } catch (ex: InvalidProtocolBufferException) {
-        Timber.e(ex, "bytesToPosition TypeConverter error")
+        Logger.e(ex) { "bytesToPosition TypeConverter error" }
         MeshProtos.Position.getDefaultInstance()
     }
 
@@ -75,7 +75,7 @@ class Converters {
     fun bytesToTelemetry(bytes: ByteArray): TelemetryProtos.Telemetry = try {
         TelemetryProtos.Telemetry.parseFrom(bytes)
     } catch (ex: InvalidProtocolBufferException) {
-        Timber.e(ex, "bytesToTelemetry TypeConverter error")
+        Logger.e(ex) { "bytesToTelemetry TypeConverter error" }
         TelemetryProtos.Telemetry.newBuilder().build() // Return an empty Telemetry object
     }
 
@@ -85,7 +85,7 @@ class Converters {
     fun bytesToPaxcounter(bytes: ByteArray): PaxcountProtos.Paxcount = try {
         PaxcountProtos.Paxcount.parseFrom(bytes)
     } catch (ex: InvalidProtocolBufferException) {
-        Timber.e(ex, "bytesToPaxcounter TypeConverter error")
+        Logger.e(ex) { "bytesToPaxcounter TypeConverter error" }
         PaxcountProtos.Paxcount.getDefaultInstance()
     }
 
@@ -95,7 +95,7 @@ class Converters {
     fun bytesToMetadata(bytes: ByteArray): MeshProtos.DeviceMetadata = try {
         MeshProtos.DeviceMetadata.parseFrom(bytes)
     } catch (ex: InvalidProtocolBufferException) {
-        Timber.e(ex, "bytesToMetadata TypeConverter error")
+        Logger.e(ex) { "bytesToMetadata TypeConverter error" }
         MeshProtos.DeviceMetadata.getDefaultInstance()
     }
 

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -48,5 +48,5 @@ dependencies {
     implementation(libs.androidx.datastore)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 }

--- a/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/BootloaderWarningDataSource.kt
+++ b/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/BootloaderWarningDataSource.kt
@@ -21,11 +21,11 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -43,9 +43,9 @@ class BootloaderWarningDataSource @Inject constructor(private val dataStore: Dat
             runCatching { Json.decodeFromString<List<String>>(jsonString).toSet() }
                 .onFailure { e ->
                     if (e is IllegalArgumentException || e is SerializationException) {
-                        Timber.w(e, "Failed to parse dismissed bootloader warning addresses, resetting preference")
+                        Logger.w(e) { "Failed to parse dismissed bootloader warning addresses, resetting preference" }
                     } else {
-                        Timber.w(e, "Unexpected error while parsing dismissed bootloader warning addresses")
+                        Logger.w(e) { "Unexpected error while parsing dismissed bootloader warning addresses" }
                     }
                 }
                 .getOrDefault(emptySet())

--- a/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/ChannelSetDataSource.kt
+++ b/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/ChannelSetDataSource.kt
@@ -18,13 +18,13 @@
 package org.meshtastic.core.datastore
 
 import androidx.datastore.core.DataStore
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import org.meshtastic.proto.AppOnlyProtos.ChannelSet
 import org.meshtastic.proto.ChannelProtos.Channel
 import org.meshtastic.proto.ChannelProtos.ChannelSettings
 import org.meshtastic.proto.ConfigProtos
-import timber.log.Timber
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -36,7 +36,7 @@ class ChannelSetDataSource @Inject constructor(private val channelSetStore: Data
         channelSetStore.data.catch { exception ->
             // dataStore.data throws an IOException when an error is encountered when reading data
             if (exception is IOException) {
-                Timber.e("Error reading DeviceConfig settings: ${exception.message}")
+                Logger.e { "Error reading DeviceConfig settings: ${exception.message}" }
                 emit(ChannelSet.getDefaultInstance())
             } else {
                 throw exception

--- a/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/LocalConfigDataSource.kt
+++ b/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/LocalConfigDataSource.kt
@@ -18,11 +18,11 @@
 package org.meshtastic.core.datastore
 
 import androidx.datastore.core.DataStore
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import org.meshtastic.proto.ConfigProtos.Config
 import org.meshtastic.proto.LocalOnlyProtos.LocalConfig
-import timber.log.Timber
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -34,7 +34,7 @@ class LocalConfigDataSource @Inject constructor(private val localConfigStore: Da
         localConfigStore.data.catch { exception ->
             // dataStore.data throws an IOException when an error is encountered when reading data
             if (exception is IOException) {
-                Timber.e("Error reading LocalConfig settings: ${exception.message}")
+                Logger.e { "Error reading LocalConfig settings: ${exception.message}" }
                 emit(LocalConfig.getDefaultInstance())
             } else {
                 throw exception
@@ -53,7 +53,7 @@ class LocalConfigDataSource @Inject constructor(private val localConfigStore: Da
             if (localField != null) {
                 builder.setField(localField, value)
             } else {
-                Timber.e("Error writing LocalConfig settings: ${config.payloadVariantCase}")
+                Logger.e { "Error writing LocalConfig settings: ${config.payloadVariantCase}" }
             }
         }
         builder.build()

--- a/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/ModuleConfigDataSource.kt
+++ b/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/ModuleConfigDataSource.kt
@@ -18,11 +18,11 @@
 package org.meshtastic.core.datastore
 
 import androidx.datastore.core.DataStore
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import org.meshtastic.proto.LocalOnlyProtos.LocalModuleConfig
 import org.meshtastic.proto.ModuleConfigProtos.ModuleConfig
-import timber.log.Timber
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -34,7 +34,7 @@ class ModuleConfigDataSource @Inject constructor(private val moduleConfigStore: 
         moduleConfigStore.data.catch { exception ->
             // dataStore.data throws an IOException when an error is encountered when reading data
             if (exception is IOException) {
-                Timber.e("Error reading LocalModuleConfig settings: ${exception.message}")
+                Logger.e { "Error reading LocalModuleConfig settings: ${exception.message}" }
                 emit(LocalModuleConfig.getDefaultInstance())
             } else {
                 throw exception
@@ -53,7 +53,7 @@ class ModuleConfigDataSource @Inject constructor(private val moduleConfigStore: 
             if (localField != null) {
                 builder.setField(localField, value)
             } else {
-                Timber.e("Error writing LocalModuleConfig settings: ${config.payloadVariantCase}")
+                Logger.e { "Error writing LocalModuleConfig settings: ${config.payloadVariantCase}" }
             }
         }
         builder.build()

--- a/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/RecentAddressesDataSource.kt
+++ b/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/RecentAddressesDataSource.kt
@@ -21,6 +21,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -29,7 +30,6 @@ import kotlinx.serialization.json.Json
 import org.json.JSONArray
 import org.json.JSONObject
 import org.meshtastic.core.datastore.model.RecentAddress
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -46,11 +46,11 @@ class RecentAddressesDataSource @Inject constructor(private val dataStore: DataS
                 try {
                     Json.decodeFromString<List<RecentAddress>>(jsonString)
                 } catch (e: IllegalArgumentException) {
-                    Timber.w("Could not parse recent addresses, falling back to legacy parsing: ${e.message}")
+                    Logger.w { "Could not parse recent addresses, falling back to legacy parsing: ${e.message}" }
                     // Fallback to legacy parsing
                     parseLegacyRecentAddresses(jsonString)
                 } catch (e: SerializationException) {
-                    Timber.w("Could not parse recent addresses, falling back to legacy parsing: ${e.message}")
+                    Logger.w { "Could not parse recent addresses, falling back to legacy parsing: ${e.message}" }
                     // Fallback to legacy parsing
                     parseLegacyRecentAddresses(jsonString)
                 }
@@ -73,7 +73,7 @@ class RecentAddressesDataSource @Inject constructor(private val dataStore: DataS
                 }
                 else -> {
                     // Unknown format, log or handle as an error if necessary
-                    Timber.w("Unknown item type in recent IP addresses: $item")
+                    Logger.w { "Unknown item type in recent IP addresses: $item" }
                     null
                 }
             }

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 
     implementation(libs.androidx.annotation)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.timber)
+    implementation(libs.kermit)
     implementation(libs.zxing.android.embedded) { isTransitive = false }
     implementation(libs.zxing.core)
 

--- a/core/model/detekt-baseline.xml
+++ b/core/model/detekt-baseline.xml
@@ -2,30 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>MagicNumber:Channel.kt$0xff</ID>
-    <ID>MagicNumber:ChannelOption.kt$.03125f</ID>
-    <ID>MagicNumber:ChannelOption.kt$.0625f</ID>
-    <ID>MagicNumber:ChannelOption.kt$.203125f</ID>
-    <ID>MagicNumber:ChannelOption.kt$.40625f</ID>
-    <ID>MagicNumber:ChannelOption.kt$.8125f</ID>
-    <ID>MagicNumber:ChannelOption.kt$1.6250f</ID>
-    <ID>MagicNumber:ChannelOption.kt$1000f</ID>
-    <ID>MagicNumber:ChannelOption.kt$1600</ID>
-    <ID>MagicNumber:ChannelOption.kt$200</ID>
-    <ID>MagicNumber:ChannelOption.kt$3.25f</ID>
-    <ID>MagicNumber:ChannelOption.kt$31</ID>
-    <ID>MagicNumber:ChannelOption.kt$400</ID>
-    <ID>MagicNumber:ChannelOption.kt$5</ID>
-    <ID>MagicNumber:ChannelOption.kt$62</ID>
-    <ID>MagicNumber:ChannelOption.kt$800</ID>
-    <ID>MagicNumber:ChannelOption.kt$ChannelOption.LONG_FAST$.250f</ID>
-    <ID>MagicNumber:ChannelOption.kt$ChannelOption.LONG_MODERATE$.125f</ID>
-    <ID>MagicNumber:ChannelOption.kt$ChannelOption.LONG_SLOW$.125f</ID>
-    <ID>MagicNumber:ChannelOption.kt$ChannelOption.MEDIUM_FAST$.250f</ID>
-    <ID>MagicNumber:ChannelOption.kt$ChannelOption.MEDIUM_SLOW$.250f</ID>
-    <ID>MagicNumber:ChannelOption.kt$ChannelOption.SHORT_FAST$.250f</ID>
-    <ID>MagicNumber:ChannelOption.kt$ChannelOption.SHORT_SLOW$.250f</ID>
-    <ID>MagicNumber:ChannelOption.kt$ChannelOption.VERY_LONG_SLOW$.0625f</ID>
     <ID>MagicNumber:ChannelSet.kt$40</ID>
     <ID>MagicNumber:ChannelSet.kt$960</ID>
     <ID>SwallowedException:ChannelSet.kt$ex: Throwable</ID>

--- a/core/model/src/main/kotlin/org/meshtastic/core/model/DeviceVersion.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/DeviceVersion.kt
@@ -17,7 +17,7 @@
 
 package org.meshtastic.core.model
 
-import timber.log.Timber
+import co.touchlab.kermit.Logger
 
 /** Provide structured access to parse and compare device version strings */
 data class DeviceVersion(val asString: String) : Comparable<DeviceVersion> {
@@ -28,7 +28,7 @@ data class DeviceVersion(val asString: String) : Comparable<DeviceVersion> {
             try {
                 verStringToInt(asString)
             } catch (e: Exception) {
-                Timber.w("Exception while parsing version '$asString', assuming version 0")
+                Logger.w { "Exception while parsing version '$asString', assuming version 0" }
                 0
             }
 

--- a/core/model/src/main/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
@@ -20,14 +20,13 @@ package org.meshtastic.core.model.util
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Base64
+import co.touchlab.kermit.Logger
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.MultiFormatWriter
 import com.journeyapps.barcodescanner.BarcodeEncoder
 import org.meshtastic.core.model.Channel
 import org.meshtastic.proto.AppOnlyProtos.ChannelSet
-import timber.log.Timber
 import java.net.MalformedURLException
-import kotlin.jvm.Throws
 
 private const val MESHTASTIC_HOST = "meshtastic.org"
 private const val CHANNEL_PATH = "/e/"
@@ -86,6 +85,6 @@ fun ChannelSet.qrCode(shouldAdd: Boolean): Bitmap? = try {
     val barcodeEncoder = BarcodeEncoder()
     barcodeEncoder.createBitmap(bitMatrix)
 } catch (ex: Throwable) {
-    Timber.e("URL was too complex to render as barcode")
+    Logger.e { "URL was too complex to render as barcode" }
     null
 }

--- a/core/service/build.gradle.kts
+++ b/core/service/build.gradle.kts
@@ -46,5 +46,5 @@ dependencies {
     implementation(projects.core.proto)
     implementation(libs.javax.inject)
     implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 }

--- a/core/service/src/main/kotlin/org/meshtastic/core/service/ServiceRepository.kt
+++ b/core/service/src/main/kotlin/org/meshtastic/core/service/ServiceRepository.kt
@@ -17,6 +17,7 @@
 
 package org.meshtastic.core.service
 
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,7 +26,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import org.meshtastic.proto.MeshProtos
 import org.meshtastic.proto.MeshProtos.MeshPacket
-import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -66,7 +66,7 @@ class ServiceRepository @Inject constructor() {
         get() = _clientNotification
 
     fun setClientNotification(notification: MeshProtos.ClientNotification?) {
-        Timber.e(notification?.message.orEmpty())
+        Logger.e { notification?.message.orEmpty() }
 
         _clientNotification.value = notification
     }
@@ -80,7 +80,7 @@ class ServiceRepository @Inject constructor() {
         get() = _errorMessage
 
     fun setErrorMessage(text: String) {
-        Timber.e(text)
+        Logger.e { text }
         _errorMessage.value = text
     }
 

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.zxing.core)
     implementation(libs.zxing.android.embedded)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 

--- a/core/ui/detekt-baseline.xml
+++ b/core/ui/detekt-baseline.xml
@@ -2,18 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ComposableParamOrder:AlertDialogs.kt$SimpleAlertDialog</ID>
-    <ID>ComposableParamOrder:EditBase64Preference.kt$EditBase64Preference</ID>
-    <ID>ComposableParamOrder:EditTextPreference.kt$EditTextPreference</ID>
-    <ID>ComposableParamOrder:MainAppBar.kt$MainAppBar</ID>
-    <ID>ComposableParamOrder:MaterialBatteryInfo.kt$MaterialBatteryInfo</ID>
-    <ID>ComposableParamOrder:NodeChip.kt$NodeChip</ID>
-    <ID>ComposableParamOrder:NodeKeyStatusIcon.kt$NodeKeyStatusIcon</ID>
-    <ID>ComposableParamOrder:SignalInfo.kt$SignalInfo</ID>
-    <ID>ComposableParamOrder:SwitchPreference.kt$SwitchPreference</ID>
-    <ID>ContentSlotReused:AdaptiveTwoPane.kt$second</ID>
-    <ID>LambdaParameterEventTrailing:ContactSharing.kt$onSharedContactRequested</ID>
-    <ID>LambdaParameterEventTrailing:MainAppBar.kt$onClickChip</ID>
     <ID>MagicNumber:EditIPv4Preference.kt$0xff</ID>
     <ID>MagicNumber:EditIPv4Preference.kt$16</ID>
     <ID>MagicNumber:EditIPv4Preference.kt$24</ID>
@@ -22,47 +10,5 @@
     <ID>MagicNumber:EditListPreference.kt$12345</ID>
     <ID>MagicNumber:EditListPreference.kt$67890</ID>
     <ID>MagicNumber:LazyColumnDragAndDropDemo.kt$50</ID>
-    <ID>ModifierMissing:AdaptiveTwoPane.kt$AdaptiveTwoPane</ID>
-    <ID>ModifierMissing:ChannelItem.kt$ChannelItem</ID>
-    <ID>ModifierMissing:ChannelSelection.kt$ChannelSelection</ID>
-    <ID>ModifierMissing:ContactSharing.kt$SharedContactDialog</ID>
-    <ID>ModifierMissing:EmojiPicker.kt$EmojiPicker</ID>
-    <ID>ModifierMissing:EmojiPicker.kt$EmojiPickerDialog</ID>
-    <ID>ModifierMissing:IndoorAirQuality.kt$IndoorAirQuality</ID>
-    <ID>ModifierMissing:LoraSignalIndicator.kt$LoraSignalIndicator</ID>
-    <ID>ModifierMissing:LoraSignalIndicator.kt$Rssi</ID>
-    <ID>ModifierMissing:LoraSignalIndicator.kt$Snr</ID>
-    <ID>ModifierMissing:LoraSignalIndicator.kt$SnrAndRssi</ID>
-    <ID>ModifierMissing:PreferenceDivider.kt$PreferenceDivider</ID>
-    <ID>ModifierMissing:SecurityIcon.kt$SecurityIcon</ID>
-    <ID>ModifierMissing:SharedContactDialog.kt$SharedContactDialog</ID>
-    <ID>ModifierMissing:SimpleAlertDialog.kt$SimpleAlertDialog</ID>
-    <ID>ModifierMissing:SlidingSelector.kt$OptionLabel</ID>
-    <ID>ModifierNotUsedAtRoot:TextDividerPreference.kt$modifier = modifier.fillMaxWidth().padding(all = 16.dp)</ID>
-    <ID>ModifierNotUsedAtRoot:TextDividerPreference.kt$modifier = modifier.fillMaxWidth().wrapContentWidth(Alignment.End)</ID>
-    <ID>ModifierReused:PreferenceCategory.kt$Card(modifier = modifier.padding(bottom = 8.dp)) { Column( modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 16.dp), horizontalAlignment = Alignment.CenterHorizontally, ) { ProvideTextStyle(MaterialTheme.typography.bodyLarge) { content() } } }</ID>
-    <ID>ModifierReused:PreferenceCategory.kt$Text( text, modifier = modifier.padding(start = 16.dp, top = 24.dp, bottom = 8.dp, end = 16.dp), style = MaterialTheme.typography.titleLarge, )</ID>
-    <ID>ModifierReused:TextDividerPreference.kt$Card(modifier = modifier.fillMaxWidth()) { Row(modifier = modifier.fillMaxWidth().padding(all = 16.dp), verticalAlignment = Alignment.CenterVertically) { Text( text = title, style = MaterialTheme.typography.bodyLarge, color = if (!enabled) { MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f) } else { Color.Unspecified }, ) if (trailingIcon != null) { Icon(trailingIcon, "trailingIcon", modifier = modifier.fillMaxWidth().wrapContentWidth(Alignment.End)) } } }</ID>
-    <ID>ModifierReused:TextDividerPreference.kt$Icon(trailingIcon, "trailingIcon", modifier = modifier.fillMaxWidth().wrapContentWidth(Alignment.End))</ID>
-    <ID>ModifierReused:TextDividerPreference.kt$Row(modifier = modifier.fillMaxWidth().padding(all = 16.dp), verticalAlignment = Alignment.CenterVertically) { Text( text = title, style = MaterialTheme.typography.bodyLarge, color = if (!enabled) { MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f) } else { Color.Unspecified }, ) if (trailingIcon != null) { Icon(trailingIcon, "trailingIcon", modifier = modifier.fillMaxWidth().wrapContentWidth(Alignment.End)) } }</ID>
-    <ID>MultipleEmitters:PreferenceCategory.kt$PreferenceCategory</ID>
-    <ID>ParameterNaming:BitwisePreference.kt$onItemSelected</ID>
-    <ID>ParameterNaming:ChannelSelection.kt$onSelected</ID>
-    <ID>ParameterNaming:ContactSharing.kt$onSharedContactRequested</ID>
-    <ID>ParameterNaming:DropDownPreference.kt$onItemSelected</ID>
-    <ID>ParameterNaming:EditIPv4Preference.kt$onValueChanged</ID>
-    <ID>ParameterNaming:EditListPreference.kt$onValuesChanged</ID>
-    <ID>ParameterNaming:EditPasswordPreference.kt$onValueChanged</ID>
-    <ID>ParameterNaming:EditTextPreference.kt$onValueChanged</ID>
-    <ID>ParameterNaming:PositionPrecisionPreference.kt$onValueChanged</ID>
-    <ID>ParameterNaming:PreferenceFooter.kt$onNegativeClicked</ID>
-    <ID>ParameterNaming:PreferenceFooter.kt$onPositiveClicked</ID>
-    <ID>ParameterNaming:SlidingSelector.kt$onOptionSelected</ID>
-    <ID>PreviewPublic:IndoorAirQuality.kt$IAQScalePreview</ID>
-    <ID>PreviewPublic:LazyColumnDragAndDropDemo.kt$LazyColumnDragAndDropDemo</ID>
-    <ID>PreviewPublic:MaterialBatteryInfo.kt$MaterialBatteryInfoPreview</ID>
-    <ID>PreviewPublic:SignalInfo.kt$SignalInfoPreview</ID>
-    <ID>PreviewPublic:SignalInfo.kt$SignalInfoSelfPreview</ID>
-    <ID>PreviewPublic:SignalInfo.kt$SignalInfoSimplePreview</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/ContactSharing.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/ContactSharing.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
+import co.touchlab.kermit.Logger
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
@@ -65,7 +66,6 @@ import org.meshtastic.core.ui.R
 import org.meshtastic.core.ui.share.SharedContactDialog
 import org.meshtastic.proto.AdminProtos
 import org.meshtastic.proto.MeshProtos
-import timber.log.Timber
 import java.net.MalformedURLException
 
 /**
@@ -90,7 +90,7 @@ fun AddContactFAB(
                     try {
                         uri.toSharedContact()
                     } catch (ex: MalformedURLException) {
-                        Timber.e("URL was malformed: ${ex.message}")
+                        Logger.e { "URL was malformed: ${ex.message}" }
                         null
                     }
                 if (sharedContact != null) {
@@ -102,7 +102,7 @@ fun AddContactFAB(
     sharedContact?.let { SharedContactDialog(sharedContact = it, onDismiss = { onSharedContactRequested(null) }) }
 
     fun zxingScan() {
-        Timber.d("Starting zxing QR code scanner")
+        Logger.d { "Starting zxing QR code scanner" }
         val zxingScan = ScanOptions()
         zxingScan.setCameraId(CAMERA_ID)
         zxingScan.setPrompt("")
@@ -115,9 +115,9 @@ fun AddContactFAB(
 
     LaunchedEffect(cameraPermissionState.status) {
         if (cameraPermissionState.status.isGranted) {
-            Timber.d("Camera permission granted")
+            Logger.d { "Camera permission granted" }
         } else {
-            Timber.d("Camera permission denied")
+            Logger.d { "Camera permission denied" }
         }
     }
 
@@ -193,7 +193,7 @@ val Uri.qrCode: Bitmap?
             val barcodeEncoder = BarcodeEncoder()
             barcodeEncoder.createBitmap(bitMatrix)
         } catch (ex: WriterException) {
-            Timber.e("URL was too complex to render as barcode: ${ex.message}")
+            Logger.e { "URL was too complex to render as barcode: ${ex.message}" }
             null
         }
 

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeViewModel.kt
@@ -20,6 +20,7 @@ package org.meshtastic.core.ui.qr
 import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import org.meshtastic.core.data.repository.RadioConfigRepository
@@ -32,7 +33,6 @@ import org.meshtastic.proto.ConfigProtos.Config
 import org.meshtastic.proto.LocalOnlyProtos.LocalConfig
 import org.meshtastic.proto.channelSet
 import org.meshtastic.proto.config
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -61,7 +61,7 @@ constructor(
         try {
             serviceRepository.meshService?.setChannel(channel.toByteArray())
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Set channel error")
+            Logger.e(ex) { "Set channel error" }
         }
     }
 
@@ -70,7 +70,7 @@ constructor(
         try {
             serviceRepository.meshService?.setConfig(config.toByteArray())
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Set config error")
+            Logger.e(ex) { "Set config error" }
         }
     }
 }

--- a/feature/firmware/build.gradle.kts
+++ b/feature/firmware/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
     implementation(libs.androidx.hilt.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.kotlinx.collections.immutable)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 
     implementation(libs.nordic)
     implementation(libs.nordic.dfu)

--- a/feature/firmware/src/main/kotlin/org/meshtastic/feature/firmware/FirmwareFileHandler.kt
+++ b/feature/firmware/src/main/kotlin/org/meshtastic/feature/firmware/FirmwareFileHandler.kt
@@ -19,6 +19,7 @@ package org.meshtastic.feature.firmware
 
 import android.content.Context
 import android.net.Uri
+import co.touchlab.kermit.Logger
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -27,7 +28,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.meshtastic.core.model.DeviceHardware
-import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -57,7 +57,7 @@ constructor(
             }
             tempDir.mkdirs()
         }
-            .onFailure { e -> Timber.w(e, "Failed to cleanup temp directory") }
+            .onFailure { e -> Logger.w(e) { "Failed to cleanup temp directory" } }
     }
 
     suspend fun checkUrlExists(url: String): Boolean = withContext(Dispatchers.IO) {
@@ -65,7 +65,7 @@ constructor(
         try {
             client.newCall(request).execute().use { response -> response.isSuccessful }
         } catch (e: IOException) {
-            Timber.w(e, "Failed to check URL existence: $url")
+            Logger.w(e) { "Failed to check URL existence: $url" }
             false
         }
     }
@@ -77,12 +77,12 @@ constructor(
                 try {
                     client.newCall(request).execute()
                 } catch (e: IOException) {
-                    Timber.w(e, "Download failed for $url")
+                    Logger.w(e) { "Download failed for $url" }
                     return@withContext null
                 }
 
             if (!response.isSuccessful) {
-                Timber.w("Download failed: ${response.code} for $url")
+                Logger.w { "Download failed: ${response.code} for $url" }
                 return@withContext null
             }
 
@@ -167,7 +167,7 @@ constructor(
                     }
                 }
             } catch (e: IOException) {
-                Timber.w(e, "Failed to extract firmware from URI")
+                Logger.w(e) { "Failed to extract firmware from URI" }
                 return@withContext null
             }
             matchingEntries.minByOrNull { it.first.name.length }?.second

--- a/feature/firmware/src/main/kotlin/org/meshtastic/feature/firmware/UpdateHandler.kt
+++ b/feature/firmware/src/main/kotlin/org/meshtastic/feature/firmware/UpdateHandler.kt
@@ -19,6 +19,7 @@ package org.meshtastic.feature.firmware
 
 import android.content.Context
 import android.net.Uri
+import co.touchlab.kermit.Logger
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
@@ -26,7 +27,6 @@ import no.nordicsemi.android.dfu.DfuServiceInitiator
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.service.ServiceRepository
-import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
@@ -81,7 +81,7 @@ class FirmwareRetriever @Inject constructor(private val fileHandler: FirmwareFil
                     return it
                 }
             } catch (e: Exception) {
-                Timber.w(e, "Direct download for $filename failed, falling back to release zip")
+                Logger.w(e) { "Direct download for $filename failed, falling back to release zip" }
             }
         }
 
@@ -141,7 +141,7 @@ constructor(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        Timber.e(e)
+        Logger.e(e) { "OTA Update failed" }
         updateState(FirmwareUpdateState.Error(e.message ?: "OTA Update failed"))
         null
     }
@@ -214,7 +214,7 @@ constructor(
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
-        Timber.e(e)
+        Logger.e(e) { "USB Update failed" }
         updateState(FirmwareUpdateState.Error(e.message ?: "USB Update failed"))
         null
     }

--- a/feature/intro/detekt-baseline.xml
+++ b/feature/intro/detekt-baseline.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues>
-    <ID>ComposableParamOrder:PermissionScreenLayout.kt$PermissionScreenLayout</ID>
-    <ID>ParameterNaming:WelcomeScreen.kt$onGetStarted</ID>
-  </CurrentIssues>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/feature/map/build.gradle.kts
+++ b/feature/map/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.common)
     implementation(libs.material)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 
     fdroidImplementation(libs.osmbonuspack)
     fdroidImplementation(libs.osmdroid.android)

--- a/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/MapView.kt
+++ b/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/MapView.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.touchlab.kermit.Logger
 import com.google.accompanist.permissions.ExperimentalPermissionsApi // Added for Accompanist
 import com.google.accompanist.permissions.rememberMultiplePermissionsState // Added for Accompanist
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -156,7 +157,6 @@ import org.osmdroid.views.overlay.Polygon
 import org.osmdroid.views.overlay.Polyline
 import org.osmdroid.views.overlay.infowindow.InfoWindow
 import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay
-import timber.log.Timber
 import java.io.File
 import java.text.DateFormat
 import kotlin.math.abs
@@ -170,7 +170,7 @@ private fun MapView.updateMarkers(
     waypointMarkers: List<MarkerWithLabel>,
     nodeClusterer: RadiusMarkerClusterer,
 ) {
-    Timber.d("Showing on map: ${nodeMarkers.size} nodes ${waypointMarkers.size} waypoints")
+    Logger.d { "Showing on map: ${nodeMarkers.size} nodes ${waypointMarkers.size} waypoints" }
     overlays.removeAll { it is MarkerWithLabel }
     // overlays.addAll(nodeMarkers + waypointMarkers)
     overlays.addAll(waypointMarkers)
@@ -271,7 +271,7 @@ fun MapView(
 
     fun loadOnlineTileSourceBase(): ITileSource {
         val id = mapViewModel.mapStyleId
-        Timber.d("mapStyleId from prefs: $id")
+        Logger.d { "mapStyleId from prefs: $id" }
         return CustomTileSource.getTileSource(id).also {
             zoomLevelMax = it.maximumZoomLevel.toDouble()
             showDownloadButton = if (it is OnlineTileSourceBase) it.tileSourcePolicy.acceptsBulkDownload() else false
@@ -295,11 +295,11 @@ fun MapView(
 
     fun MapView.toggleMyLocation() {
         if (context.gpsDisabled()) {
-            Timber.d("Telling user we need location turned on for MyLocationNewOverlay")
+            Logger.d { "Telling user we need location turned on for MyLocationNewOverlay" }
             scope.launch { context.showToast(Res.string.location_disabled) }
             return
         }
-        Timber.d("user clicked MyLocationNewOverlay ${myLocationOverlay == null}")
+        Logger.d { "user clicked MyLocationNewOverlay ${myLocationOverlay == null}" }
         if (myLocationOverlay == null) {
             myLocationOverlay =
                 MyLocationNewOverlay(this).apply {
@@ -454,15 +454,15 @@ fun MapView(
         val builder = MaterialAlertDialogBuilder(context)
         builder.setTitle(com.meshtastic.core.strings.getString(Res.string.waypoint_delete))
         builder.setNeutralButton(com.meshtastic.core.strings.getString(Res.string.cancel)) { _, _ ->
-            Timber.d("User canceled marker delete dialog")
+            Logger.d { "User canceled marker delete dialog" }
         }
         builder.setNegativeButton(com.meshtastic.core.strings.getString(Res.string.delete_for_me)) { _, _ ->
-            Timber.d("User deleted waypoint ${waypoint.id} for me")
+            Logger.d { "User deleted waypoint ${waypoint.id} for me" }
             mapViewModel.deleteWaypoint(waypoint.id)
         }
         if (waypoint.lockedTo in setOf(0, mapViewModel.myNodeNum ?: 0) && isConnected) {
             builder.setPositiveButton(com.meshtastic.core.strings.getString(Res.string.delete_for_everyone)) { _, _ ->
-                Timber.d("User deleted waypoint ${waypoint.id} for everyone")
+                Logger.d { "User deleted waypoint ${waypoint.id} for everyone" }
                 mapViewModel.sendWaypoint(waypoint.copy { expire = 1 })
                 mapViewModel.deleteWaypoint(waypoint.id)
             }
@@ -485,7 +485,7 @@ fun MapView(
 
     fun showMarkerLongPressDialog(id: Int) {
         performHapticFeedback()
-        Timber.d("marker long pressed id=$id")
+        Logger.d { "marker long pressed id=$id" }
         val waypoint = waypoints[id]?.data?.waypoint ?: return
         // edit only when unlocked or lockedTo myNodeNum
         if (waypoint.lockedTo in setOf(0, mapViewModel.myNodeNum ?: 0) && isConnected) {
@@ -691,9 +691,9 @@ fun MapView(
                 ),
             )
         } catch (ex: TileSourcePolicyException) {
-            Timber.d("Tile source does not allow archiving: ${ex.message}")
+            Logger.d { "Tile source does not allow archiving: ${ex.message}" }
         } catch (ex: Exception) {
-            Timber.d("Tile source exception: ${ex.message}")
+            Logger.d { "Tile source exception: ${ex.message}" }
         }
     }
 
@@ -897,7 +897,7 @@ fun MapView(
         EditWaypointDialog(
             waypoint = showEditWaypointDialog ?: return, // Safe call
             onSendClicked = { waypoint ->
-                Timber.d("User clicked send waypoint ${waypoint.id}")
+                Logger.d { "User clicked send waypoint ${waypoint.id}" }
                 showEditWaypointDialog = null
                 mapViewModel.sendWaypoint(
                     waypoint.copy {
@@ -910,12 +910,12 @@ fun MapView(
                 )
             },
             onDeleteClicked = { waypoint ->
-                Timber.d("User clicked delete waypoint ${waypoint.id}")
+                Logger.d { "User clicked delete waypoint ${waypoint.id}" }
                 showEditWaypointDialog = null
                 showDeleteMarkerDialog(waypoint)
             },
             onDismissRequest = {
-                Timber.d("User clicked cancel marker edit dialog")
+                Logger.d { "User clicked cancel marker edit dialog" }
                 showEditWaypointDialog = null
             },
         )

--- a/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/MapViewWithLifecycle.kt
+++ b/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/MapViewWithLifecycle.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import co.touchlab.kermit.Logger
 import org.osmdroid.config.Configuration
 import org.osmdroid.tileprovider.tilesource.ITileSource
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory
@@ -40,7 +41,6 @@ import org.osmdroid.util.BoundingBox
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.CustomZoomButtonsController
 import org.osmdroid.views.MapView
-import timber.log.Timber
 
 @SuppressLint("WakelockTimeout")
 private fun PowerManager.WakeLock.safeAcquire() {
@@ -48,9 +48,9 @@ private fun PowerManager.WakeLock.safeAcquire() {
         try {
             acquire()
         } catch (e: SecurityException) {
-            Timber.e("WakeLock permission exception: ${e.message}")
+            Logger.e { "WakeLock permission exception: ${e.message}" }
         } catch (e: IllegalStateException) {
-            Timber.e("WakeLock acquire() exception: ${e.message}")
+            Logger.e { "WakeLock acquire() exception: ${e.message}" }
         }
     }
 }
@@ -60,7 +60,7 @@ private fun PowerManager.WakeLock.safeRelease() {
         try {
             release()
         } catch (e: IllegalStateException) {
-            Timber.e("WakeLock release() exception: ${e.message}")
+            Logger.e { "WakeLock release() exception: ${e.message}" }
         }
     }
 }

--- a/feature/map/src/google/kotlin/org/meshtastic/feature/map/LocationHandler.kt
+++ b/feature/map/src/google/kotlin/org/meshtastic/feature/map/LocationHandler.kt
@@ -32,12 +32,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
+import co.touchlab.kermit.Logger
 import com.google.android.gms.common.api.ResolvableApiException
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.LocationSettingsRequest
 import com.google.android.gms.location.Priority
-import timber.log.Timber
 
 private const val INTERVAL_MILLIS = 10000L
 
@@ -66,11 +66,11 @@ fun LocationPermissionsHandler(onPermissionResult: (Boolean) -> Unit) {
     val locationSettingsLauncher =
         rememberLauncherForActivityResult(contract = ActivityResultContracts.StartIntentSenderForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
-                Timber.d("Location settings changed by user.")
+                Logger.d { "Location settings changed by user." }
                 // User has enabled location services or improved accuracy.
                 onPermissionResult(true) // Settings are now adequate, and permission was already granted.
             } else {
-                Timber.d("Location settings change cancelled by user.")
+                Logger.d { "Location settings change cancelled by user." }
                 // User chose not to change settings. The permission itself is still granted,
                 // but the experience might be degraded. For the purpose of enabling map features,
                 // we consider this as success if the core permission is there.
@@ -111,7 +111,7 @@ fun LocationPermissionsHandler(onPermissionResult: (Boolean) -> Unit) {
             val task = client.checkLocationSettings(builder.build())
 
             task.addOnSuccessListener {
-                Timber.d("Location settings are satisfied.")
+                Logger.d { "Location settings are satisfied." }
                 onPermissionResult(true) // Permission granted and settings are good
             }
 
@@ -122,11 +122,11 @@ fun LocationPermissionsHandler(onPermissionResult: (Boolean) -> Unit) {
                         locationSettingsLauncher.launch(intentSenderRequest)
                         // Result of this launch will be handled by locationSettingsLauncher's callback
                     } catch (sendEx: ActivityNotFoundException) {
-                        Timber.d("Error launching location settings resolution ${sendEx.message}.")
+                        Logger.d { "Error launching location settings resolution ${sendEx.message}." }
                         onPermissionResult(true) // Permission is granted, but settings dialog failed. Proceed.
                     }
                 } else {
-                    Timber.d("Location settings are not satisfiable.${exception.message}")
+                    Logger.d { "Location settings are not satisfiable.${exception.message}" }
                     onPermissionResult(true) // Permission is granted, but settings not ideal. Proceed.
                 }
             }

--- a/feature/map/src/google/kotlin/org/meshtastic/feature/map/MapView.kt
+++ b/feature/map/src/google/kotlin/org/meshtastic/feature/map/MapView.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.graphics.createBitmap
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.touchlab.kermit.Logger
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
@@ -124,7 +125,6 @@ import org.meshtastic.proto.MeshProtos.Position
 import org.meshtastic.proto.MeshProtos.Waypoint
 import org.meshtastic.proto.copy
 import org.meshtastic.proto.waypoint
-import timber.log.Timber
 import java.text.DateFormat
 import kotlin.math.abs
 import kotlin.math.max
@@ -219,7 +219,7 @@ fun MapView(
                             try {
                                 cameraPositionState.animate(cameraUpdate)
                             } catch (e: IllegalStateException) {
-                                Timber.d("Error animating camera to location: ${e.message}")
+                                Logger.d { "Error animating camera to location: ${e.message}" }
                             }
                         }
                     }
@@ -239,14 +239,14 @@ fun MapView(
             try {
                 @Suppress("MissingPermission")
                 fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, null)
-                Timber.d("Started location tracking")
+                Logger.d { "Started location tracking" }
             } catch (e: SecurityException) {
-                Timber.d("Location permission not available: ${e.message}")
+                Logger.d { "Location permission not available: ${e.message}" }
                 isLocationTrackingEnabled = false
             }
         } else {
             fusedLocationClient.removeLocationUpdates(locationCallback)
-            Timber.d("Stopped location tracking")
+            Logger.d { "Stopped location tracking" }
         }
     }
 
@@ -412,7 +412,7 @@ fun MapView(
                 cameraPositionState.animate(cameraUpdate)
                 hasCenteredTraceroute = true
             } catch (e: IllegalStateException) {
-                Timber.d("Error centering traceroute overlay: ${e.message}")
+                Logger.d { "Error centering traceroute overlay: ${e.message}" }
             }
         }
     }
@@ -548,7 +548,7 @@ fun MapView(
                                         CameraUpdateFactory.newLatLngBounds(bounds.build(), 100),
                                     )
                                 }
-                                Timber.d("Cluster clicked! $cluster")
+                                Logger.d { "Cluster clicked! $cluster" }
                             }
                             true
                         },
@@ -679,9 +679,9 @@ fun MapView(
                                 val currentPosition = cameraPositionState.position
                                 val newCameraPosition = CameraPosition.Builder(currentPosition).bearing(0f).build()
                                 cameraPositionState.animate(CameraUpdateFactory.newCameraPosition(newCameraPosition))
-                                Timber.d("Oriented map to north")
+                                Logger.d { "Oriented map to north" }
                             } catch (e: IllegalStateException) {
-                                Timber.d("Error orienting map to north: ${e.message}")
+                                Logger.d { "Error orienting map to north: ${e.message}" }
                             }
                         }
                     }
@@ -715,7 +715,7 @@ fun MapView(
 internal fun convertIntToEmoji(unicodeCodePoint: Int): String = try {
     String(Character.toChars(unicodeCodePoint))
 } catch (e: IllegalArgumentException) {
-    Timber.w(e, "Invalid unicode code point: $unicodeCodePoint")
+    Logger.w(e) { "Invalid unicode code point: $unicodeCodePoint" }
     "\uD83D\uDCCD"
 }
 

--- a/feature/map/src/main/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
+++ b/feature/map/src/main/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
@@ -20,6 +20,7 @@ package org.meshtastic.feature.map
 import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -44,7 +45,6 @@ import org.meshtastic.core.strings.two_days
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.feature.map.model.TracerouteOverlay
 import org.meshtastic.proto.MeshProtos
-import timber.log.Timber
 import java.util.concurrent.TimeUnit
 
 @Suppress("MagicNumber")
@@ -150,7 +150,7 @@ abstract class BaseMapViewModel(
         return try {
             serviceRepository.meshService?.packetId
         } catch (ex: RemoteException) {
-            Timber.e("RemoteException: ${ex.message}")
+            Logger.e { "RemoteException: ${ex.message}" }
             return null
         }
     }
@@ -170,7 +170,7 @@ abstract class BaseMapViewModel(
         try {
             serviceRepository.meshService?.send(p)
         } catch (ex: RemoteException) {
-            Timber.e("Send DataPacket error: ${ex.message}")
+            Logger.e { "Send DataPacket error: ${ex.message}" }
         }
     }
 

--- a/feature/messaging/build.gradle.kts
+++ b/feature/messaging/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.hilt.lifecycle.viewmodel.compose)
     implementation(libs.androidx.paging.compose)
-    implementation(libs.timber)
+    implementation(libs.kermit)
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 

--- a/feature/messaging/detekt-baseline.xml
+++ b/feature/messaging/detekt-baseline.xml
@@ -1,26 +1,5 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues>
-    <ID>ComposableParamOrder:Message.kt$MessageScreen</ID>
-    <ID>ComposableParamOrder:Message.kt$QuickChatRow</ID>
-    <ID>ComposableParamOrder:MessageActions.kt$MessageActions</ID>
-    <ID>ComposableParamOrder:MessageActions.kt$MessageStatusButton</ID>
-    <ID>ComposableParamOrder:MessageItem.kt$MessageItem</ID>
-    <ID>ComposableParamOrder:MessageList.kt$DeliveryInfo</ID>
-    <ID>ComposableParamOrder:MessageList.kt$MessageList</ID>
-    <ID>ComposableParamOrder:QuickChat.kt$OutlinedTextFieldWithCounter</ID>
-    <ID>LambdaParameterEventTrailing:Message.kt$onClick</ID>
-    <ID>LambdaParameterEventTrailing:Message.kt$onSendMessage</ID>
-    <ID>LambdaParameterEventTrailing:MessageList.kt$onReply</ID>
-    <ID>LambdaParameterEventTrailing:QuickChat.kt$onNavigateUp</ID>
-    <ID>LambdaParameterInRestartableEffect:MessageList.kt$onUnreadChanged</ID>
-    <ID>LongParameterList:MessageViewModel.kt$MessageViewModel$( private val nodeRepository: NodeRepository, radioConfigRepository: RadioConfigRepository, quickChatActionRepository: QuickChatActionRepository, private val serviceRepository: ServiceRepository, private val packetRepository: PacketRepository, private val uiPrefs: UiPrefs, private val meshServiceNotifications: MeshServiceNotifications, )</ID>
-    <ID>ModifierMissing:Message.kt$MessageScreen</ID>
-    <ID>ModifierNotUsedAtRoot:QuickChat.kt$modifier = modifier.fillMaxSize().padding(innerPadding)</ID>
-    <ID>MutableStateParam:MessageList.kt$selectedIds</ID>
-    <ID>ParameterNaming:MessageList.kt$onUnreadChanged</ID>
-    <ID>TooManyFunctions:MessageViewModel.kt$MessageViewModel : ViewModel</ID>
-    <ID>Wrapping:Message.kt${ event -&gt; when (event) { is MessageScreenEvent.SendMessage -&gt; { viewModel.sendMessage(event.text, contactKey, event.replyingToPacketId) if (event.replyingToPacketId != null) replyingToPacketId = null messageInputState.clearText() } is MessageScreenEvent.SendReaction -&gt; viewModel.sendReaction(event.emoji, event.messageId, contactKey) is MessageScreenEvent.DeleteMessages -&gt; { viewModel.deleteMessages(event.ids) selectedMessageIds.value = emptySet() showDeleteDialog = false } is MessageScreenEvent.ClearUnreadCount -&gt; viewModel.clearUnreadCount(contactKey, event.lastReadMessageId) is MessageScreenEvent.NodeDetails -&gt; navigateToNodeDetails(event.node.num) is MessageScreenEvent.SetTitle -&gt; viewModel.setTitle(event.title) is MessageScreenEvent.NavigateToMessages -&gt; navigateToMessages(event.contactKey) is MessageScreenEvent.NavigateToNodeDetails -&gt; navigateToNodeDetails(event.nodeNum) MessageScreenEvent.NavigateBack -&gt; onNavigateBack() is MessageScreenEvent.CopyToClipboard -&gt; { clipboardManager.nativeClipboard.setPrimaryClip(ClipData.newPlainText(event.text, event.text)) selectedMessageIds.value = emptySet() } } }</ID>
-  </CurrentIssues>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import co.touchlab.kermit.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -50,7 +51,6 @@ import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.proto.ConfigProtos.Config.DeviceConfig.Role
 import org.meshtastic.proto.channelSet
 import org.meshtastic.proto.sharedContact
-import timber.log.Timber
 import javax.inject.Inject
 
 private const val VERIFIED_CONTACT_FIRMWARE_CUTOFF = "2.7.12"
@@ -198,7 +198,7 @@ constructor(
         try {
             serviceRepository.onServiceAction(ServiceAction.Favorite(node))
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Favorite node error")
+            Logger.e(ex) { "Favorite node error" }
         }
     }
 
@@ -211,7 +211,7 @@ constructor(
             }
             serviceRepository.onServiceAction(ServiceAction.SendContact(contact = contact))
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Send shared contact error")
+            Logger.e(ex) { "Send shared contact error" }
         }
     }
 
@@ -219,7 +219,7 @@ constructor(
         try {
             serviceRepository.meshService?.send(p)
         } catch (ex: RemoteException) {
-            Timber.e("Send DataPacket error: ${ex.message}")
+            Logger.e { "Send DataPacket error: ${ex.message}" }
         }
     }
 }

--- a/feature/node/build.gradle.kts
+++ b/feature/node/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.hilt.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.common)
-    implementation(libs.timber)
+    implementation(libs.kermit)
     implementation(libs.coil)
     implementation(libs.markdown.renderer.android)
     implementation(libs.markdown.renderer.m3)

--- a/feature/node/detekt-baseline.xml
+++ b/feature/node/detekt-baseline.xml
@@ -3,86 +3,9 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>CommentWrapping:SignalMetrics.kt$Metric.SNR$/* Selected 12 as the max to get 4 equal vertical sections. */</ID>
-    <ID>ComposableParamOrder:DeviceMetrics.kt$DeviceMetricsChart</ID>
-    <ID>ComposableParamOrder:ElevationInfo.kt$ElevationInfo</ID>
-    <ID>ComposableParamOrder:EnvironmentCharts.kt$ChartContent</ID>
-    <ID>ComposableParamOrder:EnvironmentCharts.kt$EnvironmentMetricsChart</ID>
-    <ID>ComposableParamOrder:EnvironmentCharts.kt$MetricPlottingCanvas</ID>
-    <ID>ComposableParamOrder:HostMetricsLog.kt$HostMetricsItem</ID>
-    <ID>ComposableParamOrder:HostMetricsLog.kt$LogLine</ID>
-    <ID>ComposableParamOrder:LastHeardInfo.kt$LastHeardInfo</ID>
-    <ID>ComposableParamOrder:NodeFilterTextField.kt$NodeFilterTextField</ID>
-    <ID>ComposableParamOrder:NodeItem.kt$NodeItem</ID>
-    <ID>ComposableParamOrder:PaxMetrics.kt$PaxMetricsChart</ID>
-    <ID>ComposableParamOrder:PowerMetrics.kt$PowerMetricsChart</ID>
-    <ID>ComposableParamOrder:SatelliteCountInfo.kt$SatelliteCountInfo</ID>
-    <ID>ComposableParamOrder:SignalMetrics.kt$SignalMetricsChart</ID>
-    <ID>ComposableParamOrder:TracerouteButton.kt$TracerouteButton</ID>
-    <ID>LambdaParameterEventTrailing:TracerouteLog.kt$onNavigateUp</ID>
     <ID>LongMethod:EnvironmentMetrics.kt$@Composable fun EnvironmentMetricsScreen(viewModel: MetricsViewModel = hiltViewModel(), onNavigateUp: () -&gt; Unit)</ID>
-    <ID>LongMethod:NodeDetailsSection.kt$@Composable private fun MainNodeDetails(node: Node)</ID>
     <ID>MagicNumber:MetricsViewModel.kt$MetricsViewModel$1000L</ID>
     <ID>MagicNumber:MetricsViewModel.kt$MetricsViewModel$1e-5</ID>
     <ID>MagicNumber:MetricsViewModel.kt$MetricsViewModel$1e-7</ID>
-    <ID>ModifierMissing:CommonCharts.kt$ChartHeader</ID>
-    <ID>ModifierMissing:CommonCharts.kt$Legend</ID>
-    <ID>ModifierMissing:CommonCharts.kt$TimeLabels</ID>
-    <ID>ModifierMissing:DeviceMetrics.kt$DeviceMetricsScreen</ID>
-    <ID>ModifierMissing:EnvironmentMetrics.kt$EnvironmentMetricsScreen</ID>
-    <ID>ModifierMissing:HostMetricsLog.kt$HostMetricsLogScreen</ID>
-    <ID>ModifierMissing:NodeListScreen.kt$NodeListScreen</ID>
-    <ID>ModifierMissing:NodeStatusIcons.kt$NodeStatusIcons</ID>
-    <ID>ModifierMissing:PaxMetrics.kt$PaxMetricsItem</ID>
-    <ID>ModifierMissing:PaxMetrics.kt$PaxMetricsScreen</ID>
-    <ID>ModifierMissing:PositionLog.kt$PositionItem</ID>
-    <ID>ModifierMissing:PositionLog.kt$PositionLogScreen</ID>
-    <ID>ModifierMissing:PowerMetrics.kt$PowerMetricsScreen</ID>
-    <ID>ModifierMissing:SignalMetrics.kt$SignalMetricsScreen</ID>
-    <ID>ModifierNotUsedAtRoot:DeviceMetrics.kt$modifier = modifier.weight(weight = Y_AXIS_WEIGHT)</ID>
-    <ID>ModifierNotUsedAtRoot:DeviceMetrics.kt$modifier = modifier.width(dp)</ID>
-    <ID>ModifierNotUsedAtRoot:DeviceMetrics.kt$modifier.width(dp)</ID>
-    <ID>ModifierNotUsedAtRoot:EnvironmentCharts.kt$modifier = modifier.width(dp)</ID>
-    <ID>ModifierNotUsedAtRoot:EnvironmentCharts.kt$modifier.width(dp)</ID>
-    <ID>ModifierNotUsedAtRoot:PaxMetrics.kt$modifier.width(dp)</ID>
-    <ID>ModifierNotUsedAtRoot:PowerMetrics.kt$modifier = modifier.weight(weight = Y_AXIS_WEIGHT)</ID>
-    <ID>ModifierNotUsedAtRoot:PowerMetrics.kt$modifier = modifier.width(dp)</ID>
-    <ID>ModifierNotUsedAtRoot:PowerMetrics.kt$modifier.width(dp)</ID>
-    <ID>ModifierNotUsedAtRoot:SignalMetrics.kt$modifier = modifier.weight(weight = Y_AXIS_WEIGHT)</ID>
-    <ID>ModifierNotUsedAtRoot:SignalMetrics.kt$modifier = modifier.width(dp)</ID>
-    <ID>ModifierNotUsedAtRoot:SignalMetrics.kt$modifier.width(dp)</ID>
-    <ID>ModifierNotUsedAtRoot:TracerouteLog.kt$modifier = modifier.fillMaxSize().padding(innerPadding)</ID>
-    <ID>ModifierReused:DeviceMetrics.kt$Canvas(modifier = modifier.width(dp)) { val height = size.height val width = size.width for (i in telemetries.indices) { val telemetry = telemetries[i] /* x-value time */ val xRatio = (telemetry.time - oldest.time).toFloat() / timeDiff val x = xRatio * width /* Channel Utilization */ plotPoint( drawContext = drawContext, color = Device.CH_UTIL.color, x = x, value = telemetry.deviceMetrics.channelUtilization, divisor = MAX_PERCENT_VALUE, ) /* Air Utilization Transmit */ plotPoint( drawContext = drawContext, color = Device.AIR_UTIL.color, x = x, value = telemetry.deviceMetrics.airUtilTx, divisor = MAX_PERCENT_VALUE, ) } /* Battery Line */ var index = 0 while (index &lt; telemetries.size) { val path = Path() index = createPath( telemetries = telemetries, index = index, path = path, oldestTime = oldest.time, timeRange = timeDiff, width = width, timeThreshold = selectedTime.timeThreshold(), ) { i -&gt; val telemetry = telemetries.getOrNull(i) ?: telemetries.last() val ratio = telemetry.deviceMetrics.batteryLevel / MAX_PERCENT_VALUE val y = height - (ratio * height) return@createPath y } drawPath( path = path, color = Device.BATTERY.color, style = Stroke(width = GraphUtil.RADIUS, cap = StrokeCap.Round), ) } }</ID>
-    <ID>ModifierReused:DeviceMetrics.kt$HorizontalLinesOverlay( modifier.width(dp), lineColors = listOf(graphColor, Color.Yellow, Color.Red, graphColor, graphColor), )</ID>
-    <ID>ModifierReused:DeviceMetrics.kt$TimeAxisOverlay(modifier.width(dp), oldest = oldest.time, newest = newest.time, selectedTime.lineInterval())</ID>
-    <ID>ModifierReused:EnvironmentCharts.kt$Box( contentAlignment = Alignment.TopStart, modifier = modifier.horizontalScroll(state = scrollState, reverseScrolling = true), ) { HorizontalLinesOverlay(modifier.width(dp), lineColors = List(size = 5) { graphColor }) TimeAxisOverlay(modifier = modifier.width(dp), oldest = oldest, newest = newest, selectedTime.lineInterval()) MetricPlottingCanvas( modifier = modifier.width(dp), telemetries = telemetries, graphData = graphData, selectedTime = selectedTime, oldest = oldest, timeDiff = timeDiff, rightMin = rightMin, rightMax = rightMax, ) }</ID>
-    <ID>ModifierReused:EnvironmentCharts.kt$HorizontalLinesOverlay(modifier.width(dp), lineColors = List(size = 5) { graphColor })</ID>
-    <ID>ModifierReused:EnvironmentCharts.kt$MetricPlottingCanvas( modifier = modifier.width(dp), telemetries = telemetries, graphData = graphData, selectedTime = selectedTime, oldest = oldest, timeDiff = timeDiff, rightMin = rightMin, rightMax = rightMax, )</ID>
-    <ID>ModifierReused:EnvironmentCharts.kt$TimeAxisOverlay(modifier = modifier.width(dp), oldest = oldest, newest = newest, selectedTime.lineInterval())</ID>
-    <ID>ModifierReused:PaxMetrics.kt$HorizontalLinesOverlay(modifier.width(dp), lineColors = List(size = 5) { Color.LightGray })</ID>
-    <ID>ModifierReused:PaxMetrics.kt$Row(modifier = modifier.fillMaxWidth().fillMaxHeight(fraction = 0.33f)) { YAxisLabels( modifier = Modifier.weight(Y_AXIS_WEIGHT).fillMaxHeight().padding(start = 8.dp), labelColor = MaterialTheme.colorScheme.onSurface, minValue = minValue, maxValue = maxValue, ) Box( contentAlignment = Alignment.TopStart, modifier = Modifier.horizontalScroll(state = scrollState, reverseScrolling = true).weight(CHART_WEIGHT), ) { HorizontalLinesOverlay(modifier.width(dp), lineColors = List(size = 5) { Color.LightGray }) TimeAxisOverlay(modifier.width(dp), oldest = minTime, newest = maxTime, timeFrame.lineInterval()) Canvas(modifier = Modifier.width(dp).fillMaxHeight()) { val width = size.width val height = size.height fun xForTime(t: Int): Float = if (maxTime == minTime) width / 2 else (t - minTime).toFloat() / (maxTime - minTime) * width fun yForValue(v: Int): Float = height - (v - minValue) / (maxValue - minValue) * height fun drawLine(series: List&lt;Pair&lt;Int, Int&gt;&gt;, color: Color) { for (i in 1 until series.size) { drawLine( color = color, start = Offset(xForTime(series[i - 1].first), yForValue(series[i - 1].second)), end = Offset(xForTime(series[i].first), yForValue(series[i].second)), strokeWidth = 2.dp.toPx(), ) } } drawLine(bleSeries, PaxSeries.BLE.color) drawLine(wifiSeries, PaxSeries.WIFI.color) drawLine(totalSeries, PaxSeries.PAX.color) } } YAxisLabels( modifier = Modifier.weight(Y_AXIS_WEIGHT).fillMaxHeight().padding(end = 8.dp), labelColor = MaterialTheme.colorScheme.onSurface, minValue = minValue, maxValue = maxValue, ) }</ID>
-    <ID>ModifierReused:PaxMetrics.kt$TimeAxisOverlay(modifier.width(dp), oldest = minTime, newest = maxTime, timeFrame.lineInterval())</ID>
-    <ID>ModifierReused:PowerMetrics.kt$Canvas(modifier = modifier.width(dp)) { val width = size.width val height = size.height /* Voltage */ var index = 0 while (index &lt; telemetries.size) { val path = Path() index = createPath( telemetries = telemetries, index = index, path = path, oldestTime = oldest.time, timeRange = timeDiff, width = width, timeThreshold = selectedTime.timeThreshold(), ) { i -&gt; val telemetry = telemetries.getOrNull(i) ?: telemetries.last() val ratio = (retrieveVoltage(selectedChannel, telemetry) - voltageMin) / voltageDiff val y = height - (ratio * height) return@createPath y } drawPath( path = path, color = VOLTAGE_COLOR, style = Stroke(width = GraphUtil.RADIUS, cap = StrokeCap.Round), ) } /* Current */ index = 0 while (index &lt; telemetries.size) { val path = Path() index = createPath( telemetries = telemetries, index = index, path = path, oldestTime = oldest.time, timeRange = timeDiff, width = width, timeThreshold = selectedTime.timeThreshold(), ) { i -&gt; val telemetry = telemetries.getOrNull(i) ?: telemetries.last() val ratio = (retrieveCurrent(selectedChannel, telemetry) - Power.CURRENT.min) / currentDiff val y = height - (ratio * height) return@createPath y } drawPath( path = path, color = Power.CURRENT.color, style = Stroke(width = GraphUtil.RADIUS, cap = StrokeCap.Round), ) } }</ID>
-    <ID>ModifierReused:PowerMetrics.kt$HorizontalLinesOverlay(modifier.width(dp), lineColors = List(size = 5) { graphColor })</ID>
-    <ID>ModifierReused:PowerMetrics.kt$TimeAxisOverlay(modifier.width(dp), oldest = oldest.time, newest = newest.time, selectedTime.lineInterval())</ID>
-    <ID>ModifierReused:PowerMetrics.kt$YAxisLabels( modifier = modifier.weight(weight = Y_AXIS_WEIGHT), Power.CURRENT.color, minValue = Power.CURRENT.min, maxValue = Power.CURRENT.max, )</ID>
-    <ID>ModifierReused:PowerMetrics.kt$YAxisLabels( modifier = modifier.weight(weight = Y_AXIS_WEIGHT), VOLTAGE_COLOR, minValue = voltageMin, maxValue = voltageMax, )</ID>
-    <ID>ModifierReused:SignalMetrics.kt$Canvas(modifier = modifier.width(dp)) { val width = size.width /* Plot */ for (packet in meshPackets) { val xRatio = (packet.rxTime - oldest.rxTime).toFloat() / timeDiff val x = xRatio * width /* SNR */ plotPoint( drawContext = drawContext, color = Metric.SNR.color, x = x, value = packet.rxSnr - Metric.SNR.min, divisor = snrDiff, ) /* RSSI */ plotPoint( drawContext = drawContext, color = Metric.RSSI.color, x = x, value = packet.rxRssi - Metric.RSSI.min, divisor = rssiDiff, ) } }</ID>
-    <ID>ModifierReused:SignalMetrics.kt$HorizontalLinesOverlay(modifier.width(dp), lineColors = List(size = 5) { graphColor })</ID>
-    <ID>ModifierReused:SignalMetrics.kt$TimeAxisOverlay( modifier.width(dp), oldest = oldest.rxTime, newest = newest.rxTime, selectedTime.lineInterval(), )</ID>
-    <ID>ModifierReused:SignalMetrics.kt$YAxisLabels( modifier = modifier.weight(weight = Y_AXIS_WEIGHT), Metric.RSSI.color, minValue = Metric.RSSI.min, maxValue = Metric.RSSI.max, )</ID>
-    <ID>ModifierReused:SignalMetrics.kt$YAxisLabels( modifier = modifier.weight(weight = Y_AXIS_WEIGHT), Metric.SNR.color, minValue = Metric.SNR.min, maxValue = Metric.SNR.max, )</ID>
-    <ID>ModifierWithoutDefault:CommonCharts.kt$modifier</ID>
-    <ID>ModifierWithoutDefault:EnvironmentCharts.kt$modifier</ID>
-    <ID>MultipleEmitters:CommonCharts.kt$LegendLabel</ID>
-    <ID>MultipleEmitters:DeviceMetrics.kt$DeviceMetricsChart</ID>
-    <ID>MultipleEmitters:EnvironmentCharts.kt$EnvironmentMetricsChart</ID>
-    <ID>MultipleEmitters:NodeDetailsSection.kt$MainNodeDetails</ID>
-    <ID>MultipleEmitters:PaxMetrics.kt$PaxMetricsChart</ID>
-    <ID>MultipleEmitters:PowerMetrics.kt$PowerMetricsChart</ID>
-    <ID>MultipleEmitters:RemoteDeviceActions.kt$RemoteDeviceActions</ID>
-    <ID>MultipleEmitters:SignalMetrics.kt$SignalMetricsChart</ID>
-    <ID>ParameterNaming:NodeFilterTextField.kt$onToggleShowIgnored</ID>
-    <ID>PreviewPublic:NodeItem.kt$NodeInfoPreview</ID>
-    <ID>PreviewPublic:NodeItem.kt$NodeInfoSimplePreview</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/FirmwareReleaseSheetContent.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/FirmwareReleaseSheetContent.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
+import co.touchlab.kermit.Logger
 import com.mikepenz.markdown.m3.Markdown
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -50,7 +51,6 @@ import org.meshtastic.core.strings.download
 import org.meshtastic.core.strings.error_no_app_to_handle_link
 import org.meshtastic.core.strings.view_release
 import org.meshtastic.core.ui.util.showToast
-import timber.log.Timber
 
 @Composable
 fun FirmwareReleaseSheetContent(firmwareRelease: FirmwareRelease, modifier: Modifier = Modifier) {
@@ -72,7 +72,7 @@ fun FirmwareReleaseSheetContent(firmwareRelease: FirmwareRelease, modifier: Modi
                         context.startActivity(intent)
                     } catch (e: ActivityNotFoundException) {
                         scope.launch { context.showToast(Res.string.error_no_app_to_handle_link) }
-                        Timber.e(e)
+                        Logger.e(e) { "Failed to handle release page URL" }
                     }
                 },
                 modifier = Modifier.weight(1f),
@@ -88,7 +88,7 @@ fun FirmwareReleaseSheetContent(firmwareRelease: FirmwareRelease, modifier: Modi
                         context.startActivity(intent)
                     } catch (e: ActivityNotFoundException) {
                         scope.launch { context.showToast(Res.string.error_no_app_to_handle_link) }
-                        Timber.e(e)
+                        Logger.e(e) { "Failed to handle release zip URL" }
                     }
                 },
                 modifier = Modifier.weight(1f),

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/LinkedCoordinatesItem.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/LinkedCoordinatesItem.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.core.net.toUri
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.database.model.Node
@@ -47,7 +48,6 @@ import org.meshtastic.core.ui.component.icon
 import org.meshtastic.core.ui.theme.AppTheme
 import org.meshtastic.core.ui.util.showToast
 import org.meshtastic.proto.ConfigProtos.Config.DisplayConfig.DisplayUnits
-import timber.log.Timber
 import java.net.URLEncoder
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -82,7 +82,7 @@ fun LinkedCoordinatesItem(node: Node, displayUnits: DisplayUnits = DisplayUnits.
                     coroutineScope.launch { context.showToast("No application available to open this location!") }
                 }
             } catch (ex: ActivityNotFoundException) {
-                Timber.d("Failed to open geo intent: $ex")
+                Logger.d { "Failed to open geo intent: $ex" }
             }
         },
         onLongClick = {

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
@@ -20,6 +20,7 @@ package org.meshtastic.feature.node.detail
 import android.os.RemoteException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,7 +34,6 @@ import org.meshtastic.core.model.TelemetryType
 import org.meshtastic.core.service.ServiceAction
 import org.meshtastic.core.service.ServiceRepository
 import org.meshtastic.feature.node.component.NodeMenuAction
-import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -77,20 +77,20 @@ constructor(
         try {
             nodeRepository.setNodeNotes(nodeNum, notes)
         } catch (ex: java.io.IOException) {
-            Timber.e("Set node notes IO error: ${ex.message}")
+            Logger.e { "Set node notes IO error: ${ex.message}" }
         } catch (ex: java.sql.SQLException) {
-            Timber.e("Set node notes SQL error: ${ex.message}")
+            Logger.e { "Set node notes SQL error: ${ex.message}" }
         }
     }
 
     private fun removeNode(nodeNum: Int) = viewModelScope.launch(Dispatchers.IO) {
-        Timber.i("Removing node '$nodeNum'")
+        Logger.i { "Removing node '$nodeNum'" }
         try {
             val packetId = serviceRepository.meshService?.packetId ?: return@launch
             serviceRepository.meshService?.removeByNodenum(packetId, nodeNum)
             nodeRepository.deleteNode(nodeNum)
         } catch (ex: RemoteException) {
-            Timber.e("Remove node error: ${ex.message}")
+            Logger.e { "Remove node error: ${ex.message}" }
         }
     }
 
@@ -98,7 +98,7 @@ constructor(
         try {
             serviceRepository.onServiceAction(ServiceAction.Ignore(node))
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Ignore node error")
+            Logger.e(ex) { "Ignore node error" }
         }
     }
 
@@ -106,55 +106,55 @@ constructor(
         try {
             serviceRepository.onServiceAction(ServiceAction.Favorite(node))
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Favorite node error")
+            Logger.e(ex) { "Favorite node error" }
         }
     }
 
     private fun requestUserInfo(destNum: Int) {
-        Timber.i("Requesting UserInfo for '$destNum'")
+        Logger.i { "Requesting UserInfo for '$destNum'" }
         try {
             serviceRepository.meshService?.requestUserInfo(destNum)
         } catch (ex: RemoteException) {
-            Timber.e("Request NodeInfo error: ${ex.message}")
+            Logger.e { "Request NodeInfo error: ${ex.message}" }
         }
     }
 
     private fun requestNeighborInfo(destNum: Int) {
-        Timber.i("Requesting NeighborInfo for '$destNum'")
+        Logger.i { "Requesting NeighborInfo for '$destNum'" }
         try {
             val packetId = serviceRepository.meshService?.packetId ?: return
             serviceRepository.meshService?.requestNeighborInfo(packetId, destNum)
         } catch (ex: RemoteException) {
-            Timber.e("Request NeighborInfo error: ${ex.message}")
+            Logger.e { "Request NeighborInfo error: ${ex.message}" }
         }
     }
 
     private fun requestPosition(destNum: Int, position: Position = Position(0.0, 0.0, 0)) {
-        Timber.i("Requesting position for '$destNum'")
+        Logger.i { "Requesting position for '$destNum'" }
         try {
             serviceRepository.meshService?.requestPosition(destNum, position)
         } catch (ex: RemoteException) {
-            Timber.e("Request position error: ${ex.message}")
+            Logger.e { "Request position error: ${ex.message}" }
         }
     }
 
     private fun requestTelemetry(destNum: Int, type: TelemetryType) {
-        Timber.i("Requesting telemetry for '$destNum'")
+        Logger.i { "Requesting telemetry for '$destNum'" }
         try {
             val packetId = serviceRepository.meshService?.packetId ?: return
             serviceRepository.meshService?.requestTelemetry(packetId, destNum, type.ordinal)
         } catch (ex: RemoteException) {
-            Timber.e("Request telemetry error: ${ex.message}")
+            Logger.e { "Request telemetry error: ${ex.message}" }
         }
     }
 
     private fun requestTraceroute(destNum: Int) {
-        Timber.i("Requesting traceroute for '$destNum'")
+        Logger.i { "Requesting traceroute for '$destNum'" }
         try {
             val packetId = serviceRepository.meshService?.packetId ?: return
             serviceRepository.meshService?.requestTraceroute(packetId, destNum)
         } catch (ex: RemoteException) {
-            Timber.e("Request traceroute error: ${ex.message}")
+            Logger.e { "Request traceroute error: ${ex.message}" }
         }
     }
 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeActions.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/list/NodeActions.kt
@@ -18,13 +18,13 @@
 package org.meshtastic.feature.node.list
 
 import android.os.RemoteException
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.database.model.Node
 import org.meshtastic.core.service.ServiceAction
 import org.meshtastic.core.service.ServiceRepository
-import timber.log.Timber
 import javax.inject.Inject
 
 class NodeActions
@@ -37,7 +37,7 @@ constructor(
         try {
             serviceRepository.onServiceAction(ServiceAction.Favorite(node))
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Favorite node error")
+            Logger.e(ex) { "Favorite node error" }
         }
     }
 
@@ -45,18 +45,18 @@ constructor(
         try {
             serviceRepository.onServiceAction(ServiceAction.Ignore(node))
         } catch (ex: RemoteException) {
-            Timber.e(ex, "Ignore node error")
+            Logger.e(ex) { "Ignore node error" }
         }
     }
 
     suspend fun removeNode(nodeNum: Int) = withContext(Dispatchers.IO) {
-        Timber.i("Removing node '$nodeNum'")
+        Logger.i { "Removing node '$nodeNum'" }
         try {
             val packetId = serviceRepository.meshService?.packetId ?: return@withContext
             serviceRepository.meshService?.removeByNodenum(packetId, nodeNum)
             nodeRepository.deleteNode(nodeNum)
         } catch (ex: RemoteException) {
-            Timber.e("Remove node error: ${ex.message}")
+            Logger.e { "Remove node error: ${ex.message}" }
         }
     }
 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/HardwareModelExtensions.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/HardwareModelExtensions.kt
@@ -17,8 +17,8 @@
 
 package org.meshtastic.feature.node.metrics
 
+import co.touchlab.kermit.Logger
 import org.meshtastic.proto.MeshProtos
-import timber.log.Timber
 
 /**
  * Safely extracts the hardware model number from a HardwareModel enum.
@@ -34,6 +34,6 @@ import timber.log.Timber
 fun MeshProtos.HardwareModel.safeNumber(fallbackValue: Int = -1): Int = try {
     this.number
 } catch (e: IllegalArgumentException) {
-    Timber.w("Unknown hardware model enum value: $this, using fallback value: $fallbackValue")
+    Logger.w { "Unknown hardware model enum value: $this, using fallback value: $fallbackValue" }
     fallbackValue
 }

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import co.touchlab.kermit.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -63,7 +64,6 @@ import org.meshtastic.proto.MeshProtos
 import org.meshtastic.proto.MeshProtos.MeshPacket
 import org.meshtastic.proto.Portnums
 import org.meshtastic.proto.Portnums.PortNum
-import timber.log.Timber
 import java.io.BufferedWriter
 import java.io.FileNotFoundException
 import java.io.FileWriter
@@ -343,16 +343,16 @@ constructor(
                             }
                     }
 
-                    Timber.d("MetricsViewModel created")
+                    Logger.d { "MetricsViewModel created" }
                 } else {
-                    Timber.d("MetricsViewModel: destNum is null, skipping metrics flows initialization.")
+                    Logger.d { "MetricsViewModel: destNum is null, skipping metrics flows initialization." }
                 }
             }
     }
 
     override fun onCleared() {
         super.onCleared()
-        Timber.d("MetricsViewModel cleared")
+        Logger.d { "MetricsViewModel cleared" }
     }
 
     fun setTimeFrame(timeFrame: TimeFrame) {
@@ -395,7 +395,7 @@ constructor(
                     }
                 }
             } catch (ex: FileNotFoundException) {
-                Timber.e(ex, "Can't write file error")
+                Logger.e(ex) { "Can't write file error" }
             }
         }
 }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     implementation(libs.androidx.hilt.lifecycle.viewmodel.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.kotlinx.collections.immutable)
-    implementation(libs.timber)
+    implementation(libs.kermit)
     implementation(libs.zxing.android.embedded)
 
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)

--- a/feature/settings/detekt-baseline.xml
+++ b/feature/settings/detekt-baseline.xml
@@ -2,28 +2,18 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ComposableParamOrder:ChannelConfigScreen.kt$ChannelConfigScreen</ID>
-    <ID>ComposableParamOrder:Debug.kt$DecodedPayloadBlock</ID>
-    <ID>ComposableParamOrder:DebugSearch.kt$DebugSearchState</ID>
-    <ID>ComposableParamOrder:DebugSearch.kt$DebugSearchStateviewModelDefaults</ID>
-    <ID>ComposableParamOrder:MapReportingPreference.kt$MapReportingPreference</ID>
-    <ID>ComposableParamOrder:NodeActionButton.kt$NodeActionButton</ID>
-    <ID>ComposableParamOrder:WarningDialog.kt$WarningDialog</ID>
     <ID>CyclomaticComplexMethod:NetworkConfigItemList.kt$@Composable fun NetworkConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>CyclomaticComplexMethod:PositionConfigItemList.kt$@OptIn(ExperimentalPermissionsApi::class) @Composable fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>CyclomaticComplexMethod:RadioConfigViewModel.kt$RadioConfigViewModel$private fun processPacketResponse(packet: MeshProtos.MeshPacket)</ID>
-    <ID>LambdaParameterEventTrailing:NodeActionButton.kt$onClick</ID>
     <ID>LongMethod:AudioConfigItemList.kt$@Composable fun AudioConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:CannedMessageConfigItemList.kt$@Composable fun CannedMessageConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:DetectionSensorConfigItemList.kt$@Composable fun DetectionSensorConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:DeviceConfigItemList.kt$@OptIn(ExperimentalMaterial3ExpressiveApi::class) @Composable fun DeviceConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:DisplayConfigItemList.kt$@Composable fun DisplayConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
-    <ID>LongMethod:ExternalNotificationConfigItemList.kt$@Composable fun ExternalNotificationConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:LoRaConfigItemList.kt$@Composable fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:NetworkConfigItemList.kt$@Composable fun NetworkConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:PositionConfigItemList.kt$@OptIn(ExperimentalPermissionsApi::class) @Composable fun PositionConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:PowerConfigItemList.kt$@Composable fun PowerConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
-    <ID>LongMethod:RadioConfigScreenList.kt$@Composable fun &lt;T : MessageLite&gt; RadioConfigScreenList( title: String, onBack: () -&gt; Unit, responseState: ResponseState&lt;Any&gt;, onDismissPacketResponse: () -&gt; Unit, configState: ConfigState&lt;T&gt;, enabled: Boolean, onSave: (T) -&gt; Unit, content: LazyListScope.() -&gt; Unit, )</ID>
     <ID>LongMethod:RadioConfigViewModel.kt$RadioConfigViewModel$private fun processPacketResponse(packet: MeshProtos.MeshPacket)</ID>
     <ID>LongMethod:SecurityConfigItemList.kt$@OptIn(ExperimentalMaterial3ExpressiveApi::class) @Composable fun SecurityConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
     <ID>LongMethod:SerialConfigItemList.kt$@Composable fun SerialConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(), onBack: () -&gt; Unit)</ID>
@@ -34,35 +24,10 @@
     <ID>MagicNumber:EditChannelDialog.kt$16</ID>
     <ID>MagicNumber:EditChannelDialog.kt$32</ID>
     <ID>MagicNumber:PacketResponseStateDialog.kt$100</ID>
-    <ID>ModifierMissing:CleanNodeDatabaseScreen.kt$CleanNodeDatabaseScreen</ID>
-    <ID>ModifierMissing:Debug.kt$DebugScreen</ID>
-    <ID>ModifierMissing:DeviceConfigItemList.kt$DeviceConfigScreen</ID>
-    <ID>ModifierMissing:MapReportingPreference.kt$MapReportingPreference</ID>
-    <ID>ModifierMissing:NetworkConfigItemList.kt$NetworkConfigScreen</ID>
-    <ID>ModifierMissing:PositionConfigItemList.kt$PositionConfigScreen</ID>
-    <ID>ModifierMissing:RadioConfig.kt$RadioConfigItemList</ID>
-    <ID>ModifierMissing:RadioConfigScreenList.kt$RadioConfigScreenList</ID>
-    <ID>ModifierMissing:SecurityConfigItemList.kt$SecurityConfigScreen</ID>
-    <ID>ModifierMissing:SettingsScreen.kt$SettingsScreen</ID>
-    <ID>ModifierNotUsedAtRoot:EditChannelDialog.kt$modifier = modifier.weight(1f)</ID>
-    <ID>ModifierNotUsedAtRoot:EditDeviceProfileDialog.kt$modifier = modifier.weight(1f)</ID>
-    <ID>MultipleEmitters:CleanNodeDatabaseScreen.kt$NodesDeletionPreview</ID>
-    <ID>MultipleEmitters:RadioConfig.kt$RadioConfigItemList</ID>
     <ID>NestedBlockDepth:RadioConfigViewModel.kt$RadioConfigViewModel$private fun processPacketResponse(packet: MeshProtos.MeshPacket)</ID>
-    <ID>ParameterNaming:ChannelConfigScreen.kt$onPositiveClicked</ID>
-    <ID>ParameterNaming:CleanNodeDatabaseScreen.kt$onCheckedChanged</ID>
-    <ID>ParameterNaming:CleanNodeDatabaseScreen.kt$onDaysChanged</ID>
-    <ID>ParameterNaming:MapReportingPreference.kt$onMapReportingEnabledChanged</ID>
-    <ID>ParameterNaming:MapReportingPreference.kt$onPositionPrecisionChanged</ID>
-    <ID>ParameterNaming:MapReportingPreference.kt$onPublishIntervalSecsChanged</ID>
-    <ID>ParameterNaming:MapReportingPreference.kt$onShouldReportLocationChanged</ID>
-    <ID>PreviewPublic:MapReportingPreference.kt$MapReportingPreview</ID>
     <ID>ReturnCount:RadioConfigViewModel.kt$RadioConfigViewModel$private fun processPacketResponse(packet: MeshProtos.MeshPacket)</ID>
     <ID>TooGenericExceptionCaught:LanguageUtils.kt$LanguageUtils$e: Exception</ID>
     <ID>TooGenericExceptionCaught:RadioConfigViewModel.kt$RadioConfigViewModel$ex: Exception</ID>
     <ID>TooManyFunctions:RadioConfigViewModel.kt$RadioConfigViewModel : ViewModel</ID>
-    <ID>UnusedParameter:ChannelConfigScreen.kt$onBack: () -&gt; Unit</ID>
-    <ID>UnusedParameter:ChannelConfigScreen.kt$title: String</ID>
-    <ID>ViewModelInjection:DebugSearch.kt$viewModel</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/SettingsViewModel.kt
@@ -21,6 +21,7 @@ import android.app.Application
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -57,7 +58,6 @@ import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.proto.LocalOnlyProtos.LocalConfig
 import org.meshtastic.proto.MeshProtos
 import org.meshtastic.proto.Portnums
-import timber.log.Timber
 import java.io.BufferedWriter
 import java.io.FileNotFoundException
 import java.io.FileWriter
@@ -287,7 +287,7 @@ constructor(
                     }
                 }
             } catch (ex: FileNotFoundException) {
-                Timber.e("Can't write file error: ${ex.message}")
+                Logger.e { "Can't write file error: ${ex.message}" }
             }
         }
     }

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.touchlab.kermit.Logger
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -96,7 +97,6 @@ import org.meshtastic.core.ui.theme.AnnotationColor
 import org.meshtastic.core.ui.theme.AppTheme
 import org.meshtastic.core.ui.util.showToast
 import org.meshtastic.feature.settings.debugging.DebugViewModel.UiMeshLog
-import timber.log.Timber
 import java.io.IOException
 import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets
@@ -408,7 +408,7 @@ private suspend fun exportAllLogsToUri(context: Context, targetUri: Uri, logs: L
             withContext(Dispatchers.Main) { context.showToast(Res.string.debug_export_success, logs.size) }
         } catch (e: IOException) {
             withContext(Dispatchers.Main) { context.showToast(Res.string.debug_export_failed, e.message ?: "") }
-            Timber.w(e, "Error:IOException ")
+            Logger.w(e) { "Error:IOException" }
         }
     }
 

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
@@ -20,6 +20,7 @@ package org.meshtastic.feature.settings.debugging
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import com.google.protobuf.InvalidProtocolBufferException
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
@@ -44,7 +45,6 @@ import org.meshtastic.proto.PaxcountProtos
 import org.meshtastic.proto.Portnums.PortNum
 import org.meshtastic.proto.StoreAndForwardProtos
 import org.meshtastic.proto.TelemetryProtos
-import timber.log.Timber
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
@@ -237,7 +237,7 @@ constructor(
     }
 
     init {
-        Timber.d("DebugViewModel created")
+        Logger.d { "DebugViewModel created" }
         viewModelScope.launch {
             combine(searchManager.searchText, filterManager.filteredLogs) { searchText, logs ->
                 searchManager.findSearchMatches(searchText, logs)
@@ -250,7 +250,7 @@ constructor(
 
     override fun onCleared() {
         super.onCleared()
-        Timber.d("DebugViewModel cleared")
+        Logger.d { "DebugViewModel cleared" }
     }
 
     private fun toUiState(databaseLogs: List<MeshLog>) = databaseLogs

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import co.touchlab.kermit.Logger
 import com.google.protobuf.MessageLite
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -80,7 +81,6 @@ import org.meshtastic.proto.Portnums
 import org.meshtastic.proto.config
 import org.meshtastic.proto.deviceProfile
 import org.meshtastic.proto.moduleConfig
-import timber.log.Timber
 import java.io.FileOutputStream
 import javax.inject.Inject
 
@@ -179,7 +179,7 @@ constructor(
             }
             .launchIn(viewModelScope)
 
-        Timber.d("RadioConfigViewModel created")
+        Logger.d { "RadioConfigViewModel created" }
     }
 
     private val myNodeInfo: StateFlow<MyNodeEntity?>
@@ -205,7 +205,7 @@ constructor(
 
     override fun onCleared() {
         super.onCleared()
-        Timber.d("RadioConfigViewModel cleared")
+        Logger.d { "RadioConfigViewModel cleared" }
     }
 
     private fun request(destNum: Int, requestAction: suspend (IMeshService, Int, Int) -> Unit, errorMessage: String) =
@@ -227,7 +227,7 @@ constructor(
                         }
                     }
                 } catch (ex: RemoteException) {
-                    Timber.e("$errorMessage: ${ex.message}")
+                    Logger.e { "$errorMessage: ${ex.message}" }
                 }
             }
         }
@@ -422,7 +422,7 @@ constructor(
         try {
             meshService?.setFixedPosition(destNum, position)
         } catch (ex: RemoteException) {
-            Timber.e("Set fixed position error: ${ex.message}")
+            Logger.e { "Set fixed position error: ${ex.message}" }
         }
     }
 
@@ -436,7 +436,7 @@ constructor(
                 onResult(protobuf)
             }
         } catch (ex: Exception) {
-            Timber.e("Import DeviceProfile error: ${ex.message}")
+            Logger.e { "Import DeviceProfile error: ${ex.message}" }
             sendError(ex.customMessage)
         }
     }
@@ -452,7 +452,7 @@ constructor(
             }
             setResponseStateSuccess()
         } catch (ex: Exception) {
-            Timber.e("Can't write file error: ${ex.message}")
+            Logger.e { "Can't write file error: ${ex.message}" }
             sendError(ex.customMessage)
         }
     }
@@ -491,7 +491,7 @@ constructor(
                 setResponseStateSuccess()
             } catch (ex: Exception) {
                 val errorMessage = "Can't write security keys JSON error: ${ex.message}"
-                Timber.e(errorMessage)
+                Logger.e { errorMessage }
                 sendError(ex.customMessage)
             }
         }
@@ -514,7 +514,7 @@ constructor(
             try {
                 setChannels(channelUrl)
             } catch (ex: Exception) {
-                Timber.e(ex, "DeviceProfile channel import error")
+                Logger.e(ex) { "DeviceProfile channel import error" }
                 sendError(ex.customMessage)
             }
         }
@@ -656,7 +656,7 @@ constructor(
 
         if (data?.portnumValue == Portnums.PortNum.ROUTING_APP_VALUE) {
             val parsed = MeshProtos.Routing.parseFrom(data.payload)
-            Timber.d(debugMsg.format(parsed.errorReason.name))
+            Logger.d { debugMsg.format(parsed.errorReason.name) }
             if (parsed.errorReason != MeshProtos.Routing.Error.NONE) {
                 sendError(getStringResFrom(parsed.errorReasonValue))
             } else if (packet.from == destNum && route.isEmpty()) {
@@ -670,7 +670,7 @@ constructor(
         }
         if (data?.portnumValue == Portnums.PortNum.ADMIN_APP_VALUE) {
             val parsed = AdminProtos.AdminMessage.parseFrom(data.payload)
-            Timber.d(debugMsg.format(parsed.payloadVariantCase.name))
+            Logger.d { debugMsg.format(parsed.payloadVariantCase.name) }
             if (destNum != packet.from) {
                 sendError("Unexpected sender: ${packet.from.toUInt()} instead of ${destNum.toUInt()}.")
                 return
@@ -744,7 +744,7 @@ constructor(
                     incrementCompleted()
                 }
 
-                else -> Timber.d("No custom processing needed for ${parsed.payloadVariantCase}")
+                else -> Logger.d { "No custom processing needed for ${parsed.payloadVariantCase}" }
             }
 
             if (AdminRoute.entries.any { it.name == route }) {

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/ExternalNotificationConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/ExternalNotificationConfigItemList.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import co.touchlab.kermit.Logger
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.strings.Res
 import org.meshtastic.core.strings.advanced
@@ -79,7 +80,6 @@ import org.meshtastic.feature.settings.util.gpioPins
 import org.meshtastic.feature.settings.util.toDisplayString
 import org.meshtastic.proto.copy
 import org.meshtastic.proto.moduleConfig
-import timber.log.Timber
 import java.io.File
 
 private const val MAX_RINGTONE_SIZE = 230
@@ -116,7 +116,7 @@ fun ExternalNotificationConfigScreen(
                         }
                     }
                 } catch (e: Exception) {
-                    Timber.e(e, "Error importing ringtone")
+                    Logger.e(e) { "Error importing ringtone" }
                     Toast.makeText(context, "Error importing: ${e.message}", Toast.LENGTH_SHORT).show()
                 }
             }
@@ -308,7 +308,7 @@ fun ExternalNotificationConfigScreen(
                                             tempFile.delete()
                                         }
                                     } catch (e: Exception) {
-                                        Timber.e(e, "Failed to play ringtone")
+                                        Logger.e(e) { "Failed to play ringtone" }
                                     }
                                 },
                                 enabled = state.connected,

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/util/LanguageUtils.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/util/LanguageUtils.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalResources
 import androidx.core.os.LocaleListCompat
+import co.touchlab.kermit.Logger
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.strings.Res
 import org.meshtastic.core.strings.fr_HT
@@ -30,7 +31,6 @@ import org.meshtastic.core.strings.pt_BR
 import org.meshtastic.core.strings.zh_CN
 import org.meshtastic.core.strings.zh_TW
 import org.xmlpull.v1.XmlPullParser
-import timber.log.Timber
 import java.util.Locale
 
 object LanguageUtils {
@@ -69,7 +69,7 @@ object LanguageUtils {
                             }
                         }
                     } catch (e: Exception) {
-                        Timber.e("Error parsing locale_config.xml: ${e.message}")
+                        Logger.e { "Error parsing locale_config.xml: ${e.message}" }
                     }
                 }
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -164,7 +164,8 @@ osmbonuspack = { module = "com.github.MKergall:osmbonuspack", version = "6.9.0" 
 osmdroid-android = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroid-android" }
 osmdroid-geopackage = { module = "org.osmdroid:osmdroid-geopackage", version.ref = "osmdroid-android" }
 streamsupport-minifuture = { module = "net.sourceforge.streamsupport:streamsupport-minifuture", version = "1.7.4" }
-timber = { module = "com.jakewharton.timber:timber", version = "5.0.1" }
+    kermit = { module = "co.touchlab:kermit", version = "2.0.5" }
+
 usb-serial-android = { module = "com.github.mik3y:usb-serial-for-android", version = "3.10.0" }
 zxing-android-embedded = { module = "com.journeyapps:zxing-android-embedded", version = "4.3.0" }
 


### PR DESCRIPTION
This replaces the Timber logging library with Kermit across the entire Android application. Kermit is a multiplatform logging utility that will facilitate sharing logging code in the future.

Key changes:
- Replaced all `Timber` calls with `co.touchlab.kermit.Logger`.
- Updated `build.gradle.kts` files to replace the Timber dependency with Kermit.
- Configured Kermit in `GooglePlatformAnalytics` to use `DatadogLogWriter`, `CrashlyticsLogWriter`, and `LogcatWriter` based on the build type.
- Removed a significant number of detekt baseline suppressions related to old code style that was refactored during the replacement.
- Updated `detekt-baseline.xml` files across various modules to reflect the changes.