### PR TITLE
feat(i18n): Add string for PKI public key send failure

### DIFF
--- a/core/database/src/main/kotlin/org/meshtastic/core/database/model/Message.kt
+++ b/core/database/src/main/kotlin/org/meshtastic/core/database/model/Message.kt
@@ -40,6 +40,7 @@ import org.meshtastic.core.strings.routing_error_no_route
 import org.meshtastic.core.strings.routing_error_none
 import org.meshtastic.core.strings.routing_error_not_authorized
 import org.meshtastic.core.strings.routing_error_pki_failed
+import org.meshtastic.core.strings.routing_error_pki_send_fail_public_key
 import org.meshtastic.core.strings.routing_error_pki_unknown_pubkey
 import org.meshtastic.core.strings.routing_error_rate_limit_exceeded
 import org.meshtastic.core.strings.routing_error_timeout
@@ -66,6 +67,7 @@ fun getStringResFrom(routingError: Int): StringResource = when (routingError) {
     Routing.Error.ADMIN_BAD_SESSION_KEY_VALUE -> Res.string.routing_error_admin_bad_session_key
     Routing.Error.ADMIN_PUBLIC_KEY_UNAUTHORIZED_VALUE -> Res.string.routing_error_admin_public_key_unauthorized
     Routing.Error.RATE_LIMIT_EXCEEDED_VALUE -> Res.string.routing_error_rate_limit_exceeded
+    Routing.Error.PKI_SEND_FAIL_PUBLIC_KEY_VALUE -> Res.string.routing_error_pki_send_fail_public_key
     else -> Res.string.unrecognized
 }
 

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -72,7 +72,7 @@
     <string name="routing_error_pki_unknown_pubkey">Unknown Public Key</string>
     <string name="routing_error_admin_bad_session_key">Bad session key</string>
     <string name="routing_error_admin_public_key_unauthorized">Public Key unauthorized</string>
-
+    <string name="routing_error_pki_send_fail_public_key">PKI send failed, no public key</string>
     <string name="role_client">Client</string>
     <string name="role_client_desc">App connected or standalone messaging device.</string>
     <string name="role_client_mute">Client Mute</string>


### PR DESCRIPTION
Adds a new string resource to indicate when a PKI message fails to send because the recipient's public key is missing. This provides more specific feedback to the user in case of this particular routing error.

Allows the error messaging to be translatable.

introduced in https://github.com/meshtastic/protobufs/pull/834