### PR TITLE
build: drop compiler flags and opt-ins made redundant by Kotlin 2.4

### DIFF
--- a/.agent_memory/session_context.archive.md
+++ b/.agent_memory/session_context.archive.md
@@ -1,6 +1,12 @@
 # Agent Session Context — ARCHIVE
 # Older handover entries rotated out of session_context.md. Not read by default.
 # Consult only if you need historical detail on a specific past change.
+## 2026-05-21 — Upgraded Chirpy to a fully-personalized Live Diagnostic Node & Mesh Assistant
+- Integrated `NodeRepository` into `GeminiNanoDocAssistant.kt` and the Google AI Koin dependency injection module (`GoogleAiModule.kt`).
+- Developed a dynamic live-state prompt formatting block within `buildPrompt(...)` that queries current hardware model, firmware version, connection status, GPS capability, channel utilization, airtime, battery level/voltage, user profile long/short names, and total registered mesh peer counts & active online peers directly from `NodeRepository`'s reactive flows.
+- Injected this live radio diagnostics context dynamically as a system instruction metadata block on every user query. This empowers the on-device model to answer real-time, personalized diagnostic questions (e.g. "what is my battery level?", "how many active nodes are on my mesh right now?") with 100% on-device offline accuracy.
+- Tuned context retrieval constraints for the modern `nano-v4-full` (Gemini Nano v4) model: expanded the total context budget `MAX_CONTEXT_CHARS` from 8,000 to **32,000 characters** (up to ~12K tokens out of the model's native 32K window), and scaled `MAX_PAGE_CHARS` to **16,000 characters** and `MAX_SNIPPET_CHARS` to **8,000 characters** to supply vastly richer, more detailed, and complete documentation fragments.
+
 
 ## 2026-05-21 — Activated full on-device token streaming and polished Chirpy's personality instructions
 - Upgraded the on-device inference flow inside `GeminiNanoDocAssistant.kt` to use Firebase AI SDK's reactive `generateContentStream(prompt)` instead of the blocking `generateContent` invocation.

--- a/.agent_memory/session_context.md
+++ b/.agent_memory/session_context.md
@@ -6,6 +6,12 @@
 # the oldest entries to `session_context.archive.md` (not read by default). The
 # "Golden Context" block at the bottom is stable across sessions; keep it here.
 
+## 2026-06-12 — Kotlin 2.4 flag/opt-in cleanup (PR #5786)
+- Kotlin 2.4.0 toolchain landed on main via Renovate #5760 (kotlin 2.4.0, mokkery 3.4.1, koin-plugin 1.0.1) + kable 0.43.1 (#5750).
+- PR #5786 (branch claude/modest-carson-f0c5c6) removes what 2.4 made redundant: build-logic SHARED_COMPILER_ARGS drops `-opt-in=kotlin.uuid.ExperimentalUuidApi` (Uuid.random/parse stable; only generateV4/V7 still experimental, unused), `-opt-in=kotlin.time.ExperimentalTime` (Clock/Instant stable since 2.3, no still-experimental time API used), `-Xcontext-parameters` (stable), `-Xannotation-default-target=param-property` (compiler reported redundant, ~34 warnings/build); ComposeCompilerConfiguration drops deprecated `ComposeFeatureFlag.OptimizeNonSkippingGroups` (default behavior, flag removed in Kotlin 2.6). Also stripped per-file @OptIn(ExperimentalUuidApi) from 7 files.
+- Verified twice with full baseline + kmpSmokeCompile (1706 tasks, 2756 tests, 0 failures); no warnings referencing removed flags, no new annotation-target warnings.
+- Remaining 2.4 adoption candidates (not in this PR): explicit backing fields for the ~96 `_state`/`asStateFlow` pairs (wait for IDE 2026.1.4 support), `@IntroducedAt` for meshtastic-sdk binary compat, Swift export alpha for the iOS goal. Also still TODO: drop kotlin<2.4 renovate holds in MQTTastic + protobufs.
+
 ## 2026-06-12 — Fixed flaky NodeTest.isOnline_usesStrictThresholdBoundary (wall-clock race)
 - PR #5779 (targeting main): the test read the clock twice — `onlineTimeThreshold()` once for its expected value, then again inside the `isOnline` getter; a one-second wall-clock tick between reads turned the strict-boundary assertion into `N+1 > N+1` = false. Seen failing on loaded CI in #5760's shard-core (jvm + androidHostTest).
 - Fix: internal `Node.isOnline(threshold: Int)` overload; the public `isOnline` property delegates to it. Test pins one threshold for both construction and check, keeping the strict `>` boundary assertion (no slop widening).
@@ -30,11 +36,6 @@
 - Made teardown resilient with `if (::manager.isInitialized) manager.close()` so setup/early failures do not cascade into teardown crashes.
 - Verified with `:core:database:jvmTest --tests "org.meshtastic.core.database.DatabaseManagerWithDbRetryTest*"` and repeated it 5 consecutive runs without failures; `:core:database:detekt` also passed.
 
-## 2026-05-21 — Upgraded Chirpy to a fully-personalized Live Diagnostic Node & Mesh Assistant
-- Integrated `NodeRepository` into `GeminiNanoDocAssistant.kt` and the Google AI Koin dependency injection module (`GoogleAiModule.kt`).
-- Developed a dynamic live-state prompt formatting block within `buildPrompt(...)` that queries current hardware model, firmware version, connection status, GPS capability, channel utilization, airtime, battery level/voltage, user profile long/short names, and total registered mesh peer counts & active online peers directly from `NodeRepository`'s reactive flows.
-- Injected this live radio diagnostics context dynamically as a system instruction metadata block on every user query. This empowers the on-device model to answer real-time, personalized diagnostic questions (e.g. "what is my battery level?", "how many active nodes are on my mesh right now?") with 100% on-device offline accuracy.
-- Tuned context retrieval constraints for the modern `nano-v4-full` (Gemini Nano v4) model: expanded the total context budget `MAX_CONTEXT_CHARS` from 8,000 to **32,000 characters** (up to ~12K tokens out of the model's native 32K window), and scaled `MAX_PAGE_CHARS` to **16,000 characters** and `MAX_SNIPPET_CHARS` to **8,000 characters** to supply vastly richer, more detailed, and complete documentation fragments.
 
 ## Golden Context (stable across sessions)
 - Always check `.skills/compose-ui/strings-index.txt` before reading `strings.xml`.

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/ComposeCompilerConfiguration.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/ComposeCompilerConfiguration.kt
@@ -20,7 +20,6 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
-import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
 
 internal fun Project.configureComposeCompiler() {
     extensions.configure<ComposeCompilerGradlePluginExtension> {
@@ -40,6 +39,5 @@ internal fun Project.configureComposeCompiler() {
             .relativeToRootProject("compose-reports")
             .let(reportsDestination::set)
         stabilityConfigurationFiles.add(isolated.rootProject.projectDirectory.file("compose_compiler_config.conf"))
-        featureFlags.add(ComposeFeatureFlag.OptimizeNonSkippingGroups)
     }
 }

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
@@ -228,11 +228,7 @@ private val PUBLISHED_MODULES = setOf("api", "model", "proto")
 /** Compiler args shared across all Kotlin targets (JVM, Android, iOS, etc.). */
 private val SHARED_COMPILER_ARGS =
     listOf(
-        "-opt-in=kotlin.uuid.ExperimentalUuidApi",
-        "-opt-in=kotlin.time.ExperimentalTime",
         "-Xexpect-actual-classes",
-        "-Xcontext-parameters",
-        "-Xannotation-default-target=param-property",
         "-Xskip-prerelease-check",
         "-Xbackend-threads=0",
     )

--- a/core/datastore/src/commonTest/kotlin/org/meshtastic/core/datastore/RecentAddressesDataSourceTest.kt
+++ b/core/datastore/src/commonTest/kotlin/org/meshtastic/core/datastore/RecentAddressesDataSourceTest.kt
@@ -39,10 +39,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalUuidApi::class)
 class RecentAddressesDataSourceTest {
     private lateinit var tmpDir: Path
     private lateinit var dataSource: RecentAddressesDataSource

--- a/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/filter/FilterPrefsTest.kt
+++ b/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/filter/FilterPrefsTest.kt
@@ -32,10 +32,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalUuidApi::class)
 class FilterPrefsTest {
     private lateinit var tmpDir: Path
 

--- a/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/notification/NotificationPrefsTest.kt
+++ b/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/notification/NotificationPrefsTest.kt
@@ -31,10 +31,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalUuidApi::class)
 class NotificationPrefsTest {
     private lateinit var tmpDir: Path
 

--- a/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/tak/TakPrefsTest.kt
+++ b/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/tak/TakPrefsTest.kt
@@ -31,10 +31,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalUuidApi::class)
 class TakPrefsTest {
     private lateinit var tmpDir: Path
 

--- a/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/ui/NodeListLayoutPrefsTest.kt
+++ b/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/ui/NodeListLayoutPrefsTest.kt
@@ -32,10 +32,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalUuidApi::class)
 class NodeListLayoutPrefsTest {
     private lateinit var tmpDir: Path
     private lateinit var dataStore: DataStore<Preferences>

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -81,7 +81,6 @@ import org.meshtastic.feature.settings.navigation.ConfigRoute
 import org.meshtastic.feature.settings.navigation.getNavRouteFrom
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.feature.settings.radio.component.PacketResponseStateDialog
-import kotlin.uuid.ExperimentalUuidApi
 
 /**
  * Fixed minimum height for the "connected device" card at the top of the Connections screen. Shared across the three UI
@@ -91,7 +90,7 @@ import kotlin.uuid.ExperimentalUuidApi
 private val CardMinHeight = 100.dp
 
 /** Composable screen for managing device connections (BLE, TCP, USB). It displays connection status. */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Suppress("CyclomaticComplexMethod", "LongMethod", "MagicNumber", "ModifierMissing", "ComposableParamOrder")
 @Composable
 fun ConnectionsScreen(

--- a/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/navigation/DocsNavigation.kt
+++ b/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/navigation/DocsNavigation.kt
@@ -64,12 +64,11 @@ import org.meshtastic.feature.docs.translation.DocTranslationService
 import org.meshtastic.feature.docs.translation.TranslationResult
 import org.meshtastic.feature.docs.ui.DocsBrowserScreen
 import org.meshtastic.feature.docs.ui.DocsPageRouteScreen
-import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import org.meshtastic.core.resources.Res as CoreRes
 
 /** Registers docs navigation entries into the Settings navigation graph. */
-@OptIn(ExperimentalUuidApi::class, ExperimentalMaterial3AdaptiveApi::class)
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
 fun EntryProviderScope<NavKey>.docsEntries(backStack: NavBackStack<NavKey>) {
     entry<SettingsRoute.HelpDocs>(metadata = { ListDetailSceneStrategy.listPane() }) {
         val hasDetailSelected = remember(backStack) { backStack.any { it is SettingsRoute.HelpDocPage } }
@@ -99,7 +98,6 @@ class ChirpyUiState(
     val onNavigateToPage: (String) -> Unit,
 )
 
-@OptIn(ExperimentalUuidApi::class)
 @Composable
 private fun rememberChirpyState(
     backStack: NavBackStack<NavKey>,
@@ -208,7 +206,6 @@ private fun rememberChirpyState(
     )
 }
 
-@OptIn(ExperimentalUuidApi::class)
 @Composable
 private fun AutoIntroduceChirpy(
     showSheet: Boolean,
@@ -384,7 +381,6 @@ private const val CHIRPY_INTRO_PROMPT =
         "Do not give the user a nickname. Be punchy and fun."
 
 /** Maps an [AIDocAssistantResult] to a [ChirpyMessage]. */
-@OptIn(ExperimentalUuidApi::class)
 private suspend fun chirpyResultToMessage(result: AIDocAssistantResult): ChirpyMessage = when (result) {
     is AIDocAssistantResult.Partial ->
         ChirpyMessage(


### PR DESCRIPTION
## Summary

Now that Kotlin 2.4.0 is on main (#5760), several build-logic compiler args and source opt-ins configure features that are stable (or default) in 2.4. This PR removes them — net `-21` lines, no behavior change.

### Build logic
- **`-opt-in=kotlin.uuid.ExperimentalUuidApi`** removed: `Uuid` (incl. `random()`/`parse()`) is stable in 2.4. Only the `generateV4/V7` variants remain experimental and nothing in the repo uses them (verified against the 2.4.0 stdlib sources).
- **`-opt-in=kotlin.time.ExperimentalTime`** removed: `Clock`/`Instant` stable since 2.3; no still-experimental `kotlin.time` API (`AbstractLongTimeSource`, `TestTimeSource`, `DurationUnit.convert`) is used anywhere.
- **`-Xcontext-parameters`** removed: context parameters are stable in 2.4 (`core/ui` ViewModelExtensions compile without it).
- **`-Xannotation-default-target=param-property`** removed: the 2.4 compiler reported the flag redundant (~34 warnings per build) — `param-property` defaulting is now language behavior.
- **`ComposeFeatureFlag.OptimizeNonSkippingGroups`** removed: default Compose compiler behavior; the flag is deprecated with removal slated for Kotlin 2.6.

### Sources
- Removed the now-meaningless `@OptIn(ExperimentalUuidApi::class)` annotations/imports from 7 files (5 prefs/datastore tests, `DocsNavigation`, `ConnectionsScreen`).

## Verification

`./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile --continue` — **PASS** (1706 tasks, 2756 tests, 0 failures), run twice (before and after the annotation-target flag removal). No remaining compiler warnings referencing the removed flags, and no new annotation-target warnings (confirming the defaulting change is a no-op for this codebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)