### PR TITLE
fix(network): resolve empty MQTT address and enforce TLS on default server

### DIFF
--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -100,8 +100,8 @@ class MQTTRepositoryImpl(
 
         val rootTopic = mqttConfig?.root?.ifEmpty { DEFAULT_TOPIC_ROOT } ?: DEFAULT_TOPIC_ROOT
 
-        val rawAddress = mqttConfig?.address ?: DEFAULT_SERVER_ADDRESS
-        val endpoint = resolveEndpoint(rawAddress, mqttConfig?.tls_enabled == true)
+        val rawAddress = mqttConfig?.address?.ifEmpty { DEFAULT_SERVER_ADDRESS } ?: DEFAULT_SERVER_ADDRESS
+        val endpoint = resolveEndpoint(rawAddress, effectiveTlsEnabled(rawAddress, mqttConfig?.tls_enabled == true))
 
         val newClient =
             MqttClient(ownerId) {
@@ -246,3 +246,8 @@ fun resolveEndpoint(rawAddress: String, tlsEnabled: Boolean): MqttEndpoint = if 
     val hostAndPort = if (rawAddress.contains(":")) rawAddress else "$rawAddress:$defaultPort"
     MqttEndpoint.parse("$scheme://$hostAndPort")
 }
+
+private const val DEFAULT_PUBLIC_SERVER = "mqtt.meshtastic.org"
+
+fun effectiveTlsEnabled(address: String, tlsEnabled: Boolean): Boolean =
+    tlsEnabled || address.equals(DEFAULT_PUBLIC_SERVER, ignoreCase = true)

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
@@ -98,6 +98,30 @@ class MQTTRepositoryImplTest {
 
     // endregion
 
+    // region effectiveTlsEnabled — TLS enforcement policy for the public server.
+
+    @Test
+    fun `default server forces TLS even when tlsEnabled is false`() {
+        assertEquals(true, effectiveTlsEnabled("mqtt.meshtastic.org", tlsEnabled = false))
+    }
+
+    @Test
+    fun `default server case-insensitive match forces TLS`() {
+        assertEquals(true, effectiveTlsEnabled("MQTT.MESHTASTIC.ORG", tlsEnabled = false))
+    }
+
+    @Test
+    fun `custom server respects tlsEnabled false`() {
+        assertEquals(false, effectiveTlsEnabled("mqtt.myserver.pt", tlsEnabled = false))
+    }
+
+    @Test
+    fun `custom server respects tlsEnabled true`() {
+        assertEquals(true, effectiveTlsEnabled("mqtt.myserver.pt", tlsEnabled = true))
+    }
+
+    // endregion
+
     // region MqttJsonPayload — keep the existing JSON contract tests.
 
     @Test

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
@@ -318,17 +318,15 @@ private fun MqttAddressAndProbe(
         },
     )
     HorizontalDivider()
+    val defaultAddress = stringResource(Res.string.default_mqtt_address)
     MqttProbeRow(
         enabled = enabled && formState.value.address.isNotBlank(),
         status = probeStatus,
         onTestClick = {
             focusManager.clearFocus()
-            onProbe(
-                formState.value.address,
-                formState.value.tls_enabled,
-                formState.value.username,
-                formState.value.password,
-            )
+            val isDefault = formState.value.address.isEmpty() || formState.value.address.contains(defaultAddress)
+            val effectiveTls = formState.value.tls_enabled || isDefault
+            onProbe(formState.value.address, effectiveTls, formState.value.username, formState.value.password)
         },
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ spotless = "8.4.0"
 wire = "6.2.0"
 vico = "3.2.0-next.2"
 kable = "0.42.0"
-mqttastic = "0.3.0"
+mqttastic = "0.3.2-SNAPSHOT"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,6 +46,10 @@ dependencyResolutionManagement {
         }
         mavenCentral()
         maven {
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+            mavenContent { snapshotsOnly() }
+        }
+        maven {
             url = uri("https://jitpack.io")
             content {
                 includeGroupByRegex("com\\.github\\..*")


### PR DESCRIPTION
## Summary
- Fix empty proto address (`""`) producing `tcp://:1883` (no host) after the WebSocket→TCP migration in #5215
- Enforce TLS on `mqtt.meshtastic.org` regardless of node `tls_enabled` setting, matching [iOS client behavior](https://github.com/meshtastic/Meshtastic-Apple/blob/main/Meshtastic/Helpers/Mqtt/MqttClientProxyManager.swift#L39-L42)
- Align probe UI TLS logic with proxy behavior so "Test Connection" accurately reflects what the proxy will do
- Bump mqttastic-client-kmp to 0.3.2 which fixes Android TLS handshake failures with `network_security_config.xml` domain-specific rules

## Root Cause
PR #5215 changed the MQTT endpoint from WebSocket (`ws://host/mqtt`) to raw TCP (`tcp://host:1883`). When the protobuf `address` field is the default empty string `""`, the null-coalescing `?: DEFAULT_SERVER_ADDRESS` didn't trigger because `""` is non-null. This produced `tcp://:1883` — a valid URI with no host, causing connection failures.

## Testing
- Verified on Pixel 6a connected to 🗿_1c10 (XIAO nRF)
- Proxy connects over TLS: `MQTT Connecting to Tcp(host=mqtt.meshtastic.org, port=8883, tls=true)` → `MQTT connected and subscribed`
- Messages received over encrypted proxy: `MQTT received message on topic msh/US/2/e/PKI/...`
- All `:core:network:allTests` pass (4 new tests for TLS enforcement policy)

Closes #5330