### PR TITLE
feat(node): show our node shortname chip on the Nodes tab

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -150,7 +150,7 @@ fun NodeListScreen(
                 title = stringResource(Res.string.nodes),
                 subtitle = stringResource(Res.string.node_count_template, onlineNodeCount, nodes.size, totalNodeCount),
                 ourNode = ourNode,
-                showNodeChip = false,
+                showNodeChip = ourNode != null && connectionState is ConnectionState.Connected,
                 canNavigateUp = false,
                 onNavigateUp = {},
                 actions = {
@@ -161,7 +161,7 @@ fun NodeListScreen(
                         )
                     }
                 },
-                onClickChip = {},
+                onClickChip = { navigateToNodeDetails(it.num) },
             )
         },
         floatingActionButton = {


### PR DESCRIPTION
Every top-level tab — Conversations, Mesh map, Settings, Connected — shows the connected node's shortname chip in the app bar's upper-right corner, except the Nodes tab, which suppressed it. This adds the chip there in the same place and the same way, so it's consistent and predictable when managing multiple nodes.

Fixes #5004

### 🌟 New Features
- **Nodes tab shortname chip:** The `MainAppBar` on the Nodes list now shows our node's shortname chip, gated on the same condition the other tabs use (`ourNode != null && connectionState is ConnectionState.Connected`), instead of being hard-coded off.
- Tapping the chip opens our node's detail screen, reusing the existing `navigateToNodeDetails` callback — matching the chip's behavior on the other tabs.

### Notes
- No new ViewModel wiring was needed: `ourNode`, `connectionState`, and `navigateToNodeDetails` were already in scope in `NodeListScreen`.
- The chip renders to the left of the existing help action and is independent of the node-count subtitle, so there's no layout conflict.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->