### PR TITLE
refactor(firmware): Inject dispatcher into `BleOtaTransport`

### DIFF
--- a/feature/firmware/src/main/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
+++ b/feature/firmware/src/main/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
@@ -17,7 +17,9 @@
 package org.meshtastic.feature.firmware.ota
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.filterNotNull
@@ -47,9 +49,13 @@ import kotlin.uuid.toKotlinUuid
  * - OTA Characteristic (Write): 62ec0272-3ec5-11eb-b378-0242ac130005
  * - TX Characteristic (Notify): 62ec0272-3ec5-11eb-b378-0242ac130003
  */
-class BleOtaTransport(private val centralManager: CentralManager, private val address: String) : UnifiedOtaProtocol {
+class BleOtaTransport(
+    private val centralManager: CentralManager,
+    private val address: String,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+) : UnifiedOtaProtocol {
 
-    private val transportScope = CoroutineScope(SupervisorJob())
+    private val transportScope = CoroutineScope(SupervisorJob() + dispatcher)
     private var peripheral: Peripheral? = null
     private var otaCharacteristic: RemoteCharacteristic? = null
 

--- a/feature/firmware/src/test/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransportMtuTest.kt
+++ b/feature/firmware/src/test/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransportMtuTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import no.nordicsemi.kotlin.ble.client.RemoteCharacteristic
 import no.nordicsemi.kotlin.ble.client.RemoteService
@@ -45,10 +46,11 @@ class BleOtaTransportMtuTest {
 
     private val centralManager: CentralManager = mockk(relaxed = true)
     private val address = "00:11:22:33:44:55"
-    private val transport = BleOtaTransport(centralManager, address)
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val transport = BleOtaTransport(centralManager, address, testDispatcher)
 
     @Test
-    fun `connect requests MTU`() = runTest {
+    fun `connect requests MTU`() = runTest(testDispatcher) {
         val peripheral: Peripheral = mockk(relaxed = true)
         val otaChar: RemoteCharacteristic = mockk(relaxed = true)
         val txChar: RemoteCharacteristic = mockk(relaxed = true)


### PR DESCRIPTION
This commit introduces dependency injection for the `CoroutineDispatcher` in `BleOtaTransport`. This change improves testability by allowing a `TestDispatcher` to be provided during unit tests, ensuring more reliable and deterministic test execution.

Key changes:
- `BleOtaTransport` now accepts a `CoroutineDispatcher` in its constructor, defaulting to `Dispatchers.Default`.
- The internal `transportScope` is now created using the injected dispatcher.
- `BleOtaTransportTest` and `BleOtaTransportMtuTest` are updated to inject an `UnconfinedTestDispatcher`, and `runTest` is configured to use it.
- The `notificationFlow` in `BleOtaTransportTest` is updated with extra buffer capacity to prevent a race condition in the test setup.