### PR TITLE
fix: ensure snackbar respects safe drawing padding over host modifiers

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticSnackbarHost.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticSnackbarHost.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.ui.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
@@ -61,7 +62,7 @@ fun MeshtasticSnackbarProvider(
         content()
         SnackbarHost(
             hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter).then(hostModifier),
+            modifier = Modifier.align(Alignment.BottomCenter).safeDrawingPadding().then(hostModifier),
         )
     }
 }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/TransportIcon.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/TransportIcon.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.ui.component
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.internal
@@ -46,5 +47,5 @@ fun TransportIcon(transport: Int, viaMqtt: Boolean, modifier: Modifier = Modifie
                 MeshtasticIcons.Device to stringResource(Res.string.internal)
             else -> return
         }
-    Icon(icon, contentDescription = description, modifier = modifier)
+    Icon(icon, contentDescription = description, modifier = modifier, tint = Color.White)
 }

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
@@ -305,10 +305,7 @@ fun MessageItem(
                                     imageVector = MeshtasticIcons.HopCount,
                                     contentDescription = null,
                                     modifier = Modifier.size(14.dp),
-                                    tint =
-                                    contentColor.copy(
-                                        alpha = if (contrastLevel == ContrastLevel.HIGH) 1f else 0.7f,
-                                    ),
+                                    tint = Color.White,
                                 )
                                 Text(
                                     text =
@@ -318,6 +315,7 @@ fun MessageItem(
                                         "?"
                                     },
                                     style = metadataStyle,
+                                    color = Color.White,
                                 )
                             }
                         }


### PR DESCRIPTION
Fixes #5285 by placing safeDrawingPadding() strictly after the host modifier to prevent it from being overridden. Also updates metadata and transport icon colors for better contrast.