### PR TITLE
fix(settings): remove redundant regex option in DebugViewModel

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
@@ -385,7 +385,7 @@ class DebugViewModel(
     private fun StringBuilder.annotateNodeId(nodeId: Int): Boolean {
         val nodeIdStr = nodeId.toUInt().toString()
         // Only match if whitespace before and after
-        val regex = Regex("""(?<=\s|^)${Regex.escape(nodeIdStr)}(?=\s|$)""", RegexOption.DOT_MATCHES_ALL)
+        val regex = Regex("""(?<=\s|^)${Regex.escape(nodeIdStr)}(?=\s|$)""")
         regex.find(this)?.let { _ ->
             regex.findAll(this).toList().asReversed().forEach {
                 val idx = it.range.last + 1


### PR DESCRIPTION
This commit simplifies the regex used for annotating node IDs in the debug log by removing an unnecessary regex option.

Specific changes:
- Removed `RegexOption.DOT_MATCHES_ALL` from the `nodeId` matching logic in `DebugViewModel.kt`, as the pattern does not utilize the dot (`.`) wildcard.
