### PR TITLE
feat(service): send polite ToRadio(disconnect=true) before transport close

### DIFF
--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -95,6 +95,13 @@ interface RadioInterfaceService : RadioTransportCallback {
     /** Initiates the connection to the radio. */
     fun connect()
 
+    /**
+     * Explicitly tears down the active transport, sending a polite `ToRadio(disconnect = true)` goodbye frame first
+     * when a transport is live. Safe to call when nothing is connected — implementations must no-op in that case.
+     * Suspends until the teardown completes.
+     */
+    suspend fun disconnect()
+
     /** Returns the current device address. */
     fun getDeviceAddress(): String?
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.database.DatabaseManager
 import org.meshtastic.core.common.util.handledLaunch
@@ -148,6 +149,14 @@ class MeshServiceOrchestrator(
         // Guard stop() so we don't emit a spurious "stopped" log when TAK was never started
         if (takServerManager.isRunning.value) {
             takMeshIntegration.stop()
+        }
+        // Best-effort polite goodbye on service teardown (onDestroy / process shutdown). We launch
+        // on a fresh detached scope — not the orchestrator's per-start scope — so the subsequent
+        // scope.cancel() below doesn't interrupt the short drain delay inside disconnect(). The
+        // coroutine is fire-and-forget; typical runtime is ~100-150ms which comfortably fits
+        // inside Android's onDestroy() grace window.
+        CoroutineScope(SupervisorJob() + dispatchers.default).launch {
+            runCatching { radioInterfaceService.disconnect() }
         }
         scope?.cancel()
         scope = null

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -59,6 +59,7 @@ import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.RadioPrefs
 import org.meshtastic.core.repository.RadioTransport
 import org.meshtastic.core.repository.RadioTransportFactory
+import org.meshtastic.proto.ToRadio
 import kotlin.concurrent.Volatile
 
 /**
@@ -121,6 +122,13 @@ class SharedRadioInterfaceService(
     private var runningTransportId: InterfaceId? = null
     private var isStarted = false
 
+    /**
+     * Set while [stopTransportLocked] is draining the polite disconnect frame. [sendToRadio] checks this so any late
+     * traffic submitted after we've announced disconnection is dropped rather than racing in front of the firmware-side
+     * link teardown.
+     */
+    @Volatile private var isStopping = false
+
     private val listenersInitialized = atomic(false)
     private var heartbeatJob: Job? = null
     private var lastHeartbeatMillis = 0L
@@ -135,6 +143,13 @@ class SharedRadioInterfaceService(
         // zombie (BLE stack didn't report disconnect). Two missed heartbeat intervals gives
         // the firmware a reasonable window to respond or send telemetry.
         private const val LIVENESS_TIMEOUT_MILLIS = HEARTBEAT_INTERVAL_MILLIS * 2
+
+        /**
+         * Upper bound on how long we wait for the polite `ToRadio(disconnect = true)` frame to flush before tearing the
+         * transport down. 500ms gives BLE's write-retry path (`BleRetry` backs off 500ms) room for one attempt on a
+         * flaky GATT connection. Serial and TCP typically flush well under this window.
+         */
+        private const val POLITE_DISCONNECT_DRAIN_MS = 500L
     }
 
     private val initLock = Mutex()
@@ -191,6 +206,10 @@ class SharedRadioInterfaceService(
     override fun connect() {
         processLifecycle.coroutineScope.launch { transportMutex.withLock { startTransportLocked() } }
         initStateListeners()
+    }
+
+    override suspend fun disconnect() {
+        transportMutex.withLock { ignoreExceptionSuspend { stopTransportLocked() } }
     }
 
     override fun isMockTransport(): Boolean = transportFactory.isMockTransport()
@@ -257,9 +276,26 @@ class SharedRadioInterfaceService(
     private suspend fun stopTransportLocked() {
         val currentTransport = radioTransport
         Logger.i { "Stopping transport $currentTransport" }
+        // Best-effort polite goodbye: tell the firmware we're disconnecting on purpose so it can
+        // tear down its side of the link cleanly instead of relying on timeouts / hardware events.
+        // Flip isStopping before sending so any concurrent sendToRadio() drops incoming traffic —
+        // we don't want normal packets racing behind the disconnect frame. Skip only when already
+        // Disconnected; firmware can still consume the goodbye while handshaking or sleeping, so
+        // it's worth sending in every other state. The send is fire-and-forget through the
+        // transport's own scope; the drain delay gives async transports a window to flush before
+        // close() cancels their write scope. BLE's retry path backs off 500ms, so this window
+        // also covers one retry on flaky GATT links.
+        if (currentTransport != null && _connectionState.value != ConnectionState.Disconnected) {
+            isStopping = true
+            ignoreExceptionSuspend {
+                currentTransport.handleSendToRadio(ToRadio(disconnect = true).encode())
+                delay(POLITE_DISCONNECT_DRAIN_MS)
+            }
+        }
         isStarted = false
         radioTransport = null
         runningTransportId = null
+        isStopping = false
         currentTransport?.close()
 
         _serviceScope.cancel("stopping transport")
@@ -310,6 +346,10 @@ class SharedRadioInterfaceService(
     }
 
     override fun sendToRadio(bytes: ByteArray) {
+        if (isStopping) {
+            Logger.d { "sendToRadio: transport stopping, dropping ${bytes.size} bytes" }
+            return
+        }
         // Snapshot the transport to avoid calling handleSendToRadio on a null reference.
         // There is still a benign race: stopTransportLocked() may cancel _serviceScope
         // between the null-check and the launch, causing the coroutine to be silently

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -75,6 +75,10 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
         connectCalled = true
     }
 
+    override suspend fun disconnect() {
+        connectCalled = false
+    }
+
     override fun getDeviceAddress(): String? = _currentDeviceAddressFlow.value
 
     override fun setDeviceAddress(deviceAddr: String?): Boolean {

--- a/desktop/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktop/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -89,6 +89,10 @@ class NoopRadioInterfaceService : RadioInterfaceService {
         logWarn("NoopRadioInterfaceService.connect()")
     }
 
+    override suspend fun disconnect() {
+        logWarn("NoopRadioInterfaceService.disconnect()")
+    }
+
     override fun getDeviceAddress(): String? = null
 
     override fun setDeviceAddress(deviceAddr: String?): Boolean = false


### PR DESCRIPTION
## Summary

Send a polite `ToRadio { disconnect = true }` frame before tearing down the active transport so firmware can release its side of the streamed-API link immediately instead of waiting for its own idle timeout (tens of seconds on serial, up to 15 minutes on TCP). Mirrors `meshtastic-sdk`'s `MeshEngine` cleanup step 6.

## Changes

- `stopTransportLocked()` flips a `@Volatile isStopping` flag, dispatches the disconnect frame through the transport's own scope, waits `POLITE_DISCONNECT_DRAIN_MS` (500 ms, matched to `BleRetry`'s backoff so GATT gets one retry on flaky links), then closes.
- `sendToRadio()` short-circuits while `isStopping=true` so normal packets can't race behind the goodbye frame.
- Gate is `_connectionState != Disconnected` — firmware can still consume the frame while handshaking or sleeping, so only a truly disconnected state skips the send.
- New `suspend fun disconnect()` on `RadioInterfaceService` is called by `MeshServiceOrchestrator.stop()` on a detached `SupervisorJob` scope so the subsequent `scope.cancel()` doesn't interrupt the goodbye. Stubs added in `FakeRadioInterfaceService` and desktop `NoopStubs`.

## Notes

Split out from #5208 as an independent change.
