### PR TITLE
feat(mqtt): add phone-local MQTT proxy cutoff control

### DIFF
--- a/.agent_memory/session_context.archive.md
+++ b/.agent_memory/session_context.archive.md
@@ -1,6 +1,46 @@
 # Agent Session Context — ARCHIVE
 # Older handover entries rotated out of session_context.md. Not read by default.
 # Consult only if you need historical detail on a specific past change.
+## 2026-05-28 — Added comprehensive CarScreenDataBuilder unit coverage
+- Created `feature/car/src/test/kotlin/org/meshtastic/feature/car/util/CarScreenDataBuilderTest.kt` with 533 lines covering signal quality thresholds/boundaries, node UI mapping, node and conversation sorting, local stats fallbacks, uptime formatting, recent message limiting, contact key generation, and constants.
+- Restored the `MessageSnapshot` data class in `CarStateCoordinator.kt` and re-added `recentMessages()` plus `MAX_CONVERSATION_MESSAGES` in `CarScreenDataBuilder.kt` so the current source matched the requested pure-helper API surface for testing.
+- Verified with `./gradlew :feature:car:spotlessCheck :feature:car:detekt :feature:car:testFdroidDebugUnitTest --quiet` and the requested quiet test command (`./gradlew :feature:car:testFdroidDebugUnitTest --quiet 2>&1 | tail -20`), both successful.
+
+## 2026-05-28 — Lowered car min API to 7 and removed dead conversation code
+- Changed `feature/car` manifest `androidx.car.app.minCarApiLevel` metadata from 8 to 7.
+- Guarded `HomeScreen.showEmergencyAlert()` behind `carContext.carAppApiLevel >= 8` and logged unsupported API 7 hosts with Kermit.
+- Removed unused `ConversationScreen`, `CarTtsEngine`, message snapshot/cache/read-aloud plumbing, and now-unused car reply/read-aloud strings.
+- Simplified `CarStateCoordinator` and `CarScreenDataBuilder` to match the inline `ConversationItem` flow.
+- Verified with `./gradlew :feature:car:spotlessApply :feature:car:spotlessCheck :feature:car:detekt :feature:car:compileFdroidDebugKotlin --quiet 2>&1 | tail -30`.
+
+## 2026-05-28 — Migrated car home messages tab to ConversationItem
+- Reworked `feature/car` `HomeScreen` messaging tab to build CAL `ConversationItem` entries instead of browsable `Row`s, including `Person`/`CarMessage` helpers and native reply/mark-read callbacks.
+- Removed `HomeScreen` conversation navigation so the car host owns messaging affordances; `ConversationScreen` remains on disk for later cleanup phases.
+- Added `CarStateCoordinator.markAsRead()` using `packetRepository.clearUnreadCount(...)` with Kermit error logging via `runCatching`.
+- Verified with `./gradlew :feature:car:spotlessApply :feature:car:spotlessCheck :feature:car:detekt :feature:car:compileFdroidDebugKotlin` and the requested quiet compile command (`:feature:car:compileFdroidDebugKotlin --quiet 2>&1 | tail -20`), both successful.
+
+## 2026-05-28 — Implemented car conversation shortcuts and avatars
+- Added `feature/car/.../util/PersonIconFactory.kt` to render circular initial avatars using node-derived foreground/background colors for `Person` and shortcut icons.
+- Added `feature/car/.../service/ConversationShortcutManager.kt` to publish long-lived dynamic conversation shortcuts for favorite nodes and active channels, plus on-demand shortcut creation for notifications.
+- Wired `MeshtasticCarSession` to start/stop shortcut observation on a dedicated session coroutine scope.
+- Updated `CarNotificationManager` to ensure conversation shortcuts exist before posting and to attach both `shortcutId` and `LocusIdCompat` to messaging notifications.
+- Verified green with `./gradlew :feature:car:spotlessCheck :feature:car:detekt --quiet` and `./gradlew :feature:car:compileFdroidDebugKotlin --quiet 2>&1 | tail -20` after workspace bootstrap.
+
+## 2026-05-28 — Implemented car local stats tab and extracted screen data builder
+- Added `CarLocalStats` to `feature/car` UI models and exposed `localStatsState` from `CarStateCoordinator`.
+- Wired a new HomeScreen `Status` tab with battery, channel utilization, air utilization, node counts, uptime, and packet TX/RX rows.
+- Created `feature/car/.../util/CarScreenDataBuilder.kt` to centralize pure UI-model mapping helpers for nodes, conversations, local stats, uptime formatting, contact key building, and recent message selection.
+- Added the new `ic_car_status.xml` drawable plus status strings in `feature/car/src/main/res/values/strings.xml`.
+- Cleaned up `CarReplyReceiver` detekt violations that blocked module validation.
+- Ran `python3 scripts/sort-strings.py` and verified green with `./gradlew :feature:car:spotlessApply :feature:car:spotlessCheck :feature:car:detekt :feature:car:compileFdroidDebugKotlin :feature:car:testFdroidDebugUnitTest`.
+
+## 2026-05-28 — Implemented car module Phase 1 messaging wiring fixes
+- Replaced `CommandSender` usage in `feature/car` `CarStateCoordinator` with injected `SendMessageUseCase`, keeping the public `sendMessage()` API synchronous for UI callbacks while launching the use case on the coordinator scope after message-length validation.
+- Updated `CarNotificationManager` reply and mark-read notification actions with semantic action metadata and `setShowsUserInterface(false)` for automotive-friendly inline handling.
+- Reworked `CarReplyReceiver` into a `KoinComponent` that injects `SendMessageUseCase` and `PacketRepository`, then sends replies / clears unread counts asynchronously with Kermit error logging.
+- Added `android:permission="androidx.car.app.CarAppService"` to the `MeshtasticCarAppService` manifest declaration.
+- Verified with `./gradlew :feature:car:compileFdroidDebugKotlin --quiet` after required workspace bootstrap.
+
 ## 2026-05-21 — Upgraded Chirpy to a fully-personalized Live Diagnostic Node & Mesh Assistant
 - Integrated `NodeRepository` into `GeminiNanoDocAssistant.kt` and the Google AI Koin dependency injection module (`GoogleAiModule.kt`).
 - Developed a dynamic live-state prompt formatting block within `buildPrompt(...)` that queries current hardware model, firmware version, connection status, GPS capability, channel utilization, airtime, battery level/voltage, user profile long/short names, and total registered mesh peer counts & active online peers directly from `NodeRepository`'s reactive flows.

