### PR TITLE
fix(ci): ensure release SHA is passed correctly and validate inputs

### DIFF
--- a/.github/workflows/create-or-promote-release.yml
+++ b/.github/workflows/create-or-promote-release.yml
@@ -261,6 +261,9 @@ jobs:
             SHA=$(git rev-parse $TAG_TO_PROCESS)
           fi
           
+          # Trim whitespace to ensure clean output
+          SHA=$(echo "$SHA" | xargs)
+          
           echo "Debug: Resolved SHA: '$SHA'"
           
           if [ -z "$SHA" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,16 @@ jobs:
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
       GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
     steps:
+      - name: Debug and Validate Inputs
+        run: |
+          echo "Debug: Tag Name: ${{ inputs.tag_name }}"
+          echo "Debug: Commit SHA: ${{ inputs.commit_sha }}"
+          
+          if [ -z "${{ inputs.commit_sha }}" ] && [ "${{ inputs.channel }}" == "internal" ]; then
+             echo "::error::Internal release requires commit_sha because the tag does not exist yet."
+             exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
- Sanitize SHA output in create-or-promote-release to avoid whitespace issues
- Add input validation in release.yml to fail fast if commit_sha is missing for internal builds
- Add debug logging for workflow inputs
