### PR TITLE
fix(map): initialize Maps SDK before building marker bitmap descriptors

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/MarkerBitmapRenderer.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/MarkerBitmapRenderer.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.app.map.component
 
+import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
@@ -23,8 +24,10 @@ import android.graphics.Typeface
 import android.text.TextPaint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.core.graphics.createBitmap
+import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import org.meshtastic.core.model.Node
@@ -44,9 +47,11 @@ private const val EMOJI_PADDING_DP = 2f
  */
 @Composable
 fun rememberNodeChipDescriptor(node: Node): BitmapDescriptor {
+    val context = LocalContext.current
     val density = LocalDensity.current.density
     val fontScale = LocalDensity.current.fontScale
     return remember(node.num, node.user.short_name, node.colors, node.isIgnored) {
+        ensureMapsInitialized(context)
         renderNodeChipBitmap(node, density, fontScale)
     }
 }
@@ -54,9 +59,25 @@ fun rememberNodeChipDescriptor(node: Node): BitmapDescriptor {
 /** Renders an emoji waypoint marker as a [BitmapDescriptor] using Canvas. */
 @Composable
 fun rememberEmojiMarkerDescriptor(codePoint: Int): BitmapDescriptor {
+    val context = LocalContext.current
     val density = LocalDensity.current.density
     val fontScale = LocalDensity.current.fontScale
-    return remember(codePoint) { renderEmojiBitmap(codePoint, density, fontScale) }
+    return remember(codePoint) {
+        ensureMapsInitialized(context)
+        renderEmojiBitmap(codePoint, density, fontScale)
+    }
+}
+
+/**
+ * [BitmapDescriptorFactory] only works after the Maps SDK has been initialized, which normally happens when a
+ * GoogleMap/MapView is created. These descriptors are built during composition, and on the node-detail inline map the
+ * icon is computed before that screen's GoogleMap has loaded the SDK — so [BitmapDescriptorFactory.fromBitmap] crashes
+ * with "IBitmapDescriptorFactory is not initialized". Initialize explicitly first; [MapsInitializer.initialize] is
+ * synchronous and idempotent, so it is a no-op once the SDK is already up.
+ */
+@Suppress("DEPRECATION")
+private fun ensureMapsInitialized(context: Context) {
+    MapsInitializer.initialize(context)
 }
 
 private fun renderNodeChipBitmap(node: Node, density: Float, fontScale: Float): BitmapDescriptor {


### PR DESCRIPTION
## Problem

New FATAL on the **node-detail screen** (released alongside #5702/#5704/#5708):

```
java.lang.NullPointerException: IBitmapDescriptorFactory is not initialized
  at com.google.android.gms.maps.model.BitmapDescriptorFactory.fromBitmap(...)
  at org.meshtastic.app.map.component.MarkerBitmapRendererKt.renderNodeChipBitmap(MarkerBitmapRenderer.kt:95)
  at org.meshtastic.app.map.component.MarkerBitmapRendererKt.rememberNodeChipDescriptor(MarkerBitmapRenderer.kt:50)
  at org.meshtastic.app.node.component.InlineMapKt.InlineMap(InlineMap.kt:52)
```

`BitmapDescriptorFactory` only works after the Maps SDK has been initialized, which normally happens when a `GoogleMap`/`MapView` is created. The Canvas marker descriptors introduced in #5702 are built during composition — and on the node-detail inline map the marker icon is computed (`InlineMap.kt:52`, outside/before the `GoogleMap {}`) **before** that screen's `GoogleMap` has loaded the SDK, so `BitmapDescriptorFactory.fromBitmap()` throws.

This is why it only bites the inline map: on the full map screen a `GoogleMap` is already present, so the factory is initialized by the time markers render.

## Fix

Call `MapsInitializer.initialize(context)` before creating any descriptor, centralized in `rememberNodeChipDescriptor` / `rememberEmojiMarkerDescriptor`. It is synchronous and idempotent, so it's a no-op once the SDK is already up. Centralizing in the renderer covers every call site (inline map, waypoint markers, full map) and any future ones.

## Notes

- `MapsInitializer.initialize(Context)` is deprecated in favor of the async renderer-callback overload, but we need the **synchronous** guarantee here; suppressed locally with a comment.
- Compile-verified (`spotlessCheck`, `detekt`, `:androidApp:compileGoogleDebugKotlin` all pass). Not runtime-verified here (needs a Maps key + real `google-services.json`) — suggest a smoke test: open a node's detail screen (Position section) directly after a cold start, before visiting the full map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)