### PR TITLE
feat: replace LoRa bandwidth text input with constrained dropdown

### DIFF
--- a/feature/settings/settings-validation.md
+++ b/feature/settings/settings-validation.md
@@ -143,7 +143,7 @@ configuration settings screen. Constraints are sourced from two layers:
 | `region` | Enum | Dropdown: `RegionInfo` entries | Regional frequency plans |
 | `use_preset` | Boolean | Toggle | Controls manual vs preset LoRa settings visibility |
 | `modem_preset` | Enum | Dropdown: `ChannelOption` entries | Visible only when `use_preset = true` |
-| `bandwidth` | Integer | Numeric input | Visible only when `use_preset = false` |
+| `bandwidth` | Integer | Dropdown: valid LoRa bandwidths (7.8–500 kHz) | Visible only when `use_preset = false` |
 | `spread_factor` | Integer | Numeric input | Visible only when `use_preset = false` |
 | `coding_rate` | Integer | Numeric input | Visible only when `use_preset = false` |
 | `hop_limit` | Integer | Dropdown: 0–7 | — |

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -67,6 +67,21 @@ import org.meshtastic.proto.Config
 private val SPREAD_FACTOR_RANGE = 7..12
 private val CODING_RATE_RANGE = 5..8
 
+/** Valid LoRa bandwidth codes mapped to their display labels (kHz). */
+private val BANDWIDTH_OPTIONS: List<Pair<Int, String>> =
+    listOf(
+        8 to "7.8 kHz",
+        10 to "10.4 kHz",
+        16 to "15.6 kHz",
+        21 to "20.8 kHz",
+        31 to "31.25 kHz",
+        42 to "41.7 kHz",
+        62 to "62.5 kHz",
+        125 to "125 kHz",
+        250 to "250 kHz",
+        500 to "500 kHz",
+    )
+
 @Composable
 fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val state by viewModel.radioConfigState.collectAsStateWithLifecycle()
@@ -245,12 +260,12 @@ private fun ManualModemSettings(
     onConfigChange: (Config.LoRaConfig) -> Unit,
 ) {
     androidx.compose.foundation.layout.Column {
-        EditTextPreference(
+        DropDownPreference(
             title = stringResource(Res.string.bandwidth),
-            value = config.bandwidth,
             enabled = enabled,
-            keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-            onValueChanged = { onConfigChange(config.copy(bandwidth = it)) },
+            items = BANDWIDTH_OPTIONS,
+            selectedItem = config.bandwidth,
+            onItemSelected = { onConfigChange(config.copy(bandwidth = it)) },
         )
         HorizontalDivider()
         EditTextPreference(


### PR DESCRIPTION
The LoRa manual modem settings screen used a free-text integer input for bandwidth. This prevented users from entering valid fractional values (e.g., 15.6, 31.25, 62.5 kHz) and allowed invalid arbitrary integers.

Replaces the numeric input with a dropdown containing all 10 valid SX126x LoRa bandwidths: 7.8, 10.4, 15.6, 20.8, 31.25, 41.7, 62.5, 125, 250, and 500 kHz. Each option maps to the integer proto code used by firmware (via the `bwKHzToCode` rounding convention).

This aligns Android with Apple's enum-constrained picker approach (noted as a gap in the cross-platform audit), while including the full set of firmware-supported bandwidths rather than Apple's current subset of 5.

Also updates `settings-validation.md` to reflect the new input type.