### PR TITLE
chore(ble): Add Proguard rules for Nordic BLE library

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -43,3 +43,8 @@
 
 # R8 optimization for Kotlin null checks (AGP 9.0+)
 -processkotlinnullchecks remove
+
+# Nordic BLE
+-dontwarn no.nordicsemi.kotlin.ble.environment.android.mock.**
+-keep class no.nordicsemi.kotlin.ble.environment.android.mock.** { *; }
+-keep class no.nordicsemi.kotlin.ble.environment.android.compose.** { *; }


### PR DESCRIPTION
This commit adds Proguard rules to prevent warnings and ensure the necessary classes from the Nordic BLE library are kept during the release build process. Specifically, rules have been added for the `mock` and `compose` packages to avoid issues with code shrinking and obfuscation.