### PR TITLE
fix(build): remove Compose BOM to resolve compileSdk 37 conflict

### DIFF
--- a/build-logic/convention/src/main/kotlin/KmpFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpFeatureConventionPlugin.kt
@@ -56,9 +56,6 @@ class KmpFeatureConventionPlugin : Plugin<Project> {
                 }
 
                 sourceSets.getByName("androidMain").dependencies {
-                    // Compose BOM for consistent Android Compose versions
-                    implementation(target.dependencies.platform(libs.library("androidx-compose-bom")))
-
                     // Common Android Compose dependencies
                     implementation(libs.library("accompanist-permissions"))
                     implementation(libs.library("androidx-activity-compose"))

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -26,11 +26,6 @@ internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
 
     val hasAndroidTest = project.projectDir.resolve("src/androidTest").exists()
     dependencies {
-        val bom = libs.library("androidx-compose-bom")
-        "implementation"(platform(bom))
-        if (hasAndroidTest) {
-            "androidTestImplementation"(platform(bom))
-        }
         "debugImplementation"(libs.library("compose-multiplatform-ui-tooling"))
         "implementation"(libs.library("compose-multiplatform-runtime"))
         "runtimeOnly"(libs.library("androidx-compose-runtime-tracing"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,18 +118,11 @@ androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version =
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version = "2.11.2" }
 androidx-work-testing = { module = "androidx.work:work-testing", version = "2.11.2" }
 
-# AndroidX Compose
-androidx-compose-bom = { module = "androidx.compose:compose-bom-alpha", version = "2026.04.00" }
-androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended" } # Only used by deprecated mesh_service_example — remove when that module is deleted
-androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
-androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
+# AndroidX Compose (explicit versions — BOM removed to avoid transitive compileSdk conflicts with CMP adaptive fork)
+androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended", version = "1.7.8" } # Only used by deprecated mesh_service_example — remove when that module is deleted
 androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "androidxTracing" }
-androidx-compose-ui = { module = "androidx.compose.ui:ui" }
-androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
-androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
-androidx-compose-ui-text = { module = "androidx.compose.ui:ui-text" }
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
-androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version = "1.11.0-rc01" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version = "1.11.0-rc01" }
 
 # Compose Multiplatform
 compose-multiplatform-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }

--- a/mesh_service_example/build.gradle.kts
+++ b/mesh_service_example/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.jetbrains.lifecycle.viewmodel.compose)
     implementation(libs.jetbrains.lifecycle.runtime)
-    implementation(libs.androidx.compose.material3)
+    implementation(libs.compose.multiplatform.material3)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.material)
 


### PR DESCRIPTION
## Summary

- Removes the AndroidX Compose BOM (`compose-bom-alpha`) which was causing `checkAarMetadata` failures across 13 module tasks after Renovate bumped it to `2026.04.00`
- Pins the 3 remaining AndroidX Compose dependencies with explicit versions
- Swaps `mesh_service_example`'s `material3` dep to the CMP equivalent

## Root Cause

The `compose-bom-alpha 2026.04.00` (#5086) pulled in `androidx.compose.material3.adaptive:*:1.3.0-alpha10`, which requires **compileSdk 37**. AGP 9.1.0 only supports up to compileSdk 36.

The JetBrains CMP adaptive fork (`1.3.0-alpha06`) transitively depends on real AndroidX adaptive artifacts on Android. The old BOM (`2026.03.01`) was silently downgrading these to `1.2.0`, but the new BOM bumped them to `1.3.0-alpha10`, breaking the build.

Since the project has migrated to Compose Multiplatform (#5084), the BOM is no longer needed — CMP provides its own versioned artifacts. The BOM was actually a liability, creating invisible version conflicts between the JetBrains fork and the AndroidX originals.

## Changes

| File | Change |
|---|---|
| `libs.versions.toml` | Removed BOM + 7 unused AndroidX entries; pinned `ui-test-junit4` (`1.11.0-rc01`), `ui-test-manifest` (`1.11.0-rc01`), `material-icons-extended` (`1.7.8`) |
| `AndroidCompose.kt` | Removed BOM `platform()` declaration |
| `KmpFeatureConventionPlugin.kt` | Removed BOM `platform()` declaration |
| `mesh_service_example/build.gradle.kts` | Swapped `androidx-compose-material3` to `compose-multiplatform-material3` |

## Fixes

- Main CI failure: https://github.com/meshtastic/Meshtastic-Android/actions/runs/24309533614
- Merge queue failure for #5085: https://github.com/meshtastic/Meshtastic-Android/actions/runs/24309872270