### PR TITLE
feat(settings): add remote "Set time" admin action

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1271,6 +1271,7 @@ serial_tx_pin
 server
 session_active
 session_refresh_required
+set_time
 set_up_connection
 set_your_region
 settings

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/AdminActionsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/AdminActionsUseCase.kt
@@ -76,6 +76,20 @@ constructor(
     }
 
     /**
+     * Syncs the node's real-time clock to the phone's current time.
+     *
+     * Lets a user correct a remote node whose RTC has drifted without being on-site or using the CLI.
+     *
+     * @param destNum The node number to update.
+     * @return The packet ID of the request.
+     */
+    open suspend fun setTime(destNum: Int): Int {
+        val packetId = radioController.generatePacketId()
+        radioController.setTime(destNum, packetId)
+        return packetId
+    }
+
+    /**
      * Resets the NodeDB on the radio.
      *
      * @param destNum The node number to reset.

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AdminController.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AdminController.kt
@@ -83,6 +83,15 @@ interface AdminController {
     /** Updates the canned messages configuration on a remote node. */
     suspend fun setCannedMessages(destNum: Int, messages: String)
 
+    /**
+     * Syncs a node's real-time clock to the phone's current time via `AdminMessage.set_time_only`.
+     *
+     * Mirrors the Python CLI's `Node.setTime`: an accurate epoch-seconds timestamp is sent so a remote node whose RTC
+     * has drifted can be corrected without an on-site visit. Fire-and-forget — the firmware applies the value without
+     * an admin response (the routing ACK confirms delivery).
+     */
+    suspend fun setTime(destNum: Int, packetId: Int)
+
     // ── Remote queries ──────────────────────────────────────────────────────
 
     /** Requests the current owner (user info) from a remote node. */

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1313,6 +1313,7 @@
     <string name="server">Server</string>
     <string name="session_active">Session active</string>
     <string name="session_refresh_required">Refresh required</string>
+    <string name="set_time">Set time</string>
     <string name="set_up_connection">Set up connection</string>
     <string name="set_your_region">Set your region</string>
     <string name="settings">settings</string>
@@ -1583,3 +1584,4 @@
     <string name="zh_CN" translatable="false">简体中文</string>
     <string name="zh_TW" translatable="false">繁體中文</string>
 </resources>
