### PR TITLE
Revert "diag(r8): disable minify for release builds (animation-freeze diagnostic)"

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -41,22 +41,8 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
                 buildTypes {
                     getByName("release") {
-                        // DIAGNOSTIC BUILD (internal.60): R8 is fully disabled to prove
-                        // whether the Compose animation freeze observed since CMP 1.11.0-beta02
-                        // is caused by R8 (shrinking / consumer-rule -assumenosideeffects /
-                        // resource shrinking) or by a CMP runtime bug independent of R8.
-                        //
-                        // - If animations work in this build → R8 is the cause; follow up with
-                        //   a narrower diag (weaken Compose -keep rules to allow class-merging,
-                        //   or toggle isShrinkResources only).
-                        // - If animations remain frozen → R8 is innocent; the bug is in
-                        //   compose-multiplatform 1.11.0-beta02 itself. File upstream and
-                        //   downgrade / pin.
-                        //
-                        // REVERT once the diagnostic is concluded — release builds MUST ship
-                        // with R8 enabled.
-                        isMinifyEnabled = false
-                        isShrinkResources = false
+                        isMinifyEnabled = true
+                        isShrinkResources = true
                         proguardFiles(
                             getDefaultProguardFile("proguard-android-optimize.txt"),
                             rootProject.file("config/proguard/shared-rules.pro"),


### PR DESCRIPTION
Reverts #5174 (the R8-disable diagnostic shipped as `internal.60`).

R8 has been **exonerated** — `internal.60` shipped with R8 fully off (`isMinifyEnabled=false`, `isShrinkResources=false`) and the Compose animation freeze persisted, so the symptom is not caused by R8 shrinking, consumer-rule `-assumenosideeffects`, resource shrinking, or class merging.

Restoring `release` to `isMinifyEnabled=true` / `isShrinkResources=true`. Investigation continues toward the actual cause (current prime suspect: poisoned remote Gradle build cache serving stale Compose-compiler outputs).
