### PR TITLE
fix #4285 - Neighbor popup 

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshNeighborInfoHandler.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshNeighborInfoHandler.kt
@@ -70,11 +70,13 @@ constructor(
             val neighbors =
                 ni.neighborsList.joinToString("\n") { n ->
                     val node = nodeManager.nodeDBbyNodeNum[n.nodeId]
-                    val name = node?.let { "${it.longName} (${it.shortName})" } ?: getString(Res.string.unknown_username)
+                    val name =
+                        node?.let { "${it.longName} (${it.shortName})" } ?: getString(Res.string.unknown_username)
                     "• $name (SNR: ${n.snr})"
                 }
 
-            val formatted = "Neighbors of ${nodeManager.nodeDBbyNodeNum[packet.from]?.longName ?: "Unknown"}:\n$neighbors"
+            val formatted =
+                "Neighbors of ${nodeManager.nodeDBbyNodeNum[packet.from]?.longName ?: "Unknown"}:\n$neighbors"
 
             val responseText =
                 if (start != null) {
@@ -96,6 +98,7 @@ constructor(
 
     companion object {
         private const val MILLIS_PER_SECOND = 1000.0
+
         // Only show neighbor info responses for requests sent in the last 3 minutes
         private const val NEIGHBOR_RQ_COOLDOWN = 3 * 60 * 1000L // 3 minutes in milliseconds
     }


### PR DESCRIPTION
closes #4285 Add back in the filtering that the clanker fueled refactor of meshservice removed. 

Testing on my network now, 
Will need to also include reverting the temporary one . #4345 