### PR TITLE
ci: optimize CI pipeline for faster PR feedback

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -24,6 +24,7 @@ jobs:
   check-workflow-status:
     name: Check Workflow Status
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
     permissions: {}
     needs:
       - android-check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,7 @@ jobs:
   check-changes:
     if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     outputs:
       android: ${{ steps.filter.outputs.android }}
     steps:
@@ -54,6 +55,7 @@ jobs:
   verify-check-changes-filter:
     if: github.repository == 'meshtastic/Meshtastic-Android' && !( github.head_ref == 'scheduled-updates' || github.head_ref == 'l10n_main' )
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Verify module roots are represented in check-changes filter
@@ -113,6 +115,7 @@ jobs:
   check-workflow-status:
     name: Check Workflow Status
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
     permissions: {}
     needs: [check-changes, verify-check-changes-filter, validate-and-build]
     if: always()

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -44,17 +44,17 @@ env:
   GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
   GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
   GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
-  # Fallback VERSION_CODE for the lint-check job itself (which computes the real
-  # value from git). Downstream jobs override this with the git-derived value.
+  # Fallback VERSION_CODE for jobs that don't consume the setup output.
   VERSION_CODE: ${{ github.run_number }}
 
 jobs:
-  # ── Lint & Static Analysis ──────────────────────────────────────────
-  lint-check:
-    runs-on: ubuntu-24.04
+  # ── Fast Setup (version code + cache config) ────────────────────────
+  # Lightweight job that unblocks lint, tests, and builds in parallel.
+  setup:
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
-    timeout-minutes: 30
+    timeout-minutes: 5
     outputs:
       cache_read_only: ${{ steps.cache_config.outputs.cache_read_only }}
       version_code: ${{ steps.version_code.outputs.version_code }}
@@ -65,7 +65,7 @@ jobs:
         with:
           fetch-depth: 0
           filter: 'blob:none'
-          submodules: true
+          submodules: false
 
       - name: Determine cache read-only setting
         id: cache_config
@@ -86,27 +86,67 @@ jobs:
           VERSION_CODE=$((COMMIT_COUNT + OFFSET))
           echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
 
