### PR TITLE
fix(connections): show device name during connecting state

### DIFF
--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
@@ -206,6 +206,7 @@ open class ScannerViewModel(
                 changeDeviceAddress(it.fullAddress)
                 true
             } else {
+                radioPrefs.setDevName(it.name)
                 requestBonding(it)
                 false
             }
@@ -216,6 +217,7 @@ open class ScannerViewModel(
                 changeDeviceAddress(it.fullAddress)
                 true
             } else {
+                radioPrefs.setDevName(it.name)
                 requestPermission(it)
                 false
             }

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/ConnectingDeviceInfo.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/ConnectingDeviceInfo.kt
@@ -26,13 +26,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.model.ConnectionState
@@ -79,20 +79,17 @@ fun ConnectingDeviceInfo(
             }
         }
 
-        @OptIn(ExperimentalMaterial3ExpressiveApi::class)
-        val largeHeight = ButtonDefaults.LargeContainerHeight
-        @OptIn(ExperimentalMaterial3ExpressiveApi::class)
         Button(
-            onClick = onClickDisconnect,
-            shapes = ButtonDefaults.shapesFor(largeHeight),
-            modifier = Modifier.fillMaxWidth().height(largeHeight),
+            shape = RectangleShape,
+            modifier = Modifier.fillMaxWidth().height(40.dp),
             colors =
             ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.StatusRed,
                 contentColor = Color.White,
             ),
+            onClick = onClickDisconnect,
         ) {
-            Text(stringResource(Res.string.disconnect), style = ButtonDefaults.textStyleFor(largeHeight))
+            Text(stringResource(Res.string.disconnect))
         }
     }
 }


### PR DESCRIPTION
## Summary

- Persist the device name before initiating BLE bonding or USB permission requests, mirroring the existing bonded-device path. Previously `setDevName` was only called for already-bonded devices, so the connecting card fell back to \"Unknown Device\" during first-time connections and on subsequent app restarts.
- Reverts the Material Expressive large button styling on the connecting card disconnect button back to the standard `RectangleShape` / `40.dp` height pattern, consistent with `CurrentlyConnectedInfo`.

## Root Cause

`ScannerViewModel.onSelected()` only called `radioPrefs.setDevName()` in the `bonded == true` branches. The unbonded BLE (`requestBonding`) and USB (`requestPermission`) paths skipped it, so `persistedDeviceName` was always `null` for those devices — both during the bonding/permission wait and on every subsequent app restart.

## Changes

- `ScannerViewModel.kt`: Add `radioPrefs.setDevName(it.name)` before `requestBonding` and `requestPermission` calls in the unbonded branches of `onSelected`.
- `ConnectingDeviceInfo.kt`: Revert expressive button (`LargeContainerHeight`, `shapesFor`, `textStyleFor`, `@OptIn`) to plain `Button(shape = RectangleShape, modifier = Modifier.height(40.dp))`.