### PR TITLE
fix(node): restore long-press context menu after navigation

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -216,10 +216,13 @@ fun NodeListScreen(
 
                 items(nodes, key = { it.num }) { node ->
                     var expanded by remember { mutableStateOf(false) }
+                    val isThisNode = ourNode?.num == node.num
 
-                    Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
+                    // animateItem() must be on the root composable for LazyColumn
+                    // item animations to work correctly.
+                    Box(modifier = Modifier.animateItem().padding(horizontal = 8.dp, vertical = 4.dp)) {
                         val longClick =
-                            if (node.num != ourNode?.num) {
+                            if (!isThisNode) {
                                 { expanded = true }
                             } else {
                                 null
@@ -230,7 +233,6 @@ fun NodeListScreen(
                         when (density) {
                             NodeListDensity.COMPLETE ->
                                 NodeItem(
-                                    modifier = Modifier.animateItem(),
                                     thisNode = ourNode,
                                     thatNode = node,
                                     distanceUnits = state.distanceUnits,
@@ -246,7 +248,6 @@ fun NodeListScreen(
 
                             NodeListDensity.COMPACT ->
                                 NodeItemCompact(
-                                    modifier = Modifier.animateItem(),
                                     thisNode = ourNode,
                                     thatNode = node,
                                     distanceUnits = state.distanceUnits,
@@ -266,22 +267,26 @@ fun NodeListScreen(
                                     deviceImageUrl = deviceImageUrls[node.user.hw_model.value],
                                 )
                         }
-                        val isThisNode = remember(node) { ourNode?.num == node.num }
                         if (!isThisNode) {
-                            NodeContextMenu(
-                                expanded = expanded,
-                                node = node,
-                                onFavorite = { viewModel.favoriteNode(node) },
-                                onMute = { viewModel.muteNode(node) },
-                                onMessage = {
-                                    val route = viewModel.getDirectMessageRoute(node)
-                                    navigateToMessages(route)
-                                },
-                                onTraceRoute = { viewModel.traceRoute(node) },
-                                onIgnore = { viewModel.ignoreNode(node) },
-                                onRemove = { viewModel.removeNode(node) },
-                                onDismiss = { expanded = false },
-                            )
+                            // matchParentSize() gives the DropdownMenu a properly-sized
+                            // popup anchor that survives ListDetailSceneStrategy pane
+                            // transitions (known Popup anchoring issue in adaptive layouts).
+                            Box(modifier = Modifier.matchParentSize()) {
+                                NodeContextMenu(
+                                    expanded = expanded,
+                                    node = node,
+                                    onFavorite = { viewModel.favoriteNode(node) },
+                                    onMute = { viewModel.muteNode(node) },
+                                    onMessage = {
+                                        val route = viewModel.getDirectMessageRoute(node)
+                                        navigateToMessages(route)
+                                    },
+                                    onTraceRoute = { viewModel.traceRoute(node) },
+                                    onIgnore = { viewModel.ignoreNode(node) },
+                                    onRemove = { viewModel.removeNode(node) },
+                                    onDismiss = { expanded = false },
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

The node actions dropdown menu (favorite, mute, message, trace route, ignore, remove) triggered by long-press stopped appearing after visiting a node detail screen and navigating back. Haptics fired on long-press confirming the callback was reached, but the `DropdownMenu` popup never rendered visually.

This is a [known issue](https://issuetracker.google.com/issues/321169726) with `Popup` anchoring in adaptive navigation layouts (`ListDetailSceneStrategy` / `ListDetailPaneScaffold`).

## Root Cause

Three contributing issues:

1. **`animateItem()` on wrong composable** — was applied to `NodeItem`/`NodeItemCompact` (children of the root `Box`) instead of the root `Box` itself. `animateItem()` must be on the direct root of the `LazyColumn` item lambda for correct layout tracking. Placing it on a child caused stale layout coordinates after pane transitions.

2. **Zero-size popup anchor** — `NodeContextMenu` (containing `DropdownMenu`) was a zero-size sibling in the `Box`. After `ListDetailSceneStrategy` deactivated and reactivated the list pane, the popup's anchor coordinates became stale or unresolvable.

3. **Stale `isThisNode` computation** — `remember(node) { ourNode?.num == node.num }` was missing `ourNode` as a remember key, so it could return stale results when `ourNode` loaded after initial composition.

## Fix

1. Move `Modifier.animateItem()` from `NodeItem`/`NodeItemCompact` to the root `Box`
2. Wrap `NodeContextMenu` in `Box(Modifier.matchParentSize())` — gives the `DropdownMenu` a properly-sized popup anchor that survives pane transitions
3. Replace stale `remember(node)` with a direct `ourNode?.num == node.num` computation

## Testing

- `spotlessApply` ✅
- `detekt` ✅  
- `:feature:node:allTests` ✅
- `:feature:node:compileKotlinJvm` ✅

**Manual verification needed:** long-press a node → see dropdown → tap a node to visit details → navigate back → long-press again → dropdown should appear.