### PR TITLE
fix(mqtt): make the MQTT client-id unique per connection

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
@@ -45,6 +45,7 @@ import org.meshtastic.mqtt.ProbeResult
 import org.meshtastic.mqtt.probe
 import org.meshtastic.proto.MqttClientProxyMessage
 import org.meshtastic.proto.ToRadio
+import kotlin.uuid.Uuid
 
 @Single
 class MqttManagerImpl(
@@ -132,8 +133,10 @@ class MqttManagerImpl(
         val endpoint = resolveEndpoint(address, tlsEnabled)
         val result =
             MqttClient.probe(endpoint = endpoint) {
-                // Use node ID for consistent client identification across platforms
-                clientId = "MeshtasticAndroidMqttProbe-${nodeRepository.myId.value ?: "unknown"}"
+                // Per-connection random suffix: myId identifies the node (and is null →
+                // "unknown" before the node record loads), so two probes can collide on one
+                // client-id and evict each other (SESSION_TAKEN_OVER). See MQTTRepositoryImpl.
+                clientId = "MeshtasticAndroidMqttProbe-${nodeRepository.myId.value ?: "unknown"}-${Uuid.random()}"
                 val user = username?.takeUnless { it.isEmpty() }
                 val pass = password?.takeUnless { it.isEmpty() }
                 if (user != null) this.username = user

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -54,6 +54,7 @@ import org.meshtastic.mqtt.packet.Subscription
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.MqttClientProxyMessage
 import kotlin.concurrent.Volatile
+import kotlin.uuid.Uuid
 
 @Single(binds = [MQTTRepository::class])
 class MQTTRepositoryImpl(
@@ -112,7 +113,12 @@ class MQTTRepositoryImpl(
 
     @OptIn(ExperimentalSerializationApi::class)
     override val proxyMessageFlow: Flow<MqttClientProxyMessage> = callbackFlow {
-        val ownerId = "MeshtasticAndroidMqttProxy-${nodeRepository.myId.value ?: "unknown"}"
+        // Append a per-connection random id. myId identifies the *node* (and is null →
+        // "unknown" before the local node record loads), so it is not unique per client:
+        // clients sharing a node id — and the whole "unknown" pool on the public broker —
+        // evict each other (SESSION_TAKEN_OVER), storming reconnects. A fresh id per client
+        // (captured for its lifetime, so auto-reconnects stay stable) prevents that.
+        val ownerId = "MeshtasticAndroidMqttProxy-${nodeRepository.myId.value ?: "unknown"}-${Uuid.random()}"
         val channelSet = radioConfigRepository.channelSetFlow.first()
         val mqttConfig = radioConfigRepository.moduleConfigFlow.first().mqtt
 

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
@@ -256,7 +256,11 @@ class MQTTRepositoryImplTest {
             subscriptions.map { it.topicFilter },
         )
         assertTrue(subscriptions.all { it.maxQos == QoS.AT_LEAST_ONCE && it.noLocal })
-        assertEquals("MeshtasticAndroidMqttProxy-!12345678", harness.setups.single().ownerId)
+        assertTrue(
+            harness.setups.single().ownerId.startsWith("MeshtasticAndroidMqttProxy-!12345678-"),
+            "ownerId should be the node-scoped prefix plus a unique per-connection suffix, " +
+                "was: ${harness.setups.single().ownerId}",
+        )
         assertEquals(MqttLogLevel.DEBUG, harness.setups.single().logLevel)
 
         collector.cancelAndJoin()


### PR DESCRIPTION
## What
Append a per-connection random `Uuid` suffix to the MQTT proxy/probe client-id.

## Why
The client-id was `MeshtasticAndroidMqttProxy-$myId` (and `…Probe-$myId`), where `myId` is the **node** id — and is `null` → the literal `unknown` until the local node record loads. That isn't unique per connecting client:
- Every client whose node identity hasn't resolved yet shares the identical `MeshtasticAndroidMqttProxy-unknown`, so on the public broker they continuously evict one another.
- A replacement client after a BLE flap briefly reuses the same node-scoped id as the one still tearing down.

When a duplicate client-id connects, the broker evicts the previous holder with `SESSION_TAKEN_OVER` (0x8E); the two clients take the session back and forth — a reconnect storm. That storm is the trigger for the top `io.ktor` TLS-write crash on 2.7.14 (fixed independently in the `mqtt-client` library — this removes the trigger).

A radio only accepts one app connection at a time, so there is never a legitimate case for two clients to share an id — making a unique suffix unambiguously safe.

## Change
- `MQTTRepositoryImpl` (proxy) and `MqttManagerImpl` (probe): append `-${Uuid.random()}` to the client-id. Generated once per `MqttClient`/probe construction, so the id is captured for that client's lifetime — auto-reconnects keep the same id (no self-eviction), while a brand-new client after a flap gets a fresh one.
- `cleanStart = true` (unchanged default), so there is no durable session to preserve — a per-connection id is fine and avoids a stable broker-trackable identifier.
- `MQTTRepositoryImplTest`: assert the client-id prefix instead of exact equality.

## Testing
`spotlessCheck detekt kmpSmokeCompile :core:network:allTests :core:data:allTests` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)