### PR TITLE
feat: Add initial handling for Store and Forward PlusPlus packets

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshDataHandler.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshDataHandler.kt
@@ -156,6 +156,11 @@ constructor(
                 shouldBroadcast = false
             }
 
+            Portnums.PortNum.STORE_FORWARD_PLUSPLUS_APP_VALUE -> {
+                handleStoreForwardPlusPlus(packet)
+                shouldBroadcast = false
+            }
+
             Portnums.PortNum.ADMIN_APP_VALUE -> {
                 handleAdminMessage(packet, myNodeNum)
                 shouldBroadcast = false
@@ -184,6 +189,11 @@ constructor(
     private fun handleStoreAndForward(packet: MeshPacket, dataPacket: DataPacket, myNodeNum: Int) {
         val u = StoreAndForwardProtos.StoreAndForward.parseFrom(packet.decoded.payload)
         handleReceivedStoreAndForward(dataPacket, u, myNodeNum)
+    }
+
+    private fun handleStoreForwardPlusPlus(packet: MeshPacket) {
+        val sfpp = MeshProtos.StoreForwardPlusPlus.parseFrom(packet.decoded.payload)
+        Logger.d { "Received StoreForwardPlusPlus packet: $sfpp" }
     }
 
     private fun handlePaxCounter(packet: MeshPacket) {

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -456,6 +455,8 @@ constructor(
                         PortNum.PAXCOUNTER_APP_VALUE -> PaxcountProtos.Paxcount.parseFrom(payload).toString()
                         PortNum.STORE_FORWARD_APP_VALUE ->
                             StoreAndForwardProtos.StoreAndForward.parseFrom(payload).toString()
+                        PortNum.STORE_FORWARD_PLUSPLUS_APP_VALUE ->
+                            MeshProtos.StoreForwardPlusPlus.parseFrom(payload).toString()
                         PortNum.NEIGHBORINFO_APP_VALUE -> decodeNeighborInfo(payload)
                         PortNum.TRACEROUTE_APP_VALUE -> decodeTraceroute(packet, payload)
                         else -> payload.joinToString(" ") { HEX_FORMAT.format(it) }


### PR DESCRIPTION
This commit introduces basic handling for `STORE_FORWARD_PLUSPLUS_APP` packets.

- A new handler `handleStoreForwardPlusPlus` is added to `MeshDataHandler` to parse and log incoming Store and Forward PlusPlus packets.
- The DebugViewModel is updated to decode and display `StoreForwardPlusPlus` payloads.

@jp-bennett 👀 