### PR TITLE
fix(desktop): unbreak release builds (CMP beta03 + pwsh -P quoting)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,10 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_appVersionName: ${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }}
           APPIMAGE_EXTRACT_AND_RUN: 1
-        run: ./gradlew :desktop:packageReleaseDistributionForCurrentOS -PaboutLibraries.release=true --no-daemon
+        # Quote the -P flag: PowerShell on Windows interprets the dot in
+        # `-PaboutLibraries.release=true` as member access on `-PaboutLibraries`,
+        # splitting the token and feeding `.release=true` to Gradle as a task name.
+        run: ./gradlew :desktop:packageReleaseDistributionForCurrentOS '-PaboutLibraries.release=true' --no-daemon
 
       - name: List Desktop Binaries
         if: runner.os == 'Linux'

--- a/app/src/test/kotlin/org/meshtastic/app/ui/NavigationAssemblyTest.kt
+++ b/app/src/test/kotlin/org/meshtastic/app/ui/NavigationAssemblyTest.kt
@@ -17,7 +17,7 @@
 package org.meshtastic.app.ui
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -32,10 +32,12 @@ internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
         exclude(mapOf("group" to "androidx.compose", "module" to "compose-bom"))
     }
 
-    // CMP publishes these core AndroidX groups at the CMP version tag.
-    // Material, Material3, and Adaptive follow separate AndroidX version numbers
-    // and must NOT be included here (see CMP release notes for the mapping table).
-    val cmpVersion = libs.version("compose-multiplatform")
+    // CMP publishes these core AndroidX groups at an AndroidX version tag that
+    // tracks (but does not equal) the CMP version. The exact mapping lives in
+    // the CMP release notes; we mirror it via the `androidx-compose-bom-aligned`
+    // version ref in libs.versions.toml. Material, Material3, and Adaptive follow
+    // separate AndroidX version numbers and must NOT be included here.
+    val androidxComposeVersion = libs.version("androidx-compose-bom-aligned")
     val cmpAlignedGroups = setOf(
         "androidx.compose.animation",
         "androidx.compose.foundation",
@@ -51,7 +53,7 @@ internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
     configurations.configureEach {
         resolutionStrategy.eachDependency {
             if (requested.group in cmpAlignedGroups) {
-                useVersion(cmpVersion)
+                useVersion(androidxComposeVersion)
             } else if (requested.group == "androidx.compose.material") {
                 useVersion(materialVersion)
             }

--- a/core/barcode/src/test/kotlin/org/meshtastic/core/barcode/BarcodeScannerTest.kt
+++ b/core/barcode/src/test/kotlin/org/meshtastic/core/barcode/BarcodeScannerTest.kt
@@ -17,7 +17,7 @@
 package org.meshtastic.core.barcode
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,8 +33,8 @@ testRetry = "1.6.4"
 turbine = "1.2.1"
 
 # Compose Multiplatform
-compose-multiplatform = "1.11.0-beta02"
-compose-multiplatform-material3 = "1.11.0-alpha06"
+compose-multiplatform = "1.11.0-beta03"
+compose-multiplatform-material3 = "1.11.0-alpha07"
 # `androidx-compose-bom-aligned` tracks androidx.compose.{runtime,ui} test/tracing
 # artifacts that ship in lockstep with CMP. Kept as a separate version ref so Renovate
 # can bump androidx releases (which often land first) without dragging the
@@ -42,12 +42,12 @@ compose-multiplatform-material3 = "1.11.0-alpha06"
 # hasn't published yet (see PR #5180). Should normally match `compose-multiplatform`;
 # AndroidCompose.kt's resolutionStrategy force-aligns these groups to the CMP version
 # at resolution time regardless of the declared value here.
-androidx-compose-bom-aligned = "1.11.0-rc01"
+androidx-compose-bom-aligned = "1.11.0"
 # `androidx-compose-material` (M2) is independent of CMP and pinned separately
 # because some third-party libs (maps-compose-widgets, datadog) drag in
 # unversioned material transitives.
 androidx-compose-material = "1.7.8"
-jetbrains-adaptive = "1.3.0-alpha06"
+jetbrains-adaptive = "1.3.0-alpha07"
 
 # Google
 maps-compose = "8.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,13 +35,14 @@ turbine = "1.2.1"
 # Compose Multiplatform
 compose-multiplatform = "1.11.0-beta03"
 compose-multiplatform-material3 = "1.11.0-alpha07"
-# `androidx-compose-bom-aligned` tracks androidx.compose.{runtime,ui} test/tracing
+# `androidx-compose-bom-aligned` tracks androidx.compose.{runtime,ui,foundation,animation}
 # artifacts that ship in lockstep with CMP. Kept as a separate version ref so Renovate
 # can bump androidx releases (which often land first) without dragging the
 # `org.jetbrains.compose:*` artifacts and Gradle plugin to a version JetBrains
-# hasn't published yet (see PR #5180). Should normally match `compose-multiplatform`;
-# AndroidCompose.kt's resolutionStrategy force-aligns these groups to the CMP version
-# at resolution time regardless of the declared value here.
+# hasn't published yet (see PR #5180). Should track the AndroidX version that the
+# current `compose-multiplatform` release maps to (see CMP release notes).
+# AndroidCompose.kt's resolutionStrategy force-aligns these groups to *this* version
+# at resolution time, so it is the source of truth for the Android target.
 androidx-compose-bom-aligned = "1.11.0"
 # `androidx-compose-material` (M2) is independent of CMP and pinned separately
 # because some third-party libs (maps-compose-widgets, datadog) drag in


### PR DESCRIPTION
Run [24809290151](https://github.com/meshtastic/Meshtastic-Android/actions/runs/24809290151) blew up the desktop release matrix in two distinct ways. This PR fixes both.

### macOS + Ubuntu — `:desktop:proguardReleaseJars` failed
ProGuard aborted with 3 unresolved program-class member warnings:

```
Warning: com.patrykandpatrick.vico.compose.cartesian.ColorScaleShader:
  can't find referenced method
  'org.jetbrains.skia.Shader LinearGradientShader-VjE6UOU$default(...)'
  in program class androidx.compose.ui.graphics.ShaderKt
Warning: ColorScaleAreaFill / ColorScaleLineFill:
  can't find 'void setShader(org.jetbrains.skia.Shader)'
  in program class androidx.compose.ui.graphics.Paint
java.io.IOException: Please correct the above warnings first.
```

Vico 3.2.0-next.1 (PR #5191) requires Skia bindings that don't exist in compose-multiplatform 1.11.0-beta02. Bumping CMP to beta03 (and pulling along material3 alpha07, jetbrains-adaptive alpha07, and androidx-compose-bom-aligned 1.11.0) brings them in. Equivalent to renovate's pending [#renovate/compose-multiplatform](https://github.com/meshtastic/Meshtastic-Android/tree/renovate/compose-multiplatform).

### Windows — `Task '.release=true' not found`
PowerShell parsed `-PaboutLibraries.release=true` as member access on the token `-PaboutLibraries`, splitting it into two args and feeding `.release=true` to Gradle as a task name. Quoting the flag fixes it.

### Verification
- `./gradlew :desktop:proguardReleaseJars` — green locally (was red)
- `./gradlew spotlessApply detekt` — clean