### PR TITLE
ci(release): pass app version to desktop build via environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,9 @@ jobs:
         run: ./gradlew exportLibraryDefinitions -Pci=true
 
       - name: Package Native Distributions
-        run: ./gradlew :desktop:packageReleaseDistributionForCurrentOS -PappVersionName=${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }} --no-daemon
+        env:
+          ORG_GRADLE_PROJECT_appVersionName: ${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }}
+        run: ./gradlew :desktop:packageReleaseDistributionForCurrentOS --no-daemon
 
       - name: Upload Desktop Artifacts
         if: always()
@@ -309,9 +311,9 @@ jobs:
         with:
           name: desktop-${{ runner.os }}
           path: |
-            desktop/build/compose/binaries/main/app/*/*.dmg
-            desktop/build/compose/binaries/main/app/*/*.msi
-            desktop/build/compose/binaries/main/app/*/*.deb
+            desktop/build/compose/binaries/main-release/*/*.dmg
+            desktop/build/compose/binaries/main-release/*/*.msi
+            desktop/build/compose/binaries/main-release/*/*.deb
           retention-days: 1
           if-no-files-found: ignore
 


### PR DESCRIPTION
This commit updates the desktop distribution packaging step in the release workflow to provide the application version name through an environment variable instead of a command-line parameter.

Specific changes:
- Added `ORG_GRADLE_PROJECT_appVersionName` to the environment block of the `Package Native Distributions` step.
- Removed the `-PappVersionName` argument from the `./gradlew :desktop:packageReleaseDistributionForCurrentOS` command.