### PR TITLE
ci: Run tests and generate coverage for all modules

### DIFF
--- a/.github/workflows/reusable-android-build.yml
+++ b/.github/workflows/reusable-android-build.yml
@@ -69,7 +69,35 @@ jobs:
           echo "datadogApplicationId=$DATADOG_APPLICATION_ID" >> ./secrets.properties
           echo "datadogClientToken=$DATADOG_CLIENT_TOKEN" >> ./secrets.properties
       - name: Run Spotless, Detekt, Build, Lint, and Local Tests
-        run: ./gradlew spotlessCheck detekt assembleDebug testDebugUnitTest koverXmlReport --configuration-cache --scan
+        run: |
+          ./gradlew spotlessCheck \
+            detekt \
+            assembleDebug \
+            :app:testDebugUnitTest \
+            :core:analytics:testDebugUnitTest \
+            :core:common:testDebugUnitTest \
+            :core:data:testDebugUnitTest \
+            :core:database:testDebugUnitTest \
+            :core:datastore:testDebugUnitTest \
+            :core:di:testDebugUnitTest \
+            :core:model:testDebugUnitTest \
+            :core:navigation:testDebugUnitTest \
+            :core:network:testDebugUnitTest \
+            :core:prefs:testDebugUnitTest \
+            :core:proto:testDebugUnitTest \
+            :core:service:testDebugUnitTest \
+            :core:strings:testDebugUnitTest \
+            :core:ui:testDebugUnitTest \
+            :feature:firmware:testDebugUnitTest \
+            :feature:intro:testDebugUnitTest \
+            :feature:map:testDebugUnitTest \
+            :feature:messaging:testDebugUnitTest \
+            :feature:node:testDebugUnitTest \
+            :feature:settings:testDebugUnitTest \
+            :mesh_service_example:testDebugUnitTest \
+            koverXmlReport \
+            --configuration-cache \
+            --scan
         env:
           VERSION_CODE: ${{ env.VERSION_CODE }}
 
@@ -78,7 +106,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: meshtastic/Meshtastic-Android
-          files: app/build/reports/kover/xml/report.xml
+          files: build/reports/kover/xml/report.xml
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/reusable-android-test.yml
+++ b/.github/workflows/reusable-android-test.yml
@@ -85,7 +85,18 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedDebugAndroidTest koverXmlReport --configuration-cache --scan && ( killall -INT crashpad_handler || true )
+          script: |
+            ./gradlew :app:connectedDebugAndroidTest \
+              :core:database:connectedDebugAndroidTest \
+              :core:model:connectedDebugAndroidTest \
+              :core:ui:connectedDebugAndroidTest \
+              :feature:messaging:connectedDebugAndroidTest \
+              :feature:node:connectedDebugAndroidTest \
+              :feature:settings:connectedDebugAndroidTest \
+              :mesh_service_example:connectedDebugAndroidTest \
+              koverXmlReport \
+              --configuration-cache \
+              --scan && ( killall -INT crashpad_handler || true )
 
       - name: Upload coverage reports to Codecov
         if: ${{ !cancelled() }}
@@ -93,7 +104,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: meshtastic/Meshtastic-Android
-          files: app/build/reports/kover/xml/report.xml
+          files: build/reports/kover/xml/report.xml
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -75,7 +75,7 @@ develocity {
         capture {
             fileFingerprints.set(true)
         }
-        publishing.onlyIf { false }
+        publishing.onlyIf { System.getenv("CI") != null }
     }
     buildCache {
         local {


### PR DESCRIPTION
Expands the Gradle commands in the reusable Android build and test workflows to explicitly run unit tests, instrumented tests, and generate Kover reports for every module in the project.

This ensures that test and coverage metrics are comprehensive across the entire codebase.

Additionally, this change enables Gradle build scan publishing only within a CI environment.