### PR TITLE
fix: disable preference footer buttons when there are no unsaved changes

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/PreferenceFooter.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/PreferenceFooter.kt
@@ -52,6 +52,7 @@ fun PreferenceFooter(
                 shapes = ButtonDefaults.shapesFor(mediumHeight),
                 modifier = Modifier.height(mediumHeight).weight(1f),
                 colors = ButtonDefaults.filledTonalButtonColors(),
+                enabled = enabled,
                 onClick = onNegativeClicked,
             ) {
                 Text(text = negativeText, style = ButtonDefaults.textStyleFor(mediumHeight))
@@ -63,7 +64,8 @@ fun PreferenceFooter(
                 shapes = ButtonDefaults.shapesFor(mediumHeight),
                 modifier = Modifier.height(mediumHeight).weight(1f),
                 colors = ButtonDefaults.buttonColors(),
-                onClick = { if (enabled) onPositiveClicked() },
+                enabled = enabled,
+                onClick = onPositiveClicked,
             ) {
                 Text(text = positiveText, style = ButtonDefaults.textStyleFor(mediumHeight))
             }


### PR DESCRIPTION
Fixes #5282 by properly passing the enabled parameter to the ElevatedButtons in PreferenceFooter.