### PR TITLE
fix(app): add R8 keep rules for Compose animation/runtime/ui

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -39,6 +39,22 @@
 # replacing Koin's InstanceCreationException in stack traces, making crashes undiagnosable).
 -keep class org.koin.core.error.** { *; }
 
+# ---- Compose Runtime & Animation --------------------------------------------
+
+# R8's optimization passes (bundled with AGP 9.x) can inline and dead-code-
+# eliminate parts of the Compose frame-clock / recomposer / animation state
+# machines, causing every animation to silently freeze on its first frame in
+# release builds — indeterminate progress spinners, crossfade transitions,
+# animateFloatAsState, AnimatedVisibility, etc.
+#
+# The frame clock lives in compose.runtime, the draw loop in compose.ui,
+# and the animation drivers in compose.animation.core.  Keep all three so
+# R8 does not break the chain.
+-keep class androidx.compose.runtime.** { *; }
+-keep class androidx.compose.ui.** { *; }
+-keep class androidx.compose.animation.core.** { *; }
+-keep class androidx.compose.animation.** { *; }
+
 # ---- Compose Multiplatform --------------------------------------------------
 
 # Keep resource library internals and generated Res accessor classes so R8 does


### PR DESCRIPTION
R8 (AGP 9.x) aggressively optimizes Compose animation internals, causing all animations to silently freeze on their first frame in release builds — indeterminate progress spinners, crossfade transitions, AnimatedVisibility, animateFloatAsState, etc.

The bundled `animation-core` consumer rules only protect `throw*Exception` methods; no keep rules exist for the actual animation classes, frame clock, or recomposer.

Adds explicit keeps for `compose.runtime`, `compose.ui`, `compose.animation.core`, and `compose.animation`.

- Verified on Pixel 6a: 483 frames / 8s (~60 FPS), 0% janky, no crashes