### PR TITLE
ci(github-actions): Escape changelog output in workflow

### DIFF
--- a/.github/workflows/main-push-changelog.yml
+++ b/.github/workflows/main-push-changelog.yml
@@ -51,10 +51,8 @@ jobs:
       - name: Save changelog to file
         if: steps.last_prod_tag.outputs.tag != ''
         run: |
-          mkdir -p artifacts
-          cat << 'EOF' > artifacts/main-push-changelog.md
-          ${{ steps.changelog.outputs.changelog }}
-          EOF
+            mkdir -p artifacts
+            echo "${{ steps.changelog.outputs.changelog }}" > artifacts/main-push-changelog.md
 
       - name: Upload changelog artifact
         if: steps.last_prod_tag.outputs.tag != ''


### PR DESCRIPTION
The `main-push-changelog.yml` workflow is updated to correctly handle special characters in the changelog.

The `cat << 'EOF'` heredoc method is replaced with `echo` and quotes around the changelog output. This prevents premature termination of the heredoc if the changelog content includes a line with just `EOF`.