### PR TITLE
ci: fix scheduled-updates workflow by explicitly adding paths

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -78,6 +78,9 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      - name: Fix file permissions
+        run: sudo chown -R $USER:$USER .
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
@@ -126,6 +129,12 @@ jobs:
           branch: 'scheduled-updates'
           base: 'main'
           delete-branch: true
+          add-paths: |
+            app/src/main/assets/firmware_releases.json
+            app/src/main/assets/device_hardware.json
+            fastlane/metadata/android/**
+            **/strings.xml
+            **/README.md
           labels: |
             automation
             l10n


### PR DESCRIPTION
This pull request updates the scheduled updates GitHub Actions workflow to improve file handling and ensure that relevant files are included in pull requests created by the automation. The main changes are grouped into workflow reliability improvements and pull request content enhancements.

**Workflow reliability improvements:**
* Added a step to fix file permissions by running `sudo chown -R $USER:$USER .` before setting up the JDK, which helps prevent permission issues during the workflow execution.

**Pull request content enhancements:**
* Updated the `peter-evans/create-pull-request` step to explicitly include additional asset, metadata, and documentation files in the pull requests it creates by specifying them in the `add-paths` field. This ensures that important files like `firmware_releases.json`, `device_hardware.json`, Android metadata, all `strings.xml`, and `README.md` files are always included in the automated PRs.