### PR TITLE
Fix/splits

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,11 +156,12 @@ configure<ApplicationExtension> {
     // Configure existing product flavors (defined by convention plugin)
     // with their dynamic version names.
     productFlavors {
-        named("google") {
-            versionName = "${defaultConfig.versionName} (${defaultConfig.versionCode}) google"
-            manifestPlaceholders["MAPS_API_KEY"] = "dummy"
+        configureEach {
+            versionName = "${defaultConfig.versionName} (${defaultConfig.versionCode}) $name"
+            if (name == "google") {
+                manifestPlaceholders["MAPS_API_KEY"] = "dummy"
+            }
         }
-        named("fdroid") { versionName = "${defaultConfig.versionName} (${defaultConfig.versionCode}) fdroid" }
     }
 
     buildTypes {
@@ -186,15 +187,12 @@ secrets {
 }
 
 androidComponents {
-    onVariants(selector().all()) { variant ->
-        if (variant.name == "fdroidDebug") {
-            variant.applicationId = "com.geeksville.mesh.fdroid.debug"
-        }
-
-        if (variant.name == "googleDebug") {
-            variant.applicationId = "com.geeksville.mesh.google.debug"
+    onVariants(selector().withBuildType("debug")) { variant ->
+        variant.flavorName?.let { flavor ->
+            variant.applicationId = "com.geeksville.mesh.$flavor.debug"
         }
     }
+    
     onVariants(selector().withBuildType("release")) { variant ->
         if (variant.flavorName == "google") {
             val variantNameCapped = variant.name.replaceFirstChar { it.uppercase() }


### PR DESCRIPTION
This pull request introduces improvements to the Gradle build configuration for the Android app, focusing on simplifying flavor handling and making APK splitting conditional based on build tasks. The changes streamline how product flavors are configured, automate application ID assignment for debug builds, and ensure ABI splits are only enabled for certain build types.

Build configuration improvements:

* Conditional ABI splits: ABI splits are now enabled only when not building a bundle or Google variant, reducing unnecessary APK generation for those tasks. (`app/build.gradle.kts`, [app/build.gradle.ktsR131-R139](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R131-R139))
* Simplified product flavor configuration: The `productFlavors` block now uses `configureEach` to set the `versionName` for all flavors dynamically, and sets the `MAPS_API_KEY` placeholder for the Google flavor. (`app/build.gradle.kts`, [app/build.gradle.ktsL154-R164](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L154-R164))

Flavor and build type automation:

* Automated application ID assignment for debug builds: The `onVariants` callback now assigns application IDs for all debug variants based on their flavor, instead of hardcoding for each flavor. (`app/build.gradle.kts`, [app/build.gradle.ktsL184-R195](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L184-R195))