### PR TITLE
fix: enhance uniqueness check for Flatpak source files in release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,7 +420,7 @@ jobs:
 
       - name: Combine Flatpak source files
         run: >
-          jq -s 'add | unique_by(.dest + "/" + .["dest-filename"])' flatpak-multisrc/*/*.json
+          jq -s 'add | unique_by(.dest + "/" + .["dest-filename"] + "/" + (.["only-arches"] | tostring))' flatpak-multisrc/*/*.json
           > flatpak-sources.json
 
       - name: Upload combined Flatpak source artifact


### PR DESCRIPTION
Include `only-arches` in the uniqueness check when combining flatpak sources.