### PR TITLE
build(desktop): refactor native distribution target formats

### DIFF
--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -52,7 +52,6 @@ compose.desktop {
         }
 
         nativeDistributions {
-            targetFormats(TargetFormat.Dmg, TargetFormat.Exe, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm)
             packageName = "Meshtastic"
 
             // Ensure critical JVM modules are included in the custom JRE bundled with the app.
@@ -79,22 +78,26 @@ compose.desktop {
                 // notarize = true
                 // appleID = System.getenv("APPLE_ID")
                 // appStorePassword = System.getenv("APPLE_APP_SPECIFIC_PASSWORD")
+                targetFormats(TargetFormat.Dmg)
             }
             windows {
                 iconFile.set(project.file("src/main/resources/icon.ico"))
                 menuGroup = "Meshtastic"
                 // TODO: Must generate and set a consistent UUID for Windows upgrades.
                 // upgradeUuid = "YOUR-UPGRADE-UUID-HERE"
+                targetFormats(TargetFormat.Msi, TargetFormat.Exe)
             }
             linux {
                 iconFile.set(project.file("src/main/resources/icon.png"))
                 menuGroup = "Network"
+                targetFormats(TargetFormat.Deb, TargetFormat.Rpm, TargetFormat.AppImage)
             }
 
             // Read version from project properties (passed by CI) or default to 1.0.0
             // Native installers require strict numeric semantic versions (X.Y.Z) without suffixes
             val rawVersion =
                 project.findProperty("android.injected.version.name")?.toString()
+                    ?: project.findProperty("appVersionName")?.toString()
                     ?: System.getenv("VERSION_NAME")
                     ?: "1.0.0"
             val sanitizedVersion = Regex("^\\d+\\.\\d+\\.\\d+").find(rawVersion)?.value ?: "1.0.0"


### PR DESCRIPTION
This commit reorganizes the native distribution configuration by moving target format definitions from a global scope to platform-specific blocks. This ensures that packaging formats are correctly associated with their respective operating systems and adds support for AppImage on Linux.

Specific changes include:
- Removed the global `targetFormats` declaration in `nativeDistributions`.
- Added `TargetFormat.Dmg` to the `macOS` configuration block.
- Added `TargetFormat.Msi` and `TargetFormat.Exe` to the `windows` configuration block.
- Added `TargetFormat.Deb`, `TargetFormat.Rpm`, and `TargetFormat.AppImage` to the `linux` configuration block.
