### PR TITLE
Implements feature #4969 Make MQTT and UDP hops clear in traceroute

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RouteDiscovery.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RouteDiscovery.kt
@@ -66,8 +66,13 @@ private fun formatTraceroutePath(nodesList: List<String>, snrList: List<Int>): S
             List(nodesList.size - 1) { -128 }
         }
             .map { snr ->
-                val str = if (snr == -128) "?" else "${snr / 4f}"
-                "⇊ $str dB"
+                val str = when (snr) {
+                    -128 -> "? dB"
+                    -127 -> "MQTT"
+                    127 -> "UDP"
+                    else -> "${snr / 4f} dB"
+                }
+                "⇊ $str"
             }
 
     return nodesList


### PR DESCRIPTION
This PR implements feature reques meshtastic/design#68. The idea is very simple: On a traceroute display the hops using MQTT and UDP more clearly. Instead of the current 0.0dB value which is actually a valid RF value it should show "MQTT" or "UDP".

This is a companion feature for the firmware which was already proposed through a PR. There isn't yet a consensus of what should be implemented first. The firmware proposed feature will use 2 additional "flag" values for MQTT and UDP hops in the SNR array.
This is similar to the current value (-128) used for "unknown" and should be -127 for MQTT and 127 for UDP. The idea is to use values as far as possible from the acceptable range of SNR in LoRa communications.

In order to help decide which one should be implemented first (I favor the APPs) let me explain what will happen:
1- If the firmware feature is implemented, with the current application behavior, users will see an SNR of -31.75 for MQTT and 31.75 for UDP. This could be mistakenly assumed as RF signal's SNR. But that already happens with the 0.0dB.
2- If the APP implements this current PR, for every node that is not updated to the firmware with the new feature, users will continue to see the "0.0dB". But a user with the new application will never see the -/+ 31.75 value. So it will be less confusing
Because 2) will make things better I would prefer to see the feature implemented first in the APP. Naturally there's always the possibility that a user will not update the APP and executes a trace that goes through a node with the firmware that implements the feature, and in that case they'll see -/+ 31.75. But I believe people tend to update the APPs more frequently than the nodes.

The change was very simple and affects a single file. The image showing the new behavior is already in the feature request.