### PR TITLE
ci: remove Release environment from workflows

### DIFF
--- a/.github/workflows/post-release-cleanup.yml
+++ b/.github/workflows/post-release-cleanup.yml
@@ -19,7 +19,6 @@ permissions:
 jobs:
   cleanup_prereleases:
     runs-on: ubuntu-24.04-arm
-    environment: Release
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -104,7 +104,6 @@ jobs:
 
   promote-release:
     runs-on: ubuntu-24.04-arm
-    environment: Release
     needs: [ prepare-build-info ]
     steps:
       - name: Promote to next channel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,6 @@ jobs:
   release-google:
     runs-on: ubuntu-24.04
     needs: [prepare-build-info]
-    environment: Release
     env:
       GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
@@ -201,7 +200,6 @@ jobs:
   release-fdroid:
     runs-on: ubuntu-24.04
     needs: [prepare-build-info]
-    environment: Release
     env:
       GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
@@ -262,7 +260,6 @@ jobs:
     if: ${{ inputs.build_desktop }}
     runs-on: ${{ matrix.os }}
     needs: [prepare-build-info]
-    environment: Release
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Remove `environment: Release` from `post-release-cleanup`, `promote`, and `release` jobs.