### PR TITLE
chore(build): Enable and configure Compose Compiler reports

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     `kotlin-dsl`
-    alias(libs.plugins.android.lint)
     alias(libs.plugins.spotless)
     alias(libs.plugins.detekt)
 }

--- a/build-logic/convention/src/main/kotlin/KmpLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpLibraryComposeConventionPlugin.kt
@@ -21,14 +21,15 @@ import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.compose.ComposeExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.meshtastic.buildlogic.configureComposeCompiler
 import org.meshtastic.buildlogic.libs
 import org.meshtastic.buildlogic.plugin
 
 class KmpLibraryComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            apply(plugin = libs.plugin("compose-multiplatform").get().pluginId)
             apply(plugin = libs.plugin("compose-compiler").get().pluginId)
+            apply(plugin = libs.plugin("compose-multiplatform").get().pluginId)
 
             val compose = extensions.getByType(ComposeExtension::class.java)
             extensions.configure<KotlinMultiplatformExtension> {
@@ -38,6 +39,7 @@ class KmpLibraryComposeConventionPlugin : Plugin<Project> {
                     api(compose.dependencies.components.resources)
                 }
             }
+            configureComposeCompiler()
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -21,10 +21,7 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Project
-import org.gradle.api.provider.Provider
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
-import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 
 /**
  * Configure Compose-specific options
@@ -43,28 +40,9 @@ internal fun Project.configureAndroidCompose(
         "implementation"(libs.library("androidx-compose-runtime"))
         "runtimeOnly"(libs.library("androidx-compose-runtime-tracing"))
         "debugImplementation"(libs.library("androidx-compose-ui-tooling"))
-        
+
         // Add Espresso explicitly to avoid version mismatch issues on newer Android versions
         "androidTestImplementation"(libs.library("androidx-test-espresso-core"))
     }
-
-    extensions.configure<ComposeCompilerGradlePluginExtension> {
-        fun Provider<String>.onlyIfTrue() = flatMap { provider { it.takeIf(String::toBoolean) } }
-        fun Provider<*>.relativeToRootProject(dir: String) = map {
-            isolated.rootProject.projectDirectory
-                .dir("build")
-                .dir(projectDir.toRelativeString(rootDir))
-        }.map { it.dir(dir) }
-
-        project.providers.gradleProperty("enableComposeCompilerMetrics").onlyIfTrue()
-            .relativeToRootProject("compose-metrics")
-            .let(metricsDestination::set)
-
-        project.providers.gradleProperty("enableComposeCompilerReports").onlyIfTrue()
-            .relativeToRootProject("compose-reports")
-            .let(reportsDestination::set)
-
-        stabilityConfigurationFiles
-            .add(isolated.rootProject.projectDirectory.file("compose_compiler_config.conf"))
-    }
+    configureComposeCompiler()
 }

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/ComposeCompilerConfiguration.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/ComposeCompilerConfiguration.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.meshtastic.buildlogic
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
+
+internal fun Project.configureComposeCompiler() {
+    extensions.configure<ComposeCompilerGradlePluginExtension> {
+        fun Provider<String>.onlyIfTrue() =
+            flatMap { provider { it.takeIf(String::toBoolean) } }
+
+        fun Provider<*>.relativeToRootProject(dir: String) = map {
+            isolated.rootProject.projectDirectory
+                .dir("build")
+                .dir(projectDir.toRelativeString(rootDir))
+        }.map { it.dir(dir) }
+        project.providers.gradleProperty("enableComposeCompilerMetrics").onlyIfTrue()
+            .relativeToRootProject("compose-metrics").let(metricsDestination::set)
+        project.providers.gradleProperty("enableComposeCompilerReports").onlyIfTrue()
+            .relativeToRootProject("compose-reports").let(reportsDestination::set)
+        stabilityConfigurationFiles.add(
+            isolated.rootProject.projectDirectory.file("compose_compiler_config.conf"),
+        )
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -63,4 +63,8 @@ dependency.analysis.print.build.health=true
 ksp.incremental=true
 ksp.incremental.classpath=true
 
+# Compose Compiler Reports
+enableComposeCompilerMetrics=true
+enableComposeCompilerReports=true
+
 android.newDsl=false

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -9,5 +9,4 @@ toolchainUrl.UNIX.AARCH64=https\://api.foojay.io/disco/v3.0/ids/ff1d4fc92bcfc9d3
 toolchainUrl.UNIX.X86_64=https\://api.foojay.io/disco/v3.0/ids/08ce182188ada0b93565cd9ca4a4ab32/redirect
 toolchainUrl.WINDOWS.AARCH64=https\://api.foojay.io/disco/v3.0/ids/3dc48436acf46a9c2958682158988183/redirect
 toolchainUrl.WINDOWS.X86_64=https\://api.foojay.io/disco/v3.0/ids/d935bdb25150f4573137eb8176e8b4ec/redirect
-toolchainVendor=JETBRAINS
 toolchainVersion=21


### PR DESCRIPTION
This commit enables and configures Compose Compiler metrics and reports to help analyze and debug composition performance. The configuration logic is centralized into a new `configureComposeCompiler` extension function.

### Key Changes:

-   **Enable Reports:** Set `enableComposeCompilerMetrics` and `enableComposeCompilerReports` to `true` in `gradle.properties`.
-   **Centralized Configuration:**
    -   A new file, `ComposeCompilerConfiguration.kt`, is introduced, containing an internal `configureComposeCompiler` extension function.
    -   This function reads the new properties and sets the output directories for metrics and reports relative to each project's build folder.
    -   It also configures the stability configuration file (`compose_compiler_config.conf`).
-   **Build Logic Refactoring:**
    -   The `AndroidCompose.kt` and `KmpLibraryComposeConventionPlugin.kt` files are updated to call the new `configureComposeCompiler` function, removing duplicated configuration code.
-   **Dependency Cleanup:**
    -   Removed `toolchainVendor=JETBRAINS` from `gradle/gradle-daemon-jvm.properties` as it is redundant.
    -   Removed an unused `android.lint` plugin from `build-logic/convention/build.gradle.kts`.

as suggested in #4286 - but done with a bit more care.