### PR TITLE
fix(build): resolve all actionable compile-time warnings

### DIFF
--- a/app/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
+++ b/app/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
@@ -38,7 +38,7 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.sessionreplay.SessionReplay
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.trace.Trace
 import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.trace.opentelemetry.DatadogOpenTelemetry
@@ -175,7 +175,9 @@ class GooglePlatformAnalytics(private val context: Context, private val analytic
         // Masks all text inputs to protect message content.
         if (BuildConfig.DEBUG) {
             val sessionReplayConfig =
-                SessionReplayConfiguration.Builder(sampleRate).setPrivacy(SessionReplayPrivacy.MASK_USER_INPUT).build()
+                SessionReplayConfiguration.Builder(sampleRate)
+                    .setTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL_INPUTS)
+                    .build()
             SessionReplay.enable(sessionReplayConfig)
         }
 

--- a/app/src/google/kotlin/org/meshtastic/app/map/component/EditWaypointDialog.kt
+++ b/app/src/google/kotlin/org/meshtastic/app/map/component/EditWaypointDialog.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.atTime
@@ -120,12 +119,12 @@ fun EditWaypointDialog(
         val expireValue = waypointInput.expire ?: 0
         if (isExpiryEnabled) {
             if (expireValue != 0 && expireValue != Int.MAX_VALUE) {
-                val instant = Instant.fromEpochSeconds(expireValue.toLong())
+                val instant = kotlin.time.Instant.fromEpochSeconds(expireValue.toLong())
                 val date = java.util.Date(instant.toEpochMilliseconds())
                 selectedDateString = dateFormat.format(date)
                 selectedTimeString = timeFormat.format(date)
             } else { // If enabled but not set, default to 8 hours from now
-                val futureInstant = kotlinx.datetime.Clock.System.now() + 8.hours
+                val futureInstant = kotlin.time.Clock.System.now() + 8.hours
                 val date = java.util.Date(futureInstant.toEpochMilliseconds())
                 selectedDateString = dateFormat.format(date)
                 selectedTimeString = timeFormat.format(date)
@@ -223,7 +222,7 @@ fun EditWaypointDialog(
                                     val expireValue = waypointInput.expire ?: 0
                                     // Default to 8 hours from now if not already set
                                     if (expireValue == 0 || expireValue == Int.MAX_VALUE) {
-                                        val futureInstant = kotlinx.datetime.Clock.System.now() + 8.hours
+                                        val futureInstant = kotlin.time.Clock.System.now() + 8.hours
                                         waypointInput = waypointInput.copy(expire = futureInstant.epochSeconds.toInt())
                                     }
                                 } else {
@@ -237,9 +236,9 @@ fun EditWaypointDialog(
                         val currentInstant =
                             (waypointInput.expire ?: 0).let {
                                 if (it != 0 && it != Int.MAX_VALUE) {
-                                    Instant.fromEpochSeconds(it.toLong())
+                                    kotlin.time.Instant.fromEpochSeconds(it.toLong())
                                 } else {
-                                    kotlinx.datetime.Clock.System.now() + 8.hours
+                                    kotlin.time.Clock.System.now() + 8.hours
                                 }
                             }
                         val ldt = currentInstant.toLocalDateTime(tz)
@@ -252,9 +251,9 @@ fun EditWaypointDialog(
                                         (waypointInput.expire ?: 0)
                                             .let {
                                                 if (it != 0 && it != Int.MAX_VALUE) {
-                                                    Instant.fromEpochSeconds(it.toLong())
+                                                    kotlin.time.Instant.fromEpochSeconds(it.toLong())
                                                 } else {
-                                                    kotlinx.datetime.Clock.System.now() + 8.hours
+                                                    kotlin.time.Clock.System.now() + 8.hours
                                                 }
                                             }
                                             .toLocalDateTime(tz)
@@ -287,9 +286,9 @@ fun EditWaypointDialog(
                                         (waypointInput.expire ?: 0)
                                             .let {
                                                 if (it != 0 && it != Int.MAX_VALUE) {
-                                                    Instant.fromEpochSeconds(it.toLong())
+                                                    kotlin.time.Instant.fromEpochSeconds(it.toLong())
                                                 } else {
-                                                    kotlinx.datetime.Clock.System.now() + 8.hours
+                                                    kotlin.time.Clock.System.now() + 8.hours
                                                 }
                                             }
                                             .toLocalDateTime(tz)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,8 +44,8 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- Permissions required for providing location (from phone GPS) to mesh -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:remove="android:maxSdkVersion" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" tools:remove="android:maxSdkVersion" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <!-- This permission is required for analytics - and soon the MQTT gateway -->
     <uses-permission android:name="android.permission.INTERNET" />

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -35,9 +35,7 @@ configure<com.android.build.api.dsl.LibraryExtension> {
 
 // Suppress dep-ann warnings from AIDL-generated code where Javadoc @deprecated
 // doesn't produce @Deprecated annotations on Stub/Proxy override methods.
-tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add("-Xlint:-dep-ann")
-}
+tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-dep-ann") }
 
 // Map the Android component to a Maven publication
 afterEvaluate {

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -33,6 +33,12 @@ configure<com.android.build.api.dsl.LibraryExtension> {
     publishing { singleVariant("release") { withSourcesJar() } }
 }
 
+// Suppress dep-ann warnings from AIDL-generated code where Javadoc @deprecated
+// doesn't produce @Deprecated annotations on Stub/Proxy override methods.
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:-dep-ann")
+}
+
 // Map the Android component to a Maven publication
 afterEvaluate {
     publishing {

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidServiceRepository.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidServiceRepository.kt
@@ -27,6 +27,7 @@ import org.meshtastic.core.repository.ServiceRepository
  * in `MeshService`.
  */
 @Single(binds = [ServiceRepository::class, AndroidServiceRepository::class])
+@Suppress("DEPRECATION") // IMeshService is deprecated but still required for AIDL binding
 class AndroidServiceRepository : ServiceRepositoryImpl() {
     var meshService: IMeshService? = null
         private set

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
@@ -49,7 +49,7 @@ import org.meshtastic.core.repository.ServiceBroadcasts
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.proto.PortNum
 
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("TooManyFunctions", "LargeClass", "DEPRECATION") // IMeshService is deprecated but still required for AIDL binding
 class MeshService : Service() {
 
     private val radioInterfaceService: RadioInterfaceService by inject()
@@ -88,7 +88,6 @@ class MeshService : Service() {
         fun createIntent(context: Context) = Intent(context, MeshService::class.java)
 
         fun changeDeviceAddress(context: Context, service: IMeshService, address: String?) {
-            @Suppress("DEPRECATION") // Internal use: routes address change through AIDL binder
             service.setDeviceAddress(address)
             startService(context)
         }

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshService.kt
@@ -49,7 +49,8 @@ import org.meshtastic.core.repository.ServiceBroadcasts
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.proto.PortNum
 
-@Suppress("TooManyFunctions", "LargeClass", "DEPRECATION") // IMeshService is deprecated but still required for AIDL binding
+// IMeshService is deprecated but still required for AIDL binding
+@Suppress("TooManyFunctions", "LargeClass", "DEPRECATION")
 class MeshService : Service() {
 
     private val radioInterfaceService: RadioInterfaceService by inject()

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshServiceClient.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshServiceClient.kt
@@ -29,6 +29,7 @@ import org.meshtastic.core.common.util.SequentialJob
 
 /** A Activity-lifecycle-aware [ServiceClient] that binds [MeshService] once the Activity is started. */
 @Factory
+@Suppress("DEPRECATION") // IMeshService is deprecated but still required for AIDL binding
 class MeshServiceClient(
     private val context: Context,
     private val serviceRepository: AndroidServiceRepository,

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/testing/FakeIMeshService.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/testing/FakeIMeshService.kt
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+@file:Suppress("DEPRECATION") // IMeshService is deprecated but still required for AIDL binding
+
 package org.meshtastic.core.service.testing
 
 import org.meshtastic.core.model.DataPacket

--- a/mesh_service_example/src/main/kotlin/com/meshtastic/android/meshserviceexample/MainScreen.kt
+++ b/mesh_service_example/src/main/kotlin/com/meshtastic/android/meshserviceexample/MainScreen.kt
@@ -483,7 +483,13 @@ private fun NodeItemActions(isOnline: Boolean, onAction: (String) -> Unit) {
             Icon(Icons.Rounded.Route, "Traceroute", Modifier.size(20.dp), MaterialTheme.colorScheme.primary)
         }
         IconButton(onClick = { onAction("telemetry") }, modifier = Modifier.size(40.dp)) {
-            Icon(Icons.Rounded.BatteryUnknown, "Telemetry", Modifier.size(20.dp), MaterialTheme.colorScheme.secondary)
+            Icon(
+                @Suppress("DEPRECATION") // AutoMirrored variant not available in current icons version
+                Icons.Rounded.BatteryUnknown,
+                "Telemetry",
+                Modifier.size(20.dp),
+                MaterialTheme.colorScheme.secondary,
+            )
         }
         IconButton(onClick = { onAction("position") }, modifier = Modifier.size(40.dp)) {
             Icon(Icons.Rounded.MyLocation, "Position", Modifier.size(20.dp), MaterialTheme.colorScheme.tertiary)

--- a/mesh_service_example/src/main/kotlin/com/meshtastic/android/meshserviceexample/MeshServiceViewModel.kt
+++ b/mesh_service_example/src/main/kotlin/com/meshtastic/android/meshserviceexample/MeshServiceViewModel.kt
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+@file:Suppress("DEPRECATION") // IMeshService is deprecated but still required for AIDL binding
+
 package com.meshtastic.android.meshserviceexample
 
 import android.content.Intent


### PR DESCRIPTION
## Summary
- Remove all actionable compile-time warnings from the debug build (`assembleDebug`)
- 10 files changed across `app`, `core:api`, `core:service`, and `mesh_service_example`

## Changes

### AndroidManifest permissions
- Removed stale `tools:remove="android:maxSdkVersion"` from `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION` — no library was adding `maxSdkVersion`, so the merge rule was unnecessary and triggered a manifest merger warning.

### kotlinx.datetime deprecation (0.7+)
- Migrated `EditWaypointDialog.kt` from `kotlinx.datetime.Instant`/`Clock` to `kotlin.time.Instant`/`Clock` using fully-qualified references. The `kotlinx.datetime` extension functions (`toLocalDateTime()`, `toInstant()`) work on `kotlin.time.Instant` in kotlinx-datetime 0.7+.

### DataDog SDK deprecation
- Replaced deprecated `setPrivacy(SessionReplayPrivacy.MASK_USER_INPUT)` with `setTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL_INPUTS)` in `GooglePlatformAnalytics.kt`.

### IMeshService AIDL deprecation suppression
- Added `@file:Suppress("DEPRECATION")` to `FakeIMeshService.kt` and `MeshServiceViewModel.kt` (file-level needed to cover import statements).
- Added `@Suppress("DEPRECATION")` to `AndroidServiceRepository`, `MeshService`, and `MeshServiceClient` classes.
- Added `-Xlint:-dep-ann` Java compiler arg to `core:api` to suppress AIDL-generated `dep-ann` warnings (Javadoc `@deprecated` without `@Deprecated` annotation on Stub/Proxy overrides).

### BatteryUnknown icon deprecation
- Added `@Suppress("DEPRECATION")` on `Icons.Rounded.BatteryUnknown` usage — the suggested `Icons.AutoMirrored.Rounded.BatteryUnknown` does not exist in the current Material Icons version.

## Not addressed (unfixable in this repo)
- `Unable to strip .so` warnings — third-party native libraries
- `Deprecated Gradle features` — third-party plugins (Detekt, etc.)