### PR TITLE
feat(messaging): add entry points for filter settings

### DIFF
--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -99,9 +99,11 @@ private const val MAX_LINES = 3
  * @param message An optional message to pre-fill in the input field.
  * @param viewModel The [MessageViewModel] instance for handling business logic and state.
  * @param navigateToNodeDetails Callback to navigate to a node's detail screen.
+ * @param navigateToQuickChatOptions Callback to navigate to the quick chat options screen.
+ * @param navigateToFilterSettings Callback to navigate to the message filter settings screen.
  * @param onNavigateBack Callback to navigate back from this screen.
  */
-@Suppress("LongMethod", "CyclomaticComplexMethod") // Due to multiple states and event handling
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 fun MessageScreen(
     contactKey: String,
@@ -109,6 +111,7 @@ fun MessageScreen(
     viewModel: MessageViewModel,
     navigateToNodeDetails: (Int) -> Unit,
     navigateToQuickChatOptions: () -> Unit,
+    navigateToFilterSettings: () -> Unit,
     onNavigateBack: () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -321,6 +324,7 @@ fun MessageScreen(
                     filteredCount = filteredCount,
                     showFiltered = showFiltered,
                     onToggleShowFiltered = viewModel::toggleShowFiltered,
+                    onNavigateToFilterSettings = navigateToFilterSettings,
                 )
             }
         },

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageScreenComponents.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageScreenComponents.kt
@@ -75,6 +75,7 @@ import org.meshtastic.core.resources.delete_messages_title
 import org.meshtastic.core.resources.filter_disable_for_contact
 import org.meshtastic.core.resources.filter_enable_for_contact
 import org.meshtastic.core.resources.filter_hide_count
+import org.meshtastic.core.resources.filter_settings
 import org.meshtastic.core.resources.filter_show_count
 import org.meshtastic.core.resources.navigate_back
 import org.meshtastic.core.resources.new_messages_below
@@ -103,6 +104,7 @@ import org.meshtastic.core.ui.icon.More
 import org.meshtastic.core.ui.icon.Muted
 import org.meshtastic.core.ui.icon.Reply
 import org.meshtastic.core.ui.icon.SelectAll
+import org.meshtastic.core.ui.icon.Settings
 import org.meshtastic.core.ui.icon.Unmuted
 import org.meshtastic.core.ui.icon.Visibility
 import org.meshtastic.core.ui.icon.VisibilityOff
@@ -297,6 +299,7 @@ fun MessageTopBar(
     filteredCount: Int = 0,
     showFiltered: Boolean = false,
     onToggleShowFiltered: () -> Unit = {},
+    onNavigateToFilterSettings: () -> Unit = {},
 ) = TopAppBar(
     title = {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -328,6 +331,7 @@ fun MessageTopBar(
             filteredCount = filteredCount,
             showFiltered = showFiltered,
             onToggleShowFiltered = onToggleShowFiltered,
+            onNavigateToFilterSettings = onNavigateToFilterSettings,
         )
     },
 )
@@ -344,6 +348,7 @@ private fun MessageTopBarActions(
     filteredCount: Int,
     showFiltered: Boolean,
     onToggleShowFiltered: () -> Unit,
+    onNavigateToFilterSettings: () -> Unit,
 ) {
     if (channelIndex == DataPacket.PKC_CHANNEL_INDEX) {
         NodeKeyStatusIcon(hasPKC = true, mismatchKey = mismatchKey)
@@ -364,6 +369,7 @@ private fun MessageTopBarActions(
             filteredCount = filteredCount,
             showFiltered = showFiltered,
             onToggleShowFiltered = onToggleShowFiltered,
+            onNavigateToFilterSettings = onNavigateToFilterSettings,
         )
     }
 }
@@ -380,6 +386,7 @@ private fun OverFlowMenu(
     filteredCount: Int,
     showFiltered: Boolean,
     onToggleShowFiltered: () -> Unit,
+    onNavigateToFilterSettings: () -> Unit,
 ) {
     if (expanded) {
         DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
@@ -389,6 +396,7 @@ private fun OverFlowMenu(
                 FilteredMessagesMenuItem(showFiltered, filteredCount, onDismiss, onToggleShowFiltered)
             }
             FilterToggleMenuItem(filteringDisabled, onDismiss, onToggleFilteringDisabled)
+            FilterSettingsMenuItem(onDismiss, onNavigateToFilterSettings)
         }
     }
 }
