### PR TITLE
feat(messaging): Move message input to Scaffold bottomBar

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/ui/Main.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/Main.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.recalculateWindowInsets
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.width
@@ -464,7 +463,7 @@ fun MainScreen(uIViewModel: UIViewModel = hiltViewModel(), scanModel: BTScanMode
         NavHost(
             navController = navController,
             startDestination = NodesRoutes.NodesGraph,
-            modifier = Modifier.fillMaxSize().recalculateWindowInsets().safeDrawingPadding().imePadding(),
+            modifier = Modifier.fillMaxSize().recalculateWindowInsets().safeDrawingPadding(),
         ) {
             contactsGraph(navController, uIViewModel.scrollToTopEventFlow)
             nodesGraph(navController, uIViewModel.scrollToTopEventFlow)


### PR DESCRIPTION
This commit refactors the `Message` screen to place the message input components (`MessageInput`, `ReplySnippet`, and `QuickChatRow`) within the `bottomBar` of the `Scaffold`.

This change ensures that the input fields correctly adjust to the keyboard, preventing it from overlapping the message list. Consequently, the `imePadding()` modifier is no longer needed on the `NavHost` in `Main.kt` and has been removed.
resolves #4508