### PR TITLE
fix(ci): skip macOS signing when secrets are missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,7 +294,7 @@ jobs:
           ORG_GRADLE_PROJECT_appVersionName: ${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }}
           VERSION_CODE: ${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }}
           APPIMAGE_EXTRACT_AND_RUN: 1
-          SIGN_MACOS: ${{ runner.os == 'macOS' && 'true' || 'false' }}
+          SIGN_MACOS: ${{ runner.os == 'macOS' && secrets.APPLE_SIGNING_IDENTITY != '' && 'true' || 'false' }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}


### PR DESCRIPTION
**Problem**
The `release-desktop` job on macOS fails with:
```
Could not find certificate for '' in keychain []
```
because `SIGN_MACOS` is set to `true` on every macOS runner regardless of whether the `APPLE_SIGNING_IDENTITY` secret exists.

**Fix**
Gate `SIGN_MACOS` on `secrets.APPLE_SIGNING_IDENTITY != ''` so that when the secret is absent the build produces an unsigned `.dmg` instead of crashing.

Ref: https://github.com/meshtastic/Meshtastic-Android/actions/runs/25019272416/job/73275336321