### PR TITLE
feat(deps): Remove temporary `kotlinx-metadata-jvm` dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -187,7 +187,11 @@ androidComponents {
     }
 }
 
-project.afterEvaluate { logger.lifecycle("Version code is set to: ${extensions.getByType<ApplicationExtension>().defaultConfig.versionCode}") }
+project.afterEvaluate {
+    logger.lifecycle(
+        "Version code is set to: ${extensions.getByType<ApplicationExtension>().defaultConfig.versionCode}",
+    )
+}
 
 dependencies {
     implementation(projects.core.analytics)

--- a/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
@@ -28,9 +28,6 @@ class HiltConventionPlugin : Plugin<Project> {
             apply(plugin = "com.google.devtools.ksp")
 
             dependencies {
-                // fixme: remove when hilt supports kotlin 2.3.x
-                "ksp"(libs.library("kotlin-metadata-jvm"))
-
                 "ksp"(libs.library("hilt-compiler"))
                 "implementation"(libs.library("hilt-android"))
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,7 +125,6 @@ truth = { module = "com.google.truth:truth", version = "1.4.5" }
 
 # Jetbrains
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlin-metadata-jvm = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version = "0.9.0" }
 dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.1.0" }
 
 


### PR DESCRIPTION
The `kotlinx-metadata-jvm` dependency, which was a temporary workaround for Hilt's compatibility with Kotlin, is now removed. This is no longer necessary as recent Hilt versions support newer Kotlin releases directly.