### PR TITLE
fix(ci): disable configuration cache for Dokka build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,7 +63,7 @@ jobs:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build Dokka HTML documentation
-        run: ./gradlew dokkaGeneratePublicationHtml
+        run: ./gradlew dokkaGeneratePublicationHtml --no-configuration-cache
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
The `build-docs` job started failing on main because the Dokka task triggers KGP's `MetadataDependencyTransformationTask`, which attempts to resolve iOS metadata configurations during configuration cache serialization. Since `TAKPacket-SDK` does not publish iOS artifacts (`takpacket-sdk-iosarm64`), the resolution fails and the build errors out.

iOS targets in this project exist only for compile-time validation -- no iOS artifacts are published. Dokka's source set config already suppresses iOS source sets from documentation output. The fix adds `--no-configuration-cache` to the `dokkaGeneratePublicationHtml` invocation in CI to avoid the KGP serialization issue entirely.

Fixes https://github.com/meshtastic/Meshtastic-Android/actions/runs/26102522276/job/76757192431