### PR TITLE
build(github): add GITHUB_TOKEN to setup-java actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,6 +71,7 @@ jobs:
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: '17'
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           distribution: jetbrains
           java-version: 17
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
@@ -211,6 +212,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
@@ -282,7 +284,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
-          
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -150,6 +151,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -86,8 +86,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6


### PR DESCRIPTION
This commit standardizes the configuration of the `actions/setup-java` action across all GitHub workflows by explicitly providing the `GITHUB_TOKEN` via the `token` input. This helps prevent rate limiting issues when downloading Java distributions.

Specific changes include:
- Added `token: ${{ secrets.GITHUB_TOKEN }}` to `actions/setup-java` in the following workflows:
    - `codeql.yml`
    - `publish-core.yml`
    - `scheduled-updates.yml` (also refactored from `env` to `with` input)
    - `docs.yml`
    - `reusable-check.yml`
    - `dependency-submission.yml`
    - `release.yml`
