### PR TITLE
fix(ci): exclude kotlinNativeBundleConfiguration from flatpak source generation

### DIFF
--- a/core/ble/build.gradle.kts
+++ b/core/ble/build.gradle.kts
@@ -58,6 +58,7 @@ tasks.flatpakGradleGenerator {
             "androidHostTestCompileClasspath",
             "androidHostTestLintChecksClasspath",
             "androidHostTestRuntimeClasspath",
+            "kotlinNativeBundleConfiguration",
             "testCompileClasspath",
             "testRuntimeClasspath",
         ),

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -49,6 +49,7 @@ tasks.flatpakGradleGenerator {
             "androidHostTestCompileClasspath",
             "androidHostTestLintChecksClasspath",
             "androidHostTestRuntimeClasspath",
+            "kotlinNativeBundleConfiguration",
             "testCompileClasspath",
             "testRuntimeClasspath",
         ),

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -93,6 +93,7 @@ tasks.flatpakGradleGenerator {
             "androidDeviceTestLintChecksClasspath",
             "androidDeviceTestCompileClasspath",
             "androidCompileClasspath",
+            "kotlinNativeBundleConfiguration",
             "testCompileClasspath",
             "testRuntimeClasspath",
         ),

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -85,6 +85,7 @@ tasks.flatpakGradleGenerator {
             "androidDeviceTestLintChecksClasspath",
             "androidDeviceTestCompileClasspath",
             "androidCompileClasspath",
+            "kotlinNativeBundleConfiguration",
             "testCompileClasspath",
             "testRuntimeClasspath",
         ),

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -50,6 +50,7 @@ tasks.flatpakGradleGenerator {
             "androidDeviceTestLintChecksClasspath",
             "androidDeviceTestCompileClasspath",
             "androidCompileClasspath",
+            "kotlinNativeBundleConfiguration",
             "testCompileClasspath",
             "testRuntimeClasspath",
         ),

--- a/core/proto/build.gradle.kts
+++ b/core/proto/build.gradle.kts
@@ -137,5 +137,11 @@ publishing {
 tasks.flatpakGradleGenerator {
     outputFile = file("../../flatpak-sources-core-proto.json")
     downloadDirectory.set("./offline-repository")
-    excludeConfigurations.set(listOf("testCompileClasspath", "testRuntimeClasspath"))
+    excludeConfigurations.set(
+        listOf(
+            "kotlinNativeBundleConfiguration",
+            "testCompileClasspath",
+            "testRuntimeClasspath",
+        ),
+    )
 }

--- a/feature/messaging/build.gradle.kts
+++ b/feature/messaging/build.gradle.kts
@@ -80,6 +80,7 @@ tasks.flatpakGradleGenerator {
             "androidHostTestCompileClasspath",
             "androidHostTestLintChecksClasspath",
             "androidHostTestRuntimeClasspath",
+            "kotlinNativeBundleConfiguration",
             "testCompileClasspath",
             "testRuntimeClasspath",
         ),


### PR DESCRIPTION
On ARM64 Linux runners, the `kotlinNativeBundleConfiguration` tries to resolve `kotlin-native-prebuilt-2.3.21-linux-aarch64.tar.gz` which JetBrains has never published, causing the flatpak source generation to fail.

## Fix

Add `"kotlinNativeBundleConfiguration"` to the `excludeConfigurations` list in all 7 KMP modules that have `flatpakGradleGenerator` tasks:

- `core/database`
- `core/ble`
- `core/navigation`
- `core/common`
- `core/model`
- `core/proto`
- `feature/messaging`

This configuration provides the Kotlin/Native compiler distribution for native target compilation -- it is a build-tool artifact, not a runtime dependency needed for Flatpak offline desktop builds. The `desktopApp`, root project, and `build-logic/convention` modules are unaffected (they use `kotlin.jvm`, not KMP).