### PR TITLE
Gradle: Add flatpakGradleGenerator task

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -15,6 +15,9 @@ on:
       run_desktop_builds:
         type: boolean
         default: true
+      run_desktop_flatpak_src:
+        type: boolean
+        default: true
       upload_artifacts:
         type: boolean
         default: true
@@ -489,4 +492,50 @@ jobs:
         with:
           name: desktop-app-${{ runner.os }}-${{ runner.arch }}
           path: desktop/build/compose/binaries/main/app/
+          retention-days: 7
+
+  # ── Flatpak Sources ───────────────────────────────────────────────────
+  build-flatpak-src:
+    name: Generate Flatpak Sources (${{ matrix.os }})
+    if: inputs.run_desktop_flatpak_src == true
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    timeout-minutes: 60
+    needs: lint-check
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    env:
+      VERSION_CODE: ${{ needs.lint-check.outputs.version_code }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Gradle Setup
+        uses: ./.github/actions/gradle-setup
+        with:
+          gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache_read_only: ${{ needs.lint-check.outputs.cache_read_only }}
+
+      - name: Generate Flatpak Sources
+        env:
+          DESKTOP_ONLY: true
+        run: |
+          ./scripts/desktop-only-prep.sh
+          ./gradlew flatpakGradleGenerator --no-configuration-cache
+      
+      - run: ls -lah flatpak-sources*.json
+
+      - name: Upload Flatpak Sources
+        if: ${{ inputs.upload_artifacts }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: flatpak-sources-${{ runner.arch }}
+          path: flatpak-sources*.json
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ firebase-debug.log
 # Local library development clones
 /coil/
 /kable/
+
+# flatpakGradleGenerator output
+flatpak-sources*.json

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     `kotlin-dsl`
     alias(libs.plugins.spotless)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.flatpak.gradle.generator)
 }
 
 group = "org.meshtastic.buildlogic"
@@ -94,6 +95,12 @@ detekt {
     allRules = false
     baseline = file("detekt-baseline.xml")
     source.setFrom(files("src/main/java", "src/main/kotlin"))
+}
+
+tasks.flatpakGradleGenerator {
+    outputFile = file("../../flatpak-sources-convention.json")
+    downloadDirectory.set("./offline-repository")
+    excludeConfigurations.set(listOf("testCompileClasspath", "testRuntimeClasspath"))
 }
 
 gradlePlugin {

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -26,6 +26,7 @@ pluginManagement {
                 includeGroupByRegex("com\\.github\\..*")
             }
         }
+        maven { url = uri("../offline-repository") }
     }
 }
 
@@ -51,6 +52,7 @@ dependencyResolutionManagement {
                 includeGroupByRegex("com\\.github\\..*")
             }
         }
+        maven { url = uri("../offline-repository") }
     }
     versionCatalogs {
         create("libs") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,9 +38,17 @@ plugins {
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.test.retry) apply false
+    alias(libs.plugins.flatpak.gradle.generator)
     alias(libs.plugins.meshtastic.root)
 }
 
 dependencies {
     dokkaPlugin(libs.dokka.android.documentation.plugin)
+}
+
+tasks.flatpakGradleGenerator {
+    outputFile = file("flatpak-sources.json")
+    downloadDirectory = "./offline-repository"
+    includeConfigurations = listOf(":desktop:compileClasspath")
+    excludeConfigurations.set(listOf("testCompileClasspath", "testRuntimeClasspath"))
 }

--- a/core/ble/build.gradle.kts
+++ b/core/ble/build.gradle.kts
@@ -18,6 +18,7 @@
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
     id("meshtastic.koin")
+    alias(libs.plugins.flatpak.gradle.generator)
 }
 
 kotlin {
@@ -50,4 +51,10 @@ kotlin {
             implementation(projects.core.testing)
         }
     }
+}
+
+tasks.flatpakGradleGenerator {
+    outputFile = file("../../flatpak-sources-core-ble.json")
+    downloadDirectory.set("./offline-repository")
+    excludeConfigurations.set(listOf("androidRuntimeClasspath", "androidCompileClasspath", "androidMainLintChecksClasspath", "androidHostTestCompileClasspath", "androidHostTestLintChecksClasspath", "androidHostTestRuntimeClasspath", "testCompileClasspath", "testRuntimeClasspath"))
 }

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
     id("meshtastic.kmp.jvm.android")
     id("meshtastic.koin")
+    alias(libs.plugins.flatpak.gradle.generator)
 }
 
 kotlin {
@@ -43,4 +44,10 @@ kotlin {
 
         commonTest.dependencies { implementation(libs.kotlinx.coroutines.test) }
     }
+}
+
+tasks.flatpakGradleGenerator {
+    outputFile = file("../../flatpak-sources-core-common.json")
+    downloadDirectory.set("./offline-repository")
+    excludeConfigurations.set(listOf("androidHostTestCompileClasspath", "androidHostTestLintChecksClasspath", "androidHostTestRuntimeClasspath", "testCompileClasspath", "testRuntimeClasspath"))
 }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     alias(libs.plugins.meshtastic.kotlinx.serialization)
     alias(libs.plugins.kotlin.parcelize)
     id("meshtastic.koin")
