### PR TITLE
ci(jitpack): Use standard Gradle tasks for building

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
 jdk:
   - openjdk17
 before_install:
-  - ./gradlew :core:proto:generateGoogleReleaseProto
+  - ./gradlew :core:proto:generateProtos
 install:
-  - ./gradlew :core:api:publishToMavenLocal :core:model:publishToMavenLocal :core:proto:publishToMavenLocal -Pgoogle
+  - ./gradlew :core:proto:publishToMavenLocal :core:model:publishToMavenLocal :core:api:publishToMavenLocal
 group: org.meshtastic


### PR DESCRIPTION
Replaced `generateGoogleReleaseProto` with the standard `generateProtos` task. The `-Pgoogle` flag has been removed from the `install` step, simplifying the build process. The order of modules published to Maven Local has also been adjusted.