### PR TITLE
fix: MQTT proxy connection and probe test failures

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
@@ -44,6 +44,7 @@ import org.meshtastic.mqtt.ProbeResult
 import org.meshtastic.mqtt.probe
 import org.meshtastic.proto.MqttClientProxyMessage
 import org.meshtastic.proto.ToRadio
+import kotlin.time.Clock
 
 @Single
 class MqttManagerImpl(
@@ -125,6 +126,8 @@ class MqttManagerImpl(
         val endpoint = resolveEndpoint(address, tlsEnabled)
         val result =
             MqttClient.probe(endpoint = endpoint) {
+                // Provide a valid client ID for the probe; brokers reject empty identifiers
+                clientId = "MeshtasticProbe-${Clock.System.now().toEpochMilliseconds()}"
                 val user = username?.takeUnless { it.isEmpty() }
                 val pass = password?.takeUnless { it.isEmpty() }
                 if (user != null) this.username = user

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -225,9 +225,8 @@ class MQTTRepositoryImpl(
  * Address resolution rules:
  * - If [rawAddress] already contains a URI scheme (`scheme://…`), parse it directly via [MqttEndpoint.parse] and
  *   respect whatever transport / port the user encoded.
- * - Otherwise wrap it as a WebSocket endpoint (`ws[s]://host${WEBSOCKET_PATH}`) so the proxy works over CDNs and
- *   firewall-restricted networks where raw 1883/8883 may be blocked. The scheme is `wss` when [tlsEnabled] is `true`,
- *   `ws` otherwise.
+ * - Otherwise wrap it as a TCP endpoint using standard MQTT ports: port 8883 if [tlsEnabled] is `true`,
+ *   port 1883 otherwise. This allows standard MQTT brokers to work out of the box.
  *
  * Extracted as a top-level function so [MQTTRepositoryImplTest] can exercise every branch without spinning up the full
  * repository, and so `MqttManagerImpl` (in `:core:data`) can reuse the same parsing rules for the probe API. Visibility
@@ -236,8 +235,7 @@ class MQTTRepositoryImpl(
 fun resolveEndpoint(rawAddress: String, tlsEnabled: Boolean): MqttEndpoint = if (rawAddress.contains("://")) {
     MqttEndpoint.parse(rawAddress)
 } else {
-    val scheme = if (tlsEnabled) "wss" else "ws"
-    MqttEndpoint.parse("$scheme://$rawAddress$WEBSOCKET_PATH")
+    val port = if (tlsEnabled) 8883 else 1883
+    val scheme = if (tlsEnabled) "ssl" else "tcp"
+    MqttEndpoint.parse("$scheme://$rawAddress:$port")
 }
-
-private const val WEBSOCKET_PATH = "/mqtt"

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -219,14 +219,17 @@ class MQTTRepositoryImpl(
     }
 }
 
+private const val MQTT_PORT_PLAIN = 1883
+private const val MQTT_PORT_TLS = 8883
+
 /**
  * Resolve a user-supplied broker address into an [MqttEndpoint].
  *
  * Address resolution rules:
  * - If [rawAddress] already contains a URI scheme (`scheme://…`), parse it directly via [MqttEndpoint.parse] and
  *   respect whatever transport / port the user encoded.
- * - Otherwise wrap it as a TCP endpoint using standard MQTT ports: port 8883 if [tlsEnabled] is `true`,
- *   port 1883 otherwise. This allows standard MQTT brokers to work out of the box.
+ * - Otherwise wrap it as a TCP endpoint using standard MQTT ports: port 8883 if [tlsEnabled] is `true`, port 1883
+ *   otherwise. This allows standard MQTT brokers to work out of the box.
  *
  * Extracted as a top-level function so [MQTTRepositoryImplTest] can exercise every branch without spinning up the full
  * repository, and so `MqttManagerImpl` (in `:core:data`) can reuse the same parsing rules for the probe API. Visibility
@@ -235,7 +238,7 @@ class MQTTRepositoryImpl(
 fun resolveEndpoint(rawAddress: String, tlsEnabled: Boolean): MqttEndpoint = if (rawAddress.contains("://")) {
     MqttEndpoint.parse(rawAddress)
 } else {
-    val port = if (tlsEnabled) 8883 else 1883
+    val port = if (tlsEnabled) MQTT_PORT_TLS else MQTT_PORT_PLAIN
     val scheme = if (tlsEnabled) "ssl" else "tcp"
     MqttEndpoint.parse("$scheme://$rawAddress:$port")
 }


### PR DESCRIPTION
## Problem

MQTT proxy connections were failing with two distinct errors:

### 1. WebSocket Error on MQTT Proxy
```
Connection failed: Engine doesn't support WebSocketCapability
```

The `resolveEndpoint()` function was forcing WebSocket protocol for standard MQTT broker addresses. Standard MQTT brokers (like `mqtt.meshtastic.org`) use TCP (port 1883/8883), not WebSocket.

### 2. Invalid Client ID on Probe Test
```
Broker rejected: Connection refused: CLIENT_IDENTIFIER_NOT_VALID
```

The probe test was using an empty client ID by default, which MQTT brokers reject as invalid.

## Solution

### Fix 1: Use TCP Instead of WebSocket
- Changed `resolveEndpoint()` to default to TCP on standard MQTT ports (1883/8883)
- Users can still explicitly specify WebSocket endpoints using full URI scheme (e.g., `ws://broker/mqtt`)
- Supports: `tcp://broker:1883`, `ssl://broker:8883` by default

### Fix 2: Provide Valid Client ID for Probe
- Probe test now provides a unique client ID: `MeshtasticProbe-{timestamp}`
- Allows the test connection button to successfully validate broker connectivity

## Verification

Live logs showing successful MQTT connection (TCP):
```
MQTT Connecting to Tcp(host=mqtt.meshtastic.org, port=1883, tls=false)
MQTT subscribing to 2 topics
MQTT connected and subscribed
```

✅ TCP connection established  
✅ Topics subscribed successfully  
✅ Actively receiving MQTT messages from broker  
✅ Full MQTT proxy operational end-to-end  

## Files Changed
- `core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt` — Fixed endpoint resolution to use TCP
- `core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt` — Fixed probe with valid client ID