### PR TITLE
fix: Defer setting connected state until after nodeDB load

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshConfigFlowManager.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshConfigFlowManager.kt
@@ -85,8 +85,6 @@ constructor(
         } else {
             myNodeInfo = newMyNodeInfo
             Logger.i { "myNodeInfo committed successfully" }
-            connectionStateHolder.setState(ConnectionState.Connected)
-            serviceBroadcasts.broadcastConnection()
             connectionManager.onRadioConfigLoaded()
         }
 
@@ -123,6 +121,8 @@ constructor(
             }
             nodeManager.isNodeDbReady.value = true
             nodeManager.allowNodeDbWrites.value = true
+            connectionStateHolder.setState(ConnectionState.Connected)
+            serviceBroadcasts.broadcastConnection()
             connectionManager.onNodeDbReady()
         }
     }

--- a/app/src/main/java/com/geeksville/mesh/service/MeshConnectionManager.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshConnectionManager.kt
@@ -118,7 +118,7 @@ constructor(
     }
 
     private fun onConnectionChanged(c: ConnectionState) {
-        if (connectionStateHolder.connectionState.value == c) return
+        if (connectionStateHolder.connectionState.value == c && c !is ConnectionState.Connected) return
         Logger.d { "onConnectionChanged: ${connectionStateHolder.connectionState.value} -> $c" }
 
         sleepTimeout?.cancel()


### PR DESCRIPTION
This commit moves the setting of the `Connected` state and the connection broadcast to after the node database has finished loading.

Previously, the connected state was set when the radio configuration was committed. This could lead to a race condition where the UI might try to access node information before the node database was fully loaded.

By deferring the `Connected` state update, we ensure that the application is fully ready and the node database is populated before other components are notified of the connection. Additionally, a check in `onConnectionChanged` is updated to allow re-broadcasting the `Connected` state.