### PR TITLE
refactor(ui): remove labels from navigation suite items

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavigationSuite.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavigationSuite.kt
@@ -188,7 +188,6 @@ private fun MeshtasticNavigationBar(
                         uiViewModel = uiViewModel,
                     )
                 },
-                label = { Text(stringResource(destination.label)) },
             )
         }
     }


### PR DESCRIPTION
This commit removes the text labels from the navigation suite items in the `MeshtasticNavigationSuite` component, resulting in an icon-only navigation layout.

Specific changes include:
- Removed the `label` parameter and its associated `stringResource` call from the navigation item implementation in `MeshtasticNavigationSuite.kt`.