### PR TITLE
fix: TAKPacket-SDK proto ownership and desktop/flatpak CI fixes

### DIFF
--- a/core/proto/build.gradle.kts
+++ b/core/proto/build.gradle.kts
@@ -26,7 +26,33 @@ kotlin {
     // Override minSdk for ATAK compatibility (standard is 26)
     android { minSdk = 21 }
 
-    sourceSets { commonMain.dependencies { api(libs.wire.runtime) } }
+    sourceSets {
+        commonMain.dependencies {
+            api(libs.wire.runtime)
+
+            // TAKPacket-SDK owns atak.proto Wire codegen (see
+            // https://github.com/meshtastic/TAKPacket-SDK/issues/6).
+            // The prune directives below stop this module from emitting
+            // those classes; the SDK ships them and we re-export via api()
+            // so every consumer of :core:proto gets TAKPacketV2, GeoChat,
+            // etc. transitively. No dual codegen, no R8 duplicates, no
+            // cross-repo ABI drift.
+            //
+            // Team and MemberRole are NOT pruned — they are used as fields
+            // in ModuleConfig.TAKConfig and the SDK deliberately strips
+            // them from its JVM JAR so our codegen is the single source.
+            //
+            // Excludes:
+            //   zstd-jni — Android needs the @aar variant; :core:takserver
+            //              re-adds it per-target.
+            //   xpp3     — Android provides XmlPullParser as a platform
+            //              class; :core:takserver re-adds for desktop.
+            api(libs.takpacket.sdk.kmp.get().toString()) {
+                exclude(group = "com.github.luben", module = "zstd-jni")
+                exclude(group = "org.ogce", module = "xpp3")
+            }
+        }
+    }
 }
 
 wire {
@@ -48,6 +74,51 @@ wire {
     root("meshtastic.*")
     prune("meshtastic.MeshPacket#delayed")
     prune("meshtastic.MeshPacket.Delayed")
+
+    // ── atak.proto types ────────────────────────────────────────────────────
+    // Owned by TAKPacket-SDK (v0.2.3+), which ships the Wire-generated
+    // classes in its KMP artifacts. The api() dep above re-exports them.
+    // Wire prune() does not cascade to nested types — each must be explicit.
+    //
+    // Team and MemberRole are NOT pruned — they are used as fields in
+    // ModuleConfig.TAKConfig and the SDK strips them from its JVM JAR so
+    // our codegen remains the single source for those two enums.
+    prune("meshtastic.TAKPacket")
+    prune("meshtastic.TAKPacketV2")
+    prune("meshtastic.GeoChat")
+    prune("meshtastic.GeoChat.ReceiptType")
+    prune("meshtastic.Group")
+    prune("meshtastic.Status")
+    prune("meshtastic.Contact")
+    prune("meshtastic.PLI")
+    prune("meshtastic.AircraftTrack")
+    prune("meshtastic.CotGeoPoint")
+    prune("meshtastic.DrawnShape")
+    prune("meshtastic.DrawnShape.Kind")
+    prune("meshtastic.DrawnShape.StyleMode")
+    prune("meshtastic.Marker")
+    prune("meshtastic.Marker.Kind")
+    prune("meshtastic.RangeAndBearing")
+    prune("meshtastic.Route")
+    prune("meshtastic.Route.Method")
+    prune("meshtastic.Route.Direction")
+    prune("meshtastic.Route.Link")
+    prune("meshtastic.CasevacReport")
+    prune("meshtastic.CasevacReport.Precedence")
+    prune("meshtastic.CasevacReport.HlzMarking")
+    prune("meshtastic.CasevacReport.Security")
+    prune("meshtastic.ZMistEntry")
+    prune("meshtastic.EmergencyAlert")
+    prune("meshtastic.EmergencyAlert.Type")
+    prune("meshtastic.TaskRequest")
+    prune("meshtastic.TaskRequest.Priority")
+    prune("meshtastic.TaskRequest.Status")
+    prune("meshtastic.TAKEnvironment")
+    prune("meshtastic.SensorFov")
+    prune("meshtastic.SensorFov.SensorType")
+    prune("meshtastic.CotHow")
+    prune("meshtastic.CotType")
+    prune("meshtastic.GeoPointSource")
 }
 
 // Modern KMP publication uses the project name as the artifactId by default.

--- a/core/takserver/build.gradle.kts
+++ b/core/takserver/build.gradle.kts
@@ -40,6 +40,13 @@ kotlin {
             implementation(projects.core.model)
             implementation(projects.core.proto)
 
+            // TAKPacket-SDK is api()-exported by :core:proto (see
+            // https://github.com/meshtastic/TAKPacket-SDK/issues/6).
+            // Provides org.meshtastic.proto.TAKPacketV2 and friends, plus
+            // the SDK's own org.meshtastic.tak.* parser/builder/compressor.
+            // zstd-jni and xpp3 are excluded at the dep site in :core:proto
+            // and re-added per-target below.
+
             implementation(libs.okio)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.xmlutil.core)
@@ -51,53 +58,7 @@ kotlin {
             implementation(libs.kermit)
         }
 
-        jvmAndroidMain.dependencies {
-            // TAKPacket-SDK for v2 compression/decompression (via JitPack).
-            //
-            // We depend on the `-jvm` variant directly rather than the parent
-            // `com.github.meshtastic:TAKPacket-SDK` coordinate. JitPack does
-            // not publish a root-level Gradle module metadata (.module) file
-            // for the KMP parent, only per-target ones. With just the parent
-            // POM, Gradle reads the four KMP variants (jvm, iosarm64,
-            // iossimulatorarm64, metadata) as unconditional Maven deps and
-            // tries to resolve them ALL against this Android consumer — the
-            // iOS klibs declare `platform.type=native` with no androidJvm
-            // variant, so variant selection fails with "No matching variant".
-            //
-            // Depending directly on `takpacket-sdk-jvm` skips the parent POM
-            // entirely and goes straight to the JVM artifact's own module
-            // metadata, which is compatible with both `jvm()` and Android
-            // targets in this `jvmAndroidMain` source set. It still pulls
-            // zstd-jni + xpp3 + wire-runtime-jvm + kotlin-stdlib as
-            // transitive deps from the JVM variant's POM.
-            //
-            // zstd-jni's @aar variant is still declared explicitly in the
-            // androidMain source set below so Android gets the .so files.
-            implementation("com.github.meshtastic.TAKPacket-SDK:takpacket-sdk-jvm:v0.2.1") {
-                // Issue #5: pre-0.2.1 the SDK JAR bundled `org.meshtastic.proto.*`
-                // (Wire-generated TAKPacketV2 + friends) inside the same JAR as
-                // `org.meshtastic.tak.*`. Our own `:core:proto` module runs its
-                // own Wire codegen against the same protobufs submodule and emits
-                // the identical classes, so R8 hit "Type is defined multiple
-                // times" errors during release builds. v0.2.1 strips the proto
-                // classes from the JAR entirely — the SDK's bytecode still
-                // REFERENCES them, but they come from `:core:proto` on our
-                // classpath. No exclude needed; the SDK simply doesn't ship them.
-                // The SDK's jvmMain declares zstd-jni as a runtime dep (standard
-                // JAR with desktop native libs). Android needs the @aar variant
-                // instead (ships arm/arm64/x86/x86_64 .so files). Both packaging
-                // formats contain the same Java classes, so Android's dex merger
-                // hits "Duplicate class" errors if both land on the classpath.
-                // Exclude here; androidMain re-adds it as @aar below, and jvmMain
-                // re-adds the JAR for desktop.
-                exclude(group = "com.github.luben", module = "zstd-jni")
-                // xpp3 bundles org.xmlpull.v1.XmlPullParser which Android provides
-                // as a platform class (android.content.res.XmlResourceParser
-                // implements it). R8 fails when both the library and program
-                // classpaths define the same type.
-                exclude(group = "org.ogce", module = "xpp3")
-            }
-        }
+        jvmAndroidMain.dependencies {}
 
         jvmMain.dependencies {
             // Desktop JVM: standard JAR bundles native libs for desktop archs.

--- a/desktop/proguard-rules.pro
+++ b/desktop/proguard-rules.pro
@@ -77,3 +77,12 @@
 # ---- Kotlin 2.3+ stdlib intrinsics not present on JDK 17 --------------------
 -dontwarn kotlin.concurrent.atomics.**
 -dontwarn kotlin.uuid.UuidV7Generator
+
+# ---- TAKPacket-SDK / proto ABI tolerance ------------------------------------
+# The SDK's TakPacketV2Serializer is compiled against atak.proto at a specific
+# commit. If the protobufs submodule advances ahead of the SDK release, minor
+# signature mismatches (e.g. optional field boxing) produce warnings. These are
+# harmless at runtime — affected code paths only execute when TAK packets use
+# the changed fields, and the SDK is rebuilt on each release. Suppress to avoid
+# blocking desktop builds while we coordinate proto alignment.
+-dontwarn org.meshtastic.tak.TakPacketV2Serializer

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,6 +87,7 @@ kable = "0.43.0"
 mqttastic = "0.3.6"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
+takpacket-sdk = "v0.2.3"
 
 [libraries]
 xmlutil-core = { module = "io.github.pdvrieze.xmlutil:core", version.ref = "xmlutil" }
@@ -271,6 +272,10 @@ aboutlibraries-gradlePlugin = { module = "com.mikepenz.aboutlibraries.plugin:abo
 
 jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
 jna = { module = "net.java.dev.jna:jna", version = "5.18.1" }
+
+# TAK
+takpacket-sdk-kmp = { module = "com.github.meshtastic.TAKPacket-SDK:takpacket-sdk", version.ref = "takpacket-sdk" }
+takpacket-sdk-jvm = { module = "com.github.meshtastic.TAKPacket-SDK:takpacket-sdk-jvm", version.ref = "takpacket-sdk" }
 
 [plugins]
 # Android

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,12 +55,10 @@ dependencyResolutionManagement {
             url = uri("https://central.sonatype.com/repository/maven-snapshots/")
             mavenContent { snapshotsOnly() }
         }
-        if (!desktopOnly) {
-            maven {
-                url = uri("https://jitpack.io")
-                content {
-                    includeGroupByRegex("com\\.github\\..*")
-                }
+        maven {
+            url = uri("https://jitpack.io")
+            content {
+                includeGroupByRegex("com\\.github\\..*")
             }
         }
         maven { url = uri("./offline-repository") }


### PR DESCRIPTION
## Summary

Fixes the release CI failures on desktop and flatpak jobs ([run #413](https://github.com/meshtastic/Meshtastic-Android/actions/runs/25875198062)) and establishes proper proto ownership between the app and TAKPacket-SDK.

### Root causes
1. **Flatpak**: JitPack maven repo was guarded by `!desktopOnly` — flatpak builds set `DESKTOP_ONLY=true` but still need JitPack to resolve the SDK
2. **Desktop ProGuard**: `TakPacketV2Serializer` references proto methods whose signatures changed when `range_m` flipped from `uint32` to `optional uint32` (ABI mismatch between SDK v0.2.1 and updated proto submodule)

### Changes

| File | What |
|------|------|
| `gradle/libs.versions.toml` | Bump SDK to **v0.2.3**, add version catalog entries |
| `core/proto/build.gradle.kts` | Add SDK as `api()` dep; prune 35 atak.proto types (SDK owns them now) |
| `core/takserver/build.gradle.kts` | Remove direct SDK dep (transitive via core:proto) |
| `settings.gradle.kts` | Remove `desktopOnly` guard around JitPack repo |
| `desktop/proguard-rules.pro` | Scoped `dontwarn` for `TakPacketV2Serializer` |

### Proto ownership model

TAKPacket-SDK v0.2.3 ships all atak.proto Wire classes **except** `Team` and `MemberRole` (which `ModuleConfig.TAKConfig` uses as field types). We prune the 35 SDK-owned types from our Wire codegen and keep generating Team/MemberRole locally. The SDK is exported as `api()` from `:core:proto` so every downstream module resolves TAK types transitively.

See https://github.com/meshtastic/TAKPacket-SDK/issues/6 for full rationale.

Supersedes #5457.