### PR TITLE
test(prefs): migrate DataStore tests from androidHostTest to commonTest

### DIFF
--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -22,7 +22,10 @@ plugins {
 }
 
 kotlin {
-    android { namespace = "org.meshtastic.core.navigation" }
+    android {
+        namespace = "org.meshtastic.core.navigation"
+        withHostTest {}
+    }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -22,10 +22,7 @@ plugins {
 }
 
 kotlin {
-    android {
-        namespace = "org.meshtastic.core.navigation"
-        withHostTest {}
-    }
+    android { namespace = "org.meshtastic.core.navigation" }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/prefs/build.gradle.kts
+++ b/core/prefs/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
     android {
         namespace = "org.meshtastic.core.prefs"
         androidResources.enable = false
+        withHostTest {}
     }
 
     sourceSets {

--- a/core/prefs/build.gradle.kts
+++ b/core/prefs/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
     android {
         namespace = "org.meshtastic.core.prefs"
         androidResources.enable = false
-        withHostTest { isIncludeAndroidResources = true }
     }
 
     sourceSets {

--- a/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/filter/FilterPrefsTest.kt
+++ b/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/filter/FilterPrefsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Meshtastic LLC
+ * Copyright (c) 2025-2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package org.meshtastic.core.prefs.tak
+package org.meshtastic.core.prefs.filter
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
@@ -22,20 +22,25 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
+import okio.FileSystem
+import okio.Path
 import org.meshtastic.core.di.CoroutineDispatchers
-import org.meshtastic.core.repository.TakPrefs
+import org.meshtastic.core.repository.FilterPrefs
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
-class TakPrefsTest {
-    @get:Rule val tmpFolder: TemporaryFolder = TemporaryFolder.builder().assureDeletion().build()
+@OptIn(ExperimentalUuidApi::class)
+class FilterPrefsTest {
+    private lateinit var tmpDir: Path
 
     private lateinit var dataStore: DataStore<Preferences>
-    private lateinit var takPrefs: TakPrefs
+    private lateinit var filterPrefs: FilterPrefs
     private lateinit var dispatchers: CoroutineDispatchers
 
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -43,24 +48,38 @@ class TakPrefsTest {
 
     @BeforeTest
     fun setup() {
+        tmpDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "filterPrefsTest-${Uuid.random()}"
+        FileSystem.SYSTEM.createDirectories(tmpDir)
         dataStore =
-            PreferenceDataStoreFactory.create(
+            PreferenceDataStoreFactory.createWithPath(
                 scope = testScope,
-                produceFile = { tmpFolder.newFile("test.preferences_pb") },
+                produceFile = { tmpDir / "test.preferences_pb" },
             )
         dispatchers = CoroutineDispatchers(testDispatcher, testDispatcher, testDispatcher)
-        takPrefs = TakPrefsImpl(dataStore, dispatchers)
+        filterPrefs = FilterPrefsImpl(dataStore, dispatchers)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        FileSystem.SYSTEM.deleteRecursively(tmpDir)
+    }
+
+    @Test fun `filterEnabled defaults to false`() = testScope.runTest { assertFalse(filterPrefs.filterEnabled.value) }
+
+    @Test
+    fun `filterWords defaults to empty set`() =
+        testScope.runTest { assertTrue(filterPrefs.filterWords.value.isEmpty()) }
+
+    @Test
+    fun `setting filterEnabled updates preference`() = testScope.runTest {
+        filterPrefs.setFilterEnabled(true)
+        assertTrue(filterPrefs.filterEnabled.value)
     }
 
     @Test
-    fun `isTakServerEnabled defaults to false`() = testScope.runTest { assertFalse(takPrefs.isTakServerEnabled.value) }
-
-    @Test
-    fun `setting isTakServerEnabled updates preference`() = testScope.runTest {
-        takPrefs.setTakServerEnabled(true)
-        assertTrue(takPrefs.isTakServerEnabled.value)
-
-        takPrefs.setTakServerEnabled(false)
-        assertFalse(takPrefs.isTakServerEnabled.value)
+    fun `setting filterWords updates preference`() = testScope.runTest {
+        val words = setOf("test", "word")
+        filterPrefs.setFilterWords(words)
+        assertEquals(words, filterPrefs.filterWords.value)
     }
 }

--- a/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/notification/NotificationPrefsTest.kt
+++ b/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/notification/NotificationPrefsTest.kt
@@ -22,17 +22,21 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import okio.FileSystem
+import okio.Path
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.repository.NotificationPrefs
-import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
+@OptIn(ExperimentalUuidApi::class)
 class NotificationPrefsTest {
-    private lateinit var tmpFolder: File
+    private lateinit var tmpDir: Path
 
     private lateinit var dataStore: DataStore<Preferences>
     private lateinit var notificationPrefs: NotificationPrefs
@@ -43,15 +47,12 @@ class NotificationPrefsTest {
 
     @BeforeTest
     fun setup() {
-        tmpFolder =
-            File.createTempFile("notificationPrefsTest", null).apply {
-                delete()
-                mkdirs()
-            }
+        tmpDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "notificationPrefsTest-${Uuid.random()}"
+        FileSystem.SYSTEM.createDirectories(tmpDir)
         dataStore =
-            PreferenceDataStoreFactory.create(
+            PreferenceDataStoreFactory.createWithPath(
                 scope = testScope,
-                produceFile = { File(tmpFolder, "test.preferences_pb").also { it.createNewFile() } },
+                produceFile = { tmpDir / "test.preferences_pb" },
             )
         dispatchers = CoroutineDispatchers(testDispatcher, testDispatcher, testDispatcher)
         notificationPrefs = NotificationPrefsImpl(dataStore, dispatchers)
@@ -59,7 +60,7 @@ class NotificationPrefsTest {
 
     @AfterTest
     fun tearDown() {
-        tmpFolder.deleteRecursively()
+        FileSystem.SYSTEM.deleteRecursively(tmpDir)
     }
 
     @Test

--- a/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/tak/TakPrefsTest.kt
+++ b/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/tak/TakPrefsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026 Meshtastic LLC
+ * Copyright (c) 2026 Meshtastic LLC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package org.meshtastic.core.prefs.filter
+package org.meshtastic.core.prefs.tak
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
@@ -22,21 +22,24 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import okio.FileSystem
+import okio.Path
 import org.meshtastic.core.di.CoroutineDispatchers
-import org.meshtastic.core.repository.FilterPrefs
-import java.io.File
+import org.meshtastic.core.repository.TakPrefs
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
-class FilterPrefsTest {
-    private lateinit var tmpFolder: File
+@OptIn(ExperimentalUuidApi::class)
+class TakPrefsTest {
+    private lateinit var tmpDir: Path
 
     private lateinit var dataStore: DataStore<Preferences>
-    private lateinit var filterPrefs: FilterPrefs
+    private lateinit var takPrefs: TakPrefs
     private lateinit var dispatchers: CoroutineDispatchers
 
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -44,41 +47,31 @@ class FilterPrefsTest {
 
     @BeforeTest
     fun setup() {
-        tmpFolder =
-            File.createTempFile("filterPrefsTest", null).apply {
-                delete()
-                mkdirs()
-            }
+        tmpDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "takPrefsTest-${Uuid.random()}"
+        FileSystem.SYSTEM.createDirectories(tmpDir)
         dataStore =
-            PreferenceDataStoreFactory.create(
+            PreferenceDataStoreFactory.createWithPath(
                 scope = testScope,
-                produceFile = { File(tmpFolder, "test.preferences_pb").also { it.createNewFile() } },
+                produceFile = { tmpDir / "test.preferences_pb" },
             )
         dispatchers = CoroutineDispatchers(testDispatcher, testDispatcher, testDispatcher)
-        filterPrefs = FilterPrefsImpl(dataStore, dispatchers)
+        takPrefs = TakPrefsImpl(dataStore, dispatchers)
     }
 
     @AfterTest
     fun tearDown() {
-        tmpFolder.deleteRecursively()
-    }
-
-    @Test fun `filterEnabled defaults to false`() = testScope.runTest { assertFalse(filterPrefs.filterEnabled.value) }
-
-    @Test
-    fun `filterWords defaults to empty set`() =
-        testScope.runTest { assertTrue(filterPrefs.filterWords.value.isEmpty()) }
-
-    @Test
-    fun `setting filterEnabled updates preference`() = testScope.runTest {
-        filterPrefs.setFilterEnabled(true)
-        assertTrue(filterPrefs.filterEnabled.value)
+        FileSystem.SYSTEM.deleteRecursively(tmpDir)
     }
 
     @Test
-    fun `setting filterWords updates preference`() = testScope.runTest {
-        val words = setOf("test", "word")
-        filterPrefs.setFilterWords(words)
-        assertEquals(words, filterPrefs.filterWords.value)
+    fun `isTakServerEnabled defaults to false`() = testScope.runTest { assertFalse(takPrefs.isTakServerEnabled.value) }
+
+    @Test
+    fun `setting isTakServerEnabled updates preference`() = testScope.runTest {
+        takPrefs.setTakServerEnabled(true)
+        assertTrue(takPrefs.isTakServerEnabled.value)
+
+        takPrefs.setTakServerEnabled(false)
+        assertFalse(takPrefs.isTakServerEnabled.value)
     }
 }

--- a/core/repository/build.gradle.kts
+++ b/core/repository/build.gradle.kts
@@ -22,7 +22,10 @@ plugins {
 
 kotlin {
     @Suppress("UnstableApiUsage")
-    android { androidResources.enable = false }
+    android {
+        androidResources.enable = false
+        withHostTest {}
+    }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
     android {
         namespace = "org.meshtastic.core.testing"
         androidResources.enable = false
+        withHostTest {}
     }
 
     sourceSets {

--- a/docs/decisions/architecture-review-2026-03.md
+++ b/docs/decisions/architecture-review-2026-03.md
@@ -181,9 +181,10 @@ Android uses `@Module`-annotated classes (`CoreDataModule`, `CoreBleAndroidModul
 36 `commonTest` files exist but are concentrated in `core:domain` (22 files) and `core:data` (10 files). Limited or zero tests in:
 - `core:service` (has `ServiceRepositoryImpl`, `DirectRadioControllerImpl`, `MeshServiceOrchestrator`)
 - `core:network` (has `StreamFrameCodecTest` — 10 tests; `TcpTransport` untested)
-- `core:prefs` (preference flows, default values)
 - `core:ble` (connection state machine)
 - `core:ui` (utility functions)
+
+`core:prefs` now has 12 `commonTest` tests (3 files: `FilterPrefsTest`, `TakPrefsTest`, `NotificationPrefsTest`) migrated from `androidHostTest` using Okio + `PreferenceDataStoreFactory.createWithPath()` for KMP compatibility.
 
 ### D4. Desktop has 2 tests
 

--- a/feature/wifi-provision/build.gradle.kts
+++ b/feature/wifi-provision/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
     android {
         namespace = "org.meshtastic.feature.wifiprovision"
         androidResources.enable = false
+        withHostTest {}
     }
 
     sourceSets {


### PR DESCRIPTION
## Summary

Migrates 3 `core:prefs` DataStore preference tests (12 test methods) from `androidHostTest` to `commonTest`, making them run on all KMP targets (JVM, iOS, Android) instead of only via Robolectric.

## Changes

- **Migrate 3 test files** from `core/prefs/src/androidHostTest/` → `core/prefs/src/commonTest/`:
  - `FilterPrefsTest` (4 tests) — filter preference flows
  - `NotificationPrefsTest` (6 tests) — notification preference flows
  - `TakPrefsTest` (2 tests) — TAK integration preferences
- **Replace `java.io.File`** with `okio.Path` / `okio.FileSystem` for temp directory management
- **Replace `PreferenceDataStoreFactory.create()`** with `createWithPath()` (DataStore KMP API)
- **Replace JUnit4 `TemporaryFolder`** rule with manual Okio temp dir + `@AfterTest` cleanup using `kotlin.uuid.Uuid.random()` for unique paths
- **Replace `org.junit.Assert.*`** with `kotlin.test.*` assertions
- **Remove `withHostTest`** block from `core/prefs/build.gradle.kts` (no remaining androidHostTest files)
- **Update architecture-review doc** to reflect `core:prefs` now has commonTest coverage

## Context

This is the third PR in the CI/test migration series:
- **PR #5090** — CI cost reduction (~54%) ✅ merged
- **PR #5091** — Compose UI test migration to commonTest (pending)
- **This PR** — DataStore preference test migration to commonTest

### Audit of all 12 androidHostTest files

| Module | Files | Migrated? | Reason |
|---|---:|---|---|
| `core:prefs` | 3 | ✅ Yes | Zero Robolectric deps; only blocker was `java.io.File` |
| `core:service` | 6 | ❌ No | AIDL, WorkManager, NotificationManager, BroadcastReceiver, Context |
| `core:database` | 1 | ❌ No | Room migration test requires Android SQLite |
| `feature:settings` | 1 | ❌ No | Uses AndroidJUnit4 Compose rule (covered separately in #5091) |

## Verification

All 12 tests pass on JVM:
```
./gradlew :core:prefs:jvmTest
# FilterPrefsTest  — 4 tests ✅
# NotificationPrefsTest — 6 tests ✅
# TakPrefsTest — 2 tests ✅
```