### PR TITLE
fix: address top Crashlytics crashes and non-fatals for build 29320984

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
@@ -18,9 +18,12 @@ package org.meshtastic.app.map.component
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.currentStateAsState
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
@@ -45,6 +48,7 @@ fun NodeClusterMarkers(
     val view = LocalView.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
+    val lifecycleState by lifecycleOwner.lifecycle.currentStateAsState()
 
     // Workaround for https://github.com/googlemaps/android-maps-compose/issues/858
     // and https://github.com/googlemaps/android-maps-compose/issues/875
@@ -65,6 +69,10 @@ fun NodeClusterMarkers(
         }
         onDispose {}
     }
+
+    // Guard against the cluster renderer's async Handler trying to render markers
+    // after the lifecycle has stopped — the internal ComposeView requires an active lifecycle.
+    if (!lifecycleState.isAtLeast(Lifecycle.State.STARTED)) return
 
     Clustering(
         items = nodeClusterItems,

--- a/androidApp/src/google/kotlin/org/meshtastic/app/node/component/InlineMap.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/node/component/InlineMap.kt
@@ -17,10 +17,18 @@
 package org.meshtastic.app.node.component
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.savedstate.compose.LocalSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.Circle
@@ -46,6 +54,23 @@ fun InlineMap(node: Node, modifier: Modifier = Modifier) {
             true -> ComposeMapColorScheme.DARK
             else -> ComposeMapColorScheme.LIGHT
         }
+
+    // Workaround for maps-compose issue where MarkerComposable's internal ComposeView
+    // cannot find ViewTreeLifecycleOwner, causing crash on bitmap rendering.
+    val view = LocalView.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
+    DisposableEffect(lifecycleOwner, savedStateRegistryOwner) {
+        val root = view.rootView
+        root.setViewTreeLifecycleOwner(lifecycleOwner)
+        root.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
+        if (view !== root) {
+            view.setViewTreeLifecycleOwner(lifecycleOwner)
+            view.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
+        }
+        onDispose {}
+    }
+
     key(node.num) {
         val location = LatLng(node.latitude, node.longitude)
         val cameraState = rememberCameraPositionState {
@@ -79,7 +104,9 @@ fun InlineMap(node: Node, modifier: Modifier = Modifier) {
                     strokeWidth = 2f,
                 )
             }
-            MarkerComposable(state = rememberUpdatedMarkerState(position = latLng)) { NodeChip(node = node) }
+            MarkerComposable(state = rememberUpdatedMarkerState(position = latLng)) {
+                NodeChip(node = node, modifier = Modifier.defaultMinSize(minWidth = 64.dp, minHeight = 28.dp))
+            }
         }
     }
 }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KermitLogEngine.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KermitLogEngine.kt
@@ -23,6 +23,10 @@ import com.juul.kable.logs.LogEngine
  * Bridges Kable's internal logging to [Kermit][Logger] so BLE lifecycle events (connect, disconnect, subscribe, GATT
  * operations) appear in the standard app logs rather than going to [System.out] via Kable's default
  * [com.juul.kable.logs.SystemLogEngine].
+ *
+ * Kable logs connection failures and disconnections at error level, but these are expected BLE operational events —
+ * not application bugs. We downgrade error/assert to warn so these don't trigger non-fatal exception recording in
+ * Crashlytics (which records any Kermit Error-level log with a throwable as a non-fatal).
  */
 internal object KermitLogEngine : LogEngine {
     override fun verbose(throwable: Throwable?, tag: String, message: String) {
@@ -42,10 +46,11 @@ internal object KermitLogEngine : LogEngine {
     }
 
     override fun error(throwable: Throwable?, tag: String, message: String) {
-        Logger.e(throwable) { "[$tag] $message" }
+        // Downgrade: Kable "errors" are operational (failed connect, disconnect requested) not app bugs.
+        Logger.w(throwable) { "[$tag] $message" }
     }
 
     override fun assert(throwable: Throwable?, tag: String, message: String) {
-        Logger.e(throwable) { "[$tag] $message" }
+        Logger.w(throwable) { "[$tag] $message" }
     }
 }

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KermitLogEngine.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KermitLogEngine.kt
@@ -24,8 +24,8 @@ import com.juul.kable.logs.LogEngine
  * operations) appear in the standard app logs rather than going to [System.out] via Kable's default
  * [com.juul.kable.logs.SystemLogEngine].
  *
- * Kable logs connection failures and disconnections at error level, but these are expected BLE operational events —
- * not application bugs. We downgrade error/assert to warn so these don't trigger non-fatal exception recording in
+ * Kable logs connection failures and disconnections at error level, but these are expected BLE operational events — not
+ * application bugs. We downgrade error/assert to warn so these don't trigger non-fatal exception recording in
  * Crashlytics (which records any Kermit Error-level log with a throwable as a non-fatal).
  */
 internal object KermitLogEngine : LogEngine {


### PR DESCRIPTION
## Motivation

Build 29320984 (beta/alpha) shows two categories of Crashlytics issues:
- **Fatal crashes** (1900+ events/week): Maps clustering ComposeView lifecycle failures
- **Non-fatal noise** (26K+ events/week): Expected BLE disconnections recorded as exceptions

Both degrade signal-to-noise in Crashlytics, making real issues harder to spot.

## Approach

### Maps clustering crashes (2 issues, ~1900 events, ~1000 users)

The `android-maps-compose` library creates internal `ComposeView` instances to render markers as bitmaps. These views require a `ViewTreeLifecycleOwner` but can race with lifecycle transitions when the cluster renderer's async Handler fires after the activity stops.

**Fixes:**
- **`NodeClusterMarkers.kt`** -- Added lifecycle state guard (`isAtLeast(STARTED)`) to prevent the `Clustering` composable from rendering when the lifecycle is inactive, avoiding the async race
- **`InlineMap.kt`** -- Added the same `ViewTreeLifecycleOwner`/`SavedStateRegistryOwner` propagation workaround that the main map already had, plus `defaultMinSize` on marker content to prevent zero-size measurement

### BLE non-fatal noise (1 issue, 26K events, 1494 users)

Kable (BLE library) logs expected operational events like failed connections and disconnect requests at error level. Our `KermitLogEngine` bridge routes these to `Logger.e()`, and the `CrashlyticsLogWriter` records any Error+throwable as a non-fatal via `recordException()`.

**Fix:**
- **`KermitLogEngine.kt`** -- Downgraded `error()` and `assert()` to `Logger.w()`. Kable "errors" are normal BLE lifecycle events (connection timeouts, already-disconnected), not app bugs. They still appear in the Crashlytics log buffer for debugging but no longer pollute the non-fatals dashboard.

## Non-obvious decisions

- The lifecycle guard in `NodeClusterMarkers` uses an early return rather than wrapping `Clustering` in a conditional block -- this ensures no cluster state is retained across lifecycle transitions that could trigger stale renders.
- Downgrading ALL Kable errors to warn is intentional -- Kable's error level maps to "this BLE operation failed" which is an expected condition in radio environments, not "the app has a bug."

References: googlemaps/android-maps-compose#858, googlemaps/android-maps-compose#875