### PR TITLE
chore(strings): remove 4 unused string resources

### DIFF
--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -408,12 +408,9 @@
     <string name="userinfo">User Info</string>
     <string name="meshtastic_new_nodes_notifications">New node notifications</string>
     <string name="snr">SNR</string>
-    <string name="snr_definition">Signal-to-Noise Ratio, a measure used in communications to quantify the level of a desired signal to the level of background noise. In Meshtastic and other wireless systems, a higher SNR indicates a clearer signal that can enhance the reliability and quality of data transmission.</string>
     <string name="rssi">RSSI</string>
-    <string name="rssi_definition">Received Signal Strength Indicator, a measurement used to determine the power level being received by the antenna. A higher RSSI value generally indicates a stronger and more stable connection.</string>
     <string name="iaq_definition">(Indoor Air Quality) relative scale IAQ value as measured by Bosch BME680. Value Range 0–500.</string>
     <string name="device_metrics_log">Device Metrics</string>
-    <string name="node_map">Node Map</string>
     <string name="position_log">Position</string>
     <string name="last_position_update">Last position update</string>
     <string name="env_metrics_log">Environment Metrics</string>
@@ -460,7 +457,6 @@
     <string name="one_month">1M</string>
     <string name="max">Max</string>
     <string name="min">Min</string>
-    <string name="avg">Avg</string>
     <string name="expand_chart">Expand chart</string>
     <string name="collapse_chart">Collapse chart</string>
     <string name="unknown_age">Unknown Age</string>


### PR DESCRIPTION
Removes 4 dead string resources with zero references in the codebase after earlier feature refactors:

| String | Dropped by |
|---|---|
| `snr_definition` | #5062 (SignalMetrics redesign — InfoDialog removed) |
| `rssi_definition` | #5062 (same) |
| `node_map` | #5049 (Node Map became standalone route) |
| `avg` | #5049 (chart DRY-up; replaced by richer stats chip) |

## Scope

Conservative pass — deletions only. Does **not** collapse duplicate values (e.g. `blue` vs `tak_team_blue`, `save` vs `save_changes`) because those are context-sensitive for translators. Merging them would invalidate Crowdin translations across ~40 languages for no real maintenance win.

## Verification

```
rg -w snr_definition  # 0 hits
rg -w rssi_definition # 0 hits
rg -w node_map        # 0 hits
rg -w avg             # 0 hits
```

`./gradlew :app:assembleFdroidDebug` passes.

## Follow-up (separate issue worth filing)

#5062 silently dropped the SNR/RSSI educational tooltips that explained these signal metrics to novice users. The `*_definition` strings were their body text. Restoring that UX on the new `SelectableMetricCard` would be a nice onboarding win — tracking outside this cleanup PR.