### PR TITLE
fix(node): Correct owner ID and local user detection

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/repository/radio/NordicBleInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/NordicBleInterface.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh.repository.radio
 
 import android.annotation.SuppressLint
@@ -399,6 +398,10 @@ constructor(
                 }
             }
         } ?: Logger.w { "[$address] toRadio characteristic unavailable, can't send data" }
+    }
+
+    override fun keepAlive() {
+        Logger.d { "[$address] BLE keepAlive" }
     }
 
     /** Closes the connection to the device. */

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/SerialInterface.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/SerialInterface.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package com.geeksville.mesh.repository.radio
 
 import co.touchlab.kermit.Logger
@@ -113,6 +112,10 @@ constructor(
                     conn.connect()
                 }
         }
+    }
+
+    override fun keepAlive() {
+        Logger.d { "[$address] Serial keepAlive" }
     }
 
     override fun sendBytes(p: ByteArray) {

--- a/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/MapView.kt
+++ b/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/MapView.kt
@@ -178,22 +178,6 @@ private fun MapView.updateMarkers(
     nodeClusterer.invalidate()
 }
 
-//    private fun addWeatherLayer() {
-//        if (map.tileProvider.tileSource.name()
-//                .equals(CustomTileSource.getTileSource("ESRI World TOPO").name())
-//        ) {
-//            val layer = TilesOverlay(
-//                MapTileProviderBasic(
-//                    activity,
-//                    CustomTileSource.OPENWEATHER_RADAR
-//                ), context
-//            )
-//            layer.loadingBackgroundColor = Color.TRANSPARENT
-//            layer.loadingLineColor = Color.TRANSPARENT
-//            map.overlayManager.add(layer)
-//        }
-//    }
-
 private fun cacheManagerCallback(onTaskComplete: () -> Unit, onTaskFailed: (Int) -> Unit) =
     object : CacheManager.CacheManagerCallback {
         override fun onTaskComplete() {
@@ -225,7 +209,7 @@ private fun cacheManagerCallback(onTaskComplete: () -> Unit, onTaskFailed: (Int)
  * @param navigateToNodeDetails Callback to navigate to the details screen of a selected node.
  */
 @OptIn(ExperimentalPermissionsApi::class) // Added for Accompanist
-@Suppress("CyclomaticComplexMethod", "LongMethod")
+@Suppress("CyclomaticComplexMethod", "LongParameterList", "LongMethod")
 @Composable
 fun MapView(
     mapViewModel: MapViewModel = hiltViewModel(),
@@ -336,6 +320,7 @@ fun MapView(
     val nodes by mapViewModel.nodes.collectAsStateWithLifecycle()
     val waypoints by mapViewModel.waypoints.collectAsStateWithLifecycle(emptyMap())
     val selectedWaypointId by mapViewModel.selectedWaypointId.collectAsStateWithLifecycle()
+    val myId by mapViewModel.myId.collectAsStateWithLifecycle()
 
     LaunchedEffect(selectedWaypointId, waypoints) {
         if (selectedWaypointId != null && waypoints.containsKey(selectedWaypointId)) {
@@ -506,7 +491,7 @@ fun MapView(
         }
     }
 
-    fun getUsername(id: String?) = if (id == DataPacket.ID_LOCAL) {
+    fun getUsername(id: String?) = if (id == DataPacket.ID_LOCAL || (myId != null && id == myId)) {
         com.meshtastic.core.strings.getString(Res.string.you)
     } else {
         mapViewModel.getUser(id).longName

--- a/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/MapViewModel.kt
+++ b/feature/map/src/fdroid/kotlin/org/meshtastic/feature/map/MapViewModel.kt
@@ -65,5 +65,5 @@ constructor(
 
     val applicationId = buildConfigProvider.applicationId
 
-    fun getUser(userId: String?) = nodeRepository.getUser(userId ?: DataPacket.ID_BROADCAST)
+    override fun getUser(userId: String?) = nodeRepository.getUser(userId ?: DataPacket.ID_BROADCAST)
 }

--- a/feature/map/src/main/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
+++ b/feature/map/src/main/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.feature.map
 
 import android.os.RemoteException
@@ -79,6 +78,8 @@ abstract class BaseMapViewModel(
     val myNodeNum
         get() = myNodeInfo.value?.myNodeNum
 
+    val myId = nodeRepository.myId
+
     val nodes: StateFlow<List<Node>> =
         nodeRepository
             .getNodes()
@@ -120,6 +121,8 @@ abstract class BaseMapViewModel(
     val ourNodeInfo: StateFlow<Node?> = nodeRepository.ourNodeInfo
 
     fun getNodeByNum(nodeNum: Int): Node? = nodeRepository.nodeDBbyNum.value[nodeNum]
+
+    open fun getUser(userId: String?): MeshProtos.User = nodeRepository.getUser(userId ?: DataPacket.ID_BROADCAST)
 
     fun getUser(nodeNum: Int): MeshProtos.User = nodeRepository.getUser(nodeNum)
 

--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -495,7 +495,7 @@ private fun BoxScope.ScrollToBottomFab(coroutineScope: CoroutineScope, listState
 private fun ReplySnippet(originalMessage: Message?, onClearReply: () -> Unit, ourNode: Node?) {
     AnimatedVisibility(visible = originalMessage != null) {
         originalMessage?.let { message ->
-            val isFromLocalUser = message.node.user.id == DataPacket.ID_LOCAL
+            val isFromLocalUser = message.fromLocal
             val replyingToNodeUser = if (isFromLocalUser) ourNode?.user else message.node.user
             val unknownUserText = stringResource(Res.string.unknown)
 


### PR DESCRIPTION
This commit introduces several fixes to improve node and user identification, particularly for the local user, and enhances connection stability.

### Key Changes:
- **Correct Owner ID:** In `RadioConfigViewModel`, the `setOwner` function now ensures the correct user ID is used when setting a remote node's owner. It prevents accidentally using the local user's ID by validating it against the target node's existing user ID.
- **Improved Local User Detection:** The definition of a "local user" has been expanded. Previously, it was only checked against `DataPacket.ID_LOCAL`. Now, it also correctly compares against `myId` from `NodeRepository`. This fixes issues in `ContactsViewModel` and `MapView` where messages and map markers from the local user on other devices were not identified as "You".
- **Connection Keep-Alive:** A `keepAlive()` method has been added to the `RadioInterface` and implemented for `TCPInterface`, `SerialInterface`, and `NordicBleInterface`. A periodic heartbeat is now sent every 15 seconds from `RadioInterfaceService` for all connection types to prevent timeouts and maintain stable connections. The TCP implementation now sends an explicit `Heartbeat` packet.
- **Thread-Safe Stream Writes:** `StreamInterface` now uses a `Mutex` to protect write operations (`sendBytes`, `flushBytes`), preventing potential race conditions and data corruption when sending data over Serial or TCP connections.
- **Refactored State Updates:**
    - `NodeRepository` now uses `combine` to derive `ourNodeInfo` and `myId`, ensuring these values are always in sync with the underlying node database and connection state.
    - `ContactsViewModel` and `RadioConfigViewModel` have been refactored to use intermediate data classes or local variables for cleaner state management within `combine` blocks.
