### PR TITLE
refactor: Set minSdk to 32 and remove legacy code

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,17 +28,10 @@
         android:name="android.hardware.location.gps"
         android:required="false" />
 
-    <!-- Request legacy Bluetooth permissions on older devices -->
-    <uses-permission android:name="android.permission.BLUETOOTH"
-        android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
-        android:maxSdkVersion="30" />
-
-    <!-- API 31+ Bluetooth permissions -->
+    <!-- API 31+ Bluetooth permissions (Min SDK is 32) -->
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
-        android:usesPermissionFlags="neverForLocation"
-        tools:targetApi="s" />
+        android:usesPermissionFlags="neverForLocation" />
 
     <!-- API 33+ Notification runtime permissions -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -23,7 +23,6 @@ import android.content.Intent
 import android.graphics.Color
 import android.hardware.usb.UsbManager
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
@@ -67,14 +66,9 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
-        enableEdgeToEdge(
-            // Disable three-button navbar scrim on pre-Q devices
-            navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
-        )
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            // Disable three-button navbar scrim
-            window.setNavigationBarContrastEnforced(false)
-        }
+        enableEdgeToEdge(navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT))
+        // Disable three-button navbar scrim (unconditional on API 32+)
+        window.setNavigationBarContrastEnforced(false)
 
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -23,7 +23,6 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
-import android.os.Build
 import android.os.IBinder
 import android.os.RemoteException
 import android.util.Log
