### PR TITLE
fix(build): prevent DataDog asset transform from stripping fdroid release assets

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -47,6 +47,14 @@
 # R8 optimization for Kotlin null checks (AGP 9.0+)
 -processkotlinnullchecks remove
 
+# Compose Multiplatform resources: keep the resource library internals and generated Res
+# accessor classes so R8 does not tree-shake the resource loading infrastructure.
+# Without these rules the fdroid flavor (which has fewer transitive Compose dependencies
+# than google) crashes at startup with a misleading URLDecodeException due to R8
+# exception-class merging (see Koin keep rule above).
+-keep class org.jetbrains.compose.resources.** { *; }
+-keep class org.meshtastic.core.resources.** { *; }
+
 # Nordic BLE
 -dontwarn no.nordicsemi.kotlin.ble.environment.android.mock.**
 -keep class no.nordicsemi.kotlin.ble.environment.android.mock.** { *; }

--- a/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
@@ -17,6 +17,7 @@
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.datadog.gradle.plugin.DdExtension
+import com.datadog.gradle.plugin.InjectBuildIdToAssetsTask
 import com.datadog.gradle.plugin.InstrumentationMode
 import com.datadog.gradle.plugin.SdkCheckLevel
 import org.gradle.api.Plugin
@@ -24,8 +25,10 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.withType
 import org.meshtastic.buildlogic.libs
 import org.meshtastic.buildlogic.plugin
+import java.io.File
 
 /**
  * Convention plugin for analytics (Google Services, Crashlytics, Datadog). Segregates these plugins to only affect the
@@ -65,16 +68,36 @@ class AnalyticsConventionPlugin : Plugin<Project> {
                 }
             }
 
+            // Disable Datadog analytics/upload tasks for fdroid, but NOT the buildId
+            // inject/generate tasks. The Datadog plugin wires InjectBuildIdToAssetsTask via
+            // variant.artifacts.toTransform(SingleArtifact.ASSETS), which replaces the merged
+            // assets artifact for the entire variant. Disabling that task leaves its output
+            // directory empty, causing compressAssets to produce zero files and stripping ALL
+            // assets (including Compose Multiplatform .cvr resources) from the release APK.
             plugins.withId("com.datadoghq.dd-sdk-android-gradle-plugin") {
                 tasks.configureEach {
                     if (
                         (
                             name.contains("datadog", ignoreCase = true) ||
-                                name.contains("uploadMapping", ignoreCase = true) ||
-                                name.contains("buildId", ignoreCase = true)
+                                name.contains("uploadMapping", ignoreCase = true)
                             ) && name.contains("fdroid", ignoreCase = true)
                     ) {
                         enabled = false
+                    }
+                }
+
+                // The inject task must stay enabled to maintain the AGP artifact pipeline,
+                // but we strip the datadog.buildId file from its output to preserve fdroid
+                // sterility — no analytics artifacts should ship in the open-source flavor.
+                tasks.withType<InjectBuildIdToAssetsTask>().configureEach {
+                    if (name.contains("Fdroid", ignoreCase = true)) {
+                        doLast {
+                            // Constant: GenerateBuildIdTask.BUILD_ID_FILE_NAME
+                            val buildIdFile = File(outputAssets.get().asFile, "datadog.buildId")
+                            if (buildIdFile.exists()) {
+                                buildIdFile.delete()
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Fixes fdroid release crash (`URLDecodeException` on CMP `.cvr` resource load) caused by ALL assets being stripped from the APK
- Preserves fdroid flavor sterility — no `datadog.buildId` file ships in the APK

## Root Cause

The DataDog Gradle plugin's `InjectBuildIdToAssetsTask` calls `variant.artifacts.toTransform(SingleArtifact.ASSETS)`, **replacing** the merged assets artifact for the entire variant. `AnalyticsConventionPlugin` then disabled this task for fdroid flavors (`name.contains("buildId")`), but the AGP artifact wiring persisted — so `compressAssets` read from the disabled task's **empty** output directory, producing zero files and stripping ALL assets from the release APK.

Debug builds were unaffected because `isMinifyEnabled = false` means the DataDog plugin never registers the inject task. Google release was unaffected because the inject task runs normally there.

## Fix

**`AnalyticsConventionPlugin.kt`** — Two changes:
1. Removed `buildId` from the fdroid task-disable filter so the inject/generate tasks stay enabled (maintaining the AGP artifact pipeline)
2. Added a typed `doLast` on `InjectBuildIdToAssetsTask` for fdroid variants that deletes `datadog.buildId` from the output directory after the passthrough copy — preserving fdroid sterility

**`app/proguard-rules.pro`** — Added defensive keep rules for `org.jetbrains.compose.resources.**` and `org.meshtastic.core.resources.**` (matching `desktop/proguard-rules.pro`)

## Verification

| Check | Result |
|---|---|
| `.cvr` files in fdroid release APK | **40** ✅ |
| `datadog.buildId` in fdroid release APK | **0** ✅ |
| `assembleFdroidRelease` | **BUILD SUCCESSFUL** ✅ |
| `spotlessCheck` | ✅ |
| `detekt` | ✅ |