### PR TITLE
feat: Add stable class definitions for Meshtastic models

### DIFF
--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -2,9 +2,24 @@
 // It allows us to define classes that are not part of our codebase without wrapping them in a stable class.
 // For more information, check https://developer.android.com/jetpack/compose/performance/stability/fix#configuration-file
 
-
+// Meshtastic Models
 org.meshtastic.core.database.model.Node
 org.meshtastic.core.database.model.Message
 org.meshtastic.core.database.entity.Reaction
+org.meshtastic.core.database.entity.ReactionEntity
+org.meshtastic.core.model.**
+
+// Wire / Protocol Buffers (Migration from Google Protobuf)
+// Wire generated classes are typically immutable and stable.
 org.meshtastic.proto.**
-com.google.protobuf.ByteString
+com.squareup.wire.Message
+okio.ByteString
+
+// Kotlin Immutable Collections
+kotlinx.collections.immutable.*
+
+// Java Time
+java.time.*
+
+// External Libraries
+com.google.android.gms.maps.model.**


### PR DESCRIPTION
This pull request updates the `compose_compiler_config.conf` file to improve stability handling for external models and libraries used in the project. The main changes focus on expanding the list of recognized stable classes, especially to accommodate migration from Google Protobuf to Wire, and to add support for additional models and libraries.

Expanded stable class configuration:

* Added Meshtastic model classes, including `Node`, `Message`, `Reaction`, and `ReactionEntity`, as well as all classes under `org.meshtastic.core.model`.
* Added support for Wire/Protocol Buffers migration by recognizing all classes under `org.meshtastic.proto`, replacing `com.google.protobuf.ByteString` with `com.squareup.wire.Message` and `okio.ByteString`.

Broader library support:

* Included Kotlin immutable collections (`kotlinx.collections.immutable.*`) and Java time classes (`java.time.*`) as stable.
* Added external library support for Google Maps model classes (`com.google.android.gms.maps.model.**`).