### PR TITLE
Disable generate_release_notes in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,7 +306,7 @@ jobs:
           token: ${{ secrets.INTERNAL_BUILDS_HOST_PAT }}
           tag_name: ${{ inputs.tag_name }}
           name: ${{ inputs.tag_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})
-          generate_release_notes: true
+          generate_release_notes: false
           files: ./artifacts/*/*
           draft: false
           prerelease: true


### PR DESCRIPTION
Trying to update release notes on a draft was not working.