### PR TITLE
ci(release): Ensure artifacts are always uploaded and attested

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
         run: bundle exec fastlane internal
 
       - name: Upload Google AAB artifact
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: google-aab
@@ -154,6 +155,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Google APK artifact
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: google-apk
@@ -161,6 +163,7 @@ jobs:
           retention-days: 1
 
       - name: Attest Google artifacts provenance
+        if: always()
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: |


### PR DESCRIPTION
This commit updates the `release.yml` workflow to ensure that build artifacts (AAB and APK) are always uploaded and that their provenance is always attested, even if previous steps in the job have failed.

By adding `if: always()` to the `upload-artifact` and `attest-build-provenance` steps, we prevent a failure in the `fastlane internal` step from skipping the crucial artifact archiving and attestation process. This guarantees that build outputs are available for inspection and verification regardless of the job's overall success.