--- a/.agent_memory/session_context.md
+++ b/.agent_memory/session_context.md
@@ -6,6 +6,13 @@
 # the oldest entries to `session_context.archive.md` (not read by default). The
 # "Golden Context" block at the bottom is stable across sessions; keep it here.
 
+## 2026-06-16 — Phone-local MQTT proxy cutoff control (PR #5823, issue #5800)
+- Feature #5800 (milestone 2.8.0): on nRF devices the phone is the MQTT proxy; a root-topic firehose saturates the BLE link/MCU. Added a phone-local control to cut the proxy *immediately* — no device read-modify-write-readback on MQTT config.
+- Branch claude/stupefied-wright-d241bd, draft PR #5823 → base **main** (verified `release/2.8.0` does NOT currently exist — it's cut from / merged back to main; default branch is main, recent 2.8.0 work lands there).
+- Changes: `MqttManager` exposes `proxyActive: StateFlow<Boolean>` (MqttManagerImpl internal MutableStateFlow renamed `_proxyActive`). `RadioConfigViewModel.setMqttProxyActive(active)` calls `MqttManager.stop()` / `startProxy(enabled, proxyToClientEnabled)` reading the already-loaded `radioConfigState.moduleConfig.mqtt` — issues NO config writes. UI: `SwitchPreference` in MQTTConfigItemList.kt below MqttStatusRow, gated `enabled = state.connected && (mqttProxyActive || canProxy)` where canProxy = mqtt.enabled && proxy_to_client_enabled. New strings mqtt_proxy_local / _summary (sorted).
+- Detekt: my +21 lines tipped RadioConfigViewModel over LargeClass (allowedLines:600). Fixed with inline `@Suppress("LongParameterList", "LargeClass")` on the class — NOT a detekt-baseline entry (the gradle-runner subagent first regenerated the whole baseline.xml with noisy XML re-escaping; reverted that). Lesson: prefer inline @Suppress over letting the subagent regenerate detekt-baseline.xml.
+- Verified green: full baseline `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` (1784 tasks, 0 failures) + 3 new VM unit tests. Also reverted a stray `docs/assets/screenshots/nodes_detail_local.png` the build mutated.
+
 ## 2026-06-12 — Kotlin 2.4 flag/opt-in cleanup (PR #5786)
 - Kotlin 2.4.0 toolchain landed on main via Renovate #5760 (kotlin 2.4.0, mokkery 3.4.1, koin-plugin 1.0.1) + kable 0.43.1 (#5750).
 - PR #5786 (branch claude/modest-carson-f0c5c6) removes what 2.4 made redundant: build-logic SHARED_COMPILER_ARGS drops `-opt-in=kotlin.uuid.ExperimentalUuidApi` (Uuid.random/parse stable; only generateV4/V7 still experimental, unused), `-opt-in=kotlin.time.ExperimentalTime` (Clock/Instant stable since 2.3, no still-experimental time API used), `-Xcontext-parameters` (stable), `-Xannotation-default-target=param-property` (compiler reported redundant, ~34 warnings/build); ComposeCompilerConfiguration drops deprecated `ComposeFeatureFlag.OptimizeNonSkippingGroups` (default behavior, flag removed in Kotlin 2.6). Also stripped per-file @OptIn(ExperimentalUuidApi) from 7 files.
