### PR TITLE
chore(deps): migrate takpacket-sdk to Maven Central coordinates

### DIFF
--- a/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
@@ -119,7 +119,7 @@ private val ANDROID_ONLY_MODULES = setOf(":androidApp", ":core:api", ":core:barc
 
 /**
  * Modules excluded from Dokka aggregation. :core:proto contains only auto-generated Wire classes (no KDoc value) and
- * its TAKPacket-SDK dependency doesn't publish iOS metadata JARs to JitPack, causing
+ * its TAKPacket-SDK dependency doesn't publish iOS metadata JARs, causing
  * `transformCommonMainDependenciesMetadata` to fail during Dokka resolution.
  */
 private val DOKKA_EXCLUDED_MODULES = setOf(":core:proto")

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
@@ -122,8 +122,8 @@ internal fun Project.configureKotlinMultiplatform() {
         }
     }
 
-    // TAKPacket-SDK doesn't publish iOS metadata JARs on JitPack (the .klib exists but
-    // the metadata .jar returns 404). iOS native compilation resolves fine via .klib, but
+    // TAKPacket-SDK doesn't publish iOS metadata JARs (the .klib exists but the metadata
+    // .jar returns 404). iOS native compilation resolves fine via .klib, but
     // `transformCommonMainDependenciesMetadata` (triggered by Dokka/publishing) fails.
     // Exclude the SDK only from the CompilationDependenciesMetadata configs that feed
     // the metadata transform — NOT from Implementation/Resolvable configs which feed the
@@ -134,7 +134,7 @@ internal fun Project.configureKotlinMultiplatform() {
     )
     configurations.configureEach {
         if (name in iosMetadataConfigs) {
-            exclude(mapOf("group" to "com.github.meshtastic.TAKPacket-SDK", "module" to "takpacket-sdk"))
+            exclude(mapOf("group" to "org.meshtastic", "module" to "takpacket-sdk"))
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,7 +88,7 @@ kable = "0.43.0"
 mqttastic = "0.3.6"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
-takpacket-sdk = "0.2.3"
+takpacket-sdk = "0.2.4-SNAPSHOT"
 
 [libraries]
 xmlutil-core = { module = "io.github.pdvrieze.xmlutil:core", version.ref = "xmlutil" }
@@ -278,8 +278,8 @@ jmdns = { module = "org.jmdns:jmdns", version.ref = "jmdns" }
 jna = { module = "net.java.dev.jna:jna", version = "5.18.1" }
 
 # TAK
-takpacket-sdk-kmp = { module = "com.github.meshtastic.TAKPacket-SDK:takpacket-sdk", version.ref = "takpacket-sdk" }
-takpacket-sdk-jvm = { module = "com.github.meshtastic.TAKPacket-SDK:takpacket-sdk-jvm", version.ref = "takpacket-sdk" }
+takpacket-sdk-kmp = { module = "org.meshtastic:takpacket-sdk", version.ref = "takpacket-sdk" }
+takpacket-sdk-jvm = { module = "org.meshtastic:takpacket-sdk-jvm", version.ref = "takpacket-sdk" }
 
 [plugins]
 # Android


### PR DESCRIPTION
TAKPacket-SDK now publishes to Maven Central (snapshots) under the `org.meshtastic` group. This migrates from the old JitPack coordinates (`com.github.meshtastic.TAKPacket-SDK`) and bumps to the latest snapshot.

## Approach

- Updated `libs.versions.toml` module coordinates from `com.github.meshtastic.TAKPacket-SDK:takpacket-sdk*` to `org.meshtastic:takpacket-sdk*`
- Bumped version from `0.2.3` to `0.2.4-SNAPSHOT`
- Updated the iOS metadata exclusion in `KotlinAndroid.kt` to use the new group name

## Notes

- The existing `central.sonatype.com/repository/maven-snapshots/` repo in `settings.gradle.kts` already resolves the new artifact correctly -- no repository changes needed.
- Once a stable release is published, we can drop the `-SNAPSHOT` suffix and the snapshot repo declaration becomes unnecessary for this dependency.
- Verified both `:core:proto` and `:core:takserver` compile successfully against the new coordinates.