### PR TITLE
ci(github-actions): install `libfuse2t64` for Linux AppImage packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,10 @@ jobs:
       - name: Export Full Library Licenses
         run: ./gradlew exportLibraryDefinitions -Pci=true
 
+      - name: Install dependencies for AppImage
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libfuse2t64
+
       - name: Package Native Distributions
         env:
           ORG_GRADLE_PROJECT_appVersionName: ${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }}


### PR DESCRIPTION
This commit updates the release workflow to install `libfuse2t64` on Linux runners. This dependency is required for the successful packaging of Native Distributions as an AppImage.

Specific changes:
- Added a step to `release.yml` to install `libfuse2t64` via `apt-get` when the runner OS is Linux.