### PR TITLE
fix(fdroid): restore reproducible builds for aboutlibraries

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -91,12 +91,16 @@ jobs:
         run: ./gradlew graphUpdate
         continue-on-error: true
 
+      - name: Update AboutLibraries metadata
+        run: ./gradlew :app:exportLibraryDefinitions
+        continue-on-error: true
+
       - name: Create Pull Request if changes occurred
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
           commit-message: |
-            chore: Scheduled updates (Firmware, Hardware, Translations, Graphs)
+            chore: Scheduled updates (Firmware, Hardware, Translations, Graphs, Licenses)
 
             Automated updates for:
             - Firmware releases list
@@ -104,7 +108,8 @@ jobs:
             - Crowdin source string uploads
             - Crowdin translation downloads
             - Module dependency graphs
-          title: 'chore: Scheduled updates (Firmware, Hardware, Translations, Graphs)'
+            - AboutLibraries license metadata
+          title: 'chore: Scheduled updates (Firmware, Hardware, Translations, Graphs, Licenses)'
           body: |
             This PR includes automated updates from the scheduled workflow:
 
@@ -113,6 +118,7 @@ jobs:
             - Source strings were uploaded to Crowdin.
             - Latest translations were downloaded from Crowdin (if available).
             - Updated module dependency graphs in README.md files (if changed).
+            - Updated `aboutlibraries.json` license metadata (if dependencies changed).
 
             Please review the changes.
           branch: 'scheduled-updates'
@@ -121,6 +127,7 @@ jobs:
           add-paths: |
             app/src/main/assets/firmware_releases.json
             app/src/main/assets/device_hardware.json
+            app/src/main/resources/aboutlibraries.json
             fastlane/metadata/android/**
             **/strings.xml
             **/README.md

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -39,7 +39,8 @@ platform :android do
       properties: {
         "android.injected.version.name" => ENV['VERSION_NAME'],
         "android.injected.version.code" => ENV['VERSION_CODE'],
-        "aboutLibraries.release" => "true"
+        # Intentionally omit aboutLibraries.release — fdroid builds must use
+        # offlineMode so the output matches F-Droid's reproducible rebuild.
       }
     )
   end


### PR DESCRIPTION
Fixes #3231

**Problem:** F-Droid reproducible build verification fails because our CI fdroid build passes `-PaboutLibraries.release=true`, enabling remote license/funding fetches via `GITHUB_TOKEN`. F-Droid rebuilds with plain `./gradlew assembleFdroidRelease` (offline mode), producing a different `aboutlibraries.json` (and its R8-shrunk alias `res/M7.json`).

**Changes:**
- Remove `aboutLibraries.release=true` from the fdroid Fastlane lane so CI matches F-Droid's offline build
- Add `:app:exportLibraryDefinitions` to the scheduled-updates workflow so the committed `aboutlibraries.json` stays current as dependencies change