### PR TITLE
fix(ci): isolate JetBrains Compose Multiplatform in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -75,6 +75,14 @@
       ]
     },
     {
+      "description": "Group JetBrains Compose Multiplatform plugin and libraries (separate versioning from AndroidX Compose)",
+      "groupName": "Compose Multiplatform (JetBrains)",
+      "groupSlug": "compose-multiplatform",
+      "matchPackageNames": [
+        "/^org\\.jetbrains\\.compose/"
+      ]
+    },
+    {
       "description": "Group Kotlin standard library, coroutines, and serialization",
       "groupName": "Kotlin Ecosystem",
       "groupSlug": "kotlin",
@@ -277,6 +285,7 @@
       "matchPackageNames": [
         "/^org\\.jetbrains\\.kotlin/",
         "/^org\\.jetbrains\\.kotlinx/",
+        "/^org\\.jetbrains\\.compose/",
         "/^com\\.google\\.dagger/",
         "/^androidx\\.hilt/",
         "/^com\\.google\\.protobuf/",


### PR DESCRIPTION
## Summary
- Adds a dedicated Renovate group (`Compose Multiplatform (JetBrains)`) for `org.jetbrains.compose.*` artifacts so their versions are managed independently from AndroidX Compose
- Adds `org.jetbrains.compose` to the sensitive infrastructure list (manual approval for minor bumps)

## Problem
After #5096 landed, AndroidX Compose test artifacts (`ui-test-manifest`, `runtime-tracing`) share the `compose-multiplatform` version variable in the TOML catalog with the JetBrains CMP plugin. When Renovate sees a new AndroidX Compose version (e.g. `1.11.0-rc01`), it bumps the shared variable — but that version doesn't exist for the JetBrains plugin, breaking the build at configuration time:

```
Plugin [id: 'org.jetbrains.compose', version: '1.11.0-rc01'] was not found
```

This is actively happening: #5099 failed, Renovate rebased and opened #5100 with the same broken change.

## Fix
By giving `org.jetbrains.compose.*` its own Renovate group, version updates for JetBrains CMP will be proposed in a separate PR from AndroidX updates, preventing the version variable collision.

Closes #5100 (once this merges, Renovate will stop proposing the broken bump)