### PR TITLE
fix(mqtt): harden TLS enforcement, add user CA trust, and improve error diagnostics

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,6 +3,7 @@
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system"/>
+            <certificates src="user"/>
         </trust-anchors>
     </base-config>
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
@@ -35,6 +35,7 @@ import org.meshtastic.core.model.MqttProbeStatus
 import org.meshtastic.core.network.repository.MQTTRepository
 import org.meshtastic.core.network.repository.resolveEndpoint
 import org.meshtastic.core.repository.MqttManager
+import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketHandler
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.mqtt.ConnectionState
@@ -44,13 +45,13 @@ import org.meshtastic.mqtt.ProbeResult
 import org.meshtastic.mqtt.probe
 import org.meshtastic.proto.MqttClientProxyMessage
 import org.meshtastic.proto.ToRadio
-import kotlin.time.Clock
 
 @Single
 class MqttManagerImpl(
     private val mqttRepository: MQTTRepository,
     private val packetHandler: PacketHandler,
     private val serviceRepository: ServiceRepository,
+    private val nodeRepository: NodeRepository,
     @Named("ServiceScope") private val scope: CoroutineScope,
 ) : MqttManager {
     private var mqttMessageFlow: Job? = null
@@ -131,8 +132,8 @@ class MqttManagerImpl(
         val endpoint = resolveEndpoint(address, tlsEnabled)
         val result =
             MqttClient.probe(endpoint = endpoint) {
-                // Provide a valid client ID for the probe; brokers reject empty identifiers
-                clientId = "MeshtasticProbe-${Clock.System.now().toEpochMilliseconds()}"
+                // Use node ID for consistent client identification across platforms
+                clientId = "MeshtasticAndroidMqttProbe-${nodeRepository.myId.value ?: "unknown"}"
                 val user = username?.takeUnless { it.isEmpty() }
                 val pass = password?.takeUnless { it.isEmpty() }
                 if (user != null) this.username = user

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -290,4 +290,22 @@ fun resolveEndpoint(rawAddress: String, tlsEnabled: Boolean): MqttEndpoint = if 
 private const val DEFAULT_PUBLIC_SERVER = "mqtt.meshtastic.org"
 
 fun effectiveTlsEnabled(address: String, tlsEnabled: Boolean): Boolean =
-    tlsEnabled || address.equals(DEFAULT_PUBLIC_SERVER, ignoreCase = true)
+    tlsEnabled || extractHost(address).equals(DEFAULT_PUBLIC_SERVER, ignoreCase = true)
+
+/**
+ * Extracts the bare hostname from an address that may include a scheme, port, or path. Examples:
+ * - `mqtt.meshtastic.org` → `mqtt.meshtastic.org`
+ * - `mqtt.meshtastic.org:1883` → `mqtt.meshtastic.org`
+ * - `tcp://mqtt.meshtastic.org:1883` → `mqtt.meshtastic.org`
+ * - `ssl://mqtt.meshtastic.org` → `mqtt.meshtastic.org`
+ */
+internal fun extractHost(address: String): String {
+    val afterScheme =
+        if (address.contains("://")) {
+            address.substringAfter("://")
+        } else {
+            address
+        }
+    // Remove path (if any), then remove port
+    return afterScheme.substringBefore("/").substringBefore(":")
+}

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
@@ -111,6 +111,21 @@ class MQTTRepositoryImplTest {
     }
 
     @Test
+    fun `default server with explicit port still forces TLS`() {
+        assertEquals(true, effectiveTlsEnabled("mqtt.meshtastic.org:1883", tlsEnabled = false))
+    }
+
+    @Test
+    fun `default server with tcp scheme still forces TLS`() {
+        assertEquals(true, effectiveTlsEnabled("tcp://mqtt.meshtastic.org:1883", tlsEnabled = false))
+    }
+
+    @Test
+    fun `default server with ssl scheme still forces TLS`() {
+        assertEquals(true, effectiveTlsEnabled("ssl://mqtt.meshtastic.org", tlsEnabled = false))
+    }
+
+    @Test
     fun `custom server respects tlsEnabled false`() {
         assertEquals(false, effectiveTlsEnabled("mqtt.myserver.pt", tlsEnabled = false))
     }
@@ -118,6 +133,35 @@ class MQTTRepositoryImplTest {
     @Test
     fun `custom server respects tlsEnabled true`() {
         assertEquals(true, effectiveTlsEnabled("mqtt.myserver.pt", tlsEnabled = true))
+    }
+
+    // endregion
+
+    // region extractHost — address canonicalization tests.
+
+    @Test
+    fun `extractHost bare hostname`() {
+        assertEquals("mqtt.meshtastic.org", extractHost("mqtt.meshtastic.org"))
+    }
+
+    @Test
+    fun `extractHost with port`() {
+        assertEquals("mqtt.meshtastic.org", extractHost("mqtt.meshtastic.org:8883"))
+    }
+
+    @Test
+    fun `extractHost with tcp scheme and port`() {
+        assertEquals("mqtt.meshtastic.org", extractHost("tcp://mqtt.meshtastic.org:1883"))
+    }
+
+    @Test
+    fun `extractHost with ssl scheme no port`() {
+        assertEquals("mqtt.meshtastic.org", extractHost("ssl://mqtt.meshtastic.org"))
+    }
+
+    @Test
+    fun `extractHost with path`() {
+        assertEquals("broker.example.com", extractHost("ws://broker.example.com:8080/mqtt"))
     }
 
     // endregion

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -719,7 +719,7 @@
     <string name="mqtt_probe_success_with_info">Reachable (%1$s)</string>
     <string name="mqtt_probe_tcp_failure">Cannot reach broker (TCP)</string>
     <string name="mqtt_probe_timeout">Timed out after %1$d ms</string>
-    <string name="mqtt_probe_tls_failure">TLS handshake failed</string>
+    <string name="mqtt_probe_tls_failure">TLS handshake failed: %1$s</string>
     <string name="mqtt_status_connected">Connected</string>
     <string name="mqtt_status_connecting">Connecting…</string>
     <string name="mqtt_status_disconnected">Disconnected</string>

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
             implementation(projects.core.domain)
             implementation(projects.core.model)
             implementation(projects.core.navigation)
+            implementation(projects.core.network)
             implementation(projects.core.proto)
             implementation(projects.core.repository)
             implementation(projects.core.service)

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
@@ -49,9 +49,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.model.MqttConnectionState
 import org.meshtastic.core.model.MqttProbeStatus
+import org.meshtastic.core.network.repository.effectiveTlsEnabled
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.address
-import org.meshtastic.core.resources.default_mqtt_address
 import org.meshtastic.core.resources.encryption_enabled
 import org.meshtastic.core.resources.json_output_enabled
 import org.meshtastic.core.resources.map_reporting
@@ -183,9 +183,8 @@ fun MQTTConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     containerColor = CardDefaults.cardColors().containerColor,
                 )
                 HorizontalDivider()
-                val defaultAddress = stringResource(Res.string.default_mqtt_address)
-                val isDefault = formState.value.address.isEmpty() || formState.value.address.contains(defaultAddress)
-                val enforceTls = isDefault && formState.value.proxy_to_client_enabled
+                val resolvedAddress = formState.value.address.ifEmpty { "mqtt.meshtastic.org" }
+                val enforceTls = effectiveTlsEnabled(resolvedAddress, tlsEnabled = false)
                 SwitchPreference(
                     title = stringResource(Res.string.tls_enabled),
                     checked = formState.value.tls_enabled || enforceTls,
@@ -318,14 +317,13 @@ private fun MqttAddressAndProbe(
         },
     )
     HorizontalDivider()
-    val defaultAddress = stringResource(Res.string.default_mqtt_address)
     MqttProbeRow(
         enabled = enabled && formState.value.address.isNotBlank(),
         status = probeStatus,
         onTestClick = {
             focusManager.clearFocus()
-            val isDefault = formState.value.address.isEmpty() || formState.value.address.contains(defaultAddress)
-            val effectiveTls = formState.value.tls_enabled || isDefault
+            val resolvedAddress = formState.value.address.ifEmpty { "mqtt.meshtastic.org" }
+            val effectiveTls = effectiveTlsEnabled(resolvedAddress, formState.value.tls_enabled)
             onProbe(formState.value.address, effectiveTls, formState.value.username, formState.value.password)
         },
     )
@@ -376,7 +374,7 @@ private fun MqttProbeStatus?.toLabel(): Pair<String, Color>? = when (this) {
         stringResource(Res.string.mqtt_probe_tcp_failure) to MaterialTheme.colorScheme.error
 
     is MqttProbeStatus.TlsFailure ->
-        stringResource(Res.string.mqtt_probe_tls_failure) to MaterialTheme.colorScheme.error
+        stringResource(Res.string.mqtt_probe_tls_failure, message ?: "unknown") to MaterialTheme.colorScheme.error
 
     is MqttProbeStatus.Timeout ->
         stringResource(Res.string.mqtt_probe_timeout, timeoutMs.toInt()) to MaterialTheme.colorScheme.error


### PR DESCRIPTION
## Summary

Addresses user report that TLS isn't working correctly in the .14 Android app.

### Changes

1. **Harden `effectiveTlsEnabled()` address matching** — new `extractHost()` canonicalizes addresses that include a port or scheme (e.g. `mqtt.meshtastic.org:1883`, `tcp://mqtt.meshtastic.org`) before comparing to the default server. Prevents bypass of the TLS enforcement added in #5333.

2. **Add user CA certificate trust** — `network_security_config.xml` now includes `<certificates src="user"/>` so user-installed certificates are respected by TLS connections. Enables MITM debugging (PCAPdroid, Charles, etc.) and supports private CA deployments.

3. **Surface actual TLS exception in probe UI** — instead of a generic "TLS handshake failed" string, the probe now shows the actual error (e.g. "trust anchor not found for ...", hostname mismatch, etc.) making it possible to diagnose issues without logcat.

4. **Fix UI/runtime TLS enforcement consistency** — the TLS toggle is now forced-on for the default server unconditionally (matching runtime behavior). Both the switch state and probe now use the shared `effectiveTlsEnabled()` function as a single source of truth, preventing divergence between what the UI shows and what the connection actually does.

### Context

A user reported via Discord that:
- The app connects to `mqtt.meshtastic.org` on port 1883 (non-TLS) while UI shows TLS enabled
- TLS to custom servers fails (worked in .13)
- App doesn't trust user CA certificates

The port 1883 bug was fixed in #5333. The custom server TLS failure is expected — the old app used `TrustAllX509TrustManager` (accepting ANY cert without validation), so ".13 worked" was masking invalid server TLS configs. The improved diagnostics will help users identify and fix their server-side TLS issues.

### Testing

- All existing + 8 new unit tests pass
- spotless ✓
- detekt ✓