### PR TITLE
fix: use truthy value for `emoji` field on Reaction packets

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshActionHandler.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshActionHandler.kt
@@ -68,6 +68,7 @@ constructor(
 
     companion object {
         private const val DEFAULT_REBOOT_DELAY = 5
+        private const val EMOJI_INDICATOR = 1
     }
 
     fun onServiceAction(action: ServiceAction) {
@@ -127,16 +128,15 @@ constructor(
         val channel = action.contactKey[0].digitToInt()
         val destId = action.contactKey.substring(1)
         val dataPacket =
-            org.meshtastic.core.model
-                .DataPacket(
-                    to = destId,
-                    dataType = PortNum.TEXT_MESSAGE_APP.value,
-                    bytes = action.emoji.encodeToByteArray().toByteString(),
-                    channel = channel,
-                    replyId = action.replyId,
-                    wantAck = true,
-                    emoji = action.emoji.codePointAt(0),
-                )
+            DataPacket(
+                to = destId,
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                bytes = action.emoji.encodeToByteArray().toByteString(),
+                channel = channel,
+                replyId = action.replyId,
+                wantAck = true,
+                emoji = EMOJI_INDICATOR,
+            )
                 .apply { from = nodeManager.getMyId().takeIf { it.isNotEmpty() } ?: DataPacket.ID_LOCAL }
         commandSender.sendData(dataPacket)
         rememberReaction(action, dataPacket.id, myNodeNum)

--- a/app/src/main/java/com/geeksville/mesh/service/ReactionReceiver.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/ReactionReceiver.kt
@@ -52,6 +52,7 @@ class ReactionReceiver : BroadcastReceiver() {
         const val EXTRA_CONTACT_KEY = "contactKey"
         const val EXTRA_TO_ID = "toId"
         const val EXTRA_CHANNEL_INDEX = "channelIndex"
+        private const val EMOJI_INDICATOR = 1
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -80,7 +81,7 @@ class ReactionReceiver : BroadcastReceiver() {
                         dataType = PortNum.TEXT_MESSAGE_APP.value,
                         replyId = packetId,
                         wantAck = true,
-                        emoji = emoji.codePointAt(0),
+                        emoji = EMOJI_INDICATOR,
                     )
                 commandSender.sendData(reactionPacket)
 


### PR DESCRIPTION
Sets the `emoji` field in the `DataPacket` to a constant value of `1` for all reactions.

This change modifies how reactions are sent, using a fixed indicator instead of the emoji's codepoint to signify a reaction packet.
