### PR TITLE
fix(ci): stop scheduled-updates choking on failed baseline profile

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -133,7 +133,10 @@ jobs:
           disable-animations: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           # Writes androidApp/src/google/generated/baselineProfiles/ via the androidx.baselineprofile plugin.
-          script: ./gradlew :androidApp:generateGoogleReleaseBaselineProfile -Pci=true
+          # --no-configuration-cache: the underlying connectedGoogleNonMinifiedReleaseAndroidTest task is not
+          # config-cache serializable (SeparateTestModuleTestData / ResolutionBackedFileCollection), and the
+          # project enables org.gradle.configuration-cache by default — same workaround used in reusable-check.yml.
+          script: ./gradlew :androidApp:generateGoogleReleaseBaselineProfile -Pci=true --no-configuration-cache
 
       - name: Detect baseline profile changes
         id: baseline
@@ -221,10 +224,14 @@ jobs:
           branch: 'scheduled-updates'
           base: 'main'
           delete-branch: true
+          # Only stage the baseline-profile dir when generation actually produced changes. When the emulator
+          # boots far enough for Gradle to create an *empty* baselineProfiles/ dir but generation then fails,
+          # `git add <glob>` aborts with "pathspec did not match any files", which would hard-fail this step
+          # and defeat the continue-on-error on the generation step above.
           add-paths: |
             androidApp/src/main/assets/firmware_releases.json
             androidApp/src/main/assets/device_hardware.json
-            androidApp/src/google/generated/baselineProfiles/**
+            ${{ steps.baseline.outputs.status == 'updated' && 'androidApp/src/google/generated/baselineProfiles/**' || '' }}
             fastlane/metadata/android/**
             **/strings.xml
             **/README.md


### PR DESCRIPTION
## Why

The **Scheduled Updates** workflow has been failing on every run since ~2026-06-16 (e.g. [run 27661977672](https://github.com/meshtastic/Meshtastic-Android/actions/runs/27661977672), [27674130134](https://github.com/meshtastic/Meshtastic-Android/actions/runs/27674130134)). The firmware/hardware/translation PR — the whole point of the job — never gets created when it fails.

Root cause is two layered bugs introduced alongside the baseline-profile step (#5735):

1. **The `Create Pull Request` step hard-fails on a missing path.** The baseline-profile output dir is not committed anywhere. Once the emulator boots far enough for Gradle to create an *empty* `androidApp/src/google/generated/baselineProfiles/` dir but generation then fails, `peter-evans/create-pull-request` includes that glob in its `git add`, which aborts:
   ```
   git add -- … androidApp/src/google/generated/baselineProfiles/** …
   fatal: pathspec 'androidApp/src/google/generated/baselineProfiles/**' did not match any files
   ##[error]Unexpected error:
   ```
   `git add` validates all pathspecs before staging, so one non-matching glob aborts the entire commit. This **defeats the `continue-on-error`** on the generation step, which exists specifically so emulator flakiness can't block the firmware/translation PR. (Earlier green runs were the ones where the emulator never started Gradle, so the dir didn't exist and the action silently dropped the glob.)

2. **Generation fails every time it actually runs**, via a Gradle configuration-cache serialization error:
   ```
   :baselineprofile:connectedGoogleNonMinifiedReleaseAndroidTest … error writing value of type 'ResolutionBackedFileCollection'
   … SeparateTestModuleTestData …
   ```
   The project sets `org.gradle.configuration-cache=true` globally, and that connected-test task is not config-cache serializable.

## What changed

🛠️ **Conditional `add-paths`** — the baseline-profile glob is staged only when `steps.baseline.outputs.status == 'updated'`; otherwise the line renders empty and is filtered out. This is the fix that keeps the workflow green: the firmware/translation/strings/graphs PR now succeeds regardless of emulator state.

🛠️ **`--no-configuration-cache`** on the generation command, so the profile can actually regenerate. Matches existing precedent in `reusable-check.yml` and `release.yml`, which already disable config cache for connected/instrumentation tasks.

## Testing Performed

- YAML validated; the `add-paths` expression and generation `script` render as intended.
- The `add-paths` fix decouples PR creation from baseline-profile success — the exact failure mode in the linked runs (empty dir + failed generation) no longer reaches `git add` with a non-matching glob.
- Behaviour is observable on the next scheduled tick / manual `workflow_dispatch` once merged.