+

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/AdminControllerImpl.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.util.handledLaunch
+import org.meshtastic.core.common.util.nowSeconds
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.AdminEditScope
@@ -158,6 +159,12 @@ internal class AdminControllerImpl(
 
     override suspend fun setCannedMessages(destNum: Int, messages: String) {
         commandSender.sendAdmin(destNum) { AdminMessage(set_canned_message_module_messages = messages) }
+    }
+
+    override suspend fun setTime(destNum: Int, packetId: Int) {
+        Logger.i { "Set time requested for node $destNum" }
+        // Resolve the timestamp at send time so the value is as fresh as possible when it leaves the phone.
+        commandSender.sendAdmin(destNum, packetId) { AdminMessage(set_time_only = nowSeconds.toInt()) }
     }
 
     override suspend fun getCannedMessages(destNum: Int, packetId: Int) {

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/RadioControllerImplTest.kt
@@ -340,6 +340,25 @@ class RadioControllerImplTest {
     }
 
     @Test
+    fun setTimeSendsAdminMessageWithCurrentEpochSeconds() = runTest {
+        val controller = createController()
+
+        var sentMessage: AdminMessage? = null
+        everySuspend { commandSender.sendAdmin(any(), any(), any(), any()) } calls
+            {
+                @Suppress("UNCHECKED_CAST")
+                sentMessage = (it.args[3] as () -> AdminMessage)()
+            }
+
+        controller.setTime(destNum = 101, packetId = 11)
+
+        verifySuspend { commandSender.sendAdmin(any(), any(), any(), any()) }
+        // The phone's current time is sent; assert it is populated and a plausible recent epoch (after 2020).
+        val setTime = sentMessage?.set_time_only
+        assertTrue(setTime != null && setTime > 1_577_836_800)
+    }
+
+    @Test
     fun refreshMetadataSendsAdminWithWantResponse() = runTest {
         val controller = createController()
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -123,6 +123,8 @@ class FakeRadioController :
 
     override suspend fun setCannedMessages(destNum: Int, messages: String) {}
 
+    override suspend fun setTime(destNum: Int, packetId: Int) {}
+
     override suspend fun getOwner(destNum: Int, packetId: Int) {}
 
     override suspend fun getConfig(destNum: Int, configType: Int, packetId: Int) {}

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfig.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfig.kt
@@ -44,6 +44,7 @@ import org.meshtastic.core.resources.firmware_update_title
 import org.meshtastic.core.resources.ic_power_settings_new
 import org.meshtastic.core.resources.ic_restart_alt
 import org.meshtastic.core.resources.ic_restore
+import org.meshtastic.core.resources.ic_schedule
 import org.meshtastic.core.resources.ic_storage
 import org.meshtastic.core.resources.import_configuration
 import org.meshtastic.core.resources.message_device_managed
@@ -51,6 +52,7 @@ import org.meshtastic.core.resources.module_settings
 import org.meshtastic.core.resources.nodedb_reset
 import org.meshtastic.core.resources.radio_configuration
 import org.meshtastic.core.resources.reboot
+import org.meshtastic.core.resources.set_time
 import org.meshtastic.core.resources.shutdown
 import org.meshtastic.core.resources.tak_server
 import org.meshtastic.core.ui.component.ListItem
@@ -227,6 +229,7 @@ private fun AdvancedSection(isManaged: Boolean, isOtaCapable: Boolean, enabled: 
 }
 
 enum class AdminRoute(val icon: DrawableResource, val title: StringResource) {
+    SET_TIME(Res.drawable.ic_schedule, Res.string.set_time),
     REBOOT(Res.drawable.ic_restart_alt, Res.string.reboot),
     SHUTDOWN(Res.drawable.ic_power_settings_new, Res.string.shutdown),
     FACTORY_RESET(Res.drawable.ic_restore, Res.string.factory_reset),

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -424,6 +424,12 @@ open class RadioConfigViewModel(
         val preserveFavorites = radioConfigState.value.nodeDbResetPreserveFavorites
 
         when (route) {
+            AdminRoute.SET_TIME.name ->
+                safeLaunch(tag = "setTime") {
+                    val packetId = adminActionsUseCase.setTime(destNum)
+                    registerRequestId(packetId)
+                }
+
             AdminRoute.REBOOT.name ->
                 safeLaunch(tag = "reboot") {
                     val packetId = adminActionsUseCase.reboot(destNum)


### PR DESCRIPTION
Even with an RTC, nodes lose accurate time over the long run. This adds a one-tap **Set time** action to the remote Administration section so a user can push an accurate clock to a drifted node without being on-site or dropping to the CLI.

Resolves #5789

### 🌟 New Features
- **"Set time" remote admin action.** New `AdminRoute.SET_TIME` entry (clock icon + `set_time` string) at the top of the Administration screen. Tapping it shows the standard confirmation dialog and, on confirm, sends the phone's current time to the selected node.
- Behavior matches the existing admin actions: the flow runs the `SESSIONKEY_CONFIG` preflight first (which seeds the remote session passkey), then sends the command; completion rides the routing ACK exactly like `reboot`/`shutdown`.

### 🛠️ Refactoring & Architecture
- Added `setTime(destNum, packetId)` to the `AdminController` interface and `AdminControllerImpl`, which sends `AdminMessage(set_time_only = <current epoch seconds>)` via the existing `CommandSender`. The timestamp is resolved at send time (using the shared `nowSeconds` accessor) so it is as fresh as possible when it leaves the phone. This mirrors the SDK `AdminApi` boundary and the Python CLI's `Node.setTime`.
- Added `AdminActionsUseCase.setTime(destNum)` and wired the `AdminRoute.SET_TIME` branch in `RadioConfigViewModel.sendAdminRequest`.
- Fire-and-forget by design: `set_time_only` has no admin response (consistent with the local-node time-set already sent during the connection handshake).

### 🧹 Chores
- Added the `set_time` string resource and re-ran `scripts/sort-strings.py` (regenerates `strings-index.txt`).
- Added the `setTime` no-op override to the `FakeRadioController` test double.

### Testing Performed
- Added `setTimeSendsAdminMessageWithCurrentEpochSeconds` to `RadioControllerImplTest`, which captures the sent `AdminMessage` and asserts `set_time_only` is populated with a plausible recent epoch timestamp.
- Ran the full baseline locally — all green: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
