### PR TITLE
fix(ci): grant promote.yml required permissions in release dispatch

### DIFF
--- a/.github/workflows/create-or-promote-release.yml
+++ b/.github/workflows/create-or-promote-release.yml
@@ -28,7 +28,8 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
+  statuses: write
   id-token: write
   attestations: write
 


### PR DESCRIPTION
## Summary

- Adds `pull-requests: write` and `statuses: write` to `create-or-promote-release.yml` permissions
- Reusable workflows (like `promote.yml`) cannot exceed the caller's permission grants — this was causing `startup_failure` on release dispatch after #5259 added changelog PR creation and status posting to `promote.yml`

Fixes the `startup_failure` in [run 25019095125](https://github.com/meshtastic/Meshtastic-Android/actions/runs/25019095125).