### PR TITLE
build: upgrade TARGET_SDK to 37 and update AGP to 9.2.0-alpha08

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -21,8 +21,8 @@ VERSION_CODE_OFFSET=29314197
 # Application and SDK versions
 APPLICATION_ID=com.geeksville.mesh
 MIN_SDK=26
-TARGET_SDK=36
-COMPILE_SDK=36
+TARGET_SDK=37
+COMPILE_SDK=37
 
 # Base version name for local development and fallback
 # On CI, this is overridden by the Git tag

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 xmlutil = "0.91.3"
 
 # Android
-agp = "9.1.0"
+agp = "9.2.0-alpha08"
 appcompat = "1.7.1"
 accompanist = "0.37.3"
 


### PR DESCRIPTION
- Updates `TARGET_SDK` and `COMPILE_SDK` to 37 in `config.properties`.
- Upgrades Android Gradle Plugin (AGP) from 9.1.0 to 9.2.0-alpha08 in `gradle/libs.versions.toml`.