### PR TITLE
fix(settings): remote admin always showed local node config

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
 import androidx.navigation3.runtime.EntryProviderScope
@@ -80,7 +79,7 @@ fun getRadioConfigViewModel(backStack: NavBackStack<NavKey>, destNumOverride: In
                 backStack.lastOrNull { it is SettingsRoute.Settings }?.let { (it as SettingsRoute.Settings).destNum }
             }
     return koinViewModel<RadioConfigViewModel>(key = destNum?.toString()) {
-        parametersOf(SavedStateHandle(mapOf("destNum" to destNum)))
+        parametersOf(destNum)
     }
 }
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -16,7 +16,6 @@
  */
 package org.meshtastic.feature.settings.radio
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
@@ -115,7 +114,7 @@ data class RadioConfigState(
 @KoinViewModel
 @Suppress("LongParameterList")
 open class RadioConfigViewModel(
-    @InjectedParam savedStateHandle: SavedStateHandle,
+    @InjectedParam private val destNum: Int?,
     private val radioConfigRepository: RadioConfigRepository,
     private val packetRepository: PacketRepository,
     private val serviceRepository: ServiceRepository,
@@ -183,8 +182,6 @@ open class RadioConfigViewModel(
         probeJob?.cancel()
         _mqttProbeStatus.value = null
     }
-
-    private val destNum: Int? = savedStateHandle.get<Int>("destNum")
 
     private val _destNode = MutableStateFlow<Node?>(null)
     val destNode: StateFlow<Node?>

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
@@ -16,7 +16,6 @@
  */
 package org.meshtastic.feature.settings.radio
 
-import androidx.lifecycle.SavedStateHandle
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -117,7 +116,7 @@ class ProfileRoundTripTest {
 
         viewModel =
             RadioConfigViewModel(
-                savedStateHandle = SavedStateHandle(),
+                destNum = null,
                 radioConfigRepository = radioConfigRepository,
                 packetRepository = packetRepository,
                 serviceRepository = serviceRepository,

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -16,7 +16,6 @@
  */
 package org.meshtastic.feature.settings.radio
 
-import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
@@ -140,7 +139,7 @@ class RadioConfigViewModelTest {
     }
 
     private fun createViewModel() = RadioConfigViewModel(
-        savedStateHandle = SavedStateHandle(),
+        destNum = null,
         radioConfigRepository = radioConfigRepository,
         packetRepository = packetRepository,
         serviceRepository = serviceRepository,
@@ -407,7 +406,7 @@ class RadioConfigViewModelTest {
         nodeRepository.setNodes(listOf(node))
         viewModel =
             RadioConfigViewModel(
-                savedStateHandle = SavedStateHandle(mapOf("destNum" to 456)),
+                destNum = 456,
                 radioConfigRepository = radioConfigRepository,
                 packetRepository = packetRepository,
                 serviceRepository = serviceRepository,


### PR DESCRIPTION
## Summary

Remote admin was broken -- tapping "Remote Admin" on any node navigated to the Settings screen but always displayed the **local** node's configuration instead of the remote target.

## Root Cause

Koin 4.x's Navigation 3 `ViewModelStoreNavEntryDecorator` provides its own empty `SavedStateHandle` via `CreationExtras`, which silently overrode the one passed through `parametersOf(SavedStateHandle(mapOf("destNum" to destNum)))`. The `RadioConfigViewModel` always received `destNum = null` from `savedStateHandle.get<Int>("destNum")`, causing it to treat every session as local.

## Fix

Replace the `SavedStateHandle` indirection with a direct `@InjectedParam private val destNum: Int?` constructor parameter. This passes the destination node number reliably through Koin's DI without relying on `SavedStateHandle` population, which is incompatible with Nav 3's ViewModel scoping.

## Verification

- Confirmed on emulator: `RadioConfigVM: init destNum=1887308340` and `isLocal=false` after the fix (previously `destNum=null`, `isLocal=true`)
- All existing unit tests pass (`:feature:settings:allTests`, `:feature:node:allTests`)
- Full `assembleFdroidDebug` build succeeds