@@ -460,6 +468,19 @@ private fun FilterToggleMenuItem(filteringDisabled: Boolean, onDismiss: () -> Un
                 contentDescription = title,
             )
         },
+    )
+}
+
+@Composable
+private fun FilterSettingsMenuItem(onDismiss: () -> Unit, onNavigate: () -> Unit) {
+    val title = stringResource(Res.string.filter_settings)
+    DropdownMenuItem(
+        text = { Text(title) },
+        onClick = {
+            onDismiss()
+            onNavigate()
+        },
+        leadingIcon = { Icon(imageVector = MeshtasticIcons.Settings, contentDescription = title) },
     )
 }
 

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/navigation/ContactsNavigation.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/navigation/ContactsNavigation.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import org.koin.compose.viewmodel.koinViewModel
 import org.meshtastic.core.navigation.ContactsRoute
 import org.meshtastic.core.navigation.NodesRoute
+import org.meshtastic.core.navigation.SettingsRoute
 import org.meshtastic.core.navigation.replaceLast
 import org.meshtastic.core.ui.component.ScrollToTopEvent
 import org.meshtastic.feature.messaging.QuickChatScreen
@@ -65,6 +66,7 @@ fun EntryProviderScope<NavKey>.contactsGraph(
             navigateToNodeDetails = { id -> backStack.add(NodesRoute.NodeDetail(id)) },
             navigateToQuickChatOptions =
             dropUnlessResumed { backStack.add(org.meshtastic.core.navigation.ContactsRoute.QuickChat) },
+            navigateToFilterSettings = dropUnlessResumed { backStack.add(SettingsRoute.FilterSettings) },
             onNavigateBack = dropUnlessResumed { backStack.removeLastOrNull() },
         )
     }

--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
@@ -46,6 +46,7 @@ import org.meshtastic.core.navigation.WifiProvisionRoute
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.bottom_nav_settings
 import org.meshtastic.core.resources.export_configuration
+import org.meshtastic.core.resources.filter_settings
 import org.meshtastic.core.resources.import_configuration
 import org.meshtastic.core.resources.preferences_language
 import org.meshtastic.core.resources.remotely_administrating
@@ -53,6 +54,7 @@ import org.meshtastic.core.resources.wifi_devices
 import org.meshtastic.core.ui.component.ListItem
 import org.meshtastic.core.ui.component.MainAppBar
 import org.meshtastic.core.ui.component.MeshtasticDialog
+import org.meshtastic.core.ui.icon.FilterList
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Wifi
 import org.meshtastic.feature.settings.component.AppInfoSection
@@ -246,6 +248,15 @@ fun SettingsScreen(
                 ExpressiveSection(title = stringResource(Res.string.wifi_devices)) {
                     ListItem(text = stringResource(Res.string.wifi_devices), leadingIcon = MeshtasticIcons.Wifi) {
                         onNavigate(WifiProvisionRoute.WifiProvision())
+                    }
+                }
+
+                ExpressiveSection(title = stringResource(Res.string.filter_settings)) {
+                    ListItem(
+                        text = stringResource(Res.string.filter_settings),
+                        leadingIcon = MeshtasticIcons.FilterList,
+                    ) {
+                        onNavigate(SettingsRoute.FilterSettings)
                     }
                 }
 


### PR DESCRIPTION
Adds navigation to message filter settings from both the conversation top bar menu and the main settings screen.

- Add a "Filter settings" menu item to the `MessageTopAppBar` dropdown
- Add a Filter Settings section and list item to `SettingsScreen`
- Update `MessageScreen` to accept and propagate the `navigateToFilterSettings` callback
- Wire up the `SettingsRoute.FilterSettings` navigation in `ContactsNavigation`
- Add required string resources and icons to messaging components

https://github.com/meshtastic/Meshtastic-Android/issues/4656