### PR TITLE
feat(export): add hop start and relay node columns to CSV export

### DIFF
--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ExportDataUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ExportDataUseCase.kt
@@ -37,6 +37,12 @@ constructor(
     private val nodeRepository: NodeRepository,
     private val meshLogRepository: MeshLogRepository,
 ) {
+    companion object {
+        private const val BYTE_MASK = 0xFF
+        private const val HEX_PAD_WIDTH = 2
+        private const val HEX_RADIX = 16
+    }
+
     /**
      * Writes all persisted packet data to the provided [BufferedSink].
      *
@@ -55,7 +61,7 @@ constructor(
 
         @Suppress("MaxLineLength")
         sink.writeUtf8(
-            "\"date\",\"time\",\"from\",\"sender name\",\"sender lat\",\"sender long\",\"rx lat\",\"rx long\",\"rx elevation\",\"rx snr\",\"distance(m)\",\"hop limit\",\"payload\"\n",
+            "\"date\",\"time\",\"from\",\"sender name\",\"sender lat\",\"sender long\",\"rx lat\",\"rx long\",\"rx elevation\",\"rx snr\",\"distance(m)\",\"hop limit\",\"hop start\",\"relay node\",\"payload\"\n",
         )
 
         meshLogRepository.getAllLogsInReceiveOrder(Int.MAX_VALUE).first().forEach { packet ->
@@ -101,6 +107,15 @@ constructor(
                         }
 
                     val hopLimit = proto.hop_limit
+                    // hop_start lets a reader derive hops-away (hop_start - hop_limit) alongside hop_limit.
+                    val hopStart = proto.hop_start
+                    // relay_node carries only the last byte of the relaying node's NodeNum (0 means unset).
+                    // Emit it as a hex byte so it can be matched against the tail of a node id (e.g. !a1b2c3d4 ->
+                    // "d4").
+                    val relayNode =
+                        proto.relay_node
+                            .takeIf { it != 0 }
+                            ?.let { (it and BYTE_MASK).toString(HEX_RADIX).padStart(HEX_PAD_WIDTH, '0') } ?: ""
                     val decoded = proto.decoded
                     val encrypted = proto.encrypted
                     val payload =
@@ -118,7 +133,7 @@ constructor(
 
                     @Suppress("MaxLineLength")
                     sink.writeUtf8(
-                        "$rxDateTime,\"$rxFrom\",\"$senderName\",\"$senderLat\",\"$senderLong\",\"$rxLat\",\"$rxLong\",\"$rxAlt\",\"$rxSnr\",\"$dist\",\"$hopLimit\",\"$payload\"\n",
+                        "$rxDateTime,\"$rxFrom\",\"$senderName\",\"$senderLat\",\"$senderLong\",\"$rxLat\",\"$rxLong\",\"$rxAlt\",\"$rxSnr\",\"$dist\",\"$hopLimit\",\"$hopStart\",\"$relayNode\",\"$payload\"\n",
                     )
                 }
             }

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/ExportDataUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/ExportDataUseCaseTest.kt
@@ -50,6 +50,7 @@ class ExportDataUseCaseTest {
 
         val output = buffer.readUtf8()
         assertTrue(output.startsWith("\"date\",\"time\",\"from\""))
+        assertTrue(output.contains("\"hop limit\",\"hop start\",\"relay node\",\"payload\""))
     }
 
     @Test
@@ -78,5 +79,64 @@ class ExportDataUseCaseTest {
         val output = buffer.readUtf8()
         assertTrue(output.contains("\"1234\""))
         assertTrue(output.contains("Hello"))
+    }
+
+    @Test
+    fun `invoke writes hop start and relay node columns`() = runTest {
+        val buffer = Buffer()
+        val log =
+            MeshLog(
+                uuid = "1",
+                message_type = "TEXT",
+                received_date = 1000000000L,
+                raw_message = "",
+                fromRadio =
+                FromRadio(
+                    packet =
+                    MeshPacket(
+                        from = 1234,
+                        rx_snr = 5.0f,
+                        hop_limit = 2,
+                        hop_start = 3,
+                        relay_node = 77, // 0x4d -> matches the tail of a node id such as !........4d
+                        decoded = Data(portnum = PortNum.TEXT_MESSAGE_APP, payload = "Hello".encodeUtf8()),
+                    ),
+                ),
+            )
+        meshLogRepository.setLogs(listOf(log))
+
+        useCase(buffer, 1)
+
+        val output = buffer.readUtf8()
+        // hop limit, hop start, relay node (hex), payload
+        assertTrue(output.contains("\"2\",\"3\",\"4d\",\"Hello\""))
+    }
+
+    @Test
+    fun `invoke leaves relay node blank when unset`() = runTest {
+        val buffer = Buffer()
+        val log =
+            MeshLog(
+                uuid = "1",
+                message_type = "TEXT",
+                received_date = 1000000000L,
+                raw_message = "",
+                fromRadio =
+                FromRadio(
+                    packet =
+                    MeshPacket(
+                        from = 1234,
+                        rx_snr = 5.0f,
+                        decoded = Data(portnum = PortNum.TEXT_MESSAGE_APP, payload = "Hello".encodeUtf8()),
+                    ),
+                ),
+            )
+        meshLogRepository.setLogs(listOf(log))
+
+        useCase(buffer, 1)
+
+        val output = buffer.readUtf8()
+        // relay_node defaults to 0 (unset) -> blank field before the payload
+        assertTrue(output.contains("\"0\",\"\",\"Hello\""))
     }
 }


### PR DESCRIPTION
The packet CSV dump only exposed `hop limit`, which is enough to map whole-network coverage but not to tell *which* repeater relayed a given packet. This surfaces the relaying repeater (and the original hop count) so users can map the coverage of individual repeaters.

Resolves #5801

### 🌟 New Features
- Add a **`relay node`** column carrying the `relay_node` byte from `MeshPacket` — the last byte of the relaying node's `NodeNum`. It's emitted as a 2-digit hex value so it matches the tail of a node id (e.g. `!a1b2c3d4` → `"d4"`), and left blank when unset (`0`). This is the "last hop byte" requested in the issue: it identifies the repeater a packet was heard from.
- Add a **`hop start`** column alongside the existing `hop limit` so a reader can derive hops-away (`hop_start - hop_limit`) and confirm whether a packet was a direct vs. relayed reception.

### 🛠️ Notes on column ordering
- Both new columns are inserted **before** `payload`, keeping the free-text `payload` field last (safest for CSV with embedded commas/quotes) and leaving every pre-existing column at its current index. Tools that read columns by header name are unaffected; tools that read `payload` by fixed position will need to shift it two columns right.

### Testing Performed
- Updated `ExportDataUseCaseTest` (`core/domain` `commonTest`):
  - `invoke writes header to sink` now asserts the new `"hop start","relay node","payload"` header tail.
  - `invoke writes hop start and relay node columns` — verifies a packet with `hop_limit=2, hop_start=3, relay_node=77` serializes as `"2","3","4d","Hello"`.
  - `invoke leaves relay node blank when unset` — verifies `relay_node=0` produces a blank field.
- Full baseline: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all pass.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->