### PR TITLE
chore(ci): Use wildcard for APK paths in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: google-apk
-          path: app/build/outputs/apk/google/release/*.apk
+          path: app/build/outputs/apk/**/*.apk
           retention-days: 1
 
       - name: Attest Google artifacts provenance
@@ -198,7 +198,7 @@ jobs:
         with:
           subject-path: |
             app/build/outputs/bundle/googleRelease/app-google-release.aab
-            app/build/outputs/apk/google/release/*.apk
+            app/build/outputs/apk/**/*.apk
 
   release-fdroid:
     runs-on: ubuntu-latest
@@ -254,13 +254,13 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: fdroid-apk
-          path: app/build/outputs/apk/fdroid/release/*.apk
+          path: app/build/outputs/apk/**/*.apk
           retention-days: 1
 
       - name: Attest F-Droid APK provenance
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: app/build/outputs/apk/fdroid/release/*.apk
+          subject-path: app/build/outputs/apk/**/*.apk
 
   github-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit updates the `release.yml` GitHub Actions workflow to use a wildcard `**` in the path for locating APK files.

Previously, the paths were specific to `google/release` and `fdroid/release` build variants. The new glob pattern `app/build/outputs/apk/**/*.apk` makes the workflow more flexible and robust by automatically including APKs from any and all build variants present.

This change affects the artifact upload and provenance attestation steps for both the Google and F-Droid release jobs.
