### PR TITLE
ci: fix Gradle cache path validation warning for Robolectric jars

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -27,15 +27,6 @@ runs:
         distribution: ${{ inputs.jdk_distribution }}
         token: ${{ github.token }}
 
-    # Robolectric downloads instrumented SDK jars from Maven Central at test time.
-    # Cache them to avoid flaky SocketException failures on CI runners.
-    # Update the key when bumping robolectric version in libs.versions.toml or sdk in robolectric.properties.
-    - name: Cache Robolectric SDK jars
-      uses: actions/cache@v5
-      with:
-        path: ~/.m2/repository/org/robolectric
-        key: robolectric-4.16.1-sdk34
-
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
       with:
@@ -43,3 +34,7 @@ runs:
         cache-encryption-key: ${{ inputs.gradle_encryption_key }}
         cache-cleanup: on-success
         add-job-summary: always
+        gradle-home-cache-includes: |
+          caches
+          notifications
+          ~/.m2/repository/org/robolectric


### PR DESCRIPTION
## Summary

- Replaces the standalone `actions/cache@v5` step for `~/.m2/repository/org/robolectric` with `gradle-home-cache-includes` on `setup-gradle`
- Eliminates the `Path Validation Error: path(s) do not exist` warning that fires on cache-miss runs when no test task has populated the directory yet
- Aligns with the `gradle/actions` docs recommendation to avoid mixing `actions/cache` with `setup-gradle` for paths it can manage itself

## Notes

- First run will be a cold miss for the Robolectric path (old `robolectric-4.16.1-sdk34` key won't carry over); jars will re-download once then be cached going forward
- `cache-cleanup: on-success` now also applies to the Robolectric jars, so stale SDK versions will be pruned automatically on successful runs