### PR TITLE
ci: disable automatic AI triage workflows

### DIFF
--- a/.github/workflows/models_issue_triage.yml
+++ b/.github/workflows/models_issue_triage.yml
@@ -1,8 +1,7 @@
 name: Issue Triage (Models)
 
 on:
-  issues:
-    types: [opened]
+  workflow_dispatch:
 
 permissions:
   issues: write

--- a/.github/workflows/models_pr_triage.yml
+++ b/.github/workflows/models_pr_triage.yml
@@ -1,8 +1,7 @@
 name: PR Triage (Models)
 
 on:
-  pull_request_target:
-    types: [opened, edited]
+  workflow_dispatch:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/moderate.yml
+++ b/.github/workflows/moderate.yml
@@ -1,11 +1,6 @@
 name: AI Moderator
 on:
-  issues:
-    types: [opened]
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   spam-detection:


### PR DESCRIPTION
## Why
The AI moderation/triage workflows were running automatically on issue and PR activity, which can consume model tokens with limited value for routine events.

## What changed
This PR disables automatic execution for the AI-focused workflows by switching their triggers to `workflow_dispatch`.

- `.github/workflows/moderate.yml`
- `.github/workflows/models_pr_triage.yml`
- `.github/workflows/models_issue_triage.yml`

## Notes
The workflows are still available for manual runs when needed; they no longer run on every new issue/comment/PR event.