### PR TITLE
ci: reduce flatpak source generation thrash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,7 +373,7 @@ jobs:
       - name: Generate Flatpak Sources
         run: >
           ./gradlew :build-logic:convention:flatpakGradleGenerator flatpakGradleGenerator
-          --no-configuration-cache --refresh-dependencies --no-parallel
+          --no-configuration-cache
 
       - name: List Flatpak source files
         run: ls -R flatpak-sources-*.json

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,8 +18,6 @@
 pluginManagement {
     includeBuild("build-logic")
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         google {
             content {
                 includeGroupByRegex("com\\.android.*")
@@ -27,6 +25,8 @@ pluginManagement {
                 includeGroupByRegex("androidx.*")
             }
         }
+        mavenCentral()
+        gradlePluginPortal()
         maven { url = uri("./offline-repository") }
     }
 }
@@ -43,7 +43,6 @@ dependencyResolutionManagement {
     repositories {
         // Only enable mavenLocal for local JitPack testing; never in CI.
         if (providers.gradleProperty("useMavenLocal").isPresent) mavenLocal()
-        mavenCentral()
         google {
             content {
                 includeGroupByRegex("com\\.android.*")
@@ -51,6 +50,7 @@ dependencyResolutionManagement {
                 includeGroupByRegex("androidx.*")
             }
         }
+        mavenCentral()
         maven {
             url = uri("https://central.sonatype.com/repository/maven-snapshots/")
             mavenContent { snapshotsOnly() }


### PR DESCRIPTION
The `create-flatpak-src` CI jobs have been taking excessively long due to redundant network overhead. This PR makes two targeted changes to reduce that thrash.

## Approach

**Drop `--refresh-dependencies` and `--no-parallel` from the Gradle invocation** (`release.yml`)

- `--refresh-dependencies` forces Gradle to re-verify every artifact's metadata against Maven Central before the flatpak plugin even starts. On a pinned release tag, the dependency graph is immutable -- this verification cannot produce a different result, so it just adds latency.
- `--no-parallel` serialized all subproject `flatpakGradleGenerator` tasks. Each writes to a uniquely-named output file with no shared mutable state, so parallel execution is safe.
- The `--no-configuration-cache` flag remains because the plugin uses `getProject()` in its `@TaskAction` (incompatible with configuration cache).

**Move `google()` above `mavenCentral()` in repository ordering** (`settings.gradle.kts`)

- The flatpak-gradle-generator plugin iterates repositories sequentially (bypassing Gradle's content filters) and tries each URL for every artifact.
- With `mavenCentral()` first, Google/AndroidX artifacts 404 against Maven Central -- which rate-limits aggressively (HTTP 429) before returning 404 on retry.
- Google's repo does not rate-limit and returns 404 quickly for non-Google artifacts.
- Gradle's own resolution is unaffected because the `content {}` filters are still in place.

## Notes

- The `reusable-check.yml` workflow has the same `--refresh-dependencies --no-parallel` flags for its flatpak step. That can be updated separately if this proves stable.
- Credit to @vidplace7 for identifying the Maven Central rate-limiting as the root cause of the slowdown.