### PR TITLE
feat(flatpak): restore dynamic only-arches architecture tagging

### DIFF
--- a/gradle/flatpak.gradle.kts
+++ b/gradle/flatpak.gradle.kts
@@ -61,16 +61,26 @@ abstract class GenerateFlatpakSourcesTask : DefaultTask() {
                                 "https://maven.aliyun.com/repository/public/$mavenPath"
                             )
 
-                            entries.add(
-                                mapOf(
-                                    "type" to "file",
-                                    "url" to primaryUrl,
-                                    "sha256" to sha256,
-                                    "dest" to dest,
-                                    "dest-filename" to filename,
-                                    "mirror-urls" to mirrorUrls
-                                )
+                            val pathLower = relativePath.lowercase()
+                            val onlyArches = when {
+                                pathLower.contains("x64") || pathLower.contains("x86_64") || pathLower.contains("amd64") -> listOf("x86_64")
+                                pathLower.contains("arm64") || pathLower.contains("aarch64") -> listOf("aarch64")
+                                else -> null
+                            }
+
+                            val entry = mutableMapOf<String, Any>(
+                                "type" to "file",
+                                "url" to primaryUrl,
+                                "sha256" to sha256,
+                                "dest" to dest,
+                                "dest-filename" to filename,
+                                "mirror-urls" to mirrorUrls
                             )
+                            if (onlyArches != null) {
+                                entry["only-arches"] = onlyArches
+                            }
+
+                            entries.add(entry)
                         }
                     }
                 }


### PR DESCRIPTION
## Overview

This PR builds on top of the native Flatpak cache scanner (#5533) by restoring automated, dynamic detection of architecture-specific binary files (e.g., `linux-x64`, `linux-arm64`). It automatically injects target architectures under the `"only-arches"` metadata attribute for each matching source file.

---

## 🛠️ Detailed Changes

### Path-Based and Filename-Based Heuristics
* **Problem**: When creating a flatpak-sources.json offline repository manifest, some precompiled native libraries/binaries are architecture-specific (e.g. SQLite native drivers or Compose Desktop runner packages). If we do not specify the target architecture, the Flatpak build sandboxes on all architectures will attempt to download them, wasting bandwidth and triggering build/validation failures on incompatible host environments.
* **Solution**: Implemented relative path lowercase scanning in `GenerateFlatpakSourcesTask` to match typical architecture identifiers:
  - Detects `x64`, `x86_64`, `amd64` -> maps to `"only-arches": ["x86_64"]`
  - Detects `arm64`, `aarch64` -> maps to `"only-arches": ["aarch64"]`
* This correctly limits the scope of architecture-specific packages to the exact host systems that require them.

---

## 🧪 Verification & Results

### Spotless & Detekt Compliance
All project formatting and static analysis checks pass cleanly without any regressions:
```bash
./gradlew spotlessCheck detekt
```
> **Result**: `BUILD SUCCESSFUL` (100% clean passes).
