### PR TITLE
feat(messaging): Add bell character to alert message and refine trim

### DIFF
--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -393,7 +393,7 @@ fun MessageScreen(
                     isHomoglyphEncodingEnabled = homoglyphEncodingEnabled,
                     textFieldState = messageInputState,
                     onSendMessage = {
-                        val messageText = messageInputState.text.toString().trim()
+                        val messageText = messageInputState.text.toString().trim { it.isWhitespace() }
                         if (messageText.isNotEmpty()) {
                             onEvent(MessageScreenEvent.SendMessage(messageText, replyingToPacketId))
                         }
@@ -866,7 +866,7 @@ private fun QuickChatRow(
             // Memoize if content is static
             QuickChatAction(
                 name = "🔔",
-                message = "🔔 $alertActionMessage  ", // Bell character added to message
+                message = "🔔 $alertActionMessage \u0007", // Bell character added to message
                 mode = QuickChatAction.Mode.Append,
                 position = -1, // Assuming -1 means it's a special prepended action
             )


### PR DESCRIPTION
This commit introduces two changes to the messaging feature:

1.  The `trim()` function on the message input is replaced with `trim { it.isWhitespace() }` for more precise whitespace removal.
2.  A bell character (`\u0007`) is appended to the quick chat alert action message to trigger an audible notification on certain devices.

resikves #4456 