### PR TITLE
feat(flatpak): reconstruct standard maven filenames from local Gradle cache

### DIFF
--- a/gradle/flatpak.gradle.kts
+++ b/gradle/flatpak.gradle.kts
@@ -48,7 +48,16 @@ abstract class GenerateFlatpakSourcesTask : DefaultTask() {
                             val version = parts[2]
 
                             val groupPath = group.replace('.', '/')
-                            val mavenPath = "$groupPath/$name/$version/$filename"
+
+                            // Reconstruct correct Maven filename if Gradle cache renamed it locally (e.g. animation.aar -> animation-android-1.10.0.aar)
+                            val standardPrefix = "$name-$version"
+                            val serverFilename = if (filename.startsWith(standardPrefix)) {
+                                filename
+                            } else {
+                                "$name-$version.$ext"
+                            }
+
+                            val mavenPath = "$groupPath/$name/$version/$serverFilename"
                             val dest = "offline-repository/$groupPath/$name/$version"
 
                             val sha256 = calculateSha256(file)
@@ -67,7 +76,7 @@ abstract class GenerateFlatpakSourcesTask : DefaultTask() {
                                     "url" to primaryUrl,
                                     "sha256" to sha256,
                                     "dest" to dest,
-                                    "dest-filename" to filename,
+                                    "dest-filename" to serverFilename,
                                     "mirror-urls" to mirrorUrls
                                 )
                             )


### PR DESCRIPTION
## Overview

This PR builds on top of the native Flatpak cache scanner (#5533) by introducing standard Maven filename reconstruction to prevent 404 download errors on non-standard cached files (such as `animation.aar`).

---

## 🛠️ Detailed Changes

### Standard Maven Filename Reconstruction
* **Problem**: When walking the local Gradle cache (`~/.gradle/caches/modules-2/files-2.1`), we occasionally encounter artifacts cached with a simplified filename that doesn't include the standard maven artifact coordinate metadata (for example, `animation.aar` instead of `animation-android-1.10.0.aar`). In the Flathub sandbox build environment, attempting to download directly using the non-standard filename results in a 404 error from public repositories (such as Google Maven or Maven Central) because the remote servers only recognize the fully qualified coordinate-based filename.
* **Solution**: Implemented reconstruction logic in `GenerateFlatpakSourcesTask`:
  - Verifies whether the cached `filename` starts with the standard Maven `$name-$version` pattern.
  - If not, it automatically reconstructs the filename to match standard repository naming conventions (`$name-$version.$ext`).
  - Uses the reconstructed standard filename (`serverFilename`) for both the remote URL path construction and the final `dest-filename` mapping.

---

## 🧪 Verification & Results

### Spotless & Detekt Compliance
All project formatting and static analysis checks pass cleanly without a single lint regression:
```bash
./gradlew spotlessCheck detekt
```
> **Result**: `BUILD SUCCESSFUL` (100% clean passes).
