### PR TITLE
build(desktop): enable ProGuard for release builds

### DIFF
--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -43,6 +43,8 @@ compose.desktop {
     application {
         mainClass = "org.meshtastic.desktop.MainKt"
 
+        buildTypes.release.proguard { configurationFiles.from(project.file("proguard-rules.pro")) }
+
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Meshtastic"

--- a/desktop/proguard-rules.pro
+++ b/desktop/proguard-rules.pro
@@ -1,0 +1,4 @@
+-dontwarn android.os.Parcel**
+-dontwarn android.os.Parcelable**
+-dontwarn com.squareup.wire.AndroidMessage**
+-dontwarn io.ktor.**


### PR DESCRIPTION
This commit enables ProGuard for the desktop module's release build configuration and introduces a rules file to suppress common build warnings.

Specific changes include:
- Updated `desktop/build.gradle.kts` to include `proguard-rules.pro` in the release build type configuration.
- Created `desktop/proguard-rules.pro` with `-dontwarn` rules for Android-specific classes (`Parcel`, `Parcelable`, `AndroidMessage`) and `io.ktor` to prevent build failures during the shrinking phase.