### PR TITLE
fix(app): disable R8 optimization to fix Compose animation freeze

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,17 +1,30 @@
 # ============================================================================
 # Meshtastic Android — ProGuard / R8 rules for release minification
 # ============================================================================
-# Open-source project: obfuscation is disabled. We rely on tree-shaking and
-# code optimization for APK size reduction.
+# Open-source project: obfuscation and optimization are disabled. We rely on
+# tree-shaking (unused code removal) for APK size reduction.
 # ============================================================================
 
 # ---- General ----------------------------------------------------------------
 
-# Preserve line numbers for meaningful crash stack traces
+# Preserve line numbers for meaningful crash traces
 -keepattributes SourceFile,LineNumberTable
 
 # Open-source — no need to obfuscate
 -dontobfuscate
+
+# Disable R8 optimization passes. Tree-shaking (unused code removal) still
+# runs — only method-body rewrites and call-site transformations are suppressed.
+#
+# Why: CMP 1.11 ships consumer rules with -assumenosideeffects on
+# Composer.<clinit>() and ComposerImpl.<clinit>(), plus -assumevalues on
+# ComposeRuntimeFlags and ComposeStackTraceMode. These optimization directives
+# let R8 rewrite *call sites* (class-init triggers, flag reads) even when the
+# target classes are preserved by -keep rules. The result is that the Compose
+# recomposer/frame-clock/animation state machines silently freeze on their
+# first frame in release builds. -dontoptimize is the only directive that
+# disables processing of -assumenosideeffects/-assumevalues. See #5146.
+-dontoptimize
 
 # Dump the full merged R8 configuration (app rules + all library consumer rules)
 # for auditing. Inspect this file after a release build to see what libraries inject.
@@ -41,19 +54,16 @@
 
 # ---- Compose Runtime & Animation --------------------------------------------
 
-# R8's optimization passes (bundled with AGP 9.x) can inline and dead-code-
-# eliminate parts of the Compose frame-clock / recomposer / animation state
-# machines, causing every animation to silently freeze on its first frame in
-# release builds — indeterminate progress spinners, crossfade transitions,
-# animateFloatAsState, AnimatedVisibility, etc.
-#
-# The frame clock lives in compose.runtime, the draw loop in compose.ui,
-# and the animation drivers in compose.animation.core.  Keep all three so
-# R8 does not break the chain.
+# Defence-in-depth: prevent R8 tree-shaking of Compose infrastructure classes
+# that are referenced indirectly through compiler-generated state machines.
+# With -dontoptimize above these are largely redundant, but they provide a
+# safety net against future toolchain changes.
 -keep class androidx.compose.runtime.** { *; }
 -keep class androidx.compose.ui.** { *; }
 -keep class androidx.compose.animation.core.** { *; }
 -keep class androidx.compose.animation.** { *; }
+-keep class androidx.compose.foundation.** { *; }
+-keep class androidx.compose.material3.** { *; }
 
 # ---- Compose Multiplatform --------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds `-dontoptimize` to `app/proguard-rules.pro` to prevent R8 from processing CMP 1.11's consumer `-assumenosideeffects` / `-assumevalues` directives that silently break the Compose animation state machine in release builds.

## Problem

Even after #5146 added blanket `-keep` rules, animations still freeze in CI-built release APKs. Investigation confirmed all Compose classes and methods are structurally intact in the DEX — the issue is R8's **optimization** pass, not its **shrinking** pass.

CMP 1.11 ships consumer rules with:
- `-assumenosideeffects` on `Composer.<clinit>()` and `ComposerImpl.<clinit>()`
- `-assumevalues` on `ComposeRuntimeFlags` and `ComposeStackTraceMode`

These let R8 rewrite *call sites* (class-init triggers, flag reads) even when target classes are preserved by `-keep`. `-keep` only prevents shrinking and obfuscation — it does **not** cancel optimization directives. `-dontoptimize` is the only directive that suppresses `-assumenosideeffects` / `-assumevalues` processing.

## Changes

- Add `-dontoptimize` — disables R8 optimization while preserving tree-shaking for APK size
- Add `foundation` and `material3` to `-keep` rules as defence-in-depth
- Update comments documenting the root cause

## Verification

- `assembleGoogleRelease` builds successfully with the new rules
- Merged R8 config confirms `-dontoptimize` is active