### PR TITLE
fix(ci): resolve flatpak source merge race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,14 +410,17 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: flatpak-multisrc-*
-          merge-multiple: true
-      
+          path: flatpak-multisrc
+
       - name: List Flatpak source files
-        run: ls -R flatpak-sources-*.json
+        run: ls -R flatpak-multisrc/
+
+      - name: Validate Flatpak source files
+        run: jq empty flatpak-multisrc/*/*.json
 
       - name: Combine Flatpak source files
         run: >
-          jq -s 'add | unique_by(.dest + "/" + .["dest-filename"])' flatpak-sources-*.json
+          jq -s 'add | unique_by(.dest + "/" + .["dest-filename"])' flatpak-multisrc/*/*.json
           > flatpak-sources.json
 
       - name: Upload combined Flatpak source artifact


### PR DESCRIPTION
## Problem

The `release-flatpak-src` job fails with:
```
jq: parse error: Invalid numeric literal at line 3146, column 101
```

**Root cause:** `download-artifact@v8` with `merge-multiple: true` extracts both X64 and ARM64 artifacts into the same directory. Both runners produce files with the same names (e.g. `flatpak-sources-convention.json`) but with different content (different transitive dependencies resolved per platform). This causes file corruption.

Evidence: X64's convention.json is 3145 lines; ARM64's is 3355 lines. The jq error at line 3146 sits exactly at the corruption boundary. Both files validate individually.

## Fix

- Remove `merge-multiple: true` — each artifact now downloads into its own subdirectory
- Add explicit `path: flatpak-multisrc` for clarity
- Add `jq empty` validation step for better failure diagnostics
- Update globs to `flatpak-multisrc/*/*.json`

Fixes: https://github.com/meshtastic/Meshtastic-Android/actions/runs/25730000695/job/75554185194