### PR TITLE
docs: audit and fix stale references from recent changes

### DIFF
--- a/docs/ar-rSA/user/connections.md
+++ b/docs/ar-rSA/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/ar-rSA/user/connections.md
+++ b/docs/ar-rSA/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/ar-rSA/user/desktop.md
+++ b/docs/ar-rSA/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/ar-rSA/user/desktop.md
+++ b/docs/ar-rSA/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/ar-rSA/user/nodes.md
+++ b/docs/ar-rSA/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Request position
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/ar-rSA/user/settings-module-admin.md
+++ b/docs/ar-rSA/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/ar-rSA/user/settings-radio-user.md
+++ b/docs/ar-rSA/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Private Key           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/be-rBY/user/connections.md
+++ b/docs/be-rBY/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/be-rBY/user/connections.md
+++ b/docs/be-rBY/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Конфигурация
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/be-rBY/user/desktop.md
+++ b/docs/be-rBY/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/be-rBY/user/desktop.md
+++ b/docs/be-rBY/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/be-rBY/user/nodes.md
+++ b/docs/be-rBY/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Request position
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/be-rBY/user/settings-module-admin.md
+++ b/docs/be-rBY/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/be-rBY/user/settings-radio-user.md
+++ b/docs/be-rBY/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Прыватны ключ         | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/bg-rBG/user/connections.md
+++ b/docs/bg-rBG/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/bg-rBG/user/connections.md
+++ b/docs/bg-rBG/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Конфигурация
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/bg-rBG/user/desktop.md
+++ b/docs/bg-rBG/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/bg-rBG/user/desktop.md
+++ b/docs/bg-rBG/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/bg-rBG/user/nodes.md
+++ b/docs/bg-rBG/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Вижте на картата
-  - Поискване на позиция
-  - Mark as favorite
-  - Трасиране на маршрут
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/bg-rBG/user/settings-module-admin.md
+++ b/docs/bg-rBG/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/bg-rBG/user/settings-radio-user.md
+++ b/docs/bg-rBG/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Публичен ключ         | Your node's public key (read-only)                      |
 | Администраторски ключ | Key for remote administration                                              |
 | Частен ключ           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Управляем режим       | Restrict non-admin channel changes                                         |

--- a/docs/ca-rES/user/connections.md
+++ b/docs/ca-rES/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/ca-rES/user/connections.md
+++ b/docs/ca-rES/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/ca-rES/user/desktop.md
+++ b/docs/ca-rES/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/ca-rES/user/desktop.md
+++ b/docs/ca-rES/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/ca-rES/user/nodes.md
+++ b/docs/ca-rES/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Sol·licitar posició
-  - Mark as favorite
-  - Traçar ruta
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/ca-rES/user/settings-module-admin.md
+++ b/docs/ca-rES/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/ca-rES/user/settings-radio-user.md
+++ b/docs/ca-rES/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Private Key           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/cs-rCZ/user/connections.md
+++ b/docs/cs-rCZ/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/cs-rCZ/user/connections.md
+++ b/docs/cs-rCZ/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Nastavení
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/cs-rCZ/user/desktop.md
+++ b/docs/cs-rCZ/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/cs-rCZ/user/desktop.md
+++ b/docs/cs-rCZ/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/cs-rCZ/user/nodes.md
+++ b/docs/cs-rCZ/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Zobrazit na mapě
-  - Vyžádat pozici
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/cs-rCZ/user/settings-module-admin.md
+++ b/docs/cs-rCZ/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/cs-rCZ/user/settings-radio-user.md
+++ b/docs/cs-rCZ/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Veřejný klíč          | Your node's public key (read-only)                      |
 | Administrátorský klíč | Key for remote administration                                              |
 | Soukromý klíč         | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Řízený režim          | Restrict non-admin channel changes                                         |

--- a/docs/de-rDE/user/connections.md
+++ b/docs/de-rDE/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/de-rDE/user/connections.md
+++ b/docs/de-rDE/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Einstellungen
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/de-rDE/user/desktop.md
+++ b/docs/de-rDE/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Einstellungen öffnen        |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/de-rDE/user/desktop.md
+++ b/docs/de-rDE/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/de-rDE/user/nodes.md
+++ b/docs/de-rDE/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Auf der Karte anzeigen
-  - Position anfordern
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/de-rDE/user/settings-module-admin.md
+++ b/docs/de-rDE/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/de-rDE/user/settings-radio-user.md
+++ b/docs/de-rDE/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Öffentlicher Schlüssel                          | Your node's public key (read-only)                      |
 | Administrativer Schlüssel                       | Key for remote administration                                              |
 | Privater Schlüssel                              | Your node's private key (handle securely)               |
-| Administrativer Kanal aktiviert                 | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Fehlersuchprotokolle (Debug) | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled                                  | Enable serial console access (moved from Device Config) |
 | Verwalteter Modus                               | Restrict non-admin channel changes                                         |

--- a/docs/el-rGR/user/connections.md
+++ b/docs/el-rGR/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/el-rGR/user/connections.md
+++ b/docs/el-rGR/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/el-rGR/user/desktop.md
+++ b/docs/el-rGR/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/el-rGR/user/desktop.md
+++ b/docs/el-rGR/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/el-rGR/user/nodes.md
+++ b/docs/el-rGR/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Αίτηση θέσης
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/el-rGR/user/settings-module-admin.md
+++ b/docs/el-rGR/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/el-rGR/user/settings-radio-user.md
+++ b/docs/el-rGR/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Δημόσιο Κλειδί        | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Ιδιωτικό Κλειδί       | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/en/developer/codebase.md
+++ b/docs/en/developer/codebase.md
@@ -2,7 +2,7 @@
 title: Codebase
 parent: Developer Guide
 nav_order: 2
