### PR TITLE
fix(emoji): enable androidResources for core:ui to package emoji-data.json

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -24,6 +24,10 @@ plugins {
 }
 
 kotlin {
+    // Required for CMP files/ resources (emoji-data.json) to be packaged as Android assets.
+    // Without this, Res.readBytes() throws MissingResourceException at runtime.
+    androidLibrary { androidResources.enable = true }
+
     sourceSets {
         commonMain.dependencies {
             implementation(projects.core.common)

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerDialog.kt
@@ -125,6 +125,7 @@ fun EmojiPickerDialog(
 ) {
     val viewModel: EmojiPickerViewModel = koinViewModel()
     val isLoaded by viewModel.isLoaded.collectAsState()
+    val loadError by viewModel.loadError.collectAsState()
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var debouncedQuery by remember { mutableStateOf("") }
     var selectedCategoryIndex by rememberSaveable { mutableStateOf(0) }
@@ -147,7 +148,15 @@ fun EmojiPickerDialog(
         onDismissRequest = onDismiss,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     ) {
-        if (isLoaded) {
+        if (loadError) {
+            Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
+                Text(
+                    text = "Unable to load emoji",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else if (isLoaded) {
             EmojiPickerContent(
                 searchQuery = searchQuery,
                 debouncedQuery = debouncedQuery,

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerViewModel.kt
@@ -18,9 +18,11 @@ package org.meshtastic.core.ui.emoji
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.MissingResourceException
 import org.koin.core.annotation.KoinViewModel
 import org.meshtastic.core.repository.CustomEmojiPrefs
 
@@ -41,10 +43,21 @@ internal class EmojiPickerViewModel(
     val allEmojis: List<Emoji>
         get() = emojiRepository.all
 
+    private val _loadError = MutableStateFlow(false)
+    val loadError: StateFlow<Boolean> = _loadError
+
     init {
         viewModelScope.launch {
-            emojiRepository.preload()
-            _isLoaded.value = true
+            try {
+                emojiRepository.preload()
+                _isLoaded.value = true
+            } catch (e: MissingResourceException) {
+                Logger.e("EmojiPickerViewModel", e) { "Failed to load emoji data" }
+                _loadError.value = true
+            } catch (e: IllegalStateException) {
+                Logger.e("EmojiPickerViewModel", e) { "Failed to load emoji data" }
+                _loadError.value = true
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Build 2320900 crashes with `MissingResourceException` when opening the emoji picker because `emoji-data.json` is not packaged into the APK's assets.

## Root Cause

The convention plugin (`KotlinAndroid.kt`) defaults all KMP library modules to `androidResources.enable = false`. Without Android resources enabled, Compose Multiplatform `files/` resources -- which rely on AGP's asset pipeline -- are silently excluded from the AAR and never make it into the final APK.

The `core:resources` module works because it explicitly overrides this to `true`. The `core:ui` module (which hosts the emoji picker and its `emoji-data.json`) did not, so `Res.readBytes("files/emoji-data.json")` throws at runtime.

## Changes

- **`core/ui/build.gradle.kts`** -- Enable `androidResources` so CMP file resources flow through the asset pipeline into the APK.
- **`EmojiPickerViewModel`** -- Wrap `preload()` in a try/catch for `MissingResourceException` and `IllegalStateException` so future resource failures degrade gracefully (error state in UI) instead of crashing the app.
- **`EmojiPickerDialog`** -- Render an error placeholder when `loadError` is true.

## Testing

- `./gradlew :core:ui:compileKotlinJvm` -- passes
- `./gradlew :core:ui:allTests` -- passes
- `./gradlew :core:ui:detekt` -- passes
- `./gradlew :core:ui:spotlessCheck` -- passes