### PR TITLE
Add InlineMap implementation for F-Droid build

### DIFF
--- a/app/src/fdroid/kotlin/org/meshtastic/app/node/component/InlineMap.kt
+++ b/app/src/fdroid/kotlin/org/meshtastic/app/node/component/InlineMap.kt
@@ -17,26 +17,25 @@
 package org.meshtastic.app.node.component
 
 import android.view.ViewGroup
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import org.meshtastic.core.model.Node
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
-import org.osmdroid.tileprovider.tilesource.TileSourceFactory
 
 @Composable
 fun InlineMap(node: Node, modifier: Modifier = Modifier) {
-
     val context = androidx.compose.ui.platform.LocalContext.current
 
     val map = remember {
         MapView(context).apply {
-            layoutParams = ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT
-            )
+            layoutParams =
+                ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
 
             // Default osmdroid tile source.
             setTileSource(TileSourceFactory.MAPNIK)
@@ -51,17 +50,15 @@ fun InlineMap(node: Node, modifier: Modifier = Modifier) {
 
         map.overlays.clear()
 
-        val marker = Marker(map).apply {
-            position = point
-            setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
-        }
+        val marker =
+            Marker(map).apply {
+                position = point
+                setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
+            }
         map.overlays.add(marker)
 
         map.controller.animateTo(point)
     }
 
-    AndroidView(
-        factory = { map },
-        modifier = modifier
-    )
+    AndroidView(factory = { map }, modifier = modifier)
 }


### PR DESCRIPTION
**This implements the InlineMap component for the F-Droid build, which was previously a no-op.**

Changes:
- Added osmdroid-based map rendering
- Displays node position with a marker
- Brings F-Droid behavior closer to the Google build by showing a map preview in node details

_While osmdroid is currently unmaintained, it is already used in the app for the nodes map screen. Given that, this change avoids leaving an empty placeholder in the node details screen and provides a more consistent user experience across build variants._

Tested:
- F-Droid build compiles successfully
- Map renders correctly in node details
- Marker displays as expected