### PR TITLE
fix(canned-messages): enable multiline text editing for long message lists

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
@@ -205,6 +205,7 @@ fun EditTextPreference(
     onFocusChanged: (FocusState) -> Unit = {},
     trailingIcon: (@Composable () -> Unit)? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None,
+    multiline: Boolean = false,
 ) {
     var isFocused by remember { mutableStateOf(false) }
 
@@ -212,7 +213,8 @@ fun EditTextPreference(
         OutlinedTextField(
             modifier = Modifier.fillMaxWidth().onFocusEvent { onFocusChanged(it) },
             value = value,
-            singleLine = true,
+            singleLine = !multiline,
+            maxLines = if (multiline) 5 else 1,
             enabled = enabled,
             isError = isError,
             onValueChange = {

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/CannedMessageConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/CannedMessageConfigItemList.kt
@@ -181,6 +181,7 @@ fun CannedMessageConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Uni
                     KeyboardOptions.Default.copy(keyboardType = KeyboardType.Text, imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                     onValueChanged = { messagesInput = it },
+                    multiline = true,
                 )
             }
         }


### PR DESCRIPTION
## Summary

The canned messages config textbox was single-line only, preventing users from viewing or editing messages beyond the first visible line. Users with long lists (e.g. `Ack|Yes|No|...|QRF|Exfil|...`) couldn't scroll the cursor to later messages even after retrieving saved config from the radio.

## Changes

- Add optional `multiline` parameter to `EditTextPreference` (defaults to false for backward compat)
- Enable multiline for the messages field with maxLines=5 to make it practical for long lists

Closes #5164