### PR TITLE
fix(strings): Correct capitalization of Ham

### DIFF
--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -741,7 +741,7 @@
     <string name="long_name">Long Name</string>
     <string name="short_name">Short Name</string>
     <string name="hardware_model">Hardware model</string>
-    <string name="licensed_amateur_radio">Licensed amateur radio (HAM)</string>
+    <string name="licensed_amateur_radio">Licensed amateur radio (Ham)</string>
     <string name="licensed_amateur_radio_text">Enabling this option disables encryption and is not compatible with the default Meshtastic network.</string>
     <string name="dew_point">Dew Point</string>
     <string name="pressure">Pressure</string>


### PR DESCRIPTION
In reference to amateur radio operators, “ham” is not an acronym.
