### PR TITLE
fix: remove Android Auto manifest entry causing Play Store rejection

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -125,10 +125,6 @@
             android:name="org.apache.http.legacy"
             android:required="false" />
 
-        <!-- Android Auto: surface MessagingStyle notifications on the car's head unit -->
-        <meta-data
-            android:name="com.google.android.gms.car.application"
-            android:resource="@xml/automotive_app_desc" />
 
         <!-- Default crash collection and analytics off until we (possibly) turn it on in application.onCreate -->
         <meta-data

--- a/androidApp/src/main/res/xml/automotive_app_desc.xml
+++ b/androidApp/src/main/res/xml/automotive_app_desc.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<automotiveApp>
-    <uses name="notification" />
-</automotiveApp>


### PR DESCRIPTION
Google Play rejected the app under the Auto App Quality Guidelines because the manifest declared Android Auto support (`com.google.android.gms.car.application` meta-data + `automotive_app_desc.xml`) without providing any actual Auto functionality.

This removes the manifest entry and the XML descriptor. The Android Auto feature is still cooking in #5633 (draft) and will be re-introduced when it ships a real car UI.

**Changes:**
- Removed `<meta-data android:name="com.google.android.gms.car.application" ...>` from `androidApp/src/main/AndroidManifest.xml`
- Deleted `androidApp/src/main/res/xml/automotive_app_desc.xml`