### PR TITLE
fix: persist language switching and correctly map locales

### DIFF
--- a/app/src/main/kotlin/org/meshtastic/app/MainActivity.kt
+++ b/app/src/main/kotlin/org/meshtastic/app/MainActivity.kt
@@ -27,11 +27,11 @@ import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
-import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.ReportDrawnWhen
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
@@ -89,7 +89,7 @@ import org.meshtastic.feature.map.node.NodeMapViewModel
 import org.meshtastic.feature.node.metrics.MetricsViewModel
 import org.meshtastic.feature.node.metrics.TracerouteMapScreen
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     private val model: UIViewModel by viewModel()
 
     private val usbRepository: UsbRepository by inject()

--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
@@ -149,7 +149,10 @@ fun SettingsScreen(
 
     var showLanguagePickerDialog by rememberSaveable { mutableStateOf(false) }
     if (showLanguagePickerDialog) {
-        LanguagePickerDialog { showLanguagePickerDialog = false }
+        LanguagePickerDialog(
+            onDismiss = { showLanguagePickerDialog = false },
+            onSelect = { languageTag -> settingsViewModel.setLocale(languageTag) },
+        )
     }
 
     var showThemePickerDialog by rememberSaveable { mutableStateOf(false) }
@@ -280,7 +283,7 @@ fun SettingsScreen(
 }
 
 @Composable
-private fun LanguagePickerDialog(onDismiss: () -> Unit) {
+private fun LanguagePickerDialog(onDismiss: () -> Unit, onSelect: (String) -> Unit) {
     MeshtasticDialog(
         title = stringResource(Res.string.preferences_language),
         onDismiss = onDismiss,
@@ -289,6 +292,7 @@ private fun LanguagePickerDialog(onDismiss: () -> Unit) {
                 languageMap().forEach { (languageTag, languageName) ->
                     ListItem(text = languageName, trailingIcon = null) {
                         LanguageUtils.setAppLocale(languageTag)
+                        onSelect(languageTag)
                         onDismiss()
                     }
                 }

--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/util/LanguageUtils.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/util/LanguageUtils.kt
@@ -99,7 +99,7 @@ object LanguageUtils {
         return languageTags.associateWith { languageTag ->
             when (languageTag) {
                 SYSTEM_DEFAULT -> stringResource(Res.string.preferences_system_default)
-                "fr-HT" -> stringResource(Res.string.fr_HT)
+                "ht" -> stringResource(Res.string.fr_HT)
                 "pt-BR" -> stringResource(Res.string.pt_BR)
                 "zh-CN" -> stringResource(Res.string.zh_CN)
                 "zh-TW" -> stringResource(Res.string.zh_TW)


### PR DESCRIPTION
Migrates MainActivity to AppCompatActivity to support AppCompatDelegate per-app language backport, syncs locale state to UiPrefs, and fixes Haitian Creole tag.