### PR TITLE
ci: group Kotlin-compiler-locked tooling in one Renovate PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -91,6 +91,20 @@
         "major"
       ],
       "automerge": false
+    },
+    {
+      "description": "Coordinate the Kotlin-compiler-locked toolchain in one human-reviewed PR. Kotlin, KSP, Mokkery, and the Koin compiler plugin are version-locked to the Kotlin compiler and break when bumped out of lockstep (e.g. Mokkery 3.4.0 and kable 0.43.1 both required Kotlin 2.4.0 — PRs #5750/#5740). Supersedes the built-in group:kotlinMonorepo/group:kspMonorepo for these packages so they land together; automerge stays off so compiler bumps always get a human review plus a green CI build. The `[.:]` after kotlin intentionally excludes org.jetbrains.kotlinx (coroutines/serialization runtime), which is not compiler-locked.",
+      "groupName": "kotlin-toolchain",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchPackageNames": [
+        "/^org\\.jetbrains\\.kotlin[.:]/",
+        "/^com\\.google\\.devtools\\.ksp/",
+        "/^dev\\.mokkery/",
+        "/^io\\.insert-koin\\.compiler\\.plugin/"
+      ],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a `kotlin-toolchain` Renovate group covering the Kotlin-compiler-locked dependencies — the Kotlin Gradle plugins, KSP, Mokkery, and the Koin compiler plugin — so they bump **together in one PR** instead of separately. Automerge is disabled for the group so compiler bumps always get a human review plus a green CI build.

## Why

These are version-locked to the Kotlin compiler and break when Renovate bumps them in isolation:
- kable 0.43.1 (#5750) and Mokkery 3.4.0 (#5740) both required Kotlin 2.4.0 — each failed CI on its own because Kotlin hadn't moved.
- Renovate's built-in `group:kotlinMonorepo` / `group:kspMonorepo` only group within each origin, so Kotlin and KSP/Mokkery/Koin still land in **separate** PRs today.

This rule supersedes those built-in groups for the matched packages, so a Kotlin bump and its required tooling bumps arrive as one coordinated, CI-gated PR. The `[.:]` after `kotlin` intentionally excludes `org.jetbrains.kotlinx` (coroutines/serialization runtime), which isn't compiler-locked. Pattern follows `chrisbanes/tivi` and `google/horologist`, extended to also cover the Mokkery and Koin compiler plugins this project uses.

## Scope

Config-only — changes how *future* Renovate PRs are organized; no dependency versions change here. Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
