### PR TITLE
fix(desktop): unbreak Windows launch + Pi-installable arm64 .deb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-24.04, ubuntu-24.04-arm]
+        os: [macos-latest, windows-latest, ubuntu-22.04, ubuntu-22.04-arm]
     env:
       GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
@@ -72,22 +72,12 @@ internal fun Project.configureKotlinAndroid(commonExtension: CommonExtension) {
 
 /** Configure Kotlin Multiplatform options */
 internal fun Project.configureKotlinMultiplatform() {
-    // Skiko is an internal CMP implementation detail; third-party KMP libraries
-    // (e.g. coil3) can carry an older skiko transitive requirement that Gradle
-    // upgrades to the CMP-bundled version, triggering a "Skiko dependencies'
-    // versions are incompatible" warning from CMP's compatibility checker.
-    // Force the version to match CMP so the checker sees a consistent graph.
-    // Pinned here rather than in the version catalog because this plugin is the
-    // only consumer — bump together with the compose-multiplatform version.
-    val skikoVersion = "0.144.5"
-    configurations.configureEach {
-        resolutionStrategy.eachDependency {
-            if (requested.group == "org.jetbrains.skiko") {
-                useVersion(skikoVersion)
-                because("Align Skiko with the version bundled by Compose Multiplatform")
-            }
-        }
-    }
+    // Note: we used to force `org.jetbrains.skiko` to a hard-coded version here to
+    // align coil3's older skiko requirement with CMP's. As of CMP 1.11.x the
+    // compose-desktop module publishes `{strictly <version>}` constraints on
+    // skiko, so Gradle resolves the conflict naturally. A hard-coded force would
+    // silently downgrade skiko on the next CMP bump and break the renderer —
+    // so we let CMP own the version.
 
     extensions.configure<KotlinMultiplatformExtension> {
         // Standard KMP targets for Meshtastic

--- a/desktop/proguard-rules.pro
+++ b/desktop/proguard-rules.pro
@@ -42,13 +42,7 @@
 -dontprocesskotlinmetadata
 
 # ---- Entry point ------------------------------------------------------------
-
--keep class org.meshtastic.desktop.MainKt { *; }
-
-# ---- Ktor Java engine (desktop-only; Android uses OkHttp) -------------------
-# io.ktor.client.engine.java ships consumer rules; the shared
-# HttpClientEngineFactory ServiceLoader keep in shared-rules.pro covers the
-# reflective discovery path.
+# (org.meshtastic.desktop.MainKt is covered by the package-wide keep below.)
 
 # ---- Meshtastic desktop host shell ------------------------------------------
 
@@ -69,6 +63,42 @@
 
 -dontwarn kotlin.concurrent.atomics.**
 -dontwarn kotlin.uuid.UuidV7Generator
+
+# ---- Library consumer rules ------------------------------------------------
+# The compose-jb gradle plugin auto-injects `default-compose-desktop-rules.pro`
+# (bundled inside org.jetbrains.compose:compose-gradle-plugin) into every
+# desktop ProGuard run. That file already covers:
+#   - kotlin.**, kotlinx.coroutines.** (incl. SwingDispatcherFactory ServiceLoader)
+#   - org.jetbrains.skiko.**, org.jetbrains.skia.**
+#   - kotlinx.serialization.** (incl. @Serializable companion keeps)
+#   - kotlinx.datetime.**
+#   - androidx.compose.runtime SnapshotStateKt + Material3 SliderDefaults
+# So we DO NOT re-declare those here. Source of truth:
+#   https://github.com/JetBrains/compose-multiplatform/blob/master/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro
+#
+# However, the standalone ProGuard 7.7.0 that compose-jb invokes does NOT
+# auto-import library `META-INF/proguard/*.pro` consumer rules from arbitrary
+# jars (only R8/Android does). So any consumer-rule pattern outside the bundled
+# defaults above must be copied here manually (see Ktor SL block below).
+
+# ---- androidx.sqlite bundled driver (JNI native bridge) ---------------------
+# BundledSQLiteDriver loads `libsqliteJni` and the native code calls back into
+# JVM-land via methods on `BundledSQLiteDriverKt` (e.g. `nativeThreadSafeMode`)
+# and member methods on `BundledSQLiteDriver` itself. Because those JVM symbols
+# are referenced only from native code, ProGuard removes them as unused; the
+# native loader then crashes with `NoSuchMethodError: ... name or signature does
+# not match`. Keep the whole driver package — it's small and entirely needed at
+# runtime once the bundled SQLite driver is selected.
+-keep class androidx.sqlite.driver.bundled.** { *; }
+-keepclassmembers class androidx.sqlite.driver.bundled.** { native <methods>; *; }
+
+# ---- Ktor serialization extension providers (ServiceLoader) -----------------
+# io.ktor.serialization.kotlinx-json discovers KotlinxSerializationJsonExtensionProvider
+# via META-INF/services/io.ktor.serialization.kotlinx.KotlinxSerializationExtensionProvider.
+# Without this keep the desktop HttpClient init throws ServiceConfigurationError
+# at first request; on Windows jpackage's launcher swallows the trace and
+# surfaces it as "Failed to launch JVM".
+-keep class * implements io.ktor.serialization.kotlinx.KotlinxSerializationExtensionProvider { *; }
 
 # ---- Vico 3.2.0-next.1 ColorScale (CMP API drift) ---------------------------
 # Vico's new ColorScale* classes (ColorScaleShader, ColorScaleAreaFill,


### PR DESCRIPTION
## Why

Two production reports against the desktop release artifacts:

1. **Windows installer crashes immediately** with `Failed to launch JVM` — jpackage's launcher is hiding the real exception.
2. **arm64 `.deb` won't install on Raspberry Pi OS / Debian 12** — apt complains about missing `libasound2t64` and `libpng16-16t64`.

## What

### ProGuard (unbreaks Windows + reproduced macOS launch crash)

Verified locally that the desktop release was failing in two places, both stripped by ProGuard because the only references are non-JVM (ServiceLoader / JNI):

- **Ktor JSON ServiceLoader** — `io.ktor.serialization.kotlinx.KotlinxSerializationJsonExtensionProvider`. `HttpClient { install(ContentNegotiation) }` throws `ServiceConfigurationError` on first request.
- **androidx.sqlite bundled driver** — native `libsqliteJni` calls back into `BundledSQLiteDriverKt.nativeThreadSafeMode()`; ProGuard removes it as unused. Room can't open any DB.

Added narrowly-scoped `-keep` rules for both.

### Audit + cleanup

Compared our `desktop/proguard-rules.pro` against JetBrains' bundled [`default-compose-desktop-rules.pro`](https://github.com/JetBrains/compose-multiplatform/blob/master/gradle-plugins/compose/src/main/resources/default-compose-desktop-rules.pro), which the compose-jb gradle plugin auto-injects into every desktop ProGuard run. That file already covers `kotlin.**`, `kotlinx.coroutines.**` (including the `SwingDispatcherFactory` ServiceLoader for `Dispatchers.Main`), `org.jetbrains.skiko/skia.**`, `kotlinx.serialization`, and `kotlinx.datetime`. Dropped our redundant copies and added a comment pointing at the upstream file.

### build-logic skiko force removed

`KotlinAndroid.configureKotlinMultiplatform` was hard-coding `org.jetbrains.skiko` to `0.144.5` to silence CMP's incompatibility warning. CMP 1.11.x now publishes `{strictly}` constraints on skiko, so Gradle resolves the conflict naturally — the manual force is redundant today and would silently *downgrade* skiko (and break the renderer) on the next CMP bump.

### Linux .deb runners

Switched the desktop release matrix to `ubuntu-22.04` / `ubuntu-22.04-arm` so jpackage records the original Debian dep names (`libasound2`, `libpng16-16`) rather than Ubuntu's `*t64` transitional package names from the time_t64 transition, which don't exist on Debian 12 Bookworm / Pi OS.

## Verified locally

- `./gradlew :desktop:packageReleaseDistributionForCurrentOS spotlessApply detekt` — green
- macOS dmg launches, fetches firmware list over HTTPS, opens Room DB, starts mesh service.
- Windows / Pi install verification still depends on this PR's CI artifacts.