### PR TITLE
Fixing the translation of "Radio Configuration" for German

### DIFF
--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -322,7 +322,7 @@
     <string name="map_start_download">Herunterladen starten</string>
     <string name="exchange_position">Standort austauschen</string>
     <string name="close">Schließen</string>
-    <string name="radio_configuration">Geräteeinstellungen</string>
+    <string name="radio_configuration">Radioeinstellungen</string>
     <string name="module_settings">Moduleinstellungen</string>
     <string name="add">Hinzufügen</string>
     <string name="edit">Bearbeiten</string>


### PR DESCRIPTION
Before this change, it was "Geräteeinstellungen", which means "Device Settings". This translation was already being used for the actual Device Settings, which led to confusion.

Fixes #4257