### PR TITLE
feat: Add new regions and modem presets

### DIFF
--- a/core/model/src/main/kotlin/org/meshtastic/core/model/Channel.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/Channel.kt
@@ -94,6 +94,10 @@ data class Channel(
                         ModemPreset.LONG_MODERATE -> "LongMod"
                         ModemPreset.VERY_LONG_SLOW -> "VLongSlow"
                         ModemPreset.LONG_TURBO -> "LongTurbo"
+                        ModemPreset.LITE_FAST -> "LiteFast"
+                        ModemPreset.LITE_SLOW -> "LiteSlow"
+                        ModemPreset.NARROW_FAST -> "NarrowFast"
+                        ModemPreset.NARROW_SLOW -> "NarrowSlow"
                         else -> "Invalid"
                     }
                 } else {

--- a/core/model/src/main/kotlin/org/meshtastic/core/model/ChannelOption.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/ChannelOption.kt
@@ -101,14 +101,9 @@ internal fun LoRaConfig.radioFreq(channelNum: Int): Float {
         val channelSpacing = regionInfo.spacing + bw
         // The frequency calculation attempts to match firmware behavior,
         // where channel_num is 0-indexed in the calculation, but 1-indexed in the app's channelNum function.
-        // For amateur radio regions, regionInfo.spacing is not included in the frequency calculation.
         // Firmware example: float freq = myRegion->freqStart + myRegion->spacing + (bw / 2000) + (channel_num *
         // channelSpacing);
-        if (regionInfo.description.contains("Amateur")) {
-            (regionInfo.freqStart + bw / 2) + (channelNum - 1) * channelSpacing
-        } else {
-            (regionInfo.freqStart + regionInfo.spacing + bw / 2) + (channelNum - 1) * channelSpacing
-        }
+        (regionInfo.freqStart + regionInfo.spacing + bw / 2) + (channelNum - 1) * channelSpacing
     } else {
         0f
     }
@@ -343,16 +338,6 @@ enum class RegionInfo(
         wideLora = false,
         spacing = 0.015f,
         defaultPreset = ModemPreset.NARROW_FAST,
-    ),
-
-    /** US 433MHz Amateur Use band */
-    HAM_US433(
-        RegionCode.HAM_US433,
-        "United States 433MHz (Amateur)",
-        430.0f,
-        450.0f,
-        wideLora = false,
-        defaultPreset = ModemPreset.NARROW_SLOW,
     ),
     ;
 

--- a/core/model/src/main/kotlin/org/meshtastic/core/model/ChannelOption.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/ChannelOption.kt
@@ -78,10 +78,9 @@ val LoRaConfig.numChannels: Int
         if (bw <= 0f) return 1 // Return 1 if bandwidth is zero or negative
 
         // Calculate number of channels: spacing = gap between channels (0 for continuous spectrum)
-        // Match firmware: uint32_t numChannels = round((myRegion->freqEnd - myRegion->freqStart + myRegion->spacing) /
-        // channelSpacing);
+        // Match firmware: uint32_t numChannels = round((myRegion->freqEnd - myRegion->freqStart) / channelSpacing);
         val channelSpacing = regionInfo.spacing + bw
-        val num = Math.round((regionInfo.freqEnd - regionInfo.freqStart + regionInfo.spacing) / channelSpacing).toInt()
+        val num = Math.round((regionInfo.freqEnd - regionInfo.freqStart) / channelSpacing).toInt()
 
         // If the regional frequency range is smaller than the bandwidth, the firmware would
         // fall back to a default preset. In the app, we return 1 to avoid a crash.
@@ -100,13 +99,14 @@ internal fun LoRaConfig.radioFreq(channelNum: Int): Float {
     return if (regionInfo != null) {
         val bw = bandwidth(regionInfo)
         val channelSpacing = regionInfo.spacing + bw
-        // Match firmware: float freq = myRegion->freqStart + (bw / 2000) + (channel_num * channelSpacing);
+        // Match firmware: float freq = myRegion->freqStart + myRegion->spacing + (bw / 2000) + (channel_num *
+        // channelSpacing);
         // Note: firmware channel_num is 0-indexed in the calculation, but the app uses 1-indexed for some reason?
         // Let's re-verify the firmware logic.
         // Firmware: channel_num = hash(channelName) % numChannels;
-        // freq = myRegion->freqStart + (bw / 2000) + (channel_num * channelSpacing);
+        // freq = myRegion->freqStart + myRegion->spacing + (bw / 2000) + (channel_num * channelSpacing);
         // The app's channelNum function returns 1..numChannels if channelNum is 0.
-        (regionInfo.freqStart + bw / 2) + (channelNum - 1) * channelSpacing
+        (regionInfo.freqStart + regionInfo.spacing + bw / 2) + (channelNum - 1) * channelSpacing
     } else {
         0f
     }

--- a/core/model/src/test/kotlin/org/meshtastic/core/model/ChannelOptionTest.kt
+++ b/core/model/src/test/kotlin/org/meshtastic/core/model/ChannelOptionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,13 +14,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.model
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
+import org.meshtastic.proto.ConfigKt.loRaConfig
 import org.meshtastic.proto.ConfigProtos.Config.LoRaConfig.ModemPreset
+import org.meshtastic.proto.ConfigProtos.Config.LoRaConfig.RegionCode
 
 class ChannelOptionTest {
 
@@ -77,5 +78,25 @@ class ChannelOptionTest {
             protoPresets.size,
             ChannelOption.entries.size,
         )
+    }
+
+    @Test
+    fun `test radioFreq and numChannels for NARROW_868`() {
+        val loraConfig = loRaConfig {
+            region = RegionCode.NARROW_868
+            usePreset = true
+            modemPreset = ModemPreset.NARROW_FAST
+        }
+
+        // bw = 0.0625, spacing = 0.015, channelSpacing = 0.0775
+        // Range = 869.65 - 869.4 = 0.25
+        // numChannels = round(0.25 / 0.0775) = 3
+        assertEquals(3, loraConfig.numChannels)
+
+        // Slot 1: freqStart + spacing + bw/2 = 869.4 + 0.015 + 0.03125 = 869.44625
+        assertEquals(869.44625f, loraConfig.radioFreq(1), 0.0001f)
+
+        // Slot 3: 869.44625 + 2 * 0.0775 = 869.44625 + 0.155 = 869.60125
+        assertEquals(869.60125f, loraConfig.radioFreq(3), 0.0001f)
     }
 }

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -150,6 +150,10 @@
     <string name="label_short_turbo">Short Range - Turbo</string>
     <string name="label_short_fast">Short Range - Fast</string>
     <string name="label_short_slow">Short Range - Slow</string>
+    <string name="label_lite_fast">Lite - Fast</string>
+    <string name="label_lite_slow">Lite - Slow</string>
+    <string name="label_narrow_fast">Narrow - Fast</string>
+    <string name="label_narrow_slow">Narrow - Slow</string>
 
     <string name="config_network_wifi_enabled_summary">Enabling WiFi will disable the bluetooth connection to the app.</string>
     <string name="config_network_eth_enabled_summary">Enabling Ethernet will disable the bluetooth connection to the app. TCP node connections are not available on Apple devices.</string>

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.feature.settings.radio.component
 
 import androidx.compose.foundation.text.KeyboardActions
@@ -96,7 +95,16 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     enabled = state.connected,
                     items = RegionInfo.entries.map { it.regionCode to it.description },
                     selectedItem = formState.value.region,
-                    onItemSelected = { formState.value = formState.value.copy { region = it } },
+                    onItemSelected = {
+                        val regionInfo = RegionInfo.fromRegionCode(it)
+                        formState.value =
+                            formState.value.copy {
+                                region = it
+                                if (regionInfo != null) {
+                                    modemPreset = regionInfo.defaultPreset
+                                }
+                            }
+                    },
                 )
                 HorizontalDivider()
                 SwitchPreference(


### PR DESCRIPTION
This commit introduces several new regions and corresponding modem presets to align with recent firmware updates.

-   Adds `EU_866`, `NARROW_868`, and `HAM_US433` regions.
-   Adds new modem presets: `LITE_FAST`, `LITE_SLOW`, `NARROW_FAST`, and `NARROW_SLOW`.
-   Updates the channel calculation logic to account for channel spacing, matching the firmware's behavior.
-   Sets the default modem preset automatically when a new region is selected.
-   Updates the protobuf submodule to tom's proposed version.

This is mostly for @NomDeTom to test his proposed changes.