-last_updated: 2026-05-13
+last_updated: 2026-05-20
 aliases:
   - repository-layout
   - project-structure
@@ -56,7 +56,8 @@ Meshtastic-Android/
 │   ├── testing/
 │   └── ui/
 ├── build-logic/            # Convention plugins and build helpers
-│   └── convention/
+│   ├── convention/
+│   └── flatpak/
 ├── docs/                   # Documentation source (markdown)
 │   ├── user/
 │   └── developer/

--- a/docs/en/user/connections.md
+++ b/docs/en/user/connections.md
@@ -99,9 +99,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/en/user/connections.md
+++ b/docs/en/user/connections.md
@@ -2,7 +2,7 @@
 title: Connections
 parent: User Guide
 nav_order: 2
-last_updated: 2026-05-13
+last_updated: 2026-05-20
 description: Connect your phone or desktop to a Meshtastic radio via Bluetooth, USB, or TCP/IP.
 aliases:
   - bluetooth
@@ -22,7 +22,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -77,7 +77,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/en/user/desktop.md
+++ b/docs/en/user/desktop.md
@@ -2,7 +2,7 @@
 title: Desktop App
 parent: User Guide
 nav_order: 14
-last_updated: 2026-05-13
+last_updated: 2026-05-20
 description: Install and use the Meshtastic Desktop app on Linux, macOS, and Windows — connections, feature parity, and keyboard shortcuts.
 aliases:
   - desktop
@@ -88,10 +88,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 |----------|--------|
 | **⌘Q** / **Ctrl+Q** | Quit the application |
 | **⌘,** / **Ctrl+,** | Open Settings |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab |
 | **⌘3** / **Ctrl+3** | Switch to Map tab |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab |
 
 ### Window & System Tray
 

--- a/docs/en/user/desktop.md
+++ b/docs/en/user/desktop.md
@@ -14,11 +14,7 @@ aliases:
 
 # Desktop App
 
-The Meshtastic Desktop application provides the same mesh communication features on Linux, macOS, and Windows.
-
-## Overview
-
-The Desktop app shares its core codebase with the Android app through Kotlin Multiplatform (KMP). Most features work identically across platforms.
+The Meshtastic Desktop application shares its core codebase with Android via Kotlin Multiplatform. Most features work identically on Linux, macOS, and Windows.
 
 ## Installation
 
@@ -45,7 +41,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -60,7 +56,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -2,7 +2,7 @@
 title: Nodes
 parent: User Guide
 nav_order: 4
-last_updated: 2026-05-13
+last_updated: 2026-05-20
 description: Browse, filter, and sort mesh nodes — view details, signal quality, roles, and quick actions.
 aliases:
   - node-list
@@ -84,11 +84,12 @@ Nodes display encryption status icons next to their name:
 From the node list, you can:
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Request position
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/en/user/settings-module-admin.md
+++ b/docs/en/user/settings-module-admin.md
@@ -2,7 +2,7 @@
 title: Settings — Modules & Admin
 parent: User Guide
 nav_order: 8
-last_updated: 2026-05-13
+last_updated: 2026-05-20
 description: Configure optional feature modules (MQTT, telemetry, canned messages, TAK, and more) and perform device administration.
 aliases:
   - modules
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/en/user/settings-radio-user.md
+++ b/docs/en/user/settings-radio-user.md
@@ -2,7 +2,7 @@
 title: Settings — Radio & User
 parent: User Guide
 nav_order: 7
-last_updated: 2026-05-13
+last_updated: 2026-05-20
 description: Configure your radio hardware, LoRa presets, user profile, position sharing, power management, and security.
 aliases:
   - settings
@@ -148,7 +148,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key | Your node's public key (read-only) |
 | Admin Key | Key for remote administration |
 | Private Key | Your node's private key (handle securely) |
-| Admin Channel Enabled | Allow admin commands via channel |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log | Output live debug logging over serial/bluetooth | 
 | Serial Enabled | Enable serial console access (moved from Device Config) |
 | Managed Mode | Restrict non-admin channel changes |

--- a/docs/en/user/settings-radio-user.md
+++ b/docs/en/user/settings-radio-user.md
@@ -148,7 +148,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key | Your node's public key (read-only) |
 | Admin Key | Key for remote administration |
 | Private Key | Your node's private key (handle securely) |
-| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
+| ~~Admin Channel Enabled~~ | ⚠️ Removed — now configured automatically when an admin key is set |
 | Debug Log | Output live debug logging over serial/bluetooth | 
 | Serial Enabled | Enable serial console access (moved from Device Config) |
 | Managed Mode | Restrict non-admin channel changes |

