### PR TITLE
chore(deps): split androidx-compose version ref from CMP

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,6 +57,15 @@
       "automerge": true
     },
     {
+      "description": "Group CMP and the androidx.compose artifacts that track it so Renovate bumps them together (see PR #5180)",
+      "groupName": "compose-multiplatform",
+      "matchPackageNames": [
+        "/^org\\.jetbrains\\.compose/",
+        "androidx.compose.runtime:runtime-tracing",
+        "androidx.compose.ui:ui-test-manifest"
+      ]
+    },
+    {
       "description": "Restrict sensitive infrastructure to manual minor updates",
       "matchUpdateTypes": [
         "minor"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,11 +35,17 @@ turbine = "1.2.1"
 # Compose Multiplatform
 compose-multiplatform = "1.11.0-beta02"
 compose-multiplatform-material3 = "1.11.0-alpha06"
+# `androidx-compose-bom-aligned` tracks androidx.compose.{runtime,ui} test/tracing
+# artifacts that ship in lockstep with CMP. Kept as a separate version ref so Renovate
+# can bump androidx releases (which often land first) without dragging the
+# `org.jetbrains.compose:*` artifacts and Gradle plugin to a version JetBrains
+# hasn't published yet (see PR #5180). Should normally match `compose-multiplatform`;
+# AndroidCompose.kt's resolutionStrategy force-aligns these groups to the CMP version
+# at resolution time regardless of the declared value here.
+androidx-compose-bom-aligned = "1.11.0-beta02"
 # `androidx-compose-material` (M2) is independent of CMP and pinned separately
 # because some third-party libs (maps-compose-widgets, datadog) drag in
-# unversioned material transitives. Test/tracing artifacts in the
-# androidx.compose.{runtime,ui} groups MUST track CMP — use compose-multiplatform
-# as their version ref, not a separate pin.
+# unversioned material transitives.
 androidx-compose-material = "1.7.8"
 jetbrains-adaptive = "1.3.0-alpha06"
 
@@ -122,8 +128,8 @@ androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version
 androidx-work-testing = { module = "androidx.work:work-testing", version = "2.11.2" }
 
 # AndroidX Compose (explicit versions — BOM removed; CMP is the sole version authority)
-androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "compose-multiplatform" }
-androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-multiplatform" } # Required by Robolectric Compose tests (registers ComponentActivity)
+androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "androidx-compose-bom-aligned" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose-bom-aligned" } # Required by Robolectric Compose tests (registers ComponentActivity)
 
 # Compose Multiplatform
 compose-multiplatform-animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "compose-multiplatform" }


### PR DESCRIPTION
The `compose-multiplatform` version ref in `libs.versions.toml` was shared between two release trains with independent cadences:

- `org.jetbrains.compose.*` artifacts + the `org.jetbrains.compose` Gradle plugin
- `androidx.compose.runtime:runtime-tracing` and `androidx.compose.ui:ui-test-manifest`

Google ships the androidx side first. When Renovate noticed androidx 1.11.0-rc01 it bumped the shared variable, and #5180 choked because the JetBrains plugin at that version was not yet published to any configured repo.

- Introduce a dedicated `androidx-compose-bom-aligned` version ref for the two androidx artifacts so Renovate can bump them without dragging CMP.
- Add a Renovate `groupName` rule that bundles `org.jetbrains.compose/*` with those two androidx artifacts into a single PR, so the two refs continue to move in lockstep in practice.
- `AndroidCompose.kt`'s `resolutionStrategy` already force-aligns the `androidx.compose.{animation,foundation,runtime,ui}` groups to the CMP version at resolution time, so runtime behavior is unchanged regardless of the declared androidx version.

Verified `:app:dependencies` still resolves both androidx artifacts to `1.11.0-beta02`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>