### PR TITLE
fix(ble): cleanup races discovered while reviewing #5207

### DIFF
--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -139,10 +139,17 @@ class KableBleConnection(private val scope: CoroutineScope) : BleConnection {
             meshtasticDevice.advertisement?.let { adv -> Peripheral(adv) { commonConfig() } }
                 ?: createPeripheral(device.address) { commonConfig() }
 
-        cleanUpPeripheral(device.address)
-        peripheral = p
-
-        ActiveBleConnection.active = ActiveConnection(p, device.address)
+        // Install ownership of the new peripheral atomically. Cancellation between
+        // peripheral construction and field assignment would strand `p` (Kable allocates
+        // a per-peripheral scope + Bluetooth-state observer eagerly), so the cleanup,
+        // assignment, and ActiveBleConnection update must complete as a single unit.
+        // _deviceFlow.emit() is intentionally outside this block — making it
+        // non-cancellable could hang teardown on a slow collector.
+        withContext(NonCancellable) {
+            cleanUpPeripheral(device.address)
+            peripheral = p
+            ActiveBleConnection.active = ActiveConnection(p, device.address)
+        }
 
         _deviceFlow.emit(device)
 
@@ -212,11 +219,18 @@ class KableBleConnection(private val scope: CoroutineScope) : BleConnection {
         stateJob?.cancel()
         stateJob = null
 
+        // Capture the peripheral we own before clearing it so we can identity-check
+        // ActiveBleConnection below. A stale disconnect from an earlier connection
+        // attempt's exception handler must not clobber a newer connection that has
+        // already installed itself as active.
+        val owned = peripheral
         safeClosePeripheral("disconnect")
         peripheral = null
         connectionScope = null
 
-        ActiveBleConnection.active = null
+        if (owned != null && ActiveBleConnection.active?.peripheral === owned) {
+            ActiveBleConnection.active = null
+        }
 
         _deviceFlow.emit(null)
     }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -103,9 +103,17 @@ class BleRadioTransport(
     internal val address: String,
 ) : RadioTransport {
 
+    // Detached cleanup scope for last-ditch GATT teardown from the exception handler.
+    // Must NOT be a child of `scope`: when an uncaught exception fires in connectionScope,
+    // upper layers often tear down `scope` immediately. Launching cleanup on `scope` then
+    // races the cancellation and may never start, leaking BluetoothGatt (status 133 on
+    // the next reconnect). This scope is cancelled in close() once our own disconnect
+    // has completed and the safety net is no longer needed.
+    private val cleanupScope: CoroutineScope = CoroutineScope(SupervisorJob() + scope.coroutineContext.minusKey(Job))
+
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         Logger.w(throwable) { "[$address] Uncaught exception in connectionScope" }
-        scope.launch {
+        cleanupScope.launch {
             try {
                 bleConnection.disconnect()
             } catch (e: Exception) {
@@ -427,6 +435,10 @@ class BleRadioTransport(
                 Logger.w(e) { "[$address] Failed to disconnect in close()" }
             }
         }
+        // Our own disconnect succeeded — the exception-handler safety net is no longer
+        // needed. Cancel the detached cleanup scope so it doesn't outlive us in tests
+        // or process lifetime.
+        cleanupScope.cancel("close() called")
     }
 
     private fun dispatchPacket(packet: ByteArray) {


### PR DESCRIPTION
Two follow-up cleanup races found while reviewing the GATT-133 reconnect fix in #5207. Both are latent today (narrow timing windows) but become more likely under aggressive reconnect / multi-device scenarios.

## Changes

- **`KableBleConnection.connect()` ownership install** — Kable allocates a per-peripheral coroutine scope and Bluetooth-state observer eagerly when `Peripheral(...)` is constructed. Cancellation between peripheral construction, field assignment, and `ActiveBleConnection.active = …` could strand the new peripheral with no field referencing it for cleanup. Wrap the three-step ownership install in `withContext(NonCancellable)`. `_deviceFlow.emit()` is intentionally left outside the block to avoid hanging teardown on a slow collector.

- **`KableBleConnection.disconnect()` identity check** — `disconnect()` cleared `ActiveBleConnection.active` unconditionally. A stale disconnect from an earlier connection attempt's exception handler running after a newer connection had installed itself as active would clobber the newer entry. Capture the owned peripheral at the start of `disconnect()` and only clear `ActiveBleConnection` if it still references that same instance.

- **`BleRadioTransport` exception handler cleanup scope** — the `CoroutineExceptionHandler` on `connectionScope` launched its last-ditch `bleConnection.disconnect()` on the per-transport `scope`. When upper layers tear `scope` down in response to the same uncaught exception that triggered the handler, `scope.launch` can fail to start at all, defeating the cleanup and leaking BluetoothGatt (status 133 on the next reconnect). Use a dedicated `cleanupScope` built from `scope`'s context minus its `Job` plus a fresh `SupervisorJob` so the cleanup launch is independent of the parent's cancellation state. Cancelled in `close()` once our own disconnect completes.

## Verification

- `./gradlew :core:network:spotlessApply :core:ble:spotlessApply :core:network:detekt :core:ble:detekt` ✅
- `./gradlew :core:network:allTests :core:ble:allTests` ✅

Follow-up to #5207.