### PR TITLE
build: apply instrumented test dependencies conditionally

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
@@ -61,10 +61,13 @@ class AndroidRoomConventionPlugin : Plugin<Project> {
             }
 
             pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+                val hasAndroidTest = projectDir.resolve("src/androidTest").exists()
                 dependencies {
                     "implementation"(roomRuntime)
                     "ksp"(roomCompiler)
-                    "androidTestImplementation"(roomTesting)
+                    if (hasAndroidTest) {
+                        "androidTestImplementation"(roomTesting)
+                    }
                 }
             }
         }

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -31,10 +31,13 @@ internal fun Project.configureAndroidCompose(
         buildFeatures.compose = true
     }
 
+    val hasAndroidTest = project.projectDir.resolve("src/androidTest").exists()
     dependencies {
         val bom = libs.library("androidx-compose-bom")
         "implementation"(platform(bom))
-        "androidTestImplementation"(platform(bom))
+        if (hasAndroidTest) {
+            "androidTestImplementation"(platform(bom))
+        }
         "implementation"(libs.library("androidx-compose-ui-tooling"))
         "implementation"(libs.library("androidx-compose-runtime"))
         "runtimeOnly"(libs.library("androidx-compose-runtime-tracing"))
@@ -44,7 +47,9 @@ internal fun Project.configureAndroidCompose(
         "implementation"(libs.library("compose-multiplatform-resources"))
 
         // Add Espresso explicitly to avoid version mismatch issues on newer Android versions
-        "androidTestImplementation"(libs.library("androidx-test-espresso-core"))
+        if (hasAndroidTest) {
+            "androidTestImplementation"(libs.library("androidx-test-espresso-core"))
+        }
     }
     configureComposeCompiler()
 }

--- a/feature/firmware/build.gradle.kts
+++ b/feature/firmware/build.gradle.kts
@@ -58,9 +58,6 @@ dependencies {
     implementation(libs.markdown.renderer)
     implementation(libs.markdown.renderer.m3)
 
-    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-    androidTestImplementation(libs.androidx.test.ext.junit)
-
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.nordic.client.android.mock)


### PR DESCRIPTION
Check for the existence of `src/androidTest` before adding test-related dependencies in convention plugins. This prevents unnecessary dependency resolution for modules without instrumented tests. Additionally, removed unused test dependencies from the firmware feature module.