### PR TITLE
fix(takserver): emit *:-1:stcp contact endpoint so directed TAK-Talk/GeoChat routes over the mesh

### DIFF
--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKDefaults.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKDefaults.kt
@@ -24,7 +24,13 @@ import org.meshtastic.proto.User
 // a single exported data package (containing truststore.p12 + client.p12) works for
 // both Meshtastic-iOS and Meshtastic-Android without reconfiguration in ATAK/iTAK.
 internal const val DEFAULT_TAK_PORT = 8089
-internal const val DEFAULT_TAK_ENDPOINT = "0.0.0.0:4242:tcp"
+
+// Default contact endpoint for mesh peers (the real endpoint is never carried over
+// LoRa). MUST be the TAK "reply via this server" form `*:-1:stcp`: it makes ATAK route
+// directed GeoChat / TAK-Talk (`<marti>`) back down the Meshtastic server stream. A
+// concrete host (e.g. `0.0.0.0:4242:tcp`) makes ATAK attempt a dead direct connection,
+// so directed messages never reach the mesh while broadcast PLI still works.
+internal const val DEFAULT_TAK_ENDPOINT = "*:-1:stcp"
 
 // Bundled certificate password — matches iOS (`"meshtastic"`). Used for the
 // server.p12 / client.p12 PKCS#12 files shipped under `tak_certs/` on the classpath.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,7 +88,7 @@ kable = "0.43.0"
 mqttastic = "0.3.6"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
-takpacket-sdk = "0.5.0"
+takpacket-sdk = "0.5.1"
 
 # Gradle Plugins
 develocity = "4.4.2"


### PR DESCRIPTION
## Problem
Directed **TAK-Talk** (`<marti>`) and directed **GeoChat** never reach the mesh — only broadcast PLI does. Field captures (CoT Explorer + logcat) show ATAK never hands the directed CoT to the Meshtastic TAK server: every `RAW CoT IN (TCP …)` is a PLI, while a composed TAK-Talk simply never appears.

## Root cause
The reconstructed contact endpoint was `0.0.0.0:4242:tcp` (a dead direct-TCP address), so ATAK treats mesh peers as **directly reachable** and tries to deliver directed messages to that address instead of replying down the Meshtastic server stream. Broadcast PLI is endpoint-agnostic, hence the asymmetry (position works, directed chat/voice doesn't).

## Fix
- Emit the TAK "reply via this server" endpoint **`*:-1:stcp`** (matches real ATAK server-relayed contacts) via `DEFAULT_TAK_ENDPOINT`.
- Bump `takpacket-sdk` to **0.5.1**, which fixes the same default in the SDK's `CotXmlBuilder` across all five bindings. `__serverdestination` keeps the authentic `0.0.0.0:4242:tcp` form.

## Notes
- Verified locally: `:core:takserver:jvmTest` green against SDK 0.5.1 (mavenLocal).
- ⚠️ CI will be red until `org.meshtastic:takpacket-sdk:0.5.1` finishes publishing to Maven Central (SDK release in progress) — it goes green automatically once the artifact is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
