### PR TITLE
diag(r8): disable minify for release builds (animation-freeze diagnostic)

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -41,8 +41,22 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
                 buildTypes {
                     getByName("release") {
-                        isMinifyEnabled = true
-                        isShrinkResources = true
+                        // DIAGNOSTIC BUILD (internal.60): R8 is fully disabled to prove
+                        // whether the Compose animation freeze observed since CMP 1.11.0-beta02
+                        // is caused by R8 (shrinking / consumer-rule -assumenosideeffects /
+                        // resource shrinking) or by a CMP runtime bug independent of R8.
+                        //
+                        // - If animations work in this build → R8 is the cause; follow up with
+                        //   a narrower diag (weaken Compose -keep rules to allow class-merging,
+                        //   or toggle isShrinkResources only).
+                        // - If animations remain frozen → R8 is innocent; the bug is in
+                        //   compose-multiplatform 1.11.0-beta02 itself. File upstream and
+                        //   downgrade / pin.
+                        //
+                        // REVERT once the diagnostic is concluded — release builds MUST ship
+                        // with R8 enabled.
+                        isMinifyEnabled = false
+                        isShrinkResources = false
                         proguardFiles(
                             getDefaultProguardFile("proguard-android-optimize.txt"),
                             rootProject.file("config/proguard/shared-rules.pro"),


### PR DESCRIPTION
## ⚠️ Diagnostic build — do not merge

Disables R8 minification and resource shrinking on release builds so we can isolate whether the **Compose animation freeze** observed since CMP 1.11.0-beta02 is caused by R8 or by the CMP runtime itself.

## Background

- `internal.59` (current main, ships post-#5173) still exhibits the freeze, so the audit-fleet PRs (#5166–#5173) are ruled out.
- `-dontoptimize` is **verified** active in the merged R8 config (`app/build/outputs/mapping/{flavor}Release/configuration.txt:306`), so R8 should not be inlining or merging classes.
- Despite that, animations remain frozen.
- Possible causes still on the table:
  - R8 shrinking removing something needed
  - CMP consumer-ship `-assumenosideeffects` directives that bypass `-dontoptimize`
  - `isShrinkResources = true` stripping a runtime asset
  - **CMP 1.11.0-beta02 runtime bug** independent of R8

A no-minify build answers all four at once.

## Change

`build-logic/.../AndroidApplicationConventionPlugin.kt`:

```diff
 getByName("release") {
-    isMinifyEnabled = true
-    isShrinkResources = true
+    isMinifyEnabled = false
+    isShrinkResources = false
```

## Test plan

1. Ship as **`v2.7.14-internal.60`**.
2. Install on the same device(s) that exhibit the freeze on internal.58/.59.
3. Exercise animation-heavy paths (node-list refresh, message bubble entry, sheet expansion, theme transitions).

| Result | Conclusion | Next step |
|---|---|---|
| Animations work | R8 is the cause | Re-enable minify, weaken Compose `-keep` rules to allow class-merging — *or* re-enable minify and toggle only `isShrinkResources` to narrow further. |
| Animations frozen | R8 innocent — CMP 1.11.0-beta02 bug | File upstream issue against compose-multiplatform; plan downgrade or pin Nav3 + revert CMP. |

## Revert plan

Squash-revert this PR (or the merge commit) once we have an answer. Release builds **must** ship with R8 enabled in production.