### PR TITLE
feat(settings): Allow clearing the node status message

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/MeshActionHandler.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshActionHandler.kt
@@ -239,7 +239,7 @@ constructor(
     fun handleSetModuleConfig(id: Int, destNum: Int, payload: ByteArray) {
         val c = ModuleConfig.ADAPTER.decode(payload)
         commandSender.sendAdmin(destNum, id) { AdminMessage(set_module_config = c) }
-        c.statusmessage?.node_status?.let { status -> nodeManager.updateNodeStatus(destNum, status) }
+        c.statusmessage?.let { sm -> nodeManager.updateNodeStatus(destNum, sm.node_status) }
     }
 
     fun handleGetModuleConfig(id: Int, destNum: Int, config: Int) {

--- a/app/src/main/java/com/geeksville/mesh/service/MeshConfigHandler.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshConfigHandler.kt
@@ -66,8 +66,8 @@ constructor(
         scope.handledLaunch { radioConfigRepository.setLocalModuleConfig(config) }
         serviceRepository.setConnectionProgress("Module config received")
 
-        config.statusmessage?.node_status?.let { status ->
-            nodeManager.myNodeNum?.let { num -> nodeManager.updateNodeStatus(num, status) }
+        config.statusmessage?.let { sm ->
+            nodeManager.myNodeNum?.let { num -> nodeManager.updateNodeStatus(num, sm.node_status) }
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/service/MeshNodeManager.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshNodeManager.kt
@@ -213,8 +213,8 @@ constructor(
         updateNodeStatus(fromNum, s.status)
     }
 
-    fun updateNodeStatus(nodeNum: Int, status: String) {
-        updateNodeInfo(nodeNum) { it.nodeStatus = status }
+    fun updateNodeStatus(nodeNum: Int, status: String?) {
+        updateNodeInfo(nodeNum) { it.nodeStatus = status?.takeIf { s -> s.isNotEmpty() } }
     }
 
     fun installNodeInfo(info: ProtoNodeInfo, withBroadcast: Boolean = true) {

--- a/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/StatusMessageConfigItemList.kt
+++ b/feature/settings/src/main/kotlin/org/meshtastic/feature/settings/radio/component/StatusMessageConfigItemList.kt
@@ -18,6 +18,10 @@ package org.meshtastic.feature.settings.radio.component
 
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalFocusManager
@@ -27,6 +31,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.strings.Res
+import org.meshtastic.core.strings.clear
 import org.meshtastic.core.strings.node_status_summary
 import org.meshtastic.core.strings.status_message
 import org.meshtastic.core.strings.status_message_config
@@ -58,7 +63,7 @@ fun StatusMessageConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(),
             TitledCard(title = stringResource(Res.string.status_message_config)) {
                 EditTextPreference(
                     title = stringResource(Res.string.node_status_summary),
-                    value = formState.value.node_status ?: "",
+                    value = formState.value.node_status,
                     maxSize = 80, // status_message max_size:80
                     enabled = state.connected,
                     isError = false,
@@ -66,6 +71,16 @@ fun StatusMessageConfigScreen(viewModel: RadioConfigViewModel = hiltViewModel(),
                     KeyboardOptions.Default.copy(keyboardType = KeyboardType.Text, imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                     onValueChanged = { formState.value = formState.value.copy(node_status = it) },
+                    trailingIcon = {
+                        if (formState.value.node_status.isNotEmpty()) {
+                            IconButton(onClick = { formState.value = formState.value.copy(node_status = "") }) {
+                                Icon(
+                                    imageVector = Icons.Default.Clear,
+                                    contentDescription = stringResource(Res.string.clear),
+                                )
+                            }
+                        }
+                    },
                 )
             }
         }


### PR DESCRIPTION
This commit introduces the ability to clear the node status message.

An empty status message from the device is now correctly handled, clearing the status on the app side. Previously, an empty status was ignored.

Additionally, a clear button (`X`) has been added to the status message input field in the settings screen, providing a user-friendly way to remove the current status message.

Specific changes include:
- Modified `MeshNodeManager.updateNodeStatus` to accept a nullable `String` and clear the status if it's null or empty.
- Updated `MeshConfigHandler` and `MeshActionHandler` to pass the entire `statusmessage` object, allowing for empty status updates.
- Added a trailing clear icon to the `EditTextPreference` for the node status message in `StatusMessageConfigItemList`.