### PR TITLE
ci: Add Gradle setup to scheduled updates workflow

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -78,6 +78,15 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          build-scan-publish: true
+          build-scan-terms-of-use-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-use-agree: 'yes'
+          add-job-summary: always
+
       - name: Update Graphs
         run: ./gradlew graphUpdate
         continue-on-error: true


### PR DESCRIPTION
This commit adds a Gradle setup step to the `scheduled-updates.yml` GitHub Actions workflow.

The new `Setup Gradle` step uses the `gradle/actions/setup-gradle@v5` action to configure Gradle, enabling build scan publishing and caching before the `graphUpdate` task is run.