### PR TITLE
ci18n: Add fastlane metadata to Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,3 +6,7 @@ files:
     escape_quotes: 0
     escape_special_characters: 0
     type: android
+  - source: /fastlane/metadata/android/en-US/*.txt
+    translation: /fastlane/metadata/android/%android_code%/%original_file_name%
+  - source: /fastlane/metadata/android/en-US/changelogs/*.txt
+    translation: /fastlane/metadata/android/%android_code%/changelogs/%original_file_name%


### PR DESCRIPTION
Adds the fastlane metadata files, including changelogs, to the Crowdin configuration for translation.
