### PR TITLE
refactor(messaging): Redesign message bubbles and reaction UI

### DIFF
--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageActions.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageActions.kt
@@ -22,7 +22,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Reply
-import androidx.compose.material.icons.filled.EmojiEmotions
+import androidx.compose.material.icons.filled.AddReaction
 import androidx.compose.material.icons.twotone.AddLink
 import androidx.compose.material.icons.twotone.Cloud
 import androidx.compose.material.icons.twotone.CloudDone
@@ -61,7 +61,7 @@ internal fun ReactionButton(onSendReaction: (String) -> Unit = {}) {
         )
     }
     IconButton(onClick = { showEmojiPickerDialog = true }) {
-        Icon(imageVector = Icons.Default.EmojiEmotions, contentDescription = stringResource(Res.string.react))
+        Icon(imageVector = Icons.Default.AddReaction, contentDescription = stringResource(Res.string.react))
     }
 }
 

--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageBubble.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageBubble.kt
@@ -39,9 +39,9 @@ internal fun getMessageBubbleShape(
         )
     } else {
         RoundedCornerShape(
-            topStart = if (hasSamePrev) square else round,
+            topStart = square,
             topEnd = if (hasSamePrev) square else round,
-            bottomStart = square,
+            bottomStart = if (hasSameNext) square else round,
             bottomEnd = if (hasSameNext) square else round,
         )
     }


### PR DESCRIPTION
This commit refactors the message item display for a cleaner and more intuitive user interface.

-   **Message Bubble Redesign:**
    -   The user's name is now displayed above the message bubble for incoming messages, rather than inside it.
    -   Padding and spacing have been adjusted for a less cluttered look. Local messages are indented further for clearer distinction.
    -   Text size for the message body has been increased (`bodyMedium` to `bodyLarge`).
    -   The layout of metadata (SNR, RSSI, timestamp, status icon) within the bubble has been streamlined.

-   **Reaction UI Improvements:**
    -   An "Add Reaction" button (`+` icon) is now persistently visible next to existing reactions, providing a clear entry point for adding new ones.
    -   The visual style of reaction items has been updated. They now use `SurfaceVariant` with a border instead of `PrimaryContainer`, and the count is displayed next to the emoji rather than as a badge.
    -   The "React" icon in the message action sheet has been changed from `EmojiEmotions` to the more specific `AddReaction`.

-   **Code & Layout Cleanup:**
    -   Reactions are now displayed below the message bubble using `AnimatedVisibility`, preventing them from overlapping with the bubble.
    -   The logic for determining message bubble corner rounding has been corrected to properly handle consecutive messages from the same sender.
<img width="200" alt="image" src="https://github.com/user-attachments/assets/c4d324b5-fd8e-4529-b364-93674a610c5b" />
