### PR TITLE
fix(ci): use PRs instead of direct push for changelog updates

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -204,8 +204,18 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
           git diff --cached --quiet || {
-            git commit -m "docs: release CHANGELOG.md for v${VERSION} [skip ci]"
-            git push origin "changelog/v${VERSION}":main
+            BRANCH="automation/changelog-v${VERSION}"
+            git checkout -B "$BRANCH"
+            git commit -m "docs: release CHANGELOG.md for v${VERSION}"
+            git push origin "$BRANCH" --force
+
+            gh pr create \
+              --title "docs: release CHANGELOG.md for v${VERSION}" \
+              --body "Automated changelog stamp for production release v${VERSION}." \
+              --head "$BRANCH" \
+              --base main \
+              --label "automation" \
+              --label "skip-changelog"
           }
 
       - name: Notify Discord

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: changelog-${{ github.ref }}
@@ -59,6 +59,7 @@ jobs:
 
       - name: Update CHANGELOG.md
         if: steps.last_tag.outputs.tag != ''
+        id: update
         env:
           TAG: ${{ steps.last_tag.outputs.tag }}
         run: |
@@ -92,13 +93,40 @@ jobs:
               f.write(new_content)
           " "$UNRELEASED"
 
-      - name: Commit and push
-        if: steps.last_tag.outputs.tag != ''
+          # Check if there are actual changes
+          if git diff --quiet CHANGELOG.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update changelog PR
+        if: steps.last_tag.outputs.tag != '' && steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          BRANCH="automation/update-changelog"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Force-update the automation branch
+          git checkout -B "$BRANCH"
           git add CHANGELOG.md
-          git diff --cached --quiet || {
-            git commit -m "docs: update CHANGELOG.md [skip ci]"
-            git push origin main
-          }
+          git commit -m "docs: update CHANGELOG.md"
+          git push origin "$BRANCH" --force
+
+          # Create or update the PR
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Updated existing PR #$EXISTING_PR"
+          else
+            gh pr create \
+              --title "docs: update CHANGELOG.md" \
+              --body "Automated changelog update from push to main." \
+              --head "$BRANCH" \
+              --base main \
+              --label "automation" \
+              --label "skip-changelog"
+            echo "Created new changelog PR"
+          fi


### PR DESCRIPTION
## Summary

Fixes the `update-changelog.yml` workflow failure caused by branch protection on `main` requiring PRs and merge queue.

## Changes

- **`update-changelog.yml`** — instead of `git push origin main`, creates/updates an `automation/update-changelog` branch and opens a PR with `automation` + `skip-changelog` labels. Force-updates the same PR on subsequent pushes to main.
- **`promote.yml`** — same fix for the production changelog stamp step: creates `automation/changelog-vX.Y.Z` branch and opens a PR instead of pushing directly.

Fixes: https://github.com/meshtastic/Meshtastic-Android/actions/runs/25017031918/job/73267436520