### PR TITLE
Refactor: Improve analytics plugin application and task configuration

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/MeshtasticFlavor.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/MeshtasticFlavor.kt
@@ -48,10 +48,8 @@ fun configureFlavors(
                 register(meshtasticFlavor.name) {
                     dimension = meshtasticFlavor.dimension.name
                     flavorConfigurationBlock(this, meshtasticFlavor)
-                    if (this@apply is ApplicationExtension && this is ApplicationProductFlavor) {
-                        if (meshtasticFlavor.default) {
-                            isDefault = true
-                        }
+                    if (meshtasticFlavor.default) {
+                        isDefault = true
                     }
                 }
             }


### PR DESCRIPTION
Streamlined the `AnalyticsConventionPlugin` to enhance build performance and clarity.

- Conditionally apply analytics plugins (Google Services, Firebase Crashlytics, Datadog) only for the "google" product flavor.
- Improved task disabling logic for the "fdroid" flavor by using `plugins.withId` to configure tasks only when their respective plugins are present. This is more efficient than iterating over all tasks.
- Replaced `extensions.configure<DdExtension>` with the safer `extensions.findByType<DdExtension>()?.apply` to avoid build errors if the plugin isn't applied.