### PR TITLE
feat(database): Enable Write-Ahead Logging for Room DB

### DIFF
--- a/core/database/src/main/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/main/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -20,6 +20,7 @@ import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.room.Room
+import androidx.room.RoomDatabase
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -272,6 +273,7 @@ private fun anonymizeDbName(name: String): String =
 
 private fun buildRoomDb(app: Application, dbName: String): MeshtasticDatabase =
     Room.databaseBuilder(app.applicationContext, MeshtasticDatabase::class.java, dbName)
+        .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
         .fallbackToDestructiveMigration(false)
         .build()
 

--- a/core/database/src/main/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/main/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -115,6 +115,7 @@ abstract class MeshtasticDatabase : RoomDatabase() {
     companion object {
         fun getDatabase(context: Context): MeshtasticDatabase =
             Room.databaseBuilder(context.applicationContext, MeshtasticDatabase::class.java, "meshtastic_database")
+                .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
                 .fallbackToDestructiveMigration(false)
                 .build()
     }


### PR DESCRIPTION
Enables Write-Ahead Logging (WAL) for the Room database instances. This can improve performance by allowing reads and writes to occur concurrently.