### PR TITLE
fix(node): don't recreate Vico CartesianChartModelProducer on channel switch

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
@@ -159,26 +159,28 @@ fun GenericMetricChart(
  *
  * @param isEmpty Whether the chart data is empty — when true, nothing is rendered.
  * @param legendData Legend items shown below the chart.
- * @param key Optional key for the [CartesianChartModelProducer] (e.g. a selected channel). Pass a different value to
- *   recreate the producer.
  * @param hiddenSet Indices of hidden legend items (toggleable legend).
  * @param onToggle Callback when a legend item is toggled; when null, a read-only legend is rendered.
  * @param content Builder lambda receiving the [CartesianChartModelProducer] and a standard `Modifier.weight(1f)`
  *   suitable for the chart area.
+ *
+ * A single [CartesianChartModelProducer] is created per scaffold instance. Vico forbids swapping the producer attached
+ * to a live [CartesianChartHost] (it throws "A new `CartesianChartModelProducer` was provided…"), so callers must push
+ * new data through [CartesianChartModelProducer.runTransaction] instead of recreating the producer. Keying the scaffold
+ * on external state (e.g. a selected channel) caused exactly that crash, so the previous `key` parameter was removed.
  */
 @Composable
 fun MetricChartScaffold(
     isEmpty: Boolean,
     legendData: List<LegendData>,
     modifier: Modifier = Modifier,
-    key: Any? = Unit,
     hiddenSet: Set<Int> = emptySet(),
     onToggle: ((Int) -> Unit)? = null,
     content: @Composable ColumnScope.(CartesianChartModelProducer, Modifier) -> Unit,
 ) {
     Column(modifier = modifier) {
         if (isEmpty) return@Column
-        val modelProducer = remember(key) { CartesianChartModelProducer() }
+        val modelProducer = remember { CartesianChartModelProducer() }
         val chartModifier = Modifier.weight(1f).padding(horizontal = 8.dp).padding(bottom = 0.dp)
         content(modelProducer, chartModifier)
         Legend(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
@@ -182,12 +182,10 @@ private fun PowerMetricsChart(
     selectedX: Double?,
     onPointSelected: (Double) -> Unit,
 ) {
-    MetricChartScaffold(
-        isEmpty = telemetries.isEmpty(),
-        legendData = LEGEND_DATA,
-        modifier = modifier,
-        key = selectedChannel,
-    ) { modelProducer, chartModifier ->
+    MetricChartScaffold(isEmpty = telemetries.isEmpty(), legendData = LEGEND_DATA, modifier = modifier) {
+            modelProducer,
+            chartModifier,
+        ->
         val currentColor = PowerMetric.CURRENT.color
         val voltageColor = PowerMetric.VOLTAGE.color
         val marker =


### PR DESCRIPTION
Fixes a release crash when switching channels on the Power Metrics chart:

```
java.lang.IllegalStateException: A new `CartesianChartModelProducer` was provided.
Run data updates via `runTransaction`, not by creating new `CartesianChartModelProducer`s.
    at com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModelKt.collectAsState(CartesianChartModel.kt:116)
    at com.patrykandpatrick.vico.compose.cartesian.CartesianChartHostKt.CartesianChartHost(…)
    at org.meshtastic.feature.node.metrics.BaseMetricChartKt.GenericMetricChart(BaseMetricChart.kt:126)
    at org.meshtastic.feature.node.metrics.PowerMetricsKt.PowerMetricsChart(…)
```

## Root cause
`MetricChartScaffold` accepted a `key: Any? = Unit` parameter forwarded to `remember(key) { CartesianChartModelProducer() }`. `PowerMetricsChart` passed `selectedChannel`, so toggling a channel minted a brand-new producer and handed it to the already-live `CartesianChartHost`. Vico 3.x explicitly forbids swapping producers and throws from `CartesianChartModel.collectAsState` on the next recomposition.

## Fix
- Drop the `key` parameter from `MetricChartScaffold`; remember a single producer per scaffold instance.
- Remove `key = selectedChannel` from the `PowerMetricsChart` call site.

Channel switches already push fresh data through `modelProducer.runTransaction { … }` inside `LaunchedEffect(selectedChannel, currentData, voltageData)`, which is the intended Vico path.

## Verification
`./gradlew :feature:node:assemble :feature:node:detekt` — clean.