### PR TITLE
fix: remove JitPack repo aggressive com.github.* match

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -20,12 +20,7 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven {
-            url = uri("https://jitpack.io")
-            content {
-                includeGroupByRegex("com\\.github\\..*")
-            }
-        }
+        maven { url = uri("https://jitpack.io") }
         maven { url = uri("../offline-repository") }
     }
 }
@@ -46,12 +41,7 @@ dependencyResolutionManagement {
         }
         mavenCentral()
         gradlePluginPortal()
-        maven {
-            url = uri("https://jitpack.io")
-            content {
-                includeGroupByRegex("com\\.github\\..*")
-            }
-        }
+        maven { url = uri("https://jitpack.io") }
         maven { url = uri("../offline-repository") }
     }
     versionCatalogs {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,12 +50,7 @@ dependencyResolutionManagement {
             url = uri("https://central.sonatype.com/repository/maven-snapshots/")
             mavenContent { snapshotsOnly() }
         }
-        maven {
-            url = uri("https://jitpack.io")
-            content {
-                includeGroupByRegex("com\\.github\\..*")
-            }
-        }
+        maven { url = uri("https://jitpack.io") }
         maven { url = uri("./offline-repository") }
     }
 }


### PR DESCRIPTION
This was (probably) unnecessary, and it breaks FlatpakGradleGenerator results.

This pull request simplifies the configuration of the `jitpack.io` Maven repository in the Gradle settings files by removing restrictive content filters. Now, the repository is added without limiting its usage to specific groups, which can help avoid dependency resolution issues related to missing artifacts.

Repository configuration simplification:

* In `build-logic/settings.gradle.kts` and `settings.gradle.kts`, the `jitpack.io` Maven repository is now added without the `content` block that restricted it to only `com.github.*` dependencies. [[1]](diffhunk://#diff-1fba3f2d41f74291217a4505ff9bf30d7b6442ac6a01025aae02babf63de24cfL23-R23) [[2]](diffhunk://#diff-1fba3f2d41f74291217a4505ff9bf30d7b6442ac6a01025aae02babf63de24cfL49-R44) [[3]](diffhunk://#diff-5625e3601fa0ad3a6a2824239e5a2fde71c149597d31394f9224a08c24be7b9dL53-R53)