### PR TITLE
Add per-message transport method icons for new message format

### DIFF
--- a/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
+++ b/feature/messaging/src/main/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
@@ -315,9 +315,7 @@ internal fun MessageItem(
                         TransportIcon(
                             transport = message.transportMechanism,
                             viaMqtt = message.viaMqtt,
-                            modifier = Modifier
-                                .size(16.dp)
-                                .padding(start = 4.dp),
+                            modifier = Modifier.size(16.dp).padding(start = 4.dp),
                         )
                     }
                     if (containsBel) {


### PR DESCRIPTION
This commit changes around the location of the transport mechnanism icon to more accurately reflect the individual message transport status when multiple messages from the same node are grouped together into a block.

This also addresses a padding issue with the alert bell character that I found while testing this. The code to add the bell to the right of the hops was originally padding the end of the string, which did nothing. This moves the padding to the start of the string which gives it a bit of separation from the other items.

Before:
<img width="383" height="116" alt="before-me" src="https://github.com/user-attachments/assets/e2e9a009-c081-47e6-9a2c-77c5f87bafb7" />

<img width="389" height="69" alt="before" src="https://github.com/user-attachments/assets/6fc73290-a448-4551-b504-b97be0ceb70a" />

After:
<img width="391" height="115" alt="after-me" src="https://github.com/user-attachments/assets/75c16146-7bdd-4546-b16d-f28552d7c556" />

<img width="385" height="65" alt="after" src="https://github.com/user-attachments/assets/aa845b53-d1cf-497b-b8c1-0e10ad85835d" />
