### PR TITLE
ci: add reproducible build verification for F-Droid releases

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -100,6 +100,169 @@ jobs:
         if: inputs.run_lint == false
         run: ./gradlew kmpSmokeCompile -Pci=true --continue --scan
 
+  # ── Reproducible Build Verification ─────────────────────────────────
+  rb-check:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    if: inputs.run_lint == true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Gradle Setup
+        uses: ./.github/actions/gradle-setup
+        with:
+          gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache_read_only: 'true'
+
+      - name: Verify Reproducible Build (fdroid)
+        env:
+          VERSION_CODE: ${{ github.run_number }}
+        run: |
+          # Comprehensive RB verification for F-Droid/IzzyOnDroid.
+          # Based on: https://izzyondroid.org/docs/reproducibleBuilds/DebugFailedRBs/
+          # Catches regressions that have historically broken reproducibility:
+          #   1. aboutlibraries.json non-determinism (network fetching)
+          #   2. Datadog buildId leaking into fdroid APK
+          #   3. Google/Firebase/GMS/MLKit classes in fdroid APK
+          #   4. DEPENDENCY_INFO_BLOCK in signing block
+          #   5. Native library stripping (NDK version mismatch)
+          #   6. aboutlibraries "generated" timestamp in res/M7.json
+          #   7. baseline.prof determinism (flaky builds)
+          # See: https://github.com/meshtastic/Meshtastic-Android/issues/3231
+
+          echo "── Step 1: Verify aboutlibraries.json determinism ──"
+          rm -f app/src/main/resources/aboutlibraries.json
+          ./gradlew :app:exportLibraryDefinitions -Pci=true --no-configuration-cache
+          cp app/src/main/resources/aboutlibraries.json /tmp/aboutlibraries-run1.json
+
+          rm -f app/src/main/resources/aboutlibraries.json
+          ./gradlew :app:exportLibraryDefinitions -Pci=true --no-configuration-cache --rerun-tasks
+          cp app/src/main/resources/aboutlibraries.json /tmp/aboutlibraries-run2.json
+
+          if ! diff -q /tmp/aboutlibraries-run1.json /tmp/aboutlibraries-run2.json; then
+            echo "::error::aboutlibraries.json is NOT deterministic across runs!"
+            diff /tmp/aboutlibraries-run1.json /tmp/aboutlibraries-run2.json | head -20
+            exit 1
+          fi
+          echo "✅ aboutlibraries.json is deterministic"
+
+          echo "── Step 2: Build fdroid release APK ──"
+          ./gradlew :app:assembleFdroidRelease -Pci=true -Pmeshtastic.disableAbiSplits=true --no-configuration-cache
+
+          APK=$(find app/build/outputs/apk/fdroid/release -name "*.apk" | head -1)
+          if [ -z "$APK" ]; then
+            echo "::error::No fdroid release APK found"
+            exit 1
+          fi
+          echo "Checking APK: $APK"
+
+          echo "── Step 3: Check for datadog.buildId ──"
+          if unzip -l "$APK" | grep -q "datadog.buildId"; then
+            echo "::error::fdroid APK contains assets/datadog.buildId — breaks RB!"
+            exit 1
+          fi
+          echo "✅ No datadog.buildId in fdroid APK"
+
+          echo "── Step 4: Check for proprietary libraries (dex scan) ──"
+          TMPDIR=$(mktemp -d)
+          unzip -q "$APK" -d "$TMPDIR"
+          OFFENDERS=""
+          for pattern in "com/google/firebase" "com/google/android/gms" "com/crashlytics" "com/google/mlkit" "com/google/android/datatransport" "androidx/privacysandbox/ads"; do
+            for dex in "$TMPDIR"/classes*.dex; do
+              if [ -f "$dex" ] && strings "$dex" | grep -q "L${pattern}/"; then
+                OFFENDERS="${OFFENDERS}\n  - $pattern"
+                break
+              fi
+            done
+          done
+
+          if [ -n "$OFFENDERS" ]; then
+            echo -e "::error::fdroid APK contains proprietary libraries:${OFFENDERS}"
+            rm -rf "$TMPDIR"
+            exit 1
+          fi
+          echo "✅ No proprietary libraries in fdroid APK"
+
+          echo "── Step 5: Check for DEPENDENCY_INFO_BLOCK (signing block blob) ──"
+          # 0x504b4453 = "PKDS" — Google's dependency info signing block ID
+          if python3 -c "
+          import struct, sys
+          with open('$APK', 'rb') as f:
+              data = f.read()
+              # Search for the APK Signing Block magic
+              idx = data.rfind(b'APK Sig Block 42')
+              if idx > 0:
+                  # Scan the signing block for the dependency info ID
+                  block_start = max(0, idx - 65536)
+                  chunk = data[block_start:idx]
+                  if struct.pack('<I', 0x504b4453) in chunk:
+                      print('DEPENDENCY_INFO_BLOCK found')
+                      sys.exit(1)
+          " 2>/dev/null; then
+            echo "::error::fdroid APK contains DEPENDENCY_INFO_BLOCK — remove with dependenciesInfo { includeInApk = false }"
+            rm -rf "$TMPDIR"
+            exit 1
+          fi
+          echo "✅ No DEPENDENCY_INFO_BLOCK in signing block"
+
+          echo "── Step 6: Check native libraries have debug symbols (not stripped) ──"
+          STRIPPED_LIBS=""
+          for so in $(find "$TMPDIR" -name "*.so" 2>/dev/null); do
+            # If .symtab section is missing, the library was stripped
+            if ! readelf -S "$so" 2>/dev/null | grep -q "\.symtab"; then
+              # Libraries without symtab are stripped — this is only a problem
+              # if keepDebugSymbols is not working as expected
+              LIB_NAME=$(basename "$so")
+              STRIPPED_LIBS="${STRIPPED_LIBS} ${LIB_NAME}"
+            fi
+          done
+          # Note: Some third-party .so files arrive pre-stripped, which is OK.
+          # We only warn here; a hard failure would be too aggressive.
+          if [ -n "$STRIPPED_LIBS" ]; then
+            echo "::warning::Some native libraries appear stripped (may cause NDK-version-dependent RB failures):${STRIPPED_LIBS}"
+          else
+            echo "✅ Native libraries retain debug symbols"
+          fi
+
+          echo "── Step 7: Check aboutlibraries 'generated' timestamp not in APK ──"
+          # The M7.json (or aboutlibraries.json in Java resources) should NOT contain
+          # a "generated" field, which introduces a build-time timestamp.
+          ABOUT_JSON=""
+          if [ -f "$TMPDIR/aboutlibraries.json" ]; then
+            ABOUT_JSON="$TMPDIR/aboutlibraries.json"
+          else
+            # May be in res/ as M7.json or similar
+            ABOUT_JSON=$(find "$TMPDIR/res" -name "*.json" -exec grep -l "aboutLibraries" {} \; 2>/dev/null | head -1)
+          fi
+          if [ -n "$ABOUT_JSON" ] && grep -q '"generated"' "$ABOUT_JSON"; then
+            echo "::error::aboutlibraries contains 'generated' timestamp field — add excludeFields = listOf(\"generated\") to build config"
+            rm -rf "$TMPDIR"
+            exit 1
+          fi
+          echo "✅ No 'generated' timestamp in aboutlibraries data"
+
+          echo "── Step 8: Verify build from clean tree (version-control-info) ──"
+          if [ -f "$TMPDIR/META-INF/version-control-info.textproto" ]; then
+            if grep -q "modified: true" "$TMPDIR/META-INF/version-control-info.textproto"; then
+              echo "::warning::APK built from dirty tree (version-control-info shows modified:true). Release builds must use a clean tree."
+            else
+              echo "✅ Built from clean tree"
+            fi
+          else
+            echo "ℹ️ No version-control-info.textproto (AGP may not embed it for debug-signed builds)"
+          fi
+
+          rm -rf "$TMPDIR"
+          echo ""
+          echo "🎉 All RB checks passed"
+
   # ── Sharded Unit Tests ──────────────────────────────────────────────
   # Tests are split into 3 shards that run in parallel:
   #   shard-core:    core:* KMP module tests (allTests)

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -191,21 +191,35 @@ jobs:
           echo "✅ No proprietary libraries in fdroid APK"
 
           echo "── Step 5: Check for DEPENDENCY_INFO_BLOCK (signing block blob) ──"
