### PR TITLE
refactor(navigation): adopt sealed interface routes with subclassesOfSealed()

### DIFF
--- a/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/Routes.kt
+++ b/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/Routes.kt
@@ -63,7 +63,9 @@ sealed interface NodesRoute : Route {
 
     @Serializable data object Nodes : NodesRoute
 
-    @Serializable data class NodeDetailGraph(val destNum: Int? = null) : NodesRoute, Graph
+    @Serializable data class NodeDetailGraph(val destNum: Int? = null) :
+        NodesRoute,
+        Graph
 
     @Serializable data class NodeDetail(val destNum: Int? = null) : NodesRoute
 }
@@ -84,7 +86,8 @@ sealed interface NodeDetailRoute : Route {
 
     @Serializable data class TracerouteLog(val destNum: Int) : NodeDetailRoute
 
-    @Serializable data class TracerouteMap(val destNum: Int, val requestId: Int, val logUuid: String? = null) : NodeDetailRoute
+    @Serializable
+    data class TracerouteMap(val destNum: Int, val requestId: Int, val logUuid: String? = null) : NodeDetailRoute
 
     @Serializable data class HostMetricsLog(val destNum: Int) : NodeDetailRoute
 
@@ -95,7 +98,9 @@ sealed interface NodeDetailRoute : Route {
 
 @Serializable
 sealed interface SettingsRoute : Route {
-    @Serializable data class SettingsGraph(val destNum: Int? = null) : SettingsRoute, Graph
+    @Serializable data class SettingsGraph(val destNum: Int? = null) :
+        SettingsRoute,
+        Graph
 
     @Serializable data class Settings(val destNum: Int? = null) : SettingsRoute
 

--- a/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/TopLevelDestination.kt
+++ b/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/TopLevelDestination.kt
@@ -40,8 +40,7 @@ enum class TopLevelDestination(val label: StringResource, val route: Route) {
     ;
 
     companion object {
-        fun fromNavKey(key: NavKey?): TopLevelDestination? = entries.find { dest ->
-            key?.let { it::class == dest.route::class } == true
-        }
+        fun fromNavKey(key: NavKey?): TopLevelDestination? =
+            entries.find { dest -> key?.let { it::class == dest.route::class } == true }
     }
 }


### PR DESCRIPTION
## Summary
- Migrate Nav3 route definitions from plain wrapper `object`s to `@Serializable sealed interface` hierarchies per feature domain (e.g., `SettingsRoutes` → `SettingsRoute`), following the [JetBrains recommended multi-module aggregated sealed types pattern](https://github.com/JetBrains/kotlin-multiplatform-dev-docs/commit/a7998da69fd10b615db055c3b063dfae1dd6189d).
- Replace **54 manual `subclass()` registrations** in `NavigationConfig.kt` with **9 `subclassesOfSealed<T>()` calls**, so new routes are automatically registered at compile time — no manual wiring needed.
- Fix `WifiProvisionRoutes.WifiProvisionGraph` and `WifiProvisionRoutes.WifiProvision` missing from the polymorphic serializer, which would have caused a crash on Android process death if the user was on the WiFi provisioning screen.

## Changes

### `core/navigation/Routes.kt`
9 wrapper `object`s converted to `@Serializable sealed interface`s:
| Before | After |
|---|---|
| `object ChannelsRoutes` | `sealed interface ChannelsRoute : Route` |
| `object ConnectionsRoutes` | `sealed interface ConnectionsRoute : Route` |
| `object ContactsRoutes` | `sealed interface ContactsRoute : Route` |
| `object MapRoutes` | `sealed interface MapRoute : Route` |
| `object NodesRoutes` | `sealed interface NodesRoute : Route` |
| `object NodeDetailRoutes` | `sealed interface NodeDetailRoute : Route` |
| `object SettingsRoutes` | `sealed interface SettingsRoute : Route` |
| `object FirmwareRoutes` | `sealed interface FirmwareRoute : Route` |
| `object WifiProvisionRoutes` | `sealed interface WifiProvisionRoute : Route` |

### `core/navigation/NavigationConfig.kt`
116 lines → 44 lines. The entire `polymorphic(NavKey::class)` block is now:
```kotlin
polymorphic(NavKey::class) {
    subclassesOfSealed<ChannelsRoute>()
    subclassesOfSealed<ConnectionsRoute>()
    subclassesOfSealed<ContactsRoute>()
    subclassesOfSealed<MapRoute>()
    subclassesOfSealed<NodesRoute>()
    subclassesOfSealed<NodeDetailRoute>()
    subclassesOfSealed<SettingsRoute>()
    subclassesOfSealed<FirmwareRoute>()
    subclassesOfSealed<WifiProvisionRoute>()
}
```

### Other
- **33 files** updated with mechanical renames across `app/`, `core/`, `desktop/`, and all `feature/` modules
- Renamed local `enum class NodeDetailRoute` → `NodeDetailScreen` in `NodesNavigation.kt` to avoid collision with the new sealed interface
- Updated `AGENTS.md` and `core/navigation/README.md` to reflect the new architecture

## Verification
- `./gradlew clean assembleDebug` — BUILD SUCCESSFUL
- `./gradlew test allTests` — BUILD SUCCESSFUL, all tests pass