### PR TITLE
Update notification intents and deep link URI format

### DIFF
--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshServiceNotificationsImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshServiceNotificationsImpl.kt
@@ -731,7 +731,7 @@ class MeshServiceNotificationsImpl(
     private val openAppIntent: PendingIntent by lazy {
         val intent =
             Intent(context, Class.forName("org.meshtastic.app.MainActivity")).apply {
-                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
             }
         PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
     }
@@ -763,7 +763,7 @@ class MeshServiceNotificationsImpl(
     }
 
     private fun createOpenNodeDetailIntent(nodeNum: Int): PendingIntent {
-        val deepLinkUri = "$DEEP_LINK_BASE_URI/node?destNum=$nodeNum".toUri()
+        val deepLinkUri = "$DEEP_LINK_BASE_URI/nodes/$nodeNum".toUri()
         val deepLinkIntent =
             Intent(Intent.ACTION_VIEW, deepLinkUri, context, Class.forName("org.meshtastic.app.MainActivity")).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/WifiOtaTransportTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/WifiOtaTransportTest.kt
@@ -211,7 +211,7 @@ class WifiOtaTransportTest {
         try {
             transport.close()
 
-            assertNull(withTimeout(1_000L) { connection.readLine() })
+            assertNull(withTimeout(5_000L) { connection.readLine() })
 
             val result = transport.startOta(1L, "hash")
             assertTrue(result.isFailure)


### PR DESCRIPTION
- Add `FLAG_ACTIVITY_NEW_TASK` to `openAppIntent` to ensure proper activity launching from the service context.
- Update node detail deep link URI from `/node?destNum=` to `/nodes/`