+  # ── Lint & Static Analysis ──────────────────────────────────────────
+  lint-check:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    needs: setup
+    env:
+      VERSION_CODE: ${{ needs.setup.outputs.version_code }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: 'blob:none'
+          submodules: true
+
       - name: Gradle Setup
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache_read_only: ${{ steps.cache_config.outputs.cache_read_only }}
+          cache_read_only: ${{ needs.setup.outputs.cache_read_only }}
 
       - name: Lint, Analysis & KMP Smoke Compile
         if: inputs.run_lint == true
-        run: ./gradlew spotlessCheck detekt androidApp:lintFdroidDebug androidApp:lintGoogleDebug core:barcode:lintFdroidDebug core:barcode:lintGoogleDebug core:api:lintDebug kmpSmokeCompile -Pci=true --continue --scan
+        run: ./gradlew spotlessCheck detekt androidApp:lintFdroidDebug androidApp:lintGoogleDebug core:barcode:lintFdroidDebug core:barcode:lintGoogleDebug core:api:lintDebug kmpSmokeCompile -Pci=true --continue
 
       - name: KMP Smoke Compile (lint skipped)
         if: inputs.run_lint == false
-        run: ./gradlew kmpSmokeCompile -Pci=true --continue --scan
+        run: ./gradlew kmpSmokeCompile -Pci=true --continue
+
+  # ── Screenshot Test Validation ──────────────────────────────────────
+  screenshot-check:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 20
+    needs: setup
+    if: inputs.run_lint == true
+    env:
+      VERSION_CODE: ${{ needs.setup.outputs.version_code }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Gradle Setup
+        uses: ./.github/actions/gradle-setup
+        with:
+          gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache_read_only: ${{ needs.setup.outputs.cache_read_only }}
 
       - name: Screenshot Test Validation
-        id: screenshot-validation
-        if: inputs.run_lint == true
-        run: ./gradlew :screenshot-tests:validateDebugScreenshotTest -Pci=true --scan
+        run: ./gradlew :screenshot-tests:validateDebugScreenshotTest -Pci=true
 
       - name: Upload screenshot diff report
-        if: always() && steps.screenshot-validation.outcome == 'failure'
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: screenshot-diff-report
@@ -115,12 +155,13 @@ jobs:
           if-no-files-found: warn
 
   # ── Reproducible Build Verification ─────────────────────────────────
+  # Only runs on main push and merge-queue (not PRs) to keep PR feedback fast.
   rb-check:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 30
-    if: inputs.run_lint == true
+    if: inputs.run_lint == true && (github.event_name == 'push' || github.event_name == 'merge_group')
 
     steps:
       - name: Checkout code
@@ -301,10 +342,10 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 45
-    needs: lint-check
+    needs: setup
     if: inputs.run_unit_tests == true
     env:
-      VERSION_CODE: ${{ needs.lint-check.outputs.version_code }}
+      VERSION_CODE: ${{ needs.setup.outputs.version_code }}
     strategy:
       fail-fast: false
       matrix:
@@ -382,7 +423,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache_read_only: ${{ needs.lint-check.outputs.cache_read_only }}
+          cache_read_only: ${{ needs.setup.outputs.cache_read_only }}
 
       - name: Run Tests & Coverage (${{ matrix.shard.name }})
         run: |
@@ -390,7 +431,7 @@ jobs:
           if [[ "${{ inputs.run_coverage }}" == "true" ]]; then
             kover_tasks="${{ matrix.shard.kover }}"
           fi
-          ./gradlew ${{ matrix.shard.tasks }} $kover_tasks -Pci=true --continue --scan
+          ./gradlew ${{ matrix.shard.tasks }} $kover_tasks -Pci=true --continue
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -429,9 +470,9 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 60
-    needs: lint-check
+    needs: setup
     env:
-      VERSION_CODE: ${{ needs.lint-check.outputs.version_code }}
+      VERSION_CODE: ${{ needs.setup.outputs.version_code }}
 
     steps:
       - name: Checkout code
@@ -444,10 +485,10 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache_read_only: ${{ needs.lint-check.outputs.cache_read_only }}
+          cache_read_only: ${{ needs.setup.outputs.cache_read_only }}
 
       - name: Build Android APKs
-        run: ./gradlew androidApp:assembleFdroidDebug androidApp:assembleGoogleDebug -Pci=true --parallel --configuration-cache --continue --scan
+        run: ./gradlew androidApp:assembleFdroidDebug androidApp:assembleGoogleDebug -Pci=true --parallel --configuration-cache --continue
 
       - name: Upload debug artifact
         if: ${{ inputs.upload_artifacts }}
@@ -473,13 +514,13 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 60
-    needs: lint-check
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-24.04, ubuntu-24.04-arm]
     env:
-      VERSION_CODE: ${{ needs.lint-check.outputs.version_code }}
+      VERSION_CODE: ${{ needs.setup.outputs.version_code }}
 
     steps:
       - name: Checkout code
@@ -492,10 +533,10 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache_read_only: ${{ needs.lint-check.outputs.cache_read_only }}
+          cache_read_only: ${{ needs.setup.outputs.cache_read_only }}
 
       - name: Build Desktop
-        run: ./gradlew :desktopApp:createDistributable -Pci=true --scan
+        run: ./gradlew :desktopApp:createDistributable -Pci=true
 
       - name: Upload Desktop artifact
         if: ${{ inputs.upload_artifacts }}
@@ -513,13 +554,13 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 60
-    needs: lint-check
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     env:
-      VERSION_CODE: ${{ needs.lint-check.outputs.version_code }}
+      VERSION_CODE: ${{ needs.setup.outputs.version_code }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   issues: write
   pull-requests: write
-  actions: write
 
 jobs:
   stale_issues:


### PR DESCRIPTION
## Summary

Restructures the reusable CI workflow to parallelize lint, tests, screenshots, and builds — cutting ~7-8 min from PR wall-clock feedback time.

## Changes

| Change | Impact |
|--------|--------|
| New `setup` job (ARM, ~30s) | Computes version_code + cache_read_only, unblocking all downstream jobs to start in parallel |
| Screenshot validation → own job | Test shards no longer blocked by screenshot diffs |
| RB check → main/MQ only | Saves ~7 min compute per PR (was already parallel, no wall-clock impact) |
| Removed `--scan` from PR Gradle | Less network overhead |
| Added `timeout-minutes` to lightweight jobs | Safety net against hung runners |
| Removed `actions: write` from stale.yml | Least privilege |

## Before (measured from recent PRs)

```
check-changes → lint-check (~8-9m) → test-shards (~7-8m) → status
                                   → android-check (~3m)
                 rb-check (~7m, parallel)
Critical path: ~16 min
```

## After

```
check-changes → setup (~0.5m) → lint-check (~8-9m)
                              → test-shards (~7-8m)
                              → screenshot-check
                              → android-check (~3m)
Critical path: ~8-9 min
```

## Verification

- All YAML validated with Ruby YAML parser
- Job dependency graph verified: no circular deps, all outputs consumed correctly
- `rb-check` gated on `github.event_name == 'push' || github.event_name == 'merge_group'` so it still runs where it matters