### PR TITLE
fix(build): add explicit compose-multiplatform-animation dependency

### DIFF
--- a/.skills/project-overview/SKILL.md
+++ b/.skills/project-overview/SKILL.md
@@ -62,10 +62,31 @@ Meshtastic-Android is a Kotlin Multiplatform (KMP) application for off-grid, dec
    datadogClientToken=dummy_token
    ```
 
-## 5. Troubleshooting
+## 5. Workspace Bootstrap (MUST run before any build)
+Agents **MUST** perform these steps automatically at the start of every session before running any Gradle task. Do not wait for the user to tell you.
+
+1. **Android SDK:** `ANDROID_HOME` may not be set in agent workspaces. Detect and export it:
+   ```bash
+   # Check common macOS/Linux locations in order of preference
+   if [ -z "$ANDROID_HOME" ]; then
+     for dir in "$HOME/Library/Android/sdk" "$HOME/Android/Sdk" "/opt/android-sdk"; do
+       if [ -d "$dir" ]; then export ANDROID_HOME="$dir"; break; fi
+     done
+   fi
+   ```
+   All `./gradlew` invocations must include `ANDROID_HOME` in the environment. If the SDK cannot be found, ask the user for the path.
+
+2. **Proto submodule:** `core/proto/src/main/proto` is a Git submodule containing Protobuf definitions. It must be initialized or builds will fail with proto generation errors:
+   ```bash
+   git submodule update --init
+   ```
+
+## 6. Troubleshooting
 - **Build Failures:** Check `gradle/libs.versions.toml` for dependency conflicts.
 - **Missing Secrets:** Check `local.properties` (see Environment Setup above).
 - **JDK Version:** JDK 21 is required.
+- **SDK location not found:** See Workspace Bootstrap step 1 above.
+- **Proto generation failures:** See Workspace Bootstrap step 2 above.
 - **Configuration Cache:** Add `--no-configuration-cache` flag if cache-related issues persist.
 - **Koin Injection Failures:** Verify the KMP component is included in `app` root module wiring (`AppKoinModule`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ You are an expert Android and Kotlin Multiplatform (KMP) engineer working on Mes
 </context_and_memory>
 
 <process>
+- **Workspace Bootstrap (MUST run first):** Before executing any Gradle task in a new workspace, agents MUST automatically:
+  1. **Find the Android SDK** — `ANDROID_HOME` is often unset in agent worktrees. Probe `~/Library/Android/sdk`, `~/Android/Sdk`, and `/opt/android-sdk`. Export the first one found. If none exist, ask the user.
+  2. **Init the proto submodule** — Run `git submodule update --init`. The `core/proto/src/main/proto` submodule contains Protobuf definitions required for builds.
 - **Think First:** Reason through the problem before writing code. For complex KMP tasks involving multiple modules or source sets, outline your approach step-by-step before executing.
 - **Plan Before Execution:** Use the git-ignored `.agent_plans/` directory to write markdown implementation plans (`plan.md`) and Mermaid diagrams (`.mmd`) for complex refactors before modifying code.
 - **Atomic Execution:** Follow your plan step-by-step. Do not jump ahead. Use TDD where feasible (write `commonTest` fakes first).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -243,6 +243,7 @@ dependencies {
     implementation(libs.jetbrains.compose.material3.adaptive.layout)
     implementation(libs.jetbrains.compose.material3.adaptive.navigation)
     implementation(libs.material)
+    implementation(libs.compose.multiplatform.animation)
     implementation(libs.compose.multiplatform.material3)
     implementation(libs.compose.multiplatform.ui.tooling.preview)
     implementation(libs.compose.multiplatform.ui)

--- a/build-logic/convention/src/main/kotlin/KmpFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KmpFeatureConventionPlugin.kt
@@ -42,6 +42,7 @@ class KmpFeatureConventionPlugin : Plugin<Project> {
             extensions.configure<KotlinMultiplatformExtension> {
                 sourceSets.getByName("commonMain").dependencies {
                     // Compose Multiplatform UI
+                    implementation(libs.library("compose-multiplatform-animation"))
                     implementation(libs.library("compose-multiplatform-material3"))
 
                     // Lifecycle & ViewModel (JetBrains KMP forks — safe in commonMain)

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
             implementation(projects.core.resources)
             implementation(projects.core.service)
 
+            implementation(libs.compose.multiplatform.animation)
             implementation(libs.compose.multiplatform.material3)
             implementation(libs.compose.multiplatform.ui)
             implementation(libs.compose.multiplatform.foundation)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,6 +125,7 @@ androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version = "1.11.0-rc01" }
 
 # Compose Multiplatform
+compose-multiplatform-animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "compose-multiplatform" }
 compose-multiplatform-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
 compose-multiplatform-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
 compose-multiplatform-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }


### PR DESCRIPTION
## Summary
- Add `org.jetbrains.compose.animation:animation` as an explicit dependency — 29 source files import `androidx.compose.animation.*` but the artifact was never declared, relying on fragile transitive resolution through foundation/material3 that breaks across CMP version bumps.
- Add workspace bootstrap directions to `AGENTS.md` and `.skills/project-overview/SKILL.md` so agents auto-detect `ANDROID_HOME` and init the proto submodule in new worktrees.

## Changes

### Animation dependency (fixes broken animations)
| File | Change |
|---|---|
| `gradle/libs.versions.toml` | Add `compose-multiplatform-animation` catalog entry at `1.11.0-beta02` |
| `KmpFeatureConventionPlugin.kt` | Add animation to `commonMain` deps (covers all 6 feature modules) |
| `core/ui/build.gradle.kts` | Add explicit animation dep (8 files, 25 animation imports) |
| `app/build.gradle.kts` | Add explicit animation dep (2 files with animation imports in flavor source sets) |

### Agent workspace bootstrap
| File | Change |
|---|---|
| `AGENTS.md` | Add "Workspace Bootstrap" directive to `<process>` — SDK detection + proto submodule init |
| `.skills/project-overview/SKILL.md` | Add Section 5 with full bootstrap script, update troubleshooting |

## Version alignment verified
All CMP artifacts confirmed aligned with the 1.11.0-beta02 release manifest:
- Runtime/UI/Foundation/Animation: `1.11.0-beta02`
- Material3: `1.11.0-alpha06`
- Material3 Adaptive: `1.3.0-alpha06`
- Lifecycle: `2.11.0-alpha03`
- Navigation3: `1.1.0-rc01`
- NavigationEvent: `1.1.0-alpha01`