### PR TITLE
fix(settings): hide Status Message config until firmware v2.8.0

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
@@ -49,8 +49,8 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
     /** Support for sharing contact information via QR codes. Supported since firmware v2.6.8. */
     val supportsQrCodeSharing = atLeast(V2_6_8)
 
-    /** Support for Status Message module. Supported since firmware v2.7.17. */
-    val supportsStatusMessage = atLeast(V2_7_17)
+    /** Support for Status Message module. Supported since firmware v2.8.0. */
+    val supportsStatusMessage = atLeast(V2_8_0)
 
     /** Support for Traffic Management module. Supported since firmware v3.0.0. */
     val supportsTrafficManagementConfig = atLeast(V3_0_0)
@@ -69,9 +69,9 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
         private val V2_6_9 = DeviceVersion("2.6.9")
         private val V2_6_10 = DeviceVersion("2.6.10")
         private val V2_7_12 = DeviceVersion("2.7.12")
-        private val V2_7_17 = DeviceVersion("2.7.17")
         private val V2_7_18 = DeviceVersion("2.7.18")
         private val V2_7_19 = DeviceVersion("2.7.19")
+        private val V2_8_0 = DeviceVersion("2.8.0")
         private val V3_0_0 = DeviceVersion("3.0.0")
         private val UNRELEASED = DeviceVersion("9.9.9")
     }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
@@ -68,9 +68,9 @@ class CapabilitiesTest {
     }
 
     @Test
-    fun supportsStatusMessage_requires_V2_7_17() {
-        assertFalse(caps("2.7.16").supportsStatusMessage)
-        assertTrue(caps("2.7.17").supportsStatusMessage)
+    fun supportsStatusMessage_requires_V2_8_0() {
+        assertFalse(caps("2.7.21").supportsStatusMessage)
+        assertTrue(caps("2.8.0").supportsStatusMessage)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Raises the `supportsStatusMessage` capability gate from firmware v2.7.17 to v2.8.0, hiding the Status Message module config section for devices running pre-2.8 firmware.
- Removes the now-unused `V2_7_17` version constant and updates `CapabilitiesTest` assertions to match the new threshold.

Closes #5069