### PR TITLE
fix(ci): robust SHA passing via artifact to bypass secret masking

### DIFF
--- a/.github/workflows/create-or-promote-release.yml
+++ b/.github/workflows/create-or-promote-release.yml
@@ -271,8 +271,19 @@ jobs:
             exit 1
           fi
           
-          echo "release_commit_sha=$SHA" >> $GITHUB_OUTPUT
+          # Save SHA to file for artifact upload (bypassing secret masking in outputs)
+          echo "$SHA" > release_sha.txt
+          
+          # We don't output release_commit_sha to GITHUB_OUTPUT anymore to avoid it being dropped if masked.
+          # Downstream workflows will read the artifact.
         shell: bash
+
+      - name: Upload Release SHA Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release_sha
+          path: release_sha.txt
+          retention-days: 1
 
   call-release-workflow:
     if: ${{ !inputs.dry_run && inputs.channel == 'internal' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,20 +73,29 @@ jobs:
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
       GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
     steps:
-      - name: Debug and Validate Inputs
+      - name: Download Release SHA Artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: release_sha
+          path: .
+
+      - name: Resolve Commit SHA
+        id: resolve_sha
         run: |
-          echo "Debug: Tag Name: ${{ inputs.tag_name }}"
-          echo "Debug: Commit SHA: ${{ inputs.commit_sha }}"
-          
-          if [ -z "${{ inputs.commit_sha }}" ] && [ "${{ inputs.channel }}" == "internal" ]; then
-             echo "::error::Internal release requires commit_sha because the tag does not exist yet."
-             exit 1
+          if [ -f release_sha.txt ]; then
+            SHA=$(cat release_sha.txt)
+            echo "Using SHA from artifact: $SHA"
+            echo "SHA=$SHA" >> $GITHUB_OUTPUT
+          else
+            echo "Using input SHA or Tag"
+            echo "SHA=${{ inputs.commit_sha || inputs.tag_name }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit_sha || inputs.tag_name }}
+          ref: ${{ steps.resolve_sha.outputs.SHA }}
           fetch-depth: 0
           submodules: 'recursive'
       - name: Set up JDK 17
@@ -131,10 +140,29 @@ jobs:
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
       GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
     steps:
+      - name: Download Release SHA Artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: release_sha
+          path: .
+
+      - name: Resolve Commit SHA
+        id: resolve_sha
+        run: |
+          if [ -f release_sha.txt ]; then
+            SHA=$(cat release_sha.txt)
+            echo "Using SHA from artifact: $SHA"
+            echo "SHA=$SHA" >> $GITHUB_OUTPUT
+          else
+            echo "Using input SHA or Tag"
+            echo "SHA=${{ inputs.commit_sha || inputs.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit_sha || inputs.tag_name }}
+          ref: ${{ steps.resolve_sha.outputs.SHA }}
           fetch-depth: 0
           submodules: 'recursive'
       - name: Set up JDK 17
@@ -238,10 +266,29 @@ jobs:
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
       GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
     steps:
+      - name: Download Release SHA Artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: release_sha
+          path: .
+
+      - name: Resolve Commit SHA
+        id: resolve_sha
+        run: |
+          if [ -f release_sha.txt ]; then
+            SHA=$(cat release_sha.txt)
+            echo "Using SHA from artifact: $SHA"
+            echo "SHA=$SHA" >> $GITHUB_OUTPUT
+          else
+            echo "Using input SHA or Tag"
+            echo "SHA=${{ inputs.commit_sha || inputs.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.commit_sha || inputs.tag_name }}
+          ref: ${{ steps.resolve_sha.outputs.SHA }}
           fetch-depth: 0
           submodules: 'recursive'
       - name: Set up JDK 17


### PR DESCRIPTION
- Upload release SHA as artifact in create-or-promote workflow
- Download and use SHA artifact in release workflow jobs
- Fallback to inputs if artifact is missing
- Resolves issue where SHA output was dropped due to secret collision