### PR TITLE
ci: remove desktop build job from reusable-check to cut macOS runner costs

### DIFF
--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -21,6 +21,5 @@ jobs:
     with:
       run_lint: true
       run_unit_tests: false
-      run_desktop_builds: false
       upload_artifacts: true
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -95,9 +95,9 @@ jobs:
           PY
 
   # 2. VALIDATION & BUILD: Delegate to reusable-check.yml
-  # We disable coverage and desktop builds for PRs to keep feedback fast
-  # (< 10 mins). Desktop compilation is already covered by the :desktop:test
-  # task in the shard-app test shard.
+  # We disable coverage for PRs to keep feedback fast (< 10 mins).
+  # Desktop compilation is covered by :desktop:test in the shard-app test shard.
+  # Native desktop packaging (createDistributable) only runs in release.yml.
   validate-and-build:
     needs: check-changes
     if: needs.check-changes.outputs.android == 'true'
@@ -106,7 +106,6 @@ jobs:
       run_lint: true
       run_unit_tests: true
       run_coverage: false
-      run_desktop_builds: false
       upload_artifacts: true
     secrets: inherit
 

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -12,9 +12,6 @@ on:
       run_coverage:
         type: boolean
         default: true
-      run_desktop_builds:
-        type: boolean
-        default: true
       run_desktop_flatpak_src:
         type: boolean
         default: false
@@ -468,45 +465,6 @@ jobs:
           echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
           find app/build/outputs/apk -name "*.apk" -exec du -h {} + | awk '{print "| " $2 " | " $1 " |"}' >> $GITHUB_STEP_SUMMARY
 
-  # ── Desktop Build ───────────────────────────────────────────────────
-  build-desktop:
-    name: Build Desktop Debug (${{ matrix.os }})
-    if: inputs.run_desktop_builds == true
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-    timeout-minutes: 60
-    needs: lint-check
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-24.04, ubuntu-24.04-arm]
-    env:
-      VERSION_CODE: ${{ needs.lint-check.outputs.version_code }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-          submodules: true
-
-      - name: Gradle Setup
-        uses: ./.github/actions/gradle-setup
-        with:
-          gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache_read_only: ${{ needs.lint-check.outputs.cache_read_only }}
-
-      - name: Build Desktop
-        run: ./gradlew :desktop:createDistributable -Pci=true --scan
-
-      - name: Upload Desktop artifact
-        if: ${{ inputs.upload_artifacts }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: desktop-app-${{ runner.os }}-${{ runner.arch }}
-          path: desktop/build/compose/binaries/main/app/
-          retention-days: 7
 
   # ── Flatpak Sources ───────────────────────────────────────────────────
   build-flatpak-src:


### PR DESCRIPTION
The build-desktop job (matrix: macos-latest, windows-latest, ubuntu-24.04, ubuntu-24.04-arm) was never actually triggered — all three callers (pull-request, main-check, merge-queue) passed run_desktop_builds: false or inherited the default true but the merge queue was the only one running it.

This is safe because:
- :desktop:test already runs in the test-shards job on Linux, catching compilation and logic regressions.
- The release workflow has its own independent desktop packaging job that still validates macOS/Windows native packaging before any release ships.

The flatpak sources job is retained (Linux-only, no macOS cost).

