### PR TITLE
chore(lint): Disable ForbiddenComment detekt rule

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -705,7 +705,7 @@ style:
       - reason: 'Kotlin does not support @Inherited annotation, see https://youtrack.jetbrains.com/issue/KT-22265'
         value: 'java.lang.annotation.Inherited'
   ForbiddenComment:
-    active: true
+    active: false
     comments:
       - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
         value: 'FIXME:'


### PR DESCRIPTION
The `ForbiddenComment` rule in the detekt configuration has been deactivated. This allows the use of comments that were previously forbidden, such as those containing 'FIXME:'.
