### PR TITLE
fix(build): isolate ML Kit GenAI to the Google flavor (fix F-Droid rb-check)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -291,6 +291,7 @@ dependencies {
     googleImplementation(libs.firebase.ai)
     googleImplementation(libs.firebase.ai.ondevice)
     googleImplementation(libs.mlkit.translate)
+    googleImplementation(libs.mlkit.genai.prompt)
 
     googleImplementation(libs.androidx.appfunctions)
     googleImplementation(libs.androidx.appfunctions.service)

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FdroidAiModule.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FdroidAiModule.kt
@@ -18,6 +18,8 @@ package org.meshtastic.app.di
 
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
+import org.meshtastic.feature.discovery.ai.AlgorithmicSummaryProvider
+import org.meshtastic.feature.discovery.ai.DiscoverySummaryAiProvider
 import org.meshtastic.feature.docs.ai.AIDocAssistant
 import org.meshtastic.feature.docs.ai.KeywordFallbackAssistant
 import org.meshtastic.feature.docs.translation.DocTranslationService
@@ -27,6 +29,8 @@ import org.meshtastic.feature.docs.translation.NoOpDocTranslator
 @Module
 class FdroidAiModule {
     @Single fun aiDocAssistant(fallback: KeywordFallbackAssistant): AIDocAssistant = fallback
+
+    @Single fun discoverySummaryAiProvider(fallback: AlgorithmicSummaryProvider): DiscoverySummaryAiProvider = fallback
 
     @Single fun docTranslationService(): DocTranslationService = NoOpDocTranslator()
 }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/di/GoogleAiModule.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/di/GoogleAiModule.kt
@@ -22,8 +22,11 @@ import okio.Path.Companion.toOkioPath
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 import org.meshtastic.app.ai.GeminiNanoDocAssistant
+import org.meshtastic.app.discovery.GeminiNanoSummaryProvider
 import org.meshtastic.app.translation.MlKitDocTranslator
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.feature.discovery.DiscoverySummaryGenerator
+import org.meshtastic.feature.discovery.ai.DiscoverySummaryAiProvider
 import org.meshtastic.feature.docs.ai.AIDocAssistant
 import org.meshtastic.feature.docs.data.DocBundleLoader
 import org.meshtastic.feature.docs.data.KeywordSearchEngine
@@ -43,6 +46,10 @@ class GoogleAiModule {
         bundleLoader: DocBundleLoader,
         nodeRepository: NodeRepository,
     ): AIDocAssistant = GeminiNanoDocAssistant(searchEngine, bundleLoader, nodeRepository)
+
+    @Single
+    fun discoverySummaryAiProvider(generator: DiscoverySummaryGenerator): DiscoverySummaryAiProvider =
+        GeminiNanoSummaryProvider(generator)
 
     @Single
     fun docTranslationCache(context: Context): DocTranslationCache =

--- a/androidApp/src/google/kotlin/org/meshtastic/app/discovery/GeminiNanoSummaryProvider.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/discovery/GeminiNanoSummaryProvider.kt
@@ -14,26 +14,29 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package org.meshtastic.feature.discovery.ai
+package org.meshtastic.app.discovery
 
 import co.touchlab.kermit.Logger
 import com.google.mlkit.genai.prompt.Generation
 import com.google.mlkit.genai.prompt.GenerativeModel
 import com.google.mlkit.genai.prompt.TextPart
 import com.google.mlkit.genai.prompt.generateContentRequest
-import org.koin.core.annotation.Single
 import org.meshtastic.core.database.entity.DiscoveryPresetResultEntity
 import org.meshtastic.core.database.entity.DiscoverySessionEntity
 import org.meshtastic.feature.discovery.DiscoverySummaryGenerator
+import org.meshtastic.feature.discovery.ai.DiscoverySummaryAiProvider
 
 /**
- * Android provider that uses Gemini Nano via ML Kit GenAI Prompt API for on-device AI summaries.
+ * Google-flavor provider that uses Gemini Nano via the ML Kit GenAI Prompt API for on-device AI summaries.
+ *
+ * Lives in the Google flavor source set (not the shared `:feature:discovery` module) so the proprietary ML Kit GenAI
+ * dependency never reaches the F-Droid build. The F-Droid flavor binds
+ * [org.meshtastic.feature.discovery.ai. AlgorithmicSummaryProvider] instead.
  *
  * Falls back to [DiscoverySummaryGenerator] when:
  * - The on-device model is unavailable (unsupported hardware or not downloaded)
  * - Generation fails for any reason
  */
-@Single(binds = [DiscoverySummaryAiProvider::class])
 class GeminiNanoSummaryProvider(private val generator: DiscoverySummaryGenerator) : DiscoverySummaryAiProvider {
 
     private val log = Logger.withTag("GeminiNanoSummary")

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/di/DesktopKoinModule.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/di/DesktopKoinModule.kt
@@ -87,6 +87,8 @@ import org.meshtastic.desktop.stub.NoopMeshLocationManager
 import org.meshtastic.desktop.stub.NoopMeshWorkerManager
 import org.meshtastic.desktop.stub.NoopPhoneLocationProvider
 import org.meshtastic.desktop.stub.NoopPlatformAnalytics
+import org.meshtastic.feature.discovery.ai.AlgorithmicSummaryProvider
+import org.meshtastic.feature.discovery.ai.DiscoverySummaryAiProvider
 import org.meshtastic.feature.docs.ai.AIDocAssistant
 import org.meshtastic.feature.docs.ai.KeywordFallbackAssistant
 import org.meshtastic.feature.docs.translation.DocTranslationService
@@ -227,6 +229,7 @@ private fun desktopPlatformStubsModule() = module {
 
     // AI assistant: keyword-only fallback on desktop (no on-device model)
     single<AIDocAssistant> { get<KeywordFallbackAssistant>() }
+    single<DiscoverySummaryAiProvider> { get<AlgorithmicSummaryProvider>() }
     single<DocTranslationService> { NoOpDocTranslator() }
 
     // Desktop uses the real ApiService implementation (no flavor stub needed)

--- a/feature/discovery/build.gradle.kts
+++ b/feature/discovery/build.gradle.kts
@@ -51,7 +51,5 @@ kotlin {
         }
 
         commonTest.dependencies { implementation(projects.core.testing) }
-
-        androidMain.dependencies { implementation(libs.mlkit.genai.prompt) }
     }
 }

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ai/AlgorithmicSummaryProvider.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ai/AlgorithmicSummaryProvider.kt
@@ -21,8 +21,14 @@ import org.meshtastic.core.database.entity.DiscoveryPresetResultEntity
 import org.meshtastic.core.database.entity.DiscoverySessionEntity
 import org.meshtastic.feature.discovery.DiscoverySummaryGenerator
 
-/** JVM/Desktop fallback that delegates to the algorithmic [DiscoverySummaryGenerator]. */
-@Single(binds = [DiscoverySummaryAiProvider::class])
+/**
+ * Algorithmic [DiscoverySummaryAiProvider] that delegates to the deterministic [DiscoverySummaryGenerator].
+ *
+ * Used wherever no on-device AI model is available: Desktop, iOS, and the Android F-Droid flavor. Registered with
+ * `binds = []` so it is injectable by concrete type but is not auto-bound to [DiscoverySummaryAiProvider]; each
+ * platform binds the interface explicitly (the Google flavor binds the Gemini Nano provider instead).
+ */
+@Single(binds = [])
 class AlgorithmicSummaryProvider(private val generator: DiscoverySummaryGenerator) : DiscoverySummaryAiProvider {
 
     override val isAvailable: Boolean = true


### PR DESCRIPTION
The F-Droid reproducible-build check (`rb-check`) is failing on `main`: the `fdroidRelease` APK contains proprietary Google libraries (`com/google/firebase`, `com/google/android/gms`, `com/google/mlkit`, `com/google/android/datatransport`). The root cause is that `:feature:discovery` declared `mlkit-genai-prompt` as a plain (non-flavor-scoped) `androidMain` dependency, and `androidApp` pulls `:feature:discovery` into **both** flavors — so ML Kit GenAI (and its transitive play-services/Firebase/datatransport deps) leaked into the FOSS build. This fix isolates the proprietary on-device-AI code to the Google flavor, mirroring the existing `:feature:docs` AI seam.

### 🐛 Bug Fixes
- F-Droid `fdroidRelease` APK no longer contains ML Kit / Firebase / GMS / datatransport classes — `rb-check` Step 4 (proprietary-library dex scan) passes again.

### 🛠️ Refactoring & Architecture
- Reuse the `:feature:docs` AI-seam pattern for discovery summaries: the on-device provider lives in the Google flavor source set and the interface is bound per-flavor via Koin.
- Moved `GeminiNanoSummaryProvider` out of `:feature:discovery/androidMain` into `androidApp/src/google/.../app/discovery/`; bound via `GoogleAiModule`.
- Bound the algorithmic fallback for F-Droid (`FdroidAiModule`) and Desktop (`DesktopKoinModule`).

### 🧩 KMP Migration Milestone
- Moved `AlgorithmicSummaryProvider` from `:feature:discovery/jvmMain` → `commonMain` and registered it with `@Single(binds = [])`, so the deterministic fallback is injectable on every platform (Android F-Droid, Desktop, iOS) and the `DiscoverySummaryAiProvider` interface is bound explicitly per platform/flavor (Gemini Nano on Google, algorithmic elsewhere).

### 🧹 Chores
- Removed `mlkit-genai-prompt` from `:feature:discovery`; added it as a `googleImplementation` on `androidApp` (Google-flavor only).

### Verification Performed
- `:androidApp:dependencies --configuration fdroidReleaseRuntimeClasspath` → **no** `mlkit`/`firebase`/`play-services`/`gms`/`datatransport`/`genai` (leak gone); `googleReleaseRuntimeClasspath` still resolves `com.google.mlkit:genai-prompt`.
- Koin graph verified for **both** flavors: `:androidApp:testFdroidDebugUnitTest` + `:androidApp:testGoogleDebugUnitTest` (`KoinVerificationTest` passes — the new per-flavor bindings resolve).
- `:feature:discovery:allTests`, `:desktopApp:test`, and `spotlessCheck` + `detekt` all pass.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
