### PR TITLE
fix(meshlog): Change default retention to 30 days

### DIFF
--- a/core/prefs/src/main/kotlin/org/meshtastic/core/prefs/meshlog/MeshLogPrefs.kt
+++ b/core/prefs/src/main/kotlin/org/meshtastic/core/prefs/meshlog/MeshLogPrefs.kt
@@ -29,7 +29,7 @@ interface MeshLogPrefs {
     companion object {
         const val RETENTION_DAYS_KEY = "meshlog_retention_days"
         const val LOGGING_ENABLED_KEY = "meshlog_logging_enabled"
-        const val DEFAULT_RETENTION_DAYS = 7
+        const val DEFAULT_RETENTION_DAYS = 30
         const val DEFAULT_LOGGING_ENABLED = true
         const val MIN_RETENTION_DAYS = -1 // -1 == keep last hour
         const val MAX_RETENTION_DAYS = 365

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -16,23 +16,6 @@
  */
 import com.android.build.api.dsl.LibraryExtension
 
-/*
- * Copyright (c) 2025 Meshtastic LLC
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 plugins {
     alias(libs.plugins.meshtastic.android.library)
     alias(libs.plugins.meshtastic.android.library.compose)

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/SettingsViewModel.kt
@@ -152,11 +152,17 @@ constructor(
         val clamped = days.coerceIn(MeshLogPrefs.MIN_RETENTION_DAYS, MeshLogPrefs.MAX_RETENTION_DAYS)
         meshLogPrefs.retentionDays = clamped
         _meshLogRetentionDays.value = clamped
+        viewModelScope.launch { meshLogRepository.deleteLogsOlderThan(clamped) }
     }
 
     fun setMeshLogLoggingEnabled(enabled: Boolean) {
         meshLogPrefs.loggingEnabled = enabled
         _meshLogLoggingEnabled.value = enabled
+        if (!enabled) {
+            viewModelScope.launch { meshLogRepository.deleteAll() }
+        } else {
+            viewModelScope.launch { meshLogRepository.deleteLogsOlderThan(meshLogPrefs.retentionDays) }
+        }
     }
 
     fun setProvideLocation(value: Boolean) {

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
@@ -252,6 +252,7 @@ constructor(
         val clamped = days.coerceIn(MeshLogPrefs.MIN_RETENTION_DAYS, MeshLogPrefs.MAX_RETENTION_DAYS)
         meshLogPrefs.retentionDays = clamped
         _retentionDays.value = clamped
+        viewModelScope.launch { meshLogRepository.deleteLogsOlderThan(clamped) }
     }
 
     fun setLoggingEnabled(enabled: Boolean) {
@@ -259,6 +260,8 @@ constructor(
         _loggingEnabled.value = enabled
         if (!enabled) {
             viewModelScope.launch { meshLogRepository.deleteAll() }
+        } else {
+            viewModelScope.launch { meshLogRepository.deleteLogsOlderThan(meshLogPrefs.retentionDays) }
         }
     }
 


### PR DESCRIPTION
Increases the default mesh log retention period from 7 to 30 days.

Refactors the mesh log cleanup logic:
- Removes the immediate, one-time cleanup worker previously triggered on app start.
- Triggers log cleanup directly when the user changes the retention period or disables logging in the settings, providing more immediate feedback.