### PR TITLE
feat(desktop): add entitlements and wire MeshConnectionManager into orchestrator

### DIFF
--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
@@ -26,6 +26,7 @@ import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.database.DatabaseManager
 import org.meshtastic.core.common.util.handledLaunch
+import org.meshtastic.core.repository.MeshConnectionManager
 import org.meshtastic.core.repository.MeshMessageProcessor
 import org.meshtastic.core.repository.MeshRouter
 import org.meshtastic.core.repository.MeshServiceNotifications
@@ -57,6 +58,7 @@ class MeshServiceOrchestrator(
     private val takMeshIntegration: TAKMeshIntegration,
     private val takPrefs: TakPrefs,
     private val databaseManager: DatabaseManager,
+    private val connectionManager: MeshConnectionManager,
     @Named("ServiceScope") private val scope: CoroutineScope,
 ) {
     private var serviceJob: Job? = null
@@ -87,6 +89,7 @@ class MeshServiceOrchestrator(
         serviceJob = job
 
         serviceNotifications.initChannels()
+        connectionManager.updateStatusNotification()
 
         // Observe TAK server pref to start/stop
         takJob =

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
@@ -35,6 +35,7 @@ import org.meshtastic.core.model.service.ServiceAction
 import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.MeshActionHandler
 import org.meshtastic.core.repository.MeshConfigHandler
+import org.meshtastic.core.repository.MeshConnectionManager
 import org.meshtastic.core.repository.MeshMessageProcessor
 import org.meshtastic.core.repository.MeshRouter
 import org.meshtastic.core.repository.MeshServiceNotifications
@@ -67,6 +68,7 @@ class MeshServiceOrchestratorTest {
     private val takPrefs: TakPrefs = mock(MockMode.autofill)
     private val cotHandler: CoTHandler = mock(MockMode.autofill)
     private val databaseManager: DatabaseManager = mock(MockMode.autofill)
+    private val connectionManager: MeshConnectionManager = mock(MockMode.autofill)
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val testScope = CoroutineScope(testDispatcher)
@@ -111,6 +113,7 @@ class MeshServiceOrchestratorTest {
             takMeshIntegration = takMeshIntegration,
             takPrefs = takPrefs,
             databaseManager = databaseManager,
+            connectionManager = connectionManager,
             scope = testScope,
         )
     }

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -158,9 +158,14 @@ compose.desktop {
                 iconFile.set(project.file("src/main/resources/icon.icns"))
                 minimumSystemVersion = "12.0"
                 bundleID = "org.meshtastic.desktop"
+                entitlementsFile.set(project.file("entitlements.plist"))
                 infoPlist {
                     extraKeysRawXml =
                         """
+                        <key>NSBluetoothAlwaysUsageDescription</key>
+                        <string>Meshtastic uses Bluetooth to communicate with your Meshtastic radio device.</string>
+                        <key>NSLocalNetworkUsageDescription</key>
+                        <string>Meshtastic uses your local network to discover Meshtastic devices connected via WiFi.</string>
                         <key>NSUserNotificationAlertStyle</key>
                         <string>alert</string>
                         <key>CFBundleURLTypes</key>

--- a/desktop/entitlements.plist
+++ b/desktop/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.bluetooth</key>
+    <true/>
+</dict>
+</plist>

--- a/desktop/src/main/kotlin/org/meshtastic/desktop/Main.kt
+++ b/desktop/src/main/kotlin/org/meshtastic/desktop/Main.kt
@@ -60,9 +60,7 @@ import kotlinx.coroutines.flow.first
 import okio.Path.Companion.toPath
 import org.jetbrains.compose.resources.decodeToSvgPainter
 import org.koin.compose.koinInject
-import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
 import org.meshtastic.core.common.BuildConfigProvider
 import org.meshtastic.core.common.util.MeshtasticUri
 import org.meshtastic.core.database.desktopDataDir
@@ -107,12 +105,13 @@ private fun svgPainterResource(path: String, density: Density): Painter = rememb
 
 @OptIn(ExperimentalCoilApi::class)
 fun main(args: Array<String>) = application(exitProcessOnExit = false) {
-    Logger.i { "Meshtastic Desktop — Starting" }
-
-    remember { startKoin { modules(desktopPlatformModule(), desktopModule()) } }
-    DisposableEffect(Unit) { onDispose { stopKoin() } }
-
-    val uiViewModel = koinViewModel<UIViewModel>()
+    val koinApp = remember {
+        Logger.i { "Meshtastic Desktop — Starting" }
+        startKoin { modules(desktopPlatformModule(), desktopModule()) }
+    }
+    val systemLocale = remember { Locale.getDefault() }
+    val uiViewModel = remember { koinApp.koin.get<UIViewModel>() }
+    val httpClient = remember { koinApp.koin.get<HttpClient>() }
 
     DeepLinkHandler(args, uiViewModel)
     MeshServiceLifecycle()


### PR DESCRIPTION
## Summary

- Add `entitlements.plist` with Bluetooth and local-network usage keys for macOS desktop target
- Configure entitlements signing in `desktop/build.gradle.kts`
- Inject `MeshConnectionManager` into `MeshServiceOrchestrator` and call `updateStatusNotification()` on `start()`, mirroring what `MeshService.onStartCommand()` does on Android
- Remove unused `koinViewModel` and `stopKoin` imports from `Main.kt` (spotted by `spotlessCheck`)

## Checklist

- [x] `spotlessCheck` passes
- [x] `detekt` passes