### PR TITLE
fix(build): pin Skiko version to align with Compose Multiplatform

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
@@ -72,6 +72,21 @@ internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension) {
 
 /** Configure Kotlin Multiplatform options */
 internal fun Project.configureKotlinMultiplatform() {
+    // Skiko is an internal CMP implementation detail; third-party KMP libraries
+    // (e.g. coil3) can carry an older skiko transitive requirement that Gradle
+    // upgrades to the CMP-bundled version, triggering a "Skiko dependencies'
+    // versions are incompatible" warning from CMP's compatibility checker.
+    // Force the version to match CMP so the checker sees a consistent graph.
+    val skikoVersion = libs.version("skiko")
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.jetbrains.skiko") {
+                useVersion(skikoVersion)
+                because("Align Skiko with the version bundled by Compose Multiplatform")
+            }
+        }
+    }
+
     extensions.configure<KotlinMultiplatformExtension> {
         // Standard KMP targets for Meshtastic
         jvm()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,11 @@ turbine = "1.2.1"
 
 # Compose Multiplatform
 compose-multiplatform = "1.11.0-beta02"
+# Skiko is an internal CMP implementation detail. Pin it to the version shipped by CMP to
+# silence the "Skiko dependencies' versions are incompatible" warning emitted when transitive
+# dependencies (e.g. coil3) carry an older skiko requirement that Gradle then upgrades to the
+# CMP-bundled version. Bump this together with compose-multiplatform.
+skiko = "0.144.5"
 compose-multiplatform-material3 = "1.11.0-alpha06"
 androidx-compose-material = "1.7.8"
 jetbrains-adaptive = "1.3.0-alpha06"


### PR DESCRIPTION
## Summary

Pin `org.jetbrains.skiko` to `0.144.5` (the version bundled with CMP 1.11.0-beta02) via a `resolutionStrategy` in `configureKotlinMultiplatform()`. This eliminates the recurring `Skiko dependencies' versions are incompatible` CI warning caused by `coil3:coil-core` dragging in the older `skiko:0.9.22.2`.

## Changes

| File | Change |
|---|---|
| `gradle/libs.versions.toml` | Add `skiko = "0.144.5"` version entry |
| `build-logic` (`KotlinAndroid.kt`) | `resolutionStrategy.eachDependency` forcing `org.jetbrains.skiko` to the pinned version |

> **Note:** The `skiko` version should be bumped alongside `compose-multiplatform`.