### PR TITLE
fix(takserver): drop CoT the mesh delivers more than once

### DIFF
--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/CotDeliveryDedup.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/CotDeliveryDedup.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.takserver
+
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+/**
+ * Suppresses duplicate CoT events before they are injected into the local TAK client.
+ *
+ * The mesh can hand the bridge the same logical CoT more than once — a packet relayed over
+ * several LoRa paths, or a sender that retransmits — which makes ATAK show duplicate chat /
+ * TAK-Talk messages. This is a small TTL cache keyed by the exact, already-normalized CoT
+ * XML: an identical event seen within [ttl] is dropped, while genuine updates (a PLI with a
+ * new position, a moved marker, …) differ in content and pass through untouched.
+ *
+ * Scope: this only dedupes what the *bridge* injects. It cannot see copies the TAK client
+ * also receives over another transport (e.g. Wi-Fi network SA); for those the client dedupes
+ * by `uid`, which is why the SDK preserves the original uid/timestamps across the mesh
+ * round-trip so the two copies collapse client-side.
+ *
+ * Not thread-safe by design: it is confined to the single mesh-packet collector coroutine
+ * (`meshPacketFlow.collect { handleMeshPacket(it) }`), which processes packets sequentially.
+ */
+internal class CotDeliveryDedup(
+    private val ttl: Duration = DEFAULT_TTL,
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+    private val now: () -> Instant = Clock.System::now,
+) {
+    // normalized XML -> last-seen time. Insertion-ordered: entries are re-inserted on each
+    // sighting so the iteration order is oldest-first, which makes [evictExpired] cheap.
+    private val seen = LinkedHashMap<String, Instant>()
+
+    /**
+     * @return true if [normalizedXml] should be delivered (it is new, or its previous copy has
+     *   aged past [ttl]); false if it is a duplicate already delivered within [ttl] (drop it).
+     */
+    fun admit(normalizedXml: String): Boolean {
+        val t = now()
+        evictExpired(t)
+        if (seen.containsKey(normalizedXml)) return false // survived eviction => still within ttl
+        seen[normalizedXml] = t
+        while (seen.size > maxEntries) seen.remove(seen.keys.first())
+        return true
+    }
+
+    private fun evictExpired(t: Instant) {
+        val it = seen.entries.iterator()
+        while (it.hasNext()) {
+            // Oldest-first: stop at the first entry still within the window.
+            if (t - it.next().value > ttl) it.remove() else break
+        }
+    }
+
+    companion object {
+        val DEFAULT_TTL: Duration = 2.minutes
+        const val DEFAULT_MAX_ENTRIES: Int = 512
+    }
+}

