### PR TITLE
fix: hide battery indicator when level is 0 (never reported)

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
@@ -254,11 +254,13 @@ private fun NodeBatteryPositionRow(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        MaterialBatteryInfo(
-            level = thatNode.batteryLevel ?: 0,
-            voltage = thatNode.voltage ?: 0f,
-            contentColor = contentColor,
-        )
+        if ((thatNode.batteryLevel ?: 0) > 0) {
+            MaterialBatteryInfo(
+                level = thatNode.batteryLevel ?: 0,
+                voltage = thatNode.voltage ?: 0f,
+                contentColor = contentColor,
+            )
+        }
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
             if (distance != null) {

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItemCompact.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItemCompact.kt
@@ -200,7 +200,7 @@ fun NodeItemCompact(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 NodeChip(node = thatNode)
-                if (showPower && thatNode.batteryLevel != null) {
+                if (showPower && (thatNode.batteryLevel ?: 0) > 0) {
                     MaterialBatteryInfo(
                         level = thatNode.batteryLevel ?: 0,
                         voltage = thatNode.voltage ?: 0f,


### PR DESCRIPTION
Nodes running newer firmware no longer send battery info by default, resulting in a permanent **0%** display in the node list. This hides the battery meter entirely when `batteryLevel` is `0` or `null` — matching the existing a11y description logic that already skipped it.

Affects both **Complete** and **Compact** node list layouts.