### PR TITLE
refactor(ui): Improve EmojiPicker layout constraints

### DIFF
--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/emoji/EmojiPicker.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/emoji/EmojiPicker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,16 +14,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.ui.emoji
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
@@ -37,28 +35,26 @@ fun EmojiPicker(
     onDismiss: () -> Unit = {},
     onConfirm: (String) -> Unit,
 ) {
-    Column(verticalArrangement = Arrangement.Bottom) {
-        BackHandler { onDismiss() }
-        AndroidView(
-            factory = { context ->
-                androidx.emoji2.emojipicker.EmojiPickerView(context).apply {
-                    clipToOutline = true
-                    setRecentEmojiProvider(
-                        RecentEmojiProviderAdapter(
-                            CustomRecentEmojiProvider(viewModel.customEmojiFrequency) { updatedValue ->
-                                viewModel.customEmojiFrequency = updatedValue
-                            },
-                        ),
-                    )
-                    setOnEmojiPickedListener { emoji ->
-                        onDismiss()
-                        onConfirm(emoji.emoji)
-                    }
+    BackHandler { onDismiss() }
+    AndroidView(
+        factory = { context ->
+            androidx.emoji2.emojipicker.EmojiPickerView(context).apply {
+                clipToOutline = true
+                setRecentEmojiProvider(
+                    RecentEmojiProviderAdapter(
+                        CustomRecentEmojiProvider(viewModel.customEmojiFrequency) { updatedValue ->
+                            viewModel.customEmojiFrequency = updatedValue
+                        },
+                    ),
+                )
+                setOnEmojiPickedListener { emoji ->
+                    onDismiss()
+                    onConfirm(emoji.emoji)
                 }
-            },
-            modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.background),
-        )
-    }
+            }
+        },
+        modifier = Modifier.fillMaxWidth().wrapContentHeight().verticalScroll(rememberScrollState()),
+    )
 }
 
 @Composable

--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
@@ -22,12 +22,10 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -159,15 +157,13 @@ internal fun MessageItem(
 
                 ActiveSheet.Emoji -> {
                     // Limit height of emoji picker so it doesn't look weird full screen
-                    Box(modifier = Modifier.heightIn(max = 400.dp)) {
-                        EmojiPicker(
-                            onDismiss = { activeSheet = null },
-                            onConfirm = { emoji ->
-                                activeSheet = null
-                                sendReaction(emoji)
-                            },
-                        )
-                    }
+                    EmojiPicker(
+                        onDismiss = { activeSheet = null },
+                        onConfirm = { emoji ->
+                            activeSheet = null
+                            sendReaction(emoji)
+                        },
+                    )
                 }
 
                 null -> {}


### PR DESCRIPTION
This commit removes the fixed maximum height from the `EmojiPicker` in the messaging screen, allowing it to better adapt to different screen sizes.

The `EmojiPickerView` is now wrapped in a `verticalScroll` modifier and its height is set to `wrapContentHeight`. This prevents the picker from taking up the full screen height on larger devices while still allowing it to scroll if its content exceeds the available space. The redundant `Box` wrapper in `MessageItem.kt` has been removed.