--- a/docs/es-rES/user/connections.md
+++ b/docs/es-rES/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuración
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/es-rES/user/connections.md
+++ b/docs/es-rES/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/es-rES/user/desktop.md
+++ b/docs/es-rES/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/es-rES/user/desktop.md
+++ b/docs/es-rES/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/es-rES/user/nodes.md
+++ b/docs/es-rES/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Ver en el mapa
-  - Solicitar posición
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/es-rES/user/settings-module-admin.md
+++ b/docs/es-rES/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/es-rES/user/settings-radio-user.md
+++ b/docs/es-rES/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Clave Pública                     | Your node's public key (read-only)                      |
 | Contraseña de administrador       | Key for remote administration                                              |
 | Clave privada                     | Your node's private key (handle securely)               |
-| Admin Channel Enabled             | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log                         | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled                    | Enable serial console access (moved from Device Config) |
 | Modo "ya terminado de configurar" | Restrict non-admin channel changes                                         |

--- a/docs/et-rEE/user/connections.md
+++ b/docs/et-rEE/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Sätted
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/et-rEE/user/connections.md
+++ b/docs/et-rEE/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/et-rEE/user/desktop.md
+++ b/docs/et-rEE/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/et-rEE/user/desktop.md
+++ b/docs/et-rEE/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/et-rEE/user/nodes.md
+++ b/docs/et-rEE/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Vaata kaardil
-  - Küsi asukohta
-  - Mark as favorite
-  - Marsruudi
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/et-rEE/user/settings-module-admin.md
+++ b/docs/et-rEE/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/et-rEE/user/settings-radio-user.md
+++ b/docs/et-rEE/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Avalik võti           | Your node's public key (read-only)                      |
 | Administraatori võti  | Key for remote administration                                              |
 | Salajane võti         | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Hallatud režiim       | Restrict non-admin channel changes                                         |

--- a/docs/fi-rFI/user/connections.md
+++ b/docs/fi-rFI/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Asetukset
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/fi-rFI/user/connections.md
+++ b/docs/fi-rFI/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/fi-rFI/user/desktop.md
+++ b/docs/fi-rFI/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/fi-rFI/user/desktop.md
+++ b/docs/fi-rFI/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/fi-rFI/user/nodes.md
+++ b/docs/fi-rFI/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Näytä kartalla
-  - Pyydä sijaintia
-  - Mark as favorite
-  - Reitinselvitys
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/fi-rFI/user/settings-module-admin.md
+++ b/docs/fi-rFI/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/fi-rFI/user/settings-radio-user.md
+++ b/docs/fi-rFI/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Julkinen avain        | Your node's public key (read-only)                      |
 | Ylläpitäjän avain     | Key for remote administration                                              |
 | Yksityinen avain      | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Hallintatila          | Restrict non-admin channel changes                                         |

--- a/docs/fr-rFR/user/connections.md
+++ b/docs/fr-rFR/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/fr-rFR/user/connections.md
+++ b/docs/fr-rFR/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/fr-rFR/user/desktop.md
+++ b/docs/fr-rFR/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/fr-rFR/user/desktop.md
+++ b/docs/fr-rFR/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/fr-rFR/user/nodes.md
+++ b/docs/fr-rFR/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Afficher sur la carte
-  - Demander la position
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/fr-rFR/user/settings-module-admin.md
+++ b/docs/fr-rFR/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/fr-rFR/user/settings-radio-user.md
+++ b/docs/fr-rFR/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Clé publique          | Your node's public key (read-only)                      |
 | Clé Admin             | Key for remote administration                                              |
 | Clé privée            | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Mode géré             | Restrict non-admin channel changes                                         |

--- a/docs/ga-rIE/user/connections.md
+++ b/docs/ga-rIE/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/ga-rIE/user/connections.md
+++ b/docs/ga-rIE/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/ga-rIE/user/desktop.md
+++ b/docs/ga-rIE/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/ga-rIE/user/desktop.md
+++ b/docs/ga-rIE/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/ga-rIE/user/nodes.md
+++ b/docs/ga-rIE/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Iarr an suíomh
-  - Mark as favorite
-  - Céim rianadóireachta
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/ga-rIE/user/settings-module-admin.md
+++ b/docs/ga-rIE/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/ga-rIE/user/settings-radio-user.md
+++ b/docs/ga-rIE/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Private Key           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/gl-rES/user/connections.md
+++ b/docs/gl-rES/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/gl-rES/user/connections.md
+++ b/docs/gl-rES/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/gl-rES/user/desktop.md
+++ b/docs/gl-rES/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/gl-rES/user/desktop.md
+++ b/docs/gl-rES/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/gl-rES/user/nodes.md
+++ b/docs/gl-rES/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Solicitar posición
-  - Mark as favorite
-  - Traza-ruta
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/gl-rES/user/settings-module-admin.md
+++ b/docs/gl-rES/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/gl-rES/user/settings-radio-user.md
+++ b/docs/gl-rES/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Private Key           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/hr-rHR/user/connections.md
+++ b/docs/hr-rHR/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/hr-rHR/user/connections.md
+++ b/docs/hr-rHR/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/hr-rHR/user/desktop.md
+++ b/docs/hr-rHR/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/hr-rHR/user/desktop.md
+++ b/docs/hr-rHR/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/hr-rHR/user/nodes.md
+++ b/docs/hr-rHR/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Zatraži poziciju
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/hr-rHR/user/settings-module-admin.md
+++ b/docs/hr-rHR/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/hr-rHR/user/settings-radio-user.md
+++ b/docs/hr-rHR/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Private Key           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/ht-rHT/user/connections.md
+++ b/docs/ht-rHT/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/ht-rHT/user/connections.md
+++ b/docs/ht-rHT/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/ht-rHT/user/desktop.md
+++ b/docs/ht-rHT/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/ht-rHT/user/desktop.md
+++ b/docs/ht-rHT/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/ht-rHT/user/nodes.md
+++ b/docs/ht-rHT/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Mande pozisyon
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/ht-rHT/user/settings-module-admin.md
+++ b/docs/ht-rHT/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/ht-rHT/user/settings-radio-user.md
+++ b/docs/ht-rHT/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Private Key           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/hu-rHU/user/connections.md
+++ b/docs/hu-rHU/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/hu-rHU/user/connections.md
+++ b/docs/hu-rHU/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/hu-rHU/user/desktop.md
+++ b/docs/hu-rHU/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/hu-rHU/user/desktop.md
+++ b/docs/hu-rHU/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/hu-rHU/user/nodes.md
+++ b/docs/hu-rHU/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Megtekintés térképen
-  - Pozíció kérése
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/hu-rHU/user/settings-module-admin.md
+++ b/docs/hu-rHU/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/hu-rHU/user/settings-radio-user.md
+++ b/docs/hu-rHU/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Nyilvános kulcs       | Your node's public key (read-only)                      |
 | Admin kulcs           | Key for remote administration                                              |
 | Privát kulcs          | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Felügyelt mód         | Restrict non-admin channel changes                                         |

