### PR TITLE
chore(analytics): disable Datadog Compose action tracking

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -279,7 +279,6 @@ dependencies {
     googleImplementation(libs.maps.compose)
     googleImplementation(libs.maps.compose.utils)
     googleImplementation(libs.maps.compose.widgets)
-    googleImplementation(libs.dd.sdk.android.compose)
     googleImplementation(libs.dd.sdk.android.logs)
     googleImplementation(libs.dd.sdk.android.rum)
     googleImplementation(libs.dd.sdk.android.session.replay)

--- a/app/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
+++ b/app/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
@@ -26,7 +26,6 @@ import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.Severity
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
-import com.datadog.android.compose.enableComposeActionTracking
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.log.Logger
 import com.datadog.android.log.Logs
@@ -160,7 +159,6 @@ class GooglePlatformAnalytics(private val context: Context, private val analytic
                 .trackFrustrations(false) // Disable click-tracking based frustration detection
                 .trackLongTasks()
                 .trackNonFatalAnrs(true)
-                .enableComposeActionTracking() // Required: activates runtime consumption of Compose semantics tags
                 .setSessionSampleRate(sampleRate)
                 .build()
         Rum.enable(rumConfiguration)

--- a/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
@@ -18,7 +18,7 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.datadog.gradle.plugin.DdExtension
 import com.datadog.gradle.plugin.InjectBuildIdToAssetsTask
-import com.datadog.gradle.plugin.InstrumentationMode
+
 import com.datadog.gradle.plugin.SdkCheckLevel
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -110,7 +110,7 @@ class AnalyticsConventionPlugin : Plugin<Project> {
                             variants {
                                 register(variant.name) {
                                     site = "US5"
-                                    composeInstrumentation = InstrumentationMode.AUTO
+
                                 }
                             }
                             checkProjectDependencies = SdkCheckLevel.NONE

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -211,7 +211,7 @@ accompanist-permissions = { module = "com.google.accompanist:accompanist-permiss
 coil = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
-dd-sdk-android-compose = { module = "com.datadoghq:dd-sdk-android-compose", version.ref = "dd-sdk-android" }
+
 dd-sdk-android-logs = { module = "com.datadoghq:dd-sdk-android-logs", version.ref = "dd-sdk-android" }
 dd-sdk-android-rum = { module = "com.datadoghq:dd-sdk-android-rum", version.ref = "dd-sdk-android" }
 dd-sdk-android-session-replay = { module = "com.datadoghq:dd-sdk-android-session-replay", version.ref = "dd-sdk-android" }


### PR DESCRIPTION
Remove `dd-sdk-android-compose` dependency, `enableComposeActionTracking()` call, and `composeInstrumentation` config. Core Datadog RUM/logs/tracing remain intact.

- Remove `dd-sdk-android-compose` from `app/build.gradle.kts`
- Remove `enableComposeActionTracking()` from `GooglePlatformAnalytics`
- Remove `composeInstrumentation = InstrumentationMode.AUTO` from `AnalyticsConventionPlugin`
- Remove catalog entry from `libs.versions.toml`