### PR TITLE
fix(ui): Hide battery icon when no power data is available

### DIFF
--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/NodeItem.kt
@@ -153,11 +153,13 @@ fun NodeItem(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                MaterialBatteryInfo(
-                    level = thatNode.batteryLevel,
-                    voltage = thatNode.voltage,
-                    contentColor = contentColor,
-                )
+                if (thatNode.batteryLevel > 0 || thatNode.voltage > 0f) {
+                    MaterialBatteryInfo(
+                        level = thatNode.batteryLevel,
+                        voltage = thatNode.voltage,
+                        contentColor = contentColor,
+                    )
+                }
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
The battery info view (`MaterialBatteryInfo`) is now conditionally rendered in the `NodeItem`. It will only be displayed if either the battery level is greater than 0 or the voltage is greater than 0, preventing the display of an empty/zero-value battery icon when a node has no power source information.
