### PR TITLE
ci(github-actions): include architecture in desktop artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,7 +303,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: desktop-${{ runner.os }}
+          name: desktop-${{ runner.os }}-${{ runner.arch }}
           path: |
             desktop/build/compose/binaries/main-release/*/*.dmg
             desktop/build/compose/binaries/main-release/*/*.msi


### PR DESCRIPTION
This commit updates the `release.yml` workflow to include the runner architecture in the uploaded artifact names for desktop builds. This prevents naming collisions and clarifies build targets when running jobs on different architectures (e.g., x64 vs. arm64).

Specific changes:
- Updated the `name` property in the `actions/upload-artifact` step to use `desktop-${{ runner.os }}-${{ runner.arch }}`.
