### PR TITLE
build(desktop): dynamically configure target formats based on host OS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,7 @@ jobs:
             desktop/build/compose/binaries/main-release/*/*.exe
             desktop/build/compose/binaries/main-release/*/*.deb
             desktop/build/compose/binaries/main-release/*/*.rpm
+            desktop/build/compose/binaries/main-release/*/*.AppImage
           retention-days: 1
           if-no-files-found: ignore
 

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -78,19 +78,25 @@ compose.desktop {
                 // notarize = true
                 // appleID = System.getenv("APPLE_ID")
                 // appStorePassword = System.getenv("APPLE_APP_SPECIFIC_PASSWORD")
-                targetFormats(TargetFormat.Dmg)
             }
             windows {
                 iconFile.set(project.file("src/main/resources/icon.ico"))
                 menuGroup = "Meshtastic"
                 // TODO: Must generate and set a consistent UUID for Windows upgrades.
                 // upgradeUuid = "YOUR-UPGRADE-UUID-HERE"
-                targetFormats(TargetFormat.Msi, TargetFormat.Exe)
             }
             linux {
                 iconFile.set(project.file("src/main/resources/icon.png"))
                 menuGroup = "Network"
-                targetFormats(TargetFormat.Deb, TargetFormat.Rpm, TargetFormat.AppImage)
+            }
+
+            // Define target formats based on the current host OS to avoid configuration errors
+            // (e.g., trying to configure Linux AppImage notarization on macOS).
+            val currentOs = System.getProperty("os.name").lowercase()
+            when {
+                currentOs.contains("mac") -> targetFormats(TargetFormat.Dmg)
+                currentOs.contains("win") -> targetFormats(TargetFormat.Msi, TargetFormat.Exe)
+                else -> targetFormats(TargetFormat.Deb, TargetFormat.Rpm, TargetFormat.AppImage)
             }
 
             // Read version from project properties (passed by CI) or default to 1.0.0


### PR DESCRIPTION
This commit refactors the desktop build configuration to determine distribution target formats dynamically based on the current operating system. This prevents configuration errors when running on different platforms (e.g., attempting to configure Linux-specific formats on macOS).

Specific changes include:
- **`desktop/build.gradle.kts`**: Removed static `targetFormats` definitions from platform-specific blocks and replaced them with a conditional check on `os.name`.
- **`release.yml`**: Added `*.AppImage` to the list of artifacts collected during the CI release workflow.