### PR TITLE
ci(actions): Set up JDK 21 in scheduled-updates workflow

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -78,6 +78,14 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'jetbrains'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:


### PR DESCRIPTION
Uses `actions/setup-java@v5` to configure a Java 21 environment from the 'jetbrains' distribution.