### PR TITLE
fix(ci): use JetBrains JDK for desktop release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,7 @@ jobs:
       - name: Gradle Setup
         uses: ./.github/actions/gradle-setup
         with:
+          jdk_distribution: 'jetbrains'
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache_read_only: 'false'
 


### PR DESCRIPTION
The `release-desktop` job requires `JvmVendorSpec.JETBRAINS` (set in `desktop/build.gradle.kts:111`) but was using the default Temurin distribution. On macOS runners, foojay auto-provisioning failed:

> Cannot find a Java installation matching: {languageVersion=21, vendor=JetBrains, implementation=vendor-specific}

Passes `jdk_distribution: 'jetbrains'` to the gradle-setup action for the release-desktop job only. PR check workflows stay on Temurin to avoid download rate limiting.

Fixes: https://github.com/meshtastic/Meshtastic-Android/actions/runs/25011581929/job/73248498554