### PR TITLE
Actions: fix Flatpak source file patterns for jq

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,14 +391,14 @@ jobs:
           --no-configuration-cache --refresh-dependencies --no-parallel
 
       - name: List Flatpak source files
-        run: ls -R flatpak-sources*.json
+        run: ls -R flatpak-sources-*.json
 
       - name: Upload Flatpak source artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: flatpak-multisrc-${{ runner.arch }}
-          path: flatpak-sources*.json
+          path: flatpak-sources-*.json
           retention-days: 1
 
   release-flatpak-src:
@@ -413,11 +413,11 @@ jobs:
           merge-multiple: true
       
       - name: List Flatpak source files
-        run: ls -R flatpak-sources*.json
+        run: ls -R flatpak-sources-*.json
 
       - name: Combine Flatpak source files
         run: >
-          jq -s 'add | unique_by(.dest + "/" + .["dest-filename"])' flatpak-sources*.json
+          jq -s 'add | unique_by(.dest + "/" + .["dest-filename"])' flatpak-sources-*.json
           > flatpak-sources.json
 
       - name: Upload combined Flatpak source artifact

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -557,12 +557,12 @@ jobs:
           ./gradlew :build-logic:convention:flatpakGradleGenerator flatpakGradleGenerator
           --no-configuration-cache --refresh-dependencies --no-parallel
       
-      - run: ls -lah flatpak-sources*.json
+      - run: ls -lah flatpak-sources-*.json
 
       - name: Upload Flatpak Sources
         if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@v7
         with:
           name: flatpak-sources-${{ runner.arch }}
-          path: flatpak-sources*.json
+          path: flatpak-sources-*.json
           retention-days: 7


### PR DESCRIPTION
All flatpak source files we generate match 'flatpak-sources-*.json'.

This changes the workflows to use a stricter glob-match (including `-`) to try and avoid race conditions with jq.