### PR TITLE
fix: clarify position precision as ± radius 

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/PositionPrecisionPreference.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/PositionPrecisionPreference.kt
@@ -93,7 +93,7 @@ fun PositionPrecisionPreference(
 
                 val precisionMeters = precisionBitsToMeters(value).toInt()
                 Text(
-                    text = precisionMeters.toDistanceString(unit),
+                    text = "± ${precisionMeters.toDistanceString(unit)}",
                     modifier = Modifier.padding(bottom = 16.dp),
                     fontSize = MaterialTheme.typography.bodyLarge.fontSize,
                     overflow = TextOverflow.Ellipsis,

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/compass/CompassViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/compass/CompassViewModel.kt
@@ -123,7 +123,8 @@ class CompassViewModel(
         val isAligned = isAligned(trueHeading, bearingDegrees)
         val lastUpdateText = targetPositionTimeSec?.let { formatElapsed(it) }
         val angularErrorDeg = calculateAngularError(positionalAccuracyMeters, distanceMeters)
-        val errorRadiusText = positionalAccuracyMeters?.toInt()?.toDistanceString(current.displayUnits)
+        val errorRadiusText =
+            positionalAccuracyMeters?.toInt()?.let { "± ${it.toDistanceString(current.displayUnits)}" }
 
         return current.copy(
             heading = trueHeading,

--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/compass/CompassViewModelTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/compass/CompassViewModelTest.kt
@@ -154,7 +154,7 @@ class CompassViewModelTest {
                 ),
             )
 
-        assertEquals("12 m", state.errorRadiusText)
+        assertEquals("± 12 m", state.errorRadiusText)
     }
 
     @Test
@@ -172,7 +172,7 @@ class CompassViewModelTest {
                 ),
             )
 
-        assertEquals("25 m", state.errorRadiusText)
+        assertEquals("± 25 m", state.errorRadiusText)
     }
 
     @Test
@@ -189,7 +189,7 @@ class CompassViewModelTest {
                 ),
             )
 
-        assertEquals("8 m", state.errorRadiusText)
+        assertEquals("± 8 m", state.errorRadiusText)
     }
 
     @Test
@@ -205,7 +205,7 @@ class CompassViewModelTest {
                 ),
             )
 
-        assertEquals("729 m", state.errorRadiusText)
+        assertEquals("± 729 m", state.errorRadiusText)
     }
 
     @Test
@@ -240,7 +240,7 @@ class CompassViewModelTest {
                 location = PhoneLocation(1.0, 1.0, 0.0, 1000L),
             )
 
-        assertEquals("12 m", state.errorRadiusText)
+        assertEquals("± 12 m", state.errorRadiusText)
         assertNotNull(state.angularErrorDeg)
         assertEquals(180f, state.angularErrorDeg)
     }
@@ -260,7 +260,7 @@ class CompassViewModelTest {
                 location = PhoneLocation(1.0, 1.0, 0.0, 1000L),
             )
 
-        assertEquals("12 m", state.errorRadiusText)
+        assertEquals("± 12 m", state.errorRadiusText)
         assertNotNull(state.angularErrorDeg)
         assertEquals(85.4f, state.angularErrorDeg, 0.5f)
     }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MapReportingPreference.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MapReportingPreference.kt
@@ -120,7 +120,7 @@ fun MapReportingPreference(
                     val precisionMeters = precisionBitsToMeters(positionPrecision).toInt()
                     val unit = DistanceUnit.Companion.getFromLocale()
                     Text(
-                        text = precisionMeters.toDistanceString(unit),
+                        text = "± ${precisionMeters.toDistanceString(unit)}",
                         modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
                         fontSize = MaterialTheme.typography.bodyLarge.fontSize,
                         overflow = TextOverflow.Companion.Ellipsis,


### PR DESCRIPTION
Add '±' prefix to all position precision distance labels so users
understand the value represents a radius of uncertainty, not a
diameter or absolute area. Resolves ambiguity reported when comparing
Android vs iOS channel position precision displays.