### PR TITLE
build: Configure JitPack publishing for core modules

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -34,7 +34,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             apply(plugin = "meshtastic.spotless")
             apply(plugin = "meshtastic.dokka")
             apply(plugin = "meshtastic.kover")
-            apply(plugin = "maven-publish")
 
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)

--- a/build-logic/convention/src/main/kotlin/KmpLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpLibraryConventionPlugin.kt
@@ -32,7 +32,6 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
             apply(plugin = "meshtastic.spotless")
             apply(plugin = "meshtastic.dokka")
             apply(plugin = "meshtastic.kover")
-            apply(plugin = "maven-publish")
 
             configureKotlinMultiplatform()
         }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -3,4 +3,5 @@ jdk:
 before_install:
   - ./gradlew :core:proto:generateGoogleReleaseProto
 install:
-  - ./gradlew publishToMavenLocal -Pgoogle
+  - ./gradlew :core:api:publishToMavenLocal :core:model:publishToMavenLocal :core:proto:publishToMavenLocal -Pgoogle
+group: org.meshtastic

--- a/mesh_service_example/build.gradle.kts
+++ b/mesh_service_example/build.gradle.kts
@@ -36,10 +36,12 @@ configure<ApplicationExtension> {
     testOptions { unitTests.isReturnDefaultValues = true }
 }
 
+val meshtasticVersion = "main-SNAPSHOT"
+
 dependencies {
-    implementation(projects.core.api)
-    implementation(projects.core.model)
-    implementation(projects.core.proto)
+    implementation("com.github.meshtastic.Meshtastic-Android:core-api:$meshtasticVersion")
+    implementation("com.github.meshtastic.Meshtastic-Android:core-model:$meshtasticVersion")
+    implementation("com.github.meshtastic.Meshtastic-Android:core-proto:$meshtasticVersion")
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)


### PR DESCRIPTION
This commit prepares the project for publishing core library modules (`api`, `model`, `proto`) to JitPack. It updates the build configuration to publish only these specific modules and adjusts the example app to consume them from JitPack, confirming the setup.

### Key Changes:
- **JitPack Configuration (`jitpack.yml`):**
    - The `install` step now explicitly targets `publishToMavenLocal` for the `:core:api`, `:core:model`, and `:core:proto` modules.
    - Adds `group: org.meshtastic` to define the Maven group ID for the published artifacts.
- **Example App Dependencies:**
    - The `mesh_service_example` module now pulls core dependencies from JitPack using the `main-SNAPSHOT` version instead of referencing local project modules.
- **Build Plugins:**
    - The `maven-publish` plugin has been removed from the `AndroidLibraryConventionPlugin` and `KmpLibraryConventionPlugin` to prevent all modules from being published by default.
