### PR TITLE
build(desktop): include `java.net.http` module in native distribution

### DIFF
--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -59,6 +59,8 @@ compose.desktop {
             )
             packageName = "Meshtastic"
 
+            modules("java.net.http")
+
             // App Icon
             macOS { iconFile.set(project.file("src/main/resources/icon.png")) }
             windows { iconFile.set(project.file("src/main/resources/icon.png")) }


### PR DESCRIPTION
- Added `java.net.http` to the JDK modules list in `desktop/build.gradle.kts` to ensure the standard Java HTTP client is available in the packaged desktop application.
