### PR TITLE
feat: arrange power metrics in vertical per-channel columns

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/PowerMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/PowerMetrics.kt
@@ -17,10 +17,12 @@
 package org.meshtastic.feature.node.component
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.common.util.NumberFormatter
 import org.meshtastic.core.model.Node
@@ -34,11 +36,7 @@ import org.meshtastic.core.ui.icon.Voltage
 import org.meshtastic.feature.node.model.VectorMetricInfo
 
 /**
- * Displays environmental metrics for a node, including temperature, humidity, pressure, and other sensor data.
- *
- * WARNING: All metrics must be added in pairs (e.g., voltage and current for each channel) due to the display logic,
- * which arranges metrics in columns of two. If an odd number of metrics is provided, the UI may not display as
- * intended.
+ * Displays power metrics for a node, grouped by channel with voltage and current readings.
  */
 @Composable
 @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -47,49 +45,49 @@ internal fun PowerMetrics(node: Node) {
         with(node.powerMetrics) {
             if ((ch1_voltage ?: 0f) != 0f) {
                 add(
-                    VectorMetricInfo(
-                        Res.string.channel_1,
-                        "${NumberFormatter.format(ch1_voltage ?: 0f, 2)}V",
-                        MeshtasticIcons.Voltage,
-                    ),
-                )
-                add(
-                    VectorMetricInfo(
-                        Res.string.channel_1,
-                        "${NumberFormatter.format(ch1_current ?: 0f, 1)}mA",
-                        MeshtasticIcons.PowerSupply,
+                    Pair(
+                        VectorMetricInfo(
+                            Res.string.channel_1,
+                            "${NumberFormatter.format(ch1_voltage ?: 0f, 2)}V",
+                            MeshtasticIcons.Voltage,
+                        ),
+                        VectorMetricInfo(
+                            Res.string.channel_1,
+                            "${NumberFormatter.format(ch1_current ?: 0f, 1)}mA",
+                            MeshtasticIcons.PowerSupply,
+                        ),
                     ),
                 )
             }
             if ((ch2_voltage ?: 0f) != 0f) {
                 add(
-                    VectorMetricInfo(
-                        Res.string.channel_2,
-                        "${NumberFormatter.format(ch2_voltage ?: 0f, 2)}V",
-                        MeshtasticIcons.Voltage,
-                    ),
-                )
-                add(
-                    VectorMetricInfo(
-                        Res.string.channel_2,
-                        "${NumberFormatter.format(ch2_current ?: 0f, 1)}mA",
-                        MeshtasticIcons.PowerSupply,
+                    Pair(
+                        VectorMetricInfo(
+                            Res.string.channel_2,
+                            "${NumberFormatter.format(ch2_voltage ?: 0f, 2)}V",
+                            MeshtasticIcons.Voltage,
+                        ),
+                        VectorMetricInfo(
+                            Res.string.channel_2,
+                            "${NumberFormatter.format(ch2_current ?: 0f, 1)}mA",
+                            MeshtasticIcons.PowerSupply,
+                        ),
                     ),
                 )
             }
             if ((ch3_voltage ?: 0f) != 0f) {
                 add(
-                    VectorMetricInfo(
-                        Res.string.channel_3,
-                        "${NumberFormatter.format(ch3_voltage ?: 0f, 2)}V",
-                        MeshtasticIcons.Voltage,
-                    ),
-                )
-                add(
-                    VectorMetricInfo(
-                        Res.string.channel_3,
-                        "${NumberFormatter.format(ch3_current ?: 0f, 1)}mA",
-                        MeshtasticIcons.PowerSupply,
+                    Pair(
+                        VectorMetricInfo(
+                            Res.string.channel_3,
+                            "${NumberFormatter.format(ch3_voltage ?: 0f, 2)}V",
+                            MeshtasticIcons.Voltage,
+                        ),
+                        VectorMetricInfo(
+                            Res.string.channel_3,
+                            "${NumberFormatter.format(ch3_current ?: 0f, 1)}mA",
+                            MeshtasticIcons.PowerSupply,
+                        ),
                     ),
                 )
             }
@@ -100,8 +98,19 @@ internal fun PowerMetrics(node: Node) {
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalArrangement = Arrangement.SpaceEvenly,
     ) {
-        metrics.forEach { metric ->
-            InfoCard(icon = metric.icon, text = stringResource(metric.label), value = metric.value)
+        metrics.forEach { (voltageMetric, currentMetric) ->
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                InfoCard(
+                    icon = voltageMetric.icon,
+                    text = stringResource(voltageMetric.label),
+                    value = voltageMetric.value,
+                )
+                InfoCard(
+                    icon = currentMetric.icon,
+                    text = stringResource(currentMetric.label),
+                    value = currentMetric.value,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Thank you for sending in a pull request, here's some tips to get started!

## Summary

Restructures the node detail "Power Metrics" section so each channel's voltage and current are grouped into a vertical column, with voltage stacked directly above current. Previously every channel contributed two independent `InfoCard`s that were flattened into a single `FlowRow` with `Arrangement.SpaceEvenly`, which scattered the voltage/current pairs across the row on wide screens.

Each populated channel is now built as a (voltage, current) pair and rendered as its own `Column` inside the outer `FlowRow`, so the pairs stay together and the layout uses vertical space more efficiently. The existing zero-value suppression is preserved: channels reporting `0f` voltage are still omitted entirely. Labels, `V`/`mA` formatting, and the voltage/power icons are unchanged.

Because the metrics are now grouped structurally, the misleading KDoc warning that said metrics "must be added in pairs ... due to the display logic, which arranges metrics in columns of two" no longer applies and has been removed. The KDoc summary line, which had a copy-paste error describing environmental metrics (temperature, humidity, pressure), has been corrected to describe power metrics.

## Why this matters

On wide screens the flat `FlowRow` spread each channel's voltage and current apart, making the section harder to read and wasting vertical space. Grouping per channel into vertical columns keeps each channel's readings together and uses the available space more efficiently, as requested in #4507.

## Testing

This is a self-contained Compose layout change confined to `PowerMetrics.kt`. The metric selection, zero-value suppression, number formatting, and icon choices are unchanged; only the arrangement of the existing cards into per-channel columns differs. The `PowerMetrics(node)` composable remains the one rendered by `TelemetricActionsSection`.

Fixes #4507
