### PR TITLE
fix(ci): install JetBrains JDK 21 for lint-check job

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -109,6 +109,7 @@ jobs:
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache_read_only: ${{ needs.setup.outputs.cache_read_only }}
+          install_jetbrains_jdk: 'true'
 
       - name: Lint, Analysis & KMP Smoke Compile
         if: inputs.run_lint == true


### PR DESCRIPTION
The `lint-check` CI job runs `detekt` which includes `:desktopApp:detekt`. The desktop app module's Kotlin toolchain requires JetBrains JDK 21, but the lint-check job was not installing it -- causing toolchain resolution to fail with a 400 error from the foojay provisioning API.

This adds `install_jetbrains_jdk: 'true'` to the gradle-setup step in the lint-check job, matching what the desktop-build and flatpak jobs already do.