### PR TITLE
chore: Apply maven-publish plugin consistently

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -34,6 +34,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             apply(plugin = "meshtastic.spotless")
             apply(plugin = "meshtastic.dokka")
             apply(plugin = "meshtastic.kover")
+            apply(plugin = "maven-publish")
 
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)

--- a/build-logic/convention/src/main/kotlin/KmpLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpLibraryConventionPlugin.kt
@@ -32,6 +32,7 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
             apply(plugin = "meshtastic.spotless")
             apply(plugin = "meshtastic.dokka")
             apply(plugin = "meshtastic.kover")
+            apply(plugin = "maven-publish")
 
             configureKotlinMultiplatform()
         }

--- a/gradle/publishing.gradle.kts
+++ b/gradle/publishing.gradle.kts
@@ -1,5 +1,7 @@
-import java.util.Properties
 import java.io.FileInputStream
+import java.util.Properties
+
+project.pluginManager.apply("maven-publish")
 
 val configProperties = Properties()
 val configFile = rootProject.file("config.properties")


### PR DESCRIPTION
This commit applies the `maven-publish` plugin at the project level and within the `KmpLibraryConventionPlugin` and `AndroidLibraryConventionPlugin` convention plugins. This ensures that publishing capabilities are consistently available for all library modules, standardizing the build configuration.