### PR TITLE
Add 'fdroid' flavor to pull request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/reusable-check.yml
     with:
       api_levels: '[35]' # Only test latest API on PRs for speed
-      flavors: '["google"]'
+      flavors: '["google","fdroid"]'
     secrets: inherit
 
   skip-notice:


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration to expand the set of build flavors tested on pull requests.

* The `flavors` parameter in `.github/workflows/pull-request.yml` is updated to include both `"google"` and `"fdroid"`, ensuring that pull requests are tested against both build variants.