### PR TITLE
Consider hopStart=0 when calculating hops for packets

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -1573,7 +1573,7 @@ class MeshService : Service() {
     private fun getHopsAwayForPacket(packet: MeshPacket): Int =
         if (packet.decoded.portnumValue == Portnums.PortNum.RANGE_TEST_APP_VALUE) {
             0 // These don't come with the .hop params, but do not propagate, so they must be 0
-        } else if (packet.hopStart == 0 && !packet.decoded.hasBitfield())  {
+        } else if (packet.hopStart == 0 && !packet.decoded.hasBitfield()) {
             // Firmware prior to 2.3.0 doesn't set hopStart. The bitfield was added in 2.5.0. Its
             // absence is used to approximate firmware versions where hopStart is missing and when
             // the number of hops away cannot be calculated.


### PR DESCRIPTION
Consider packets transmitted with 0 hops when calculating the hops for a packet. This is a follow-on to https://github.com/meshtastic/firmware/pull/9120 for the Android app. 

Prior to firmware v2.3.0 nodes did not provide a `hop_start` in packets. This meant that receiving a hop_start value of 0 could mean two different things; either the node was older and didn't supply a hop_start, or the transmitting node had LoRa number of hops set to 0. This PR uses the presence of the `bitfield`, added in v2.5.0, to distinguish between these two cases.

When hop_start=0 and the bitfield is present, we can trust that the transmitting node had LoRa number of hops set to 0. `getHopsAwayForPacket` considers the presence of the bitfield, and returns 0 for the number of hops away in this case.
