### PR TITLE
fix: prevent node details hang when device hardware API is unreachable

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/DeviceHardwareRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/DeviceHardwareRepositoryImpl.kt
@@ -17,6 +17,9 @@
 package org.meshtastic.core.data.repository
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
@@ -25,6 +28,7 @@ import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.data.datasource.BootloaderOtaQuirksJsonDataSource
 import org.meshtastic.core.data.datasource.DeviceHardwareJsonDataSource
 import org.meshtastic.core.data.datasource.DeviceHardwareLocalDataSource
+import org.meshtastic.core.data.util.staleWhileRevalidateFlow
 import org.meshtastic.core.database.entity.DeviceHardwareEntity
 import org.meshtastic.core.database.entity.asExternalModel
 import org.meshtastic.core.di.CoroutineDispatchers
@@ -42,6 +46,9 @@ class DeviceHardwareRepositoryImpl(
     private val bootloaderOtaQuirksJsonDataSource: BootloaderOtaQuirksJsonDataSource,
     private val dispatchers: CoroutineDispatchers,
 ) : DeviceHardwareRepository {
+
+    /** Single-flight guard so concurrent collectors don't duplicate the full-table refresh. */
+    private val refreshMutex = Mutex()
 
     /**
      * Retrieves device hardware information by its model ID and optional target string.
@@ -61,29 +68,37 @@ class DeviceHardwareRepositoryImpl(
                 " target=$target, forceRefresh=$forceRefresh)"
         }
 
-        val quirks = loadQuirks()
-
         if (forceRefresh) {
             Logger.d { "DeviceHardwareRepository: forceRefresh=true, clearing cache" }
             localDataSource.deleteAllDeviceHardware()
         }
 
-        // 1. Seed from bundled JSON if the DB is completely empty (first launch or post-wipe).
-        if (!localDataSource.hasAnyEntries()) {
-            seedCacheFromBundledJson()
-        }
+        ensureSeeded()
 
-        // 2. Check cache; refresh from network if stale, empty, or forced.
         var entities = lookupEntities(hwModel, target)
         if (forceRefresh || entities.isEmpty() || entities.any { it.isStale() }) {
-            refreshFromNetworkWithTimeout()
+            singleFlightRefresh()
             entities = lookupEntities(hwModel, target)
         }
 
-        // 3. Resolve and return the best available data.
-        val matched = disambiguate(entities, target)
-        Result.success(applyBootloaderQuirk(hwModel, matched?.asExternalModel(), quirks, target))
+        Result.success(resolveHardware(hwModel, entities, target))
     }
+
+    /**
+     * Non-blocking Flow that emits cached/bundled hardware data immediately, then refreshes from the network if stale.
+     * Safe to use inside Flow `combine` transforms.
+     */
+    override fun observeDeviceHardware(hwModel: Int, target: String?): Flow<DeviceHardware?> = staleWhileRevalidateFlow(
+        loadFromCache = {
+            ensureSeeded()
+            resolveHardware(hwModel, lookupEntities(hwModel, target), target)
+        },
+        shouldFetch = { cached -> cached == null || lookupEntities(hwModel, target).any { it.isStale() } },
+        fetch = { singleFlightRefresh() },
+        context = dispatchers.io,
+        networkTimeoutMs = NETWORK_REFRESH_TIMEOUT_MS,
+        tag = "DeviceHardwareRepository",
+    )
 
     /** Looks up entities by hwModel, falling back to a target-only lookup when needed. */
     private suspend fun lookupEntities(hwModel: Int, target: String?): List<DeviceHardwareEntity> =
@@ -91,36 +106,47 @@ class DeviceHardwareRepositoryImpl(
             target?.let { listOfNotNull(localDataSource.getByTarget(it)) } ?: emptyList()
         }
 
-    private suspend fun seedCacheFromBundledJson() {
-        safeCatching {
-            Logger.d { "DeviceHardwareRepository: seeding cache from bundled JSON" }
-            val jsonHardware = jsonDataSource.loadDeviceHardwareFromJsonAsset()
-            localDataSource.insertAllDeviceHardware(jsonHardware)
+    /** Seeds the local DB from bundled JSON if completely empty. */
+    private suspend fun ensureSeeded() {
+        if (!localDataSource.hasAnyEntries()) {
+            safeCatching {
+                Logger.d { "DeviceHardwareRepository: seeding cache from bundled JSON" }
+                val jsonHardware = jsonDataSource.loadDeviceHardwareFromJsonAsset()
+                localDataSource.insertAllDeviceHardware(jsonHardware)
+            }
+                .onFailure { e -> Logger.w(e) { "DeviceHardwareRepository: failed to seed cache from bundled JSON" } }
         }
-            .onFailure { e -> Logger.w(e) { "DeviceHardwareRepository: failed to seed cache from bundled JSON" } }
     }
 
     /**
-     * Attempts a network refresh with a bounded timeout so a slow/unresponsive API
-     * never blocks the UI. Falls back gracefully to cached or bundled data on timeout.
+     * Performs a single-flight network refresh: concurrent callers share one in-flight request rather than each
+     * triggering a full API fetch.
      */
-    private suspend fun refreshFromNetworkWithTimeout() {
-        safeCatching {
-            val completed = withTimeoutOrNull(NETWORK_REFRESH_TIMEOUT_MS) {
-                refreshFromNetwork()
+    private suspend fun singleFlightRefresh() {
+        refreshMutex.withLock {
+            safeCatching {
+                val completed =
+                    withTimeoutOrNull(NETWORK_REFRESH_TIMEOUT_MS) {
+                        Logger.d { "DeviceHardwareRepository: fetching from remote API" }
+                        val remoteHardware = remoteDataSource.getAllDeviceHardware()
+                        Logger.d { "DeviceHardwareRepository: remote returned ${remoteHardware.size} entries" }
+                        localDataSource.insertAllDeviceHardware(remoteHardware)
+                    }
+                if (completed == null) {
+                    Logger.w {
+                        "DeviceHardwareRepository: network refresh timed out after ${NETWORK_REFRESH_TIMEOUT_MS}ms"
+                    }
+                }
             }
-            if (completed == null) {
-                Logger.w { "DeviceHardwareRepository: network refresh timed out after ${NETWORK_REFRESH_TIMEOUT_MS}ms" }
-            }
+                .onFailure { e -> Logger.w(e) { "DeviceHardwareRepository: network refresh failed" } }
         }
-            .onFailure { e -> Logger.w(e) { "DeviceHardwareRepository: network refresh failed" } }
     }
 
-    private suspend fun refreshFromNetwork() {
-        Logger.d { "DeviceHardwareRepository: fetching from remote API" }
-        val remoteHardware = remoteDataSource.getAllDeviceHardware()
-        Logger.d { "DeviceHardwareRepository: remote returned ${remoteHardware.size} entries" }
-        localDataSource.insertAllDeviceHardware(remoteHardware)
+    /** Resolves entities into a [DeviceHardware] domain model with quirk application. */
+    private fun resolveHardware(hwModel: Int, entities: List<DeviceHardwareEntity>, target: String?): DeviceHardware? {
+        val matched = disambiguate(entities, target)
+        val quirks = loadQuirks()
+        return applyBootloaderQuirk(hwModel, matched?.asExternalModel(), quirks, target)
     }
 
     private fun disambiguate(entities: List<DeviceHardwareEntity>, target: String?): DeviceHardwareEntity? =
@@ -139,11 +165,8 @@ class DeviceHardwareRepositoryImpl(
     private fun DeviceHardwareEntity.isStale(): Boolean =
         isIncomplete() || (nowMillis - this.lastUpdated) > CACHE_EXPIRATION_TIME_MS
 
-    private fun loadQuirks(): List<BootloaderOtaQuirk> {
-        val quirks = bootloaderOtaQuirksJsonDataSource.loadBootloaderOtaQuirksFromJsonAsset()
-        Logger.d { "DeviceHardwareRepository: loaded ${quirks.size} bootloader quirks" }
-        return quirks
-    }
+    private fun loadQuirks(): List<BootloaderOtaQuirk> =
+        bootloaderOtaQuirksJsonDataSource.loadBootloaderOtaQuirksFromJsonAsset()
 
     private fun applyBootloaderQuirk(
         hwModel: Int,
@@ -154,11 +177,6 @@ class DeviceHardwareRepositoryImpl(
         val matchedQuirk = quirks.firstOrNull { it.hwModel == hwModel }
         val withQuirk =
             if (matchedQuirk != null) {
-                Logger.d {
-                    "DeviceHardwareRepository: applying quirk: " +
-                        "requiresBootloaderUpgradeForOta=${matchedQuirk.requiresBootloaderUpgradeForOta}, " +
-                        "infoUrl=${matchedQuirk.infoUrl}"
-                }
                 hw.copy(
                     requiresBootloaderUpgradeForOta = matchedQuirk.requiresBootloaderUpgradeForOta,
                     bootloaderInfoUrl = matchedQuirk.infoUrl,
@@ -166,8 +184,6 @@ class DeviceHardwareRepositoryImpl(
             } else {
                 hw
             }
-
-        // If the device reported a specific build environment via pio_env, trust it for firmware retrieval
         reportedTarget?.let { withQuirk.copy(platformioTarget = it) } ?: withQuirk
     }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/DeviceHardwareRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/DeviceHardwareRepositoryImpl.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.data.repository
 
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.common.util.safeCatching
@@ -47,8 +48,8 @@ class DeviceHardwareRepositoryImpl(
      *
      * Pipeline:
      * 1. If the local DB is empty, seed it from the bundled JSON asset (instant baseline).
-     * 2. If the cached entry is stale or missing, refresh from the remote API.
-     * 3. Return the best available data from the DB.
+     * 2. If the cached entry is stale or missing, refresh from the remote API with a timeout.
+     * 3. Return the best available data from the DB (never blocks longer than [NETWORK_REFRESH_TIMEOUT_MS]).
      */
     override suspend fun getDeviceHardwareByModel(
         hwModel: Int,
@@ -75,7 +76,7 @@ class DeviceHardwareRepositoryImpl(
         // 2. Check cache; refresh from network if stale, empty, or forced.
         var entities = lookupEntities(hwModel, target)
         if (forceRefresh || entities.isEmpty() || entities.any { it.isStale() }) {
-            refreshFromNetwork()
+            refreshFromNetworkWithTimeout()
             entities = lookupEntities(hwModel, target)
         }
 
@@ -99,14 +100,27 @@ class DeviceHardwareRepositoryImpl(
             .onFailure { e -> Logger.w(e) { "DeviceHardwareRepository: failed to seed cache from bundled JSON" } }
     }
 
-    private suspend fun refreshFromNetwork() {
+    /**
+     * Attempts a network refresh with a bounded timeout so a slow/unresponsive API
+     * never blocks the UI. Falls back gracefully to cached or bundled data on timeout.
+     */
+    private suspend fun refreshFromNetworkWithTimeout() {
         safeCatching {
-            Logger.d { "DeviceHardwareRepository: fetching from remote API" }
-            val remoteHardware = remoteDataSource.getAllDeviceHardware()
-            Logger.d { "DeviceHardwareRepository: remote returned ${remoteHardware.size} entries" }
-            localDataSource.insertAllDeviceHardware(remoteHardware)
+            val completed = withTimeoutOrNull(NETWORK_REFRESH_TIMEOUT_MS) {
+                refreshFromNetwork()
+            }
+            if (completed == null) {
+                Logger.w { "DeviceHardwareRepository: network refresh timed out after ${NETWORK_REFRESH_TIMEOUT_MS}ms" }
+            }
         }
             .onFailure { e -> Logger.w(e) { "DeviceHardwareRepository: network refresh failed" } }
+    }
+
+    private suspend fun refreshFromNetwork() {
+        Logger.d { "DeviceHardwareRepository: fetching from remote API" }
+        val remoteHardware = remoteDataSource.getAllDeviceHardware()
+        Logger.d { "DeviceHardwareRepository: remote returned ${remoteHardware.size} entries" }
+        localDataSource.insertAllDeviceHardware(remoteHardware)
     }
 
     private fun disambiguate(entities: List<DeviceHardwareEntity>, target: String?): DeviceHardwareEntity? =
@@ -159,5 +173,8 @@ class DeviceHardwareRepositoryImpl(
 
     companion object {
         private val CACHE_EXPIRATION_TIME_MS = TimeConstants.ONE_DAY.inWholeMilliseconds
+
+        /** Maximum time to wait for the remote API before falling back to cached/bundled data. */
+        private const val NETWORK_REFRESH_TIMEOUT_MS = 5_000L
     }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.data.repository
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.common.util.safeCatching
@@ -82,10 +83,15 @@ open class FirmwareReleaseRepositoryImpl(
 
     private suspend fun refreshFromNetwork() {
         safeCatching {
-            Logger.d { "Fetching fresh firmware releases from remote API." }
-            val networkReleases = remoteDataSource.getFirmwareReleases()
-            localDataSource.insertFirmwareReleases(networkReleases.releases.stable, FirmwareReleaseType.STABLE)
-            localDataSource.insertFirmwareReleases(networkReleases.releases.alpha, FirmwareReleaseType.ALPHA)
+            val completed = withTimeoutOrNull(NETWORK_REFRESH_TIMEOUT_MS) {
+                Logger.d { "Fetching fresh firmware releases from remote API." }
+                val networkReleases = remoteDataSource.getFirmwareReleases()
+                localDataSource.insertFirmwareReleases(networkReleases.releases.stable, FirmwareReleaseType.STABLE)
+                localDataSource.insertFirmwareReleases(networkReleases.releases.alpha, FirmwareReleaseType.ALPHA)
+            }
+            if (completed == null) {
+                Logger.w { "FirmwareReleaseRepository: network refresh timed out after ${NETWORK_REFRESH_TIMEOUT_MS}ms" }
+            }
         }
             .onFailure { e -> Logger.w(e) { "FirmwareReleaseRepository: network refresh failed" } }
     }
@@ -108,5 +114,8 @@ open class FirmwareReleaseRepositoryImpl(
 
     companion object {
         private val CACHE_EXPIRATION_TIME_MS = TimeConstants.ONE_HOUR.inWholeMilliseconds
+
+        /** Maximum time to wait for the remote API before falling back to cached/bundled data. */
+        private const val NETWORK_REFRESH_TIMEOUT_MS = 5_000L
     }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
@@ -18,17 +18,19 @@ package org.meshtastic.core.data.repository
 
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.data.datasource.FirmwareReleaseJsonDataSource
 import org.meshtastic.core.data.datasource.FirmwareReleaseLocalDataSource
+import org.meshtastic.core.data.util.staleWhileRevalidateFlow
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.FirmwareReleaseEntity
 import org.meshtastic.core.database.entity.FirmwareReleaseType
 import org.meshtastic.core.database.entity.asExternalModel
+import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.util.TimeConstants
 import org.meshtastic.core.network.FirmwareReleaseRemoteDataSource
 import org.meshtastic.core.repository.FirmwareReleaseRepository
@@ -38,76 +40,53 @@ open class FirmwareReleaseRepositoryImpl(
     private val remoteDataSource: FirmwareReleaseRemoteDataSource,
     private val localDataSource: FirmwareReleaseLocalDataSource,
     private val jsonDataSource: FirmwareReleaseJsonDataSource,
+    private val dispatchers: CoroutineDispatchers,
 ) : FirmwareReleaseRepository {
 
-    /**
-     * A flow that provides the latest STABLE firmware release.
-     *
-     * Pipeline:
-     * 1. If the local DB is empty, seed it from the bundled JSON asset (instant baseline).
-     * 2. Immediately emit the cached version.
-     * 3. If the cached version is stale, refresh from the remote API and re-emit.
-     *
-     * Collectors should use `.distinctUntilChanged()` to avoid redundant UI updates.
-     */
+    /** Single-flight guard so concurrent collectors share one network refresh. */
+    private val refreshMutex = Mutex()
+
     override val stableRelease: Flow<FirmwareRelease?> = getLatestFirmware(FirmwareReleaseType.STABLE)
 
-    /**
-     * A flow that provides the latest ALPHA firmware release.
-     *
-     * @see stableRelease for behavior details.
-     */
     override val alphaRelease: Flow<FirmwareRelease?> = getLatestFirmware(FirmwareReleaseType.ALPHA)
 
-    private fun getLatestFirmware(releaseType: FirmwareReleaseType): Flow<FirmwareRelease?> = flow {
-        // 1. Seed from bundled JSON if the DB is completely empty (first launch or post-wipe).
-        if (!localDataSource.hasAnyEntries()) {
-            seedCacheFromBundledJson()
-        }
-
-        // 2. Emit cached data immediately.
-        val cachedRelease = localDataSource.getLatestRelease(releaseType)
-        emit(cachedRelease?.asExternalModel())
-
-        // 3. If fresh, we're done.
-        if (cachedRelease?.isStale() == false) {
-            return@flow
-        }
-
-        // 4. Cache is stale or empty — refresh from network and re-emit.
-        refreshFromNetwork()
-        val finalRelease = localDataSource.getLatestRelease(releaseType)
-        Logger.d { "Emitting final firmware for $releaseType from cache." }
-        emit(finalRelease?.asExternalModel())
-    }
-
-    private suspend fun refreshFromNetwork() {
-        safeCatching {
-            val completed = withTimeoutOrNull(NETWORK_REFRESH_TIMEOUT_MS) {
-                Logger.d { "Fetching fresh firmware releases from remote API." }
-                val networkReleases = remoteDataSource.getFirmwareReleases()
-                localDataSource.insertFirmwareReleases(networkReleases.releases.stable, FirmwareReleaseType.STABLE)
-                localDataSource.insertFirmwareReleases(networkReleases.releases.alpha, FirmwareReleaseType.ALPHA)
-            }
-            if (completed == null) {
-                Logger.w { "FirmwareReleaseRepository: network refresh timed out after ${NETWORK_REFRESH_TIMEOUT_MS}ms" }
-            }
-        }
-            .onFailure { e -> Logger.w(e) { "FirmwareReleaseRepository: network refresh failed" } }
-    }
+    private fun getLatestFirmware(releaseType: FirmwareReleaseType): Flow<FirmwareRelease?> = staleWhileRevalidateFlow(
+        loadFromCache = {
+            ensureSeeded()
+            localDataSource.getLatestRelease(releaseType)?.asExternalModel()
+        },
+        shouldFetch = { cached ->
+            cached == null || localDataSource.getLatestRelease(releaseType)?.isStale() != false
+        },
+        fetch = { singleFlightRefresh() },
+        context = dispatchers.default,
+        networkTimeoutMs = NETWORK_REFRESH_TIMEOUT_MS,
+        tag = "FirmwareReleaseRepository",
+    )
 
     override suspend fun invalidateCache() {
         localDataSource.deleteAllFirmwareReleases()
     }
 
-    private suspend fun seedCacheFromBundledJson() {
-        safeCatching {
-            Logger.d { "FirmwareReleaseRepository: seeding cache from bundled JSON" }
-            val jsonReleases = jsonDataSource.loadFirmwareReleaseFromJsonAsset()
-            localDataSource.insertFirmwareReleases(jsonReleases.releases.stable, FirmwareReleaseType.STABLE)
-            localDataSource.insertFirmwareReleases(jsonReleases.releases.alpha, FirmwareReleaseType.ALPHA)
+    private suspend fun ensureSeeded() {
+        if (!localDataSource.hasAnyEntries()) {
+            safeCatching {
+                Logger.d { "FirmwareReleaseRepository: seeding cache from bundled JSON" }
+                val jsonReleases = jsonDataSource.loadFirmwareReleaseFromJsonAsset()
+                localDataSource.insertFirmwareReleases(jsonReleases.releases.stable, FirmwareReleaseType.STABLE)
+                localDataSource.insertFirmwareReleases(jsonReleases.releases.alpha, FirmwareReleaseType.ALPHA)
+            }
+                .onFailure { e -> Logger.w(e) { "FirmwareReleaseRepository: failed to seed cache from bundled JSON" } }
         }
-            .onFailure { e -> Logger.w(e) { "FirmwareReleaseRepository: failed to seed cache from bundled JSON" } }
+    }
+
+    private suspend fun singleFlightRefresh() {
+        refreshMutex.withLock {
+            Logger.d { "FirmwareReleaseRepository: fetching from remote API" }
+            val networkReleases = remoteDataSource.getFirmwareReleases()
+            localDataSource.insertFirmwareReleases(networkReleases.releases.stable, FirmwareReleaseType.STABLE)
+            localDataSource.insertFirmwareReleases(networkReleases.releases.alpha, FirmwareReleaseType.ALPHA)
+        }
     }
 
     private fun FirmwareReleaseEntity.isStale(): Boolean = (nowMillis - this.lastUpdated) > CACHE_EXPIRATION_TIME_MS

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/util/StaleWhileRevalidateFlow.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/util/StaleWhileRevalidateFlow.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.data.util
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withTimeoutOrNull
+import org.meshtastic.core.common.util.safeCatching
+import kotlin.coroutines.CoroutineContext
+
+private const val DEFAULT_NETWORK_TIMEOUT_MS = 5_000L
+
+/**
+ * Creates a cold Flow that implements the stale-while-revalidate caching pattern:
+ * 1. Load and emit cached data immediately (UI never waits for network).
+ * 2. If [shouldFetch] returns true, attempt a network refresh bounded by [networkTimeoutMs].
+ * 3. Reload from cache and emit again if the data changed.
+ *
+ * The [fetch] lambda is expected to write results to the local cache as a side-effect; [loadFromCache] is called again
+ * after fetch to pick up the fresh data.
+ *
+ * All work runs on [context] (typically an IO dispatcher).
+ *
+ * @param T The domain model type emitted to collectors.
+ * @param loadFromCache Loads the current best-available data from local storage.
+ * @param shouldFetch Decides whether a network refresh is needed based on the cached value (suspendable).
+ * @param fetch Performs the network call and persists results locally (side-effect only).
+ * @param context The coroutine context for cache/network operations.
+ * @param networkTimeoutMs Maximum time to wait for [fetch] before falling back to cached data.
+ * @param tag Logging tag for diagnostics.
+ */
+internal fun <T : Any> staleWhileRevalidateFlow(
+    loadFromCache: suspend () -> T?,
+    shouldFetch: suspend (T?) -> Boolean,
+    fetch: suspend () -> Unit,
+    context: CoroutineContext,
+    networkTimeoutMs: Long = DEFAULT_NETWORK_TIMEOUT_MS,
+    tag: String = "StaleWhileRevalidate",
+): Flow<T?> = flow {
+    val cached = loadFromCache()
+    emit(cached)
+
+    if (!shouldFetch(cached)) return@flow
+
+    val completed =
+        withTimeoutOrNull(networkTimeoutMs) {
+            safeCatching { fetch() }.onFailure { e -> Logger.w(e) { "$tag: network fetch failed" } }
+        }
+    if (completed == null) {
+        Logger.w { "$tag: network fetch timed out after ${networkTimeoutMs}ms" }
+    }
+
+    val fresh = loadFromCache()
+    if (fresh != cached) {
+        emit(fresh)
+    }
+}
+    .flowOn(context)

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/IsOtaCapableUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/IsOtaCapableUseCase.kt
@@ -16,11 +16,12 @@
  */
 package org.meshtastic.core.domain.usecase.settings
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import org.koin.core.annotation.Single
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.RadioController
@@ -37,6 +38,7 @@ interface IsOtaCapableUseCase {
     operator fun invoke(): Flow<Boolean>
 }
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Single
 class IsOtaCapableUseCaseImpl(
     private val nodeRepository: NodeRepository,
@@ -52,17 +54,13 @@ class IsOtaCapableUseCaseImpl(
                 if (node == null || connectionState != ConnectionState.Connected) {
                     flowOf(false)
                 } else if (radioPrefs.isBle() || radioPrefs.isSerial() || radioPrefs.isTcp()) {
-                    flow {
-                        val hwModel = node.user.hw_model
-                        val hw = deviceHardwareRepository.getDeviceHardwareByModel(hwModel.value).getOrNull()
-                        // If we have hardware info, check if it's an architecture known to support OTA/DFU
-                        val isOtaCapable =
-                            hw?.let {
-                                it.isEsp32Arc ||
-                                    it.architecture.contains("nrf", ignoreCase = true) ||
-                                    it.requiresDfu == true
-                            } ?: (hwModel != HardwareModel.UNSET)
-                        emit(isOtaCapable)
+                    val hwModel = node.user.hw_model
+                    deviceHardwareRepository.observeDeviceHardware(hwModel.value).map { hw ->
+                        hw?.let {
+                            it.isEsp32Arc ||
+                                it.architecture.contains("nrf", ignoreCase = true) ||
+                                it.requiresDfu == true
+                        } ?: (hwModel != HardwareModel.UNSET)
                     }
                 } else {
                     flowOf(false)

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/IsOtaCapableUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/IsOtaCapableUseCaseTest.kt
@@ -19,10 +19,10 @@ package org.meshtastic.core.domain.usecase.settings
 import app.cash.turbine.test
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
-import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.model.Node
@@ -77,7 +77,7 @@ class IsOtaCapableUseCaseTest {
                 hwModel = HardwareModel.TBEAM.value,
                 requiresDfu = false,
             )
-        everySuspend { deviceHardwareRepository.getDeviceHardwareByModel(any()) } returns Result.success(hw)
+        dev.mokkery.every { deviceHardwareRepository.observeDeviceHardware(any(), any()) } returns flowOf(hw)
 
         useCase().test {
             assertTrue(awaitItem())
@@ -95,7 +95,7 @@ class IsOtaCapableUseCaseTest {
         dev.mokkery.every { radioPrefs.devAddr } returns MutableStateFlow("x12345678") // x for BLE
 
         val hw = DeviceHardware(activelySupported = false, hwModel = HardwareModel.TBEAM.value)
-        everySuspend { deviceHardwareRepository.getDeviceHardwareByModel(any()) } returns Result.success(hw)
+        dev.mokkery.every { deviceHardwareRepository.observeDeviceHardware(any(), any()) } returns flowOf(hw)
 
         useCase().test {
             assertFalse(awaitItem())
@@ -119,7 +119,7 @@ class IsOtaCapableUseCaseTest {
                 hwModel = HardwareModel.TBEAM.value,
                 requiresDfu = true,
             )
-        everySuspend { deviceHardwareRepository.getDeviceHardwareByModel(any()) } returns Result.success(hw)
+        dev.mokkery.every { deviceHardwareRepository.observeDeviceHardware(any(), any()) } returns flowOf(hw)
 
         useCase().test {
             assertTrue(awaitItem())
@@ -136,7 +136,7 @@ class IsOtaCapableUseCaseTest {
             MutableStateFlow(org.meshtastic.core.model.ConnectionState.Connected)
         dev.mokkery.every { radioPrefs.devAddr } returns MutableStateFlow("x12345678") // x for BLE
 
-        everySuspend { deviceHardwareRepository.getDeviceHardwareByModel(any()) } returns Result.failure(Exception())
+        dev.mokkery.every { deviceHardwareRepository.observeDeviceHardware(any(), any()) } returns flowOf(null)
 
         useCase().test {
             assertFalse(awaitItem())

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/DeviceHardwareRepository.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/DeviceHardwareRepository.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.repository
 
+import kotlinx.coroutines.flow.Flow
 import org.meshtastic.core.model.DeviceHardware
 
 interface DeviceHardwareRepository {
@@ -32,4 +33,15 @@ interface DeviceHardwareRepository {
         target: String? = null,
         forceRefresh: Boolean = false,
     ): Result<DeviceHardware?>
+
+    /**
+     * Observes device hardware information as a non-blocking [Flow].
+     *
+     * Emits cached/bundled data immediately and refreshes from the network in the background if stale. Suitable for use
+     * inside Flow `combine` transforms where suspending would block the UI.
+     *
+     * @param hwModel The hardware model identifier.
+     * @param target Optional PlatformIO target environment name to disambiguate multiple variants.
+     */
+    fun observeDeviceHardware(hwModel: Int, target: String? = null): Flow<DeviceHardware?>
 }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDeviceHardwareRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDeviceHardwareRepository.kt
@@ -16,6 +16,8 @@
  */
 package org.meshtastic.core.testing
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.repository.DeviceHardwareRepository
 
@@ -50,6 +52,11 @@ class FakeDeviceHardwareRepository :
     ): Result<DeviceHardware?> {
         calls.add(Triple(hwModel, target, forceRefresh))
         return hardware[hwModel to target] ?: hardware[hwModel to null] ?: Result.success(null)
+    }
+
+    override fun observeDeviceHardware(hwModel: Int, target: String?): Flow<DeviceHardware?> {
+        val result = hardware[hwModel to target] ?: hardware[hwModel to null] ?: Result.success(null)
+        return flowOf(result.getOrNull())
     }
 
     /** Seeds a successful lookup for the given model/target pair. */

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.entity.FirmwareRelease
+import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
@@ -113,7 +114,18 @@ constructor(
                 IdentityGroup(ourNode, myInfo, profile)
             }
 
-        // 3. Metadata & Request Timestamps
+        // 3. Device Hardware — non-blocking Flow derived from stable (hwModel, pioEnv) key.
+        val hardwareFlow: Flow<DeviceHardware?> =
+            combine(nodeFlow, identityFlow) { node, identity ->
+                val isLocal = node.num == identity.ourNode?.num
+                val pioEnv = if (isLocal) identity.myInfo?.pioEnv else null
+                HardwareKey(node.user.hw_model.value, pioEnv)
+            }
+                .distinctUntilChanged()
+                .flatMapLatest { key -> deviceHardwareRepository.observeDeviceHardware(key.hwModel, key.target) }
+                .onStart { emit(null) }
+
+        // 4. Metadata & Request Timestamps
         val metadataFlow =
             combine(
                 meshLogRepository
@@ -129,7 +141,7 @@ constructor(
                 MetadataGroup(edition = edition, stable = stable, alpha = alpha, trTime = trTime, niTime = niTime)
             }
 
-        // 4. Requests History (we still query request logs by the target nodeId)
+        // 5. Requests History (we still query request logs by the target nodeId)
         val requestsFlow =
             combine(
                 meshLogRepository.getRequestLogs(nodeId, PortNum.TRACEROUTE_APP).onStart { emit(emptyList()) },
@@ -139,17 +151,25 @@ constructor(
             }
 
         // Assemble final UI state
-        return combine(nodeFlow, metricsLogsFlow, identityFlow, metadataFlow, requestsFlow) {
-                node,
-                logs,
-                identity,
-                metadata,
-                requests,
-            ->
+        return combine(
+            nodeFlow,
+            metricsLogsFlow,
+            identityFlow,
+            metadataFlow,
+            requestsFlow,
+            hardwareFlow,
+        ) { args: Array<Any?> ->
+            @Suppress("UNCHECKED_CAST")
+            val node = args[NODE_INDEX] as Node
+            val logs = args[LOGS_INDEX] as LogsGroup
+            val identity = args[IDENTITY_INDEX] as IdentityGroup
+            val metadata = args[METADATA_INDEX] as MetadataGroup
+            val requests = args[REQUESTS_INDEX] as Pair<List<MeshLog>, List<MeshLog>>
+            val hw = args[HARDWARE_INDEX] as DeviceHardware?
+
             val (trReqs, niReqs) = requests
             val isLocal = node.num == identity.ourNode?.num
             val pioEnv = if (isLocal) identity.myInfo?.pioEnv else null
-            val hw = deviceHardwareRepository.getDeviceHardwareByModel(node.user.hw_model.value, pioEnv).getOrNull()
 
             val moduleConfig = identity.profile.module_config
             val displayUnits = identity.profile.config?.display?.units ?: Config.DisplayConfig.DisplayUnits.METRIC
@@ -215,6 +235,8 @@ constructor(
         }
     }
 
+    private data class HardwareKey(val hwModel: Int, val target: String?)
+
     private data class LogsGroup(
         val telemetry: List<Telemetry>,
         val packets: List<MeshPacket>,
@@ -233,4 +255,13 @@ constructor(
         val trTime: Long?,
         val niTime: Long?,
     )
+
+    private companion object {
+        const val NODE_INDEX = 0
+        const val LOGS_INDEX = 1
+        const val IDENTITY_INDEX = 2
+        const val METADATA_INDEX = 3
+        const val REQUESTS_INDEX = 4
+        const val HARDWARE_INDEX = 5
+    }
 }


### PR DESCRIPTION
## Problem

When the Meshtastic device hardware REST API is down or slow, the node details screen hangs with an infinite loading spinner. This was reported by QA testing a t096 (Heltec Mesh Node 096) -- a device whose hardware info IS in the bundled JSON asset but triggers a stale cache refresh on open.

The root cause: `DeviceHardwareRepository.getDeviceHardwareByModel()` is a suspend function called inside a Flow `combine` transform. The Ktor HTTP client has a 30s timeout, so the entire UI pipeline blocks waiting for a network call that will never succeed.

## Approach

Rather than a band-aid timeout, this PR introduces a reusable **stale-while-revalidate** Flow pattern for offline-first repository access:

1. **Always emit cached/bundled data first** -- the UI never waits for the network
2. **Check staleness and refresh in the background** (bounded by a 5s timeout)
3. **Re-emit fresh data** if the refresh succeeds and data actually changed

Key design decisions:
- New `staleWhileRevalidateFlow` utility in `core:data` -- cold Flow, no scope ownership needed
- `Mutex` single-flight guard prevents concurrent collectors from duplicating the full-table API fetch
- `observeDeviceHardware()` Flow method added to `DeviceHardwareRepository` interface for use in combine transforms; existing suspend `getDeviceHardwareByModel()` retained for one-shot callers (firmware update screen)
- `FirmwareReleaseRepositoryImpl` refactored to use the same utility for consistency
- Both repos use injected `CoroutineDispatchers` for testability

## Changes

- **`core/data/.../util/StaleWhileRevalidateFlow.kt`** -- new reusable utility
- **`core/repository/.../DeviceHardwareRepository.kt`** -- added `observeDeviceHardware()` Flow API
- **`core/data/.../DeviceHardwareRepositoryImpl.kt`** -- full rewrite with Mutex, stale-while-revalidate
- **`core/data/.../FirmwareReleaseRepositoryImpl.kt`** -- refactored to same pattern + injected dispatchers
- **`feature/node/.../CommonGetNodeDetailsUseCase.kt`** -- hardware lookup is now a Flow input to combine (not a blocking suspend call inside it)
- **`core/domain/.../IsOtaCapableUseCase.kt`** -- switched to `observeDeviceHardware().map {}`
- **`core/testing/.../FakeDeviceHardwareRepository.kt`** -- added `observeDeviceHardware` stub
- **`core/domain/.../IsOtaCapableUseCaseTest.kt`** -- updated mocks

## Testing

All affected module tests pass: `core:data`, `core:domain`, `core:testing`, `feature:node`, `feature:firmware`. Detekt and spotless clean.