### PR TITLE
chore(ci): Simplify jitpack.yml build steps

### DIFF
--- a/gradle/publishing.gradle.kts
+++ b/gradle/publishing.gradle.kts
@@ -29,4 +29,6 @@ if (project.version == "unspecified") {
         ?: System.getenv("VERSION_NAME")
         ?: props.getProperty("VERSION_NAME_BASE")
         ?: "0.0.0-SNAPSHOT"
+
+    println("Configured publication version for project ${project.name}: ${project.version}")
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,5 @@
 jdk:
   - openjdk17
-before_install:
-  - ./gradlew :core:proto:generateProtos
 install:
-  - ./gradlew :core:proto:publishToMavenLocal :core:model:publishToMavenLocal :core:api:publishToMavenLocal
+  - ./gradlew publishToMavenLocal
 group: org.meshtastic


### PR DESCRIPTION
Removes the `before_install` step and simplifies the `install` command in `jitpack.yml` to use a single top-level `publishToMavenLocal` Gradle task.

Additionally, a print statement has been added to `publishing.gradle.kts` to log the configured version for each project during the publication process.
