### PR TITLE
fix(notifications): Suppress notifications for muted contacts an…

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshDataHandler.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshDataHandler.kt
@@ -757,6 +757,7 @@ constructor(
         }
     }
 
+    @Suppress("LongMethod")
     private fun rememberReaction(packet: MeshPacket) = scope.handledLaunch {
         val emoji = packet.decoded.payload.toByteArray().decodeToString()
         val fromId = dataMapper.toNodeID(packet.from)


### PR DESCRIPTION
prevents notifications from being generated for messages or reactions from muted contacts or nodes.

The `isSilent` flag, which checks if either a conversation or a specific node is muted, is now used to conditionally suppress notification creation for both text messages and emoji reactions. This ensures that user preferences for muting are respected.

### Key Changes:
- **Message Notifications:** In `MeshDataHandler`, a check for `!isSilent` is added before updating a message notification, preventing it from appearing if the sender or conversation is muted.
- **Reaction Notifications:** The logic for creating reaction notifications is now wrapped in an `if (!isSilent)` block, stopping notifications for reactions from muted sources.

resolves #4303 