### PR TITLE
ci: Refine APK artifact paths and enable automatic release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
           tag_name: ${{ inputs.tag_name }}
           target_commitish: ${{ inputs.commit_sha || github.sha }}
           name: ${{ inputs.tag_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})
-          generate_release_notes: false
+          generate_release_notes: true
           files: ./artifacts/*/*
           draft: true
           prerelease: true


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` workflow to improve artifact handling and release note generation for both Google and F-Droid APKs. The primary changes focus on making the artifact paths more specific and enabling automatic release notes.

Artifact handling improvements:

* Changed the upload and provenance attestation paths for Google APKs to target only `app/build/outputs/apk/google/release/*.apk`, ensuring only release builds are processed. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L174-R174) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L187-R187)
* Updated the upload and provenance attestation paths for F-Droid APKs to target only `app/build/outputs/apk/fdroid/release/*.apk`, improving specificity and consistency.

Release process enhancement:

* Set `generate_release_notes` to `true` for GitHub releases, enabling automatic generation of release notes.