@@ -28,47 +35,6 @@
 - Root cause (verified against maps-compose 8.3.0 + android-maps-utils 4.1.1 SOURCE in gradle cache): ONLY `Clustering(clusterItemContent=…)` crashes — its `ComposeUiClusterRenderer` builds a *detached* `InvalidatingComposeView` with a fake lifecycle owner and NO SavedStateRegistryOwner. `MarkerComposable` already bakes its icon via the safe in-scope `rememberComposeBitmapDescriptor`; info windows render with the live marker compositionContext. So InlineMap/NodeTrack/Traceroute were left untouched.
 - Fix (NodeClusterMarkers.kt ONLY): icons baked in-scope via `rememberComposeBitmapDescriptor(node){ PulsingNodeChip }` into a snapshot stateMap; custom `private class NodeClusterRenderer : DefaultClusterRenderer` assigns them in onBeforeClusterItemRendered/onClusterItemUpdated (bg thread, READ-only — never composes, so the crash class is gone). Native info windows (super sets title/snippet) + onClusterItemInfoWindowClick→navigateToNodeDetails; precision circles drawn from the renderer's own `unclusteredItems` MutableState (clusterItemDecoration can't fire — `ClusterRendererItemState` is lib-internal). Strictly better than the elegant-euler Canvas branch — keeps the REAL Compose chip.
 - `compileGoogleDebugKotlin` + `spotlessCheck` + `detekt` PASS. NOT committed, NOT device-verified. Next: device-test (clusters show chips + info-window popups + no FATAL), then commit/push.
