### PR TITLE
fix(settings): restore Import/Export button functionality in #4913

### DIFF
--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
@@ -90,7 +90,7 @@ fun SettingsScreen(
     val state by viewModel.radioConfigState.collectAsStateWithLifecycle()
 
     var deviceProfile by remember { mutableStateOf<DeviceProfile?>(null) }
-    var showEditDeviceProfileDialog by rememberSaveable { mutableStateOf(false) }
+    var showEditDeviceProfileDialog by remember { mutableStateOf(false) }
 
     val importConfigLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {


### PR DESCRIPTION
The Export/Import buttons in Settings stopped working in 2.7.14. 

**Root Cause:**
The `showEditDeviceProfileDialog` state was changed from `remember` to `rememberSaveable` in commit 72b981f73 (KMP audit). This caused state management issues when button callbacks tried to update the state.

**Solution:**
Reverted `showEditDeviceProfileDialog` back to `remember` since this UI state doesn't need to persist across process death. It only needs to persist for the lifetime of the Settings composition.

**Testing:**
- Build passes ✓
- Lint passes ✓
- Export/Import dialog should now appear when buttons are tapped

Closes #4913