### PR TITLE
build: remove PKG from desktop distribution targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,7 +306,6 @@ jobs:
           name: desktop-${{ runner.os }}
           path: |
             desktop/build/compose/binaries/main-release/*/*.dmg
-            desktop/build/compose/binaries/main-release/*/*.pkg
             desktop/build/compose/binaries/main-release/*/*.msi
             desktop/build/compose/binaries/main-release/*/*.exe
             desktop/build/compose/binaries/main-release/*/*.deb

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -51,7 +51,6 @@ compose.desktop {
         nativeDistributions {
             targetFormats(
                 TargetFormat.Dmg,
-                TargetFormat.Pkg,
                 TargetFormat.Exe,
                 TargetFormat.Msi,
                 TargetFormat.Deb,


### PR DESCRIPTION
- Remove `TargetFormat.Pkg` from the native distribution configuration in `desktop/build.gradle.kts`.
- Update the GitHub Actions release workflow to stop collecting and uploading `.pkg` files as artifacts.
