### PR TITLE
fix: address top Crashlytics crashes in beta 2.7.14

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
@@ -17,14 +17,12 @@
 package org.meshtastic.app.map.component
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
-import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.google.maps.android.clustering.Cluster
 import com.google.maps.android.clustering.view.DefaultClusterRenderer
@@ -54,15 +52,18 @@ fun NodeClusterMarkers(
     // If that view is not attached to the hierarchy (which it often isn't during rendering),
     // it fails to find the Lifecycle and SavedState owners. We propagate them to the root view
     // so the internal snapshot view can find them when walking up the tree.
-    // We do this in a SideEffect to ensure it happens before or during composition of children.
-    SideEffect {
+    // DisposableEffect runs at composition time (not post-composition like SideEffect),
+    // ensuring owners are set before the Clustering composable triggers marker rendering.
+    DisposableEffect(lifecycleOwner, savedStateRegistryOwner) {
         val root = view.rootView
-        if (root.findViewTreeLifecycleOwner() == null) {
-            root.setViewTreeLifecycleOwner(lifecycleOwner)
+        root.setViewTreeLifecycleOwner(lifecycleOwner)
+        root.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
+        // Also set on the view itself in case the internal renderer walks from a child
+        if (view !== root) {
+            view.setViewTreeLifecycleOwner(lifecycleOwner)
+            view.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
         }
-        if (root.findViewTreeSavedStateRegistryOwner() == null) {
-            root.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
-        }
+        onDispose { }
     }
 
     Clustering(

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
@@ -63,7 +63,7 @@ fun NodeClusterMarkers(
             view.setViewTreeLifecycleOwner(lifecycleOwner)
             view.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
         }
-        onDispose { }
+        onDispose {}
     }
 
     Clustering(

--- a/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/NumberFormatter.kt
+++ b/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/NumberFormatter.kt
@@ -23,13 +23,17 @@ import kotlin.math.roundToLong
 object NumberFormatter {
     /** Formats a double value with the specified number of decimal places. */
     fun format(value: Double, decimalPlaces: Int): String {
+        if (value.isNaN() || value.isInfinite()) return "—"
         val factor = 10.0.pow(decimalPlaces)
         val rounded = (value * factor).roundToLong()
         return formatFixedPoint(rounded, decimalPlaces)
     }
 
     /** Formats a float value with the specified number of decimal places. */
-    fun format(value: Float, decimalPlaces: Int): String = format(value.toDouble(), decimalPlaces)
+    fun format(value: Float, decimalPlaces: Int): String {
+        if (value.isNaN() || value.isInfinite()) return "—"
+        return format(value.toDouble(), decimalPlaces)
+    }
 
     private fun formatFixedPoint(scaledValue: Long, decimalPlaces: Int): String {
         if (decimalPlaces == 0) return scaledValue.toString()

--- a/core/common/src/commonTest/kotlin/org/meshtastic/core/common/util/NumberFormatterTest.kt
+++ b/core/common/src/commonTest/kotlin/org/meshtastic/core/common/util/NumberFormatterTest.kt
@@ -35,4 +35,17 @@ class NumberFormatterTest {
         assertEquals("1", NumberFormatter.format(1.23, 0))
         assertEquals("-1", NumberFormatter.format(-1.23, 0))
     }
+
+    @Test
+    fun testFormatNaN() {
+        assertEquals("—", NumberFormatter.format(Double.NaN, 2))
+        assertEquals("—", NumberFormatter.format(Float.NaN, 1))
+    }
+
+    @Test
+    fun testFormatInfinity() {
+        assertEquals("—", NumberFormatter.format(Double.POSITIVE_INFINITY, 2))
+        assertEquals("—", NumberFormatter.format(Double.NEGATIVE_INFINITY, 2))
+        assertEquals("—", NumberFormatter.format(Float.POSITIVE_INFINITY, 1))
+    }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/StoreForwardPacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/StoreForwardPacketHandlerImpl.kt
@@ -51,12 +51,13 @@ class StoreForwardPacketHandlerImpl(
 
     override fun handleStoreAndForward(packet: MeshPacket, dataPacket: DataPacket, myNodeNum: Int) {
         val payload = packet.decoded?.payload ?: return
-        val u = try {
-            StoreAndForward.ADAPTER.decode(payload)
-        } catch (e: IOException) {
-            Logger.e(e) { "Failed to parse StoreAndForward packet" }
-            return
-        }
+        val u =
+            try {
+                StoreAndForward.ADAPTER.decode(payload)
+            } catch (e: IOException) {
+                Logger.e(e) { "Failed to parse StoreAndForward packet" }
+                return
+            }
         handleReceivedStoreAndForward(dataPacket, u, myNodeNum)
     }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/StoreForwardPacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/StoreForwardPacketHandlerImpl.kt
@@ -51,7 +51,12 @@ class StoreForwardPacketHandlerImpl(
 
     override fun handleStoreAndForward(packet: MeshPacket, dataPacket: DataPacket, myNodeNum: Int) {
         val payload = packet.decoded?.payload ?: return
-        val u = StoreAndForward.ADAPTER.decode(payload)
+        val u = try {
+            StoreAndForward.ADAPTER.decode(payload)
+        } catch (e: IOException) {
+            Logger.e(e) { "Failed to parse StoreAndForward packet" }
+            return
+        }
         handleReceivedStoreAndForward(dataPacket, u, myNodeNum)
     }
 

--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/manager/StoreForwardPacketHandlerImplTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/manager/StoreForwardPacketHandlerImplTest.kt
@@ -338,4 +338,20 @@ class StoreForwardPacketHandlerImplTest {
 
         verifySuspend { packetRepository.updateSFPPStatus(any(), any(), any(), any(), any(), any(), any()) }
     }
+
+    // ---------- Legacy S&F: malformed proto ----------
+
+    @Test
+    fun `handleStoreAndForward with malformed payload does not crash`() = testScope.runTest {
+        val malformedPayload = ByteString.of(0xFF.toByte(), 0xFE.toByte(), 0x07, 0x0E)
+        val packet = MeshPacket(
+            from = 999,
+            decoded = Data(portnum = PortNum.STORE_FORWARD_APP, payload = malformedPayload),
+        )
+        val dataPacket = makeDataPacket(999)
+
+        // Should not throw — the handler catches the IOException from proto decoding
+        handler.handleStoreAndForward(packet, dataPacket, myNodeNum)
+        advanceUntilIdle()
+    }
 }

--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/manager/StoreForwardPacketHandlerImplTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/manager/StoreForwardPacketHandlerImplTest.kt
@@ -344,10 +344,8 @@ class StoreForwardPacketHandlerImplTest {
     @Test
     fun `handleStoreAndForward with malformed payload does not crash`() = testScope.runTest {
         val malformedPayload = ByteString.of(0xFF.toByte(), 0xFE.toByte(), 0x07, 0x0E)
-        val packet = MeshPacket(
-            from = 999,
-            decoded = Data(portnum = PortNum.STORE_FORWARD_APP, payload = malformedPayload),
-        )
+        val packet =
+            MeshPacket(from = 999, decoded = Data(portnum = PortNum.STORE_FORWARD_APP, payload = malformedPayload))
         val dataPacket = makeDataPacket(999)
 
         // Should not throw — the handler catches the IOException from proto decoding

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/SerialConnectionImpl.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/SerialConnectionImpl.kt
@@ -87,12 +87,7 @@ internal class SerialConnectionImpl(
 
         port.open(usbDeviceConnection)
         try {
-            port.setParameters(
-                115200,
-                UsbSerialPort.DATABITS_8,
-                UsbSerialPort.STOPBITS_1,
-                UsbSerialPort.PARITY_NONE,
-            )
+            port.setParameters(115200, UsbSerialPort.DATABITS_8, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE)
 
             // Assert DTR/RTS so native USB-CDC firmware (RAK4631 / nRF52840) recognizes the host as
             // present and starts its serial-side Meshtastic protocol. Empirically, omitting these

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/SerialConnectionImpl.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/SerialConnectionImpl.kt
@@ -86,14 +86,28 @@ internal class SerialConnectionImpl(
         }
 
         port.open(usbDeviceConnection)
-        port.setParameters(115200, UsbSerialPort.DATABITS_8, UsbSerialPort.STOPBITS_1, UsbSerialPort.PARITY_NONE)
+        try {
+            port.setParameters(
+                115200,
+                UsbSerialPort.DATABITS_8,
+                UsbSerialPort.STOPBITS_1,
+                UsbSerialPort.PARITY_NONE,
+            )
 
-        // Assert DTR/RTS so native USB-CDC firmware (RAK4631 / nRF52840) recognizes the host as
-        // present and starts its serial-side Meshtastic protocol. Empirically, omitting these
-        // signals causes the firmware to never respond to WAKE_BYTES, stalling the handshake at
-        // Stage 1. Bridge-chip boards (CH340, CP210x, FTDI) tolerate the assertion.
-        port.dtr = true
-        port.rts = true
+            // Assert DTR/RTS so native USB-CDC firmware (RAK4631 / nRF52840) recognizes the host as
+            // present and starts its serial-side Meshtastic protocol. Empirically, omitting these
+            // signals causes the firmware to never respond to WAKE_BYTES, stalling the handshake at
+            // Stage 1. Bridge-chip boards (CH340, CP210x, FTDI) tolerate the assertion.
+            port.dtr = true
+            port.rts = true
+        } catch (e: java.io.IOException) {
+            Logger.w(e) { "USB control transfer failed during port setup — device may have disconnected" }
+            closed.set(true)
+            ignoreException(silent = true) { port.close() }
+            closedLatch.countDown()
+            listener.onDisconnected(e)
+            return
+        }
 
         Logger.d { "Starting serial reader thread" }
         val io =


### PR DESCRIPTION
The in-flight beta (build 29320970) is showing several high-volume crashes in Crashlytics. This PR addresses the top 4 actionable issues by impact, covering ~2,264 crash events across ~1,213 users in the past week.

## Approach

Each fix is minimal and defensive -- catch or guard against bad input rather than redesigning call sites:

- **Maps cluster renderer** (1,828 events / 987 users) -- The `ComposeUiClusterRenderer` creates a standalone `ComposeView` for marker bitmaps that fails to find a `ViewTreeLifecycleOwner`. The existing `SideEffect` workaround ran post-composition, leaving a race window. Switched to `DisposableEffect` (runs at composition time) and unconditionally propagates lifecycle/savedstate owners to both `rootView` and the hosting `view`.

- **StoreAndForward proto decode** (179 events / 170 users) -- Malformed mesh packets crash `StoreAndForward.ADAPTER.decode()` with a `ProtocolException`. Wrapped in try-catch matching the identical pattern already used by `handleStoreForwardPlusPlus` right below it.

- **NumberFormatter NaN** (163 events / 14 users) -- Sensor telemetry can deliver NaN temperature values, which crash `roundToLong()`. Added a guard returning "--" for NaN/Infinity inputs.

- **USB serial controlTransfer** (94 events / 12 users) -- `setParameters()` throws `IOException` when the device disconnects during port setup. Wrapped the setup sequence in try-catch with proper cleanup (`closedLatch.countDown()`, port close, disconnect callback).

## Notes

- The maps crash is a known upstream issue ([googlemaps/android-maps-compose#858](https://github.com/googlemaps/android-maps-compose/issues/858)). The `DisposableEffect` fix reduces the race window but a full resolution requires an upstream library fix.
- Tests added for NumberFormatter NaN/Infinity and malformed StoreAndForward payloads.
- Verified with `:core:common:allTests`, `:core:data:allTests`, and `compileGoogleDebugKotlin`.