### PR TITLE
fix(map): apply kotlinx-serialization compiler plugin to androidApp

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
     alias(libs.plugins.meshtastic.android.application)
     alias(libs.plugins.meshtastic.android.application.flavors)
     alias(libs.plugins.meshtastic.android.application.compose)
+    alias(libs.plugins.meshtastic.kotlinx.serialization)
     id("meshtastic.koin")
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.secrets)


### PR DESCRIPTION
## Problem

Crashlytics is reporting a runtime crash in the latest build:

```
kotlinx.serialization.SerializationException: Serializer for class 'CustomTileProviderConfig' is not found.
Please ensure that class is marked as '@Serializable' and that the serialization compiler plugin is applied.
  ...
  kotlinx.serialization.json.Json.encodeToString(Json.java:205)
  org.meshtastic.app.map.repository.CustomTileProviderRepositoryImpl$saveDataToPrefs$2.invokeSuspend(CustomTileProviderRepository.kt:97)
```

## Root cause

The class **is** annotated `@Serializable` — this is not a missing annotation, nor an R8/minification issue. The `androidApp` module pulled in the kotlinx-serialization **runtime** (`kotlinx-serialization-json`) but never applied the **compiler plugin** (`org.jetbrains.kotlin.plugin.serialization`).

Without the compiler plugin, `@Serializable` is inert — no `$serializer` is synthesized. The code still compiles (the annotation and `Json` resolve from the runtime lib), but `Json.encodeToString` falls back to a reflective serializer lookup at runtime, finds nothing, and throws the exception above. Note the tail of the message: *"…and that the serialization compiler plugin is applied."*

Every other module that serializes (16 of them across `core/*` and `feature/*`) applies the shared `meshtastic.kotlinx.serialization` convention plugin. `androidApp` was the lone exception. The bug only surfaced now because the custom-tile-provider save path is rarely exercised — it would crash in debug too.

`MapCameraPosition` (also `@Serializable` in `androidApp`) had the same latent bug.

## Fix

Apply the existing `meshtastic.kotlinx.serialization` convention plugin to `androidApp`, exactly as the other serializing modules do. The convention plugin adds `serialization-core` when `kotlin.android` is present (composes cleanly with the existing `serialization-json` dep) and applies the compiler plugin so `$serializer` classes are generated for all `@Serializable` types in the module.

## Verification

- `./gradlew spotlessCheck detekt :androidApp:assembleGoogleDebug` — pass (the affected classes live in `src/google`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)