### PR TITLE
fix(ci): revert jetbrains JDK for desktop release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,7 +274,6 @@ jobs:
       - name: Gradle Setup
         uses: ./.github/actions/gradle-setup
         with:
-          jdk_distribution: 'jetbrains'
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache_read_only: 'false'
 


### PR DESCRIPTION
## Summary
- Reverts #5251 — `setup-java@v5` with `distribution: jetbrains` only has JDK 11, not 21, breaking `ubuntu-22.04` and `ubuntu-22.04-arm` desktop release builds.
- Run [#367](https://github.com/meshtastic/Meshtastic-Android/actions/runs/24998108703) confirmed all 4 desktop targets pass with the default `temurin` JDK 21. That run's failure was in `release-google` (Fastlane), unrelated to JDK distribution.