--- a/docs/is-rIS/user/connections.md
+++ b/docs/is-rIS/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/is-rIS/user/connections.md
+++ b/docs/is-rIS/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/is-rIS/user/desktop.md
+++ b/docs/is-rIS/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/is-rIS/user/desktop.md
+++ b/docs/is-rIS/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/is-rIS/user/nodes.md
+++ b/docs/is-rIS/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Óska eftir staðsetningu
-  - Mark as favorite
-  - Ferilkönnun
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/is-rIS/user/settings-module-admin.md
+++ b/docs/is-rIS/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/is-rIS/user/settings-radio-user.md
+++ b/docs/is-rIS/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Private Key           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/it-rIT/user/connections.md
+++ b/docs/it-rIT/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/it-rIT/user/connections.md
+++ b/docs/it-rIT/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configurazione
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/it-rIT/user/desktop.md
+++ b/docs/it-rIT/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/it-rIT/user/desktop.md
+++ b/docs/it-rIT/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/it-rIT/user/nodes.md
+++ b/docs/it-rIT/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Visualizza sulla mappa
-  - Richiedi posizione
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/it-rIT/user/settings-module-admin.md
+++ b/docs/it-rIT/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/it-rIT/user/settings-radio-user.md
+++ b/docs/it-rIT/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Chiave Pubblica                 | Your node's public key (read-only)                      |
 | Chiave Amministratore           | Key for remote administration                                              |
 | Chiave Privata                  | Your node's private key (handle securely)               |
-| Canale Amministratore Abilitato | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Log di debug                    | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled                  | Enable serial console access (moved from Device Config) |
 | Modalità Gestita                | Restrict non-admin channel changes                                         |

--- a/docs/iw-rIL/user/connections.md
+++ b/docs/iw-rIL/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/iw-rIL/user/connections.md
+++ b/docs/iw-rIL/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/iw-rIL/user/desktop.md
+++ b/docs/iw-rIL/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/iw-rIL/user/desktop.md
+++ b/docs/iw-rIL/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/iw-rIL/user/nodes.md
+++ b/docs/iw-rIL/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - בקש מיקום
-  - Mark as favorite
-  - בדיקת מסלול
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/iw-rIL/user/settings-module-admin.md
+++ b/docs/iw-rIL/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/iw-rIL/user/settings-radio-user.md
+++ b/docs/iw-rIL/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Private Key           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/ja-rJP/user/connections.md
+++ b/docs/ja-rJP/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/ja-rJP/user/connections.md
+++ b/docs/ja-rJP/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### 設定
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/ja-rJP/user/desktop.md
+++ b/docs/ja-rJP/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/ja-rJP/user/desktop.md
+++ b/docs/ja-rJP/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/ja-rJP/user/nodes.md
+++ b/docs/ja-rJP/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - 位置を求める
-  - Mark as favorite
-  - ルート追跡
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/ja-rJP/user/settings-module-admin.md
+++ b/docs/ja-rJP/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/ja-rJP/user/settings-radio-user.md
+++ b/docs/ja-rJP/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | 公開鍵                   | Your node's public key (read-only)                      |
 | 管理者キー                 | Key for remote administration                                              |
 | 秘密鍵                   | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | 管理モード                 | Restrict non-admin channel changes                                         |

--- a/docs/ko-rKR/user/connections.md
+++ b/docs/ko-rKR/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/ko-rKR/user/connections.md
+++ b/docs/ko-rKR/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### 설정
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/ko-rKR/user/desktop.md
+++ b/docs/ko-rKR/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/ko-rKR/user/desktop.md
+++ b/docs/ko-rKR/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/ko-rKR/user/nodes.md
+++ b/docs/ko-rKR/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - 위치 요청
-  - Mark as favorite
-  - 추적 루트
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/ko-rKR/user/settings-module-admin.md
+++ b/docs/ko-rKR/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/ko-rKR/user/settings-radio-user.md
+++ b/docs/ko-rKR/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | 공개 키                  | Your node's public key (read-only)                      |
 | Admin 키               | Key for remote administration                                              |
 | 개인 키                  | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | 관리 모드                 | Restrict non-admin channel changes                                         |

