### PR TITLE
refactor: Use device address to manage service lifecycle

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -134,7 +134,7 @@ class MeshService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        val a = radioInterfaceService.getBondedDeviceAddress()
+        val a = radioInterfaceService.getDeviceAddress()
         val wantForeground = a != null && a != NO_DEVICE_SELECTED
 
         val notification = connectionManager.updateStatusNotification()
@@ -159,12 +159,18 @@ class MeshService : Service() {
             return START_NOT_STICKY
         }
         return if (!wantForeground) {
+            Logger.i { "Stopping mesh service because no device is selected" }
             ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
             stopSelf()
             START_NOT_STICKY
         } else {
             START_STICKY
         }
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        Logger.i { "Mesh service: onTaskRemoved" }
     }
 
     override fun onBind(intent: Intent?): IBinder = binder


### PR DESCRIPTION
This commit updates `MeshService` to use the current device address (`getDeviceAddress`) instead of the bonded device address (`getBondedDeviceAddress`) to determine if it should run in the foreground.

This ensures the service correctly stops itself when no device is actively selected, improving lifecycle management. Logging has also been added to clarify when the service is stopped for this reason and to note when the task is removed.