### PR TITLE
chore(deps): batch bump KSP, Wire, CMP, Material

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ turbine = "1.2.1"
 compose-screenshot = "0.0.1-alpha14"
 
 # Compose Multiplatform
-compose-multiplatform = "1.11.0-rc01"
+compose-multiplatform = "1.11.0"
 compose-multiplatform-material3 = "1.11.0-alpha07"
 # `androidx-compose-bom-aligned` tracks androidx.compose.{runtime,ui,foundation,animation}
 # artifacts that ship in lockstep with CMP. Kept as a separate version ref so Renovate
@@ -73,7 +73,7 @@ datadog-gradle = "1.26.0"
 dd-sdk-android = "3.9.1"
 detekt = "2.0.0-alpha.3"
 dokka = "2.2.0"
-devtools-ksp = "2.3.7"
+devtools-ksp = "2.3.8"
 firebase-crashlytics-gradle = "3.0.7"
 google-services-gradle = "4.4.4"
 markdownRenderer = "0.40.2"
@@ -81,7 +81,7 @@ okio = "3.17.0"
 uri-kmp = "0.0.21"
 osmdroid-android = "6.1.20"
 spotless = "8.4.0"
-wire = "6.2.0"
+wire = "6.3.0"
 vico = "3.2.0-next.4"
 kable = "0.42.0"
 mqttastic = "0.3.6"
@@ -228,7 +228,7 @@ dokka-android-documentation-plugin = { module = "org.jetbrains.dokka:android-doc
 markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
 markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 markdown-renderer-android = { module = "com.mikepenz:multiplatform-markdown-renderer-android", version.ref = "markdownRenderer" }
-material = { module = "com.google.android.material:material", version = "1.13.0" }
+material = { module = "com.google.android.material:material", version = "1.14.0" }
 
 kable-core = { module = "com.juul.kable:kable-core", version.ref = "kable" }
 meshtastic-mqtt-client = { module = "org.meshtastic:mqtt-client", version.ref = "mqttastic" }


### PR DESCRIPTION
## Dependency Bumps

Consolidates 4 Renovate PRs (#5440, #5441, #5442, #5443) into a single update.

### Changes

| Dependency | From | To | Highlight |
|---|---|---|---|
| **devtools-ksp** | 2.3.7 | 2.3.8 | `getSymbolsWithAnnotation` up to **~2× faster** via PSI-based resolution; auto-enables `ksp.project.isolation` with Gradle Isolated Projects |
| **wire** | 6.2.0 | 6.3.0 | **Security fix** ([GHSA-7xpr-hc2w-34m9](https://github.com/advisories/GHSA-7xpr-hc2w-34m9)): rejects negative lengths when skipping protobuf groups — crafted payloads now throw `ProtocolException` instead of unchecked exceptions |
| **compose-multiplatform** | 1.11.0-rc01 | 1.11.0 | Stable release. Bumps upstream Jetpack compose from 1.11.0→1.11.1. Desktop Metal offscreen rendering crash fix. No material3 version change (stays 1.11.0-alpha07) |
| **com.google.android.material** | 1.13.0 | 1.14.0 | M3 Expressive (opt-in), massive a11y/keyboard-nav overhaul, Snackbar close icon, many bug fixes. minSdk raised to 23 (we're at 26 ✅) |

### What this unlocks

- **KSP 2.3.8** — Faster KSP annotation processing improves build times, especially in annotation-heavy modules (Koin, Room)
- **Wire 6.3.0** — Hardens protobuf parsing against malicious mesh payloads (relevant since we parse radio packets from untrusted BLE sources)
- **CMP 1.11.0 stable** — Moves us off RC to stable; gets us iOS parallel rendering enabled by default, new `ComposeUIView` API for UIKit embedding, v2 Compose UI Test APIs, and numerous iOS/Desktop/Web bug fixes
- **MDC 1.14.0** — Opt-in M3 Expressive design system when we're ready; a11y improvements flow through to the splash screen theme and Datadog session replay

### Compatibility

- ✅ Kotlin 2.3.21 satisfies all requirements (CMP needs ≥2.2, KSP targets 2.3)
- ✅ No `Shader`/`NativePaint`/`NativeCanvas` usage (CMP breaking changes don't apply)
- ✅ `androidx-compose-bom-aligned` already at 1.11.1 (matches CMP 1.11.0 stable mapping)
- ✅ `compose-multiplatform-material3` stays at 1.11.0-alpha07 (unchanged in CMP stable)
- ✅ Build, tests, spotlessCheck, and detekt all pass locally

Closes #5440, closes #5441, closes #5442, closes #5443