### PR TITLE
refactor(firmware): replace PlatformBackHandler with NavigationBackHandler

### DIFF
--- a/core/ui/src/androidMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
+++ b/core/ui/src/androidMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
@@ -21,7 +21,6 @@ package org.meshtastic.core.ui.util
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.provider.Settings
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
@@ -179,11 +178,6 @@ actual fun KeepScreenOn(enabled: Boolean) {
             }
         }
     }
-}
-
-@Composable
-actual fun PlatformBackHandler(enabled: Boolean, onBack: () -> Unit) {
-    BackHandler(enabled = enabled, onBack = onBack)
 }
 
 @Composable

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
@@ -55,9 +55,6 @@ expect fun rememberSaveFileLauncher(
 /** Keeps the screen awake while [enabled] is true. No-op on platforms that don't support it. */
 @Composable expect fun KeepScreenOn(enabled: Boolean)
 
-/** Intercepts the platform back gesture/button while [enabled] is true. No-op on platforms without a system back. */
-@Composable expect fun PlatformBackHandler(enabled: Boolean, onBack: () -> Unit)
-
 /** Returns a launcher to request location permissions. */
 @Composable expect fun rememberRequestLocationPermission(onGranted: () -> Unit, onDenied: () -> Unit = {}): () -> Unit
 

--- a/core/ui/src/iosMain/kotlin/org/meshtastic/core/ui/util/NoopStubs.kt
+++ b/core/ui/src/iosMain/kotlin/org/meshtastic/core/ui/util/NoopStubs.kt
@@ -50,8 +50,6 @@ actual fun rememberOpenFileLauncher(onUriReceived: (CommonUri?) -> Unit): (mimeT
 
 @Composable actual fun KeepScreenOn(enabled: Boolean) {}
 
-@Composable actual fun PlatformBackHandler(enabled: Boolean, onBack: () -> Unit) {}
-
 @Composable actual fun rememberRequestLocationPermission(onGranted: () -> Unit, onDenied: () -> Unit): () -> Unit = {}
 
 @Composable actual fun rememberOpenLocationSettings(): () -> Unit = {}

--- a/core/ui/src/jvmMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
+++ b/core/ui/src/jvmMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
@@ -115,12 +115,6 @@ actual fun KeepScreenOn(enabled: Boolean) {
     // No-op on JVM/Desktop
 }
 
-/** JVM no-op — Desktop has no system back gesture. */
-@Composable
-actual fun PlatformBackHandler(enabled: Boolean, onBack: () -> Unit) {
-    // No-op on JVM/Desktop — no system back button
-}
-
 @Composable
 actual fun rememberRequestLocationPermission(onGranted: () -> Unit, onDenied: () -> Unit): () -> Unit = {
     Logger.w { "Location permissions not implemented on Desktop" }

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
@@ -70,6 +70,9 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
@@ -141,7 +144,6 @@ import org.meshtastic.core.ui.icon.Usb
 import org.meshtastic.core.ui.icon.Warning
 import org.meshtastic.core.ui.icon.Wifi
 import org.meshtastic.core.ui.util.KeepScreenOn
-import org.meshtastic.core.ui.util.PlatformBackHandler
 import org.meshtastic.core.ui.util.rememberOpenFileLauncher
 import org.meshtastic.core.ui.util.rememberOpenUrl
 import org.meshtastic.core.ui.util.rememberSaveFileLauncher
@@ -185,7 +187,12 @@ fun FirmwareUpdateScreen(onNavigateUp: () -> Unit, viewModel: FirmwareUpdateView
 
     KeepScreenOn(shouldKeepFirmwareScreenOn(state))
 
-    PlatformBackHandler(enabled = shouldKeepFirmwareScreenOn(state)) { showExitConfirmation = true }
+    val backHandlerState = rememberNavigationEventState(NavigationEventInfo.None)
+    NavigationBackHandler(
+        state = backHandlerState,
+        isBackEnabled = shouldKeepFirmwareScreenOn(state),
+        onBackCompleted = { showExitConfirmation = true },
+    )
 
     if (showExitConfirmation) {
         MeshtasticDialog(


### PR DESCRIPTION
Migrates FirmwareUpdateScreen to use the multiplatform `NavigationBackHandler` from `navigationevent-compose` (already transitive via `navigation3-ui`). This provides proper predictive back gesture support on all platforms instead of the platform-specific expect/actual pattern.

### Changes
- Replace `PlatformBackHandler` usage in `FirmwareUpdateScreen` with `NavigationBackHandler`
- Delete the now-unused `PlatformBackHandler` expect/actual declarations from all source sets (commonMain, androidMain, jvmMain, iosMain)
- Remove unused `BackHandler` import from Android source set

### Why
CMP 1.11 ships `navigationevent-compose` transitively through Nav3 UI. `NavigationBackHandler` is the standard multiplatform replacement for the old platform-specific back handling APIs, with built-in predictive back gesture support.