### PR TITLE
fix(appfunctions): keep AppSearch document-factory constructors under R8 full mode

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -40,6 +40,22 @@
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
 
+# ---- AppSearch / AppFunctions generated document factories ------------------
+# AppSearch's DocumentClassFactoryRegistry loads the generated
+# `$$__AppSearch__*` factory classes by name and instantiates them via their
+# no-arg constructor (reflection). AppSearch's own consumer rule keeps the
+# factory *class* (`-keep ... class ** implements DocumentClassFactory {}`) but
+# not its members. Under R8 full mode (AGP 8+ default, and we're on AGP 9) a
+# bare `-keep class X {}` no longer implicitly retains the default constructor,
+# so the constructor is tree-shaken and runtime construction fails with
+# NoSuchMethodException — e.g.
+# androidx.appfunctions.metadata.$$__AppSearch__AppFunctionRuntimeMetadata.<init>[]
+# crashing AppFunctionManager.getInstance(). Upstream tracking: b/440484133.
+# Keep the no-arg constructor explicitly until AppSearch's rules cover it.
+-keepclassmembers class * implements androidx.appsearch.app.DocumentClassFactory {
+    <init>();
+}
+
 # Compose runtime/ui/animation/foundation/material3 keep rules now live in
 # config/proguard/shared-rules.pro so both Android (R8) and desktop (ProGuard)
 # get the same defence-in-depth coverage against CMP 1.11 optimizer folding.


### PR DESCRIPTION
## Why

Internal/release (minified) builds crash on the first AppFunctions state sync with `ExceptionInInitializerError` at `AppFunctionManager.getInstance()`. The root cause is `NoSuchMethodException` for `androidx.appfunctions.metadata.$$__AppSearch__AppFunctionRuntimeMetadata.<init>[]`.

AppSearch instantiates its generated `$$__AppSearch__*` document factories reflectively via `DocumentClassFactoryRegistry`. AppSearch's own consumer rule keeps the factory **class** with a bare `-keep class ** implements DocumentClassFactory {}`. Under **R8 full mode** (the AGP 8+ default, and we're on AGP 9.2.1) a bare keep no longer implicitly retains the default constructor, so the no-arg ctor is tree-shaken and reflective construction fails. Debug builds don't minify, which is why this only surfaces in release. Upstream tracking: Google issue b/440484133 — appfunctions' own rules even carry a "remove once AppSearch updates their rules" TODO.

## Changes

🐛 **Bug Fixes**
- Add an explicit `-keepclassmembers` rule in `androidApp/proguard-rules.pro` restoring the no-arg constructor on `androidx.appsearch.app.DocumentClassFactory` implementations. `-keepclassmembers` (rather than `-keep`) only restores the ctor on factories the upstream rule already retains, keeping the rule minimal. It is package-agnostic, so it covers both the library's internal metadata docs and our own `@AppFunctionSerializable` models in `androidApp/src/google/.../appfunctions/AppFunctionModels.kt`.

## Testing Performed

- `:androidApp:minifyGoogleReleaseWithR8` — passes with no R8 warnings.
- Confirmed the fix at the R8 level: `build/outputs/mapping/googleRelease/seeds.txt` now lists the previously-stripped constructor as kept:
  ```
  androidx.appfunctions.metadata.$$__AppSearch__AppFunctionRuntimeMetadata: $$__AppSearch__AppFunctionRuntimeMetadata()
  ```
  13 generated-factory constructors are retained in total; none of them appear in R8's `usage.txt` removal list.

Affects release-only R8 behavior in an Android-only feature, so Spotless/detekt and the unit-test baseline are unaffected.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)