### PR TITLE
fix(deps): pin androidx-compose runtime-tracing/ui-test to CMP version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,10 +35,11 @@ turbine = "1.2.1"
 # Compose Multiplatform
 compose-multiplatform = "1.11.0-beta02"
 compose-multiplatform-material3 = "1.11.0-alpha06"
-# AndroidX Compose test/tracing artifacts share a version track with CMP but are resolved
-# independently by Maven. Pinning them to their own ref prevents Renovate from bumping the
-# CMP plugin version when a new AndroidX Compose pre-release appears.
-androidx-compose = "1.11.0-rc01"
+# `androidx-compose-material` (M2) is independent of CMP and pinned separately
+# because some third-party libs (maps-compose-widgets, datadog) drag in
+# unversioned material transitives. Test/tracing artifacts in the
+# androidx.compose.{runtime,ui} groups MUST track CMP — use compose-multiplatform
+# as their version ref, not a separate pin.
 androidx-compose-material = "1.7.8"
 jetbrains-adaptive = "1.3.0-alpha06"
 
@@ -121,8 +122,8 @@ androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version
 androidx-work-testing = { module = "androidx.work:work-testing", version = "2.11.2" }
 
 # AndroidX Compose (explicit versions — BOM removed; CMP is the sole version authority)
-androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "androidx-compose" }
-androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose" } # Required by Robolectric Compose tests (registers ComponentActivity)
+androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "compose-multiplatform" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-multiplatform" } # Required by Robolectric Compose tests (registers ComponentActivity)
 
 # Compose Multiplatform
 compose-multiplatform-animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "compose-multiplatform" }


### PR DESCRIPTION
## Tightest theory yet for the internal-build animation freeze

`gradle/libs.versions.toml` had two satellite AndroidX-coords artifacts wired against a separate `androidx-compose = "1.11.0-rc01"` ref:

- `androidx-compose-runtime-tracing` → `androidx.compose.runtime:runtime-tracing`
- `androidx-compose-ui-test-manifest` → `androidx.compose.ui:ui-test-manifest`

`runtime-tracing` is added as `runtimeOnly` to every Android target by `build-logic/.../AndroidCompose.kt`. At `1.11.0-rc01` it transitively requests `androidx.compose.runtime:runtime:1.11.0-rc01`. Gradle's "highest wins" then upgrades that — but `AndroidCompose.kt`'s `resolutionStrategy` force-pins `androidx.compose.runtime` back down to the CMP plugin version (`1.11.0-beta02`).

Net result in `main`'s shipped APK (verified against `./gradlew :app:dependencies --configuration googleReleaseRuntimeClasspath`):

| Artifact | Bytecode compiled against | Class on runtime classpath |
|---|---|---|
| `runtime-tracing` | `1.11.0-rc01` APIs | `1.11.0-rc01` |
| `runtime` | — | `1.11.0-beta02` (force-pinned down) |
| `ui` / `foundation` / `animation` | — | `1.11.0-beta02` |

`runtime-tracing` calling into a `runtime` it wasn't compiled against is exactly the kind of subtle ABI skew that can silently misbehave under recomposition / tracing paths — which is what an indeterminate progress bar exercises. Fits the symptoms:

- ✅ Started at PR #5036 (CMP 1.11.x bump introduced the rc01-vs-beta02 split)
- ✅ R8 disable (#5174) didn't fix it — runtime ABI skew, not obfuscation
- ✅ CI release builds froze while local dev builds animate — the build-cache can return classes compiled against either side of the skew

### Fix

Both satellite artifacts now use `version.ref = "compose-multiplatform"` so they always match the AndroidX runtime CMP itself publishes. Drops the now-unused `androidx-compose` version ref.

`./gradlew :app:dependencies --configuration googleReleaseRuntimeClasspath` confirms `runtime`, `runtime-tracing`, `ui`, `foundation`, `animation` all resolve cleanly to `1.11.0-beta02`.

### Sequencing vs other in-flight branches

This is the cheapest-to-test theory and doesn't change any user-visible code. Suggest cutting `internal.62` from this branch (along with the cache nuke) before resorting to the PR #5178 CMP downgrade.
