### PR TITLE
ci: refine workflow permissions and version parsing logic

### DIFF
--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -7,6 +7,9 @@ on:
       - '**/*.md'
       - 'docs/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: main-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/main-push-changelog.yml
+++ b/.github/workflows/main-push-changelog.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 concurrency:
   group: main-push-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -4,6 +4,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+permissions:
+  contents: read
+
 concurrency:
   group: build-mq-${{ github.ref }}
   cancel-in-progress: true
@@ -23,6 +26,7 @@ jobs:
   check-workflow-status:
     name: Check Workflow Status
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
       - android-check
     if: always()

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -77,9 +77,14 @@ jobs:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: Determine Version Name from Tag
-        id: get_version_name
-        run: echo "APP_VERSION_NAME=$(echo ${{ inputs.tag_name }} | sed 's/-.*//' | sed 's/v//')" >> $GITHUB_OUTPUT
+      - name: Prep APP_VERSION_NAME
+        id: prep_version
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          VERSION_NAME=$(echo $INPUT_TAG_NAME | sed 's/-.*//' | sed 's/v//')
+          echo "APP_VERSION_NAME=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "Parsed Version: $VERSION_NAME"
 
       - name: Extract VERSION_CODE_OFFSET from config.properties
         id: get_version_code_offset

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -38,14 +38,18 @@ jobs:
 
       - name: Configure Version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          VERSION_SUFFIX: ${{ inputs.version_suffix }}
         run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "VERSION_NAME=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            echo "VERSION_NAME=$RELEASE_TAG" >> $GITHUB_ENV
           else
              # Use a timestamp-based version for manual/branch builds to avoid collisions
              # or use the base version + suffix
              BASE_VERSION=$(grep "VERSION_NAME_BASE" config.properties | cut -d'=' -f2)
-             echo "VERSION_NAME=${BASE_VERSION}${{ inputs.version_suffix }}" >> $GITHUB_ENV
+             echo "VERSION_NAME=${BASE_VERSION}${VERSION_SUFFIX}" >> $GITHUB_ENV
           fi
 
       - name: Publish to GitHub Packages

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,9 @@ on:
       - 'docs/**'
       - '.gitignore'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -113,6 +116,7 @@ jobs:
   check-workflow-status:
     name: Check Workflow Status
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [check-changes, verify-check-changes-filter, validate-and-build]
     if: always()
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,14 @@ jobs:
           ref: ${{ inputs.tag_name }}
           fetch-depth: 0
           submodules: 'recursive'
-      - name: Determine Version Name from Tag
-        id: get_version_name
-        run: echo "APP_VERSION_NAME=$(echo ${{ inputs.tag_name }} | sed 's/-.*//' | sed 's/v//')" >> $GITHUB_OUTPUT
+      - name: Prep APP_VERSION_NAME
+        id: prep_version
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          VERSION_NAME=$(echo $INPUT_TAG_NAME | sed 's/-.*//' | sed 's/v//')
+          echo "APP_VERSION_NAME=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "Parsed Version: $VERSION_NAME"
 
       - name: Extract VERSION_CODE_OFFSET from config.properties
         id: get_version_code_offset

--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -144,6 +144,7 @@ jobs:
   check-workflow-status:
     name: Check Workflow Status
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
         - update_assets
     if: always()


### PR DESCRIPTION
This commit updates several GitHub Action workflows to improve security by explicitly defining permissions and refactors version string parsing for better reliability and readability.

Specific changes include:
- **Security & Permissions**: Added explicit `permissions` blocks (e.g., `contents: read`, `contents: write`) to `main-check.yml`, `pull-request.yml`, `merge-queue.yml`, and `main-push-changelog.yml`.
- **Workflow Reliability**: Refactored version name extraction in `promote.yml`, `release.yml`, and `publish-core.yml` to use environment variables instead of direct shell interpolation, reducing the risk of injection and improving logging.
- **Workflow Cleanup**: Added `permissions: {}` to status check jobs in `pull-request.yml`, `scheduled-updates.yml`, and `merge-queue.yml` to follow the principle of least privilege.
- **Improved Logging**: Added "Parsed Version" echo statements to version preparation steps to assist in debugging CI/CD pipeline runs.
