### PR TITLE
Release: Add MacOS ReleaseUberJar target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,13 +296,18 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        # Build the release distribution for the current OS.
+        # On macOS, also build a ReleaseUberJar for the Homebrew Cask.
         # Quote the -P flag: PowerShell on Windows interprets the dot in
         # `-PaboutLibraries.release=true` as member access on `-PaboutLibraries`,
         # splitting the token and feeding `.release=true` to Gradle as a task name.
-        run: ./gradlew :desktop:packageReleaseDistributionForCurrentOS '-PaboutLibraries.release=true' --no-daemon
+        run: >
+          ./gradlew :desktop:packageReleaseDistributionForCurrentOS
+          ${{ contains(runner.os, 'macOS') && ':desktop:packageReleaseUberJarForCurrentOS' }}
+          '-PaboutLibraries.release=true' --no-daemon
 
       - name: List Desktop Binaries
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: ls -R desktop/build/compose/binaries/main-release
 
       - name: Upload Desktop Artifacts
@@ -317,6 +322,7 @@ jobs:
             desktop/build/compose/binaries/main-release/*/*.deb
             desktop/build/compose/binaries/main-release/*/*.rpm
             desktop/build/compose/binaries/main-release/*/*.AppImage
+            desktop/build/compose/jars/*-release.jar
           retention-days: 1
           if-no-files-found: ignore
 
@@ -331,6 +337,7 @@ jobs:
             desktop/build/compose/binaries/main-release/*/*.deb
             desktop/build/compose/binaries/main-release/*/*.rpm
             desktop/build/compose/binaries/main-release/*/*.AppImage
+            desktop/build/compose/jars/*-release.jar
 
   github-release:
     if: ${{ !cancelled() && !failure() }}


### PR DESCRIPTION
This pull request updates the release workflow to support packaging and uploading a MacOS UberJar, which is used for **Homebrew** distribution. The workflow now builds and uploads the UberJar artifact alongside existing Linux and MacOS binaries.

Packaging improvements for MacOS and Homebrew:

* Added a new step in the release workflow to build the MacOS UberJar using the Gradle `:desktop:packageReleaseUberJarForCurrentOS` task, specifically for MacOS runners.

Artifact management enhancements:

* Updated the artifact upload steps to include the newly built UberJar (`desktop/build/compose/jars/*-release.jar`) for both Linux and MacOS, ensuring it is available for distribution. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R328) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R343)
* Modified the binary listing step to run on both Linux and MacOS, reflecting the new MacOS packaging process.