### PR TITLE
feat(service): Introduce fallback worker to ensure service stays alive

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
     <!-- Needed to open our bluetooth connection to our paired device (after reboot) -->
@@ -124,7 +125,7 @@
         <service
             android:name="com.geeksville.mesh.service.MeshService"
             android:enabled="true"
-            android:foregroundServiceType="connectedDevice|location"
+            android:foregroundServiceType="connectedDevice|location|dataSync"
             android:exported="true" tools:ignore="ExportedActivity">
             <intent-filter>
                 <action android:name="com.geeksville.mesh.Service" />

--- a/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/radio/RadioInterfaceService.kt
@@ -257,7 +257,8 @@ constructor(
     /** Start our configured interface (if it isn't already running) */
     private fun startInterface() {
         if (radioIf !is NopInterface) {
-            Logger.w { "Can't start interface - $radioIf is already running" }
+            // Already running
+            return
         } else {
             val address = getBondedDeviceAddress()
             if (address == null) {

--- a/app/src/main/java/com/geeksville/mesh/worker/ServiceKeepAliveWorker.kt
+++ b/app/src/main/java/com/geeksville/mesh/worker/ServiceKeepAliveWorker.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025-2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.geeksville.mesh.worker
+
+import android.app.Notification
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import co.touchlab.kermit.Logger
+import com.geeksville.mesh.R
+import com.geeksville.mesh.service.MeshService
+import com.geeksville.mesh.service.startService
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import org.meshtastic.core.service.MeshServiceNotifications
+import org.meshtastic.core.service.SERVICE_NOTIFY_ID
+
+/**
+ * A worker whose sole purpose is to start the MeshService from the background. This is used as a fallback when
+ * `startForegroundService` is blocked by Android 14+ restrictions. It runs as an Expedited worker to gain temporary
+ * foreground start privileges.
+ */
+@HiltWorker
+class ServiceKeepAliveWorker
+@AssistedInject
+constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val serviceNotifications: MeshServiceNotifications,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun getForegroundInfo(): ForegroundInfo {
+        // We use the same notification channel as the main service notification
+        // to minimize user disruption.
+        // On Android 12+, we need to provide a foreground info for expedited work.
+        val notification = createNotification()
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                SERVICE_NOTIFY_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+            )
+        } else {
+            ForegroundInfo(SERVICE_NOTIFY_ID, notification)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun doWork(): Result {
+        Logger.i { "ServiceKeepAliveWorker: Attempting to start MeshService" }
+        return try {
+            MeshService.startService(applicationContext)
+            Result.success()
+        } catch (e: Exception) {
+            Logger.e(e) { "ServiceKeepAliveWorker failed to start service" }
+            Result.failure()
+        }
+    }
+
+    private fun createNotification(): Notification {
+        // We ensure channels are created
+        serviceNotifications.initChannels()
+
+        // We create a generic "Resuming" notification.
+        // We use "my_service" which matches NotificationType.ServiceState.channelId in MeshServiceNotificationsImpl
+
+        return NotificationCompat.Builder(applicationContext, "my_service")
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("Resuming Mesh Service")
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .build()
+    }
+}

--- a/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/LocalConfigDataSource.kt
+++ b/core/datastore/src/main/kotlin/org/meshtastic/core/datastore/LocalConfigDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.meshtastic.core.datastore
 
 import androidx.datastore.core.DataStore
@@ -53,7 +52,8 @@ class LocalConfigDataSource @Inject constructor(private val localConfigStore: Da
             if (localField != null) {
                 builder.setField(localField, value)
             } else {
-                Logger.e { "Error writing LocalConfig settings: ${config.payloadVariantCase}" }
+                // Some fields like SESSIONKEY are not intended to be persisted in LocalConfig
+                Logger.d { "Skipping non-persistent LocalConfig field: ${field.name}" }
             }
         }
         builder.build()


### PR DESCRIPTION
This commit introduces `ServiceKeepAliveWorker`, an expedited `CoroutineWorker`, to ensure the `MeshService` can be reliably started from the background. This worker acts as a fallback mechanism for Android 14+ devices, which may block `startForegroundService` calls due to new restrictions.

When a foreground service start is denied, the app now schedules this one-time expedited worker. The worker has temporary permission to start a foreground service, ensuring the `MeshService` is launched successfully.

### Key Changes:

-   **`ServiceKeepAliveWorker`:**
    -   A new `HiltWorker` that runs as an expedited task to start `MeshService`.
    -   Displays a temporary "Resuming Mesh Service" notification while active, as required for expedited workers on newer Android versions.

-   **`MeshServiceStarter.kt`:**
    -   When `context.startForegroundService()` fails with `ForegroundServiceStartNotAllowedException`, it now logs a warning and schedules the `ServiceKeepAliveWorker` as a fallback.

-   **`AndroidManifest.xml` & `MeshService.kt`:**
    -   Added `FOREGROUND_SERVICE_DATA_SYNC` permission and service type to comply with foreground service requirements and align with the worker's function.

-   **Crashlytics Logging (`GooglePlatformAnalytics.kt`):**
    -   Improved Crashlytics logging to filter out `CancellationException` and only report genuine errors or exceptions, reducing noise from standard coroutine behavior.
    -   Non-fatal exceptions are now only recorded for log severities of `Error` or higher, unless an explicit `Throwable` is provided.
