### PR TITLE
Display traceroutes with 0 hops

### DIFF
--- a/core/model/src/main/kotlin/org/meshtastic/core/model/RouteDiscovery.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/RouteDiscovery.kt
@@ -39,7 +39,9 @@ val MeshProtos.MeshPacket.fullRouteDiscovery: RouteDiscovery?
 
                         val fullRouteBack = listOf(sourceId) + routeBackList + destinationId
                         clearRouteBack()
-                        if (hopStart > 0 && snrBackCount > 0) { // otherwise back route is invalid
+                        // hopStart was not populated prior to 2.3.0. The bitfield was added in 2.5.0 and
+                        // is used to detect versions where hopStart can be trusted to have been set.
+                        if ((hopStart > 0 || hasBitfield()) && snrBackCount > 0) { // otherwise back route is invalid
                             addAllRouteBack(fullRouteBack)
                         }
                     }


### PR DESCRIPTION
This is a follow-up to #4101. The traceroute dialog does not display when packets use 0 hops. This PR corrects this for nodes running recent firmware versions.

I suspect the original logic is due to nodes with older version 2.3.0 not supporting hopStart when they transmit messages. The bitfield was added in firmware version 2.5.0, and we can use its presence to determine if a node has a firmware version where hopStart is populated, even when it may be 0.