### PR TITLE
fix: update notification icon

### DIFF
--- a/core/resources/src/androidMain/res/drawable/meshtastic_ic_notification.xml
+++ b/core/resources/src/androidMain/res/drawable/meshtastic_ic_notification.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025 Meshtastic LLC
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:scaleX="0.24"
+        android:scaleY="0.24"
+        android:translateY="5.4">
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M64.716,13.073L37.867,52.447L32.204,48.585L61.878,5.068C62.516,4.132 63.575,3.572 64.707,3.571C65.839,3.57 66.899,4.128 67.538,5.063L97.281,48.512L91.625,52.384L64.716,13.073Z" />
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M8.379,52.406L39.741,6.415L34.078,2.553L2.716,48.544L8.379,52.406Z" />
+    </group>
+</vector>

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidNotificationManager.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidNotificationManager.kt
@@ -24,6 +24,7 @@ import androidx.core.content.getSystemService
 import org.koin.core.annotation.Single
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
+import org.meshtastic.core.resources.R.drawable
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.getString
 import org.meshtastic.core.resources.meshtastic_alerts_notifications
@@ -36,7 +37,8 @@ import android.app.NotificationManager as SystemNotificationManager
 @Single
 class AndroidNotificationManager(private val context: Context) : NotificationManager {
 
-    private val notificationManager = context.getSystemService<SystemNotificationManager>()!!
+    private val notificationManager =
+        checkNotNull(context.getSystemService<SystemNotificationManager>()) { "NotificationManager not found" }
 
     private data class ChannelConfig(val id: String, val importance: Int)
 
@@ -106,7 +108,7 @@ class AndroidNotificationManager(private val context: Context) : NotificationMan
             NotificationCompat.Builder(context, notification.category.channelConfig().id)
                 .setContentTitle(notification.title)
                 .setContentText(notification.message)
-                .setSmallIcon(android.R.drawable.ic_dialog_info)
+                .setSmallIcon(drawable.meshtastic_ic_notification)
                 .setAutoCancel(true)
                 .setSilent(notification.isSilent)
 

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshServiceNotificationsImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshServiceNotificationsImpl.kt
@@ -51,6 +51,7 @@ import org.meshtastic.core.repository.MeshServiceNotifications
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.SERVICE_NOTIFY_ID
+import org.meshtastic.core.resources.R.drawable
 import org.meshtastic.core.resources.R.raw
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.client_notification
@@ -111,7 +112,8 @@ class MeshServiceNotificationsImpl(
     private val nodeRepository: Lazy<NodeRepository>,
 ) : MeshServiceNotifications {
 
-    private val notificationManager = context.getSystemService<NotificationManager>()!!
+    private val notificationManager =
+        checkNotNull(context.getSystemService<NotificationManager>()) { "NotificationManager not found" }
 
     companion object {
         const val MAX_BATTERY_LEVEL = 100
@@ -418,7 +420,7 @@ class MeshServiceNotificationsImpl(
                     if (nodeId == DataPacket.ID_LOCAL) {
                         ourNode ?: nodeRepository.value.getNode(nodeId)
                     } else {
-                        nodeRepository.value.getNode(nodeId ?: "")
+                        nodeRepository.value.getNode(nodeId.orEmpty())
                     }
                 }
                 .first()
@@ -480,7 +482,7 @@ class MeshServiceNotificationsImpl(
 
         val summaryNotification =
             commonBuilder(NotificationType.DirectMessage)
-                .setSmallIcon(context.applicationInfo.icon)
+                .setSmallIcon(drawable.meshtastic_ic_notification)
                 .setStyle(messagingStyle)
                 .setGroup(GROUP_KEY_MESSAGES)
                 .setGroupSummary(true)
@@ -841,7 +843,7 @@ class MeshServiceNotificationsImpl(
         type: NotificationType,
         contentIntent: PendingIntent? = null,
     ): NotificationCompat.Builder {
-        val smallIcon = context.applicationInfo.icon
+        val smallIcon = drawable.meshtastic_ic_notification
 
         return NotificationCompat.Builder(context, type.channelId)
             .setSmallIcon(smallIcon)

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/ReplyReceiver.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/ReplyReceiver.kt
@@ -58,8 +58,8 @@ class ReplyReceiver :
         val remoteInput = RemoteInput.getResultsFromIntent(intent)
 
         if (remoteInput != null) {
-            val contactKey = intent.getStringExtra(CONTACT_KEY) ?: ""
-            val message = remoteInput.getCharSequence(KEY_TEXT_REPLY)?.toString() ?: ""
+            val contactKey = intent.getStringExtra(CONTACT_KEY).orEmpty()
+            val message = remoteInput.getCharSequence(KEY_TEXT_REPLY)?.toString().orEmpty()
 
             val pendingResult = goAsync()
             scope.launch {

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/worker/ServiceKeepAliveWorker.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/worker/ServiceKeepAliveWorker.kt
@@ -28,6 +28,7 @@ import co.touchlab.kermit.Logger
 import org.koin.android.annotation.KoinWorker
 import org.meshtastic.core.repository.MeshServiceNotifications
 import org.meshtastic.core.repository.SERVICE_NOTIFY_ID
+import org.meshtastic.core.resources.R.drawable
 import org.meshtastic.core.service.MeshService
 import org.meshtastic.core.service.startService
 
@@ -80,7 +81,7 @@ class ServiceKeepAliveWorker(
         // We use "my_service" which matches NotificationType.ServiceState.channelId in MeshServiceNotificationsImpl
 
         return NotificationCompat.Builder(applicationContext, "my_service")
-            .setSmallIcon(applicationContext.applicationInfo.icon)
+            .setSmallIcon(drawable.meshtastic_ic_notification)
             .setContentTitle("Resuming Mesh Service")
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)


### PR DESCRIPTION
- Replace generic and application icons with `meshtastic_ic_notification` for all service and app notifications.
- Replace unsafe null assertions (`!!`) with `checkNotNull` for system service retrieval.
- Use `String.orEmpty()` for cleaner null-safe string handling.

resolves #5291 