### PR TITLE
ci: improve release cleanup and optimize build tasks

### DIFF
--- a/.github/workflows/create-or-promote-release.yml
+++ b/.github/workflows/create-or-promote-release.yml
@@ -141,16 +141,20 @@ jobs:
 
   cleanup-on-failure:
     needs: [determine-tags, call-release-workflow]
-    if: ${{ failure() && !inputs.dry_run && inputs.channel == 'internal' }}
+    if: ${{ (failure() || cancelled()) && !inputs.dry_run && inputs.channel == 'internal' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Delete Failed Tag
+      - name: Delete Failed or Cancelled Tag
         env:
           FINAL_TAG: ${{ needs.determine-tags.outputs.final_tag }}
         run: |
-          echo "Release workflow failed. Deleting tag $FINAL_TAG to allow a clean retry..."
-          git push origin :refs/tags/"$FINAL_TAG" || echo "Tag was not pushed or already deleted."
+          if [ -n "$FINAL_TAG" ]; then
+            echo "Release workflow failed or was cancelled. Deleting tag $FINAL_TAG to allow a clean retry..."
+            git push origin :refs/tags/"$FINAL_TAG" || echo "Tag was not pushed or already deleted."
+          else
+            echo "No tag was created to delete."
+          fi

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,7 @@ platform :android do
   desc "Build the F-Droid release"
   lane :fdroid_build do
     gradle(
-      task: "clean assembleFdroidRelease",
+      task: "assembleFdroidRelease",
       properties: {
         "android.injected.version.name" => ENV['VERSION_NAME'],
         "android.injected.version.code" => ENV['VERSION_CODE']
@@ -46,7 +46,7 @@ platform :android do
   desc "Build the Google Release"
   private_lane :build_google_release do
     gradle(
-      task: "clean bundleGoogleRelease assembleGoogleRelease",
+      task: "bundleGoogleRelease assembleGoogleRelease",
       print_command: false,
       properties: {
         "android.injected.version.name" => ENV['VERSION_NAME'],


### PR DESCRIPTION
- Update the `cleanup-on-failure` job in `create-or-promote-release.yml` to trigger on both failure and cancellation.
- Add a check to ensure `FINAL_TAG` is set before attempting to delete the remote tag in the release workflow.
- Remove redundant `clean` tasks from `fdroid_build` and `build_google_release` lanes in `fastlane/Fastfile` to improve build efficiency.