### PR TITLE
fix(fdroid): prevent NotImplementedError crash on firmware release fetch

### DIFF
--- a/app/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
+++ b/app/src/fdroid/kotlin/org/meshtastic/app/di/FDroidNetworkModule.kt
@@ -25,12 +25,18 @@ import org.meshtastic.core.network.service.ApiService
 @Module
 class FDroidNetworkModule {
 
+    /**
+     * F-Droid builds intentionally avoid network calls to the Meshtastic API.
+     *
+     * We throw [UnsupportedOperationException] (an [Exception], not an [Error]) so that `safeCatching {}` in the
+     * repositories captures the failure and falls back to the bundled JSON assets instead of crashing the app.
+     */
     @Single
     fun provideApiService(): ApiService = object : ApiService {
         override suspend fun getDeviceHardware(): List<NetworkDeviceHardware> =
-            throw NotImplementedError("API calls to getDeviceHardware are not supported on Fdroid builds.")
+            throw UnsupportedOperationException("getDeviceHardware is not supported on F-Droid builds.")
 
         override suspend fun getFirmwareReleases(): NetworkFirmwareReleases =
-            throw NotImplementedError("API calls to getFirmwareReleases are not supported on Fdroid builds.")
+            throw UnsupportedOperationException("getFirmwareReleases is not supported on F-Droid builds.")
     }
 }


### PR DESCRIPTION
F-Droid builds crashed on launch when the firmware update flow queried `getFirmwareReleases()`:

```
kotlin.NotImplementedError: API calls to getFirmwareReleases are not supported on Fdroid builds.
  at FDroidNetworkModule$provideApiService$1.getFirmwareReleases(FDroidNetworkModule.kt:34)
  at FirmwareReleaseRemoteDataSource$getFirmwareReleases$2.invokeSuspend(FirmwareReleaseRemoteDataSource.kt:31)
```

The F-Droid `ApiService` stub threw `kotlin.NotImplementedError`, which extends `Error` — not `Exception`. Both `FirmwareReleaseRepositoryImpl` and `DeviceHardwareRepositoryImpl` wrap the remote call in `safeCatching {}`, which only catches `Exception`, so the error escaped the cache-then-JSON-fallback logic and crashed the launch coroutine.

- Switch both stub methods to throw `UnsupportedOperationException` so `safeCatching` captures the failure and the bundled JSON asset fallback runs as designed.
- No behavior change for Google/Desktop builds, which use the real `ApiServiceImpl`.

Verified with `./gradlew :app:assembleFdroidDebug`.