### PR TITLE
feat(ui): Remove uptime from SignalInfo

### DIFF
--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SignalInfo.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/SignalInfo.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.database.model.Node
-import org.meshtastic.core.model.util.formatUptime
 import org.meshtastic.core.strings.Res
 import org.meshtastic.core.strings.air_utilization
 import org.meshtastic.core.strings.channel_utilization
@@ -96,9 +95,6 @@ fun SignalInfo(
                     }
                 }
             }
-        }
-        if (node.deviceMetrics.uptimeSeconds > 0) {
-            UptimeInfo(uptime = formatUptime(node.deviceMetrics.uptimeSeconds), contentColor = contentColor)
         }
     }
 }


### PR DESCRIPTION
This commit removes the device uptime display from the `SignalInfo` component. The `UptimeInfo` composable and its related logic have been removed to no longer show this metric in this part of the UI.