-          # 0x504b4453 = "PKDS" — Google's dependency info signing block ID
-          if python3 -c "
+          # Parse the APK Signing Block structure to find the dependency info pair.
+          # Naive byte scans produce false positives in large APKs.
+          if python3 << 'PYEOF'
           import struct, sys
-          with open('$APK', 'rb') as f:
+
+          with open("$APK", "rb") as f:
               data = f.read()
-              # Search for the APK Signing Block magic
-              idx = data.rfind(b'APK Sig Block 42')
-              if idx > 0:
-                  # Scan the signing block for the dependency info ID
-                  block_start = max(0, idx - 65536)
-                  chunk = data[block_start:idx]
-                  if struct.pack('<I', 0x504b4453) in chunk:
-                      print('DEPENDENCY_INFO_BLOCK found')
-                      sys.exit(1)
-          " 2>/dev/null; then
+
+          magic = b"APK Sig Block 42"
+          idx = data.rfind(magic)
+          if idx < 0:
+              sys.exit(0)
+
+          block_size = struct.unpack_from("<Q", data, idx - 8)[0]
+          block_start = idx + 16 - 8 - block_size
+          pos = int(block_start)
+          end = idx - 8
+
+          while pos + 12 <= end:
+              pair_size = struct.unpack_from("<Q", data, pos)[0]
+              pair_id = struct.unpack_from("<I", data, pos + 8)[0]
+              if pair_id == 0x504b4453:
+                  print(f"DEPENDENCY_INFO_BLOCK found (id=0x{pair_id:08x})")
+                  sys.exit(1)
+              pos += 8 + int(pair_size)
+
+          sys.exit(0)
+          PYEOF
+          then
             echo "::error::fdroid APK contains DEPENDENCY_INFO_BLOCK — remove with dependenciesInfo { includeInApk = false }"
             rm -rf "$TMPDIR"
             exit 1


### PR DESCRIPTION
This adds a comprehensive set of checks to the CI pipeline to ensure APK reproducibility and compliance with F-Droid/IzzyOnDroid requirements. The new job catches common regressions that break determinism or accidentally include proprietary components.

- Add `rb-check` job to the reusable check workflow
- Verify `aboutlibraries.json` determinism across consecutive Gradle runs
- Scan APK dex files for prohibited proprietary libraries (GMS, Firebase, MLKit, etc.)
- Detect non-deterministic artifacts like `datadog.buildId` and `DEPENDENCY_INFO_BLOCK`
- Check for build-time timestamps in `aboutlibraries` metadata
- Validate native library symbol retention and build tree cleanliness via `version-control-info`