--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/CotDeliveryDedup.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/CotDeliveryDedup.kt
@@ -24,19 +24,17 @@ import kotlin.time.Instant
 /**
  * Suppresses duplicate CoT events before they are injected into the local TAK client.
  *
- * The mesh can hand the bridge the same logical CoT more than once — a packet relayed over
- * several LoRa paths, or a sender that retransmits — which makes ATAK show duplicate chat /
- * TAK-Talk messages. This is a small TTL cache keyed by the exact, already-normalized CoT
- * XML: an identical event seen within [ttl] is dropped, while genuine updates (a PLI with a
- * new position, a moved marker, …) differ in content and pass through untouched.
+ * The mesh can hand the bridge the same logical CoT more than once — a packet relayed over several LoRa paths, or a
+ * sender that retransmits — which makes ATAK show duplicate chat / TAK-Talk messages. This is a small TTL cache keyed
+ * by the exact, already-normalized CoT XML: an identical event seen within [ttl] is dropped, while genuine updates (a
+ * PLI with a new position, a moved marker, …) differ in content and pass through untouched.
  *
- * Scope: this only dedupes what the *bridge* injects. It cannot see copies the TAK client
- * also receives over another transport (e.g. Wi-Fi network SA); for those the client dedupes
- * by `uid`, which is why the SDK preserves the original uid/timestamps across the mesh
- * round-trip so the two copies collapse client-side.
+ * Scope: this only dedupes what the *bridge* injects. It cannot see copies the TAK client also receives over another
+ * transport (e.g. Wi-Fi network SA); for those the client dedupes by `uid`, which is why the SDK preserves the original
+ * uid/timestamps across the mesh round-trip so the two copies collapse client-side.
  *
- * Not thread-safe by design: it is confined to the single mesh-packet collector coroutine
- * (`meshPacketFlow.collect { handleMeshPacket(it) }`), which processes packets sequentially.
+ * Not thread-safe by design: it is confined to the single mesh-packet collector coroutine (`meshPacketFlow.collect {
+ * handleMeshPacket(it) }`), which processes packets sequentially.
  */
 internal class CotDeliveryDedup(
     private val ttl: Duration = DEFAULT_TTL,
@@ -48,8 +46,8 @@ internal class CotDeliveryDedup(
     private val seen = LinkedHashMap<String, Instant>()
 
     /**
-     * @return true if [normalizedXml] should be delivered (it is new, or its previous copy has
-     *   aged past [ttl]); false if it is a duplicate already delivered within [ttl] (drop it).
+     * @return true if [normalizedXml] should be delivered (it is new, or its previous copy has aged past [ttl]); false
+     *   if it is a duplicate already delivered within [ttl] (drop it).
      */
     fun admit(normalizedXml: String): Boolean {
         val t = now()

--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
@@ -82,6 +82,11 @@ class TAKMeshIntegration(
 
     @Volatile private var currentRole: MemberRole = MemberRole.Unspecifed
 
+    // Drops CoT the bridge has already injected within a short window — guards against the
+    // same mesh message arriving via multiple LoRa relay paths or a retransmit. Touched only
+    // from the single meshPacketFlow collector coroutine (handleMeshPacket), so no locking.
+    private val deliveryDedup = CotDeliveryDedup()
+
     fun start(scope: CoroutineScope) {
         if (!isRunning.compareAndSet(expectedValue = false, newValue = true)) return
 
@@ -335,6 +340,13 @@ class TAKMeshIntegration(
             // and collapse inter-tag whitespace so ATAK's streaming parser sees
             // bare <event>...</event> on a single line. Centralized in the SDK.
             val xml = CotMeshSanitizer.normalizeCotXml(rawXml)
+            // Drop exact duplicates the mesh delivered more than once (multi-path relay or
+            // retransmit) so ATAK doesn't surface doubled chat / TAK-Talk messages. Genuine
+            // updates (new PLI position, moved marker, …) differ in content and pass through.
+            if (!deliveryDedup.admit(xml)) {
+                Logger.d { "Dropped duplicate CoT from mesh (already delivered within dedup window)" }
+                return
+            }
             // Logger.d { "RAW CoT IN (mesh): $xml" }
             // Routes: ATAK ignores b-m-r CoT events over TCP streaming.
             // Convert to a KML data package and write to ATAK's auto-import dir.

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/CotDeliveryDedupTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/CotDeliveryDedupTest.kt
@@ -63,7 +63,7 @@ class CotDeliveryDedupTest {
     }
 
     @Test
-    fun `cache is bounded by maxEntries, evicting oldest`() {
+    fun `cache is bounded by maxEntries and evicts oldest`() {
         val dedup = CotDeliveryDedup(ttl = 60.minutes, maxEntries = 2, now = { clock })
         assertTrue(dedup.admit("a"))
         assertTrue(dedup.admit("b"))

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/CotDeliveryDedupTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/CotDeliveryDedupTest.kt
@@ -28,7 +28,7 @@ class CotDeliveryDedupTest {
     private var clock = Instant.fromEpochSeconds(1_000_000)
 
     @Test
-    fun `first sighting admitted, immediate exact repeat dropped`() {
+    fun `first sighting admitted then immediate exact repeat dropped`() {
         val dedup = CotDeliveryDedup(ttl = 2.minutes, now = { clock })
         val xml = """<event uid="TAKTALK-MESSAGE-abc" type="m-t-t"><detail><text>hi</text></detail></event>"""
         assertTrue(dedup.admit(xml), "first copy delivered")

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/CotDeliveryDedupTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/CotDeliveryDedupTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.takserver
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+class CotDeliveryDedupTest {
+
+    private var clock = Instant.fromEpochSeconds(1_000_000)
+
+    @Test
+    fun `first sighting admitted, immediate exact repeat dropped`() {
+        val dedup = CotDeliveryDedup(ttl = 2.minutes, now = { clock })
+        val xml = """<event uid="TAKTALK-MESSAGE-abc" type="m-t-t"><detail><text>hi</text></detail></event>"""
+        assertTrue(dedup.admit(xml), "first copy delivered")
+        assertFalse(dedup.admit(xml), "identical copy within TTL dropped")
+        assertFalse(dedup.admit(xml), "and again")
+    }
+
+    @Test
+    fun `distinct events are all admitted`() {
+        val dedup = CotDeliveryDedup(now = { clock })
+        assertTrue(dedup.admit("""<event uid="A"/>"""))
+        assertTrue(dedup.admit("""<event uid="B"/>"""))
+    }
+
+    @Test
+    fun `same uid but changed content is not a duplicate`() {
+        // PLIs reuse the device uid every position update — keying on exact XML lets updates through.
+        val dedup = CotDeliveryDedup(now = { clock })
+        assertTrue(dedup.admit("""<event uid="N" type="a-f-G-U-C"><point lat="1.0"/></event>"""))
+        assertTrue(dedup.admit("""<event uid="N" type="a-f-G-U-C"><point lat="2.0"/></event>"""))
+    }
+
+    @Test
+    fun `duplicate is re-admitted once the TTL window elapses`() {
+        val dedup = CotDeliveryDedup(ttl = 2.minutes, now = { clock })
+        val xml = """<event uid="X"/>"""
+        assertTrue(dedup.admit(xml))
+        clock += 60.seconds
+        assertFalse(dedup.admit(xml), "still within the 2-minute window")
+        clock += 90.seconds // 150s since first sighting > 120s TTL
+        assertTrue(dedup.admit(xml), "window expired, delivered again")
+    }
+
+    @Test
+    fun `cache is bounded by maxEntries, evicting oldest`() {
+        val dedup = CotDeliveryDedup(ttl = 60.minutes, maxEntries = 2, now = { clock })
+        assertTrue(dedup.admit("a"))
+        assertTrue(dedup.admit("b"))
+        assertTrue(dedup.admit("c")) // evicts oldest ("a")
+        assertTrue(dedup.admit("a"), "oldest was evicted, so treated as new")
+        assertFalse(dedup.admit("c"), "still cached")
+    }
+}


### PR DESCRIPTION
## Problem
When the same two nodes are reachable by more than one path (e.g. both on Wi-Fi *and* the mesh, or a LoRa message relayed over several hops), ATAK surfaces **duplicate** chat / TAK-Talk messages. CoT's identity model is dedup-by-\`uid\`, but two copies only collapse at the client if they match.

This PR addresses the duplicates the **bridge itself** can emit: the mesh can hand \`handleV2Packet\` the same logical CoT event more than once (multi-path relay, or a sender retransmit).

## Fix
- New \`CotDeliveryDedup\` — a small TTL (2 min) cache keyed by the exact, already-normalized CoT XML, bounded to 512 entries, with an injectable clock.
- \`handleV2Packet\` consults it before injecting to the TAK client: an identical event within the window is dropped; genuine updates (new PLI position, moved marker, …) differ in content and pass through.
- Confined to the single \`meshPacketFlow\` collector coroutine, so no locking.

## Scope (what this does *not* do)
It dedupes only what the **bridge** injects — it can't see copies the TAK client receives over another transport (e.g. Wi-Fi network SA). For those, the client dedupes by \`uid\`, which is why #5661 hands ATAK the \`*:-1:stcp\` contact and the SDK preserves the uid/timestamps across the round-trip so the copies collapse client-side. (\`ensureMinimumStaleForMesh\` already excludes ephemeral \`m-t-t\`/\`b-t-f\` via \`STATIC_COT_PREFIXES\`, so chat/TAK-Talk timestamps are preserved — no change needed there.)

## Tests
5 unit tests (\`CotDeliveryDedupTest\`) with an injected clock: exact-repeat drop, distinct events pass, same-uid-changed-content passes, re-admit after the TTL elapses, and \`maxEntries\` eviction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)