### PR TITLE
fix(ci): make JBR setup-java resilient to GitHub API rate limits

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -39,12 +39,20 @@ runs:
         key: jbr-21-${{ runner.os }}-${{ runner.arch }}
 
     - name: Set up JetBrains JDK 21 (for Compose Desktop)
-      if: inputs.install_jetbrains_jdk == 'true'
+      if: inputs.install_jetbrains_jdk == 'true' && steps.cache-jbr.outputs.cache-hit != 'true'
+      id: setup-jbr
+      continue-on-error: true
       uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'jetbrains'
+        check-latest: false
         token: ${{ github.token }}
+
+    - name: JBR setup skipped or failed — Gradle will auto-provision via Foojay
+      if: inputs.install_jetbrains_jdk == 'true' && steps.cache-jbr.outputs.cache-hit != 'true' && steps.setup-jbr.outcome == 'failure'
+      shell: bash
+      run: echo "::warning::JBR setup-java failed (likely GitHub API rate limit). Gradle will auto-provision JBR via Foojay toolchain resolver."
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6


### PR DESCRIPTION
The `release-desktop` macOS ARM64 build consistently fails because `actions/setup-java` hits GitHub API rate limits when resolving JetBrains Runtime versions. This is a bootstrapping problem -- the cache is empty because setup-java has never succeeded, and setup-java fails because of rate limits on the shared runner IP.

## Approach

Three changes to the `gradle-setup` composite action:

- **Skip setup-java when cached** -- adds `steps.cache-jbr.outputs.cache-hit != 'true'` condition so a cache hit bypasses the GitHub API entirely.
- **`continue-on-error: true`** -- on a cache miss, if the API is still rate-limited, the build continues instead of failing.
- **`check-latest: false`** -- explicitly disables unnecessary latest-version resolution.

## Why this works without breaking anything

The project already has Gradle's Foojay toolchain auto-provisioner configured (`settings.gradle.kts`) and `desktopApp` declares `JvmVendorSpec.JETBRAINS` in its toolchain block. When setup-java fails, Gradle downloads JBR directly from JetBrains' CDN via the Foojay Disco API -- completely bypassing GitHub's rate-limited API. Once any run succeeds, the tool-cache gets populated and subsequent runs skip the API call entirely.