--- a/docs/lt-rLT/user/connections.md
+++ b/docs/lt-rLT/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/lt-rLT/user/connections.md
+++ b/docs/lt-rLT/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/lt-rLT/user/desktop.md
+++ b/docs/lt-rLT/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/lt-rLT/user/desktop.md
+++ b/docs/lt-rLT/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/lt-rLT/user/nodes.md
+++ b/docs/lt-rLT/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Prašyti pozicijos
-  - Mark as favorite
-  - Žinutės kelias
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/lt-rLT/user/settings-module-admin.md
+++ b/docs/lt-rLT/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/lt-rLT/user/settings-radio-user.md
+++ b/docs/lt-rLT/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Viešasis raktas       | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Privatus raktas       | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/nl-rNL/user/connections.md
+++ b/docs/nl-rNL/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/nl-rNL/user/connections.md
+++ b/docs/nl-rNL/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/nl-rNL/user/desktop.md
+++ b/docs/nl-rNL/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/nl-rNL/user/desktop.md
+++ b/docs/nl-rNL/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/nl-rNL/user/nodes.md
+++ b/docs/nl-rNL/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Positie aanvragen
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/nl-rNL/user/settings-module-admin.md
+++ b/docs/nl-rNL/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/nl-rNL/user/settings-radio-user.md
+++ b/docs/nl-rNL/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Publieke sleutel      | Your node's public key (read-only)                      |
 | Admin Sleutel         | Key for remote administration                                              |
 | Privésleutel          | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Beheerde modus        | Restrict non-admin channel changes                                         |

--- a/docs/no-rNO/user/connections.md
+++ b/docs/no-rNO/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/no-rNO/user/connections.md
+++ b/docs/no-rNO/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/no-rNO/user/desktop.md
+++ b/docs/no-rNO/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/no-rNO/user/desktop.md
+++ b/docs/no-rNO/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/no-rNO/user/nodes.md
+++ b/docs/no-rNO/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Forespør posisjon
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/no-rNO/user/settings-module-admin.md
+++ b/docs/no-rNO/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/no-rNO/user/settings-radio-user.md
+++ b/docs/no-rNO/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Offentlig nøkkel      | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Privat nøkkel         | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/pl-rPL/user/connections.md
+++ b/docs/pl-rPL/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Konfiguracja
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/pl-rPL/user/connections.md
+++ b/docs/pl-rPL/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/pl-rPL/user/desktop.md
+++ b/docs/pl-rPL/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/pl-rPL/user/desktop.md
+++ b/docs/pl-rPL/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/pl-rPL/user/nodes.md
+++ b/docs/pl-rPL/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Pokaż na mapie
-  - Poproś o pozycję
-  - Mark as favorite
-  - Pokaż trasę
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/pl-rPL/user/settings-module-admin.md
+++ b/docs/pl-rPL/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/pl-rPL/user/settings-radio-user.md
+++ b/docs/pl-rPL/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Klucz publiczny       | Your node's public key (read-only)                      |
 | Klucz administratora  | Key for remote administration                                              |
 | Klucz prywatny        | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/pt-rBR/user/connections.md
+++ b/docs/pt-rBR/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/pt-rBR/user/connections.md
+++ b/docs/pt-rBR/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/pt-rBR/user/desktop.md
+++ b/docs/pt-rBR/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/pt-rBR/user/desktop.md
+++ b/docs/pt-rBR/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/pt-rBR/user/nodes.md
+++ b/docs/pt-rBR/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Solicitar posição
-  - Mark as favorite
-  - Traçar rota
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/pt-rBR/user/settings-module-admin.md
+++ b/docs/pt-rBR/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/pt-rBR/user/settings-radio-user.md
+++ b/docs/pt-rBR/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Chave Publica          | Your node's public key (read-only)                      |
 | Chave do Administrador | Key for remote administration                                              |
 | Chave Privada          | Your node's private key (handle securely)               |
-| Admin Channel Enabled  | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log              | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled         | Enable serial console access (moved from Device Config) |
 | Modo Administrado      | Restrict non-admin channel changes                                         |

--- a/docs/pt-rPT/user/connections.md
+++ b/docs/pt-rPT/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/pt-rPT/user/connections.md
+++ b/docs/pt-rPT/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuração
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/pt-rPT/user/desktop.md
+++ b/docs/pt-rPT/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/pt-rPT/user/desktop.md
+++ b/docs/pt-rPT/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/pt-rPT/user/nodes.md
+++ b/docs/pt-rPT/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Solicitar posição
-  - Mark as favorite
-  - Traçar rota
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/pt-rPT/user/settings-module-admin.md
+++ b/docs/pt-rPT/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/pt-rPT/user/settings-radio-user.md
+++ b/docs/pt-rPT/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Chave pública          | Your node's public key (read-only)                      |
 | Chave do Administrador | Key for remote administration                                              |
 | Chave privada          | Your node's private key (handle securely)               |
-| Admin Channel Enabled  | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log              | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled         | Enable serial console access (moved from Device Config) |
 | Modo Administrado      | Restrict non-admin channel changes                                         |

