### PR TITLE
fix: add explicit DI binds and ensure scans start after DataStore load

### DIFF
--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
@@ -24,7 +24,7 @@ import org.koin.core.annotation.Single
 import kotlin.time.Duration
 import kotlin.uuid.Uuid
 
-@Single
+@Single(binds = [BleScanner::class])
 class KableBleScanner(private val loggingConfig: BleLoggingConfig) : BleScanner {
     override fun scan(timeout: Duration, serviceUuid: Uuid?, address: String?): Flow<BleDevice> {
         val scanner = Scanner {

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/AndroidNetworkMonitor.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/AndroidNetworkMonitor.kt
@@ -20,7 +20,7 @@ import android.net.ConnectivityManager
 import kotlinx.coroutines.flow.Flow
 import org.koin.core.annotation.Single
 
-@Single
+@Single(binds = [NetworkMonitor::class])
 class AndroidNetworkMonitor(private val connectivityManager: ConnectivityManager) : NetworkMonitor {
     override val networkAvailable: Flow<Boolean> = connectivityManager.networkAvailable()
 }

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/AndroidServiceDiscovery.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/AndroidServiceDiscovery.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.koin.core.annotation.Single
 
-@Single
+@Single(binds = [ServiceDiscovery::class])
 class AndroidServiceDiscovery(private val nsdManager: NsdManager) : ServiceDiscovery {
     override val resolvedServices: Flow<List<DiscoveredService>> =
         nsdManager.serviceList(NetworkConstants.SERVICE_TYPE).map { list ->

--- a/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmNetworkMonitor.kt
+++ b/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmNetworkMonitor.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.koin.core.annotation.Single
 
-@Single
+@Single(binds = [NetworkMonitor::class])
 class JvmNetworkMonitor : NetworkMonitor {
     override val networkAvailable: Flow<Boolean> = flowOf(true)
 }

--- a/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmServiceDiscovery.kt
+++ b/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmServiceDiscovery.kt
@@ -30,7 +30,7 @@ import javax.jmdns.JmDNS
 import javax.jmdns.ServiceEvent
 import javax.jmdns.ServiceListener
 
-@Single
+@Single(binds = [ServiceDiscovery::class])
 class JvmServiceDiscovery(private val dispatchers: CoroutineDispatchers) : ServiceDiscovery {
     @Suppress("TooGenericExceptionCaught")
     override val resolvedServices: Flow<List<DiscoveredService>> =

--- a/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
+++ b/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
@@ -42,7 +42,7 @@ import org.meshtastic.feature.connections.model.getMeshtasticShortName
 import java.util.Locale
 
 @Suppress("LongParameterList")
-@Single
+@Single(binds = [GetDiscoveredDevicesUseCase::class])
 class AndroidGetDiscoveredDevicesUseCase(
     private val bluetoothRepository: BluetoothRepository,
     private val recentAddressesDataSource: RecentAddressesDataSource,

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -141,13 +141,14 @@ fun ConnectionsScreen(
     //
     // Keys include bleAutoScan/networkAutoScan so the effect re-fires once DataStore delivers the persisted `true`
     // value (initial composition sees `false` from the Eagerly-seeded StateFlow before the disk read completes).
-    DisposableEffect(bleAutoScan, networkAutoScan, localNetworkPermissionGranted) {
+    DisposableEffect(bleAutoScan) {
         if (bleAutoScan) scanModel.startBleScan()
+        onDispose { scanModel.stopBleScan() }
+    }
+
+    DisposableEffect(networkAutoScan, localNetworkPermissionGranted) {
         if (networkAutoScan && localNetworkPermissionGranted) scanModel.startNetworkScan()
-        onDispose {
-            scanModel.stopBleScan()
-            scanModel.stopNetworkScan()
-        }
+        onDispose { scanModel.stopNetworkScan() }
     }
 
     /* Animate waiting for the configurations */

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -138,7 +138,10 @@ fun ConnectionsScreen(
     // Auto-start scans on screen entry when the user has previously opted in via the toggle. Stop on exit so we don't
     // drain battery in the background. Network auto-start is additionally gated on the runtime local-network grant so
     // we don't trigger the system picker for users who declined the permission.
-    DisposableEffect(localNetworkPermissionGranted) {
+    //
+    // Keys include bleAutoScan/networkAutoScan so the effect re-fires once DataStore delivers the persisted `true`
+    // value (initial composition sees `false` from the Eagerly-seeded StateFlow before the disk read completes).
+    DisposableEffect(bleAutoScan, networkAutoScan, localNetworkPermissionGranted) {
         if (bleAutoScan) scanModel.startBleScan()
         if (networkAutoScan && localNetworkPermissionGranted) scanModel.startNetworkScan()
         onDispose {


### PR DESCRIPTION
Explicitly bind implementation classes to their respective interfaces in Koin annotations to ensure correct dependency injection. Additionally, update the `DisposableEffect` in `ConnectionsScreen` to re-fire when scan settings are loaded from DataStore.

- Add explicit `binds` to `@Single` for `NetworkMonitor`, `BleScanner`, `ServiceDiscovery`, and `GetDiscoveredDevicesUseCase`
- Include `bleAutoScan` and `networkAutoScan` as keys in `ConnectionsScreen` scan initialization effect to handle delayed DataStore emissions