### PR TITLE
fix(ci): prevent literal 'false' task name in desktop release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,7 @@ jobs:
         # splitting the token and feeding `.release=true` to Gradle as a task name.
         run: >
           ./gradlew :desktop:packageReleaseDistributionForCurrentOS
-          ${{ contains(runner.os, 'macOS') && ':desktop:packageReleaseUberJarForCurrentOS' }}
+          ${{ contains(runner.os, 'macOS') && ':desktop:packageReleaseUberJarForCurrentOS' || '' }}
           '-PaboutLibraries.release=true' --no-daemon
 
       - name: List Desktop Binaries


### PR DESCRIPTION
## Problem

Desktop release builds on Linux, Windows, and ARM runners fail with:

```
Task 'false' not found in root project 'MeshtasticAndroid'
```

**Failed run:** https://github.com/meshtastic/Meshtastic-Android/actions/runs/25707605450/job/75480995659

## Root Cause

The GitHub Actions expression `${{ contains(runner.os, 'macOS') && ':desktop:packageReleaseUberJarForCurrentOS' }}` returns the **literal string `false`** when `contains()` is falsy — not an empty string. Gradle then tries to resolve `false` as a task name.

## Fix

Add `|| ''` so the expression yields an empty string on non-macOS runners:

```yaml
${{ contains(runner.os, 'macOS') && ':desktop:packageReleaseUberJarForCurrentOS' || '' }}
```