+    alias(libs.plugins.flatpak.gradle.generator)
 }
 
 kotlin {
@@ -76,4 +77,10 @@ dependencies {
     "kspJvmTest"(libs.androidx.room.compiler)
     "kspAndroidHostTest"(libs.androidx.room.compiler)
     "kspAndroidDeviceTest"(libs.androidx.room.compiler)
+}
+
+tasks.flatpakGradleGenerator {
+    outputFile = file("../../flatpak-sources-core-database.json")
+    downloadDirectory.set("./offline-repository")
+    excludeConfigurations.set(listOf("androidRuntimeClasspath", "androidMainLintChecksClasspath", "androidHostTestRuntimeClasspath", "androidHostTestLintChecksClasspath", "androidHostTestCompileClasspath", "androidDeviceTestRuntimeClasspath", "androidDeviceTestLintChecksClasspath", "androidDeviceTestCompileClasspath", "androidCompileClasspath", "testCompileClasspath", "testRuntimeClasspath"))
 }

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
     id("meshtastic.kmp.jvm.android")
     id("meshtastic.publishing")
+    alias(libs.plugins.flatpak.gradle.generator)
 }
 
 kotlin {
@@ -71,4 +72,10 @@ publishing {
             artifactId = baseId.replace("model-", "meshtastic-android-model-")
         }
     }
+}
+
+tasks.flatpakGradleGenerator {
+    outputFile = file("../../flatpak-sources-core-model.json")
+    downloadDirectory.set("./offline-repository")
+    excludeConfigurations.set(listOf("androidRuntimeClasspath", "androidMainLintChecksClasspath", "androidHostTestRuntimeClasspath", "androidHostTestLintChecksClasspath", "androidHostTestCompileClasspath", "androidDeviceTestRuntimeClasspath", "androidDeviceTestLintChecksClasspath", "androidDeviceTestCompileClasspath", "androidCompileClasspath", "testCompileClasspath", "testRuntimeClasspath"))
 }

--- a/core/proto/build.gradle.kts
+++ b/core/proto/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
     alias(libs.plugins.meshtastic.kmp.library)
     alias(libs.plugins.wire)
     id("meshtastic.publishing")
+    alias(libs.plugins.flatpak.gradle.generator)
 }
 
 kotlin {
@@ -60,4 +61,10 @@ publishing {
             artifactId = baseId.replace("proto-", "meshtastic-android-proto-")
         }
     }
+}
+
+tasks.flatpakGradleGenerator {
+    outputFile = file("../../flatpak-sources-core-proto.json")
+    downloadDirectory.set("./offline-repository")
+    excludeConfigurations.set(listOf("testCompileClasspath", "testRuntimeClasspath"))
 }

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
     alias(libs.plugins.meshtastic.koin)
     id("meshtastic.kover")
     id("meshtastic.aboutlibraries")
+    alias(libs.plugins.flatpak.gradle.generator)
 }
 
 configureGraphTasks()
@@ -321,4 +322,13 @@ dependencies {
     testImplementation(libs.koin.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(kotlin("test"))
+}
+
+// Must be run on each architecture to generate separate flatpak-sources.
+tasks.flatpakGradleGenerator {
+    val arch = System.getProperty("os.arch").let { if (it == "amd64") "x86_64" else it }
+    outputFile = file("../flatpak-sources-desktop-$arch.json")
+    downloadDirectory.set("./offline-repository")
+    onlyArches = arch
+    excludeConfigurations.set(listOf("testCompileClasspath", "testRuntimeClasspath"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -300,6 +300,7 @@ wire = { id = "com.squareup.wire", version.ref = "wire" }
 room = { id = "androidx.room3", version.ref = "room" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 test-retry = { id = "org.gradle.test-retry", version.ref = "testRetry" }
+flatpak-gradle-generator = { id = "io.github.jwharm.flatpak-gradle-generator", version = "1.7.0" }
 
 # Meshtastic
 meshtastic-android-application = { id = "meshtastic.android.application" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ pluginManagement {
         google()
         mavenCentral()
         maven { url = uri("https://jitpack.io") }
+        maven { url = uri("./offline-repository") }
     }
 }
 
@@ -55,6 +56,7 @@ dependencyResolutionManagement {
                 includeGroupByRegex("com\\.github\\..*")
             }
         }
+        maven { url = uri("./offline-repository") }
     }
 }
 


### PR DESCRIPTION
This PR adds a new gradle task [`flatpakGradleGenerator`](https://github.com/jwharm/flatpak-gradle-generator)

run with:
```sh
./scripts/desktop-only-prep.sh
DESKTOP_ONLY=true ./gradlew flatpakGradleGenerator --no-configuration-cache
```
this generates a json file `flatpak-sources.json` containing all dependencies needed to build `:desktop`.
When a flatpak builds using this `flatpak-source.json` file, all dependencies are stored to a dir `offline-repository` which gradle now leverages as a fallback maven repository.

In the future we may distribute this as part of GitHub Releases? (So they can be consumed by FlatPak builds directly).