### PR TITLE
fix(ci): align release.yml labels with actual repo labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,8 @@
 # .github/release.yml - GitHub Release Notes Configuration
+#
+# Labels here must match actual repo labels. Run `gh label list` to verify.
+# Auto-labeler: .github/workflows/pull-request-target.yml
+# AI classifier: .github/workflows/models_pr_triage.yml
 
 changelog:
   exclude:
@@ -12,10 +16,9 @@ changelog:
       - ci
       - build
       - testing
-      - test
       - refactor
       - documentation
-      - translation
+      - l10n
     authors:
       - renovate[bot]
       - dependabot[bot]
@@ -25,7 +28,6 @@ changelog:
     - title: 🏗️ Features
       labels:
         - enhancement
-        - feature
     - title: 🖥️ Desktop
       labels:
         - desktop
@@ -33,7 +35,6 @@ changelog:
       labels:
         - bug
         - bugfix
-        - fix
     - title: 📝 Other Changes
       labels:
         - '*'


### PR DESCRIPTION
## Summary

Removes phantom labels from `.github/release.yml` that never match any PR because they don't exist as repo labels.

## Changes

- `test` removed (repo uses `testing`)
- `translation` → replaced with `l10n` (the actual repo label)
- `feature` removed (repo only uses `enhancement`)
- `fix` removed (repo only uses `bugfix`)
- Added comments documenting where to verify label names

**Impact:** `l10n` PRs were not being excluded from changelogs because `translation` never matched. Now they will be properly excluded.