--- a/docs/ro-rRO/user/connections.md
+++ b/docs/ro-rRO/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/ro-rRO/user/connections.md
+++ b/docs/ro-rRO/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/ro-rRO/user/desktop.md
+++ b/docs/ro-rRO/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/ro-rRO/user/desktop.md
+++ b/docs/ro-rRO/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/ro-rRO/user/nodes.md
+++ b/docs/ro-rRO/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Vizualizați pe hartă
-  - Solicită poziția
-  - Mark as favorite
-  - Trasare traseu
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/ro-rRO/user/settings-module-admin.md
+++ b/docs/ro-rRO/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/ro-rRO/user/settings-radio-user.md
+++ b/docs/ro-rRO/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Chei publice          | Your node's public key (read-only)                      |
 | Cheie Administrator   | Key for remote administration                                              |
 | Cheia privată         | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Mod Gestionat         | Restrict non-admin channel changes                                         |

--- a/docs/ru-rRU/user/connections.md
+++ b/docs/ru-rRU/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/ru-rRU/user/connections.md
+++ b/docs/ru-rRU/user/connections.md
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Настройки
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/ru-rRU/user/desktop.md
+++ b/docs/ru-rRU/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/ru-rRU/user/desktop.md
+++ b/docs/ru-rRU/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/ru-rRU/user/nodes.md
+++ b/docs/ru-rRU/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Показать на карте
-  - Запросить позицию
-  - Mark as favorite
-  - Трассировка маршрута
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/ru-rRU/user/settings-module-admin.md
+++ b/docs/ru-rRU/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/ru-rRU/user/settings-radio-user.md
+++ b/docs/ru-rRU/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Публичный ключ        | Your node's public key (read-only)                      |
 | Ключ администратора   | Key for remote administration                                              |
 | Приватный ключ        | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Журнал отладки        | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Управляемый режим     | Restrict non-admin channel changes                                         |

--- a/docs/sk-rSK/user/connections.md
+++ b/docs/sk-rSK/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/sk-rSK/user/connections.md
+++ b/docs/sk-rSK/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/sk-rSK/user/desktop.md
+++ b/docs/sk-rSK/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/sk-rSK/user/desktop.md
+++ b/docs/sk-rSK/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/sk-rSK/user/nodes.md
+++ b/docs/sk-rSK/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Požiadať o pozíciu
-  - Mark as favorite
-  - Trasovanie
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/sk-rSK/user/settings-module-admin.md
+++ b/docs/sk-rSK/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/sk-rSK/user/settings-radio-user.md
+++ b/docs/sk-rSK/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Verejný kľúč          | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Súkromný kľúč         | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/sl-rSI/user/connections.md
+++ b/docs/sl-rSI/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/sl-rSI/user/connections.md
+++ b/docs/sl-rSI/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/sl-rSI/user/desktop.md
+++ b/docs/sl-rSI/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/sl-rSI/user/desktop.md
+++ b/docs/sl-rSI/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/sl-rSI/user/nodes.md
+++ b/docs/sl-rSI/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Zahtevaj položaj
-  - Mark as favorite
-  - Pot
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/sl-rSI/user/settings-module-admin.md
+++ b/docs/sl-rSI/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/sl-rSI/user/settings-radio-user.md
+++ b/docs/sl-rSI/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Javni ključ           | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Zasebni ključ         | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/sq-rAL/user/connections.md
+++ b/docs/sq-rAL/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/sq-rAL/user/connections.md
+++ b/docs/sq-rAL/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/sq-rAL/user/desktop.md
+++ b/docs/sq-rAL/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/sq-rAL/user/desktop.md
+++ b/docs/sq-rAL/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/sq-rAL/user/nodes.md
+++ b/docs/sq-rAL/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Kërkoni pozicionin
-  - Mark as favorite
-  - Traceroute
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/sq-rAL/user/settings-module-admin.md
+++ b/docs/sq-rAL/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/sq-rAL/user/settings-radio-user.md
+++ b/docs/sq-rAL/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Public Key            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Private Key           | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/sr-rLatn/user/connections.md
+++ b/docs/sr-rLatn/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/sr-rLatn/user/connections.md
+++ b/docs/sr-rLatn/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/sr-rLatn/user/desktop.md
+++ b/docs/sr-rLatn/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Отвори подешавања           |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/sr-rLatn/user/desktop.md
+++ b/docs/sr-rLatn/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/sr-rLatn/user/nodes.md
+++ b/docs/sr-rLatn/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Захтевај позицију
-  - Mark as favorite
-  - Праћење руте
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/sr-rLatn/user/settings-module-admin.md
+++ b/docs/sr-rLatn/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/sr-rLatn/user/settings-radio-user.md
+++ b/docs/sr-rLatn/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Javni ključ           | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Privatni ključ        | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/srp/user/connections.md
+++ b/docs/srp/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/srp/user/connections.md
+++ b/docs/srp/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/srp/user/desktop.md
+++ b/docs/srp/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Отвори подешавања           |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/srp/user/desktop.md
+++ b/docs/srp/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/srp/user/nodes.md
+++ b/docs/srp/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Захтевај позицију
-  - Mark as favorite
-  - Праћење руте
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/srp/user/settings-module-admin.md
+++ b/docs/srp/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/srp/user/settings-radio-user.md
+++ b/docs/srp/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Јавни кључ            | Your node's public key (read-only)                      |
 | Admin Key             | Key for remote administration                                              |
 | Приватни кључ         | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Managed Mode          | Restrict non-admin channel changes                                         |

