### PR TITLE
fix(database): update @Relation annotations for Room 3.0.0-alpha05

### DIFF
--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/NodeEntity.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/NodeEntity.kt
@@ -43,8 +43,8 @@ import org.meshtastic.proto.Position as WirePosition
 
 data class NodeWithRelations(
     @Embedded val node: NodeEntity,
-    @Relation(entity = MetadataEntity::class, parentColumn = "num", entityColumn = "num")
-    val metadata: MetadataEntity? = null,
+    @Relation(entity = MetadataEntity::class, parentColumns = ["num"], entityColumns = ["num"])
+    val metadata: MetadataEntity?,
 ) {
     fun toModel() = with(node) {
         Node(

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/Packet.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/Packet.kt
@@ -33,8 +33,8 @@ import org.meshtastic.core.model.util.getShortDateTime
 
 data class PacketEntity(
     @Embedded val packet: Packet,
-    @Relation(entity = ReactionEntity::class, parentColumn = "packet_id", entityColumn = "reply_id")
-    val reactions: List<ReactionEntity> = emptyList(),
+    @Relation(entity = ReactionEntity::class, parentColumns = ["packet_id"], entityColumns = ["reply_id"])
+    val reactions: List<ReactionEntity>,
 ) {
     suspend fun toMessage(getNode: suspend (userId: String?) -> Node) = with(packet) {
         val node = getNode(data.from)


### PR DESCRIPTION
Room 3.0.0-alpha05 (merged via #5498) changed the `@Relation` annotation API, breaking KSP processing on main.

**What changed:**
- `parentColumn` (String) was removed in favor of `parentColumns` (Array<String>)
- `entityColumn` (String) was removed in favor of `entityColumns` (Array<String>)
- Default values on `@Relation`-annotated constructor parameters now cause constructor matching failures in the KSP processor

**Fix:**
- Updated `NodeWithRelations` and `PacketEntity` to use the array-form parameters
- Removed default values from the relation properties (Room instantiates these classes itself, so defaults were unused)

Verified locally that `:core:database:kspAndroidMain` passes with these changes.