### PR TITLE
build: conditionalize JitPack repository for desktop-only builds

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -20,12 +20,6 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven {
-            url = uri("https://jitpack.io")
-            content {
-                includeGroupByRegex("com\\.github\\..*")
-            }
-        }
         maven { url = uri("../offline-repository") }
     }
 }
@@ -46,12 +40,6 @@ dependencyResolutionManagement {
         }
         mavenCentral()
         gradlePluginPortal()
-        maven {
-            url = uri("https://jitpack.io")
-            content {
-                includeGroupByRegex("com\\.github\\..*")
-            }
-        }
         maven { url = uri("../offline-repository") }
     }
     versionCatalogs {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,10 +21,15 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven { url = uri("https://jitpack.io") }
         maven { url = uri("./offline-repository") }
     }
 }
+
+// Desktop-only mode: skip Android-only modules when ANDROID_HOME is unavailable (e.g. Flatpak builds).
+// Activate via: DESKTOP_ONLY=true ./gradlew :desktop:packageUberJarForCurrentOS
+val desktopOnly =
+    providers.gradleProperty("desktop.only").orNull?.toBoolean() == true ||
+        System.getenv("DESKTOP_ONLY")?.toBoolean() == true
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver") version "1.0.0"
@@ -50,10 +55,12 @@ dependencyResolutionManagement {
             url = uri("https://central.sonatype.com/repository/maven-snapshots/")
             mavenContent { snapshotsOnly() }
         }
-        maven {
-            url = uri("https://jitpack.io")
-            content {
-                includeGroupByRegex("com\\.github\\..*")
+        if (!desktopOnly) {
+            maven {
+                url = uri("https://jitpack.io")
+                content {
+                    includeGroupByRegex("com\\.github\\..*")
+                }
             }
         }
         maven { url = uri("./offline-repository") }
@@ -78,12 +85,6 @@ toolchainManagement {
         }
     }
 }
-
-// Desktop-only mode: skip Android-only modules when ANDROID_HOME is unavailable (e.g. Flatpak builds).
-// Activate via: DESKTOP_ONLY=true ./gradlew :desktop:packageUberJarForCurrentOS
-val desktopOnly =
-    providers.gradleProperty("desktop.only").orNull?.toBoolean() == true ||
-        System.getenv("DESKTOP_ONLY")?.toBoolean() == true
 
 include(
     ":core:ble",


### PR DESCRIPTION
build: conditionalize JitPack repository for desktop-only builds

- Remove JitPack from `pluginManagement` and `dependencyResolutionManagement` in `build-logic/settings.gradle.kts`.
- Relocate the `desktopOnly` property declaration in the root `settings.gradle.kts` to allow its use during repository configuration.
- Wrap the JitPack repository in `dependencyResolutionManagement` with a `!desktopOnly` check to prevent dependency resolution attempts when building in Android-less environments (e.g., Flatpak).