### PR TITLE
fix(ci): unblock Dokka documentation generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,9 +70,9 @@ firebase-debug.log
 /kable/
 .opencode/
 # Synced docs in composeResources (generated from docs/ source by syncDocsToComposeResources task)
-feature/docs/src/commonMain/composeResources/files/docs/user/
-feature/docs/src/commonMain/composeResources/files/docs/developer/
-feature/docs/src/commonMain/composeResources/files/docs/assets/
+feature/docs/src/commonMain/composeResources/files/docs/
+# Synced translated docs (generated from docs/{locale}/ by syncTranslatedDocsToComposeResources task)
+feature/docs/src/commonMain/composeResources/files/*/docs/
 
 /desktop/bin/
 /build-logic/convention/bin/

--- a/androidApp/src/google/kotlin/org/meshtastic/app/di/GoogleAiModule.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/di/GoogleAiModule.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.app.di
 
 import android.content.Context
+import okio.FileSystem
 import okio.Path.Companion.toOkioPath
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
@@ -37,7 +38,7 @@ class GoogleAiModule {
 
     @Single
     fun docTranslationCache(context: Context): DocTranslationCache =
-        DocTranslationCache(cacheDir = context.cacheDir.toOkioPath())
+        DocTranslationCache(cacheDir = context.cacheDir.toOkioPath(), fileSystem = FileSystem.SYSTEM)
 
     @Single fun docTranslationService(cache: DocTranslationCache): DocTranslationService = MlKitDocTranslator(cache)
 }

--- a/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
@@ -37,7 +37,7 @@ class RootConventionPlugin : Plugin<Project> {
             val modules = allModules()
 
             apply(plugin = "org.jetbrains.dokka")
-            configureDokkaAggregation(modules)
+            configureDokkaAggregation(modules.filter { it !in DOKKA_EXCLUDED_MODULES })
 
             apply(plugin = "org.jetbrains.kotlinx.kover")
             configureKover()
@@ -116,6 +116,13 @@ private val ALL_MODULES_FULL =
 
 /** Android-only modules that don't apply the KMP plugin. */
 private val ANDROID_ONLY_MODULES = setOf(":androidApp", ":core:api", ":core:barcode", ":feature:widget")
+
+/**
+ * Modules excluded from Dokka aggregation. :core:proto contains only auto-generated Wire classes (no KDoc value) and
+ * its TAKPacket-SDK dependency doesn't publish iOS metadata JARs to JitPack, causing
+ * `transformCommonMainDependenciesMetadata` to fail during Dokka resolution.
+ */
+private val DOKKA_EXCLUDED_MODULES = setOf(":core:proto")
 
 private fun allModules(): List<String> = ALL_MODULES_FULL
 

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
@@ -122,6 +122,22 @@ internal fun Project.configureKotlinMultiplatform() {
         }
     }
 
+    // TAKPacket-SDK doesn't publish iOS metadata JARs on JitPack (the .klib exists but
+    // the metadata .jar returns 404). iOS native compilation resolves fine via .klib, but
+    // `transformCommonMainDependenciesMetadata` (triggered by Dokka/publishing) fails.
+    // Exclude the SDK only from the CompilationDependenciesMetadata configs that feed
+    // the metadata transform — NOT from Implementation/Resolvable configs which feed the
+    // actual compiler classpath.
+    val iosMetadataConfigs = setOf(
+        "iosArm64CompilationDependenciesMetadata",
+        "iosSimulatorArm64CompilationDependenciesMetadata",
+    )
+    configurations.configureEach {
+        if (name in iosMetadataConfigs) {
+            exclude(mapOf("group" to "com.github.meshtastic.TAKPacket-SDK", "module" to "takpacket-sdk"))
+        }
+    }
+
     configureMokkery()
     configureKotlin<KotlinMultiplatformExtension>()
 }

--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
@@ -509,7 +509,7 @@ class TAKMeshIntegration(
                 """<precisionLocation[^>]*/>""", // iTAK camelCase variant
                 """<precisionLocation[^>]*>.*?</precisionLocation>""",
             )
-                .map { Regex(it, RegexOption.DOT_MATCHES_ALL) }
+                .map { Regex("(?s)$it") }
 
         // Strip any attribute with value "???" — unknown/placeholder metadata
         private val UNKNOWN_ATTR_PATTERN = Regex("""\s+\w+\s*=\s*"[?]{3}"""")

--- a/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/translation/DocTranslationCache.kt
+++ b/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/translation/DocTranslationCache.kt
@@ -33,7 +33,7 @@ import okio.buffer
  */
 class DocTranslationCache(
     private val cacheDir: Path,
-    private val fileSystem: FileSystem = FileSystem.SYSTEM,
+    private val fileSystem: FileSystem,
     private val maxCacheSizeBytes: Long = MAX_CACHE_SIZE_BYTES,
 ) {
     companion object {


### PR DESCRIPTION
## Why

The Deploy Documentation CI workflow (`docs.yml`) has been failing on every push to `main` since the CMP files-qualifier fix in #5494 allowed Dokka to progress past its first error. Three pre-existing issues were masked behind the earlier `IllegalStateException` and now surface sequentially during `dokkaGeneratePublicationHtml`.

## Approach

**1. TAKPacket-SDK iOS metadata JARs missing on JitPack**

The SDK publishes `.klib` and `.module` for iOS targets but the metadata `.jar` referenced in Gradle module metadata returns 404 from JitPack. This causes `transformCommonMainDependenciesMetadata` to fail for any module that transitively depends on the SDK.

Fixed by excluding the SDK from the iOS `CompilationDependenciesMetadata` configurations that feed the metadata transform task. Actual iOS native compilation resolves fine via `.klib` and is unaffected. Also excluded `:core:proto` from Dokka aggregation since it only contains auto-generated Wire classes (no KDoc value).

**2. `RegexOption.DOT_MATCHES_ALL` in commonMain metadata compilation**

`TAKMeshIntegration.kt` used `RegexOption.DOT_MATCHES_ALL` which is not available in the common stdlib metadata klib (only resolved per-target). Replaced with the portable `(?s)` inline flag -- consistent with the pattern already used in `CoTDetailStripper.kt` in the same module.

**3. `FileSystem.SYSTEM` default parameter in metadata compilation**

`DocTranslationCache` used `FileSystem.SYSTEM` as a default constructor parameter value, but this symbol lives in Okio's `systemFileSystemMain` source set (not `commonMain`) and is invisible to the metadata compiler. Removed the default; callers now pass it explicitly.

**4. .gitignore cleanup**

Consolidated the generated composeResources docs ignore rules and added the translated docs pattern (`files/*/docs/`) which was missing.

## Verification

- `dokkaGeneratePublicationHtml` passes locally
- `spotlessApply detekt assembleDebug` passes
- `:core:takserver:allTests` and `:feature:docs:allTests` pass
- `kmpSmokeCompile` (includes iOS targets) passes