### PR TITLE
fix(database): make withDb retry logic resilient to varying close messages

### DIFF
--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -169,7 +169,7 @@ open class DatabaseManager(
 
     private val limitedIo = dispatchers.io.limitedParallelism(4)
 
-    /** Execute [block] with the current DB instance. */
+    /** Execute [block] with the current DB instance. Retries once if the pool closes during a DB switch. */
     @Suppress("TooGenericExceptionCaught")
     override suspend fun <T> withDb(block: suspend (MeshtasticDatabase) -> T): T? = withContext(limitedIo) {
         val db = _currentDb.value ?: return@withContext null
@@ -180,16 +180,31 @@ open class DatabaseManager(
         } catch (e: CancellationException) {
             throw e // Preserve structured concurrency cancellation propagation.
         } catch (e: Exception) {
-            // If the connection pool was closed between capturing `db` and executing the query
-            // (e.g., during a database switch), retry once with the current DB instance.
-            if (e.message?.contains("Connection pool is closed") == true) {
-                Logger.w { "withDb: connection pool closed, retrying with current DB" }
-                val retryDb = _currentDb.value ?: return@withContext null
-                block(retryDb)
+            // If the active database switched while we held a reference to the old one,
+            // and the exception indicates a closed pool/connection, retry with the new DB.
+            val retryDb = _currentDb.value
+            if (retryDb != null && retryDb !== db && isDbClosedException(e)) {
+                Logger.w { "withDb: database closed during switch (${e.message}), retrying with current DB" }
+                try {
+                    block(retryDb)
+                } catch (retryEx: Exception) {
+                    retryEx.addSuppressed(e)
+                    throw retryEx
+                }
             } else {
                 throw e
             }
         }
+    }
+
+    private fun isDbClosedException(e: Exception): Boolean = generateSequence<Throwable>(e) { it.cause }
+        .any { throwable ->
+            val msg = throwable.message?.lowercase() ?: return@any false
+            "closed" in msg && DB_TERMS.any { it in msg }
+        }
+
+    private companion object {
+        val DB_TERMS = listOf("pool", "database", "connection", "sqlite")
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes the flaky `DatabaseManagerWithDbRetryTest::withDb retries against current database when previous pool closes during switch` test that keeps flapping on CI.

## Root Cause

The `withDb` retry mechanism only triggered on the exact string `"Connection pool is closed"`, but Room KMP with the bundled SQLite driver can produce different error messages when a database is closed (e.g., `"database is closed"`, `"Cannot use connection, it is closed"`). When the message didn't match, the retry was skipped and the test failed.

## Changes

Replaces the brittle single-message check with a more robust approach:

1. **Reference comparison** (`retryDb !== db`) — confirms a DB switch actually occurred before retrying
2. **Cause-chain scan** — inspects the full exception chain for "closed" + a DB-related term (`pool`, `database`, `connection`, `sqlite`)
3. **Suppressed exception preservation** — if the retry also fails, the original exception is attached as suppressed for debuggability

## Testing

- `./gradlew :core:database:testAndroidHostTest :core:database:allTests` ✅
- `./gradlew :core:database:spotlessCheck :core:database:detekt` ✅