### PR TITLE
refactor(deps): inject CoroutineDispatchers

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
+++ b/app/src/main/java/com/geeksville/mesh/MeshServiceClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh
 
 import android.content.Context
@@ -31,6 +30,7 @@ import com.geeksville.mesh.service.MeshService
 import com.geeksville.mesh.service.startService
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
+import kotlinx.coroutines.launch
 import org.meshtastic.core.service.IMeshService
 import org.meshtastic.core.service.ServiceRepository
 import javax.inject.Inject
@@ -75,10 +75,12 @@ constructor(
         super.onStart(owner)
         Logger.d { "Lifecycle: ON_START" }
 
-        try {
-            bindMeshService()
-        } catch (ex: BindFailedException) {
-            Logger.e { "Bind of MeshService failed: ${ex.message}" }
+        owner.lifecycleScope.launch {
+            try {
+                bindMeshService()
+            } catch (ex: BindFailedException) {
+                Logger.e { "Bind of MeshService failed: ${ex.message}" }
+            }
         }
     }
 
@@ -93,7 +95,7 @@ constructor(
     // endregion
 
     @Suppress("TooGenericExceptionCaught")
-    private fun bindMeshService() {
+    private suspend fun bindMeshService() {
         Logger.d { "Binding to mesh service!" }
         try {
             MeshService.startService(context)

--- a/app/src/main/java/com/geeksville/mesh/android/ServiceClient.kt
+++ b/app/src/main/java/com/geeksville/mesh/android/ServiceClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh.android
 
 import android.content.ComponentName
@@ -25,6 +24,7 @@ import android.os.IBinder
 import android.os.IInterface
 import co.touchlab.kermit.Logger
 import com.geeksville.mesh.util.exceptionReporter
+import kotlinx.coroutines.delay
 import java.io.Closeable
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -64,7 +64,7 @@ open class ServiceClient<T : IInterface>(private val stubFactory: (IBinder) -> T
         }
     }
 
-    fun connect(c: Context, intent: Intent, flags: Int) {
+    suspend fun connect(c: Context, intent: Intent, flags: Int) {
         context = c
         if (isClosed) {
             isClosed = false
@@ -73,7 +73,7 @@ open class ServiceClient<T : IInterface>(private val stubFactory: (IBinder) -> T
                 // Try
                 // a short sleep to see if that helps
                 Logger.e { "Needed to use the second bind attempt hack" }
-                Thread.sleep(500) // was 200ms, but received an autobug from a Galaxy Note4, android 6.0.1
+                delay(500) // was 200ms, but received an autobug from a Galaxy Note4, android 6.0.1
                 if (!c.bindService(intent, connection, flags)) {
                     throw BindFailedException()
                 }

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh.repository.radio
 
 import android.app.Application
@@ -31,7 +30,6 @@ import com.geeksville.mesh.repository.network.NetworkRepository
 import com.geeksville.mesh.util.ignoreException
 import com.geeksville.mesh.util.toRemoteExceptions
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -99,7 +97,7 @@ constructor(
     val mockInterfaceAddress: String by lazy { toInterfaceAddress(InterfaceId.MOCK, "") }
 
     /** We recreate this scope each time we stop an interface */
-    var serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    var serviceScope = CoroutineScope(dispatchers.io + SupervisorJob())
 
     private var radioIf: IRadioInterface = NopInterface("")
 
@@ -292,7 +290,7 @@ constructor(
 
         // cancel any old jobs and get ready for the new ones
         serviceScope.cancel("stopping interface")
-        serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        serviceScope = CoroutineScope(dispatchers.io + SupervisorJob())
 
         if (logSends) {
             sentPacketsLog.close()

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/TCPInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/TCPInterface.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh.repository.radio
 
 import co.touchlab.kermit.Logger
@@ -23,9 +22,9 @@ import com.geeksville.mesh.repository.network.NetworkRepository
 import com.geeksville.mesh.util.Exceptions
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import org.meshtastic.core.di.CoroutineDispatchers
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.IOException
@@ -34,8 +33,13 @@ import java.net.InetAddress
 import java.net.Socket
 import java.net.SocketTimeoutException
 
-class TCPInterface @AssistedInject constructor(service: RadioInterfaceService, @Assisted private val address: String) :
-    StreamInterface(service) {
+class TCPInterface
+@AssistedInject
+constructor(
+    service: RadioInterfaceService,
+    private val dispatchers: CoroutineDispatchers,
+    @Assisted private val address: String,
+) : StreamInterface(service) {
 
     companion object {
         const val MAX_RETRIES_ALLOWED = Int.MAX_VALUE
@@ -143,7 +147,7 @@ class TCPInterface @AssistedInject constructor(service: RadioInterfaceService, @
     }
 
     // Create a socket to make the connection with the server
-    private suspend fun startConnect() = withContext(Dispatchers.IO) {
+    private suspend fun startConnect() = withContext(dispatchers.io) {
         val attemptStart = System.currentTimeMillis()
         Logger.i { "[$address] TCP connection attempt starting..." }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/contact/ContactsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/contact/ContactsViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh.ui.contact
 
 import androidx.lifecycle.ViewModel
@@ -30,7 +29,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
 import org.meshtastic.core.data.repository.NodeRepository
 import org.meshtastic.core.data.repository.PacketRepository
@@ -163,8 +161,8 @@ constructor(
                             longName = longName,
                             lastMessageTime = getShortDate(data.time),
                             lastMessageText = if (fromLocal) data.text else "$shortName: ${data.text}",
-                            unreadCount = runBlocking(Dispatchers.IO) { packetRepository.getUnreadCount(contactKey) },
-                            messageCount = runBlocking(Dispatchers.IO) { packetRepository.getMessageCount(contactKey) },
+                            unreadCount = packetRepository.getUnreadCount(contactKey),
+                            messageCount = packetRepository.getMessageCount(contactKey),
                             isMuted = settings[contactKey]?.isMuted == true,
                             isUnmessageable = user.isUnmessagable,
                             nodeColors =

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,27 +14,31 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.data.datasource
 
 import dagger.Lazy
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.database.dao.DeviceHardwareDao
 import org.meshtastic.core.database.entity.DeviceHardwareEntity
 import org.meshtastic.core.database.entity.asEntity
+import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.NetworkDeviceHardware
 import javax.inject.Inject
 
-class DeviceHardwareLocalDataSource @Inject constructor(private val deviceHardwareDaoLazy: Lazy<DeviceHardwareDao>) {
+class DeviceHardwareLocalDataSource
+@Inject
+constructor(
+    private val deviceHardwareDaoLazy: Lazy<DeviceHardwareDao>,
+    private val dispatchers: CoroutineDispatchers,
+) {
     private val deviceHardwareDao by lazy { deviceHardwareDaoLazy.get() }
 
-    suspend fun insertAllDeviceHardware(deviceHardware: List<NetworkDeviceHardware>) = withContext(Dispatchers.IO) {
+    suspend fun insertAllDeviceHardware(deviceHardware: List<NetworkDeviceHardware>) = withContext(dispatchers.io) {
         deviceHardware.forEach { deviceHardware -> deviceHardwareDao.insert(deviceHardware.asEntity()) }
     }
 
-    suspend fun deleteAllDeviceHardware() = withContext(Dispatchers.IO) { deviceHardwareDao.deleteAll() }
+    suspend fun deleteAllDeviceHardware() = withContext(dispatchers.io) { deviceHardwareDao.deleteAll() }
 
     suspend fun getByHwModel(hwModel: Int): DeviceHardwareEntity? =
-        withContext(Dispatchers.IO) { deviceHardwareDao.getByHwModel(hwModel) }
+        withContext(dispatchers.io) { deviceHardwareDao.getByHwModel(hwModel) }
 }

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,36 +14,40 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.data.datasource
 
 import dagger.Lazy
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.database.dao.FirmwareReleaseDao
 import org.meshtastic.core.database.entity.FirmwareReleaseEntity
 import org.meshtastic.core.database.entity.FirmwareReleaseType
 import org.meshtastic.core.database.entity.asDeviceVersion
 import org.meshtastic.core.database.entity.asEntity
+import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.NetworkFirmwareRelease
 import javax.inject.Inject
 
-class FirmwareReleaseLocalDataSource @Inject constructor(private val firmwareReleaseDaoLazy: Lazy<FirmwareReleaseDao>) {
+class FirmwareReleaseLocalDataSource
+@Inject
+constructor(
+    private val firmwareReleaseDaoLazy: Lazy<FirmwareReleaseDao>,
+    private val dispatchers: CoroutineDispatchers,
+) {
     private val firmwareReleaseDao by lazy { firmwareReleaseDaoLazy.get() }
 
     suspend fun insertFirmwareReleases(
         firmwareReleases: List<NetworkFirmwareRelease>,
         releaseType: FirmwareReleaseType,
-    ) = withContext(Dispatchers.IO) {
+    ) = withContext(dispatchers.io) {
         firmwareReleases.forEach { firmwareRelease ->
             firmwareReleaseDao.insert(firmwareRelease.asEntity(releaseType))
         }
     }
 
-    suspend fun deleteAllFirmwareReleases() = withContext(Dispatchers.IO) { firmwareReleaseDao.deleteAll() }
+    suspend fun deleteAllFirmwareReleases() = withContext(dispatchers.io) { firmwareReleaseDao.deleteAll() }
 
     suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? =
-        withContext(Dispatchers.IO) {
+        withContext(dispatchers.io) {
             val releases = firmwareReleaseDao.getReleasesByType(releaseType)
             if (releases.isEmpty()) {
                 return@withContext null

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/DeviceHardwareRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/DeviceHardwareRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,17 +14,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.data.repository
 
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.data.datasource.BootloaderOtaQuirksJsonDataSource
 import org.meshtastic.core.data.datasource.DeviceHardwareJsonDataSource
 import org.meshtastic.core.data.datasource.DeviceHardwareLocalDataSource
 import org.meshtastic.core.database.entity.DeviceHardwareEntity
 import org.meshtastic.core.database.entity.asExternalModel
+import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.BootloaderOtaQuirk
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.network.DeviceHardwareRemoteDataSource
@@ -41,6 +40,7 @@ constructor(
     private val localDataSource: DeviceHardwareLocalDataSource,
     private val jsonDataSource: DeviceHardwareJsonDataSource,
     private val bootloaderOtaQuirksJsonDataSource: BootloaderOtaQuirksJsonDataSource,
+    private val dispatchers: CoroutineDispatchers,
 ) {
 
     /**
@@ -58,7 +58,7 @@ constructor(
      */
     @Suppress("LongMethod")
     suspend fun getDeviceHardwareByModel(hwModel: Int, forceRefresh: Boolean = false): Result<DeviceHardware?> =
-        withContext(Dispatchers.IO) {
+        withContext(dispatchers.io) {
             Logger.d {
                 "DeviceHardwareRepository: getDeviceHardwareByModel(hwModel=$hwModel, forceRefresh=$forceRefresh)"
             }

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/LocationRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/LocationRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.data.repository
 
 import android.Manifest.permission.ACCESS_COARSE_LOCATION
@@ -28,13 +27,13 @@ import androidx.core.location.LocationManagerCompat
 import androidx.core.location.LocationRequestCompat
 import androidx.core.location.altitude.AltitudeConverterCompat
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import org.meshtastic.core.analytics.platform.PlatformAnalytics
+import org.meshtastic.core.di.CoroutineDispatchers
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -45,6 +44,7 @@ constructor(
     private val context: Application,
     private val locationManager: dagger.Lazy<LocationManager>,
     private val analytics: PlatformAnalytics,
+    private val dispatchers: CoroutineDispatchers,
 ) {
 
     /** Status of whether the app is actively subscribed to location changes. */
@@ -97,7 +97,7 @@ constructor(
                     this@requestLocationUpdates,
                     provider,
                     locationRequest,
-                    Dispatchers.IO.asExecutor(),
+                    dispatchers.io.asExecutor(),
                     locationListener,
                 )
             }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -49,6 +49,7 @@ configure<LibraryExtension> {
 }
 
 dependencies {
+    implementation(projects.core.di)
     implementation(projects.core.model)
     implementation(projects.core.proto)
     implementation(projects.core.strings)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,6 +48,7 @@ configure<LibraryExtension> {
 }
 
 dependencies {
+    implementation(projects.core.di)
     implementation(projects.core.model)
 
     implementation(libs.coil.network.core)

--- a/core/network/src/main/kotlin/org/meshtastic/core/network/DeviceHardwareRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/org/meshtastic/core/network/DeviceHardwareRemoteDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,16 +14,20 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.network
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.NetworkDeviceHardware
 import org.meshtastic.core.network.service.ApiService
 import javax.inject.Inject
 
-class DeviceHardwareRemoteDataSource @Inject constructor(private val apiService: ApiService) {
+class DeviceHardwareRemoteDataSource
+@Inject
+constructor(
+    private val apiService: ApiService,
+    private val dispatchers: CoroutineDispatchers,
+) {
     suspend fun getAllDeviceHardware(): List<NetworkDeviceHardware> =
-        withContext(Dispatchers.IO) { apiService.getDeviceHardware() }
+        withContext(dispatchers.io) { apiService.getDeviceHardware() }
 }

--- a/core/network/src/main/kotlin/org/meshtastic/core/network/FirmwareReleaseRemoteDataSource.kt
+++ b/core/network/src/main/kotlin/org/meshtastic/core/network/FirmwareReleaseRemoteDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,16 +14,20 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.network
 
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.NetworkFirmwareReleases
 import org.meshtastic.core.network.service.ApiService
 import javax.inject.Inject
 
-class FirmwareReleaseRemoteDataSource @Inject constructor(private val apiService: ApiService) {
+class FirmwareReleaseRemoteDataSource
+@Inject
+constructor(
+    private val apiService: ApiService,
+    private val dispatchers: CoroutineDispatchers,
+) {
     suspend fun getFirmwareReleases(): NetworkFirmwareReleases =
-        withContext(Dispatchers.IO) { apiService.getFirmwareReleases() }
+        withContext(dispatchers.io) { apiService.getFirmwareReleases() }
 }

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -1086,5 +1086,4 @@
     <string name="compass_uncertainty">Estimated area: \u00b1%1$s (\u00b1%2$s)</string>
     <string name="compass_uncertainty_unknown">Estimated area: unknown accuracy</string>
     <string name="mark_as_read">Mark as read</string>
-    <string name="now">now</string>
 </resources>

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/util/FormatAgo.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/util/FormatAgo.kt
@@ -17,24 +17,16 @@
 package org.meshtastic.core.ui.util
 
 import android.text.format.DateUtils
-import com.meshtastic.core.strings.getString
-import org.meshtastic.core.strings.Res
-import org.meshtastic.core.strings.now
 
 @Suppress("MagicNumber")
 fun formatAgo(lastSeenUnix: Int, currentTimeMillis: Long = System.currentTimeMillis()): String {
     val timeInMillis = lastSeenUnix * 1000L
-    val diff = currentTimeMillis - timeInMillis
 
-    return if (diff < 60_000L) {
-        getString(Res.string.now)
-    } else {
-        DateUtils.getRelativeTimeSpanString(
-            timeInMillis,
-            currentTimeMillis,
-            DateUtils.MINUTE_IN_MILLIS,
-            DateUtils.FORMAT_ABBREV_RELATIVE,
-        )
-            .toString()
-    }
+    return DateUtils.getRelativeTimeSpanString(
+        timeInMillis,
+        currentTimeMillis,
+        DateUtils.SECOND_IN_MILLIS,
+        DateUtils.FORMAT_ABBREV_RELATIVE,
+    )
+        .toString()
 }


### PR DESCRIPTION
This commit refactors the codebase to use an injected `CoroutineDispatchers` provider instead of hardcoding `Dispatchers.IO` or `Dispatchers.Default`. This improves testability by allowing dispatchers to be replaced with test dispatchers in unit tests.

It also removes a `runBlocking` call in `ContactsViewModel` for better performance and responsiveness. Additionally, `Thread.sleep` has been replaced with `delay` to make the function suspendable.

Key changes:
- Introduced `CoroutineDispatchers` dependency in various data sources, repositories, and services.
- Replaced direct calls to `Dispatchers.IO` and `Dispatchers.Default` with the injected `dispatchers` instance.
- Added the `core:di` module as a dependency to `core:database` and `core:network`.
- Removed `runBlocking` from `ContactsViewModel` when fetching message counts.
- Replaced `Thread.sleep` with `delay` in `ServiceClient`.
- Simplified the `formatAgo` utility to use `DateUtils.SECOND_IN_MILLIS` for more accurate relative time formatting, removing the special "now" case.

inspired by #4125 , but done with a bit more caution