### PR TITLE
fix(crashlytics): resolve beta 2.7.14 crash issues

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
@@ -110,8 +110,9 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
             dao.upsertContactSettings(listOf(updated))
         }
 
-    override suspend fun getQueuedPackets(): List<DataPacket> =
-        withContext(dispatchers.io) { dbManager.currentDb.value.packetDao().getQueuedPackets() }
+    override suspend fun getQueuedPackets(): List<DataPacket> = withContext(dispatchers.io) {
+        dbManager.currentDb.value.packetDao().getAllDataPackets().filter { it.status == MessageStatus.QUEUED }
+    }
 
     suspend fun insertRoomPacket(packet: RoomPacket) =
         withContext(dispatchers.io) { dbManager.currentDb.value.packetDao().insert(packet) }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
@@ -338,15 +338,16 @@ interface PacketDao {
     )
     suspend fun findPacketBySfppHash(hash: ByteString): Packet?
 
+    // Fetches all DataPackets for the current node, ordered by time.
+    // Callers should filter by status in Kotlin (avoids SQLite json_extract dependency).
     @Query(
         """
     SELECT data FROM packet
     WHERE (myNodeNum = 0 OR myNodeNum = (SELECT myNodeNum FROM my_node))
-      AND json_extract(data, '${"$"}.status') = 'QUEUED'
     ORDER BY received_time ASC
     """,
     )
-    suspend fun getQueuedPackets(): List<DataPacket>
+    suspend fun getAllDataPackets(): List<DataPacket>
 
     @Query(
         """

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonPacketDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonPacketDaoTest.kt
@@ -164,7 +164,7 @@ abstract class CommonPacketDaoTest {
                 ),
             )
         packetDao.insert(queuedPacket)
-        val queued = packetDao.getQueuedPackets()
+        val queued = packetDao.getAllDataPackets().filter { it.status == MessageStatus.QUEUED }
         assertNotNull(queued)
         assertEquals(1, queued.size)
         assertEquals("Queued", queued.first().text)

--- a/feature/widget/src/main/kotlin/org/meshtastic/feature/widget/LocalStatsWidget.kt
+++ b/feature/widget/src/main/kotlin/org/meshtastic/feature/widget/LocalStatsWidget.kt
@@ -18,6 +18,7 @@ package org.meshtastic.feature.widget
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
@@ -36,13 +37,13 @@ import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.LocalSize
-import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.CircularProgressIndicator
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.LinearProgressIndicator
 import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.action.actionStartActivity
 import androidx.glance.appwidget.components.CircleIconButton
 import androidx.glance.appwidget.components.Scaffold
 import androidx.glance.appwidget.components.TitleBar
@@ -148,10 +149,8 @@ class LocalStatsWidget :
                     GlanceModifier.fillMaxSize()
                         .clickable(
                             actionStartActivity(
-                                android.content.ComponentName(
-                                    context.packageName,
-                                    "org.meshtastic.app.MainActivity",
-                                ),
+                                context.packageManager.getLaunchIntentForPackage(context.packageName)
+                                    ?: Intent().setClassName(context.packageName, "org.meshtastic.app.MainActivity"),
                             ),
                         ),
                 ) {


### PR DESCRIPTION
Fixes two crashes surfaced by Crashlytics in the 2.7.14 closed beta build.

- **Remove `json_extract()` from PacketDao query** — Android's bundled SQLite lacks the JSON1 extension on some devices (e.g. Huawei P30 Lite / Android 10), causing a `SQLiteException`. Now fetches candidate packets and filters `status == QUEUED` in Kotlin. (22 events / 7 users)

- **Fix Glance widget ActionTrampoline crash** — Replace `actionStartActivity(ComponentName(...))` with the Intent-based overload from `appwidget.action`, using `getLaunchIntentForPackage()` with explicit fallback. Fixes crash on Android 13+ where Glance restricts implicit activity launches. (2 events / 1 user)

A third issue (Ktor TLS `ClosedWriteChannelException`, 1 event) was triaged and deferred — transient network error deep in Ktor internals.