### PR TITLE
fix(ci): update APP_VERSION_NAME output reference in workflows

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -67,7 +67,7 @@ jobs:
   prepare-build-info:
     runs-on: ubuntu-latest
     outputs:
-      APP_VERSION_NAME: ${{ steps.get_version_name.outputs.APP_VERSION_NAME }}
+      APP_VERSION_NAME: ${{ steps.prep_version.outputs.APP_VERSION_NAME }}
       APP_VERSION_CODE: ${{ steps.calculate_version_code.outputs.versionCode }}
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
   prepare-build-info:
     runs-on: ubuntu-latest
     outputs:
-      APP_VERSION_NAME: ${{ steps.get_version_name.outputs.APP_VERSION_NAME }}
+      APP_VERSION_NAME: ${{ steps.prep_version.outputs.APP_VERSION_NAME }}
       APP_VERSION_CODE: ${{ steps.calculate_version_code.outputs.versionCode }}
     env:
       GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}


### PR DESCRIPTION
This commit updates the `prepare-build-info` job in the promotion and release workflows to correctly reference the version name from the `prep_version` step instead of the deprecated or incorrect `get_version_name` step.

Specific changes:
- Updated the `APP_VERSION_NAME` output mapping in `.github/workflows/promote.yml`.
- Updated the `APP_VERSION_NAME` output mapping in `.github/workflows/release.yml`.
