### PR TITLE
feat(deps): Update Wire to v6.0.0-alpha02

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
     compileOnly(libs.secrets.gradlePlugin)
     compileOnly(libs.spotless.gradlePlugin)
     compileOnly(libs.test.retry.gradlePlugin)
-    compileOnly("com.dropbox.dependency-guard:dependency-guard:0.5.0")
     compileOnly(libs.truth)
 
     detektPlugins(libs.detekt.formatting)

--- a/core/proto/build.gradle.kts
+++ b/core/proto/build.gradle.kts
@@ -46,6 +46,8 @@ wire {
         boxOneOfsMinSize = 5000
     }
     root("meshtastic.*")
+    prune("meshtastic.MeshPacket#delayed")
+    prune("meshtastic.MeshPacket.Delayed")
 }
 
 // Modern KMP publication uses the project name as the artifactId by default.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ compose-multiplatform = "1.10.0"
 
 # Google
 hilt = "2.59.1"
-maps-compose = "8.0.1"
+maps-compose = "8.0.0"
 
 # Networking
 ktor = "3.4.0"
@@ -43,7 +43,7 @@ detekt = "1.23.8"
 devtools-ksp = "2.3.5"
 markdownRenderer = "0.39.2"
 osmdroid-android = "6.1.20"
-wire = "5.5.0"
+wire = "6.0.0-alpha02"
 vico = "3.0.0-beta.3"
 # Removed gradle-doctor
 dependency-guard = "0.5.0"
@@ -51,11 +51,9 @@ dependency-guard = "0.5.0"
 
 [libraries]
 # AndroidX
-androidx-activity = { module = "androidx.activity:activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.12.3" }
 androidx-annotation = { module = "androidx.annotation:annotation", version = "1.9.1" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
-androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version = "2.2.1" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version = "1.17.0" }
 androidx-core-location-altitude = { module = "androidx.core:core-location-altitude", version = "1.0.0-beta01" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version = "1.2.0" }
@@ -79,7 +77,6 @@ androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runt
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 androidx-paging-common = { module = "androidx.paging:paging-common", version.ref = "paging" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }
-androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "paging" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 androidx-room-paging = { module = "androidx.room:room-paging", version.ref = "room" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
@@ -108,7 +105,7 @@ androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version = "34.8.0" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
-guava = { module = "com.google.guava:guava", version = "33.5.0-jre" }
+guava = { module = "com.google.guava:guava", version = "33.5.0-android" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
@@ -171,7 +168,6 @@ markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer", v
 markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 markdown-renderer-android = { module = "com.mikepenz:multiplatform-markdown-renderer-android", version.ref = "markdownRenderer" }
 material = { module = "com.google.android.material:material", version = "1.13.0" }
-mgrs = { module = "mil.nga:mgrs", version = "2.1.3" }
 nordic = { module = "no.nordicsemi.kotlin.ble:client-android", version = "2.0.0-alpha12" }
 nordic-dfu = { module = "no.nordicsemi.android:dfu", version = "2.10.1" }
 org-eclipse-paho-client-mqttv3 = { module = "org.eclipse.paho:org.eclipse.paho.client.mqttv3", version = "1.2.5" }
@@ -210,7 +206,6 @@ test-retry-gradlePlugin = { module = "org.gradle:test-retry-gradle-plugin", vers
 # Android
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
-android-lint = { id = "com.android.lint", version.ref = "agp" }
 
 # Jetbrains
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
@@ -242,7 +237,6 @@ wire = { id = "com.squareup.wire", version.ref = "wire" }
 room = { id = "androidx.room", version.ref = "room" }
 spotless = { id = "com.diffplug.spotless", version = "8.2.1" }
 test-retry = { id = "org.gradle.test-retry", version.ref = "testRetry" }
-# Removed gradle-doctor
 dependency-guard = { id = "com.dropbox.dependency-guard", version.ref = "dependency-guard" }
 
 # Meshtastic


### PR DESCRIPTION
This commit updates the Wire library from v5.2.1 to v6.0.0-alpha02 and removes several unused dependencies.

Key changes include:
- Upgrading the Wire Gradle plugin and its runtime dependencies.
- Pruning the unused `delayed` field from `MeshPacket` in the protobuf generation, which is no longer supported in Wire v6.