### PR TITLE
refactor: migrate remaining raw stateIn(WhileSubscribed) to stateInWhileSubscribed extension

### DIFF
--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -29,7 +28,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.meshtastic.core.datastore.RecentAddressesDataSource
@@ -108,7 +106,7 @@ open class ScannerViewModel(
     private val discoveredDevicesFlow =
         showMockTransport
             .flatMapLatest { showMock -> getDiscoveredDevicesUseCase.invoke(showMock) }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+            .stateInWhileSubscribed(initialValue = null)
 
     /** A combined list of bonded and scanned BLE devices for the UI. */
     val bleDevicesForUi: StateFlow<List<DeviceListEntry>> =
@@ -131,7 +129,7 @@ open class ScannerViewModel(
             }
             .flowOn(dispatchers.default)
             .distinctUntilChanged()
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+            .stateInWhileSubscribed(initialValue = emptyList())
 
     /** UI StateFlow for USB devices. */
     val usbDevicesForUi: StateFlow<List<DeviceListEntry>> =

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeDetailViewModel.kt
@@ -21,13 +21,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
 import org.meshtastic.core.model.DataPacket
@@ -35,6 +33,7 @@ import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.service.ServiceAction
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.core.resources.UiText
+import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.feature.node.component.NodeMenuAction
 import org.meshtastic.feature.node.domain.usecase.GetNodeDetailsUseCase
 import org.meshtastic.feature.node.metrics.EnvironmentMetricsState
@@ -81,7 +80,7 @@ class NodeDetailViewModel(
                 if (nodeId == null) return@flatMapLatest flowOf(NodeDetailUiState())
                 getNodeDetailsUseCase(nodeId)
             }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), NodeDetailUiState())
+            .stateInWhileSubscribed(initialValue = NodeDetailUiState())
 
     fun start(nodeId: Int) {
         if (manualNodeId.value != nodeId) {

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
@@ -23,7 +23,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
@@ -31,7 +30,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
@@ -106,7 +104,7 @@ open class MetricsViewModel(
                 if (nodeId == null) return@flatMapLatest flowOf(MetricsState.Empty)
                 getNodeDetailsUseCase(nodeId).map { it.metricsState }
             }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), MetricsState.Empty)
+            .stateInWhileSubscribed(initialValue = MetricsState.Empty)
 
     private val environmentState: StateFlow<EnvironmentMetricsState> =
         activeNodeId
@@ -114,7 +112,7 @@ open class MetricsViewModel(
                 if (nodeId == null) return@flatMapLatest flowOf(EnvironmentMetricsState())
                 getNodeDetailsUseCase(nodeId).map { it.environmentState }
             }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), EnvironmentMetricsState())
+            .stateInWhileSubscribed(initialValue = EnvironmentMetricsState())
 
     private val _timeFrame = MutableStateFlow(TimeFrame.TWENTY_FOUR_HOURS)
 


### PR DESCRIPTION
## Summary

Three ViewModels (`NodeDetailViewModel`, `MetricsViewModel`, `ScannerViewModel`) were inconsistently using raw `.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ...)` instead of the project-standard `stateInWhileSubscribed` context-receiver extension defined in `core/ui/ViewModelExtensions.kt`.

## Changes

- **`feature/node` — `NodeDetailViewModel`**: 1 site migrated; `SharingStarted` + `stateIn` imports removed
- **`feature/node` — `MetricsViewModel`**: 2 sites migrated; `SharingStarted` + `stateIn` imports removed (extension import was already present)
- **`feature/connections` — `ScannerViewModel`**: 2 sites migrated; `SharingStarted` + `stateIn` imports removed

## Motivation

The `stateInWhileSubscribed` extension centralises the `WhileSubscribed` timeout (5 s default) in one place. Every other ViewModel in the project already used it; these three were missed. Making the pattern uniform reduces cognitive overhead and ensures any future change to the default timeout propagates automatically.

## Testing

- `./gradlew :feature:node:allTests :feature:connections:allTests` — all pass
- `./gradlew :feature:node:spotlessApply :feature:connections:spotlessApply` — clean