### PR TITLE
fix(node): restore view-tree owners on map dispose so node-list popups aren't invisible

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
@@ -24,8 +24,10 @@ import androidx.compose.ui.platform.LocalView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.currentStateAsState
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.google.maps.android.clustering.Cluster
 import com.google.maps.android.clustering.view.DefaultClusterRenderer
@@ -58,16 +60,31 @@ fun NodeClusterMarkers(
     // so the internal snapshot view can find them when walking up the tree.
     // DisposableEffect runs at composition time (not post-composition like SideEffect),
     // ensuring owners are set before the Clustering composable triggers marker rendering.
+    // Capture and restore the previous owners on dispose. The owners here are NavEntry-scoped
+    // (transient) lifecycles; leaving one attached to the activity root view after this screen is
+    // destroyed makes subsequently opened Popups/DropdownMenus inherit a DESTROYED lifecycle and
+    // render at 0x0 (invisible). See the node-list popup regression and InlineMap.
     DisposableEffect(lifecycleOwner, savedStateRegistryOwner) {
         val root = view.rootView
+        val prevRootLifecycleOwner = root.findViewTreeLifecycleOwner()
+        val prevRootSavedStateRegistryOwner = root.findViewTreeSavedStateRegistryOwner()
         root.setViewTreeLifecycleOwner(lifecycleOwner)
         root.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
         // Also set on the view itself in case the internal renderer walks from a child
+        val prevViewLifecycleOwner = view.findViewTreeLifecycleOwner()
+        val prevViewSavedStateRegistryOwner = view.findViewTreeSavedStateRegistryOwner()
         if (view !== root) {
             view.setViewTreeLifecycleOwner(lifecycleOwner)
             view.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
         }
-        onDispose {}
+        onDispose {
+            root.setViewTreeLifecycleOwner(prevRootLifecycleOwner)
+            root.setViewTreeSavedStateRegistryOwner(prevRootSavedStateRegistryOwner)
+            if (view !== root) {
+                view.setViewTreeLifecycleOwner(prevViewLifecycleOwner)
+                view.setViewTreeSavedStateRegistryOwner(prevViewSavedStateRegistryOwner)
+            }
+        }
     }
 
     // Guard against the cluster renderer's async Handler trying to render markers

--- a/androidApp/src/google/kotlin/org/meshtastic/app/node/component/InlineMap.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/node/component/InlineMap.kt
@@ -26,8 +26,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -55,20 +57,28 @@ fun InlineMap(node: Node, modifier: Modifier = Modifier) {
             else -> ComposeMapColorScheme.LIGHT
         }
 
-    // Workaround for maps-compose issue where MarkerComposable's internal ComposeView
-    // cannot find ViewTreeLifecycleOwner, causing crash on bitmap rendering.
+    // Workaround for a maps-compose issue where MarkerComposable's internal ComposeView cannot find a
+    // ViewTreeLifecycleOwner, causing a crash on bitmap rendering. We attach the current owners to the
+    // window root view for the lifetime of the map.
+    //
+    // IMPORTANT: capture and restore the previous owners on dispose. This InlineMap is hosted inside the
+    // node-detail NavEntry, whose LocalLifecycleOwner is a transient, entry-scoped lifecycle. Leaving it
+    // attached to the activity root view after the entry is destroyed (e.g. navigating back to the node
+    // list) would make every subsequently opened Popup/DropdownMenu inherit a DESTROYED lifecycle and
+    // render at 0x0 (invisible). See the node-list popup regression.
     val view = LocalView.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
     DisposableEffect(lifecycleOwner, savedStateRegistryOwner) {
         val root = view.rootView
+        val prevRootLifecycleOwner = root.findViewTreeLifecycleOwner()
+        val prevRootSavedStateRegistryOwner = root.findViewTreeSavedStateRegistryOwner()
         root.setViewTreeLifecycleOwner(lifecycleOwner)
         root.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
-        if (view !== root) {
-            view.setViewTreeLifecycleOwner(lifecycleOwner)
-            view.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
+        onDispose {
+            root.setViewTreeLifecycleOwner(prevRootLifecycleOwner)
+            root.setViewTreeSavedStateRegistryOwner(prevRootSavedStateRegistryOwner)
         }
-        onDispose {}
     }
 
     key(node.num) {


### PR DESCRIPTION
## Problem

On the **Nodes** list, all popups — the sort/filter menus and the long-press `NodeContextMenu` — stopped appearing after navigating into a node detail and back. The popup window was created (and even grabbed focus) but its content measured to **`0×0`** (`dumpsys window` → `mAttrs={(0,0)(0x0)}`), so nothing drew.

## Root cause

`InlineMap` (rendered inside the node-detail screen) and `NodeClusterMarkers` (Map screen) set the **activity root view's** `ViewTreeLifecycleOwner` / `ViewTreeSavedStateRegistryOwner` to work around a maps-compose `MarkerComposable` crash — but with an empty `onDispose {}`:

```kotlin
view.rootView.setViewTreeLifecycleOwner(lifecycleOwner)   // activity ROOT view
...
onDispose {}                                              // never restored
```

`lifecycleOwner` is the host screen's **NavEntry-scoped, transient** lifecycle. Visiting a node detail with a location attaches that owner to the activity root view; navigating back **destroys** the lifecycle but leaves it on the root view. Every `Popup`/`DropdownMenu` opened afterward inherits its lifecycle from the root view → gets a **DESTROYED** lifecycle → its content never composes → `0×0` invisible window.

This explains why it affected *all* popups, *any* popup type, only *after* a detail visit, and was unaffected by Compose-level changes. Regression from #5684 (bisected on-device: good through `internal.111`, bad at HEAD).

## Fix

Capture the previous owners (`findViewTreeLifecycleOwner()` / `findViewTreeSavedStateRegistryOwner()`) before overwriting and **restore them in `onDispose`**, in both `InlineMap.kt` and `NodeClusterMarkers.kt`. The maps crash workaround stays intact; we just no longer leak a destroyed lifecycle onto the root view.

## Verification

Built and run on an emulator. After repeated node detail → back round-trips:
- Sort/filter menu renders (`576×1952`)
- Long-press context menu renders (`531×692`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)