### PR TITLE
fix: truncate traceroute chart x-values to whole seconds to prevent Vico crash

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TracerouteChart.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TracerouteChart.kt
@@ -112,7 +112,7 @@ internal fun resolveTraceroutePoints(requests: List<MeshLog>, results: List<Mesh
         val requestPacketId = request.fromRadio.packet?.id
         val result = results.find { it.fromRadio.packet?.decoded?.request_id == requestPacketId }
         val route = result?.fromRadio?.packet?.fullRouteDiscovery
-        val timeSeconds = request.received_date.toDouble() / MS_PER_SEC
+        val timeSeconds = (request.received_date / MS_PER_SEC).toDouble()
 
         val forwardHops = route?.let { maxOf(0, it.route.size - 2) }
         val returnHops = route?.let { if (it.route_back.isNotEmpty()) maxOf(0, it.route_back.size - 2) else null }

--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/metrics/TracerouteChartTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/metrics/TracerouteChartTest.kt
@@ -242,6 +242,19 @@ class TracerouteChartTest {
     }
 
     @Test
+    fun timeSeconds_truncatesSubSecondPrecision() {
+        // received_date with sub-second remainder (e.g. 1000 seconds + 456 ms)
+        val requestTime = 1000L * MS_PER_SEC + 456L
+        val requests = listOf(makeRequest(id = 1, receivedDateMillis = requestTime))
+        val results = emptyList<MeshLog>()
+
+        val point = resolveTraceroutePoints(requests, results).first()
+
+        // Must truncate to whole seconds to avoid Vico "x-values are too precise" crash
+        assertEquals(1000.0, point.timeSeconds)
+    }
+
+    @Test
     fun returnHops_computedWhenRouteBackAvailable() {
         val requests = listOf(makeRequest(id = 1, receivedDateMillis = 1000L * MS_PER_SEC))
         // 1 intermediate hop on return path, with hop_start and snr_back set


### PR DESCRIPTION
## Summary

- Fixes `IllegalArgumentException: The x-values are too precise` crash on the traceroute log screen
- `MeshLog.received_date` (epoch millis) was divided as `toDouble() / MS_PER_SEC`, preserving sub-millisecond fractional precision that exceeded Vico's 4-decimal-place limit on `xDeltaGcd` computation
- Changed to integer division first (`received_date / MS_PER_SEC`), truncating to whole seconds — consistent with `PaxMetrics` and all other charts that use integer epoch-second sources (`Telemetry.time`, `MeshPacket.rx_time`)

## Changes

- **`TracerouteChart.kt:115`** — `(request.received_date / MS_PER_SEC).toDouble()` instead of `request.received_date.toDouble() / MS_PER_SEC`
- **`TracerouteChartTest.kt`** — added `timeSeconds_truncatesSubSecondPrecision` test to guard against regression