### PR TITLE
fix(settings): Correct hop_limit type for LoRa config

### DIFF
--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -181,8 +181,8 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     title = stringResource(Res.string.hop_limit),
                     summary = stringResource(Res.string.config_lora_hop_limit_summary),
                     items = hopLimitItems,
-                    selectedItem = formState.value.hop_limit.toLong(),
-                    onItemSelected = { formState.value = formState.value.copy(hop_limit = it.toInt()) },
+                    selectedItem = formState.value.hop_limit,
+                    onItemSelected = { formState.value = formState.value.copy(hop_limit = it) },
                     enabled = state.connected,
                 )
                 HorizontalDivider()


### PR DESCRIPTION
The `hop_limit` property was being incorrectly converted to a Long for the `SingleSelectItem`. This commit corrects the type to align with the form state, removing the unnecessary `toLong()` and `toInt()` conversions.
addresses #4503 