### PR TITLE
fix(map): keep compass icon visible while following bearing

### DIFF
--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/MapControlsOverlay.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/MapControlsOverlay.kt
@@ -42,6 +42,7 @@ import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.MyLocation
 import org.meshtastic.core.ui.icon.Refresh
 import org.meshtastic.core.ui.icon.Tune
+import org.meshtastic.core.ui.theme.StatusColors.StatusBlue
 import org.meshtastic.core.ui.theme.StatusColors.StatusRed
 
 /**
@@ -127,9 +128,11 @@ fun MapControlsOverlay(
 
 @Composable
 private fun CompassButton(onClick: () -> Unit, bearing: Float, isFollowing: Boolean) {
+    // Tint, not `primary` — tinting the icon `primary` painted it the same color as its own primary-colored
+    // button background, making the compass disappear while following.
     val iconTint =
         when {
-            isFollowing -> MaterialTheme.colorScheme.primary
+            isFollowing -> MaterialTheme.colorScheme.StatusBlue
             bearing == 0f -> MaterialTheme.colorScheme.StatusRed
             else -> null
         }


### PR DESCRIPTION
## Problem
The compass button on the Mesh Map disappears whenever the map is following the phone's bearing.

## Root cause
`CompassButton` (in `MapControlsOverlay.kt`) tinted the icon `MaterialTheme.colorScheme.primary` while following. But `MapButton` renders a `FilledIconButton`, whose container is **also** `colorScheme.primary` — so the icon was painted the same green as its own background and vanished. Because `isFollowing` is the first branch in the `when`, this happened for any bearing.

This is theme-robust to reason about: the app defaults to `dynamicColor = true`, so `primary` is device-dependent, but the icon and its container were always the *same* role, hence always invisible.

## Fix
Tint the following-state icon `StatusColors.StatusBlue` instead — a fixed indigo that stays legible on the primary-colored button and matches the existing pattern (the `bearing == 0f` branch already uses fixed `StatusRed`).

```kotlin
val iconTint =
    when {
        isFollowing -> MaterialTheme.colorScheme.StatusBlue
        bearing == 0f -> MaterialTheme.colorScheme.StatusRed
        else -> null
    }
```

## Testing
- `./gradlew :feature:map:allTests :feature:map:detekt spotlessCheck` — pass (23 tests, no detekt/spotless violations).
- Not yet device-verified visually; worth a quick look in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
