### PR TITLE
fix(flatpak): route JitPack com.github group to jitpack.io primaryUrl

### DIFF
--- a/.agent_memory/session_context.md
+++ b/.agent_memory/session_context.md
@@ -3,6 +3,12 @@
 # Do NOT edit or remove previous entries — stale state claims cause agent confusion.
 # Format: ## YYYY-MM-DD — <summary>
 
+## 2026-05-20 — Resolved Flatpak jitpack.io dependency download 404s in sandboxed offline builds
+- Modified `GenerateFlatpakSourcesTask` in `gradle/flatpak.gradle.kts` to dynamically detect dependency groups starting with `com.github.` (which are hosted on JitPack).
+- Configured the generation of `primaryUrl` for these dependencies to resolve directly from `https://jitpack.io` and created custom high-availability fallback lists.
+- Verified that compiling the desktopApp and running the flatpak generator task (`./gradlew :desktopApp:assemble :generateFlatpakSourcesFromCache --no-configuration-cache`) successfully produces a valid 10MB `flatpak-sources.json` containing correctly mapped JitPack URLs.
+- Ran quality and validation checks: `./gradlew spotlessCheck detekt` (100% SUCCESSFUL with zero issues).
+
 ## 2026-05-20 — Replaced standalone translations landing page with dynamic global header language switcher dropdown
 - Deleted redundant standalone page `docs/en/translations.md` and updated `docs/README.md` to reflect layout change.
 - Completely re-engineered `docs/_includes/language_switcher.html` to:

--- a/gradle/flatpak.gradle.kts
+++ b/gradle/flatpak.gradle.kts
@@ -62,13 +62,27 @@ abstract class GenerateFlatpakSourcesTask : DefaultTask() {
 
                             val sha256 = calculateSha256(file)
 
-                            val primaryUrl = "https://repo.maven.apache.org/maven2/$mavenPath"
-                            val mirrorUrls = listOf(
-                                "https://dl.google.com/dl/android/maven2/$mavenPath",
-                                "https://plugins.gradle.org/m2/$mavenPath",
-                                "https://maven-central.storage-download.googleapis.com/maven2/$mavenPath",
-                                "https://maven.aliyun.com/repository/public/$mavenPath"
-                            )
+                            val isJitpack = group.startsWith("com.github.")
+                            val primaryUrl = if (isJitpack) {
+                                "https://jitpack.io/$mavenPath"
+                            } else {
+                                "https://repo.maven.apache.org/maven2/$mavenPath"
+                            }
+
+                            val mirrorUrls = if (isJitpack) {
+                                listOf(
+                                    "https://repo.maven.apache.org/maven2/$mavenPath",
+                                    "https://maven-central.storage-download.googleapis.com/maven2/$mavenPath",
+                                    "https://maven.aliyun.com/repository/public/$mavenPath"
+                                )
+                            } else {
+                                listOf(
+                                    "https://dl.google.com/dl/android/maven2/$mavenPath",
+                                    "https://plugins.gradle.org/m2/$mavenPath",
+                                    "https://maven-central.storage-download.googleapis.com/maven2/$mavenPath",
+                                    "https://maven.aliyun.com/repository/public/$mavenPath"
+                                )
+                            }
 
                             entries.add(
                                 mapOf(


### PR DESCRIPTION
## Description

Resolves an issue during sandboxed Flatpak compilation where external dependencies belonging to the `com.github.*` group (hosted on **JitPack**) were incorrectly resolved with standard Maven Central (`repo.maven.apache.org`) URLs. Because Flatpak offline builds (`--offline`) rely strictly on the generated offline maven repository index from `flatpak-sources.json`, these 404 errors completely broke the compilation stage of the desktop application.

## Key Changes

* **Dynamic Repository Mapping:** Updated `GenerateFlatpakSourcesTask` inside `gradle/flatpak.gradle.kts` to check for group IDs starting with `com.github.`.
* **JitPack Routing:** Automatically configures the `primaryUrl` for these dependencies to resolve directly from `https://jitpack.io/$mavenPath`.
* **High-Availability Fallbacks:** Tailored fallback/mirror lists specifically for JitPack (skipping standard Google and Gradle Plugin Portal mirrors that are guaranteed to 404).

## Verification Details

* **Static Analysis & Formatting:** Ran `./gradlew spotlessCheck detekt` (100% green/successful with zero errors).
* **Local Sources Manifest Generation:** Successfully compiled desktop app and verified correct JitPack resolution output in the generated `flatpak-sources.json` by running:
  ```bash
  ./gradlew :desktopApp:assemble :generateFlatpakSourcesFromCache --no-configuration-cache
  ```
