### PR TITLE
refactor(ble): increase default timeout for BLE profiling

### DIFF
--- a/core/ble/src/main/kotlin/org/meshtastic/core/ble/BleConnection.kt
+++ b/core/ble/src/main/kotlin/org/meshtastic/core/ble/BleConnection.kt
@@ -157,7 +157,7 @@ class BleConnection(
     @Suppress("TooGenericExceptionCaught")
     suspend fun <T> profile(
         serviceUuid: Uuid,
-        timeout: kotlin.time.Duration = 10.seconds,
+        timeout: kotlin.time.Duration = 30.seconds,
         setup: suspend CoroutineScope.(no.nordicsemi.kotlin.ble.client.RemoteService) -> T,
     ): T {
         val p = peripheralFlow.first { it != null }!!


### PR DESCRIPTION
- Update the default `timeout` value in the `BleConnection.profile` function from 10 seconds to 30 seconds.