### PR TITLE
fix(docs): use locale subdirectory inside files/ instead of qualifier

### DIFF
--- a/feature/docs/build.gradle.kts
+++ b/feature/docs/build.gradle.kts
@@ -112,7 +112,7 @@ val syncTranslatedDocsToComposeResources by
         group = "docs"
 
         val docsDir = rootProject.layout.projectDirectory.dir("docs")
-        val targetBase = layout.projectDirectory.dir("src/commonMain/composeResources")
+        val targetBase = layout.projectDirectory.dir("src/commonMain/composeResources/files")
 
         from(docsDir) {
             // Crowdin outputs dirs in Android qualifier format (fr, pt-rBR, zh-rCN)
@@ -126,14 +126,14 @@ val syncTranslatedDocsToComposeResources by
 
         into(targetBase)
 
-        // Crowdin %android_code% already outputs CMP qualifier format (pt-rBR),
-        // so we just need to prepend "files-" and nest under docs/
+        // Crowdin %android_code% already outputs CMP qualifier format (pt-rBR).
+        // Locale goes as a subdirectory *inside* files/ (CMP doesn't support qualifiers on files/).
         eachFile {
             val segments = relativePath.segments
             if (segments.size >= 3) {
                 val qualifier = segments[0]
                 val rest = segments.drop(1).joinToString("/")
-                path = "files-$qualifier/docs/$rest"
+                path = "$qualifier/docs/$rest"
             }
         }
         includeEmptyDirs = false

--- a/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/data/DocBundleLoader.kt
+++ b/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/data/DocBundleLoader.kt
@@ -142,7 +142,7 @@ class DefaultDocBundleLoader : DocBundleLoader {
         // Try qualifiers in specificity order (mirrors Android resource resolution):
         // "pt-rBR" → "pt" → give up
         for (qualifier in localeQualifiers(locale)) {
-            val localePath = "files-$qualifier/docs/$section/${page.id}.md"
+            val localePath = "files/$qualifier/docs/$section/${page.id}.md"
             try {
                 val bytes = Res.readBytes(localePath)
                 return stripFrontmatter(bytes.decodeToString())
@@ -162,7 +162,7 @@ class DefaultDocBundleLoader : DocBundleLoader {
                 DocSection.DeveloperGuide -> "developer"
             }
         return localeQualifiers(locale).any { qualifier ->
-            val localePath = "files-$qualifier/docs/$section/${page.id}.md"
+            val localePath = "files/$qualifier/docs/$section/${page.id}.md"
             try {
                 Res.readBytes(localePath)
                 true


### PR DESCRIPTION
## Problem

The Main CI and Deploy Documentation workflows on `main` are failing with:

```
java.lang.IllegalStateException: The 'files' directory doesn't support qualifiers: 'files-tr-rTR'.
```

Compose Multiplatform permanently disallows locale qualifiers on the `files` resource type -- only `drawable`, `values`, `string`, `font`, and `plurals` support them. The `syncTranslatedDocsToComposeResources` Gradle task was writing translated markdown into `composeResources/files-{locale}/docs/`, which the CMP resource accessor generator rejects.

## Approach

The fix places the locale as a subdirectory **inside** the unqualified `files/` directory rather than as a qualifier on the directory name itself. CMP allows arbitrary hierarchies within `files/`, so `files/{locale}/docs/user/foo.md` works perfectly.

Two files changed:
- **`feature/docs/build.gradle.kts`** -- Sync task now targets `composeResources/files/` and maps paths to `$qualifier/docs/$rest` instead of `files-$qualifier/docs/$rest`
- **`DocBundleLoader.kt`** -- Runtime path construction updated from `"files-$qualifier/..."` to `"files/$qualifier/..."`

No changes needed to `crowdin.yml`, runtime APIs, or locale resolution logic.

## Verification

- `generateResourceAccessorsForCommonMain` passes
- `compileKotlinJvm` for `:feature:docs` passes
- Translated docs correctly land at `files/tr-rTR/docs/user/...`, `files/fr-rFR/docs/user/...`, etc.