### PR TITLE
feat: Integrate AlertHost into desktop application and add UI tests

### DIFF
--- a/core/ui/src/androidTest/kotlin/org/meshtastic/core/ui/component/AlertHostTest.kt
+++ b/core/ui/src/androidTest/kotlin/org/meshtastic/core/ui/component/AlertHostTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.component
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+import org.meshtastic.core.ui.util.AlertManager
+
+class AlertHostTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun alertHost_showsDialog_whenAlertIsTriggered() {
+        val alertManager = AlertManager()
+        val title = "Alert Title"
+        val message = "Alert Message"
+
+        composeTestRule.setContent { AlertHost(alertManager = alertManager) }
+
+        alertManager.showAlert(title = title, message = message)
+
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+        composeTestRule.onNodeWithText(message).assertIsDisplayed()
+    }
+}

--- a/desktop/src/main/kotlin/org/meshtastic/desktop/Main.kt
+++ b/desktop/src/main/kotlin/org/meshtastic/desktop/Main.kt
@@ -173,6 +173,7 @@ fun main(args: Array<String>) = application(exitProcessOnExit = false) {
     val appIcon = classpathPainterResource("icon.png")
 
     val notificationManager = remember { koinApp.koin.get<DesktopNotificationManager>() }
+    val alertManager = remember { koinApp.koin.get<org.meshtastic.core.ui.util.AlertManager>() }
     val desktopPrefs = remember { koinApp.koin.get<DesktopPreferencesDataSource>() }
     val windowState = rememberWindowState()
 
@@ -309,7 +310,10 @@ fun main(args: Array<String>) = application(exitProcessOnExit = false) {
             // re-reads Locale.current and all stringResource() calls update.  Unlike key(), this
             // preserves remembered state (including the navigation backstack).
             CompositionLocalProvider(LocalAppLocale provides localePref) {
-                AppTheme(darkTheme = isDarkTheme) { DesktopMainScreen(backStack) }
+                AppTheme(darkTheme = isDarkTheme) {
+                    org.meshtastic.core.ui.component.AlertHost(alertManager)
+                    DesktopMainScreen(backStack)
+                }
             }
         }
     }


### PR DESCRIPTION
- Injected `AlertManager` into the desktop `Main.kt` and added the `AlertHost` component to the top-level composition.
- Added `AlertHostTest` in `core:ui` to verify that `AlertHost` correctly displays dialogs when an alert is triggered via the manager.