### PR TITLE
feat(db): enhance public key conflict handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ This file serves as a comprehensive guide for AI agents and developers working o
 -   **Protobuf:** Communication with the device uses Protobufs. The definitions are in `core/proto`. This is a Git submodule, but the build system handles it.
 -   **Legacy:** Some code in `app/` uses the `com.geeksville.mesh` package. Newer code in `core/` and `feature/` uses `org.meshtastic.*`. Respect the existing package structure of the file you are editing.
 -   **Versioning:** Do not manually edit `versionCode` or `versionName`. These are managed by the build system and CI/CD.
+-   **Database Safety:** When modifying critical database logic (e.g., `NodeInfoDao`), always ensure you have explicit test coverage for security edge cases (like PKC conflicts or key wiping). Refer to `core/database/src/androidTest/kotlin/org/meshtastic/core/database/dao/NodeInfoDaoTest.kt` for examples.
 
 ## 7. Troubleshooting
 

--- a/core/database/README.md
+++ b/core/database/README.md
@@ -1,5 +1,25 @@
 # `:core:database`
 
+This module provides the local Room database persistence layer for the application.
+
+## Key Components
+
+-   **`MeshtasticDatabase`**: The main Room database class.
+-   **DAOs (Data Access Objects)**:
+    -   `NodeInfoDao`: Manages storage and retrieval of node information (`NodeEntity`). Contains critical logic for handling Public Key Conflict (PKC) resolution and preventing identity wiping attacks.
+    -   `PacketDao`: Handles storage of mesh packets.
+    -   `ChatMessageDao`: Manages chat message history.
+-   **Entities**:
+    -   `NodeEntity`: Represents a node on the mesh.
+    -   `PacketEntity`: Represents a stored packet.
+
+## Security Considerations
+
+### Public Key Conflict (PKC) Handling
+The `NodeInfoDao` implements specific logic to protect against impersonation and "wipe" attacks:
+-   **Wipe Protection**: Receiving an `is_licensed=true` packet (which normally clears the public key for compliance) will **not** clear an existing valid public key if one is already known. This prevents attackers from sending fake licensed packets to wipe keys from the DB.
+-   **Conflict Detection**: If a new key arrives for an existing node ID that conflicts with a known valid key, the key is set to `ERROR_BYTE_STRING` to flag the potential impersonation.
+
 ## Module dependency graph
 
 <!--region graph-->


### PR DESCRIPTION
Strengthens the `NodeInfoDao` logic to provide robust protection against public key conflict (PKC) and identity wipe attacks.

Key changes include:

-   Updates will no longer clear a known valid public key, even if an incoming packet indicates `is_licensed=true`. This prevents an attacker from wiping a node's identity from the database.
-   Refactors the key resolution logic into a dedicated `resolvePublicKey` function for clarity.
-   If an incoming update is a placeholder (default name, unset hardware model), the existing node's identity (user info, keys) is now preserved while still updating metadata like last heard time and telemetry.
-   Adds and updates tests to verify the new security logic, including scenarios for key mismatches, routine updates, and licensed users.
-   Updates documentation for the new database safety and PKC handling rules for developers.
