### PR TITLE
ci: remove mesh_service_example from CI checks and Codecov

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -74,7 +74,8 @@ jobs:
           }
 
           allowed_extra_roots = {'baselineprofile'}
-          expected_roots = module_roots | allowed_extra_roots
+          excluded_roots = {'mesh_service_example'}
+          expected_roots = (module_roots | allowed_extra_roots) - excluded_roots
 
           filter_paths = {
               path.split('/')[0]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,6 @@ jobs:
               - 'desktop/**'
               - 'core/**'
               - 'feature/**'
-              - 'mesh_service_example/**'
               # Shared build infrastructure
               - 'build-logic/**'
               - 'config/**'

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Lint, Analysis & KMP Smoke Compile
         if: inputs.run_lint == true
-        run: ./gradlew spotlessCheck detekt app:lintFdroidDebug app:lintGoogleDebug core:barcode:lintFdroidDebug core:barcode:lintGoogleDebug core:api:lintDebug mesh_service_example:lintDebug kmpSmokeCompile -Pci=true --continue --scan
+        run: ./gradlew spotlessCheck detekt app:lintFdroidDebug app:lintGoogleDebug core:barcode:lintFdroidDebug core:barcode:lintGoogleDebug core:api:lintDebug kmpSmokeCompile -Pci=true --continue --scan
 
       - name: KMP Smoke Compile (lint skipped)
         if: inputs.run_lint == false
@@ -176,14 +176,12 @@ jobs:
               :desktop:test
               :core:barcode:testFdroidDebugUnitTest
               :core:barcode:testGoogleDebugUnitTest
-              :mesh_service_example:test
             kover: >-
               :app:koverXmlReportFdroidDebug
               :app:koverXmlReportGoogleDebug
               :core:barcode:koverXmlReportFdroidDebug
               :core:barcode:koverXmlReportGoogleDebug
               :desktop:koverXmlReport
-              :mesh_service_example:koverXmlReportDebug
 
     steps:
       - name: Checkout code
@@ -287,7 +285,6 @@ jobs:
           tasks=(
             "app:assembleFdroidDebug"
             "app:assembleGoogleDebug"
-            "mesh_service_example:assembleDebug"
           )
 
           if [[ "${{ inputs.run_instrumented_tests }}" == "true" ]]; then


### PR DESCRIPTION
## Summary

- Removes `mesh_service_example` from lint, unit test, coverage (Codecov), and assembly tasks in `reusable-check.yml`
- Removes `mesh_service_example/**` from the PR path filter in `pull-request.yml` so changes to the deprecated module no longer trigger CI

The module is deprecated and scheduled for removal — there is no value in continuing to build, test, or report coverage for it.