### PR TITLE
feat(connections): Improve connection screen UI and logic

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/network/NetworkRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/network/NetworkRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh.repository.network
 
 import android.net.ConnectivityManager
@@ -47,7 +46,8 @@ constructor(
         private const val SERVICE_TYPE = "_meshtastic._tcp"
 
         fun NsdServiceInfo.toAddressString() = buildString {
-            append(@Suppress("DEPRECATION") host.toString().substring(1))
+            @Suppress("DEPRECATION")
+            append(host.hostAddress)
             if (serviceType.trim('.') == SERVICE_TYPE && port != SERVICE_PORT) {
                 append(":$port")
             }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshConnectionManager.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshConnectionManager.kt
@@ -137,6 +137,7 @@ constructor(
         serviceBroadcasts.broadcastConnection()
         Logger.d { "Starting connect" }
         connectTimeMsec = System.currentTimeMillis()
+        scope.handledLaunch { nodeRepository.clearMyNodeInfo() }
         startConfigOnly()
     }
 
@@ -219,6 +220,7 @@ constructor(
         commandSender.sendAdmin(myNodeNum) {
             setTimeOnly = (System.currentTimeMillis() / MILLISECONDS_IN_SECOND).toInt()
         }
+        updateStatusNotification()
     }
 
     private fun reportConnection() {

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -160,6 +160,7 @@ class MeshService : Service() {
         }
         return if (!wantForeground) {
             ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+            stopSelf()
             START_NOT_STICKY
         } else {
             START_STICKY

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/ConnectingDeviceInfo.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/ConnectingDeviceInfo.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.geeksville.mesh.ui.connections.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.strings.Res
+import org.meshtastic.core.strings.connecting
+import org.meshtastic.core.strings.disconnect
+import org.meshtastic.core.ui.theme.StatusColors.StatusRed
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun ConnectingDeviceInfo(
+    deviceName: String,
+    deviceAddress: String,
+    onClickDisconnect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            CircularWavyProgressIndicator(modifier = Modifier.size(40.dp))
+
+            Column {
+                Text(text = deviceName, style = MaterialTheme.typography.titleMedium)
+                Text(text = deviceAddress, style = MaterialTheme.typography.bodySmall)
+                Text(text = stringResource(Res.string.connecting), style = MaterialTheme.typography.labelSmall)
+            }
+        }
+
+        Button(
+            shape = RectangleShape,
+            modifier = Modifier.fillMaxWidth().height(40.dp),
+            colors =
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.StatusRed,
+                contentColor = Color.White,
+            ),
+            onClick = onClickDisconnect,
+        ) {
+            Text(stringResource(Res.string.disconnect))
+        }
+    }
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/EmptyStateContent.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/EmptyStateContent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh.ui.connections.components
 
 import androidx.compose.foundation.layout.Arrangement
@@ -39,9 +38,14 @@ import androidx.compose.ui.unit.dp
 import org.meshtastic.core.ui.theme.AppTheme
 
 @Composable
-fun EmptyStateContent(imageVector: ImageVector? = null, text: String, actionButton: @Composable (() -> Unit)? = null) {
+fun EmptyStateContent(
+    text: String,
+    modifier: Modifier = Modifier,
+    imageVector: ImageVector? = null,
+    actionButton: @Composable (() -> Unit)? = null,
+) {
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -63,7 +67,7 @@ fun EmptyStateContent(imageVector: ImageVector? = null, text: String, actionButt
 fun EmptyStateContentPreview() {
     AppTheme {
         Surface {
-            EmptyStateContent(imageVector = Icons.Rounded.BluetoothDisabled, text = "No devices found") {
+            EmptyStateContent(text = "No devices found", imageVector = Icons.Rounded.BluetoothDisabled) {
                 Button(onClick = {}) { Text("Button") }
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/connections/components/NetworkDevices.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh.ui.connections.components
 
 import androidx.compose.foundation.layout.Arrangement
@@ -52,17 +51,17 @@ import androidx.compose.ui.unit.dp
 import com.geeksville.mesh.model.BTScanModel
 import com.geeksville.mesh.model.DeviceListEntry
 import com.geeksville.mesh.repository.network.NetworkRepository
-import com.geeksville.mesh.ui.connections.isIPAddress
+import com.geeksville.mesh.ui.connections.isValidAddress
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.service.ConnectionState
 import org.meshtastic.core.strings.Res
 import org.meshtastic.core.strings.add_network_device
+import org.meshtastic.core.strings.address
 import org.meshtastic.core.strings.cancel
 import org.meshtastic.core.strings.confirm_forget_connection
 import org.meshtastic.core.strings.discovered_network_devices
 import org.meshtastic.core.strings.forget_connection
-import org.meshtastic.core.strings.ip_address
 import org.meshtastic.core.strings.ip_port
 import org.meshtastic.core.strings.no_network_devices
 import org.meshtastic.core.strings.recent_network_devices
@@ -89,8 +88,8 @@ fun NetworkDevices(
         AddDeviceDialog(
             searchDialogState,
             onHideDialog = { showSearchDialog = false },
-            onClickAdd = { ipAddress, fullAddress ->
-                scanModel.onSelected(DeviceListEntry.Tcp(ipAddress, fullAddress))
+            onClickAdd = { address, fullAddress ->
+                scanModel.onSelected(DeviceListEntry.Tcp(address, fullAddress))
                 showSearchDialog = false
             },
         )
@@ -163,9 +162,9 @@ fun NetworkDevices(
 private fun AddDeviceDialog(
     sheetState: SheetState,
     onHideDialog: () -> Unit,
-    onClickAdd: (ipAddress: String, fullAddress: String) -> Unit,
+    onClickAdd: (address: String, fullAddress: String) -> Unit,
 ) {
-    val ipState = rememberTextFieldState("")
+    val addressState = rememberTextFieldState("")
     val portState = rememberTextFieldState(NetworkRepository.SERVICE_PORT.toString())
 
     val scope = rememberCoroutineScope()
@@ -175,11 +174,11 @@ private fun AddDeviceDialog(
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
-                    state = ipState,
+                    state = addressState,
                     labelPosition = TextFieldLabelPosition.Above(),
                     lineLimits = TextFieldLineLimits.SingleLine,
-                    label = { Text(stringResource(Res.string.ip_address)) },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal, imeAction = ImeAction.Next),
+                    label = { Text(stringResource(Res.string.address)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Next),
                     modifier = Modifier.weight(.7f),
                 )
 
@@ -202,18 +201,18 @@ private fun AddDeviceDialog(
                 Button(
                     modifier = Modifier.weight(1f),
                     onClick = {
-                        val ipAddress = ipState.text.toString()
-                        if (ipAddress.isIPAddress()) {
+                        val address = addressState.text.toString()
+                        if (address.isValidAddress()) {
                             val portString = portState.text.toString()
 
                             val combinedString =
                                 if (portString.isNotEmpty() && portString.toInt() != NetworkRepository.SERVICE_PORT) {
-                                    "$ipAddress:$portString"
+                                    "$address:$portString"
                                 } else {
-                                    ipAddress
+                                    address
                                 }
 
-                            onClickAdd(ipState.text.toString(), "t$combinedString")
+                            onClickAdd(addressState.text.toString(), "t$combinedString")
 
                             scope
                                 .launch { sheetState.hide() }

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/NodeInfoWriteDataSource.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/NodeInfoWriteDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.data.datasource
 
 import org.meshtastic.core.database.entity.MetadataEntity
@@ -27,6 +26,8 @@ interface NodeInfoWriteDataSource {
     suspend fun installConfig(mi: MyNodeEntity, nodes: List<NodeEntity>)
 
     suspend fun clearNodeDB(preserveFavorites: Boolean)
+
+    suspend fun clearMyNodeInfo()
 
     suspend fun deleteNode(num: Int)
 

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoWriteDataSource.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoWriteDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.data.datasource
 
 import kotlinx.coroutines.withContext
@@ -42,6 +41,9 @@ constructor(
 
     override suspend fun clearNodeDB(preserveFavorites: Boolean) =
         withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().clearNodeInfo(preserveFavorites) } }
+
+    override suspend fun clearMyNodeInfo() =
+        withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().clearMyNodeInfo() } }
 
     override suspend fun deleteNode(num: Int) =
         withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().deleteNode(num) } }

--- a/core/data/src/main/kotlin/org/meshtastic/core/data/repository/NodeRepository.kt
+++ b/core/data/src/main/kotlin/org/meshtastic/core/data/repository/NodeRepository.kt
@@ -150,6 +150,8 @@ constructor(
     suspend fun clearNodeDB(preserveFavorites: Boolean = false) =
         withContext(dispatchers.io) { nodeInfoWriteDataSource.clearNodeDB(preserveFavorites) }
 
+    suspend fun clearMyNodeInfo() = withContext(dispatchers.io) { nodeInfoWriteDataSource.clearMyNodeInfo() }
+
     suspend fun deleteNode(num: Int) = withContext(dispatchers.io) {
         nodeInfoWriteDataSource.deleteNode(num)
         nodeInfoWriteDataSource.deleteMetadata(num)

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -217,6 +217,7 @@
     <string name="ethernet_ip">Ethernet IP:</string>
     <string name="connecting">Connecting</string>
     <string name="not_connected">Not connected</string>
+    <string name="no_device_selected">No device selected</string>
     <string name="connected_sleeping">Connected to radio, but it is sleeping</string>
     <string name="app_too_old">Application update required</string>
     <string name="must_update">You must update this application on the app store (or Github). It is too old to talk to this radio firmware.  Please read our <a href="https://meshtastic.org/docs/software/android/installation">docs</a> on this topic.</string>


### PR DESCRIPTION
This commit introduces several enhancements to the connection screen's user interface and underlying logic for a smoother user experience.

Key changes include:
- A new "No device selected" empty state is displayed on the connection screen when no device is active.
- The screen now shows a dedicated "Connecting" state with device info while a connection is being established.
- MyNodeInfo is now cleared from the database upon initiating a new connection to prevent displaying stale information.
- The "Add network device" dialog now accepts both IP addresses and domain names.
- The `MeshService` is now properly stopped when it's no longer needed in the foreground.


https://github.com/user-attachments/assets/5c564f5a-43e5-4a7a-af24-12ce43e768c9