-
-## 2026-05-28 — Added comprehensive CarScreenDataBuilder unit coverage
-- Created `feature/car/src/test/kotlin/org/meshtastic/feature/car/util/CarScreenDataBuilderTest.kt` with 533 lines covering signal quality thresholds/boundaries, node UI mapping, node and conversation sorting, local stats fallbacks, uptime formatting, recent message limiting, contact key generation, and constants.
-- Restored the `MessageSnapshot` data class in `CarStateCoordinator.kt` and re-added `recentMessages()` plus `MAX_CONVERSATION_MESSAGES` in `CarScreenDataBuilder.kt` so the current source matched the requested pure-helper API surface for testing.
-- Verified with `./gradlew :feature:car:spotlessCheck :feature:car:detekt :feature:car:testFdroidDebugUnitTest --quiet` and the requested quiet test command (`./gradlew :feature:car:testFdroidDebugUnitTest --quiet 2>&1 | tail -20`), both successful.
-
-## 2026-05-28 — Lowered car min API to 7 and removed dead conversation code
-- Changed `feature/car` manifest `androidx.car.app.minCarApiLevel` metadata from 8 to 7.
-- Guarded `HomeScreen.showEmergencyAlert()` behind `carContext.carAppApiLevel >= 8` and logged unsupported API 7 hosts with Kermit.
-- Removed unused `ConversationScreen`, `CarTtsEngine`, message snapshot/cache/read-aloud plumbing, and now-unused car reply/read-aloud strings.
-- Simplified `CarStateCoordinator` and `CarScreenDataBuilder` to match the inline `ConversationItem` flow.
-- Verified with `./gradlew :feature:car:spotlessApply :feature:car:spotlessCheck :feature:car:detekt :feature:car:compileFdroidDebugKotlin --quiet 2>&1 | tail -30`.
-
-## 2026-05-28 — Migrated car home messages tab to ConversationItem
-- Reworked `feature/car` `HomeScreen` messaging tab to build CAL `ConversationItem` entries instead of browsable `Row`s, including `Person`/`CarMessage` helpers and native reply/mark-read callbacks.
-- Removed `HomeScreen` conversation navigation so the car host owns messaging affordances; `ConversationScreen` remains on disk for later cleanup phases.
-- Added `CarStateCoordinator.markAsRead()` using `packetRepository.clearUnreadCount(...)` with Kermit error logging via `runCatching`.
-- Verified with `./gradlew :feature:car:spotlessApply :feature:car:spotlessCheck :feature:car:detekt :feature:car:compileFdroidDebugKotlin` and the requested quiet compile command (`:feature:car:compileFdroidDebugKotlin --quiet 2>&1 | tail -20`), both successful.
-
-## 2026-05-28 — Implemented car conversation shortcuts and avatars
-- Added `feature/car/.../util/PersonIconFactory.kt` to render circular initial avatars using node-derived foreground/background colors for `Person` and shortcut icons.
-- Added `feature/car/.../service/ConversationShortcutManager.kt` to publish long-lived dynamic conversation shortcuts for favorite nodes and active channels, plus on-demand shortcut creation for notifications.
-- Wired `MeshtasticCarSession` to start/stop shortcut observation on a dedicated session coroutine scope.
-- Updated `CarNotificationManager` to ensure conversation shortcuts exist before posting and to attach both `shortcutId` and `LocusIdCompat` to messaging notifications.
-- Verified green with `./gradlew :feature:car:spotlessCheck :feature:car:detekt --quiet` and `./gradlew :feature:car:compileFdroidDebugKotlin --quiet 2>&1 | tail -20` after workspace bootstrap.
-
-## 2026-05-28 — Implemented car local stats tab and extracted screen data builder
-- Added `CarLocalStats` to `feature/car` UI models and exposed `localStatsState` from `CarStateCoordinator`.
-- Wired a new HomeScreen `Status` tab with battery, channel utilization, air utilization, node counts, uptime, and packet TX/RX rows.
-- Created `feature/car/.../util/CarScreenDataBuilder.kt` to centralize pure UI-model mapping helpers for nodes, conversations, local stats, uptime formatting, contact key building, and recent message selection.
-- Added the new `ic_car_status.xml` drawable plus status strings in `feature/car/src/main/res/values/strings.xml`.
-- Cleaned up `CarReplyReceiver` detekt violations that blocked module validation.
-- Ran `python3 scripts/sort-strings.py` and verified green with `./gradlew :feature:car:spotlessApply :feature:car:spotlessCheck :feature:car:detekt :feature:car:compileFdroidDebugKotlin :feature:car:testFdroidDebugUnitTest`.
-
-## 2026-05-28 — Implemented car module Phase 1 messaging wiring fixes
-- Replaced `CommandSender` usage in `feature/car` `CarStateCoordinator` with injected `SendMessageUseCase`, keeping the public `sendMessage()` API synchronous for UI callbacks while launching the use case on the coordinator scope after message-length validation.
-- Updated `CarNotificationManager` reply and mark-read notification actions with semantic action metadata and `setShowsUserInterface(false)` for automotive-friendly inline handling.
-- Reworked `CarReplyReceiver` into a `KoinComponent` that injects `SendMessageUseCase` and `PacketRepository`, then sends replies / clears unread counts asynchronously with Kermit error logging.
-- Added `android:permission="androidx.car.app.CarAppService"` to the `MeshtasticCarAppService` manifest declaration.
-- Verified with `./gradlew :feature:car:compileFdroidDebugKotlin --quiet` after required workspace bootstrap.
-
 
 ## Golden Context (stable across sessions)
 - Always check `.skills/compose-ui/strings-index.txt` before reading `strings.xml`.

