### PR TITLE
feat: Localize traceroute strings

### DIFF
--- a/core/model/src/main/kotlin/org/meshtastic/core/model/RouteDiscovery.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/RouteDiscovery.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.model
 
 import org.jetbrains.compose.resources.StringResource
@@ -72,25 +71,36 @@ private fun formatTraceroutePath(nodesList: List<String>, snrList: List<Int>): S
         .joinToString("\n")
 }
 
-private fun RouteDiscovery.getTracerouteResponse(getUser: (nodeNum: Int) -> String): String = buildString {
+private fun RouteDiscovery.getTracerouteResponse(
+    getUser: (nodeNum: Int) -> String,
+    headerTowards: String = "Route traced toward destination:\n\n",
+    headerBack: String = "Route traced back to us:\n\n",
+): String = buildString {
     if (routeList.isNotEmpty()) {
-        append("Route traced toward destination:\n\n")
+        append(headerTowards)
         append(formatTraceroutePath(routeList.map(getUser), snrTowardsList))
     }
     if (routeBackList.isNotEmpty()) {
         append("\n\n")
-        append("Route traced back to us:\n\n")
+        append(headerBack)
         append(formatTraceroutePath(routeBackList.map(getUser), snrBackList))
     }
 }
 
-fun MeshProtos.MeshPacket.getTracerouteResponse(getUser: (nodeNum: Int) -> String): String? =
-    fullRouteDiscovery?.getTracerouteResponse(getUser)
+fun MeshProtos.MeshPacket.getTracerouteResponse(
+    getUser: (nodeNum: Int) -> String,
+    headerTowards: String = "Route traced toward destination:\n\n",
+    headerBack: String = "Route traced back to us:\n\n",
+): String? = fullRouteDiscovery?.getTracerouteResponse(getUser, headerTowards, headerBack)
 
 /** Returns a traceroute response string only when the result is complete (both directions). */
-fun MeshProtos.MeshPacket.getFullTracerouteResponse(getUser: (nodeNum: Int) -> String): String? = fullRouteDiscovery
+fun MeshProtos.MeshPacket.getFullTracerouteResponse(
+    getUser: (nodeNum: Int) -> String,
+    headerTowards: String = "Route traced toward destination:\n\n",
+    headerBack: String = "Route traced back to us:\n\n",
+): String? = fullRouteDiscovery
     ?.takeIf { it.routeList.isNotEmpty() && it.routeBackList.isNotEmpty() }
-    ?.getTracerouteResponse(getUser)
+    ?.getTracerouteResponse(getUser, headerTowards, headerBack)
 
 enum class TracerouteMapAvailability {
     Ok,

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -440,6 +440,10 @@
     <string name="view_on_map">View on map</string>
     <string name="traceroute_map_no_data">This traceroute does not have any mappable nodes yet.</string>
     <string name="traceroute_showing_nodes">Showing %1$d/%2$d nodes</string>
+    <string name="traceroute_duration">Duration: %1$s s</string>
+    <string name="traceroute_time_and_text">%1$s - %2$s</string>
+    <string name="traceroute_route_towards_dest">Route traced toward destination:\n\n</string>
+    <string name="traceroute_route_back_to_us">Route traced back to us:\n\n</string>
     <string name="twenty_four_hours">24H</string>
     <string name="forty_eight_hours">48H</string>
     <string name="one_week">1W</string>


### PR DESCRIPTION
Refactors traceroute functionality to use localized string resources instead of hardcoded English text.

This includes localizing:
- Route headers ("Route traced toward destination", "Route traced back to us")
- Duration display ("Duration: ...")
- Log entry format ("time - text")

resolves #4221 