### PR TITLE
refactor(messaging): Use dialog for emoji picker and rename state

### DIFF
--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/emoji/EmojiPicker.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/emoji/EmojiPicker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,15 +14,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.ui.emoji
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -31,18 +30,21 @@ import androidx.emoji2.emojipicker.RecentEmojiProviderAdapter
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.meshtastic.core.ui.component.BottomSheetDialog
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EmojiPicker(
+    modifier: Modifier = Modifier,
     viewModel: EmojiPickerViewModel = hiltViewModel(),
     onDismiss: () -> Unit = {},
     onConfirm: (String) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.Bottom) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.Bottom) {
         BackHandler { onDismiss() }
         AndroidView(
             factory = { context ->
                 androidx.emoji2.emojipicker.EmojiPickerView(context).apply {
                     clipToOutline = true
+                    isNestedScrollingEnabled = true
                     setRecentEmojiProvider(
                         RecentEmojiProviderAdapter(
                             CustomRecentEmojiProvider(viewModel.customEmojiFrequency) { updatedValue ->
@@ -56,13 +58,13 @@ fun EmojiPicker(
                     }
                 }
             },
+            update = { view -> view.isNestedScrollingEnabled = true },
             modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.background),
         )
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EmojiPickerDialog(onDismiss: () -> Unit = {}, onConfirm: (String) -> Unit) =
-    BottomSheetDialog(onDismiss = onDismiss, modifier = Modifier.fillMaxHeight(fraction = .4f)) {
-        EmojiPicker(onConfirm = onConfirm, onDismiss = onDismiss)
-    }
+    BottomSheetDialog(onDismiss = onDismiss) { EmojiPicker(onConfirm = onConfirm, onDismiss = onDismiss) }


### PR DESCRIPTION
This commit refactors how the emoji picker is displayed and clarifies the state management for message item overlays.

- The `EmojiPicker` is now presented inside a dedicated `EmojiPickerDialog` instead of being a state within the `MessageItem`'s `ModalBottomSheet`.
- The `ActiveSheet` enum, which managed the bottom sheet's content, has been renamed to `ActiveOverlay` for better clarity, as it now controls both the modal sheet and the new emoji dialog.
- The `EmojiPicker` itself now supports nested scrolling.
- Removed the fixed height constraint on the emoji picker, allowing the `BottomSheetDialog` to manage its size.