--- a/docs/sv-rSE/user/connections.md
+++ b/docs/sv-rSE/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/sv-rSE/user/connections.md
+++ b/docs/sv-rSE/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Konfiguration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/sv-rSE/user/desktop.md
+++ b/docs/sv-rSE/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/sv-rSE/user/desktop.md
+++ b/docs/sv-rSE/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/sv-rSE/user/nodes.md
+++ b/docs/sv-rSE/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Visa på karta
-  - Begär position
-  - Mark as favorite
-  - Traceroute (spåra rutt)
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/sv-rSE/user/settings-module-admin.md
+++ b/docs/sv-rSE/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/sv-rSE/user/settings-radio-user.md
+++ b/docs/sv-rSE/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Publik nyckel         | Your node's public key (read-only)                      |
 | Admin-nyckel          | Key for remote administration                                              |
 | Privat nyckel         | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Hanterat läge         | Restrict non-admin channel changes                                         |

--- a/docs/tr-rTR/user/connections.md
+++ b/docs/tr-rTR/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/tr-rTR/user/connections.md
+++ b/docs/tr-rTR/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Yapılandırma
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/tr-rTR/user/desktop.md
+++ b/docs/tr-rTR/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/tr-rTR/user/desktop.md
+++ b/docs/tr-rTR/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/tr-rTR/user/nodes.md
+++ b/docs/tr-rTR/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - View on map
-  - Konum iste
-  - Mark as favorite
-  - Yol izle
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/tr-rTR/user/settings-module-admin.md
+++ b/docs/tr-rTR/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/tr-rTR/user/settings-radio-user.md
+++ b/docs/tr-rTR/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Genel Anahtar         | Your node's public key (read-only)                      |
 | Yönetici Anahtarı     | Key for remote administration                                              |
 | Özel Anahtar          | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Yönetilen Mod         | Restrict non-admin channel changes                                         |

--- a/docs/uk-rUA/user/connections.md
+++ b/docs/uk-rUA/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/uk-rUA/user/connections.md
+++ b/docs/uk-rUA/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Налаштування
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/uk-rUA/user/desktop.md
+++ b/docs/uk-rUA/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/uk-rUA/user/desktop.md
+++ b/docs/uk-rUA/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/uk-rUA/user/nodes.md
+++ b/docs/uk-rUA/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - Переглянути на мапі
-  - Запит місцезнаходження
-  - Mark as favorite
-  - Маршрут
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/uk-rUA/user/settings-module-admin.md
+++ b/docs/uk-rUA/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/uk-rUA/user/settings-radio-user.md
+++ b/docs/uk-rUA/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | Відкритий ключ        | Your node's public key (read-only)                      |
 | Ключ адміністратора   | Key for remote administration                                              |
 | Приватний ключ        | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | Керований режим       | Restrict non-admin channel changes                                         |

--- a/docs/zh-rCN/user/connections.md
+++ b/docs/zh-rCN/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/zh-rCN/user/connections.md
+++ b/docs/zh-rCN/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### Configuration
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/zh-rCN/user/desktop.md
+++ b/docs/zh-rCN/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | 打开设置                        |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/zh-rCN/user/desktop.md
+++ b/docs/zh-rCN/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/zh-rCN/user/nodes.md
+++ b/docs/zh-rCN/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - 查看地图
-  - 请求位置
-  - Mark as favorite
-  - 追踪器
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/zh-rCN/user/settings-module-admin.md
+++ b/docs/zh-rCN/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/zh-rCN/user/settings-radio-user.md
+++ b/docs/zh-rCN/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | 公钥                    | Your node's public key (read-only)                      |
 | 管理员密钥                 | Key for remote administration                                              |
 | 私钥                    | Your node's private key (handle securely)               |
-| Admin Channel Enabled | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | Debug Log             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled        | Enable serial console access (moved from Device Config) |
 | 管理模式                  | Restrict non-admin channel changes                                         |

--- a/docs/zh-rTW/user/connections.md
+++ b/docs/zh-rTW/user/connections.md
@@ -98,9 +98,9 @@ A successful connection is confirmed with a status indicator:
 
 ## Reconnection Behavior
 
-The app reconnects to the **last selected device** on startup. You can manually switch transports from the connections screen at any time.
+The app reconnects to the **last selected device** on startup. You can switch transports from the Connect screen at any time.
 
-To disconnect from a radio, use the disconnect button on the connections screen:
+To disconnect from a radio, tap the disconnect button on the Connect screen:
 
 ![Disconnect from radio](../../assets/screenshots/connections_disconnect.png)
 

--- a/docs/zh-rTW/user/connections.md
+++ b/docs/zh-rTW/user/connections.md
@@ -21,7 +21,7 @@ Bluetooth Low Energy is the default and most common connection method on Android
 ### Pairing a Device
 
 1. Ensure your Meshtastic radio is powered on and in pairing mode.
-2. Open the app and navigate to **Connections**.
+2. Open the app and navigate to the **Connect** tab.
 3. Tap **Scan for Devices** — nearby Meshtastic radios will appear.
 4. Select your device from the list.
 5. Accept the Bluetooth pairing prompt if shown.
@@ -76,7 +76,7 @@ Some Meshtastic radios support WiFi connectivity, allowing TCP-based connections
 ### 設定
 
 1. Connect your radio to a WiFi network via the radio's web interface or settings.
