### PR TITLE
ci: Fix and improve Kover coverage reporting

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -120,9 +120,16 @@ jobs:
             fi
           fi
           
-          # Run coverage report if any tests were executed
-          if [[ $TASKS == *"test"* ]]; then
-             TASKS="$TASKS koverXmlReport"
+          # Run coverage report if unit tests were executed
+          if [ "${{ inputs.run_unit_tests }}" = "true" ] && [ "$IS_FIRST_API" = "true" ]; then
+            if [ "$IS_FIRST_FLAVOR" = "true" ]; then
+              TASKS="$TASKS koverXmlReportDebug "
+            fi
+            if [ "$FLAVOR" = "google" ]; then
+              TASKS="$TASKS koverXmlReportGoogleDebug "
+            elif [ "$FLAVOR" = "fdroid" ]; then
+              TASKS="$TASKS koverXmlReportFdroidDebug "
+            fi
           fi
           
           echo "tasks=$TASKS" >> $GITHUB_OUTPUT
@@ -160,7 +167,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: meshtastic/Meshtastic-Android
-          files: "**/build/reports/kover/report.xml"
+          files: "**/build/reports/kover/report*.xml"
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}


### PR DESCRIPTION
This commit refines the code coverage reporting logic within the CI workflow.

Previously, the `koverXmlReport` task was triggered if any test task was run. This has been made more specific to only run for unit tests (`inputs.run_unit_tests == "true"`), preventing it from running unnecessarily during instrumentation tests.

Additionally, the logic now correctly generates coverage reports for individual product flavors (`google`, `fdroid`) instead of a generic one. The Codecov upload step has also been updated to glob all `report*.xml` files to ensure these flavor-specific reports are properly collected and uploaded.
