### PR TITLE
fix(ui): Prevent NaN values in environment metrics

### DIFF
--- a/core/model/src/main/kotlin/org/meshtastic/core/model/util/UnitConversions.kt
+++ b/core/model/src/main/kotlin/org/meshtastic/core/model/util/UnitConversions.kt
@@ -26,6 +26,8 @@ object UnitConversions {
 
     /** Formats temperature as a string with the unit suffix. */
     fun Float.toTempString(isFahrenheit: Boolean): String {
+        if (this.isNaN()) return "--"
+
         val temp = if (isFahrenheit) celsiusToFahrenheit(this) else this
         val unit = if (isFahrenheit) "F" else "C"
 

--- a/core/model/src/test/kotlin/org/meshtastic/core/model/util/UnitConversionsTest.kt
+++ b/core/model/src/test/kotlin/org/meshtastic/core/model/util/UnitConversionsTest.kt
@@ -78,6 +78,12 @@ class UnitConversionsTest {
     }
 
     @Test
+    fun `toTempString handles NaN`() {
+        assertEquals("--", Float.NaN.toTempString(false))
+        assertEquals("--", Float.NaN.toTempString(true))
+    }
+
+    @Test
     fun `celsiusToFahrenheit converts correctly`() {
         mapOf(
             0.0f to 32.0f,

--- a/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/EnvironmentMetrics.kt
+++ b/feature/node/src/main/kotlin/org/meshtastic/feature/node/component/EnvironmentMetrics.kt
@@ -145,15 +145,17 @@ internal fun EnvironmentMetrics(
                     }
                     if (hasTemperature() && hasRelativeHumidity()) {
                         val dewPoint = UnitConversions.calculateDewPoint(temperature, relativeHumidity)
-                        add(
-                            DrawableMetricInfo(
-                                Res.string.dew_point,
-                                dewPoint.toTempString(isFahrenheit),
-                                org.meshtastic.feature.node.R.drawable.ic_outlined_dew_point_24,
-                            ),
-                        )
+                        if (!dewPoint.isNaN()) {
+                            add(
+                                DrawableMetricInfo(
+                                    Res.string.dew_point,
+                                    dewPoint.toTempString(isFahrenheit),
+                                    org.meshtastic.feature.node.R.drawable.ic_outlined_dew_point_24,
+                                ),
+                            )
+                        }
                     }
-                    if (hasSoilTemperature()) {
+                    if (hasSoilTemperature() && !soilTemperature.isNaN()) {
                         add(
                             DrawableMetricInfo(
                                 Res.string.soil_temperature,


### PR DESCRIPTION
This commit prevents `NaN` (Not a Number) values from being displayed for dew point and soil temperature in the environment metrics UI.

It introduces checks to ensure that `NaN` values, which can occur during sensor readings or calculations, are handled gracefully and not passed to the UI layer.

### Key Changes:

- **`EnvironmentMetrics.kt`**:
  - Added a check to only display the dew point metric if the calculated value is not `NaN`.
  - Added a `!soilTemperature.isNaN()` check before displaying the soil temperature metric.
- **`UnitConversions.kt`**:
  - The `toTempString` extension function now returns `"--"` if the float value is `NaN`, providing a fallback display string.
- **`UnitConversionsTest.kt`**:
  - Added a new unit test to verify that `toTempString` correctly handles `NaN` inputs.
