### PR TITLE
build: migrate KMP Android DSL from androidLibrary {} to android {}

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
@@ -118,7 +118,7 @@ internal fun Project.configureKotlinMultiplatform() {
 
                 // Default: disable Android resources for most KMP modules.
                 // Modules that need resources (e.g. core:resources) override this
-                // explicitly in their build.gradle.kts androidLibrary {} block.
+                // explicitly in their build.gradle.kts android {} block.
                 androidResources.enable = false
 
                 // Set the namespace automatically if not already set

--- a/core/ble/build.gradle.kts
+++ b/core/ble/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         withHostTest { isIncludeAndroidResources = true }
         withDeviceTest { instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner" }
     }

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest {} }
+    android { withHostTest {} }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         withHostTest { isIncludeAndroidResources = true }
         withDeviceTest { instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner" }
     }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/prefs/build.gradle.kts
+++ b/core/prefs/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest {} }
+    android { withHostTest {} }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/proto/build.gradle.kts
+++ b/core/proto/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 
 kotlin {
     // Override minSdk for ATAK compatibility (standard is 26)
-    androidLibrary { minSdk = 21 }
+    android { minSdk = 21 }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/repository/build.gradle.kts
+++ b/core/repository/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest {} }
+    android { withHostTest {} }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/resources/build.gradle.kts
+++ b/core/resources/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         androidResources {
             enable = true
             resourcePrefix = "meshtastic_"

--- a/core/service/build.gradle.kts
+++ b/core/service/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/takserver/build.gradle.kts
+++ b/core/takserver/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 
 kotlin {
     @Suppress("UnstableApiUsage")
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -18,7 +18,7 @@
 plugins { alias(libs.plugins.meshtastic.kmp.library) }
 
 kotlin {
-    androidLibrary { withHostTest {} }
+    android { withHostTest {} }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 kotlin {
     // Required for CMP files/ resources (emoji-data.json) to be packaged as Android assets.
     // Without this, Res.readBytes() throws MissingResourceException at runtime.
-    androidLibrary { androidResources.enable = true }
+    android { androidResources.enable = true }
 
     sourceSets {
         commonMain.dependencies {

--- a/feature/connections/build.gradle.kts
+++ b/feature/connections/build.gradle.kts
@@ -18,7 +18,7 @@
 plugins { alias(libs.plugins.meshtastic.kmp.feature) }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/feature/firmware/build.gradle.kts
+++ b/feature/firmware/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/feature/intro/build.gradle.kts
+++ b/feature/intro/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/feature/map/build.gradle.kts
+++ b/feature/map/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/feature/node/build.gradle.kts
+++ b/feature/node/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { isIncludeAndroidResources = true } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/feature/wifi-provision/build.gradle.kts
+++ b/feature/wifi-provision/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "org.meshtastic.feature.wifiprovision"
         withHostTest {}
     }


### PR DESCRIPTION
## What

Renames the Kotlin Multiplatform Android DSL block from the deprecated `androidLibrary { }` to `android { }` across all 22 KMP library modules.

## Why

On AGP 9.2.1 (our current version), `android { }` (inside `kotlin { }`) is the documented block for the `com.android.kotlin.multiplatform.library` plugin. `androidLibrary { }` is **deprecated since AGP 9.1.0-alpha09** and slated for removal in a future release (expected AGP 10.0). Per the [official Android-KMP plugin docs](https://developer.android.com/kotlin/multiplatform/plugin): *"Starting with AGP 8.12.0, a new `android{}` block was introduced to replace `androidLibrary{}`."*

## Changes

- `androidLibrary {` → `android {` in 22 module `build.gradle.kts` files (`core/*`, `feature/*`)
- Updated one stale comment in the convention plugin

The `findByType<KotlinMultiplatformAndroidLibraryTarget>()` calls in `build-logic` are **unchanged** — verified against the AGP 9.2.1 API jar that this type still backs the target and `...Target extends ...Extension`, so the accessor rename doesn't affect target lookup.

## Verification

- ✅ `./gradlew help` — all modules configure cleanly, no unresolved-reference or deprecation warnings
- ✅ `./gradlew build --dry-run` — full task graph wires up
- ✅ `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all pass (spotless introduced no changes)

Also audited the rest of the build for AGP 9 / Kotlin 2.3 deprecations (kotlinOptions, kapt, jcenter, legacy variant API, deprecated gradle.properties flags, manifest `package=`, etc.) — none found. Confirmed all module tests execute (no silently-skipped suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)