### PR TITLE
ci: disable Flatpak source generation for PR and merge queue checks

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -17,7 +17,7 @@ on:
         default: true
       run_desktop_flatpak_src:
         type: boolean
-        default: true
+        default: false
       upload_artifacts:
         type: boolean
         default: true


### PR DESCRIPTION
The Generate Flatpak Sources job defaults to running on every PR and merge queue check via `reusable-check.yml`, but is only needed for release builds. Release workflows already have their own independent Flatpak jobs in `release.yml`.

Changes the default for `run_desktop_flatpak_src` from `true` to `false` so PR, merge queue, and main-check workflows skip it automatically.