### PR TITLE
fix: redact MeshLog proto secrets and centralize Compose keep-rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -40,15 +40,6 @@
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
 
-# ---- Compose Runtime & Animation --------------------------------------------
-
-# Defence-in-depth: prevent R8 tree-shaking of Compose infrastructure classes
-# that are referenced indirectly through compiler-generated state machines.
-# With -dontoptimize above these are largely redundant, but they provide a
-# safety net against future toolchain changes.
--keep class androidx.compose.runtime.** { *; }
--keep class androidx.compose.ui.** { *; }
--keep class androidx.compose.animation.core.** { *; }
--keep class androidx.compose.animation.** { *; }
--keep class androidx.compose.foundation.** { *; }
--keep class androidx.compose.material3.** { *; }
+# Compose runtime/ui/animation/foundation/material3 keep rules now live in
+# config/proguard/shared-rules.pro so both Android (R8) and desktop (ProGuard)
+# get the same defence-in-depth coverage against CMP 1.11 optimizer folding.

--- a/config/proguard/shared-rules.pro
+++ b/config/proguard/shared-rules.pro
@@ -177,3 +177,24 @@
 
 # Core model classes (used in serialization, Room, and Koin injection)
 -keep class org.meshtastic.core.model.** { *; }
+
+# ---- Compose Runtime & Animation --------------------------------------------
+
+# Defence-in-depth: prevent tree-shaking of Compose infrastructure classes that
+# are referenced indirectly through compiler-generated state machines. Applies
+# to BOTH R8 (Android app) and ProGuard (desktop distribution).
+#
+# Why shared: CMP 1.11 ships consumer rules with -assumenosideeffects on
+# Composer.<clinit>() / ComposerImpl.<clinit>() and -assumevalues on
+# ComposeRuntimeFlags / ComposeStackTraceMode. If the optimizer runs (R8 full
+# mode on Android, ProGuard with optimize.set(true) on desktop) these call
+# sites can be rewritten even when the target classes are kept, causing the
+# recomposer / frame-clock / animation state machines to silently freeze on
+# the first frame. -dontoptimize (set per-host) is the primary defence; these
+# keep rules are a safety net against future toolchain changes. See #5146.
+-keep class androidx.compose.runtime.** { *; }
+-keep class androidx.compose.ui.** { *; }
+-keep class androidx.compose.animation.core.** { *; }
+-keep class androidx.compose.animation.** { *; }
+-keep class androidx.compose.foundation.** { *; }
+-keep class androidx.compose.material3.** { *; }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImpl.kt
@@ -32,6 +32,8 @@ import org.meshtastic.core.common.util.nowSeconds
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.util.isLora
+import org.meshtastic.core.model.util.toOneLineString
+import org.meshtastic.core.model.util.toPIIString
 import org.meshtastic.core.repository.FromRadioPacketHandler
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.MeshMessageProcessor
@@ -125,11 +127,11 @@ class MeshMessageProcessorImpl(
                 proto.xmodemPacket != null -> "XmodemPacket" to proto.xmodemPacket.toString()
                 proto.deviceuiConfig != null -> "DeviceUIConfig" to proto.deviceuiConfig.toString()
                 proto.fileInfo != null -> "FileInfo" to proto.fileInfo.toString()
-                proto.my_info != null -> "MyInfo" to proto.my_info.toString()
-                proto.node_info != null -> "NodeInfo" to proto.node_info.toString()
-                proto.config != null -> "Config" to proto.config.toString()
-                proto.moduleConfig != null -> "ModuleConfig" to proto.moduleConfig.toString()
-                proto.channel != null -> "Channel" to proto.channel.toString()
+                proto.my_info != null -> "MyInfo" to proto.my_info!!.toOneLineString()
+                proto.node_info != null -> "NodeInfo" to proto.node_info!!.toPIIString()
+                proto.config != null -> "Config" to proto.config!!.toOneLineString()
+                proto.moduleConfig != null -> "ModuleConfig" to proto.moduleConfig!!.toOneLineString()
+                proto.channel != null -> "Channel" to proto.channel!!.toOneLineString()
                 proto.clientNotification != null -> "ClientNotification" to proto.clientNotification.toString()
                 else -> return
             }

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/Extensions.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/Extensions.kt
@@ -18,8 +18,11 @@
 
 package org.meshtastic.core.model.util
 
+import org.meshtastic.proto.Channel
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.MeshPacket
+import org.meshtastic.proto.ModuleConfig
+import org.meshtastic.proto.MyNodeInfo
 import org.meshtastic.proto.Telemetry
 
 /**
@@ -45,6 +48,24 @@ fun Config.toOneLineString(): String {
 
 fun MeshPacket.toOneLineString(): String {
     val redactedFields = """(public_key|private_key|admin_key)=[^,}]+""" // Redact keys
+    return this.toString().replace(redactedFields.toRegex()) { "${it.groupValues[1]}=[REDACTED]" }.replace('\n', ' ')
+}
+
+fun Channel.toOneLineString(): String {
+    // Redact the channel preshared key (psk) from logs.
+    val redactedFields = """(psk)=[^,}]+"""
+    return this.toString().replace(redactedFields.toRegex()) { "${it.groupValues[1]}=[REDACTED]" }.replace('\n', ' ')
+}
+
+fun ModuleConfig.toOneLineString(): String {
+    // Redact MQTT credentials from logs.
+    val redactedFields = """(password|username)=[^,}]+"""
+    return this.toString().replace(redactedFields.toRegex()) { "${it.groupValues[1]}=[REDACTED]" }.replace('\n', ' ')
+}
+
+fun MyNodeInfo.toOneLineString(): String {
+    // Redact the hardware unique identifier from logs.
+    val redactedFields = """(device_id)=[^,}]+"""
     return this.toString().replace(redactedFields.toRegex()) { "${it.groupValues[1]}=[REDACTED]" }.replace('\n', ' ')
 }
 


### PR DESCRIPTION
Two release-posture hardening fixes from the architecture audit.

**MeshLog secret redaction (`core/data`)**
- `MeshMessageProcessorImpl.logVariant()` was calling `.toString()` on `FromRadio` proto variants whose bodies include secrets (channel PSK, admin/private/public keys, MQTT creds, device_id). These strings were persisted to the `MeshLog` SQLite table in plaintext.
- Route `MyNodeInfo`, `NodeInfo`, `Config`, `ModuleConfig`, and `Channel` variants through redacting `toOneLineString()` helpers. New helpers added in `core/model/Extensions.kt` for the types that lacked one.

**Compose keep-rule parity (`config/proguard`)**
- Moved Compose `runtime`/`ui`/`animation`/`foundation`/`material3` `-keep` rules out of `app/proguard-rules.pro` into `config/proguard/shared-rules.pro`, which is already wired into both the Android application build (`AndroidApplicationConventionPlugin.kt:48`) and the Desktop proguard config (`desktop/build.gradle.kts:131`).
- Without this, Desktop release was at risk of the CMP 1.11 optimizer folding recomposition — the `-assumenosideeffects` + `-assumevalues` consumer rules are only countered by keeping the Compose runtime classes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>