### PR TITLE
ci: reduce CI costs by ~54% — skip desktop builds in PR/main, reduce scheduled frequency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      # Only rebuild docs when source code changes (Dokka generates from KDoc)
+      - 'app/src/**'
+      - 'core/**/src/**'
+      - 'feature/**/src/**'
+      - 'desktop/src/**'
+      - 'build-logic/**'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - '.github/workflows/docs.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -29,11 +39,11 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment; cancel queued runs since only the latest
+# main state matters for documentation.
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build-docs:

--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -20,8 +20,9 @@ jobs:
     uses: ./.github/workflows/reusable-check.yml
     with:
       run_lint: true
-      run_unit_tests: true
-      run_instrumented_tests: true
-      api_levels: '[35]' # One API level is enough for post-merge sanity check
+      run_unit_tests: false
+      run_instrumented_tests: false
+      run_desktop_builds: false
+      api_levels: '[35]'
       upload_artifacts: true
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -99,7 +99,9 @@ jobs:
           PY
 
   # 2. VALIDATION & BUILD: Delegate to reusable-check.yml
-  # We disable instrumented tests and coverage for PRs to keep feedback fast (< 10 mins).
+  # We disable instrumented tests, coverage, and desktop builds for PRs to keep
+  # feedback fast (< 10 mins). Desktop compilation is already covered by the
+  # :desktop:test task in the shard-app test shard.
   validate-and-build:
     needs: check-changes
     if: needs.check-changes.outputs.android == 'true'
@@ -109,6 +111,7 @@ jobs:
       run_unit_tests: true
       run_instrumented_tests: false
       run_coverage: false
+      run_desktop_builds: false
       api_levels: '[35]'
       upload_artifacts: true
     secrets: inherit

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -18,6 +18,9 @@ on:
       api_levels:
         type: string
         default: '[35]'
+      run_desktop_builds:
+        type: boolean
+        default: true
       upload_artifacts:
         type: boolean
         default: true
@@ -358,6 +361,7 @@ jobs:
   # ── Desktop Build ───────────────────────────────────────────────────
   build-desktop:
     name: Build Desktop Debug (${{ matrix.os }})
+    if: inputs.run_desktop_builds == true
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -2,8 +2,8 @@ name: Scheduled Updates (Firmware, Hardware, Translations)
 
 on:
   schedule:
-    - cron: '0 * * * *' # Run every hour
-  workflow_dispatch:     # Allow manual triggering
+    - cron: '0 */4 * * *' # Run every 4 hours (was hourly — reduced to cut cascade CI cost)
+  workflow_dispatch:       # Allow manual triggering
 
 jobs:
   update_assets:


### PR DESCRIPTION
## Summary

Audited all 24 CI workflows for value, efficiency, and effectiveness. Implements the top recommendations to cut estimated billable minutes by ~54% (~4,180 min/week).

## Changes

### 1. Skip desktop builds in PR CI (~1,480 min/week saved)
- Added `run_desktop_builds` input to `reusable-check.yml` (default `true` for backward compat)
- PR CI sets `run_desktop_builds: false` — desktop compilation is already validated by the `:desktop:test` task in the `shard-app` test shard
- Eliminates 4 runner jobs per PR (macOS @ 10x, Windows @ 2x, 2x Linux)

### 2. Simplify Main CI to lint-only smoke check (~1,600 min/week saved)
- Main CI now skips unit tests, instrumented tests, and desktop builds
- The merge queue already runs the comprehensive validation suite before anything lands on main — running it again post-merge is redundant
- 30% of Main CI runs were being cancelled anyway due to rapid successive pushes

### 3. Reduce Scheduled Updates from hourly to every 4 hours (~900 min/week saved)
- Changed cron from `0 * * * *` to `0 */4 * * *`
- Only 13% of hourly runs produced changes (13 PRs from 100 runs in 7 days)
- Each merged scheduled-updates PR triggers cascade Main CI + Docs + Changelog runs
- `workflow_dispatch` still available for on-demand runs

### 4. Add path filters and cancel-in-progress to Deploy Documentation (~200 min/week saved)
- Docs only rebuild when source code changes (KDoc in `src/` dirs, build files)
- Switched `cancel-in-progress` from `false` to `true` — only the latest main state matters for docs

## What's preserved
- **Merge Queue CI is untouched** — remains the comprehensive gate with full lint, tests, instrumented tests (API 26 + 35), and desktop builds on all 4 OS targets
- All `workflow_dispatch` triggers still work for manual runs
- `run_desktop_builds` defaults to `true` so any other callers of `reusable-check.yml` are unaffected