### PR TITLE
feat: enhance map navigation and waypoint handling

### DIFF
--- a/app/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapViewProvider.kt
+++ b/app/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapViewProvider.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.app.map
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.Single
@@ -34,8 +35,10 @@ class FdroidMapViewProvider : MapViewProvider {
         tracerouteOverlay: Any?,
         tracerouteNodePositions: Map<Int, Any>,
         onTracerouteMappableCountChanged: (Int, Int) -> Unit,
+        waypointId: Int?,
     ) {
         val mapViewModel: MapViewModel = koinViewModel()
+        LaunchedEffect(waypointId) { mapViewModel.setWaypointId(waypointId) }
         org.meshtastic.app.map.MapView(
             modifier = modifier,
             mapViewModel = mapViewModel,

--- a/app/src/fdroid/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/app/src/fdroid/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -47,6 +47,12 @@ class MapViewModel(
     private val _selectedWaypointId = MutableStateFlow(savedStateHandle.get<Int>("waypointId"))
     val selectedWaypointId: StateFlow<Int?> = _selectedWaypointId.asStateFlow()
 
+    fun setWaypointId(id: Int?) {
+        if (id != null) {
+            _selectedWaypointId.value = id
+        }
+    }
+
     var mapStyleId: Int
         get() = mapPrefs.mapStyle.value
         set(value) {

--- a/app/src/google/kotlin/org/meshtastic/app/map/GoogleMapViewProvider.kt
+++ b/app/src/google/kotlin/org/meshtastic/app/map/GoogleMapViewProvider.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.app.map
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.Single
@@ -34,8 +35,10 @@ class GoogleMapViewProvider : MapViewProvider {
         tracerouteOverlay: Any?,
         tracerouteNodePositions: Map<Int, Any>,
         onTracerouteMappableCountChanged: (Int, Int) -> Unit,
+        waypointId: Int?,
     ) {
         val mapViewModel: MapViewModel = koinViewModel()
+        LaunchedEffect(waypointId) { mapViewModel.setWaypointId(waypointId) }
         org.meshtastic.app.map.MapView(
             modifier = modifier,
             mapViewModel = mapViewModel,

--- a/app/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/app/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -91,6 +91,20 @@ class MapViewModel(
     private val _selectedWaypointId = MutableStateFlow(savedStateHandle.get<Int>("waypointId"))
     val selectedWaypointId: StateFlow<Int?> = _selectedWaypointId.asStateFlow()
 
+    fun setWaypointId(id: Int?) {
+        if (id != null && _selectedWaypointId.value != id) {
+            _selectedWaypointId.value = id
+            viewModelScope.launch {
+                val wpMap = waypoints.first { it.containsKey(id) }
+                wpMap[id]?.let { packet ->
+                    val waypoint = packet.waypoint!!
+                    val latLng = LatLng((waypoint.latitude_i ?: 0) / 1e7, (waypoint.longitude_i ?: 0) / 1e7)
+                    cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 15f)
+                }
+            }
+        }
+    }
+
     private val targetLatLng =
         googleMapsPrefs.cameraTargetLat.value
             .takeIf { it != 0.0 }

--- a/app/src/google/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefs.kt
+++ b/app/src/google/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefs.kt
@@ -123,14 +123,30 @@ class GoogleMapsPrefsImpl(
     }
 
     override val cameraTargetLat: StateFlow<Double> =
-        dataStore.data.map { it[KEY_CAMERA_TARGET_LAT_PREF] ?: 0.0 }.stateIn(scope, SharingStarted.Eagerly, 0.0)
+        dataStore.data
+            .map {
+                try {
+                    it[KEY_CAMERA_TARGET_LAT_PREF] ?: 0.0
+                } catch (_: ClassCastException) {
+                    it[floatPreferencesKey(KEY_CAMERA_TARGET_LAT_PREF.name)]?.toDouble() ?: 0.0
+                }
+            }
+            .stateIn(scope, SharingStarted.Eagerly, 0.0)
 
     override fun setCameraTargetLat(value: Double) {
         scope.launch { dataStore.edit { it[KEY_CAMERA_TARGET_LAT_PREF] = value } }
     }
 
     override val cameraTargetLng: StateFlow<Double> =
-        dataStore.data.map { it[KEY_CAMERA_TARGET_LNG_PREF] ?: 0.0 }.stateIn(scope, SharingStarted.Eagerly, 0.0)
+        dataStore.data
+            .map {
+                try {
+                    it[KEY_CAMERA_TARGET_LNG_PREF] ?: 0.0
+                } catch (_: ClassCastException) {
+                    it[floatPreferencesKey(KEY_CAMERA_TARGET_LNG_PREF.name)]?.toDouble() ?: 0.0
+                }
+            }
+            .stateIn(scope, SharingStarted.Eagerly, 0.0)
 
     override fun setCameraTargetLng(value: Double) {
         scope.launch { dataStore.edit { it[KEY_CAMERA_TARGET_LNG_PREF] = value } }

--- a/app/src/main/kotlin/org/meshtastic/app/navigation/ContactsNavigation.kt
+++ b/app/src/main/kotlin/org/meshtastic/app/navigation/ContactsNavigation.kt
@@ -88,6 +88,7 @@ private fun ContactsEntryContent(
     val requestChannelSet by uiViewModel.requestChannelSet.collectAsStateWithLifecycle()
     val contactsViewModel = koinViewModel<ContactsViewModel>()
     val messageViewModel = koinViewModel<MessageViewModel>()
+    initialContactKey?.let { messageViewModel.setContactKey(it) }
 
     AdaptiveContactsScreen(
         backStack = backStack,

--- a/app/src/main/kotlin/org/meshtastic/app/navigation/MapNavigation.kt
+++ b/app/src/main/kotlin/org/meshtastic/app/navigation/MapNavigation.kt
@@ -26,12 +26,13 @@ import org.meshtastic.feature.map.MapScreen
 import org.meshtastic.feature.map.SharedMapViewModel
 
 fun EntryProviderScope<NavKey>.mapGraph(backStack: NavBackStack<NavKey>) {
-    entry<MapRoutes.Map> {
+    entry<MapRoutes.Map> { args ->
         val viewModel = koinViewModel<SharedMapViewModel>()
         MapScreen(
             viewModel = viewModel,
             onClickNodeChip = { backStack.add(NodesRoutes.NodeDetailGraph(it)) },
             navigateToNodeDetails = { backStack.add(NodesRoutes.NodeDetailGraph(it)) },
+            waypointId = args.waypointId,
         )
     }
 }

--- a/app/src/main/kotlin/org/meshtastic/app/navigation/NodesNavigation.kt
+++ b/app/src/main/kotlin/org/meshtastic/app/navigation/NodesNavigation.kt
@@ -111,6 +111,7 @@ fun EntryProviderScope<NavKey>.nodeDetailGraph(
 
     entry<NodeDetailRoutes.NodeMap> { args ->
         val vm = koinViewModel<NodeMapViewModel>()
+        vm.setDestNum(args.destNum)
         NodeMapScreen(vm, onNavigateUp = { backStack.removeLastOrNull() })
     }
 

--- a/app/src/main/kotlin/org/meshtastic/app/ui/Main.kt
+++ b/app/src/main/kotlin/org/meshtastic/app/ui/Main.kt
@@ -299,24 +299,36 @@ fun MainScreen(uIViewModel: UIViewModel = koinViewModel(), scanModel: ScannerVie
                                 TopLevelDestination.Nodes -> {
                                     val onNodesList = currentKey is NodesRoutes.Nodes
                                     if (!onNodesList) {
-                                        backStack.clear()
-                                        backStack.add(destination.route)
+                                        if (backStack.isNotEmpty()) {
+                                            backStack[0] = destination.route
+                                            while (backStack.size > 1) backStack.removeAt(backStack.lastIndex)
+                                        } else {
+                                            backStack.add(destination.route)
+                                        }
                                     }
                                     uIViewModel.emitScrollToTopEvent(ScrollToTopEvent.NodesTabPressed)
                                 }
                                 TopLevelDestination.Conversations -> {
                                     val onConversationsList = currentKey is ContactsRoutes.Contacts
                                     if (!onConversationsList) {
-                                        backStack.clear()
-                                        backStack.add(destination.route)
+                                        if (backStack.isNotEmpty()) {
+                                            backStack[0] = destination.route
+                                            while (backStack.size > 1) backStack.removeAt(backStack.lastIndex)
+                                        } else {
+                                            backStack.add(destination.route)
+                                        }
                                     }
                                     uIViewModel.emitScrollToTopEvent(ScrollToTopEvent.ConversationsTabPressed)
                                 }
                                 else -> Unit
                             }
                         } else {
-                            backStack.clear()
-                            backStack.add(destination.route)
+                            if (backStack.isNotEmpty()) {
+                                backStack[0] = destination.route
+                                while (backStack.size > 1) backStack.removeAt(backStack.lastIndex)
+                            } else {
+                                backStack.add(destination.route)
+                            }
                         }
                     },
                 )

--- a/app/src/main/kotlin/org/meshtastic/app/ui/node/AdaptiveNodeListScreen.kt
+++ b/app/src/main/kotlin/org/meshtastic/app/ui/node/AdaptiveNodeListScreen.kt
@@ -66,7 +66,8 @@ fun AdaptiveNodeListScreen(
         val currentKey = backStack.lastOrNull()
         val isNodesRoute = currentKey is NodesRoutes.Nodes || currentKey is NodesRoutes.NodesGraph
         val previousKey = if (backStack.size > 1) backStack[backStack.size - 2] else null
-        val isFromDifferentGraph = previousKey !is NodesRoutes.NodesGraph && previousKey !is NodesRoutes.Nodes
+        val isFromDifferentGraph =
+            previousKey != null && previousKey !is NodesRoutes.NodesGraph && previousKey !is NodesRoutes.Nodes
 
         if (isFromDifferentGraph && !isNodesRoute) {
             // Navigate back via NavController to return to the previous screen

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/MapViewProvider.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/MapViewProvider.kt
@@ -37,6 +37,7 @@ interface MapViewProvider {
         tracerouteOverlay: Any? = null,
         tracerouteNodePositions: Map<Int, Any> = emptyMap(),
         onTracerouteMappableCountChanged: (Int, Int) -> Unit = { _, _ -> },
+        waypointId: Int? = null,
     )
 }
 

--- a/feature/map/src/androidMain/kotlin/org/meshtastic/feature/map/MapScreen.kt
+++ b/feature/map/src/androidMain/kotlin/org/meshtastic/feature/map/MapScreen.kt
@@ -35,6 +35,7 @@ fun MapScreen(
     navigateToNodeDetails: (Int) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SharedMapViewModel,
+    waypointId: Int? = null,
 ) {
     val ourNodeInfo by viewModel.ourNodeInfo.collectAsStateWithLifecycle()
     val isConnected by viewModel.isConnected.collectAsStateWithLifecycle()
@@ -58,6 +59,7 @@ fun MapScreen(
             modifier = Modifier.fillMaxSize().padding(paddingValues),
             viewModel = viewModel,
             navigateToNodeDetails = navigateToNodeDetails,
+            waypointId = waypointId,
         )
     }
 }

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/node/NodeMapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/node/NodeMapViewModel.kt
@@ -18,8 +18,10 @@ package org.meshtastic.feature.map.node
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
@@ -44,11 +46,19 @@ class NodeMapViewModel(
     buildConfigProvider: BuildConfigProvider,
     private val mapPrefs: MapPrefs,
 ) : ViewModel() {
-    private val destNum = savedStateHandle.get<Int>("destNum") ?: 0
+    private val destNumFromRoute = savedStateHandle.get<Int>("destNum")
+    private val manualDestNum = MutableStateFlow<Int?>(null)
+
+    private val destNumFlow =
+        combine(MutableStateFlow(destNumFromRoute), manualDestNum) { route, manual -> manual ?: route ?: 0 }
+
+    fun setDestNum(num: Int) {
+        manualDestNum.value = num
+    }
 
     val node =
-        nodeRepository.nodeDBbyNum
-            .mapLatest { it[destNum] }
+        destNumFlow
+            .flatMapLatest { destNum -> nodeRepository.nodeDBbyNum.mapLatest { it[destNum] } }
             .distinctUntilChanged()
             .stateInWhileSubscribed(initialValue = null)
 
@@ -57,8 +67,9 @@ class NodeMapViewModel(
     private val ourNodeNumFlow = nodeRepository.myNodeInfo.map { it?.myNodeNum }.distinctUntilChanged()
 
     val positionLogs: StateFlow<List<Position>> =
-        ourNodeNumFlow
-            .map { if (destNum == it) MeshLog.NODE_NUM_LOCAL else destNum }
+        combine(ourNodeNumFlow, destNumFlow) { ourNodeNum, destNum ->
+            if (destNum == ourNodeNum) MeshLog.NODE_NUM_LOCAL else destNum
+        }
             .distinctUntilChanged()
             .flatMapLatest { logId ->
                 meshLogRepository.getMeshPacketsFrom(logId, PortNum.POSITION_APP.value).map { packets ->

--- a/feature/messaging/src/androidMain/kotlin/org/meshtastic/feature/messaging/ui/contact/AdaptiveContactsScreen.kt
+++ b/feature/messaging/src/androidMain/kotlin/org/meshtastic/feature/messaging/ui/contact/AdaptiveContactsScreen.kt
@@ -78,7 +78,8 @@ fun AdaptiveContactsScreen(
             // Check if we navigated here from another screen (e.g., from Nodes or Map)
             val previousKey = if (backStack.size > 1) backStack[backStack.size - 2] else null
             val isFromDifferentGraph =
-                previousKey !is ContactsRoutes.ContactsGraph &&
+                previousKey != null &&
+                    previousKey !is ContactsRoutes.ContactsGraph &&
                     previousKey !is ContactsRoutes.Contacts &&
                     previousKey !is ContactsRoutes.Messages
 

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
@@ -151,6 +151,12 @@ class MessageViewModel(
         }
     }
 
+    fun setContactKey(contactKey: String) {
+        if (contactKeyForPagedMessages.value != contactKey) {
+            contactKeyForPagedMessages.value = contactKey
+        }
+    }
+
     fun setTitle(title: String) {
         viewModelScope.launch { _title.value = title }
     }


### PR DESCRIPTION
This commit improves the map and navigation experience by implementing direct waypoint focusing, refining backstack management, and fixing navigation state issues across the app.

Specific changes include:
- **Map & Waypoints**:
    - Added `waypointId` support to `MapViewProvider` and both Google and F-Droid `MapViewModel` implementations.
    - Implemented auto-centering and zooming to a specific waypoint on the map when a `waypointId` is provided.
    - Fixed a `ClassCastException` in `GoogleMapsPrefs` when migrating camera target coordinates from older preference formats.
- **Navigation & Lifecycle**:
    - Updated `Main` navigation logic to properly reset the backstack when switching between top-level destinations (Nodes and Conversations).
    - Fixed an issue where `isFromDifferentGraph` was incorrectly calculated due to a null check in `AdaptiveContactsScreen` and `AdaptiveNodeListScreen`.
    - Added `setDestNum` and `setContactKey` to their respective ViewModels to ensure correct state initialization when navigating directly to details screens.
- **Node Map**:
    - Refactored `NodeMapViewModel` to use a reactive flow for `destNum`, allowing for manual updates and better handling of destination changes.
- **Messaging**:
    - Added `setContactKey` to `MessageViewModel` to ensure the correct message thread is loaded when navigating from the contacts graph.

fixes #4801
fixes #4811