### PR TITLE
build: switch Java distribution from Zulu to JetBrains in GitHub Actions

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          distribution: zulu
+          distribution: jetbrains
           java-version: 17
 
       - name: Generate and submit dependency graph

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'jetbrains'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'jetbrains'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'jetbrains'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
@@ -205,7 +205,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'jetbrains'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
@@ -276,7 +276,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'jetbrains'
           
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'jetbrains'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
@@ -149,7 +149,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'jetbrains'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'zulu'
+          distribution: 'jetbrains'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Swaps out java distribution to Jetbrains for KMP build compliance.