@@ -477,14 +476,10 @@ class MeshService : Service() {
                 this,
                 SERVICE_NOTIFY_ID,
                 notification,
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    if (hasLocationPermission()) {
-                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
-                    } else {
-                        ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-                    }
+                if (hasLocationPermission()) {
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
                 } else {
-                    0 // No specific type needed for older Android versions
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
                 },
             )
         } catch (ex: Exception) {
@@ -1359,7 +1354,7 @@ class MeshService : Service() {
         val failure =
             when {
                 address == null -> "no_active_address"
-                myNodeNum == null -> "no_my_node"
+                myNodeInfo == null -> "no_my_node"
                 else -> null
             }
         if (failure != null) {
@@ -1368,7 +1363,7 @@ class MeshService : Service() {
         }
 
         val safeAddress = address!!
-        val myNum = myNodeNum!!
+        val myNum = myNodeNum
         val storeForwardConfig = moduleConfig.storeForward
         val lastRequest = meshPrefs.getStoreForwardLastRequest(safeAddress)
         val (window, max) =

--- a/app/src/main/java/com/geeksville/mesh/service/MeshServiceStarter.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshServiceStarter.kt
@@ -19,7 +19,6 @@ package com.geeksville.mesh.service
 
 import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context
-import android.os.Build
 import co.touchlab.kermit.Logger
 import com.geeksville.mesh.BuildConfig
 
@@ -36,13 +35,9 @@ fun MeshService.Companion.startService(context: Context) {
     Logger.i { "Trying to start service debug=${BuildConfig.DEBUG}" }
 
     val intent = createIntent(context)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        try {
-            context.startForegroundService(intent)
-        } catch (ex: ForegroundServiceStartNotAllowedException) {
-            Logger.e { "Unable to start service: ${ex.message}" }
-        }
-    } else {
+    try {
         context.startForegroundService(intent)
+    } catch (ex: ForegroundServiceStartNotAllowedException) {
+        Logger.e { "Unable to start service: ${ex.message}" }
     }
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/ConnectionsScreen.kt
@@ -18,8 +18,6 @@
 package com.geeksville.mesh.ui.connections
 
 import android.net.InetAddresses
-import android.os.Build
-import android.util.Patterns
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -93,12 +91,7 @@ import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.feature.settings.radio.component.PacketResponseStateDialog
 import org.meshtastic.proto.ConfigProtos
 
-fun String?.isIPAddress(): Boolean = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-    @Suppress("DEPRECATION")
-    this != null && Patterns.IP_ADDRESS.matcher(this).matches()
-} else {
-    InetAddresses.isNumericAddress(this.toString())
-}
+fun String?.isIPAddress(): Boolean = InetAddresses.isNumericAddress(this.toString())
 
 /**
  * Composable screen for managing device connections (BLE, TCP, USB). It handles permission requests for location and

--- a/config.properties
+++ b/config.properties
@@ -20,7 +20,7 @@ VERSION_CODE_OFFSET=29314197
 
 # Application and SDK versions
 APPLICATION_ID=com.geeksville.mesh
-MIN_SDK=26
+MIN_SDK=32
 TARGET_SDK=36
 COMPILE_SDK=36
 

--- a/core/common/src/androidMain/kotlin/org/meshtastic/core/common/ContextServices.kt
+++ b/core/common/src/androidMain/kotlin/org/meshtastic/core/common/ContextServices.kt
@@ -21,7 +21,6 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.location.LocationManager
-import android.os.Build
 import androidx.core.content.ContextCompat
 
 /** Checks if the device has a GPS receiver. */
@@ -44,22 +43,12 @@ fun Context.gpsDisabled(): Boolean {
  * Determines the list of Bluetooth permissions that are currently missing. Internal helper for
  * [hasBluetoothPermission].
  *
- * For Android S (API 31) and above, this includes [Manifest.permission.BLUETOOTH_SCAN] and
- * [Manifest.permission.BLUETOOTH_CONNECT]. For older versions, it includes [Manifest.permission.ACCESS_FINE_LOCATION]
- * as it is required for Bluetooth scanning.
+ * This includes [Manifest.permission.BLUETOOTH_SCAN] and [Manifest.permission.BLUETOOTH_CONNECT].
  *
  * @return Array of missing Bluetooth permission strings. Empty if all are granted.
  */
 private fun Context.getBluetoothPermissions(): Array<String> {
-    val requiredPermissions = mutableListOf<String>()
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        requiredPermissions.add(Manifest.permission.BLUETOOTH_SCAN)
-        requiredPermissions.add(Manifest.permission.BLUETOOTH_CONNECT)
-    } else {
-        // ACCESS_FINE_LOCATION is required for Bluetooth scanning on pre-S devices.
-        requiredPermissions.add(Manifest.permission.ACCESS_FINE_LOCATION)
-    }
+    val requiredPermissions = listOf(Manifest.permission.BLUETOOTH_SCAN, Manifest.permission.BLUETOOTH_CONNECT)
     return requiredPermissions
         .filter { ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED }
         .toTypedArray()

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/LocationRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/LocationRepository.kt
@@ -77,7 +77,7 @@ constructor(
 
         val providerList = buildList {
             val providers = allProviders
-            if (android.os.Build.VERSION.SDK_INT >= 31 && LocationManager.FUSED_PROVIDER in providers) {
+            if (LocationManager.FUSED_PROVIDER in providers) {
                 add(LocationManager.FUSED_PROVIDER)
             } else {
                 if (LocationManager.GPS_PROVIDER in providers) add(LocationManager.GPS_PROVIDER)

--- a/core/model/src/main/kotlin/org/meshtastic/core/model/util/DistanceExtensions.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/util/DistanceExtensions.kt
@@ -33,20 +33,9 @@ enum class DistanceUnit(val symbol: String, val multiplier: Float, val system: I
 
     companion object {
         fun getFromLocale(locale: Locale = Locale.getDefault()): DisplayUnits =
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
-                when (LocaleData.getMeasurementSystem(ULocale.forLocale(locale))) {
-                    LocaleData.MeasurementSystem.SI -> DisplayUnits.METRIC
-                    else -> DisplayUnits.IMPERIAL
-                }
-            } else {
-                when (locale.country.uppercase(locale)) {
-                    "US",
-                    "LR",
-                    "MM",
-                    "GB",
-                    -> DisplayUnits.IMPERIAL
-                    else -> DisplayUnits.METRIC
-                }
+            when (LocaleData.getMeasurementSystem(ULocale.forLocale(locale))) {
+                LocaleData.MeasurementSystem.SI -> DisplayUnits.METRIC
+                else -> DisplayUnits.IMPERIAL
             }
     }
 }

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/theme/Theme.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/theme/Theme.kt
@@ -19,7 +19,6 @@
 
 package org.meshtastic.core.ui.theme
 
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
@@ -283,7 +282,7 @@ fun AppTheme(
 ) {
     val colorScheme =
         when {
-            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            dynamicColor -> {
                 val context = LocalContext.current
                 if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
             }


### PR DESCRIPTION
This commit increases the minimum SDK version to 32 (Android 12L), which allows for the removal of compatibility code for older Android versions.

Key changes:
- Bumps `minSdk` from 26 to 32.
- Removes conditional logic and permissions for Android versions below 12.
- Simplifies Bluetooth permission handling, location services, and UI code.
