### PR TITLE
docs(governance): add agent behavior and cost efficiency rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,50 @@ KMP modules have different task names than pure-Android modules. Using the wrong
 > See `AGENTS.md` for full rules (verify before push, branch naming, protos, coding conventions).
 > Contextual `.github/instructions/` files enforce conventions scoped to relevant source sets.
 
+## Agent Behavior Rules
+
+### Code quality — do it right the first time
+
+When refactoring or improving code, implement the correct solution fully. Do not defer improvements as "too large", "out of scope", or "a separate refactoring". Research proper APIs and patterns before implementing — take the correct approach, not the simple one.
+
+### Git hygiene — preserve commit history
+
+Always make new commits. Never `--amend`, `rebase -i`, squash, or `--force-with-lease` unless the user explicitly requests it. Commit history is rollback safety — destroying it without permission is unacceptable.
+
+### Workflow scope push limitation
+
+The Copilot CLI OAuth token cannot push changes to `.github/workflows/` files (requires `workflow` scope). If a push fails with a permission/scope error on workflow files, immediately tell the user to push manually (`gh auth refresh -s workflow && git push`). Do not retry or attempt workarounds.
+
+### Parallel agents — no destructive git operations
+
+When dispatching parallel agents on a shared worktree, agents must never run `git reset --hard`, `git clean`, or `git checkout -- .`. Commit work immediately before running any git operations that could affect the index or working tree.
+
+### Audit before applying
+
+When porting, migrating, or applying external code/patterns, audit each change for relevance and correctness in our context. Do not blindly copy — evaluate whether each piece is appropriate and worth keeping.
+
+## Context & Cost Efficiency
+
+### Compact before research phases
+
+When a session shifts from implementation to open-ended research or exploration (e.g., "do deep research on…", "check documentation for…"), proactively compact the session first. Research generates high-volume tool output that inflates context rapidly.
+
+### Split sessions at phase boundaries
+
+Do not keep a single session alive across multiple discrete deliverables. When a phase completes (PR opened, spec finalized, implementation merged), suggest starting a fresh session for the next phase. A compact summary in the new session's first message is far cheaper than carrying forward accumulated checkpoint history.
+
+### Avoid redundant skill-context re-injection
+
+If a skill's context has already been injected in the current session, do not re-inject the full payload on subsequent invocations. Reference the earlier context instead. If compaction occurred since the last injection, a brief summary is sufficient — not the full skill document again.
+
+### Agent-merge check-ins belong in their own session
+
+PR lifecycle check-ins (merge condition checks, CI status polling) should run in a dedicated short-lived session, not in the development session. They only need PR metadata and CI status — not the accumulated dev context.
+
+### Compact by turn 12 in exploratory sessions
+
+Any session that passes ~10-12 turns without compaction should be compacted. Context cost grows with every turn — later turns pay for the full accumulated history of all prior turns. Don't let sessions run 15+ turns uncompacted.
+
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan


### PR DESCRIPTION
## Why

Session history analysis revealed recurring friction patterns where AI agents made preventable mistakes (force-pushing without permission, deferring improvements, retrying blocked pushes) and cost-inefficient behaviors (multi-day sessions without compaction, redundant skill re-injections, 27KB agent-merge payloads bloating dev sessions).

These rules encode the lessons learned so future sessions don't repeat the same mistakes.

## What changed

Adds two new governance sections to `.github/copilot-instructions.md`:

**Agent Behavior Rules** -- addressing patterns that caused user corrections across 5+ sessions:
- No lazy deferral: implement the correct solution, not the quick one
- No unsolicited amend/squash/force-push: commit history is rollback safety
- Workflow scope: fail fast on `.github/workflows/` push failures
- No destructive git in parallel agents: prevents the `git reset --hard` wipe observed in fleet dispatches
- Audit before applying: no cargo-culting external code

**Context & Cost Efficiency** -- addressing token waste patterns observed in the heaviest sessions (54-74 turns, 100-160 hour spans):
- Compact before research phases
- Split sessions at natural phase boundaries
- Avoid redundant skill-context re-injection (observed 3x in single sessions)
- Agent-merge check-ins in dedicated sessions (27KB injections don't belong in dev context)
- Hard ceiling: compact by turn 12 in exploratory sessions