### PR TITLE
chore(docs): Refine Dokka source set configuration

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
@@ -37,11 +37,18 @@ fun Project.configureDokka() {
                 suppress.set(true)
             }
 
-            // Ensure source sets containing core logic are not suppressed
-            val isCoreSourceSet = name in listOf("main", "commonMain", "androidMain", "fdroid", "google")
-            if (isCoreSourceSet) {
-                suppress.set(false)
-            }
+            // Dokka 2.x requires each source file to belong to exactly one source set.
+            val baseSourceSets = listOf(
+                "main",
+                "commonMain",
+                "androidMain",
+                "fdroid",
+                "google",
+                "release"
+            )
+
+            val isCoreSourceSet = name in baseSourceSets
+            suppress.set(!isCoreSourceSet)
 
             sourceLink {
                 enableJdkDocumentationLink.set(true)
@@ -50,7 +57,8 @@ fun Project.configureDokka() {
 
                 // Standardized repo-root based source links
                 localDirectory.set(project.projectDir)
-                val relativePath = project.projectDir.relativeTo(rootProject.projectDir).path.replace("\\", "/")
+                val relativePath =
+                    project.projectDir.relativeTo(rootProject.projectDir).path.replace("\\", "/")
                 remoteUrl.set(URI("https://github.com/meshtastic/Meshtastic-Android/blob/main/$relativePath"))
                 remoteLineSuffix.set("#L")
             }


### PR DESCRIPTION
Dokka requires each source file to belong to a single source set to prevent duplication. This change refines the logic for including source sets in the documentation generation.

The configuration now explicitly suppresses variant-specific source sets (like `fdroidRelease`) and favors the inclusion of base and flavor-specific source sets (e.g., `main`, `commonMain`, `fdroid`, `google`, `release`) to ensure each file is processed only once.
