### PR TITLE
ci(github): add conditional desktop build to release workflows

### DIFF
--- a/.github/workflows/create-or-promote-release.yml
+++ b/.github/workflows/create-or-promote-release.yml
@@ -20,6 +20,11 @@ on:
         required: true
         type: boolean
         default: false
+      build_desktop:
+        description: 'Whether to build the desktop distribution'
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -124,6 +129,7 @@ jobs:
       tag_name: ${{ needs.determine-tags.outputs.final_tag }}
       channel: ${{ inputs.channel }}
       base_version: ${{ inputs.base_version }}
+      build_desktop: ${{ inputs.build_desktop }}
     secrets: inherit
 
   call-promote-workflow:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
         description: 'The channel to create a release for or promote to'
         required: true
         type: string
+      build_desktop:
+        description: 'Whether to build the desktop distribution'
+        required: false
+        type: boolean
+        default: false
     secrets:
       GSERVICES:
         required: true
@@ -270,6 +275,7 @@ jobs:
           subject-path: app/build/outputs/apk/fdroid/release/*.apk
 
   release-desktop:
+    if: ${{ inputs.build_desktop }}
     runs-on: ${{ matrix.os }}
     needs: [prepare-build-info]
     environment: Release
@@ -334,6 +340,7 @@ jobs:
           if-no-files-found: ignore
 
   github-release:
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-24.04-arm
     needs: [prepare-build-info, release-google, release-fdroid, release-desktop]
     env:


### PR DESCRIPTION
This commit introduces the ability to optionally build and include desktop distributions during the release process. It adds a `build_desktop` input to the release workflows and ensures the GitHub release step proceeds even if specific platform jobs are skipped.

Specific changes include:
- **`release.yml`**:
    - Added a `build_desktop` boolean input (defaulting to `false`).
    - Added a conditional check to the `release-desktop` job to only run if `build_desktop` is true.
    - Updated the `github-release` job condition to ensure it executes as long as dependencies haven't failed or been cancelled, accommodating skipped jobs.
- **`create-or-promote-release.yml`**:
    - Added a `build_desktop` boolean input.
    - Updated the `call-release-workflow` job to pass the `build_desktop` input to the downstream release workflow.
