### PR TITLE
ci: change jdk from jetbrains to temurin in non-release workflows

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
-          distribution: jetbrains
+          distribution: temurin
           java-version: 17
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
@@ -150,7 +150,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle

--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle


### PR DESCRIPTION
avoid ratelimits by reserving `jetbrains` for release