### PR TITLE
fix(ci): use GitHub compare API for changelog author resolution

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -101,10 +101,14 @@ jobs:
               | sed -e :a -e '/^\n*$/{$d;N;ba}'
           }
 
-          # Helper: generate notes using git log (works between any two refs)
+          # Helper: generate notes using GitHub compare API (works between any two refs)
           generate_notes_git() {
             local from_ref="$1" to_ref="$2"
-            git log --no-merges --format="* %s by @%an in [\`%h\`](https://github.com/${REPO}/commit/%H)" "$from_ref".."$to_ref" 2>/dev/null || true
+            gh api "repos/${REPO}/compare/${from_ref}...${to_ref}" \
+              --jq '.commits[]
+                | select(.parents | length == 1)
+                | "* \(.commit.message | split("\n")[0]) by \(.commit.author.name) (@\(.author.login // .commit.author.name)) in [`\(.sha[0:9])`](https://github.com/'"${REPO}"'/commit/\(.sha))"' \
+              2>/dev/null || true
           }
 
           # Helper: demote ### headings to #### for nesting under channel sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,19 @@ See [GitHub Releases](https://github.com/meshtastic/Meshtastic-Android/releases)
 * chore(deps): update room to v3.0.0-alpha05 (#5498) by @renovate[bot] in [`59499e827`](https://github.com/meshtastic/Meshtastic-Android/commit/59499e82723bdef4f1116ae5996814d59ab85595)
 * chore(deps): update org.junit.platform:junit-platform-launcher to v6.1.0 (#5502) by @renovate[bot] in [`2b7621221`](https://github.com/meshtastic/Meshtastic-Android/commit/2b76212217122604eeb14ba02ea45d93809773a0)
 * chore(deps): update org.junit.vintage:junit-vintage-engine to v6.1.0 (#5503) by @renovate[bot] in [`ae127a1e1`](https://github.com/meshtastic/Meshtastic-Android/commit/ae127a1e15bdbbae6395a4c21da6440297cdb13b)
-* docs: move English sources into docs/en/ locale folder (#5501) by @James Rich in [`11bc37c96`](https://github.com/meshtastic/Meshtastic-Android/commit/11bc37c96878cd1d9a822c1dad658f43c9be6604)
-* fix(ci): exclude pre-release tags from docs-release workflow (#5499) by @James Rich in [`92cfbaee9`](https://github.com/meshtastic/Meshtastic-Android/commit/92cfbaee9b8819804571ae15fd0815b8ab785bce)
+* docs: move English sources into docs/en/ locale folder (#5501) by James Rich (@jamesarich) in [`11bc37c96`](https://github.com/meshtastic/Meshtastic-Android/commit/11bc37c96878cd1d9a822c1dad658f43c9be6604)
+* fix(ci): exclude pre-release tags from docs-release workflow (#5499) by James Rich (@jamesarich) in [`92cfbaee9`](https://github.com/meshtastic/Meshtastic-Android/commit/92cfbaee9b8819804571ae15fd0815b8ab785bce)
 * docs: update CHANGELOG.md (#5495) by @github-actions[bot] in [`51d2c7b15`](https://github.com/meshtastic/Meshtastic-Android/commit/51d2c7b15cf1b3520cfbef13b8dbcff0b72748e4)
 * chore(deps): update compose-multiplatform to v1.11.2 (#5497) by @renovate[bot] in [`619897de8`](https://github.com/meshtastic/Meshtastic-Android/commit/619897de85616eb9bebedf850970abd24571f705)
-* fix(ci): unblock Dokka documentation generation (#5496) by @James Rich in [`228765a15`](https://github.com/meshtastic/Meshtastic-Android/commit/228765a159b6f1498566d3fe6005f91b470761b4)
-* fix(docs): use locale subdirectory inside files/ instead of qualifier (#5494) by @James Rich in [`418861d35`](https://github.com/meshtastic/Meshtastic-Android/commit/418861d356f1edf5ac0c4b00f3bfc761ad34e609)
+* fix(ci): unblock Dokka documentation generation (#5496) by James Rich (@jamesarich) in [`228765a15`](https://github.com/meshtastic/Meshtastic-Android/commit/228765a159b6f1498566d3fe6005f91b470761b4)
+* fix(docs): use locale subdirectory inside files/ instead of qualifier (#5494) by James Rich (@jamesarich) in [`418861d35`](https://github.com/meshtastic/Meshtastic-Android/commit/418861d356f1edf5ac0c4b00f3bfc761ad34e609)
 * docs: update CHANGELOG.md (#5473) by @github-actions[bot] in [`3121ea09a`](https://github.com/meshtastic/Meshtastic-Android/commit/3121ea09a3abb43713f0a090dac5147b6ae76f84)
-* chore: Scheduled updates (Firmware, Hardware, Translations, Graphs) (#5465) by @James Rich in [`83bb1a31f`](https://github.com/meshtastic/Meshtastic-Android/commit/83bb1a31f75bfd2717428f2fed287eb1e830302f)
+* chore: Scheduled updates (Firmware, Hardware, Translations, Graphs) (#5465) by James Rich (@jamesarich) in [`83bb1a31f`](https://github.com/meshtastic/Meshtastic-Android/commit/83bb1a31f75bfd2717428f2fed287eb1e830302f)
 * chore(deps): update peter-evans/create-pull-request action to v8 (#5493) by @renovate[bot] in [`a141df437`](https://github.com/meshtastic/Meshtastic-Android/commit/a141df437298b039086e9084ec234f925ffa09b2)
 * chore(deps): update node to v24 (#5491) by @renovate[bot] in [`cdf57ced8`](https://github.com/meshtastic/Meshtastic-Android/commit/cdf57ced8e9d6a6ce66a88f10da304a41b0ab4c1)
 * chore(deps): update compose-multiplatform to v1.3.0-beta01 (#5490) by @renovate[bot] in [`3bfaa466a`](https://github.com/meshtastic/Meshtastic-Android/commit/3bfaa466afc01fe03cc69ba7437610441ba8bcf7)
-* fix(ci): disable configuration cache for Dokka build (#5492) by @James Rich in [`fe2cbae87`](https://github.com/meshtastic/Meshtastic-Android/commit/fe2cbae8756c4af9f1daacd842ab0fde097ffab6)
-* docs: comprehensive accuracy audit and CI fix (#5489) by @James Rich in [`ece771edb`](https://github.com/meshtastic/Meshtastic-Android/commit/ece771edb06f0110050baac322a093214b89f6c8)
+* fix(ci): disable configuration cache for Dokka build (#5492) by James Rich (@jamesarich) in [`fe2cbae87`](https://github.com/meshtastic/Meshtastic-Android/commit/fe2cbae8756c4af9f1daacd842ab0fde097ffab6)
+* docs: comprehensive accuracy audit and CI fix (#5489) by James Rich (@jamesarich) in [`ece771edb`](https://github.com/meshtastic/Meshtastic-Android/commit/ece771edb06f0110050baac322a093214b89f6c8)
 * chore(deps): update actions/setup-java action to v5 (#5484) by @renovate[bot] in [`bbdc4a300`](https://github.com/meshtastic/Meshtastic-Android/commit/bbdc4a300406ae417ad7a70fb4cdd826debb5cb3)
 * chore(deps): update actions/upload-pages-artifact action to v5 (#5487) by @renovate[bot] in [`4afa1a032`](https://github.com/meshtastic/Meshtastic-Android/commit/4afa1a032fc465464e7408ef36d0505876ce9d61)
 * chore(deps): update gradle/actions action to v6 (#5488) by @renovate[bot] in [`21993b6cc`](https://github.com/meshtastic/Meshtastic-Android/commit/21993b6cc7eba8776262c3805942ddc460ab0c5b)
@@ -33,15 +33,15 @@ See [GitHub Releases](https://github.com/meshtastic/Meshtastic-Android/releases)
 * chore(deps): update actions/github-script action to v9 (#5483) by @renovate[bot] in [`f8a5f894a`](https://github.com/meshtastic/Meshtastic-Android/commit/f8a5f894a86b6145b86143888f7ea1fe3d9ccbb6)
 * chore(deps): update actions/deploy-pages action to v5 (#5482) by @renovate[bot] in [`d7cccd0db`](https://github.com/meshtastic/Meshtastic-Android/commit/d7cccd0dba442d8c8892a4aac8124f565563434a)
 * chore(deps): update actions/checkout action to v6 (#5481) by @renovate[bot] in [`2e484e219`](https://github.com/meshtastic/Meshtastic-Android/commit/2e484e219c132b89597ffa939e1801765a5d5352)
-* feat(docs): In-app documentation browser with Jekyll site and Docusaurus sync (#5445) by @James Rich in [`fc0df1a79`](https://github.com/meshtastic/Meshtastic-Android/commit/fc0df1a79ad1d8ce355803f5ac6eb4a1f2ec78c3)
-* feat: adopt Material 3 Expressive design system (M3-native APIs only) (#5479) by @James Rich in [`f5128798a`](https://github.com/meshtastic/Meshtastic-Android/commit/f5128798a808219a28e9ee0916c079edcb203744)
+* feat(docs): In-app documentation browser with Jekyll site and Docusaurus sync (#5445) by James Rich (@jamesarich) in [`fc0df1a79`](https://github.com/meshtastic/Meshtastic-Android/commit/fc0df1a79ad1d8ce355803f5ac6eb4a1f2ec78c3)
+* feat: adopt Material 3 Expressive design system (M3-native APIs only) (#5479) by James Rich (@jamesarich) in [`f5128798a`](https://github.com/meshtastic/Meshtastic-Android/commit/f5128798a808219a28e9ee0916c079edcb203744)
 * chore(deps): update core/proto/src/main/proto digest to 59cb394 (#5480) by @renovate[bot] in [`72436e70b`](https://github.com/meshtastic/Meshtastic-Android/commit/72436e70bc1db9373581bc53e8cc62548e596744)
-* fix(nav): remote admin nodenum + Nav3 consolidation and improvements (#5478) by @James Rich in [`df4f10c4d`](https://github.com/meshtastic/Meshtastic-Android/commit/df4f10c4d64a273688aa9dbe5284ac3737756310)
+* fix(nav): remote admin nodenum + Nav3 consolidation and improvements (#5478) by James Rich (@jamesarich) in [`df4f10c4d`](https://github.com/meshtastic/Meshtastic-Android/commit/df4f10c4d64a273688aa9dbe5284ac3737756310)
 * chore(deps): update markdownrenderer to v0.41.0 (#5471) by @renovate[bot] in [`f6587a123`](https://github.com/meshtastic/Meshtastic-Android/commit/f6587a12364cc490b5872ed7bc77cfeed9e414a6)
-* fix(settings): add input validation for BLE PIN, LoRa modem, and ambient lighting (#5477) by @James Rich in [`1dd47bc09`](https://github.com/meshtastic/Meshtastic-Android/commit/1dd47bc09032fe0972af7eed6a7554e61be7a02b)
-* refactor(build): rename entry modules and remove DESKTOP_ONLY mode (#5476) by @James Rich in [`f4b6b02ac`](https://github.com/meshtastic/Meshtastic-Android/commit/f4b6b02acecdd8855408db7d92757f2495fbc11f)
-* ci: remove desktop build job from reusable-check to cut macOS runner costs (#5475) by @James Rich in [`d24fc9ac9`](https://github.com/meshtastic/Meshtastic-Android/commit/d24fc9ac9245b69718e2cb2a6c3a872e36d8c28c)
-* fix(database): make withDb retry logic resilient to varying close messages (#5474) by @James Rich in [`057d5bb77`](https://github.com/meshtastic/Meshtastic-Android/commit/057d5bb778a72cf4359abc7fae904d587cdc90a2)
+* fix(settings): add input validation for BLE PIN, LoRa modem, and ambient lighting (#5477) by James Rich (@jamesarich) in [`1dd47bc09`](https://github.com/meshtastic/Meshtastic-Android/commit/1dd47bc09032fe0972af7eed6a7554e61be7a02b)
+* refactor(build): rename entry modules and remove DESKTOP_ONLY mode (#5476) by James Rich (@jamesarich) in [`f4b6b02ac`](https://github.com/meshtastic/Meshtastic-Android/commit/f4b6b02acecdd8855408db7d92757f2495fbc11f)
+* ci: remove desktop build job from reusable-check to cut macOS runner costs (#5475) by James Rich (@jamesarich) in [`d24fc9ac9`](https://github.com/meshtastic/Meshtastic-Android/commit/d24fc9ac9245b69718e2cb2a6c3a872e36d8c28c)
+* fix(database): make withDb retry logic resilient to varying close messages (#5474) by James Rich (@jamesarich) in [`057d5bb77`](https://github.com/meshtastic/Meshtastic-Android/commit/057d5bb778a72cf4359abc7fae904d587cdc90a2)
 * chore(deps): update wire to v6.4.0 (#5466) by @renovate[bot] in [`f0e12695b`](https://github.com/meshtastic/Meshtastic-Android/commit/f0e12695bbf3df16b043476ff98856b727d6a2f7)
 * chore(deps): update spotless to v8.5.1 (#5468) by @renovate[bot] in [`c91219d8b`](https://github.com/meshtastic/Meshtastic-Android/commit/c91219d8b0411975c059c7a5ae6eb370386954f6)
 * chore(deps): update vico to v3.2.0-next.5 (#5470) by @renovate[bot] in [`4bacff81c`](https://github.com/meshtastic/Meshtastic-Android/commit/4bacff81c5abad536b40f7370ae5d302b74a11fe)
@@ -50,220 +50,220 @@ See [GitHub Releases](https://github.com/meshtastic/Meshtastic-Android/releases)
 Changes since [`v2.7.13`](https://github.com/meshtastic/Meshtastic-Android/releases/tag/v2.7.13):
 
 #### 🏗️ Features
-* refactor(ble): Centralize BLE logic into a core module by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4550
-* feat(ble): Add support for `FromRadioSync` characteristic by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4609
-* feat(widget): Add Local Stats glance widget by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4642
-* chore(deps): bump deps to take advantage of new functionality by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4658
-* feat(maps): Google maps improvements for network and offline tilesources by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4664
-* feat: Improve edge-to-edge and display cutout handling by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4669
-* feat: upcoming support for tak and trafficmanagement configs, device hw by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4671
-* feat: settings rework by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4678
-* feat: settings rework part 2, domain and usecase abstraction, tests by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4680
-* feat: service decoupling by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4685
-* refactor: migrate :core:database to Room Kotlin Multiplatform by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4702
-* refactor(ble): improve connection lifecycle and enhance OTA reliability by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4721
-* refactor: migrate preferences to DataStore and decouple core:domain for KMP by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4731
-* refactor: migrate core modules to Kotlin Multiplatform and consolidat… by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4735
-* feat: Migrate project to Kotlin Multiplatform (KMP) architecture by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4738
-* refactor: migrate from Hilt to Koin and expand KMP common modules by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4746
-* refactor: migrate core UI and features to KMP, adopt Navigation 3 by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4750
-* feat: introduce Desktop target and expand Kotlin Multiplatform (KMP) architecture by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4761
-* build(desktop): enable ProGuard for release builds by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4772
-* feat(desktop): implement DI auto-wiring and validation by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4782
-* feat(desktop): expand supported native distribution formats by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4783
-* feat: Complete ViewModel extraction and update documentation by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4817
-* refactor: Replace Nordic, use Kable backend for Desktop and Android with BLE support by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4818
-* feat: Integrate notification management and preferences across platforms by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4819
-* feat: service extraction by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4828
-* feat: build logic by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4829
-* feat: Desktop USB serial transport by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4836
+* refactor(ble): Centralize BLE logic into a core module by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4550
+* feat(ble): Add support for `FromRadioSync` characteristic by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4609
+* feat(widget): Add Local Stats glance widget by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4642
+* chore(deps): bump deps to take advantage of new functionality by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4658
+* feat(maps): Google maps improvements for network and offline tilesources by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4664
+* feat: Improve edge-to-edge and display cutout handling by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4669
+* feat: upcoming support for tak and trafficmanagement configs, device hw by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4671
+* feat: settings rework by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4678
+* feat: settings rework part 2, domain and usecase abstraction, tests by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4680
+* feat: service decoupling by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4685
+* refactor: migrate :core:database to Room Kotlin Multiplatform by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4702
+* refactor(ble): improve connection lifecycle and enhance OTA reliability by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4721
+* refactor: migrate preferences to DataStore and decouple core:domain for KMP by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4731
+* refactor: migrate core modules to Kotlin Multiplatform and consolidat… by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4735
+* feat: Migrate project to Kotlin Multiplatform (KMP) architecture by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4738
+* refactor: migrate from Hilt to Koin and expand KMP common modules by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4746
+* refactor: migrate core UI and features to KMP, adopt Navigation 3 by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4750
+* feat: introduce Desktop target and expand Kotlin Multiplatform (KMP) architecture by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4761
+* build(desktop): enable ProGuard for release builds by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4772
+* feat(desktop): implement DI auto-wiring and validation by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4782
+* feat(desktop): expand supported native distribution formats by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4783
+* feat: Complete ViewModel extraction and update documentation by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4817
+* refactor: Replace Nordic, use Kable backend for Desktop and Android with BLE support by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4818
+* feat: Integrate notification management and preferences across platforms by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4819
+* feat: service extraction by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4828
+* feat: build logic by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4829
+* feat: Desktop USB serial transport by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4836
 * Add "Exclude MQTT" filter to Nodes view. by @VictorioBerra in https://github.com/meshtastic/Meshtastic-Android/pull/4825
-* feat: mqtt by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4841
-* feat: Integrate Mokkery and Turbine into KMP testing framework by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4845
-* feat: Complete app module thinning and feature module extraction by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4844
-* feat: Enhance test coverage  by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4847
-* feat: Implement KMP ServiceDiscovery for TCP devices by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4854
-* feat: Add KMP URI handling, import, and QR code generation support by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4856
-* feat: KMP Debug Panel Migration and Update Documentation by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4859
-* feat: Migrate to Room 3.0 and update related documentation and tracks by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4865
-* feat: Implement iOS support and unify Compose Multiplatform infrastructure by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4876
+* feat: mqtt by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4841
+* feat: Integrate Mokkery and Turbine into KMP testing framework by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4845
+* feat: Complete app module thinning and feature module extraction by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4844
+* feat: Enhance test coverage  by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4847
+* feat: Implement KMP ServiceDiscovery for TCP devices by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4854
+* feat: Add KMP URI handling, import, and QR code generation support by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4856
+* feat: KMP Debug Panel Migration and Update Documentation by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4859
+* feat: Migrate to Room 3.0 and update related documentation and tracks by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4865
+* feat: Implement iOS support and unify Compose Multiplatform infrastructure by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4876
 * Add InlineMap implementation for F-Droid build by @theKorzh in https://github.com/meshtastic/Meshtastic-Android/pull/4877
-* refactor(desktop): remove native MenuBar from main window by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4888
-* feat: Migrate networking to Ktor and enhance multiplatform support by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4890
-* refactor: adaptive UI components for Navigation 3 by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4891
-* feat: Integrate AlertHost into desktop application and add UI tests by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4893
-* feat: implement global SnackbarManager and consolidate common UI setup by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4909
-* feat: implement unified deep link routing for Kotlin Multiplatform by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4910
-* refactor: BLE transport and UI for Kotlin Multiplatform unification by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4911
-* Refactor map layer management and navigation infrastructure by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4921
-* feat: migrate to Material 3 Expressive APIs by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4934
-* Refactor nav3 architecture and enhance adaptive layouts by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4944
-* feat(tak): introduce built-in Local TAK Server and mesh integration by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4951
-* feat(analytics): expand DataDog RUM integration and align with iOS parity by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4970
-* feat(wifi): introduce BLE-based WiFi provisioning for nymea-compatible devices by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4968
-* feat(wifi-provision): add mPWRD-OS branding and disclaimer banner by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4978
-* feat(charts): adopt Vico best practices, add sensor data, and migrate TracerouteLog by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5026
-* refactor(icons): migrate to self-hosted VectorDrawable XMLs via MeshtasticIcons by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5030
-* feat(messaging): add IME Send action to message input by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5047
-* feat(metrics): redesign position log with SelectableMetricCard and add CSV export to all metrics screens by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5062
-* feat(core/ui): add safeLaunch, UiState, KMP permissions, and CMP lifecycle modernization by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5118
-* feat(desktop): add entitlements and wire MeshConnectionManager into orchestrator by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5127
-* feat(environment): add 1-Wire multi-thermometer (DS18B20) display support by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5130
-* feat: add high-contrast theme with accessible message bubbles by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5135
-* feat(mqtt): migrate to MQTTastic-Client-KMP by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5165
-* feat(mqtt): adopt mqttastic-client-kmp 0.2.0 — disconnect reasons + Test Connection by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5181
-* feat(firmware): nRF52 BLE Legacy DFU support by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5209
-* feat(service): send polite ToRadio(disconnect=true) before transport close by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5210
-* feat(node): smoother remote-admin UX with per-node session tracking by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5217
-* fix(ble): unblock reconnect + kable audit (logging, priority, backoff, StateFlow) by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5222
-* feat: Enhance mPWRD-os WiFi provisioning success state and UI components by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5225
-* feat(messaging): add entry points for filter settings by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5229
-* feat(messaging): send message on Enter keypress by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5246
-* feat(desktop): native OS notifications via libnotify/osascript/PowerShell by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5253
+* refactor(desktop): remove native MenuBar from main window by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4888
+* feat: Migrate networking to Ktor and enhance multiplatform support by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4890
+* refactor: adaptive UI components for Navigation 3 by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4891
+* feat: Integrate AlertHost into desktop application and add UI tests by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4893
+* feat: implement global SnackbarManager and consolidate common UI setup by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4909
+* feat: implement unified deep link routing for Kotlin Multiplatform by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4910
+* refactor: BLE transport and UI for Kotlin Multiplatform unification by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4911
+* Refactor map layer management and navigation infrastructure by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4921
+* feat: migrate to Material 3 Expressive APIs by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4934
+* Refactor nav3 architecture and enhance adaptive layouts by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4944
+* feat(tak): introduce built-in Local TAK Server and mesh integration by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4951
+* feat(analytics): expand DataDog RUM integration and align with iOS parity by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4970
+* feat(wifi): introduce BLE-based WiFi provisioning for nymea-compatible devices by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4968
+* feat(wifi-provision): add mPWRD-OS branding and disclaimer banner by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4978
+* feat(charts): adopt Vico best practices, add sensor data, and migrate TracerouteLog by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5026
+* refactor(icons): migrate to self-hosted VectorDrawable XMLs via MeshtasticIcons by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5030
+* feat(messaging): add IME Send action to message input by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5047
+* feat(metrics): redesign position log with SelectableMetricCard and add CSV export to all metrics screens by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5062
+* feat(core/ui): add safeLaunch, UiState, KMP permissions, and CMP lifecycle modernization by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5118
+* feat(desktop): add entitlements and wire MeshConnectionManager into orchestrator by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5127
+* feat(environment): add 1-Wire multi-thermometer (DS18B20) display support by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5130
+* feat: add high-contrast theme with accessible message bubbles by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5135
+* feat(mqtt): migrate to MQTTastic-Client-KMP by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5165
+* feat(mqtt): adopt mqttastic-client-kmp 0.2.0 — disconnect reasons + Test Connection by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5181
+* feat(firmware): nRF52 BLE Legacy DFU support by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5209
+* feat(service): send polite ToRadio(disconnect=true) before transport close by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5210
+* feat(node): smoother remote-admin UX with per-node session tracking by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5217
+* fix(ble): unblock reconnect + kable audit (logging, priority, backoff, StateFlow) by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5222
+* feat: Enhance mPWRD-os WiFi provisioning success state and UI components by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5225
+* feat(messaging): add entry points for filter settings by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5229
+* feat(messaging): send message on Enter keypress by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5246
+* feat(desktop): native OS notifications via libnotify/osascript/PowerShell by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5253
 * feat(auto): enable Android Auto messaging notifications by @riddlemd in https://github.com/meshtastic/Meshtastic-Android/pull/5265
-* fix: update emoji catalog metadata and improve picker synchronization by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5292
-* fix: update notification icon by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5293
-* feat(connections): connection sorting & conversation empty channel ranking by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5295
-* fix(connections): improve BLE scan reliability and UI lifecycle by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5329
-* feat: event firmware easter egg with ambient branding by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5354
-* feat: align theme with Design Standards v1.3, remove contrast setting by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5355
-* feat(desktop): fix mac notifications, new desktop icons by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5403
-* Update notification intents and deep link URI format by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5408
-* fix: clarify position precision as ± radius  by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5428
-* feat: TAK v2 protocol integration with zstd compression and full CoT type support by @thebentern in https://github.com/meshtastic/Meshtastic-Android/pull/5434
+* fix: update emoji catalog metadata and improve picker synchronization by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5292
+* fix: update notification icon by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5293
+* feat(connections): connection sorting & conversation empty channel ranking by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5295
+* fix(connections): improve BLE scan reliability and UI lifecycle by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5329
+* feat: event firmware easter egg with ambient branding by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5354
+* feat: align theme with Design Standards v1.3, remove contrast setting by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5355
+* feat(desktop): fix mac notifications, new desktop icons by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5403
+* Update notification intents and deep link URI format by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5408
+* fix: clarify position precision as ± radius  by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5428
+* feat: TAK v2 protocol integration with zstd compression and full CoT type support by Ben Meadors (@thebentern) in https://github.com/meshtastic/Meshtastic-Android/pull/5434
 #### 🖥️ Desktop
-* fix(desktop): keep Vico package to prevent bytecode verification errors by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5424
+* fix(desktop): keep Vico package to prevent bytecode verification errors by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5424
 #### 🛠️ Fixes
-* fix(strings): replace plurals by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4596
-* fix: replace fdroid map_style_selection string by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4598
-* refactor(test): Introduce MeshTestApplication for robust testing by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4602
-* fix: spotless by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4604
-* feat(build): Implement flavor-specific barcode scanning and build improvements by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4611
+* fix(strings): replace plurals by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4596
+* fix: replace fdroid map_style_selection string by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4598
+* refactor(test): Introduce MeshTestApplication for robust testing by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4602
+* fix: spotless by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4604
+* feat(build): Implement flavor-specific barcode scanning and build improvements by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4611
 * fix(qr): add channels as key to remember block to fix add-channel rac… by @nreisbeck in https://github.com/meshtastic/Meshtastic-Android/pull/4607
-* chore(ble): Add Proguard rules for Nordic BLE library by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4618
-* ci(release): Use wildcards for APK paths in release workflow by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4619
-* chore(ci): Use wildcard for APK paths in release workflow by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4622
-* chore(ci): Refine analytics task filtering and improve release debugging by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4624
-* Fix/splits by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4626
+* chore(ble): Add Proguard rules for Nordic BLE library by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4618
+* ci(release): Use wildcards for APK paths in release workflow by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4619
+* chore(ci): Use wildcard for APK paths in release workflow by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4622
+* chore(ci): Refine analytics task filtering and improve release debugging by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4624
+* Fix/splits by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4626
 * Align FDroid MapView constructor with Google version (Issue #4576) by @ujade in https://github.com/meshtastic/Meshtastic-Android/pull/4630
-* refactor(analytics): reduce tracking footprint by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4649
-* fix(map): location perms and button visibility, breadcrumb taps by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4651
+* refactor(analytics): reduce tracking footprint by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4649
+* fix(map): location perms and button visibility, breadcrumb taps by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4651
 * fix(strings): Correct capitalization of Ham by @alecperkins in https://github.com/meshtastic/Meshtastic-Android/pull/4620
-* ci: Split Google artifact attestations and ensure F-Droid uploads by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4665
-* fix: Replace strings.xml with app_name resource by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4666
-* Disable generate_release_notes in release workflow by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4668
-* fix: ui tweaks by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4696
-* refactor: simplify traceroute tracking and unify cooldown button logic by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4699
-* feat: Add "Mark all as read" and unread message count indicators by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4720
-* fix(widget): ensure local stats widget gets updates by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4722
-* refactor(ble): increase default timeout for BLE profiling by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4728
-* refactor: enhance handshake stall guard and extend coverage to Stage 2 by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4730
-* build(ci): optimize release workflow and update Room configuration by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4775
-* Disable ProGuard for desktop release and add application icon by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4776
-* fix(ble): implement scanning for unbonded devices in common connections ui by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4779
-* fix: fix animation stalls and update dependencies for stability by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4784
-* build(desktop): include `java.net.http` module in native distribution by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4787
-* build: remove PKG from desktop distribution targets by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4788
-* build: Update desktop app icons, versioning, and packaging configuration by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4789
-* refactor(settings): improve destination node handling in RadioConfigViewModel by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4790
-* feat(desktop): add enter-to-send functionality in messaging by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4793
-* feat: enhance map navigation and waypoint handling by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4814
-* build: fix license generation and analytics build tasks by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4820
-* fix: resolve crashes and debug filter issues in Metrics and MapView by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4824
-* fix(map, settings): allow null IDs and implement request timeout by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4851
-* docs: Unify notification channel management and migrate unit tests by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4867
-* fix: Implement reconnection logic and stabilize BLE connection flow by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4870
-* fix: Update messaging feature with contact item keys and MQTT limits by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4871
-* fix: specify jetbrains in gradle-daemon-jvm.properties by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4872
-* fix(settings): remove redundant regex option in DebugViewModel by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4881
-* refactor(service): update string formatting for local stats notif by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4885
-* refactor(messaging): fix contact key derivation in ContactsViewModel by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4887
-* feat: optimistically persist local configs and channels by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4898
-* refactor(di): specify disk cache directory for ImageLoader by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4899
-* refactor: null safety, update date/time libraries, and migrate tests by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4900
-* refactor: remove demoscenario and enhance BLE connection stability by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4914
-* refactor(ui): remove labels from navigation suite items by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4924
-* build: enable `-Xjvm-default=all` compiler flag by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4929
-* fix(ci): update APP_VERSION_NAME output reference in workflows by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4935
+* ci: Split Google artifact attestations and ensure F-Droid uploads by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4665
+* fix: Replace strings.xml with app_name resource by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4666
+* Disable generate_release_notes in release workflow by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4668
+* fix: ui tweaks by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4696
+* refactor: simplify traceroute tracking and unify cooldown button logic by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4699
+* feat: Add "Mark all as read" and unread message count indicators by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4720
+* fix(widget): ensure local stats widget gets updates by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4722
+* refactor(ble): increase default timeout for BLE profiling by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4728
+* refactor: enhance handshake stall guard and extend coverage to Stage 2 by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4730
+* build(ci): optimize release workflow and update Room configuration by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4775
+* Disable ProGuard for desktop release and add application icon by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4776
+* fix(ble): implement scanning for unbonded devices in common connections ui by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4779
+* fix: fix animation stalls and update dependencies for stability by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4784
+* build(desktop): include `java.net.http` module in native distribution by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4787
+* build: remove PKG from desktop distribution targets by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4788
+* build: Update desktop app icons, versioning, and packaging configuration by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4789
+* refactor(settings): improve destination node handling in RadioConfigViewModel by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4790
+* feat(desktop): add enter-to-send functionality in messaging by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4793
+* feat: enhance map navigation and waypoint handling by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4814
+* build: fix license generation and analytics build tasks by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4820
+* fix: resolve crashes and debug filter issues in Metrics and MapView by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4824
+* fix(map, settings): allow null IDs and implement request timeout by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4851
+* docs: Unify notification channel management and migrate unit tests by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4867
+* fix: Implement reconnection logic and stabilize BLE connection flow by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4870
+* fix: Update messaging feature with contact item keys and MQTT limits by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4871
+* fix: specify jetbrains in gradle-daemon-jvm.properties by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4872
+* fix(settings): remove redundant regex option in DebugViewModel by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4881
+* refactor(service): update string formatting for local stats notif by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4885
+* refactor(messaging): fix contact key derivation in ContactsViewModel by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4887
+* feat: optimistically persist local configs and channels by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4898
+* refactor(di): specify disk cache directory for ImageLoader by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4899
+* refactor: null safety, update date/time libraries, and migrate tests by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4900
+* refactor: remove demoscenario and enhance BLE connection stability by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4914
+* refactor(ui): remove labels from navigation suite items by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4924
+* build: enable `-Xjvm-default=all` compiler flag by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4929
+* fix(ci): update APP_VERSION_NAME output reference in workflows by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4935
 * fix(strings): Fix public key description by @Klavionik in https://github.com/meshtastic/Meshtastic-Android/pull/4957
-* feat: implement XModem file transfers and enhance BLE connection robustness by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4959
-* Refactor navigation to use NodeDetail route and fix radio settings by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4960
-* Refactor and unify firmware update logic across platforms by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4966
-* fix: improve PKI message routing and resolve database migration racecondition by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4996
+* feat: implement XModem file transfers and enhance BLE connection robustness by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4959
+* Refactor navigation to use NodeDetail route and fix radio settings by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4960
+* Refactor and unify firmware update logic across platforms by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4966
+* fix: improve PKI message routing and resolve database migration racecondition by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4996
 * fix: resolve correct node public key in sendSharedContact and favoriteNode by @Copilot in https://github.com/meshtastic/Meshtastic-Android/pull/5005
-* fix: resolve bugs across connection, PKI, admin, packet flow, and stability subsystems by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5011
-* fix(tak): resolve frequent TAK client disconnections by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5015
-* fix(service): resolve MeshService crash from eager notification channel init by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5034
-* style: update ic_no_cell and ic_place vector drawables by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5040
-* fix(build): prevent DataDog asset transform from stripping fdroid release assets by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5044
-* fix(icons): replace outline (FILL=0) pathData with filled (FILL=1) from upstream Material Symbols by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5056
-* fix(charts): hoist rememberVicoZoomState above vararg layers to prevent ClassCastException by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5060
-* fix(ui): add missing @ParameterName annotations on actual rememberReadTextFromUri declarations by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5072
-* fix(settings): hide Status Message config until firmware v2.8.0 by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5070
-* fix(transport): Kable BLE audit + thread-safety, MQTT, and logging fixes across transport layers by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5071
-* fix(build): remove Compose BOM to resolve compileSdk 37 conflict by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5088
-* fix(connections): show device name during connecting state by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5085
-* fix(build): add explicit compose-multiplatform-animation dependency by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5095
-* fix(nav): restore broken traceroute map navigation by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5104
-* fix(build): overhaul R8 rules and DRY up build-logic conventions by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5109
-* fix(proguard): disable shrinking for Compose animation classes  by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5116
-* fix(icons): audit and correct icon migration regressions from #5030 #5040 #5056 by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5136
-* fix: align BLE connection handshake with firmware protocol expectations by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5141
-* fix(app): add R8 keep rules for Compose animation/runtime/ui by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5146
-* perf(messaging): batch node + reply lookups in message loading by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5149
-* fix(app): disable R8 optimization to fix Compose animation freeze by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5150
-* fix(node): don't recreate Vico CartesianChartModelProducer on channel switch by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5160
-* refactor: use injected ioDispatcher and ApplicationCoroutineScope by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5167
-* fix: redact MeshLog proto secrets and centralize Compose keep-rules by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5166
-* fix(ui): stable LazyColumn keys, semantic roles, and content descriptions by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5168
-* fix(ui): finish accessibility roles and action labels for clickable surfaces by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5170
-* fix(widget): drive updates via debounced state observer by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5185
-* fix(transport): improve BLE / TCP / USB reconnect and handshake resilience by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5196
-* fix(fdroid): prevent NotImplementedError crash on firmware release fetch by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5197
-* fix(compass): stop coarse network fixes from clobbering GPS fixes by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5200
-* fix(canned-messages): enable multiline text editing for long message lists by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5203
-* fix(settings): restore Import/Export button functionality in #4913 by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5204
-* refactor: eliminate Accompanist permissions library by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5211
-* fix: MQTT proxy connection and probe test failures by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5215
+* fix: resolve bugs across connection, PKI, admin, packet flow, and stability subsystems by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5011
+* fix(tak): resolve frequent TAK client disconnections by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5015
+* fix(service): resolve MeshService crash from eager notification channel init by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5034
+* style: update ic_no_cell and ic_place vector drawables by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5040
+* fix(build): prevent DataDog asset transform from stripping fdroid release assets by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5044
+* fix(icons): replace outline (FILL=0) pathData with filled (FILL=1) from upstream Material Symbols by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5056
+* fix(charts): hoist rememberVicoZoomState above vararg layers to prevent ClassCastException by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5060
+* fix(ui): add missing @ParameterName annotations on actual rememberReadTextFromUri declarations by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5072
+* fix(settings): hide Status Message config until firmware v2.8.0 by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5070
+* fix(transport): Kable BLE audit + thread-safety, MQTT, and logging fixes across transport layers by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5071
+* fix(build): remove Compose BOM to resolve compileSdk 37 conflict by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5088
+* fix(connections): show device name during connecting state by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5085
+* fix(build): add explicit compose-multiplatform-animation dependency by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5095
+* fix(nav): restore broken traceroute map navigation by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5104
+* fix(build): overhaul R8 rules and DRY up build-logic conventions by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5109
+* fix(proguard): disable shrinking for Compose animation classes  by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5116
+* fix(icons): audit and correct icon migration regressions from #5030 #5040 #5056 by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5136
+* fix: align BLE connection handshake with firmware protocol expectations by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5141
+* fix(app): add R8 keep rules for Compose animation/runtime/ui by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5146
+* perf(messaging): batch node + reply lookups in message loading by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5149
+* fix(app): disable R8 optimization to fix Compose animation freeze by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5150
+* fix(node): don't recreate Vico CartesianChartModelProducer on channel switch by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5160
+* refactor: use injected ioDispatcher and ApplicationCoroutineScope by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5167
+* fix: redact MeshLog proto secrets and centralize Compose keep-rules by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5166
+* fix(ui): stable LazyColumn keys, semantic roles, and content descriptions by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5168
+* fix(ui): finish accessibility roles and action labels for clickable surfaces by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5170
+* fix(widget): drive updates via debounced state observer by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5185
+* fix(transport): improve BLE / TCP / USB reconnect and handshake resilience by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5196
+* fix(fdroid): prevent NotImplementedError crash on firmware release fetch by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5197
+* fix(compass): stop coarse network fixes from clobbering GPS fixes by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5200
+* fix(canned-messages): enable multiline text editing for long message lists by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5203
+* fix(settings): restore Import/Export button functionality in #4913 by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5204
+* refactor: eliminate Accompanist permissions library by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5211
+* fix: MQTT proxy connection and probe test failures by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5215
 * fix(ble): ensure GATT cleanup runs under NonCancellable on cancellation by @jdogg172 in https://github.com/meshtastic/Meshtastic-Android/pull/5207
-* fix(ble): cleanup races discovered while reviewing #5207 by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5221
+* fix(ble): cleanup races discovered while reviewing #5207 by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5221
 * fix(ui): make footer buttons expand downwards by @zt64 in https://github.com/meshtastic/Meshtastic-Android/pull/5226
-* fix(desktop): suppress Vico ColorScale ProGuard warnings by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5232
-* fix(desktop): unbreak release crash via correct ProGuard rules by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5236
-* fix(crashlytics): resolve beta 2.7.14 crash issues by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5245
-* fix: Resolve top Crashlytics issues for 29320633 beta release by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5278
-* fix: persist language switching and correctly map locales by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5287
-* fix: ensure snackbar respects safe drawing padding over host modifiers by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5290
+* fix(desktop): suppress Vico ColorScale ProGuard warnings by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5232
+* fix(desktop): unbreak release crash via correct ProGuard rules by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5236
+* fix(crashlytics): resolve beta 2.7.14 crash issues by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5245
+* fix: Resolve top Crashlytics issues for 29320633 beta release by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5278
+* fix: persist language switching and correctly map locales by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5287
+* fix: ensure snackbar respects safe drawing padding over host modifiers by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5290
 * fix(ui): align Cancel and Send enabled state by @elagin in https://github.com/meshtastic/Meshtastic-Android/pull/5284
-* fix(data): default new-node notifications off for event firmware by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5323
-* fix(network): resolve empty MQTT address and enforce TLS on default server by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5333
-* fix(mqtt): harden TLS enforcement, add user CA trust, and improve error diagnostics by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5365
-* fix: clamp future lastHeard timestamps to current time on ingestion by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5418
-* revert: Update retry settings in gradle-wrapper.properties by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5430
-* fix: update screenshots by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5435
+* fix(data): default new-node notifications off for event firmware by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5323
+* fix(network): resolve empty MQTT address and enforce TLS on default server by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5333
+* fix(mqtt): harden TLS enforcement, add user CA trust, and improve error diagnostics by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5365
+* fix: clamp future lastHeard timestamps to current time on ingestion by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5418
+* revert: Update retry settings in gradle-wrapper.properties by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5430
+* fix: update screenshots by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5435
 #### 📝 Other Changes
-* refactor(ui): compose resources, domain layer by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4628
+* refactor(ui): compose resources, domain layer by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4628
 * Add per-message transport method icons for new message format by @Kealper in https://github.com/meshtastic/Meshtastic-Android/pull/4643
-* build: apply instrumented test dependencies conditionally by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4698
-* docs: summarize KMP migration progress and architectural decisions by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4770
-* ci(release): pass app version to desktop build via environment variable by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4774
-* ai: Establish conductor documentation and governance framework by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4780
+* build: apply instrumented test dependencies conditionally by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4698
+* docs: summarize KMP migration progress and architectural decisions by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4770
+* ci(release): pass app version to desktop build via environment variable by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4774
+* ai: Establish conductor documentation and governance framework by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4780
 * fix: fix wrong getChannelUrl() call causing loss of "add" flag and un… by @skobkin in https://github.com/meshtastic/Meshtastic-Android/pull/4809
-* chore: Enhance CI coverage reporting and add main branch workflow by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4873
-* build(desktop): enable ProGuard minification and tree-shaking by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4904
-* build: update Compose Multiplatform and migrate lifecycle dependencies by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4932
-* chore: standardize resources and update documentation for Navigation 3 by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/4961
-* feat(settings): add DNS support and fix UDP protocol toggle by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5013
-* fix: use payload labels in pr_enforce_labels.yml to avoid rate limiting by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5018
-* fix: scope labeler trigger to reduce rate limiting and fix bugfix typo by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5020
-* test(prefs): migrate DataStore tests from androidHostTest to commonTest by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5092
-* fix(resources): add resourcePrefix to KMP + widget modules, rename prefixed resources by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5111
-* fix(charts): apply Vico 3.1.0 best-practice audit fixes by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5138
-* refactor(di): adopt @KoinApplication with startKoin<T>() compiler plugin API by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5152
-* test: migrate MigrationTest to runTest and add missing repository fakes by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5171
-* refactor: consolidate metric formatting through MetricFormatter by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5169
-* chore(r8): remove redundant keep rules covered by consumer rules by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5172
-* Revert "diag(r8): disable minify for release builds (animation-freeze diagnostic)" by @jamesarich in https://github.com/meshtastic/Meshtastic-Android/pull/5176
+* chore: Enhance CI coverage reporting and add main branch workflow by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4873
+* build(desktop): enable ProGuard minification and tree-shaking by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4904
+* build: update Compose Multiplatform and migrate lifecycle dependencies by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4932
+* chore: standardize resources and update documentation for Navigation 3 by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/4961
+* feat(settings): add DNS support and fix UDP protocol toggle by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5013
+* fix: use payload labels in pr_enforce_labels.yml to avoid rate limiting by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5018
+* fix: scope labeler trigger to reduce rate limiting and fix bugfix typo by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5020
+* test(prefs): migrate DataStore tests from androidHostTest to commonTest by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5092
+* fix(resources): add resourcePrefix to KMP + widget modules, rename prefixed resources by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5111
+* fix(charts): apply Vico 3.1.0 best-practice audit fixes by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5138
+* refactor(di): adopt @KoinApplication with startKoin<T>() compiler plugin API by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5152
+* test: migrate MigrationTest to runTest and add missing repository fakes by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5171
+* refactor: consolidate metric formatting through MetricFormatter by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5169
+* chore(r8): remove redundant keep rules covered by consumer rules by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5172
+* Revert "diag(r8): disable minify for release builds (animation-freeze diagnostic)" by James Rich (@jamesarich) in https://github.com/meshtastic/Meshtastic-Android/pull/5176
 * Fix node-details remove action to preserve confirmation flow by @Copilot in https://github.com/meshtastic/Meshtastic-Android/pull/5192
 * Change default ContrastLevel from STANDARD to MEDIUM by @somenice in https://github.com/meshtastic/Meshtastic-Android/pull/5325
 


### PR DESCRIPTION
## Summary

The changelog workflow's `generate_notes_git()` helper used `git log %an`, which outputs the committer's display name (e.g., "James Rich") instead of their GitHub username. This caused `@`-mentions to render as broken links like `@James Rich` rather than proper profile links.

## Approach

- Replaced the `git log` fallback in `generate_notes_git()` with the GitHub compare API (`repos/{owner}/{repo}/compare/{base}...{head}`), which returns the correct `.author.login` field.
- Updated the output format to show both the display name and handle: `by Name (@handle)`.
- Fixed all existing incorrect entries in `CHANGELOG.md` (211 `@James Rich` -> `James Rich (@jamesarich)`, 1 `@thebentern` -> `Ben Meadors (@thebentern)`).

## Notes

The GitHub `generate-notes` API path (used when the previous ref is a production tag) already resolved usernames correctly. This fix addresses only the git-log fallback path used between non-production channel tags.