### PR TITLE
ci: Split Google artifact attestations and ensure F-Droid uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,13 +195,17 @@ jobs:
           path: app/build/outputs/apk/**/*.apk
           retention-days: 1
 
-      - name: Attest Google artifacts provenance
+      - name: Attest Google AAB provenance
         if: always()
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: |
-            app/build/outputs/bundle/googleRelease/app-google-release.aab
-            app/build/outputs/apk/**/*.apk
+          subject-path: app/build/outputs/bundle/googleRelease/app-google-release.aab
+
+      - name: Attest Google APK provenance
+        if: always()
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: app/build/outputs/apk/**/*.apk
 
   release-fdroid:
     runs-on: ubuntu-latest
@@ -257,6 +261,7 @@ jobs:
         run: ls -R app/build/outputs/
 
       - name: Upload F-Droid APK artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: fdroid-apk
@@ -264,6 +269,7 @@ jobs:
           retention-days: 1
 
       - name: Attest F-Droid APK provenance
+        if: always()
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: app/build/outputs/apk/**/*.apk


### PR DESCRIPTION
- Separate Google AAB and APK provenance attestations into individual steps
- Add `if: always()` condition to F-Droid APK upload and attestation steps