### PR TITLE
fix(connections): improve BLE scan reliability and UI lifecycle

### DIFF
--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
@@ -29,11 +29,15 @@ class KableBleScanner(private val loggingConfig: BleLoggingConfig) : BleScanner 
     override fun scan(timeout: Duration, serviceUuid: Uuid?, address: String?): Flow<BleDevice> {
         val scanner = Scanner {
             logging { applyConfig(loggingConfig) }
-            // Use separate match blocks so each filter is evaluated independently (OR semantics).
-            // Combining address and service UUID in a single match{} creates an AND filter which
-            // silently drops results on OEM stacks (Samsung, Xiaomi) when the device uses a
-            // random resolvable private address.
-            if (address != null) {
+            // When both address and serviceUuid are provided, use OR-semantics so the device
+            // is found even if one filter is ineffective on the current platform (e.g.
+            // CoreBluetooth may not re-report a cached identifier via the address filter).
+            if (address != null && serviceUuid != null) {
+                filters {
+                    match { this.address = address }
+                    match { services = listOf(serviceUuid) }
+                }
+            } else if (address != null) {
                 filters { match { this.address = address } }
             } else if (serviceUuid != null) {
                 filters { match { services = listOf(serviceUuid) } }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -177,10 +177,11 @@ class BleRadioTransport(
             try {
                 val d =
                     withTimeoutOrNull(SCAN_TIMEOUT) {
-                        // Scan by service UUID rather than address. CoreBluetooth (macOS) caches
-                        // peripheral identifiers aggressively and may not re-report a device when
-                        // filtering by address alone, causing findDevice() to time out on Desktop.
-                        scanner.scan(timeout = SCAN_TIMEOUT, serviceUuid = SERVICE_UUID).first {
+                        // Pass both service UUID and address so the scanner can apply the most
+                        // efficient platform filter. Android uses address (OS-level HW filter),
+                        // while CoreBluetooth (macOS) needs the service UUID because it caches
+                        // peripheral identifiers and may not re-report by address alone.
+                        scanner.scan(timeout = SCAN_TIMEOUT, serviceUuid = SERVICE_UUID, address = address).first {
                             it.address.equals(address, ignoreCase = true)
                         }
                     }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -177,7 +177,10 @@ class BleRadioTransport(
             try {
                 val d =
                     withTimeoutOrNull(SCAN_TIMEOUT) {
-                        scanner.scan(timeout = SCAN_TIMEOUT, serviceUuid = SERVICE_UUID, address = address).first {
+                        // Scan by service UUID rather than address. CoreBluetooth (macOS) caches
+                        // peripheral identifiers aggressively and may not re-report a device when
+                        // filtering by address alone, causing findDevice() to time out on Desktop.
+                        scanner.scan(timeout = SCAN_TIMEOUT, serviceUuid = SERVICE_UUID).first {
                             it.address.equals(address, ignoreCase = true)
                         }
                     }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.ble.MeshtasticBleConstants.SERVICE_UUID
 import org.meshtastic.core.model.RadioNotConnectedException
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.testing.FakeBleConnection
@@ -37,6 +38,7 @@ import org.meshtastic.core.testing.FakeBluetoothRepository
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BleRadioTransportTest {
@@ -167,6 +169,30 @@ class BleRadioTransportTest {
         // the policy must NEVER signal a permanent disconnect on its own. Only explicit close()
         // (verified separately by the service layer) may emit isPermanent = true.
         verify(mode = VerifyMode.not) { service.onDisconnect(isPermanent = true, errorMessage = any()) }
+
+        bleTransport.close()
+    }
+
+    @Test
+    fun `findDevice scans with both service UUID and address`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        scanner.emitDevice(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        advanceTimeBy(3_001)
+
+        assertNotNull(scanner.lastScanServiceUuid, "scan must include serviceUuid")
+        assertEquals(SERVICE_UUID, scanner.lastScanServiceUuid)
+        assertEquals(address, scanner.lastScanAddress)
 
         bleTransport.close()
     }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -75,8 +75,16 @@ class FakeBleScanner :
     BleScanner {
     private val foundDevices = mutableSharedFlow<BleDevice>(replay = 10)
 
-    override fun scan(timeout: Duration, serviceUuid: Uuid?, address: String?): Flow<BleDevice> = flow {
-        emitAll(foundDevices)
+    var lastScanServiceUuid: Uuid? = null
+        private set
+
+    var lastScanAddress: String? = null
+        private set
+
+    override fun scan(timeout: Duration, serviceUuid: Uuid?, address: String?): Flow<BleDevice> {
+        lastScanServiceUuid = serviceUuid
+        lastScanAddress = address
+        return flow { emitAll(foundDevices) }
     }
 
     fun emitDevice(device: BleDevice) {

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -135,16 +136,13 @@ fun ConnectionsScreen(
             onDenied = { scanModel.stopNetworkScan() },
         )
 
-    // Auto-start scans on screen entry when the user has previously opted in via the toggle. Stop on exit so we don't
-    // drain battery in the background. Network auto-start is additionally gated on the runtime local-network grant so
-    // we don't trigger the system picker for users who declined the permission.
-    //
-    // Keys include bleAutoScan/networkAutoScan so the effect re-fires once DataStore delivers the persisted `true`
-    // value (initial composition sees `false` from the Eagerly-seeded StateFlow before the disk read completes).
-    DisposableEffect(bleAutoScan) {
-        if (bleAutoScan) scanModel.startBleScan()
-        onDispose { scanModel.stopBleScan() }
-    }
+    // Auto-start BLE scan on screen entry when the user has previously opted in. Stop on screen exit to save battery.
+    // We use `Unit` as the key so the effect is stable across recompositions — the toggle button manages scan
+    // start/stop directly and must not be interrupted by this effect re-firing when `bleAutoScan` changes.
+    // A LaunchedEffect watches bleAutoScan separately to handle the DataStore delivering `true` after the initial
+    // `false` (disk read latency), without triggering a dispose/restart cycle that kills an in-progress scan.
+    LaunchedEffect(bleAutoScan) { if (bleAutoScan && !scanModel.isBleScanning.value) scanModel.startBleScan() }
+    DisposableEffect(Unit) { onDispose { scanModel.stopBleScan() } }
 
     DisposableEffect(networkAutoScan, localNetworkPermissionGranted) {
         if (networkAutoScan && localNetworkPermissionGranted) scanModel.startNetworkScan()


### PR DESCRIPTION
On macOS, CoreBluetooth caches peripheral identifiers, which can cause scans filtered by address to time out. This change switches to scanning by service UUID and filtering the results manually to ensure reliable discovery on Desktop. It also refines the UI scan logic to prevent state changes from interrupting active scans.

- Scan by service UUID and filter results by address in `BleRadioTransport` to fix Desktop timeouts
- Decouple scan auto-start from cleanup in `ConnectionsScreen` using `LaunchedEffect` and `DisposableEffect(Unit)`
- Prevent scan restarts when `bleAutoScan` state is updated from disk or DataStore
- Ensure `stopBleScan()` is called only when the screen is actually disposed