### PR TITLE
feat: enable WAL connection pool for parallel reads

### DIFF
--- a/core/database/src/androidMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
+++ b/core/database/src/androidMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
@@ -32,10 +32,8 @@ import org.meshtastic.core.database.MeshtasticDatabase.Companion.configureCommon
 
 /** Returns a [RoomDatabase.Builder] configured for Android with the given [dbName]. */
 actual fun getDatabaseBuilder(dbName: String): RoomDatabase.Builder<MeshtasticDatabase> {
-    val app = ContextServices.app
-    val dbFile = app.getDatabasePath(dbName)
+    val dbFile = ContextServices.app.getDatabasePath(dbName)
     return Room.databaseBuilder<MeshtasticDatabase>(
-        context = app.applicationContext,
         name = dbFile.absolutePath,
         factory = { MeshtasticDatabaseConstructor.initialize() },
     )
@@ -44,10 +42,7 @@ actual fun getDatabaseBuilder(dbName: String): RoomDatabase.Builder<MeshtasticDa
 
 /** Returns a [RoomDatabase.Builder] configured for an in-memory Android database. */
 actual fun getInMemoryDatabaseBuilder(): RoomDatabase.Builder<MeshtasticDatabase> =
-    Room.inMemoryDatabaseBuilder<MeshtasticDatabase>(
-        context = ContextServices.app.applicationContext,
-        factory = { MeshtasticDatabaseConstructor.initialize() },
-    )
+    Room.inMemoryDatabaseBuilder<MeshtasticDatabase>(factory = { MeshtasticDatabaseConstructor.initialize() })
         .configureCommon()
 
 /** Returns the Android directory where database files are stored. */

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -120,7 +120,9 @@ abstract class MeshtasticDatabase : RoomDatabase() {
     companion object {
         /** Configures a [RoomDatabase.Builder] with standard settings for this project. */
         fun <T : RoomDatabase> RoomDatabase.Builder<T>.configureCommon(): RoomDatabase.Builder<T> =
-            this.fallbackToDestructiveMigration(dropAllTables = false).setQueryCoroutineContext(ioDispatcher)
+            this.fallbackToDestructiveMigration(dropAllTables = false)
+                .setMultipleConnectionPool(maxNumOfReaders = 4, maxNumOfWriters = 1)
+                .setQueryCoroutineContext(ioDispatcher)
     }
 }
 


### PR DESCRIPTION
Enables Room 3 new APIs in the database configuration layer.

## Changes
1. **Connection pool** — Configure `setMultipleConnectionPool(maxNumOfReaders = 4, maxNumOfWriters = 1)` in `configureCommon()` for WAL-mode parallel reads
2. **No-Context builders** — Drop redundant `Context` param from Android's `databaseBuilder` and `inMemoryDatabaseBuilder` (Room 3.0.0-alpha03 overloads; we already pass absolute paths)

## Impact
- Improved read performance under concurrent access (message list + search + sync can run in parallel)
- Aligns Android builders with JVM/iOS implementations (all now use context-free overloads)
- No schema change required
- WAL mode was already enabled by default in Room