### PR TITLE
fix(ui): add missing @ParameterName annotations on actual rememberReadTextFromUri declarations

### DIFF
--- a/core/ui/src/androidMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
+++ b/core/ui/src/androidMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
@@ -139,7 +139,7 @@ actual fun rememberOpenFileLauncher(onUriReceived: (CommonUri?) -> Unit): (mimeT
 
 @Suppress("Wrapping")
 @Composable
-actual fun rememberReadTextFromUri(): suspend (CommonUri, Int) -> String? {
+actual fun rememberReadTextFromUri(): suspend (uri: CommonUri, maxChars: Int) -> String? {
     val context = LocalContext.current
     return remember(context) {
         { uri, maxChars ->

--- a/core/ui/src/jvmMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
+++ b/core/ui/src/jvmMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
@@ -89,7 +89,7 @@ actual fun rememberOpenFileLauncher(onUriReceived: (CommonUri?) -> Unit): (mimeT
 
 /** JVM — Reads text from a file URI. */
 @Composable
-actual fun rememberReadTextFromUri(): suspend (CommonUri, Int) -> String? = { uri, maxChars ->
+actual fun rememberReadTextFromUri(): suspend (uri: CommonUri, maxChars: Int) -> String? = { uri, maxChars ->
     withContext(Dispatchers.IO) {
         @Suppress("TooGenericExceptionCaught")
         try {


### PR DESCRIPTION
## Summary
- Adds named parameters (`uri`, `maxChars`) to the return type of `actual fun rememberReadTextFromUri()` in both `androidMain` and `jvmMain` to match the `expect` declaration in `commonMain`.
- Fixes compiler warning: `Annotation @ParameterName(name = "uri") is missing on actual declaration` at `PlatformUtils.kt:92:1`.