### PR TITLE
fix(map): scope cluster-renderer ViewTreeLifecycleOwner to map host view

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
@@ -17,7 +17,18 @@
 package org.meshtastic.app.map.component
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.currentStateAsState
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.savedstate.compose.LocalSavedStateRegistryOwner
+import androidx.savedstate.findViewTreeSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.google.maps.android.clustering.Cluster
 import com.google.maps.android.clustering.view.DefaultClusterRenderer
 import com.google.maps.android.compose.Circle
@@ -36,6 +47,40 @@ fun NodeClusterMarkers(
     navigateToNodeDetails: (Int) -> Unit,
     onClusterClick: (Cluster<NodeClusterItem>) -> Boolean,
 ) {
+    val view = LocalView.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
+    val lifecycleState by lifecycleOwner.lifecycle.currentStateAsState()
+
+    // maps-compose renders each non-clustered item to a bitmap through an off-screen ComposeView that
+    // it attaches under the MapView (see ComposeUiClusterRenderer + NoDrawContainerView in
+    // MapComposeViewRender). That ComposeView walks up the view tree for a ViewTreeLifecycleOwner and,
+    // when it finds none, crashes with "Composed into the View which doesn't propagate
+    // ViewTreeLifecycleOwner!" (googlemaps/android-maps-compose#875 / #325) — a FATAL on the map screen.
+    //
+    // Propagate the owners onto this map screen's host view (LocalView.current), which is an ancestor
+    // of the internally-created MapView, so the renderer's ComposeView can resolve them. We deliberately
+    // do NOT touch view.rootView (the activity root): attaching a transient NavEntry lifecycle there is
+    // what caused the node-list popup regression (#5684), which is why #5704 removed the prior, broader
+    // workaround entirely. Scoping to the map host view and restoring the previous owners on dispose
+    // keeps the fix local to the map and leaves Popups/DropdownMenus untouched.
+    DisposableEffect(view, lifecycleOwner, savedStateRegistryOwner) {
+        val prevLifecycleOwner = view.findViewTreeLifecycleOwner()
+        val prevSavedStateRegistryOwner = view.findViewTreeSavedStateRegistryOwner()
+        view.setViewTreeLifecycleOwner(lifecycleOwner)
+        view.setViewTreeSavedStateRegistryOwner(savedStateRegistryOwner)
+        onDispose {
+            view.setViewTreeLifecycleOwner(prevLifecycleOwner)
+            view.setViewTreeSavedStateRegistryOwner(prevSavedStateRegistryOwner)
+        }
+    }
+
+    // The cluster renderer drives marker rendering from an async Handler (DefaultClusterRenderer's
+    // MarkerModifier), which can fire after this screen has stopped and the internal ComposeView is
+    // detached — at which point no owner is reachable regardless of the above. Skip rendering once the
+    // lifecycle is no longer at least STARTED to close most of that race.
+    if (!lifecycleState.isAtLeast(Lifecycle.State.STARTED)) return
+
     Clustering(
         items = nodeClusterItems,
         onClusterClick = onClusterClick,


### PR DESCRIPTION
## Problem

The top FATAL crash on the google flavor of 2.7.14 is `com.google.maps.android.compose.clustering.ComposeUiClusterRenderer.renderViewToBitmapDescriptor` — `IllegalStateException: Composed into the View which doesn't propagate ViewTreeLifecycleOwner!`. It is **still present in build 29321006**, i.e. after #5704.

maps-compose renders each non-clustered item to a bitmap through an off-screen `ComposeView` that it attaches under the `MapView` (`ComposeUiClusterRenderer` + `NoDrawContainerView`). That `ComposeView` walks up the view tree for a `ViewTreeLifecycleOwner`; when it finds none it crashes. There is no upstream fix as of maps-compose 8.3.0 (latest) — tracked unresolved as [googlemaps/android-maps-compose#875](https://github.com/googlemaps/android-maps-compose/issues/875) / [#325](https://github.com/googlemaps/android-maps-compose/issues/325).

#5704 removed the previous workaround because it attached a transient NavEntry lifecycle to the **activity root**, which caused the node-list popup 0×0 regression (#5684).

## Fix

Re-introduce owner propagation, but **scoped to `LocalView.current`** (the map screen's host view, an ancestor of the internally-created `MapView`) instead of `view.rootView`:

- Sets `ViewTreeLifecycleOwner` + `SavedStateRegistryOwner` on the map host view so the renderer's internal `ComposeView` can resolve them.
- **Captures and restores** the previous owners on dispose, so Popups/DropdownMenus are left untouched (avoids reopening #5684).
- Keeps a `Lifecycle.STARTED` guard to skip the cluster renderer's async-`Handler` render after the screen has stopped.

`Clustering(...)`, `clusterItemContent`, and the precision-circle `clusterItemDecoration` are unchanged — no feature regression.

## Caveats

- This is a mitigation, not a hermetic seal: the async-Handler-after-dispose tail can only be fully closed by removing the library's ComposeView path entirely (a Canvas custom-renderer rewrite, which would require reimplementing the precision-circle decoration). Filed as a possible follow-up.
- Compile-verified (`spotlessCheck`, `detekt`, `:androidApp:compileGoogleDebugKotlin` all pass) but **not runtime-verified** here (needs a Maps key + real `google-services.json`). Suggest a smoke test: zoom to form/break clusters on the map, then navigate back and open a node-list popup to confirm popups still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)