### PR TITLE
feat: batch nodeinfos

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImpl.kt
@@ -59,6 +59,7 @@ class FromRadioPacketHandlerImpl(
         val myInfo = proto.my_info
         val metadata = proto.metadata
         val nodeInfo = proto.node_info
+        val nodeInfoBatch = proto.node_info_batch
         val configCompleteId = proto.config_complete_id
         val mqttProxyMessage = proto.mqttClientProxyMessage
         val queueStatus = proto.queueStatus
@@ -78,6 +79,10 @@ class FromRadioPacketHandlerImpl(
             metadata != null -> router.value.configFlowManager.handleLocalMetadata(metadata)
             nodeInfo != null -> {
                 router.value.configFlowManager.handleNodeInfo(nodeInfo)
+                serviceRepository.setConnectionProgress("Nodes (${router.value.configFlowManager.newNodeCount})")
+            }
+            nodeInfoBatch != null -> {
+                nodeInfoBatch.items.forEach { info -> router.value.configFlowManager.handleNodeInfo(info) }
                 serviceRepository.setConnectionProgress("Nodes (${router.value.configFlowManager.newNodeCount})")
             }
             configCompleteId != null -> router.value.configFlowManager.handleConfigComplete(configCompleteId)

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImpl.kt
@@ -82,7 +82,7 @@ class FromRadioPacketHandlerImpl(
                 serviceRepository.setConnectionProgress("Nodes (${router.value.configFlowManager.newNodeCount})")
             }
             nodeInfoBatch != null -> {
-                nodeInfoBatch.items.forEach { info -> router.value.configFlowManager.handleNodeInfo(info) }
+                router.value.configFlowManager.handleNodeInfoBatch(nodeInfoBatch.items)
                 serviceRepository.setConnectionProgress("Nodes (${router.value.configFlowManager.newNodeCount})")
             }
             configCompleteId != null -> router.value.configFlowManager.handleConfigComplete(configCompleteId)

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
@@ -77,8 +77,8 @@ class MeshConfigFlowManagerImpl(
     override fun handleConfigComplete(configCompleteId: Int) {
         when (configCompleteId) {
             HandshakeConstants.CONFIG_NONCE -> handleConfigOnlyComplete()
-            HandshakeConstants.NODE_INFO_NONCE,
             HandshakeConstants.BATCH_NODE_INFO_NONCE,
+            HandshakeConstants.NODE_INFO_NONCE,
             -> handleNodeInfoComplete()
             else -> Logger.w { "Config complete id mismatch: $configCompleteId" }
         }
@@ -169,6 +169,10 @@ class MeshConfigFlowManagerImpl(
 
     override fun handleNodeInfo(info: NodeInfo) {
         newNodes.add(info)
+    }
+
+    override fun handleNodeInfoBatch(items: List<NodeInfo>) {
+        newNodes.addAll(items)
     }
 
     override fun handleFileInfo(info: FileInfo) {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
@@ -77,7 +77,9 @@ class MeshConfigFlowManagerImpl(
     override fun handleConfigComplete(configCompleteId: Int) {
         when (configCompleteId) {
             HandshakeConstants.CONFIG_NONCE -> handleConfigOnlyComplete()
-            HandshakeConstants.NODE_INFO_NONCE -> handleNodeInfoComplete()
+            HandshakeConstants.NODE_INFO_NONCE,
+            HandshakeConstants.BATCH_NODE_INFO_NONCE,
+            -> handleNodeInfoComplete()
             else -> Logger.w { "Config complete id mismatch: $configCompleteId" }
         }
     }
@@ -120,10 +122,11 @@ class MeshConfigFlowManagerImpl(
 
     private fun handleNodeInfoComplete() {
         Logger.i { "NodeInfo complete (Stage 2)" }
-        val entities = newNodes.map { info ->
-            nodeManager.installNodeInfo(info, withBroadcast = false)
-            nodeManager.nodeDBbyNodeNum[info.num]!!
-        }
+        val entities =
+            newNodes.map { info ->
+                nodeManager.installNodeInfo(info, withBroadcast = false)
+                nodeManager.nodeDBbyNodeNum[info.num]!!
+            }
         newNodes.clear()
 
         scope.handledLaunch {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -263,7 +263,7 @@ class MeshConnectionManagerImpl(
     }
 
     override fun startNodeInfoOnly() {
-        val action = { packetHandler.sendToRadio(ToRadio(want_config_id = HandshakeConstants.NODE_INFO_NONCE)) }
+        val action = { packetHandler.sendToRadio(ToRadio(want_config_id = HandshakeConstants.BATCH_NODE_INFO_NONCE)) }
         startHandshakeStallGuard(2, action)
         action()
     }

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImplTest.kt
@@ -36,6 +36,7 @@ import org.meshtastic.proto.FromRadio
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.MqttClientProxyMessage
 import org.meshtastic.proto.MyNodeInfo
+import org.meshtastic.proto.NodeInfoBatch
 import org.meshtastic.proto.QueueStatus
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -159,6 +160,24 @@ class FromRadioPacketHandlerImplTest {
         handler.handleFromRadio(proto)
 
         verify { mqttManager.handleMqttProxyMessage(proxyMsg) }
+    }
+
+    @Test
+    fun `handleFromRadio routes NODE_INFO_BATCH items to configFlowManager and updates status`() {
+        val node1 = ProtoNodeInfo(num = 1111)
+        val node2 = ProtoNodeInfo(num = 2222)
+        val node3 = ProtoNodeInfo(num = 3333)
+        val batch = NodeInfoBatch(items = listOf(node1, node2, node3))
+        val proto = FromRadio(node_info_batch = batch)
+
+        every { configFlowManager.newNodeCount } returns 3
+
+        handler.handleFromRadio(proto)
+
+        verify { configFlowManager.handleNodeInfo(node1) }
+        verify { configFlowManager.handleNodeInfo(node2) }
+        verify { configFlowManager.handleNodeInfo(node3) }
+        verify { serviceRepository.setConnectionProgress("Nodes (3)") }
     }
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImplTest.kt
@@ -163,20 +163,19 @@ class FromRadioPacketHandlerImplTest {
     }
 
     @Test
-    fun `handleFromRadio routes NODE_INFO_BATCH items to configFlowManager and updates status`() {
+    fun `handleFromRadio routes NODE_INFO_BATCH to handleNodeInfoBatch and updates status`() {
         val node1 = ProtoNodeInfo(num = 1111)
         val node2 = ProtoNodeInfo(num = 2222)
         val node3 = ProtoNodeInfo(num = 3333)
-        val batch = NodeInfoBatch(items = listOf(node1, node2, node3))
+        val items = listOf(node1, node2, node3)
+        val batch = NodeInfoBatch(items = items)
         val proto = FromRadio(node_info_batch = batch)
 
         every { configFlowManager.newNodeCount } returns 3
 
         handler.handleFromRadio(proto)
 
-        verify { configFlowManager.handleNodeInfo(node1) }
-        verify { configFlowManager.handleNodeInfo(node2) }
-        verify { configFlowManager.handleNodeInfo(node3) }
+        verify { configFlowManager.handleNodeInfoBatch(items) }
         verify { serviceRepository.setConnectionProgress("Nodes (3)") }
     }
 

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImplTest.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.data.manager
+
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verifyNoMoreCalls
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.model.Node
+import org.meshtastic.core.repository.CommandSender
+import org.meshtastic.core.repository.HandshakeConstants
+import org.meshtastic.core.repository.MeshConnectionManager
+import org.meshtastic.core.repository.NodeManager
+import org.meshtastic.core.repository.PacketHandler
+import org.meshtastic.core.repository.PlatformAnalytics
+import org.meshtastic.core.repository.RadioConfigRepository
+import org.meshtastic.core.repository.ServiceBroadcasts
+import org.meshtastic.core.testing.FakeNodeRepository
+import org.meshtastic.core.testing.FakeServiceRepository
+import org.meshtastic.proto.NodeInfo
+import org.meshtastic.proto.ToRadio
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MeshConfigFlowManagerImplTest {
+
+    private val connectionManager = mock<MeshConnectionManager>(MockMode.autofill)
+    private val nodeRepository = FakeNodeRepository()
+    private val serviceRepository = FakeServiceRepository()
+    private val radioConfigRepository = mock<RadioConfigRepository>(MockMode.autofill)
+    private val serviceBroadcasts = mock<ServiceBroadcasts>(MockMode.autofill)
+    private val analytics = mock<PlatformAnalytics>(MockMode.autofill)
+    private val commandSender = mock<CommandSender>(MockMode.autofill)
+    private val packetHandler = mock<PacketHandler>(MockMode.autofill)
+    private val nodeManager = mock<NodeManager>(MockMode.autofill)
+
+    // Tracks nodes installed via nodeManager.installNodeInfo so assertions can inspect them
+    private val installedNodes: MutableMap<Int, Node> = mutableMapOf()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var manager: MeshConfigFlowManagerImpl
+
+    @BeforeTest
+    fun setUp() {
+        every { connectionManager.startNodeInfoOnly() } returns Unit
+        every { connectionManager.onRadioConfigLoaded() } returns Unit
+        every { connectionManager.onNodeDbReady() } returns Unit
+        every { packetHandler.sendToRadio(any<ToRadio>()) } returns Unit
+        every { serviceBroadcasts.broadcastConnection() } returns Unit
+        every { nodeManager.nodeDBbyNodeNum } returns installedNodes
+        every { nodeManager.myNodeNum } returns null
+        every { nodeManager.setNodeDbReady(any<Boolean>()) } returns Unit
+        every { nodeManager.setAllowNodeDbWrites(any<Boolean>()) } returns Unit
+        every { nodeManager.installNodeInfo(any<NodeInfo>(), any<Boolean>()) } returns Unit
+
+        manager =
+            MeshConfigFlowManagerImpl(
+                nodeManager = nodeManager,
+                connectionManager = lazy { connectionManager },
+                nodeRepository = nodeRepository,
+                radioConfigRepository = radioConfigRepository,
+                serviceRepository = serviceRepository,
+                serviceBroadcasts = serviceBroadcasts,
+                analytics = analytics,
+                commandSender = commandSender,
+                packetHandler = packetHandler,
+            )
+    }
+
+    // -------------------------------------------------------------------------
+    // handleNodeInfo / handleNodeInfoBatch — accumulation
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `handleNodeInfo accumulates nodes and increments newNodeCount`() {
+        manager.handleNodeInfo(NodeInfo(num = 1))
+        manager.handleNodeInfo(NodeInfo(num = 2))
+
+        assertEquals(2, manager.newNodeCount)
+    }
+
+    @Test
+    fun `handleNodeInfoBatch adds all items in one shot`() {
+        val items = listOf(NodeInfo(num = 10), NodeInfo(num = 11), NodeInfo(num = 12))
+
+        manager.handleNodeInfoBatch(items)
+
+        assertEquals(3, manager.newNodeCount)
+    }
+
+    @Test
+    fun `handleNodeInfoBatch with empty list leaves count at zero`() {
+        manager.handleNodeInfoBatch(emptyList())
+
+        assertEquals(0, manager.newNodeCount)
+    }
+
+    @Test
+    fun `handleNodeInfoBatch with single item equals count of one`() {
+        manager.handleNodeInfoBatch(listOf(NodeInfo(num = 7)))
+
+        assertEquals(1, manager.newNodeCount)
+    }
+
+    @Test
+    fun `handleNodeInfoBatch and handleNodeInfo accumulate together`() {
+        manager.handleNodeInfo(NodeInfo(num = 1))
+        manager.handleNodeInfoBatch(listOf(NodeInfo(num = 2), NodeInfo(num = 3)))
+
+        assertEquals(3, manager.newNodeCount)
+    }
+
+    // -------------------------------------------------------------------------
+    // handleConfigComplete — nonce routing
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `handleConfigComplete with BATCH_NODE_INFO_NONCE triggers Stage 2 completion`() = runTest(testDispatcher) {
+        manager.start(backgroundScope)
+        manager.handleNodeInfoBatch(listOf(NodeInfo(num = 100)))
+        // installNodeInfo is a no-op mock; seed the map so nodeDBbyNodeNum[num] is non-null
+        installedNodes[100] = Node(num = 100)
+
+        manager.handleConfigComplete(HandshakeConstants.BATCH_NODE_INFO_NONCE)
+        advanceUntilIdle()
+
+        verify { connectionManager.onNodeDbReady() }
+    }
+
+    @Test
+    fun `handleConfigComplete with NODE_INFO_NONCE (legacy) also triggers Stage 2 completion`() =
+        runTest(testDispatcher) {
+            manager.start(backgroundScope)
+            manager.handleNodeInfo(NodeInfo(num = 200))
+            installedNodes[200] = Node(num = 200)
+
+            manager.handleConfigComplete(HandshakeConstants.NODE_INFO_NONCE)
+            advanceUntilIdle()
+
+            verify { connectionManager.onNodeDbReady() }
+        }
+
+    @Test
+    fun `handleConfigComplete with unknown nonce takes no action`() = runTest(testDispatcher) {
+        manager.start(backgroundScope)
+
+        manager.handleConfigComplete(99999)
+        advanceUntilIdle()
+
+        verifyNoMoreCalls(connectionManager)
+    }
+
+    // -------------------------------------------------------------------------
+    // handleConfigComplete Stage 2 — newNodes cleared after completion
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `newNodeCount resets to zero after Stage 2 completion`() = runTest(testDispatcher) {
+        manager.start(backgroundScope)
+        manager.handleNodeInfoBatch(listOf(NodeInfo(num = 1), NodeInfo(num = 2)))
+        installedNodes[1] = Node(num = 1)
+        installedNodes[2] = Node(num = 2)
+        assertEquals(2, manager.newNodeCount)
+
+        manager.handleConfigComplete(HandshakeConstants.BATCH_NODE_INFO_NONCE)
+        advanceUntilIdle()
+
+        assertEquals(0, manager.newNodeCount)
+    }
+
+    // -------------------------------------------------------------------------
+    // handleConfigComplete Stage 2 — empty batch edge case
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `Stage 2 completion with empty batch signals readiness with no installed nodes`() = runTest(testDispatcher) {
+        manager.start(backgroundScope)
+        // Intentionally skip any handleNodeInfo* calls — simulates an empty NodeInfoBatch
+
+        manager.handleConfigComplete(HandshakeConstants.BATCH_NODE_INFO_NONCE)
+        advanceUntilIdle()
+
+        verify { connectionManager.onNodeDbReady() }
+    }
+}

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
@@ -35,6 +35,7 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.repository.AppWidgetUpdater
 import org.meshtastic.core.repository.CommandSender
+import org.meshtastic.core.repository.HandshakeConstants
 import org.meshtastic.core.repository.HistoryManager
 import org.meshtastic.core.repository.MeshLocationManager
 import org.meshtastic.core.repository.MeshServiceNotifications
@@ -54,6 +55,7 @@ import org.meshtastic.proto.Config
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.ModuleConfig
+import org.meshtastic.proto.ToRadio
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -151,17 +153,6 @@ class MeshConnectionManagerImplTest {
 
     @Test
     fun `Disconnected state stops services`() = runTest(testDispatcher) {
-        every { packetHandler.sendToRadio(any<org.meshtastic.proto.ToRadio>()) } returns Unit
-        every { serviceNotifications.updateServiceStateNotification(any(), any()) } returns Unit
-        every { packetHandler.stopPacketQueue() } returns Unit
-        every { locationManager.stop() } returns Unit
-        every { mqttManager.stop() } returns Unit
-        every { packetHandler.sendToRadio(any<org.meshtastic.proto.ToRadio>()) } returns Unit
-        every { serviceNotifications.updateServiceStateNotification(any(), any()) } returns Unit
-        every { packetHandler.stopPacketQueue() } returns Unit
-        every { locationManager.stop() } returns Unit
-        every { mqttManager.stop() } returns Unit
-        every { nodeManager.nodeDBbyNodeNum } returns emptyMap()
         manager.start(backgroundScope)
         // Transition to Connected first so that Disconnected actually does something
         radioConnectionState.value = ConnectionState.Connected
@@ -266,5 +257,26 @@ class MeshConnectionManagerImplTest {
 
         verify { mqttManager.start(any(), true, true) }
         verify { historyManager.requestHistoryReplay(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `startNodeInfoOnly sends BATCH_NODE_INFO_NONCE not the legacy nonce`() = runTest(testDispatcher) {
+        val sentPackets = mutableListOf<ToRadio>()
+        every { packetHandler.sendToRadio(any<ToRadio>()) } calls
+            { call ->
+                sentPackets.add(call.arg(0))
+                Unit
+            }
+
+        manager.start(backgroundScope)
+        manager.startNodeInfoOnly()
+        advanceUntilIdle()
+
+        val nodeInfoPacket = sentPackets.firstOrNull { (it.want_config_id ?: 0) != 0 }
+        assertEquals(
+            HandshakeConstants.BATCH_NODE_INFO_NONCE,
+            nodeInfoPacket?.want_config_id,
+            "startNodeInfoOnly must use BATCH_NODE_INFO_NONCE, not the legacy NODE_INFO_NONCE",
+        )
     }
 }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/MockInterface.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/MockInterface.kt
@@ -25,6 +25,7 @@ import org.meshtastic.core.common.util.nowSeconds
 import org.meshtastic.core.model.Channel
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.util.getInitials
+import org.meshtastic.core.repository.HandshakeConstants
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.RadioTransport
 import org.meshtastic.proto.AdminMessage
@@ -39,6 +40,7 @@ import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.Neighbor
 import org.meshtastic.proto.NeighborInfo
 import org.meshtastic.proto.NodeInfo
+import org.meshtastic.proto.NodeInfoBatch
 import org.meshtastic.proto.PortNum
 import org.meshtastic.proto.QueueStatus
 import org.meshtastic.proto.Routing
@@ -301,58 +303,79 @@ class MockInterface(private val service: RadioInterfaceService, val address: Str
         service.handleFromRadio(makeAck(MY_NODE + 1, packet.from, packet.id).encode())
     }
 
+    // / Generate a fake NodeInfo for a simulated node
+    @Suppress("MagicNumber")
+    private fun makeSimNodeInfo(numIn: Int, lat: Double, lon: Double) = NodeInfo(
+        num = numIn,
+        user =
+        User(
+            id = DataPacket.nodeNumToDefaultId(numIn),
+            long_name = "Sim " + numIn.toString(16),
+            short_name = getInitials("Sim " + numIn.toString(16)),
+            hw_model = HardwareModel.ANDROID_SIM,
+        ),
+        position =
+        ProtoPosition(
+            latitude_i = org.meshtastic.core.model.Position.degI(lat),
+            longitude_i = org.meshtastic.core.model.Position.degI(lon),
+            altitude = 35,
+            time = nowSeconds.toInt(),
+            precision_bits = Random.nextInt(10, 19),
+        ),
+    )
+
     private fun sendConfigResponse(configId: Int) {
-        Logger.d { "Sending mock config response" }
+        Logger.d { "Sending mock config response for nonce=$configId" }
+        when (configId) {
+            HandshakeConstants.CONFIG_NONCE -> sendStage1ConfigResponse(configId)
+            HandshakeConstants.BATCH_NODE_INFO_NONCE,
+            HandshakeConstants.NODE_INFO_NONCE,
+            -> sendStage2NodeInfoResponse(configId)
+            else -> Logger.w { "Unknown config nonce $configId — ignoring" }
+        }
+    }
 
-        // / Generate a fake node info entry
-        @Suppress("MagicNumber")
-        fun makeNodeInfo(numIn: Int, lat: Double, lon: Double) = FromRadio(
-            node_info =
-            NodeInfo(
-                num = numIn,
-                user =
-                User(
-                    id = DataPacket.nodeNumToDefaultId(numIn),
-                    long_name = "Sim " + numIn.toString(16),
-                    short_name = getInitials("Sim " + numIn.toString(16)),
-                    hw_model = HardwareModel.ANDROID_SIM,
-                ),
-                position =
-                ProtoPosition(
-                    latitude_i = org.meshtastic.core.model.Position.degI(lat),
-                    longitude_i = org.meshtastic.core.model.Position.degI(lon),
-                    altitude = 35,
-                    time = nowSeconds.toInt(),
-                    precision_bits = Random.nextInt(10, 19),
-                ),
-            ),
-        )
-
-        // Simulated network data to feed to our app
+    /** Stage 1: send my_info, metadata, config, channels, then config_complete_id. No nodes. */
+    private fun sendStage1ConfigResponse(configId: Int) {
         val packets =
             arrayOf(
-                // MyNodeInfo
                 FromRadio(my_info = ProtoMyNodeInfo(my_node_num = MY_NODE)),
                 FromRadio(
                     metadata = DeviceMetadata(firmware_version = "9.9.9.abcdefg", hw_model = HardwareModel.ANDROID_SIM),
                 ),
-
-                // Fake NodeDB
-                makeNodeInfo(MY_NODE, 32.776665, -96.796989), // dallas
-                makeNodeInfo(MY_NODE + 1, 32.960758, -96.733521), // richardson
                 FromRadio(config = Config(lora = defaultLoRaConfig)),
                 FromRadio(config = Config(lora = defaultLoRaConfig)),
                 FromRadio(channel = defaultChannel),
                 FromRadio(config_complete_id = configId),
+            )
+        packets.forEach { p -> service.handleFromRadio(p.encode()) }
+    }
 
-                // Done with config response, now pretend to receive some text messages
+    /**
+     * Stage 2: send all nodes as a single [NodeInfoBatch], then config_complete_id. After the handshake completes,
+     * simulate live traffic.
+     */
+    private fun sendStage2NodeInfoResponse(configId: Int) {
+        val batch =
+            NodeInfoBatch(
+                items =
+                listOf(
+                    makeSimNodeInfo(MY_NODE, 32.776665, -96.796989), // dallas
+                    makeSimNodeInfo(MY_NODE + 1, 32.960758, -96.733521), // richardson
+                ),
+            )
+        val packets =
+            arrayOf(
+                FromRadio(node_info_batch = batch),
+                FromRadio(config_complete_id = configId),
+
+                // Simulate live traffic after handshake
                 makeTextMessage(MY_NODE + 1),
                 makeNeighborInfo(MY_NODE + 1),
                 makePosition(MY_NODE + 1),
                 makeTelemetry(MY_NODE + 1),
                 makeNodeStatus(MY_NODE + 1),
             )
-
         packets.forEach { p -> service.handleFromRadio(p.encode()) }
     }
 }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/MockInterface.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/MockInterface.kt
@@ -352,8 +352,9 @@ class MockInterface(private val service: RadioInterfaceService, val address: Str
     }
 
     /**
-     * Stage 2: send all nodes as a single [NodeInfoBatch], then config_complete_id. After the handshake completes,
-     * simulate live traffic.
+     * Stage 2: send all nodes as a single [NodeInfoBatch], then config_complete_id. Live traffic is simulated in a
+     * separate coroutine after a short delay so it arrives *after* the handshake completion coroutine has had a chance
+     * to commit the node DB — matching real-world ordering.
      */
     private fun sendStage2NodeInfoResponse(configId: Int) {
         val batch =
@@ -364,18 +365,22 @@ class MockInterface(private val service: RadioInterfaceService, val address: Str
                     makeSimNodeInfo(MY_NODE + 1, 32.960758, -96.733521), // richardson
                 ),
             )
-        val packets =
-            arrayOf(
-                FromRadio(node_info_batch = batch),
-                FromRadio(config_complete_id = configId),
+        listOf(FromRadio(node_info_batch = batch), FromRadio(config_complete_id = configId)).forEach { p ->
+            service.handleFromRadio(p.encode())
+        }
 
-                // Simulate live traffic after handshake
+        // Simulate live traffic after the handshake has completed. Launched in a separate
+        // coroutine with a small delay so these packets arrive after onNodeDbReady() runs.
+        service.serviceScope.handledLaunch {
+            delay(200)
+            listOf(
                 makeTextMessage(MY_NODE + 1),
                 makeNeighborInfo(MY_NODE + 1),
                 makePosition(MY_NODE + 1),
                 makeTelemetry(MY_NODE + 1),
                 makeNodeStatus(MY_NODE + 1),
             )
-        packets.forEach { p -> service.handleFromRadio(p.encode()) }
+                .forEach { p -> service.handleFromRadio(p.encode()) }
+        }
     }
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/HandshakeConstants.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/HandshakeConstants.kt
@@ -19,8 +19,8 @@ package org.meshtastic.core.repository
 /**
  * Shared constants for the two-stage mesh handshake protocol.
  *
- * Stage 1 (`CONFIG_NONCE`): requests device config, module config, and channels. Stage 2 (`NODE_INFO_NONCE`): requests
- * the full node database.
+ * Stage 1 (`CONFIG_NONCE`): requests device config, module config, and channels. Stage 2 (`BATCH_NODE_INFO_NONCE`):
+ * requests the full node database with batched NodeInfo delivery.
  *
  * Both [MeshConfigFlowManager] (consumer) and [MeshConnectionManager] (sender) reference these.
  */
@@ -28,6 +28,9 @@ object HandshakeConstants {
     /** Nonce sent in `want_config_id` to request config-only (Stage 1). */
     const val CONFIG_NONCE = 69420
 
-    /** Nonce sent in `want_config_id` to request node info only (Stage 2). */
+    /** Nonce sent in `want_config_id` to request node info only — unbatched legacy (Stage 2). */
     const val NODE_INFO_NONCE = 69421
+
+    /** Nonce sent in `want_config_id` to request node info only — batched (Stage 2). */
+    const val BATCH_NODE_INFO_NONCE = 69423
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/HandshakeConstants.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/HandshakeConstants.kt
@@ -18,9 +18,9 @@ package org.meshtastic.core.repository
 
 /**
  * Shared constants for the two-stage mesh handshake protocol.
- *
- * Stage 1 (`CONFIG_NONCE`): requests device config, module config, and channels. Stage 2 (`BATCH_NODE_INFO_NONCE`):
- * requests the full node database with batched NodeInfo delivery.
+ * - Stage 1 ([CONFIG_NONCE]): requests device config, module config, and channels.
+ * - Stage 2 ([BATCH_NODE_INFO_NONCE], primary): requests the full node database with batched [NodeInfoBatch] delivery.
+ * - Stage 2 ([NODE_INFO_NONCE], legacy): requests node info one-at-a-time; kept for firmware that pre-dates batching.
  *
  * Both [MeshConfigFlowManager] (consumer) and [MeshConnectionManager] (sender) reference these.
  */
@@ -31,6 +31,8 @@ object HandshakeConstants {
     /** Nonce sent in `want_config_id` to request node info only — unbatched legacy (Stage 2). */
     const val NODE_INFO_NONCE = 69421
 
-    /** Nonce sent in `want_config_id` to request node info only — batched (Stage 2). */
+    // 69422 intentionally skipped — reserved for future use.
+
+    /** Nonce sent in `want_config_id` to request node info only — batched (Stage 2, primary). */
     const val BATCH_NODE_INFO_NONCE = 69423
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshConfigFlowManager.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshConfigFlowManager.kt
@@ -37,6 +37,16 @@ interface MeshConfigFlowManager {
     fun handleNodeInfo(info: NodeInfo)
 
     /**
+     * Handles a batch of node information records delivered in a single [NodeInfoBatch] message.
+     *
+     * The default implementation simply delegates to [handleNodeInfo] for each item. Implementations should override
+     * this with a bulk `addAll` to avoid per-item overhead on large meshes.
+     */
+    fun handleNodeInfoBatch(items: List<NodeInfo>) {
+        items.forEach { handleNodeInfo(it) }
+    }
+
+    /**
      * Handles a [FileInfo] packet received during STATE_SEND_FILEMANIFEST.
      *
      * Each packet describes one file available on the device. Accumulated into [RadioConfigRepository.fileManifestFlow]


### PR DESCRIPTION

This pull request adds support for batch processing of node information, improving the efficiency and reliability of node info synchronization in the mesh network. The changes update the handshake to use a new batch nonce, introduce handling for `NodeInfoBatch` messages, and include comprehensive tests for both batch and legacy flows.

**Batch node info handling and handshake updates:**

* Added support for receiving and processing `NodeInfoBatch` in `FromRadioPacketHandlerImpl`, routing it to the new `handleNodeInfoBatch` method and updating connection progress accordingly. [[1]](diffhunk://#diff-1e4262a240784523f33f8aac2b69eb35ffcfae7c6859592cdcd5681b3650675eR62) [[2]](diffhunk://#diff-1e4262a240784523f33f8aac2b69eb35ffcfae7c6859592cdcd5681b3650675eR84-R87)
* Updated `MeshConfigFlowManagerImpl` to accumulate nodes from batches, handle both legacy and batch nonces for config completion, and provide a new `handleNodeInfoBatch` method for bulk node addition. [[1]](diffhunk://#diff-c6487605a73163d87cac8e343bd404aba7d6f2ce3a951203a5fd5e7b57cb3abdL80-R82) [[2]](diffhunk://#diff-c6487605a73163d87cac8e343bd404aba7d6f2ce3a951203a5fd5e7b57cb3abdL123-R126) [[3]](diffhunk://#diff-c6487605a73163d87cac8e343bd404aba7d6f2ce3a951203a5fd5e7b57cb3abdR174-R177)
* Modified `MeshConnectionManagerImpl` so that `startNodeInfoOnly` now requests the batch node info nonce (`BATCH_NODE_INFO_NONCE`) instead of the legacy one.

**Testing improvements:**

* Added a new test suite `MeshConfigFlowManagerImplTest` covering batch and legacy node info flows, nonce handling, and edge cases like empty batches.
* Enhanced `FromRadioPacketHandlerImplTest` to verify correct handling and status updates when receiving a `NodeInfoBatch`. [[1]](diffhunk://#diff-2ad626d98a7f3cfd8c08016966676889d74ee30c2b88365f0dfa227ea0315c47R39) [[2]](diffhunk://#diff-2ad626d98a7f3cfd8c08016966676889d74ee30c2b88365f0dfa227ea0315c47R165-R181)
* Improved `MeshConnectionManagerImplTest` to check that `startNodeInfoOnly` uses the correct batch nonce and to clean up redundant code. [[1]](diffhunk://#diff-a0818fcf9c8d0bd8251eec31be0c9b8a47c58648c2b5c4d1241843b717766f73R38) [[2]](diffhunk://#diff-a0818fcf9c8d0bd8251eec31be0c9b8a47c58648c2b5c4d1241843b717766f73R58) [[3]](diffhunk://#diff-a0818fcf9c8d0bd8251eec31be0c9b8a47c58648c2b5c4d1241843b717766f73L154-L164) [[4]](diffhunk://#diff-a0818fcf9c8d0bd8251eec31be0c9b8a47c58648c2b5c4d1241843b717766f73R261-R281)

**Mock and utility updates:**

* Updated imports and mock implementations to support new batch-related types and constants, and refactored mock node info generation for clarity. [[1]](diffhunk://#diff-3afee752903d99986b0f2fc74aa32e77e9a271395de0abaa3eb83d498f20342fR28) [[2]](diffhunk://#diff-3afee752903d99986b0f2fc74aa32e77e9a271395de0abaa3eb83d498f20342fR43) [[3]](diffhunk://#diff-3afee752903d99986b0f2fc74aa32e77e9a271395de0abaa3eb83d498f20342fL304-R308)