### PR TITLE
fix(charts): hoist rememberVicoZoomState above vararg layers to prevent ClassCastException

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
@@ -96,6 +96,11 @@ fun GenericMetricChart(
     onPointSelected: ((Double) -> Unit)? = null,
     vicoScrollState: VicoScrollState = rememberVicoScrollState(),
 ) {
+    // Hoist zoom state above rememberCartesianChart so that the variable slot count
+    // from the vararg layers spread does not shift this remember call during recomposition
+    // (toggling legend chips changes the layer count, which corrupts the slot table).
+    val zoomState = rememberVicoZoomState(zoomEnabled = true, initialZoom = Zoom.Content)
+
     val markerVisibilityListener =
         remember(onPointSelected) {
             object : CartesianMarkerVisibilityListener {
@@ -126,7 +131,7 @@ fun GenericMetricChart(
         modelProducer = modelProducer,
         modifier = modifier,
         scrollState = vicoScrollState,
-        zoomState = rememberVicoZoomState(zoomEnabled = true, initialZoom = Zoom.Content),
+        zoomState = zoomState,
     )
 }
 


### PR DESCRIPTION
## Summary
- Fixes `ClassCastException: CartesianChart cannot be cast to Zoom` crash when tapping legend chips on metric charts
- Hoists `rememberVicoZoomState` above `rememberCartesianChart` in `GenericMetricChart` so its Compose slot position is stable regardless of the layer count

## Root Cause
When toggling legend chips (e.g. on Environment Metrics), the number of `LineCartesianLayer` instances changes. The `rememberCartesianChart(*layers.toTypedArray(), ...)` vararg spread allocates a variable number of Compose slots depending on the layer count. Because `rememberVicoZoomState` was called *after* this spread, its slot shifted during recomposition — causing the Compose runtime to read a `CartesianChart` object from the wrong slot instead of the expected `Zoom` value.

## Fix
Move `rememberVicoZoomState` to the top of `GenericMetricChart`, before `rememberCartesianChart`, giving it a stable slot position unaffected by the variable layer count.