### PR TITLE
refactor(node): Improve public key conflict handling

### DIFF
--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/EditBase64Preference.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/EditBase64Preference.kt
@@ -51,7 +51,7 @@ import org.meshtastic.core.strings.Res
 import org.meshtastic.core.strings.error
 import org.meshtastic.core.strings.reset
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod", "MagicNumber")
 @Composable
 fun EditBase64Preference(
     modifier: Modifier = Modifier,
@@ -65,14 +65,16 @@ fun EditBase64Preference(
     onGenerateKey: (() -> Unit)? = null,
     trailingIcon: (@Composable () -> Unit)? = null,
 ) {
-    var valueState by remember { mutableStateOf(value.encodeToString()) }
-    val isError = value.encodeToString() != valueState
+    val isMismatch = value.size == 32 && value.toByteArray().all { it == 0.toByte() }
+    val errorString = stringResource(Res.string.error)
+    var valueState by remember { mutableStateOf(if (isMismatch) errorString else value.encodeToString()) }
+    val isError = value.encodeToString() != valueState || isMismatch
 
     // don't update values while the user is editing
     var isFocused by remember { mutableStateOf(false) }
     LaunchedEffect(value) {
         if (!isFocused) {
-            valueState = value.encodeToString()
+            valueState = if (isMismatch) errorString else value.encodeToString()
         }
     }
 

--- a/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/NodeKeyStatusIcon.kt
+++ b/core/ui/src/main/kotlin/org/meshtastic/core/ui/component/NodeKeyStatusIcon.kt
@@ -63,6 +63,7 @@ import org.meshtastic.core.strings.encryption_pkc
 import org.meshtastic.core.strings.encryption_pkc_text
 import org.meshtastic.core.strings.encryption_psk
 import org.meshtastic.core.strings.encryption_psk_text
+import org.meshtastic.core.strings.error
 import org.meshtastic.core.strings.security_icon_help_dismiss
 import org.meshtastic.core.strings.security_icon_help_show_all
 import org.meshtastic.core.strings.security_icon_help_show_less
@@ -170,6 +171,7 @@ enum class NodeKeySecurityState(
     ),
 }
 
+@Suppress("LongMethod", "MagicNumber")
 @Composable
 private fun KeyStatusDialog(title: StringResource, text: StringResource, key: ByteString?, onDismiss: () -> Unit = {}) {
     var showAll by rememberSaveable { mutableStateOf(false) }
@@ -190,16 +192,30 @@ private fun KeyStatusDialog(title: StringResource, text: StringResource, key: By
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(text = stringResource(text), textAlign = TextAlign.Center)
                     Spacer(Modifier.height(16.dp))
-                    if (key != null && title == Res.string.encryption_pkc) {
-                        val keyString = Base64.encodeToString(key.toByteArray(), Base64.NO_WRAP)
+                    if (key != null && (title == Res.string.encryption_pkc || title == Res.string.encryption_error)) {
+                        val isMismatch = key.size == 32 && key.toByteArray().all { it == 0.toByte() }
+                        val keyString =
+                            if (isMismatch) {
+                                stringResource(Res.string.error)
+                            } else {
+                                Base64.encodeToString(key.toByteArray(), Base64.NO_WRAP)
+                            }
                         Text(
                             text = stringResource(Res.string.config_security_public_key) + ":",
                             textAlign = TextAlign.Center,
                         )
                         Spacer(Modifier.height(8.dp))
-                        SelectionContainer { Text(text = keyString, textAlign = TextAlign.Center) }
-                        Spacer(Modifier.height(8.dp))
-                        CopyIconButton(valueToCopy = keyString, modifier = Modifier.padding(start = 8.dp))
+                        SelectionContainer {
+                            Text(
+                                text = keyString,
+                                textAlign = TextAlign.Center,
+                                color = if (isMismatch) MaterialTheme.colorScheme.error else Color.Unspecified,
+                            )
+                        }
+                        if (!isMismatch) {
+                            Spacer(Modifier.height(8.dp))
+                            CopyIconButton(valueToCopy = keyString, modifier = Modifier.padding(start = 8.dp))
+                        }
                         Spacer(Modifier.height(16.dp))
                     }
                 }


### PR DESCRIPTION
This commit refactors the logic for handling public key (PKC) updates for nodes in the database to be more robust and explicit.

Key changes:
-   Sets the public key to a specific `ERROR_BYTE_STRING` upon detecting a genuine mismatch between two valid, non-empty keys.
-   Preserves the existing key during routine node updates (e.g., position packets) that don't contain a new key.
-   Allows a node to recover from the error state if it later provides a valid, matching key.
-   Explicitly clears the public key for licensed (HAM) users, as they do not use PKC.
-   Updates the UI in Node Details and related components to visually indicate the error state, preventing users from copying the invalid key.

This new logic provides a clearer and more predictable state for node public keys, especially in cases of factory resets or hardware ID collisions.
