### PR TITLE
chore(github): update GitHub token reference in workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: '17'
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ github.token }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
@@ -212,7 +212,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
@@ -284,7 +284,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'jetbrains'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -151,7 +151,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6


### PR DESCRIPTION
This commit updates the way the GitHub token is referenced across various CI/CD workflows, switching from `${{ secrets.GITHUB_TOKEN }}` to `${{ github.token }}` for consistency and better alignment with current GitHub Actions best practices.

Specific changes include:
- Updated Java setup steps in `codeql.yml`, `scheduled-updates.yml`, `reusable-check.yml`, and `release.yml`.
- Replaced `${{ secrets.GITHUB_TOKEN }}` with `${{ github.token }}` in all affected workflow files.