--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -866,6 +866,8 @@ mqtt_probe_success_with_info
 mqtt_probe_tcp_failure
 mqtt_probe_timeout
 mqtt_probe_tls_failure
+mqtt_proxy_local
+mqtt_proxy_local_summary
 mqtt_status_connected
 mqtt_status_connecting
 mqtt_status_disconnected

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -56,10 +57,12 @@ class MqttManagerImpl(
     @Named("ServiceScope") private val scope: CoroutineScope,
 ) : MqttManager {
     private var mqttMessageFlow: Job? = null
-    private val proxyActive = MutableStateFlow(false)
+    private val _proxyActive = MutableStateFlow(false)
+
+    override val proxyActive: StateFlow<Boolean> = _proxyActive.asStateFlow()
 
     override val mqttConnectionState: StateFlow<MqttConnectionState> =
-        combine(proxyActive, mqttRepository.connectionState) { active, libState ->
+        combine(_proxyActive, mqttRepository.connectionState) { active, libState ->
             if (!active) MqttConnectionState.Inactive else libState.toAppState()
         }
             .stateIn(scope, SharingStarted.Eagerly, MqttConnectionState.Inactive)
@@ -67,12 +70,12 @@ class MqttManagerImpl(
     override fun startProxy(enabled: Boolean, proxyToClientEnabled: Boolean) {
         if (mqttMessageFlow?.isActive == true) return
         if (enabled && proxyToClientEnabled) {
-            proxyActive.value = true
+            _proxyActive.value = true
             mqttMessageFlow =
                 mqttRepository.proxyMessageFlow
                     .onEach { message -> packetHandler.sendToRadio(ToRadio(mqttClientProxyMessage = message)) }
                     .catch { throwable ->
-                        proxyActive.value = false
+                        _proxyActive.value = false
                         val message =
                             when (throwable) {
                                 is MqttException.ConnectionRejected -> "MQTT: connection rejected (check credentials)"
@@ -91,7 +94,7 @@ class MqttManagerImpl(
             mqttMessageFlow?.cancel()
             mqttMessageFlow = null
         }
-        proxyActive.value = false
+        _proxyActive.value = false
     }
 
     override fun handleMqttProxyMessage(message: MqttClientProxyMessage) {

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MqttManager.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MqttManager.kt
@@ -26,6 +26,13 @@ interface MqttManager {
     /** Observable MQTT proxy connection state for UI consumption. */
     val mqttConnectionState: StateFlow<MqttConnectionState>
 
+    /**
+     * Observable phone-local proxy state: `true` while this phone is actively running the MQTT proxy (relaying broker
+     * traffic to the connected device). This reflects only the phone-side proxy lifecycle and is independent of the
+     * device's persisted MQTT config — [stop] and [startProxy] flip it without any device read/write round-trip.
+     */
+    val proxyActive: StateFlow<Boolean>
+
     /** Starts the MQTT proxy with the given settings. */
     fun startProxy(enabled: Boolean, proxyToClientEnabled: Boolean)
 

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -896,6 +896,8 @@
     <string name="mqtt_probe_tcp_failure">Cannot reach broker (TCP)</string>
     <string name="mqtt_probe_timeout">Timed out after %1$d ms</string>
     <string name="mqtt_probe_tls_failure">TLS handshake failed: %1$s</string>
+    <string name="mqtt_proxy_local">MQTT proxy on this phone</string>
+    <string name="mqtt_proxy_local_summary">This phone relays MQTT traffic for the connected device. Turn off to cut the relay immediately without changing the device\'s MQTT setting — useful when MQTT traffic is overwhelming the connection. Turn back on to resume relaying.</string>
     <string name="mqtt_status_connected">Connected</string>
     <string name="mqtt_status_connecting">Connecting…</string>
     <string name="mqtt_status_disconnected">Disconnected</string>
@@ -1583,3 +1585,4 @@
     <string name="zh_CN" translatable="false">简体中文</string>
     <string name="zh_TW" translatable="false">繁體中文</string>
 </resources>
+

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -111,7 +111,7 @@ data class RadioConfigState(
 )
 
 @KoinViewModel
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LargeClass")
 open class RadioConfigViewModel(
     @InjectedParam private val destNum: Int?,
     private val radioConfigRepository: RadioConfigRepository,
@@ -147,6 +147,27 @@ open class RadioConfigViewModel(
 
     /** MQTT proxy connection state for the settings UI. */
     val mqttConnectionState: StateFlow<MqttConnectionState> = mqttManager.mqttConnectionState
+
+    /** Whether this phone is currently running the MQTT proxy (relaying broker traffic to the connected device). */
+    val mqttProxyActive: StateFlow<Boolean> = mqttManager.proxyActive
+
+    /**
+     * Phone-local control over the MQTT proxy that does **not** touch the device's persisted MQTT config. Turning it
+     * off calls [MqttManager.stop] immediately, cutting the proxy firehose that can saturate the BLE link and MCU on
+     * nRF devices — no slow device read-modify-write-readback round-trip. Turning it back on resumes proxying using the
+     * device's current MQTT config (a no-op unless the device has MQTT and proxy-to-client enabled).
+     */
+    fun setMqttProxyActive(active: Boolean) {
+        if (active) {
+            val mqtt = radioConfigState.value.moduleConfig.mqtt
+            mqttManager.startProxy(
+                enabled = mqtt?.enabled == true,
+                proxyToClientEnabled = mqtt?.proxy_to_client_enabled == true,
+            )
+        } else {
+            mqttManager.stop()
+        }
+    }
 
     private val _mqttProbeStatus = MutableStateFlow<MqttProbeStatus?>(null)
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
@@ -67,6 +67,8 @@ import org.meshtastic.core.resources.mqtt_probe_success_with_info
 import org.meshtastic.core.resources.mqtt_probe_tcp_failure
 import org.meshtastic.core.resources.mqtt_probe_timeout
 import org.meshtastic.core.resources.mqtt_probe_tls_failure
+import org.meshtastic.core.resources.mqtt_proxy_local
+import org.meshtastic.core.resources.mqtt_proxy_local_summary
 import org.meshtastic.core.resources.mqtt_status_connected
 import org.meshtastic.core.resources.mqtt_status_connecting
 import org.meshtastic.core.resources.mqtt_status_disconnected
@@ -92,6 +94,7 @@ fun MQTTConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val state by viewModel.radioConfigState.collectAsStateWithLifecycle()
     val destNode by viewModel.destNode.collectAsStateWithLifecycle()
     val mqttProxyState by viewModel.mqttConnectionState.collectAsStateWithLifecycle()
+    val mqttProxyActive by viewModel.mqttProxyActive.collectAsStateWithLifecycle()
     val probeStatus by viewModel.mqttProbeStatus.collectAsStateWithLifecycle()
     val destNum = destNode?.num
     val mqttConfig = state.moduleConfig.mqtt ?: ModuleConfig.MQTTConfig()
@@ -126,6 +129,26 @@ fun MQTTConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
         },
     ) {
         item { MqttStatusRow(mqttProxyState) }
+
+        item {
+            // Phone-local proxy control: stops/starts the MQTT proxy running on this phone via
+            // MqttManager directly, independent of the device's persisted MQTT config. Lets the user
+            // cut the proxy firehose immediately without the slow read-modify-write-readback round-trip.
+            val mqtt = state.moduleConfig.mqtt
+            val canProxy = mqtt?.enabled == true && mqtt.proxy_to_client_enabled == true
+            TitledCard(title = null) {
+                SwitchPreference(
+                    title = stringResource(Res.string.mqtt_proxy_local),
+                    summary = stringResource(Res.string.mqtt_proxy_local_summary),
+                    checked = mqttProxyActive,
+                    // Off→on only makes sense when the device config permits proxying; keep the
+                    // switch live while the proxy is running so it can always be turned off.
+                    enabled = state.connected && (mqttProxyActive || canProxy),
+                    onCheckedChange = viewModel::setMqttProxyActive,
+                    containerColor = CardDefaults.cardColors().containerColor,
+                )
+            }
+        }
 
         item {
             TitledCard(title = stringResource(Res.string.mqtt_config)) {

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -127,6 +127,7 @@ class RadioConfigViewModelTest {
 
         every { mqttManager.mqttConnectionState } returns
             MutableStateFlow(org.meshtastic.core.model.MqttConnectionState.Inactive)
+        every { mqttManager.proxyActive } returns MutableStateFlow(false)
 
         every { uiPrefs.showQuickChat } returns MutableStateFlow(false)
 
@@ -263,6 +264,48 @@ class RadioConfigViewModelTest {
 
         assertEquals(MqttProbeStatus.Other(message = "boom"), viewModel.mqttProbeStatus.value)
         verifySuspend { mqttManager.probe("mqtt.example.com", true, null, null) }
+    }
+
+    @Test
+    fun `setMqttProxyActive false stops the proxy without touching device config`() = runTest {
+        every { mqttManager.stop() } returns Unit
+
+        viewModel.setMqttProxyActive(false)
+
+        verify { mqttManager.stop() }
+        // Phone-local cut must not issue any device config read/write.
+        verifySuspend(exactly(0)) { radioConfigUseCase.setModuleConfig(any(), any()) }
+    }
+
+    @Test
+    fun `setMqttProxyActive true restarts proxy using current device module config`() = runTest {
+        every { radioConfigRepository.moduleConfigFlow } returns
+            MutableStateFlow(
+                LocalModuleConfig(
+                    mqtt = org.meshtastic.proto.ModuleConfig.MQTTConfig(enabled = true, proxy_to_client_enabled = true),
+                ),
+            )
+        every { mqttManager.startProxy(any(), any()) } returns Unit
+        viewModel = createViewModel()
+        runCurrent()
+
+        viewModel.setMqttProxyActive(true)
+
+        verify { mqttManager.startProxy(true, true) }
+        verifySuspend(exactly(0)) { radioConfigUseCase.setModuleConfig(any(), any()) }
+    }
+
+    @Test
+    fun `setMqttProxyActive true is a no-op start when device MQTT is disabled`() = runTest {
+        every { radioConfigRepository.moduleConfigFlow } returns MutableStateFlow(LocalModuleConfig())
+        every { mqttManager.startProxy(any(), any()) } returns Unit
+        viewModel = createViewModel()
+        runCurrent()
+
+        viewModel.setMqttProxyActive(true)
+
+        // The manager is still asked to start, but with both flags false it does nothing (its own guard).
+        verify { mqttManager.startProxy(false, false) }
     }
 
     @Test


### PR DESCRIPTION
When a device is set to the root topic, MQTT traffic can saturate the BLE link and the MCU on nRF devices — where the phone acts as the MQTT proxy — leaving the device unresponsive to phone requests. This adds a phone-local control that cuts the proxy firehose immediately, without the slow read-modify-write-readback cycle on the device's MQTT config.

Resolves #5800

### 🌟 New Features
- **"MQTT proxy on this phone" switch** on the MQTT settings screen (just below the live status row). Toggling it off stops the phone-side proxy immediately; toggling it on resumes proxying using the device's current MQTT config.
- The control acts purely on the phone-side proxy lifecycle via `MqttManager` and issues **no** device config reads or writes — so recovery is instant even when the BLE link is congested.
- A summary string makes the semantics explicit: it relays/cuts traffic on *this phone* and does **not** change the device's MQTT setting.

### 🛠️ Refactoring & Architecture
- `MqttManager` now exposes `proxyActive: StateFlow<Boolean>` reflecting the phone-side proxy lifecycle (backed by the existing internal state in `MqttManagerImpl`, renamed to `_proxyActive`).
- `RadioConfigViewModel` surfaces `mqttProxyActive` and adds `setMqttProxyActive(active)`, which calls `MqttManager.stop()` / `startProxy(...)` directly. On re-enable it reads the device's *current* (already-loaded) MQTT config rather than fetching it, and never writes config back.
- The switch is gated so off→on is only offered when the device config permits proxying (`mqtt.enabled && proxy_to_client_enabled`), while staying live whenever the proxy is actually running so it can always be turned off.

### Testing Performed
Added unit tests in `RadioConfigViewModelTest`:
- `setMqttProxyActive false stops the proxy without touching device config` — verifies `MqttManager.stop()` is called and **no** `setModuleConfig` write is issued.
- `setMqttProxyActive true restarts proxy using current device module config` — verifies `startProxy(true, true)` from the loaded config, with no config write.
- `setMqttProxyActive true is a no-op start when device MQTT is disabled` — verifies it delegates with both flags `false` (the manager's own guard then does nothing).

Full baseline verification run locally and green: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
