### PR TITLE
chore(ci): Refine analytics task filtering and improve release debugging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,9 @@ jobs:
           VERSION_CODE: ${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }}
         run: bundle exec fastlane internal
 
+      - name: List outputs
+        run: ls -R app/build/outputs/
+
       - name: Upload Google AAB artifact
         if: always()
         uses: actions/upload-artifact@v6
@@ -249,6 +252,9 @@ jobs:
           VERSION_NAME: ${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }}
           VERSION_CODE: ${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }}
         run: bundle exec fastlane fdroid_build
+
+      - name: List outputs
+        run: ls -R app/build/outputs/
 
       - name: Upload F-Droid APK artifact
         uses: actions/upload-artifact@v6

--- a/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
@@ -50,7 +50,7 @@ class AnalyticsConventionPlugin : Plugin<Project> {
             // This avoids iterating all tasks with a generic filter and improves configuration performance.
             plugins.withId("com.google.gms.google-services") {
                 tasks.configureEach {
-                    if (name.contains("fdroid", ignoreCase = true)) {
+                    if (name.contains("GoogleServices", ignoreCase = true) && name.contains("fdroid", ignoreCase = true)) {
                         enabled = false
                     }
                 }
@@ -58,7 +58,7 @@ class AnalyticsConventionPlugin : Plugin<Project> {
 
             plugins.withId("com.google.firebase.crashlytics") {
                 tasks.configureEach {
-                    if (name.contains("fdroid", ignoreCase = true)) {
+                    if (name.contains("Crashlytics", ignoreCase = true) && name.contains("fdroid", ignoreCase = true)) {
                         enabled = false
                     }
                 }
@@ -66,7 +66,7 @@ class AnalyticsConventionPlugin : Plugin<Project> {
 
             plugins.withId("com.datadoghq.dd-sdk-android-gradle-plugin") {
                 tasks.configureEach {
-                    if (name.contains("fdroid", ignoreCase = true)) {
+                    if ((name.contains("datadog", ignoreCase = true) || name.contains("uploadMapping", ignoreCase = true)) && name.contains("fdroid", ignoreCase = true)) {
                         enabled = false
                     }
                 }


### PR DESCRIPTION
This commit refines the logic for disabling analytics-related tasks for F-Droid builds and adds debugging steps to the release workflow.

The `AnalyticsConventionPlugin.kt` has been updated to use more specific task name filters. Previously, any task containing "fdroid" was disabled. Now, the logic specifically targets tasks containing "GoogleServices", "Crashlytics", "datadog", or "uploadMapping" in conjunction with "fdroid". This improves build configuration performance by avoiding overly broad task filtering.

Additionally, the `release.yml` GitHub Actions workflow has been enhanced. It now includes a step to list the contents of the `app/build/outputs/` directory for both the "internal" and "fdroid_build" jobs. This will provide better visibility into the generated build artifacts for easier debugging of the release process.
