### PR TITLE
ci(github): add Release environment to desktop release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,7 @@ jobs:
   release-desktop:
     runs-on: ${{ matrix.os }}
     needs: [prepare-build-info]
+    environment: Release
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This commit adds the `environment: Release` property to the `release-desktop` job in the GitHub Actions workflow. This ensures that the desktop release process runs within the context of the "Release" environment, enabling access to environment-specific secrets and protection rules.
