### PR TITLE
fix: show loading overlay immediately for remote config sub-screens

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
@@ -127,8 +127,7 @@ fun EntryProviderScope<NavKey>.settingsGraph(backStack: NavBackStack<NavKey>) {
     }
 
     ConfigRoute.entries.forEach { routeInfo ->
-        configComposable(routeInfo.route::class, backStack) { viewModel ->
-            LaunchedEffect(Unit) { viewModel.setResponseStateLoading(routeInfo) }
+        configComposable(routeInfo.route::class, backStack, routeInfo) { viewModel ->
             when (routeInfo) {
                 ConfigRoute.USER ->
                     UserConfigScreen(viewModel, onBack = dropUnlessResumed { backStack.removeLastOrNull() })
@@ -164,8 +163,7 @@ fun EntryProviderScope<NavKey>.settingsGraph(backStack: NavBackStack<NavKey>) {
     }
 
     ModuleRoute.entries.forEach { routeInfo ->
-        configComposable(routeInfo.route::class, backStack) { viewModel ->
-            LaunchedEffect(Unit) { viewModel.setResponseStateLoading(routeInfo) }
+        configComposable(routeInfo.route::class, backStack, routeInfo) { viewModel ->
             when (routeInfo) {
                 ModuleRoute.MQTT ->
                     MQTTConfigScreen(viewModel, onBack = dropUnlessResumed { backStack.removeLastOrNull() })
@@ -266,7 +264,15 @@ expect fun SettingsMainScreen(
 fun <R : Route> EntryProviderScope<NavKey>.configComposable(
     route: KClass<R>,
     backStack: NavBackStack<NavKey>,
+    routeInfo: Enum<*>,
     content: @Composable (RadioConfigViewModel) -> Unit,
 ) {
-    addEntryProvider(route) { content(getRadioConfigViewModel(backStack)) }
+    addEntryProvider(route) {
+        val viewModel = getRadioConfigViewModel(backStack)
+        // Set loading state before content reads the StateFlow, ensuring
+        // LoadingOverlay is visible from the very first composition frame.
+        remember { viewModel.ensureLoadingForRemote().let { true } }
+        LaunchedEffect(Unit) { viewModel.setResponseStateLoading(routeInfo) }
+        content(viewModel)
+    }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -476,6 +476,17 @@ open class RadioConfigViewModel(
         _radioConfigState.update { it.copy(responseState = ResponseState.Empty) }
     }
 
+    /**
+     * Sets the initial loading state for remote config sub-screens. Must be called before the first
+     * `collectAsStateWithLifecycle` read so the LoadingOverlay is visible from the very first composition frame.
+     */
+    fun ensureLoadingForRemote() {
+        val state = _radioConfigState.value
+        if (!state.isLocal && state.responseState is ResponseState.Empty) {
+            _radioConfigState.update { it.copy(responseState = ResponseState.Loading()) }
+        }
+    }
+
     fun setResponseStateLoading(route: Enum<*>) {
         val destNum = destNum ?: destNode.value?.num ?: return
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -71,7 +71,21 @@ private val CODING_RATE_RANGE = 5..8
 fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val state by viewModel.radioConfigState.collectAsStateWithLifecycle()
     val loraConfig = state.radioConfig.lora ?: Config.LoRaConfig()
-    val primarySettings = state.channelList.getOrNull(0) ?: return
+    val primarySettings = state.channelList.getOrNull(0)
+
+    if (primarySettings == null) {
+        RadioConfigScreenList(
+            title = stringResource(Res.string.lora),
+            onBack = onBack,
+            configState = rememberConfigState(initialValue = loraConfig),
+            enabled = false,
+            responseState = state.responseState,
+            onDismissPacketResponse = viewModel::clearPacketResponse,
+            onSave = {},
+        ) {}
+        return
+    }
+
     val formState = rememberConfigState(initialValue = loraConfig)
 
     val primaryChannel = remember(formState.value) { Channel(primarySettings, formState.value) }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -48,6 +48,7 @@ import org.meshtastic.core.domain.usecase.settings.RadioResponseResult
 import org.meshtastic.core.domain.usecase.settings.ToggleAnalyticsUseCase
 import org.meshtastic.core.domain.usecase.settings.ToggleHomoglyphEncodingUseCase
 import org.meshtastic.core.model.MqttProbeStatus
+import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.repository.AnalyticsPrefs
 import org.meshtastic.core.repository.FileService
@@ -75,6 +76,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -138,8 +140,8 @@ class RadioConfigViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() = RadioConfigViewModel(
-        destNum = null,
+    private fun createViewModel(destNum: Int? = null) = RadioConfigViewModel(
+        destNum = destNum,
         radioConfigRepository = radioConfigRepository,
         packetRepository = packetRepository,
         serviceRepository = serviceRepository,
@@ -609,5 +611,108 @@ class RadioConfigViewModelTest {
         // It's hard to assert sendError directly without a mock on a channel, but we can verify it doesn't stay loading
         // actually sendError updates the state? No, sendError sends an event.
         // But the requestIds gets cleared.
+    }
+
+    @Test
+    fun `ensureLoadingForRemote sets loading state for remote nodes`() = runTest {
+        val localNode = Node(num = 100, user = User(id = "!100"))
+        val remoteNode = Node(num = 456, user = User(id = "!456"))
+        nodeRepository.setNodes(listOf(localNode, remoteNode))
+        nodeRepository.setMyNodeInfo(
+            MyNodeInfo(
+                myNodeNum = 100,
+                hasGPS = false,
+                model = null,
+                firmwareVersion = null,
+                couldUpdate = false,
+                shouldUpdate = false,
+                currentPacketId = 0,
+                messageTimeoutMsec = 0,
+                minAppVersion = 0,
+                maxChannels = 8,
+                hasWifi = false,
+                channelUtilization = 0f,
+                airUtilTx = 0f,
+                deviceId = null,
+            ),
+        )
+
+        val remoteVm = createViewModel(destNum = 456)
+
+        // Remote VM starts with Empty responseState
+        assertEquals(ResponseState.Empty, remoteVm.radioConfigState.value.responseState)
+        assertFalse(remoteVm.radioConfigState.value.isLocal)
+
+        // ensureLoadingForRemote should transition to Loading
+        remoteVm.ensureLoadingForRemote()
+        assertTrue(remoteVm.radioConfigState.value.responseState is ResponseState.Loading)
+    }
+
+    @Test
+    fun `ensureLoadingForRemote is no-op for local nodes`() = runTest {
+        val localNode = Node(num = 100, user = User(id = "!100"))
+        nodeRepository.setNodes(listOf(localNode))
+        nodeRepository.setMyNodeInfo(
+            MyNodeInfo(
+                myNodeNum = 100,
+                hasGPS = false,
+                model = null,
+                firmwareVersion = null,
+                couldUpdate = false,
+                shouldUpdate = false,
+                currentPacketId = 0,
+                messageTimeoutMsec = 0,
+                minAppVersion = 0,
+                maxChannels = 8,
+                hasWifi = false,
+                channelUtilization = 0f,
+                airUtilTx = 0f,
+                deviceId = null,
+            ),
+        )
+
+        val localVm = createViewModel(destNum = 100)
+
+        // Local VM should have isLocal = true
+        assertTrue(localVm.radioConfigState.value.isLocal)
+
+        // ensureLoadingForRemote should NOT change responseState
+        localVm.ensureLoadingForRemote()
+        assertEquals(ResponseState.Empty, localVm.radioConfigState.value.responseState)
+    }
+
+    @Test
+    fun `ensureLoadingForRemote is no-op when already loading`() = runTest {
+        val localNode = Node(num = 100, user = User(id = "!100"))
+        val remoteNode = Node(num = 456, user = User(id = "!456"))
+        nodeRepository.setNodes(listOf(localNode, remoteNode))
+        nodeRepository.setMyNodeInfo(
+            MyNodeInfo(
+                myNodeNum = 100,
+                hasGPS = false,
+                model = null,
+                firmwareVersion = null,
+                couldUpdate = false,
+                shouldUpdate = false,
+                currentPacketId = 0,
+                messageTimeoutMsec = 0,
+                minAppVersion = 0,
+                maxChannels = 8,
+                hasWifi = false,
+                channelUtilization = 0f,
+                airUtilTx = 0f,
+                deviceId = null,
+            ),
+        )
+
+        val remoteVm = createViewModel(destNum = 456)
+
+        // Set loading first
+        remoteVm.ensureLoadingForRemote()
+        assertTrue(remoteVm.radioConfigState.value.responseState is ResponseState.Loading)
+
+        // Calling again should still be Loading (no-op, not a new instance)
+        remoteVm.ensureLoadingForRemote()
+        assertTrue(remoteVm.radioConfigState.value.responseState is ResponseState.Loading)
     }
 }


### PR DESCRIPTION
## Problem

When navigating to config/module sub-screens (Channels, LoRa, Device config, etc.) for **remote nodes**, users see a blank screen instead of a loading indicator. This doesn't affect locally-connected Bluetooth nodes.

## Root Cause

Navigation 3's `rememberViewModelStoreNavEntryDecorator` creates a **separate ViewModelStore per navigation entry**. When navigating from `SettingsRoute.Settings(destNum=X)` → any sub-screen (e.g., `SettingsRoute.ChannelConfig`), a brand new `RadioConfigViewModel` is created with:
- `responseState = Empty` (no loading overlay visible)
- `channelList = emptyList()` (no content to render)

The `LaunchedEffect(Unit)` that sets `responseState = Loading` and fires admin requests only runs **after** the first composition frame — creating a blank screen on that frame.

For **local nodes**, this is imperceptible because the init block subscribes to local database flows that emit data immediately. For **remote nodes**, data must be fetched over the mesh network, so the blank state persists visibly until the `LaunchedEffect` fires.

## Fix

Three targeted changes:

### 1. `RadioConfigViewModel.ensureLoadingForRemote()`
New method that sets `responseState = Loading()` when the node is remote and state is still `Empty`. Called **synchronously during composition** (before `collectAsStateWithLifecycle` reads the StateFlow), so the initial Compose State value already reflects `Loading`.

### 2. `configComposable()` consolidation  
Updated to:
- Accept `routeInfo` parameter
- Call `ensureLoadingForRemote()` via `remember{}` before content renders
- Include the `LaunchedEffect(setResponseStateLoading)` that was previously duplicated in every content lambda

### 3. `LoRaConfigScreen` empty-state handling
Previously returned early on empty `channelList`, rendering **nothing** (not even a scaffold). Now renders a `RadioConfigScreenList` with the loading overlay visible while data loads.

## Why the Settings menu is unaffected

The parent `SettingsRoute.Settings` entry uses its **own** entry in `settingsGraph` (not `configComposable`), so `ensureLoadingForRemote()` is never called for it. The Settings menu continues to start with `responseState = Empty` as before.

## Testing

- Added 3 new unit tests for `ensureLoadingForRemote()`:
  - Sets loading state for remote nodes ✓
  - No-op for local nodes ✓  
  - No-op when already loading ✓
- All existing tests pass
- `spotlessApply`, `detekt`, `assembleDebug`, `test`, `allTests` all pass