### PR TITLE
fix(release): publish GitHub release on promotion instead of staying draft

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -139,6 +139,7 @@ jobs:
           gh release edit ${{ inputs.tag_name }} \
             --tag ${{ inputs.final_tag }} \
             --title "${{ inputs.release_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})" \
+            --draft=false \
             --prerelease=${{ inputs.channel != 'production' }}
 
       - name: Notify Discord


### PR DESCRIPTION
## Summary

- The `closed` (and all promotion) channel was leaving GitHub releases in `draft` state after promotion
- `release.yml` creates releases with `draft: true`; `promote.yml` updated title/tag/prerelease but never un-drafted
- Added `--draft=false` to the `gh release edit` command in `promote.yml` so releases are published when promoted to any channel (`closed`, `open`, `production`)