### PR TITLE
fix(firmware): surface error state when BLE OTA connection attempts are exhausted

### DIFF
--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -237,10 +237,20 @@ class FirmwareUpdateViewModel(
                                     updateState = { _state.value = it },
                                 )
 
-                            if (_state.value is FirmwareUpdateState.Success) {
-                                verifyUpdateResult(originalDeviceAddress)
-                            } else if (_state.value is FirmwareUpdateState.Error) {
-                                tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
+                            when (_state.value) {
+                                is FirmwareUpdateState.Success -> verifyUpdateResult(originalDeviceAddress)
+
+                                is FirmwareUpdateState.Error -> {
+                                    tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
+                                }
+
+                                else -> {
+                                    // Defense-in-depth: handler returned without setting a terminal state
+                                    Logger.w { "Firmware update returned without terminal state: ${_state.value}" }
+                                    _state.value =
+                                        FirmwareUpdateState.Error(UiText.Resource(Res.string.firmware_update_failed))
+                                    tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
+                                }
                             }
                         } catch (e: CancellationException) {
                             Logger.w(e) { "Firmware update cancelled — cause: ${e.cause} message: ${e.message}" }
@@ -315,10 +325,18 @@ class FirmwareUpdateViewModel(
                         )
                     tempFirmwareFile = updateArtifact ?: extractedFile
 
-                    if (_state.value is FirmwareUpdateState.Success) {
-                        verifyUpdateResult(originalDeviceAddress)
-                    } else if (_state.value is FirmwareUpdateState.Error) {
-                        tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
+                    when (_state.value) {
+                        is FirmwareUpdateState.Success -> verifyUpdateResult(originalDeviceAddress)
+
+                        is FirmwareUpdateState.Error -> {
+                            tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
+                        }
+
+                        else -> {
+                            Logger.w { "Firmware update returned without terminal state: ${_state.value}" }
+                            _state.value = FirmwareUpdateState.Error(UiText.Resource(Res.string.firmware_update_failed))
+                            tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
+                        }
                     }
                 } catch (e: CancellationException) {
                     throw e

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/Esp32OtaUpdateHandler.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/Esp32OtaUpdateHandler.kt
@@ -156,7 +156,7 @@ class Esp32OtaUpdateHandler(
                 delay(GATT_RELEASE_DELAY_MS)
 
                 val transport = transportFactory()
-                if (!connectToDevice(transport, connectionAttempts, updateState)) return@withContext null
+                connectToDevice(transport, connectionAttempts, updateState)
 
                 try {
                     executeOtaSequence(transport, firmwareBytes, sha256Hash, rebootMode, updateState)
@@ -255,7 +255,7 @@ class Esp32OtaUpdateHandler(
         transport: UnifiedOtaProtocol,
         attempts: Int,
         updateState: (FirmwareUpdateState) -> Unit,
-    ): Boolean {
+    ) {
         // Show "waiting for reboot" state before first connection attempt
         updateState(
             FirmwareUpdateState.Processing(ProgressState(UiText.Resource(Res.string.firmware_update_waiting_reboot))),
@@ -269,13 +269,12 @@ class Esp32OtaUpdateHandler(
                     ),
                 )
                 transport.connect().getOrThrow()
-                return true
+                return
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                 if (i == attempts) throw e
                 delay(RETRY_DELAY)
             }
         }
-        return false
     }
 
     @Suppress("LongMethod")

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuHandler.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuHandler.kt
@@ -141,7 +141,7 @@ class SecureDfuHandler(
                 var completed = false
                 try {
                     // ── 5. Connect to device in DFU mode ─────────────────────────────
-                    if (!connectWithRetry(transport, updateState)) return@withContext null
+                    connectWithRetry(transport, updateState)
 
                     // ── 6. Init packet ────────────────────────────────────────────
                     updateState(
@@ -252,13 +252,11 @@ class SecureDfuHandler(
         return if (legacyHit != null) DfuProtocolKind.LEGACY else DfuProtocolKind.SECURE
     }
 
-    private suspend fun connectWithRetry(
-        transport: DfuUploadTransport,
-        updateState: (FirmwareUpdateState) -> Unit,
-    ): Boolean {
+    private suspend fun connectWithRetry(transport: DfuUploadTransport, updateState: (FirmwareUpdateState) -> Unit) {
         updateState(
             FirmwareUpdateState.Processing(ProgressState(UiText.Resource(Res.string.firmware_update_waiting_reboot))),
         )
+        var lastError: Throwable? = null
         for (attempt in 1..CONNECT_ATTEMPTS) {
             updateState(
                 FirmwareUpdateState.Processing(
@@ -269,12 +267,16 @@ class SecureDfuHandler(
             )
             val result = transport.connectToDfuMode()
             if (result.isSuccess) {
-                return true
+                return
             }
-            Logger.w { "DFU: Connect attempt $attempt/$CONNECT_ATTEMPTS failed: ${result.exceptionOrNull()?.message}" }
+            lastError = result.exceptionOrNull()
+            Logger.w { "DFU: Connect attempt $attempt/$CONNECT_ATTEMPTS failed: ${lastError?.message}" }
             if (attempt < CONNECT_ATTEMPTS) delay(RETRY_DELAY_MS)
         }
-        return false
+        throw DfuException.ConnectionFailed(
+            "Failed to connect to DFU device after $CONNECT_ATTEMPTS attempts",
+            lastError,
+        )
     }
 
     private suspend fun obtainZipFile(


### PR DESCRIPTION
## Summary

Fixes #5695 — BLE OTA updates get stuck on "Connecting attempt X/Y" and never show an error when all connection attempts fail.

## Root Cause

`SecureDfuHandler.connectWithRetry()` returned `false` on failure without emitting `FirmwareUpdateState.Error`. The caller returned `null`, and the ViewModel had no fallback for this case — leaving the UI permanently frozen.

## Changes

| File | Change |
|---|---|
| `SecureDfuHandler.kt` | Throw `DfuException.ConnectionFailed` after all attempts exhausted (caught by existing error handler) |
| `Esp32OtaUpdateHandler.kt` | Remove dead-code `return false`, use `Unit` return — structural consistency |
| `FirmwareUpdateViewModel.kt` | Defense-in-depth: if `startUpdate()` returns without terminal state, transition to `Error` |

## Research & Validation

Cross-referenced against:
- **Nordic DFU Library** (`NordicSemiconductor/Android-DFU-Library`) — always reports errors to the user; never silently swallows connection failures
- **Meshtastic firmware** (`meshtastic/firmware`) — confirmed Heltec Tracker v1.2 is ESP32-S3 using OTA Loader partition; nRF52 devices use Adafruit Legacy DFU (service `0x1530`)
- Existing timeouts (15s connect, 10s scan × 3 retries × 4 attempts) are consistent with Nordic reference values

## Testing

- `./gradlew :feature:firmware:compileKotlinJvm` ✅
- `./gradlew :feature:firmware:allTests` ✅
- `./gradlew :feature:firmware:detekt` ✅ (after spotlessApply)