### PR TITLE
fix(ci): pre-install JetBrains JDK 21 for Compose Desktop builds

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -7,6 +7,9 @@ inputs:
   jdk_distribution:
     description: 'JDK distribution (temurin or jetbrains)'
     default: 'temurin'
+  install_jetbrains_jdk:
+    description: 'Also install JetBrains JDK 21 for Compose Desktop toolchain resolution'
+    default: 'false'
   gradle_encryption_key:
     description: 'Encryption key for Gradle remote cache'
     required: false
@@ -25,6 +28,14 @@ runs:
       with:
         java-version: '21'
         distribution: ${{ inputs.jdk_distribution }}
+        token: ${{ github.token }}
+
+    - name: Set up JetBrains JDK 21 (for Compose Desktop)
+      if: inputs.install_jetbrains_jdk == 'true'
+      uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: 'jetbrains'
         token: ${{ github.token }}
 
     - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,7 @@ jobs:
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache_read_only: 'false'
+          install_jetbrains_jdk: 'true'
 
       - name: Install dependencies for AppImage
         if: runner.os == 'Linux'
@@ -369,6 +370,7 @@ jobs:
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache_read_only: 'true'
+          install_jetbrains_jdk: 'true'
 
       # Uses an isolated Gradle user home so every artifact actually traverses the
       # network — the flatpak-sources plugin captures URLs via BuildOperationListener and

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -534,6 +534,7 @@ jobs:
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache_read_only: ${{ needs.setup.outputs.cache_read_only }}
+          install_jetbrains_jdk: 'true'
 
       - name: Build Desktop
         run: ./gradlew :desktopApp:createDistributable -Pci=true
@@ -574,6 +575,7 @@ jobs:
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache_read_only: true
+          install_jetbrains_jdk: 'true'
 
       # Isolated Gradle user home — see explanation in release.yml.
       # packageUberJarForCurrentOS is what the in-flatpak build invokes; it resolves the FULL

--- a/.github/workflows/verify-flatpak.yml
+++ b/.github/workflows/verify-flatpak.yml
@@ -31,6 +31,11 @@ jobs:
           distribution: temurin
           java-version: 21
 
+      - uses: actions/setup-java@v5
+        with:
+          distribution: jetbrains
+          java-version: 21
+
       - uses: gradle/actions/setup-gradle@v6
 
       - name: Generate flatpak-sources.json


### PR DESCRIPTION
## Problem

The release CI run ([#26598182026](https://github.com/meshtastic/Meshtastic-Android/actions/runs/26598182026)) is failing on all aarch64 and macOS runners for desktop and flatpak-source jobs. The root cause is the Foojay Disco API intermittently returning HTTP 400/500 errors when Gradle's toolchain resolver tries to auto-provision JetBrains JDK 21:

```
Cannot find a Java installation on your machine matching:
{languageVersion=21, vendor=JetBrains, implementation=vendor-specific}
Some toolchain resolvers had provisioning failures: foojay
(Received status code 400 from server: Bad Request)
```

The x64 Ubuntu builds happened to succeed (foojay worked for that arch), but macOS-arm64 and Linux-arm64 all failed.

## Fix

Pre-install JetBrains JDK 21 via `actions/setup-java` (which downloads directly from JetBrains, not foojay) so Gradle's toolchain auto-detection finds it locally without hitting the unreliable API.

- Added `install_jetbrains_jdk` input to the `gradle-setup` composite action (defaults to `false` to avoid slowing down Android-only jobs)
- Enabled it for all desktop and flatpak-source jobs across `release.yml`, `reusable-check.yml`, and `verify-flatpak.yml`