### PR TITLE
ci(release): Use wildcards for APK paths in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: google-apk
-          path: app/build/outputs/apk/google/release/app-google-release.apk
+          path: app/build/outputs/apk/google/release/*.apk
           retention-days: 1
 
       - name: Attest Google artifacts provenance
@@ -198,7 +198,7 @@ jobs:
         with:
           subject-path: |
             app/build/outputs/bundle/googleRelease/app-google-release.aab
-            app/build/outputs/apk/google/release/app-google-release.apk
+            app/build/outputs/apk/google/release/*.apk
 
   release-fdroid:
     runs-on: ubuntu-latest
@@ -254,13 +254,13 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: fdroid-apk
-          path: app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
+          path: app/build/outputs/apk/fdroid/release/*.apk
           retention-days: 1
 
       - name: Attest F-Droid APK provenance
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
+          subject-path: app/build/outputs/apk/fdroid/release/*.apk
 
   github-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit updates the `release.yml` GitHub Actions workflow to use wildcards for APK file paths.

Previously, the workflow used explicit filenames like `app-google-release.apk`. This has been changed to `*.apk` to make the build process more resilient to changes in APK naming conventions, such as the inclusion of version numbers in the filename.

This modification applies to the artifact upload and provenance attestation steps for both the Google and F-Droid release jobs.
