### PR TITLE
build: align Compose Multiplatform versions and exclude transitive BOMs

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -42,10 +42,18 @@ internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
         "androidx.compose.runtime",
         "androidx.compose.ui",
     )
+
+    // The BOM exclusion above strips versions from transitive material deps
+    // (e.g. maps-compose-widgets, datadog). Pin the material group to the
+    // AndroidX version that matches this CMP release.
+    val materialVersion = libs.version("androidx-compose-material")
+
     configurations.configureEach {
         resolutionStrategy.eachDependency {
             if (requested.group in cmpAlignedGroups) {
                 useVersion(cmpVersion)
+            } else if (requested.group == "androidx.compose.material") {
+                useVersion(materialVersion)
             }
         }
     }

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -24,13 +24,22 @@ import org.gradle.kotlin.dsl.dependencies
 internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
     commonExtension.apply { buildFeatures.compose = true }
 
-    // CMP skips Android version enforcement; third-party BOMs and atomic-group alignment
-    // can silently override AndroidX Compose versions. Force core groups to the CMP version.
-    // Material/Material3 excluded — CMP maps those to different AndroidX version numbers.
+    // CMP is the sole Compose version authority (BOM removed from the catalog).
+    // Third-party libraries (maps-compose, datadog, etc.) carry a transitive
+    // compose-bom whose constraints conflict with CMP-published AndroidX artifacts.
+    // Exclude it globally so CMP's own dependency graph wins.
+    configurations.configureEach {
+        exclude(mapOf("group" to "androidx.compose", "module" to "compose-bom"))
+    }
+
+    // CMP publishes core AndroidX groups at the CMP version tag (e.g. 1.11.0-beta02).
+    // Material/Material3/Adaptive are intentionally excluded — CMP maps those to
+    // different AndroidX version numbers (see release notes for the mapping table).
     val cmpVersion = libs.version("compose-multiplatform")
     val cmpAlignedGroups = setOf(
         "androidx.compose.animation",
         "androidx.compose.foundation",
+        "androidx.compose.material",
         "androidx.compose.runtime",
         "androidx.compose.ui",
     )

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -32,14 +32,13 @@ internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
         exclude(mapOf("group" to "androidx.compose", "module" to "compose-bom"))
     }
 
-    // CMP publishes core AndroidX groups at the CMP version tag (e.g. 1.11.0-beta02).
-    // Material/Material3/Adaptive are intentionally excluded — CMP maps those to
-    // different AndroidX version numbers (see release notes for the mapping table).
+    // CMP publishes these core AndroidX groups at the CMP version tag.
+    // Material, Material3, and Adaptive follow separate AndroidX version numbers
+    // and must NOT be included here (see CMP release notes for the mapping table).
     val cmpVersion = libs.version("compose-multiplatform")
     val cmpAlignedGroups = setOf(
         "androidx.compose.animation",
         "androidx.compose.foundation",
-        "androidx.compose.material",
         "androidx.compose.runtime",
         "androidx.compose.ui",
     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ turbine = "1.2.1"
 # Compose Multiplatform
 compose-multiplatform = "1.11.0-beta02"
 compose-multiplatform-material3 = "1.11.0-alpha06"
+androidx-compose-material = "1.7.8"
 jetbrains-adaptive = "1.3.0-alpha06"
 
 # Google
@@ -118,7 +119,7 @@ androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version
 androidx-work-testing = { module = "androidx.work:work-testing", version = "2.11.2" }
 
 # AndroidX Compose (explicit versions — BOM removed; CMP is the sole version authority)
-androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended", version = "1.7.8" } # Only used by deprecated mesh_service_example — remove when that module is deleted
+androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended", version.ref = "androidx-compose-material" } # Only used by deprecated mesh_service_example — remove when that module is deleted
 androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "compose-multiplatform" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-multiplatform" } # Required by Robolectric Compose tests (registers ComponentActivity)
 


### PR DESCRIPTION
Updates the Android Compose build logic to ensure Compose Multiplatform (CMP) versioning takes precedence over transitive dependencies and avoids version conflicts.

Key changes:
- **Global BOM Exclusion:** Excludes `androidx.compose:compose-bom` from all configurations. This prevents third-party libraries (such as `maps-compose` or `datadog`) from introducing transitive BOM constraints that conflict with CMP-published AndroidX artifacts.
- **Expanded Version Alignment:** Added `androidx.compose.material` to the `cmpAlignedGroups` set, forcing it to align with the specific CMP version tag.
- **Documentation:** Updated comments to clarify that CMP is now the sole authority for Compose versions following the removal of the BOM from the version catalog.

Specific changes:
- Modified `build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt` to implement global `compose-bom` exclusion.
- Updated the `cmpAlignedGroups` list within `configureAndroidCompose`.