### PR TITLE
feat: Check if NFC is enabled and prompt user to enable it

### DIFF
--- a/core/nfc/src/main/kotlin/org/meshtastic/core/nfc/NfcScanner.kt
+++ b/core/nfc/src/main/kotlin/org/meshtastic/core/nfc/NfcScanner.kt
@@ -28,7 +28,7 @@ import co.touchlab.kermit.Logger
 import java.io.IOException
 
 @Composable
-fun NfcScannerEffect(onResult: (String?) -> Unit) {
+fun NfcScannerEffect(onResult: (String?) -> Unit, onNfcDisabled: (() -> Unit)? = null) {
     val context = LocalContext.current
     val activity = context as? Activity ?: return
 
@@ -36,6 +36,9 @@ fun NfcScannerEffect(onResult: (String?) -> Unit) {
 
     DisposableEffect(nfcAdapter) {
         if (nfcAdapter == null) {
+            onDispose {}
+        } else if (!nfcAdapter.isEnabled) {
+            onNfcDisabled?.invoke()
             onDispose {}
         } else {
             val readerCallback = NfcAdapter.ReaderCallback { tag: Tag -> handleNfcTag(tag, onResult) }

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -12,7 +12,7 @@
   ~ GNU General Public License for more details.
   ~
   ~ You should have received a copy of the GNU General Public License
-  ~ along with this program.  See <https://www.gnu.org/licenses/>.
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
 <resources>
@@ -1179,4 +1179,5 @@
     <string name="share_channels_qr">Share Channels QR Code</string>
     <string name="scan_nfc_text">Bring your device close to the NFC tag to scan.</string>
     <string name="generate_qr_code">Generate QR Code</string>
+    <string name="nfc_disabled">NFC is disabled. Please enable it in system settings.</string>
 </resources>

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/ImportFab.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/ImportFab.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import org.jetbrains.compose.resources.stringResource
@@ -41,7 +42,9 @@ import org.meshtastic.core.nfc.NfcScannerEffect
 import org.meshtastic.core.strings.Res
 import org.meshtastic.core.strings.cancel
 import org.meshtastic.core.strings.input_shared_contact_url
+import org.meshtastic.core.strings.nfc_disabled
 import org.meshtastic.core.strings.okay
+import org.meshtastic.core.strings.open_settings
 import org.meshtastic.core.strings.scan_channels_nfc
 import org.meshtastic.core.strings.scan_channels_qr
 import org.meshtastic.core.strings.scan_nfc
@@ -52,6 +55,7 @@ import org.meshtastic.core.strings.share_channels_qr
 import org.meshtastic.core.strings.url
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.QrCode2
+import org.meshtastic.core.ui.util.openNfcSettings
 
 /**
  * Unified Floating Action Button for importing Meshtastic data (Contacts, Channels, etc.) via NFC, QR, or URL.
@@ -72,6 +76,8 @@ fun ImportFab(
     var expanded by remember { mutableStateOf(false) }
     var showUrlDialog by remember { mutableStateOf(false) }
     var isNfcScanning by remember { mutableStateOf(false) }
+    var showNfcDisabledDialog by remember { mutableStateOf(false) }
+    val context = LocalContext.current
 
     val barcodeScanner =
         rememberBarcodeScanner(
@@ -91,8 +97,33 @@ fun ImportFab(
                     isNfcScanning = false
                 }
             },
+            onNfcDisabled = {
+                isNfcScanning = false
+                showNfcDisabledDialog = true
+            },
         )
         NfcScanningDialog(onDismiss = { isNfcScanning = false })
+    }
+
+    if (showNfcDisabledDialog) {
+        AlertDialog(
+            onDismissRequest = { showNfcDisabledDialog = false },
+            title = { Text(stringResource(Res.string.scan_nfc)) },
+            text = { Text(stringResource(Res.string.nfc_disabled)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        context.openNfcSettings()
+                        showNfcDisabledDialog = false
+                    },
+                ) {
+                    Text(stringResource(Res.string.open_settings))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showNfcDisabledDialog = false }) { Text(stringResource(Res.string.cancel)) }
+            },
+        )
     }
 
     if (showUrlDialog) {

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/util/ContextExtensions.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/util/ContextExtensions.kt
@@ -19,6 +19,8 @@ package org.meshtastic.core.ui.util
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.Intent
+import android.provider.Settings
 import android.widget.Toast
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
@@ -40,4 +42,9 @@ fun Context.findActivity(): Activity? = when (this) {
     is Activity -> this
     is ContextWrapper -> baseContext.findActivity()
     else -> null
+}
+
+fun Context.openNfcSettings() {
+    val intent = Intent(Settings.ACTION_NFC_SETTINGS)
+    startActivity(intent)
 }


### PR DESCRIPTION
- Add a check to see if NFC is enabled before starting a scan.
- Implement a dialog to inform the user that NFC is disabled, with a button to open system settings.
- Add `nfc_disabled`, `open_settings` and related string resources.
- Create an `openNfcSettings` context extension for easy access to NFC settings.
- Refactor `MainActivity` to use a common `handleMeshtasticUri` function for both deep links and NFC NDEF messages.