### PR TITLE
refactor(node): migrate to non-deprecated Vico chart APIs

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
@@ -140,7 +140,7 @@ fun GenericMetricChart(
                 // x-step, Vico computes the GCD of consecutive x-value differences which can
                 // be as small as 1 second, making the chart logically enormous. A 60-second
                 // floor keeps the internal slot count reasonable for any practical interval.
-                getXStep = { model -> maxOf(model.getXDeltaGcd(), MIN_X_STEP_SECONDS) },
+                getXStep = { model, _, _ -> maxOf(model.getXDeltaGcd(), MIN_X_STEP_SECONDS) },
             ),
             modelProducer = modelProducer,
             modifier = modifier,

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/DeviceMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/DeviceMetrics.kt
@@ -50,7 +50,7 @@ import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
 import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.rememberVicoScrollState
 import org.jetbrains.compose.resources.stringResource
@@ -274,7 +274,7 @@ private fun DeviceMetricsChart(
             modelProducer.runTransaction {
                 /* Series for Left Axis (0-100%) */
                 if (leftLayerSeriesStyles.isNotEmpty()) {
-                    lineSeries {
+                    lineModel {
                         if (batteryData.isNotEmpty()) {
                             series(
                                 x = batteryData.map { it.time },
@@ -297,7 +297,7 @@ private fun DeviceMetricsChart(
                 }
                 /* Series for Right Axis (Voltage) */
                 if (voltageData.isNotEmpty()) {
-                    lineSeries {
+                    lineModel {
                         series(
                             x = voltageData.map { it.time },
                             y = voltageData.map { it.device_metrics?.voltage ?: 0f },

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentCharts.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentCharts.kt
@@ -32,7 +32,7 @@ import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
 import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianChartModelProducer
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import org.jetbrains.compose.resources.stringResource
@@ -205,7 +205,7 @@ fun EnvironmentMetricsChart(
             modelProducer.runTransaction {
                 /* Pressure on its own layer/axis */
                 if (showPressure && pressureData.isNotEmpty()) {
-                    lineSeries {
+                    lineModel {
                         series(
                             x = pressureData.map { it.time },
                             y = pressureData.map { Environment.BAROMETRIC_PRESSURE.getValue(it)!! },
@@ -216,7 +216,7 @@ fun EnvironmentMetricsChart(
                 otherMetrics.forEach { metric ->
                     val metricData = otherMetricsData[metric] ?: emptyList()
                     if (metricData.isNotEmpty()) {
-                        lineSeries {
+                        lineModel {
                             series(x = metricData.map { it.time }, y = metricData.map { metric.getValue(it)!! })
                         }
                     }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/HostMetricsChart.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/HostMetricsChart.kt
@@ -27,7 +27,7 @@ import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
 import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import org.meshtastic.core.common.util.formatString
 import org.meshtastic.core.resources.Res
@@ -155,7 +155,7 @@ internal fun HostMetricsChart(
         LaunchedEffect(chartData) {
             modelProducer.runTransaction {
                 if (chartData.hasLoad) {
-                    lineSeries {
+                    lineModel {
                         if (load1Data.isNotEmpty()) {
                             series(x = load1Data.map { it.time }, y = load1Data.map { it.value })
                         }
@@ -168,7 +168,7 @@ internal fun HostMetricsChart(
                     }
                 }
                 if (memData.isNotEmpty()) {
-                    lineSeries { series(x = memData.map { it.time }, y = memData.map { it.value }) }
+                    lineModel { series(x = memData.map { it.time }, y = memData.map { it.value }) }
                 }
             }
         }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PaxMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PaxMetrics.kt
@@ -42,7 +42,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import org.jetbrains.compose.resources.StringResource
@@ -107,7 +107,7 @@ private fun PaxMetricsChart(
 
         LaunchedEffect(totalSeries, bleSeries, wifiSeries) {
             modelProducer.runTransaction {
-                lineSeries {
+                lineModel {
                     series(x = bleSeries.map { it.first }, y = bleSeries.map { it.second })
                     series(x = wifiSeries.map { it.first }, y = wifiSeries.map { it.second })
                     series(x = totalSeries.map { it.first }, y = totalSeries.map { it.second })

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
@@ -48,7 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
 import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
@@ -211,7 +211,7 @@ private fun PowerMetricsChart(
         LaunchedEffect(selectedChannel, currentData, voltageData) {
             modelProducer.runTransaction {
                 if (currentData.isNotEmpty()) {
-                    lineSeries {
+                    lineModel {
                         series(
                             x = currentData.map { it.time },
                             y = currentData.map { retrieveCurrent(selectedChannel, it) },
@@ -219,7 +219,7 @@ private fun PowerMetricsChart(
                     }
                 }
                 if (voltageData.isNotEmpty()) {
-                    lineSeries {
+                    lineModel {
                         series(
                             x = voltageData.map { it.time },
                             y = voltageData.map { retrieveVoltage(selectedChannel, it) },

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/SignalMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/SignalMetrics.kt
@@ -44,7 +44,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
 import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import org.meshtastic.core.common.util.DateFormatter
 import org.meshtastic.core.common.util.MetricFormatter
@@ -143,11 +143,11 @@ private fun SignalMetricsChart(
         LaunchedEffect(rssiData, snrData) {
             modelProducer.runTransaction {
                 if (rssiData.isNotEmpty()) {
-                    /* Use separate lineSeries calls to associate them with different vertical axes */
-                    lineSeries { series(x = rssiData.map { it.rx_time }, y = rssiData.map { it.rx_rssi }) }
+                    /* Use separate lineModel calls to associate them with different vertical axes */
+                    lineModel { series(x = rssiData.map { it.rx_time }, y = rssiData.map { it.rx_rssi }) }
                 }
                 if (snrData.isNotEmpty()) {
-                    lineSeries { series(x = snrData.map { it.rx_time }, y = snrData.map { it.rx_snr }) }
+                    lineModel { series(x = snrData.map { it.rx_time }, y = snrData.map { it.rx_snr }) }
                 }
             }
         }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TracerouteChart.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TracerouteChart.kt
@@ -27,7 +27,7 @@ import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
 import com.patrykandpatrick.vico.compose.cartesian.axis.VerticalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvider
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import org.meshtastic.core.common.util.formatString
 import org.meshtastic.core.model.MeshLog
@@ -157,15 +157,15 @@ internal fun TracerouteMetricsChart(
         LaunchedEffect(forwardData, returnData, rttData) {
             modelProducer.runTransaction {
                 if (forwardData.isNotEmpty()) {
-                    lineSeries {
+                    lineModel {
                         series(x = forwardData.map { it.timeSeconds }, y = forwardData.map { it.forwardHops!! })
                     }
                 }
                 if (returnData.isNotEmpty()) {
-                    lineSeries { series(x = returnData.map { it.timeSeconds }, y = returnData.map { it.returnHops!! }) }
+                    lineModel { series(x = returnData.map { it.timeSeconds }, y = returnData.map { it.returnHops!! }) }
                 }
                 if (rttData.isNotEmpty()) {
-                    lineSeries { series(x = rttData.map { it.timeSeconds }, y = rttData.map { it.roundTripSeconds!! }) }
+                    lineModel { series(x = rttData.map { it.timeSeconds }, y = rttData.map { it.roundTripSeconds!! }) }
                 }
             }
         }


### PR DESCRIPTION
## What changed

Vico 3.2.1 deprecated two charting APIs used across the node metrics charts. This migrates to their replacements:

- **`lineSeries` → `lineModel`** — a drop-in rename (the deprecated `lineSeries` simply delegates to `lineModel`). Updated the import + all call sites in `DeviceMetrics`, `EnvironmentCharts`, `HostMetricsChart`, `PaxMetrics`, `PowerMetrics`, `SignalMetrics`, and `TracerouteChart`.
- **`rememberCartesianChart` `getXStep` lambda** — the new overload's lambda receives `(model, minX, maxX)`. Updated `BaseMetricChart` from `{ model -> ... }` to `{ model, _, _ -> ... }`; the 60-second floor logic is unchanged.

## Why

These were the deprecation warnings flooding the Kotlin compiler output for `feature/node`. No behavior change — purely clearing deprecated API usage.

## Reviewer notes

- Verified locally: `spotlessApply spotlessCheck detekt` pass and `:feature:node:allTests` is green (627 tests). No remaining `lineSeries`/`getXStep` deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)