### PR TITLE
fix(proto): prune TakTalkMessage and TakTalkRoomData from Wire codegen

### DIFF
--- a/core/proto/build.gradle.kts
+++ b/core/proto/build.gradle.kts
@@ -118,6 +118,8 @@ wire {
     prune("meshtastic.CotHow")
     prune("meshtastic.CotType")
     prune("meshtastic.GeoPointSource")
+    prune("meshtastic.TakTalkMessage")
+    prune("meshtastic.TakTalkRoomData")
 }
 
 // Modern KMP publication uses the project name as the artifactId by default.


### PR DESCRIPTION
The proto submodule update to `9ab4a1d` ("Add TAKTALK message and room data structures to atak.proto") introduced `TakTalkMessage` and `TakTalkRoomData` message types. These are owned by TAKPacket-SDK, which ships the Wire-generated classes in its KMP artifacts. Without pruning them from our Wire codegen, the fdroid release build produces duplicate classes that break the rb-check CI job.

This adds the two missing `prune()` directives in `core/proto/build.gradle.kts`, consistent with how all other TAKPacket-SDK-owned atak.proto types are already handled.