-2. In the app, go to **Connections → TCP**.
+2. In the app, go to **Connect → TCP**.
 3. Enter the radio's IP address and port (default: 4403).
 4. Tap **Connect**.
 

--- a/docs/zh-rTW/user/desktop.md
+++ b/docs/zh-rTW/user/desktop.md
@@ -87,10 +87,10 @@ The Desktop app uses the same Compose Multiplatform UI with adaptations for larg
 | ------------------- | --------------------------- |
 | **⌘Q** / **Ctrl+Q** | Quit the application        |
 | **⌘,** / **Ctrl+,** | Open Settings               |
-| **⌘1** / **Ctrl+1** | Switch to Conversations tab |
+| **⌘1** / **Ctrl+1** | Switch to Messages tab |
 | **⌘2** / **Ctrl+2** | Switch to Nodes tab         |
 | **⌘3** / **Ctrl+3** | Switch to Map tab           |
-| **⌘4** / **Ctrl+4** | Switch to Connections tab   |
+| **⌘4** / **Ctrl+4** | Switch to Connect tab   |
 
 ### Window & System Tray
 

--- a/docs/zh-rTW/user/desktop.md
+++ b/docs/zh-rTW/user/desktop.md
@@ -44,7 +44,7 @@ The most reliable connection method on Desktop:
 
 1. Connect your Meshtastic radio via USB cable.
 2. The app should detect the serial port automatically.
-3. If not detected, select the correct serial port from the connections menu.
+3. If not detected, select the correct serial port from the Connect menu.
 
 ### TCP/IP
 
@@ -59,7 +59,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 
 1. Ensure your system has a Bluetooth adapter.
 2. The app scans for nearby Meshtastic radios automatically.
-3. Select your device from the connections screen.
+3. Select your device from the Connect screen.
 
 ## Feature Parity
 

--- a/docs/zh-rTW/user/nodes.md
+++ b/docs/zh-rTW/user/nodes.md
@@ -85,11 +85,12 @@ From the node list, you can:
 
 - **Tap** a node to view its detail page
 - **Long-press** for quick actions:
+  - Mark/remove favorite
+  - Mute/unmute notifications
   - Send a direct message
-  - 在地圖上檢視
-  - 要求位置
-  - Mark as favorite
-  - 路由追蹤
+  - Trace route
+  - Ignore/unignore
+  - Remove node
 
 ## Filtering & Sorting
 

--- a/docs/zh-rTW/user/settings-module-admin.md
+++ b/docs/zh-rTW/user/settings-module-admin.md
@@ -234,7 +234,7 @@ View detailed diagnostic information:
 
 - **"No response from target node"** — the target may be out of range, offline, or have a mismatched admin key. Verify the admin key matches on both nodes.
 - **Changes not applying** — some settings require a reboot to take effect. Try the Reboot action after saving.
-- **Can't see remote settings** — ensure your node has the admin key for the target node and that Admin Channel is enabled in Security Config.
+- **Can't see remote settings** — ensure your node has the admin key for the target node. The admin channel is configured automatically when an admin key is set.
 
 ## Related Topics
 

--- a/docs/zh-rTW/user/settings-radio-user.md
+++ b/docs/zh-rTW/user/settings-radio-user.md
@@ -147,7 +147,7 @@ The modem preset controls the fundamental tradeoff between **range** and **data 
 | 公鑰                               | Your node's public key (read-only)                      |
 | 管理金鑰                             | Key for remote administration                                              |
 | 私鑰                               | Your node's private key (handle securely)               |
-| Admin Channel Enabled - 管理員頻道已啟用 | Allow admin commands via channel                                           |
+| ~~Admin Channel Enabled~~ | ⚠️ **Removed** — this toggle has been removed from the UI; admin channel behavior is now handled automatically |
 | 除錯日誌                             | Output live debug logging over serial/bluetooth                            |
 | Serial Enabled                   | Enable serial console access (moved from Device Config) |
 | 管理模式                             | Restrict non-admin channel changes                                         |


### PR DESCRIPTION
Recent commits renamed UI tab labels, reordered the node context menu, and removed the Admin Channel toggle -- but the docs still referenced the old state. This PR brings all 200+ doc files (English source + 39 localized directories) back in sync with the current codebase.

## What changed

- **Tab label renames** -- "Conversations" is now "Messages" and "Connections" is now "Connect" in all keyboard shortcut tables, navigation instructions, and inline references.
- **Node context menu** -- Updated from the old 5-item list (message, view on map, request position, favorite, traceroute) to the canonical 6-item order: favorite, mute, message, trace route, ignore, remove.
- **Admin Channel Enabled toggle removed** -- Marked as removed in the Security Config table and updated the troubleshooting guidance that referenced it.
- **Prose polish** -- Removed a redundant "Overview" section from desktop.md, tightened wording, and made UI terminology consistent ("Connect screen" not "connections screen").
- **Developer docs** -- Added `build-logic/flatpak/` to the repository tree in codebase.md.
- **Dates** -- Updated `last_updated` frontmatter on all modified English source pages.

## Approach

Cross-referenced the git log from the last ~3 days against every English doc page, identified stale references, fixed them, then propagated all fixes to localized docs via scripted replacements and regex-based bulk edits.

## Notes

- Localized docs get English replacement text for the affected lines (these are UI labels and structured content, not prose that was previously translated).
- No code changes; docs-only PR.