### PR TITLE
fix(ci): exclude pre-release tags from docs-release workflow

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - '!v*-*'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Why

The `Docs Release` workflow triggers on any tag matching `v*.*.*`, which includes internal/pre-release tags like `v2.7.14-internal.93`. When such a tag is pushed, the workflow starts but immediately fails because the `github-pages` environment rejects the deployment -- resulting in a 2-second job with zero steps executed.

Example failure: https://github.com/meshtastic/Meshtastic-Android/actions/runs/26116912390/job/76808453783

## Approach

Added a negative glob pattern `!v*-*` to the tag filter. This excludes any tag containing a hyphen after the `v` prefix, which covers all pre-release suffixes (`-internal.N`, `-rc.N`, `-alpha.N`, etc.) while still matching clean release tags like `v2.7.14`.