### PR TITLE
fix(flatpak): source desktop metadata from in-repo packaging dir

### DIFF
--- a/scripts/verify-flatpak/desktop-offline.yaml
+++ b/scripts/verify-flatpak/desktop-offline.yaml
@@ -65,9 +65,13 @@ modules:
         # Point Gradle at the offline mirror produced by flatpak-sources.json
         GRADLE_USER_HOME: /run/build/meshtastic-desktop/.gradle
     build-commands:
-      - install -Dm644 -t /app/share/icons/hicolor/scalable/apps org.meshtastic.desktop.svg
-      - install -Dm644 -t /app/share/applications org.meshtastic.desktop.desktop
-      - install -Dm644 -t /app/share/metainfo org.meshtastic.desktop.metainfo.xml
+      # Install desktop metadata from the in-repo packaging sources (mirrors vid's upstream manifest,
+      # which stopped shipping standalone root-level copies as of 2026-05-30).
+      - install -Dm644 desktopApp/packaging/icons/icon.svg /app/share/icons/hicolor/scalable/apps/org.meshtastic.desktop.svg
+      - install -Dm644 -t /app/share/applications desktopApp/packaging/linux/org.meshtastic.desktop.desktop
+      - desktop-file-edit --set-key="Exec" --set-value="meshtastic-wrapper.sh %U"
+        /app/share/applications/org.meshtastic.desktop.desktop
+      - install -Dm644 -t /app/share/metainfo desktopApp/packaging/linux/org.meshtastic.desktop.metainfo.xml
       # Redirect the Gradle wrapper to the bundled distribution (no network).
       - sed -i 's|distributionUrl=.*|distributionUrl=gradle-all.zip|' gradle/wrapper/gradle-wrapper.properties
       - echo "org.gradle.java.installations.auto-detect=false" >> gradle.properties
@@ -83,12 +87,9 @@ modules:
         JAR_FILE=$(find desktopApp/build/compose/jars/ -name "*.jar" -type f | head -1)
         && install -Dm755 "$JAR_FILE" /app/lib/meshtastic-desktop.jar
     sources:
-      - type: file
-        path: org.meshtastic.desktop.desktop
-      - type: file
-        path: org.meshtastic.desktop.metainfo.xml
-      - type: file
-        path: org.meshtastic.desktop.svg
+      # Desktop metadata (.desktop/.metainfo.xml/.svg) now lives inside the meshtastic-android
+      # source tree (desktopApp/packaging/...) and is installed by build-commands above —
+      # no longer sourced as standalone root-level files.
       - type: dir
         path: meshtastic-android
       - type: file


### PR DESCRIPTION
## Problem

The Flatpak offline-verification job (`verify-flatpak.yml` → `build-flatpak`) started failing on **2026-05-30** with:

```
Failed to download sources: module meshtastic-desktop:
Can't find file at org.meshtastic.desktop.desktop
```

It had been **green as recently as 2026-05-28** — nothing in this repo's app code changed the manifest in between.

## Root cause (external/upstream)

Our overlay manifest `scripts/verify-flatpak/desktop-offline.yaml` pulled the desktop metadata as **root-level `type: file` sources**:

```yaml
- type: file
  path: org.meshtastic.desktop.desktop
- type: file
  path: org.meshtastic.desktop.metainfo.xml
- type: file
  path: org.meshtastic.desktop.svg
```

Those paths resolve against the **cloned upstream repo** (`vidplace7/org.meshtastic.desktop`) that the workflow checks out, *not* our repo. On 2026-05-30 vid restructured that repo (commits #14 "Cleanup metainfo", #15, #16) to install the metadata directly from the Meshtastic-Android source tree (`desktopApp/packaging/...`) and **removed the standalone root-level copies**. vid's repo root no longer contains those files, so flatpak-builder can't find them.

This is unrelated to any app/feature change — it's pure upstream drift in the third-party packaging repo.

## Fix

Mirror vid's current upstream manifest. The metadata already lives in our repo and is vendored into the build via the existing `type: dir` `meshtastic-android` source, so:

- Install `org.meshtastic.desktop.svg` from `desktopApp/packaging/icons/icon.svg`
- Install the `.desktop` / `.metainfo.xml` from `desktopApp/packaging/linux/`
- Add the `desktop-file-edit --set-key=Exec --set-value="meshtastic-wrapper.sh %U"` fixup (the in-repo `.desktop` has `Exec=meshtastic-desktop`)
- Remove the three stale root-level `type: file` sources

All offline-specific overlay differences (bundled Gradle dist, `--offline`, `flatpak-sources.json`, JBR-vendor sed, `GRADLE_USER_HOME`) are preserved.

## Validation

- YAML parses; the three referenced files exist under `desktopApp/packaging/`.
- The change mirrors vid's known-good upstream manifest, and the existing build-commands already reference repo-root-relative paths (`./gradlew`, `desktopApp/build.gradle.kts`) that worked on 05-28 — so `desktopApp/packaging/...` resolves identically.
- **Not** locally runnable on macOS: flatpak-builder's nested bwrap fails under Docker Desktop's seccomp sandbox, and `--download-only` doesn't execute build-commands. CI's Linux runners exercise the full offline build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)