### PR TITLE
build(github): switch Java distribution to Zulu across workflows

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          distribution: jetbrains
+          distribution: zulu
           java-version: 17
 
       - name: Generate and submit dependency graph

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'zulu'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'temurin'
+          distribution: 'zulu'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'zulu'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
@@ -210,7 +210,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'zulu'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
@@ -285,7 +285,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'zulu'
           
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'zulu'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This commit standardizes the Java distribution used in GitHub Actions workflows by switching from `jetbrains` and `temurin` to `zulu`.

Specific changes include:
- Updated `.github/workflows/publish-core.yml` to use `zulu` distribution.
- Updated `.github/workflows/scheduled-updates.yml` to use `zulu` distribution.
- Updated `.github/workflows/docs.yml` to use `zulu` distribution.
- Updated `.github/workflows/dependency-submission.yml` to use `zulu` distribution.
- Updated all jobs in `.github/workflows/release.yml` to use `zulu` distribution.
