### PR TITLE
feat(network): on-device capture-replay transport + ingestion fuzzing/hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ offline-repository/
 !.claude/settings.json
 !.claude/agents/
 build-scan-*.scan
+# burningmesh capture replay assets (private data — generated via replay_server.py --export)
+*.fromradio

--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -303,6 +303,7 @@ delete_selection
 delivery_confirmed
 delivery_confirmed_reboot_warning
 demo_mode
+demo_mode_replay
 desc_node_filter_clear
 description
 desktop_notification_title

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImpl.kt
@@ -32,6 +32,7 @@ import org.meshtastic.core.common.util.clampTimestampToNow
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.common.util.nowSeconds
+import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.util.isLora
@@ -115,18 +116,25 @@ class MeshMessageProcessorImpl(
     }
 
     private fun processFromRadio(proto: FromRadio, myNodeNum: Int?) {
-        // Any decoded FromRadio proves the radio link is alive — keep the local node fresh.
-        refreshLocalNodeLastHeard()
+        // The FromRadio *decode* boundary is guarded by the caller, but the per-variant handlers below are not. A
+        // single malformed-but-decodable packet from any peer must not throw out to the receivedData collector and
+        // cancel it — that would silently deafen the radio (a remote DoS). Contain handler failures here: log and drop
+        // the packet, then carry on. (safeCatching still re-throws CancellationException, preserving cancellation.)
+        safeCatching {
+            // Any decoded FromRadio proves the radio link is alive — keep the local node fresh.
+            refreshLocalNodeLastHeard()
 
-        // Audit log every incoming variant
-        logVariant(proto)
+            // Audit log every incoming variant
+            logVariant(proto)
 
-        val packet = proto.packet
-        if (packet != null) {
-            handleReceivedMeshPacket(packet, myNodeNum)
-        } else {
-            fromRadioDispatcher.handleFromRadio(proto)
+            val packet = proto.packet
+            if (packet != null) {
+                handleReceivedMeshPacket(packet, myNodeNum)
+            } else {
+                fromRadioDispatcher.handleFromRadio(proto)
+            }
         }
+            .onFailure { Logger.e(it) { "Dropped a FromRadio after a handler error; receive pipeline kept alive" } }
     }
 
     private fun logVariant(proto: FromRadio) {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImplTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.data.manager
 
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
@@ -114,6 +115,21 @@ class MeshMessageProcessorImplTest {
         processor.handleFromRadio(garbage, myNodeNum)
         advanceUntilIdle()
         // No crash
+    }
+
+    @Test
+    fun `a throwing handler does not propagate out of handleFromRadio`() = runTest(testDispatcher) {
+        processor = createProcessor(backgroundScope)
+        // A malformed-but-decodable packet can make a downstream handler throw. That must NOT escape to the
+        // receivedData collector, which would cancel the collection and silently deafen the radio (a remote DoS).
+        // Regression guard for the safeCatching in processFromRadio: before that fix this call rethrew and failed.
+        every { fromRadioDispatcher.handleFromRadio(any()) } throws RuntimeException("hostile packet")
+        val fromRadio = FromRadio(log_record = LogRecord(message = "boom")) // routes to fromRadioDispatcher
+
+        processor.handleFromRadio(fromRadio.encode(), myNodeNum) // must return normally, not throw
+        advanceUntilIdle()
+
+        verify { fromRadioDispatcher.handleFromRadio(any()) } // handler ran and threw, yet we are still here
     }
 
     // ---------- handleReceivedMeshPacket: early buffering ----------

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/InterfaceId.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/InterfaceId.kt
@@ -21,6 +21,7 @@ enum class InterfaceId(val id: Char) {
     BLUETOOTH('x'),
     MOCK('m'),
     NOP('n'),
+    REPLAY('r'),
     SERIAL('s'),
     TCP('t'),
     ;

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/AndroidRadioTransportFactory.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/AndroidRadioTransportFactory.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.network.radio
 import android.content.Context
 import android.hardware.usb.UsbManager
 import android.provider.Settings
+import co.touchlab.kermit.Logger
 import org.koin.core.annotation.Single
 import org.meshtastic.core.ble.BleConnectionFactory
 import org.meshtastic.core.ble.BleScanner
@@ -60,6 +61,7 @@ class AndroidRadioTransportFactory(
         return when (interfaceId) {
             InterfaceId.MOCK,
             InterfaceId.NOP,
+            InterfaceId.REPLAY,
             InterfaceId.TCP,
             -> true
 
@@ -79,6 +81,8 @@ class AndroidRadioTransportFactory(
 
         return when (interfaceId) {
             InterfaceId.MOCK -> MockRadioTransport(callback = service, scope = service.serviceScope, address = rest)
+
+            InterfaceId.REPLAY -> createReplayTransport(service, rest)
 
             InterfaceId.TCP ->
                 TcpRadioTransport(
@@ -102,5 +106,34 @@ class AndroidRadioTransportFactory(
 
             InterfaceId.BLUETOOTH -> error("BLE addresses should be handled by BaseRadioTransportFactory")
         }
+    }
+
+    /**
+     * Replay selection ("r"). Replays the bundled burningmesh capture asset on-device via [ReplayRadioTransport] —
+     * realistic ~200-node traffic for perf / benchmark / populated-UI work. The asset only ships in debug (and
+     * benchmark) builds; when it is absent we fall back to the lightweight synthetic [MockRadioTransport] so selecting
+     * the entry still yields a working virtual device.
+     */
+    private fun createReplayTransport(service: RadioInterfaceService, rest: String): RadioTransport {
+        val replayFrames =
+            runCatching { context.assets.open(REPLAY_ASSET_NAME).use { it.readBytes() } }
+                .getOrNull()
+                ?.takeIf { it.isNotEmpty() }
+        return if (replayFrames != null) {
+            Logger.i { "Replay device → replaying $REPLAY_ASSET_NAME (${replayFrames.size} bytes)" }
+            ReplayRadioTransport(
+                callback = service,
+                scope = service.serviceScope,
+                address = rest,
+                frames = replayFrames,
+            )
+        } else {
+            Logger.w { "Replay device selected but $REPLAY_ASSET_NAME asset is missing — falling back to mock" }
+            MockRadioTransport(callback = service, scope = service.serviceScope, address = rest)
+        }
+    }
+
+    private companion object {
+        const val REPLAY_ASSET_NAME = "burningmesh.fromradio"
     }
 }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BaseRadioTransportFactory.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BaseRadioTransportFactory.kt
@@ -43,6 +43,7 @@ abstract class BaseRadioTransportFactory(
             InterfaceId.SERIAL.id,
             InterfaceId.BLUETOOTH.id,
             InterfaceId.MOCK.id,
+            InterfaceId.REPLAY.id,
             '!',
             -> true
 

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransport.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.radio
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import okio.Buffer
+import okio.EOFException
+import org.meshtastic.core.common.util.handledLaunch
+import org.meshtastic.core.repository.HandshakeConstants
+import org.meshtastic.core.repository.RadioTransport
+import org.meshtastic.core.repository.RadioTransportCallback
+import org.meshtastic.proto.FromRadio
+import org.meshtastic.proto.ToRadio
+
+/**
+ * A [RadioTransport] that replays a pre-captured stream of `FromRadio` frames entirely on-device — no network and no
+ * paired radio. It is the deterministic, self-contained traffic source behind the "Demo Mode (Replay)" connection
+ * entry, used to drive realistic ~200-node mesh traffic into the app for Macrobenchmark / Baseline Profile journeys and
+ * populated-UI (node list / map / message) tests.
+ *
+ * ### What it exercises
+ * Frames are handed verbatim to [RadioTransportCallback.handleFromRadio] — the *same* ingestion entry a live
+ * BLE/TCP/Serial radio uses — so everything downstream (protobuf decode, the want_config state machine, node-DB and
+ * packet handling, the UI) runs exactly as in production. The only things it skips are the physical link and the stream
+ * framing layer: it deals in already-deframed `FromRadio` payloads.
+ *
+ * ### Asset format (`*.fromradio`)
+ * A flat, three-section container. **Every integer is a big-endian (network-order) unsigned 32-bit value:**
+ *
+ * ```
+ *   ┌─ Stage-1: config section ────────────────────────────────────────────┐
+ *   │  u32  C                          number of config frames              │
+ *   │  C ×  ( u32 len, len bytes )     each blob = one serialized FromRadio │
+ *   ├─ Stage-2: node section ──────────────────────────────────────────────┤
+ *   │  u32  N                          number of node_info frames           │
+ *   │  N ×  ( u32 len, len bytes )     each blob = one serialized FromRadio │
+ *   ├─ packet section ─────────────────────────────────────────────────────┤
+ *   │       ( u32 len, len bytes ) *   repeated until end-of-buffer         │
+ *   └──────────────────────────────────────────────────────────────────────┘
+ * ```
+ *
+ * Each `len`-prefixed blob is a single `FromRadio` message as produced by Wire's `encode()`. By section:
+ * - **config** — `my_info`, `metadata`, `config.*`, `moduleConfig.*`, and `channel` frames: everything the app needs to
+ *   come up, but **no** `node_info` (the app ignores NodeInfo during Stage 1).
+ * - **node** — the connected node first, then the captured node DB (one `node_info` per frame).
+ * - **packet** — the captured `MeshPacket` traffic, in capture order; the section has no count and runs to EOF.
+ *
+ * `config_complete_id` is deliberately **omitted** from the file — this transport injects it per phase (below) with the
+ * app's own nonce, exactly as real firmware echoes the request.
+ *
+ * The file is produced by the burningmesh-replay tool (`replay_server.py --export PATH`, which also sanitizes capture
+ * PII). **This class is the authoritative reader of the format; keep the exporter and [ReplayRadioTransportTest]'s
+ * `asset()` encoder in sync with the layout above.**
+ *
+ * ### Handshake & runtime behaviour
+ * Driven by the app's two-phase want_config handshake ([HandshakeConstants]):
+ * - **Stage 1** ([HandshakeConstants.CONFIG_NONCE]) → emit the config section, then `config_complete_id`.
+ * - **Stage 2** ([HandshakeConstants.NODE_INFO_NONCE]) → emit the node section, then `config_complete_id`, then start
+ *   streaming the packet section **once** (a re-issued Stage-2 request does not restart it).
+ *
+ * The packet stream is paced at [packetDelayMs] and does not loop; it stops when [scope] is cancelled. Outbound
+ * [ToRadio] traffic other than want_config (heartbeats, app packets) is ignored — the replay is strictly read-only, and
+ * frames are held in memory, so [close] has nothing to release.
+ *
+ * ### Robustness
+ * The asset is parsed up front and every length is validated against the bytes actually remaining, so a truncated or
+ * corrupt file fails fast with [IllegalArgumentException] rather than a cryptic buffer underflow or an out-of-memory
+ * allocation. [handleSendToRadio] likewise tolerates any inbound bytes (undecodable [ToRadio] is ignored, not thrown).
+ * The bundled asset is trusted, but this same reader is a convenient injection point for malformed-input / fuzz testing
+ * of the ingestion path — see `ReplayFuzz` in the test sources.
+ */
+class ReplayRadioTransport(
+    private val callback: RadioTransportCallback,
+    private val scope: CoroutineScope,
+    val address: String,
+    frames: ByteArray,
+    private val packetDelayMs: Long = DEFAULT_PACKET_DELAY_MS,
+) : RadioTransport {
+
+    private val configFrames: List<ByteArray>
+    private val nodeFrames: List<ByteArray>
+    private val packetFrames: List<ByteArray>
+
+    init {
+        val buffer = Buffer().write(frames)
+        configFrames = buffer.readSection(counted = true, label = "config")
+        nodeFrames = buffer.readSection(counted = true, label = "node")
+        packetFrames = buffer.readSection(counted = false, label = "packet")
+    }
+
+    private var packetsStarted = false
+
+    override fun start() {
+        Logger.i {
+            "Starting replay transport: ${configFrames.size} config, ${nodeFrames.size} node, " +
+                "${packetFrames.size} packet frames"
+        }
+        callback.onConnect()
+    }
+
+    override fun handleSendToRadio(p: ByteArray) {
+        // Undecodable ToRadio is ignored rather than thrown: the replay must tolerate any bytes the app — or a fuzz
+        // harness — hands it, exactly as it tolerates a malformed asset.
+        val wantConfigId = runCatching { ToRadio.ADAPTER.decode(p).want_config_id }.getOrNull()
+        when (wantConfigId) {
+            HandshakeConstants.CONFIG_NONCE ->
+                scope.handledLaunch {
+                    emit(configFrames)
+                    complete(HandshakeConstants.CONFIG_NONCE)
+                }
+
+            HandshakeConstants.NODE_INFO_NONCE ->
+                scope.handledLaunch {
+                    emit(nodeFrames)
+                    complete(HandshakeConstants.NODE_INFO_NONCE)
+                    if (!packetsStarted) {
+                        packetsStarted = true
+                        streamPackets()
+                    }
+                }
+            // All other ToRadio traffic (heartbeats, outbound packets) is ignored — this is a read-only replay.
+        }
+    }
+
+    private fun emit(frames: List<ByteArray>) = frames.forEach { callback.handleFromRadio(it) }
+
+    private fun complete(nonce: Int) = callback.handleFromRadio(FromRadio(config_complete_id = nonce).encode())
+
+    private suspend fun streamPackets() {
+        Logger.d { "Replay streaming ${packetFrames.size} packets at ${packetDelayMs}ms spacing" }
+        for (frame in packetFrames) {
+            callback.handleFromRadio(frame)
+            if (packetDelayMs > 0) delay(packetDelayMs)
+        }
+        Logger.i { "Replay finished (${packetFrames.size} packets)" }
+    }
+
+    override suspend fun close() {
+        // Frames live in memory; the streaming coroutine is cancelled with the scope.
+    }
+
+    /**
+     * Reads one section of the asset. A [counted] section is prefixed with a `u32` frame count; the final (packet)
+     * section is uncounted and runs to end-of-buffer. Every frame length is checked against the bytes still available,
+     * so a malformed/truncated asset throws [IllegalArgumentException] up front instead of underflowing the buffer or
+     * allocating a multi-gigabyte array from a bogus length.
+     */
+    private fun Buffer.readSection(counted: Boolean, label: String): List<ByteArray> {
+        val expected = if (counted) readUInt32("$label frame count") else Int.MAX_VALUE
+        val frames = ArrayList<ByteArray>(if (counted) expected.coerceAtMost(MAX_PREALLOC) else 0)
+        while (frames.size < expected && !exhausted()) {
+            val len = readUInt32("$label[${frames.size}] length")
+            require(len.toLong() <= size) {
+                "Malformed replay asset: $label frame ${frames.size} declares $len bytes, only $size remain"
+            }
+            frames += readByteArray(len.toLong())
+        }
+        require(!counted || frames.size == expected) {
+            "Malformed replay asset: $label section truncated — read ${frames.size} of $expected frames"
+        }
+        return frames
+    }
+
+    /** Reads a big-endian `u32` as a non-negative [Int], rejecting truncation and the >2 GiB high-bit range. */
+    private fun Buffer.readUInt32(label: String): Int {
+        if (size < INT_BYTES) throw IllegalArgumentException("Malformed replay asset: truncated $label")
+        val value =
+            try {
+                readInt()
+            } catch (e: EOFException) {
+                throw IllegalArgumentException("Malformed replay asset: truncated $label", e)
+            }
+        require(value >= 0) { "Malformed replay asset: implausible $label ($value)" }
+        return value
+    }
+
+    companion object {
+        /** ~10 packets/sec, matching the burningmesh-replay steady-rate rig used for ingestion perf work. */
+        const val DEFAULT_PACKET_DELAY_MS = 100L
+
+        private const val INT_BYTES = 4
+
+        /** Cap the up-front list capacity from a (validated but still attacker-influenced) count to avoid OOM. */
+        private const val MAX_PREALLOC = 4096
+    }
+}

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/ReplayFuzz.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/ReplayFuzz.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.radio
+
+import okio.Buffer
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.proto.Data
+import org.meshtastic.proto.FromRadio
+import org.meshtastic.proto.MeshPacket
+import org.meshtastic.proto.NodeInfo
+import org.meshtastic.proto.Position
+import org.meshtastic.proto.User
+import kotlin.random.Random
+
+/**
+ * Deterministic fuzz toolkit for the on-device replay ingestion path — the same `FromRadio` entry every BLE / TCP /
+ * serial peer feeds (`RadioTransportCallback.handleFromRadio`). It ships with the app's tests (runs under `allTests`),
+ * so the parse / decode boundary is continuously fuzzed in CI at zero runtime and zero app-size cost.
+ *
+ * Untrusted radio input is a real attack surface: a malicious or buggy peer within range controls these bytes. This
+ * toolkit drives that surface with three input strategies, each aimed at a different layer:
+ * - [randomBytes] — unstructured noise; worst case for the stream/asset parser and the protobuf decoder.
+ * - [mutate] — bit-flips / truncations / extensions of a *valid* encoding; near-valid corruption that reaches deep
+ *   field-parsing paths a random blob never would.
+ * - [adversarialFromRadio] — a structurally **valid** `FromRadio` carrying hostile field values (out-of-range
+ *   coordinates, NaN / infinite metrics, oversized / RTL / emoji names, random sub-payloads). This is the corpus for
+ *   the layer where the real robustness gap lives: the post-decode handlers, which are not exception-isolated.
+ *
+ * **Everything is seeded.** A failing case is fully described by its integer seed, so a CI failure reproduces locally
+ * by pinning that seed — there is no hidden global RNG. Typical use:
+ * ```
+ * ReplayFuzz.forSeeds { random, seed ->
+ *     val input = ReplayFuzz.mutate(random, validFrame)
+ *     val error = runCatching { target(input) }.exceptionOrNull()
+ *     assertTrue(error == null || error is IllegalArgumentException) { "seed=$seed -> $error" }
+ * }
+ * ```
+ *
+ * Scope: this is a *library-level* fuzzer (parser, decoder, handshake). End-to-end fuzzing of the live stack —
+ * framing + UI + ANR — belongs in the capture tool's live `--fuzz` mode against a device; handler-level fuzzing needs
+ * the full `MeshMessageProcessor` graph and is a separate integration harness. The [adversarialFromRadio] corpus here
+ * is designed to feed that harness when it lands.
+ */
+@Suppress("MagicNumber")
+object ReplayFuzz {
+
+    /** Default seed sweep per invariant. Each seed is microseconds of work, so this stays well within CI budgets. */
+    const val DEFAULT_ITERATIONS = 1000
+
+    private const val MAX_RANDOM_LEN = 2048
+    private const val MAX_NAME_LEN = 8192
+    private const val MAX_PAYLOAD_LEN = 256
+
+    /** Runs [body] over the deterministic seed sweep `0 until [count]`; each seed gets its own pinned [Random]. */
+    inline fun forSeeds(count: Int = DEFAULT_ITERATIONS, body: (random: Random, seed: Int) -> Unit) {
+        for (seed in 0 until count) body(Random(seed), seed)
+    }
+
+    /** Unstructured noise of bounded length (bounded so a fuzz sweep can never OOM the test JVM). */
+    fun randomBytes(random: Random, maxLen: Int = MAX_RANDOM_LEN): ByteArray =
+        ByteArray(random.nextInt(maxLen + 1)).also(random::nextBytes)
+
+    /**
+     * A bit-flipped / truncated / extended copy of [input] — near-valid corruption that exercises field-parsing paths
+     * while staying small enough to be safe in CI. Returns fresh noise if [input] is empty.
+     */
+    fun mutate(random: Random, input: ByteArray): ByteArray {
+        if (input.isEmpty()) return randomBytes(random, 16)
+        val keep = random.nextInt(input.size + 1) // truncate to a 0..size prefix
+        val tail = if (random.nextBoolean()) randomBytes(random, 16) else ByteArray(0) // sometimes extend
+        val out = input.copyOf(keep) + tail
+        repeat(random.nextInt(1, 4)) {
+            // flip 1..3 bits
+            if (out.isNotEmpty()) {
+                val i = random.nextInt(out.size)
+                out[i] = (out[i].toInt() xor (1 shl random.nextInt(8))).toByte()
+            }
+        }
+        return out
+    }
+
+    /** A valid `FromRadio` carrying hostile content. Variant chosen by [random]. Corpus for handler/UI fuzzing. */
+    fun adversarialFromRadio(random: Random): FromRadio = if (random.nextBoolean()) {
+        FromRadio(node_info = adversarialNode(random))
+    } else {
+        FromRadio(packet = adversarialPacket(random))
+    }
+
+    /** A NodeInfo with extreme identity, signal, and location values — the kind a malicious node could advertise. */
+    fun adversarialNode(random: Random): NodeInfo = NodeInfo(
+        num = random.nextInt(),
+        snr = HOSTILE_FLOATS.random(random),
+        last_heard = random.nextInt(),
+        hops_away = random.nextInt(),
+        user =
+        User(
+            id = "!${random.nextInt().toUInt().toString(16)}",
+            long_name = hostileString(random),
+            short_name = hostileString(random),
+        ),
+        // Unconstrained, so trivially outside the valid +/-90 deg / +/-180 deg ranges (stored x 1e7).
+        position = Position(latitude_i = random.nextInt(), longitude_i = random.nextInt()),
+    )
+
+    /** A MeshPacket with extreme envelope fields and a random (malformed-for-its-portnum) decoded payload. */
+    fun adversarialPacket(random: Random): MeshPacket = MeshPacket(
+        id = random.nextInt(),
+        to = random.nextInt(),
+        channel = random.nextInt(),
+        rx_time = random.nextInt(),
+        hop_limit = random.nextInt(),
+        decoded = Data(payload = randomBytes(random, MAX_PAYLOAD_LEN).toByteString()),
+    )
+
+    /** Encodes the three replay sections (mirrors `replay_server.py --export` / [ReplayRadioTransport]'s reader). */
+    fun asset(config: List<FromRadio>, nodes: List<FromRadio>, packets: List<FromRadio>): ByteArray {
+        val buffer = Buffer()
+        fun section(frames: List<FromRadio>, counted: Boolean) {
+            if (counted) buffer.writeInt(frames.size)
+            frames.forEach { frame ->
+                val bytes = frame.encode()
+                buffer.writeInt(bytes.size)
+                buffer.write(bytes)
+            }
+        }
+        section(config, counted = true)
+        section(nodes, counted = true)
+        section(packets, counted = false)
+        return buffer.readByteArray()
+    }
+
+    private val HOSTILE_FLOATS =
+        listOf(Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.MAX_VALUE, -Float.MAX_VALUE)
+
+    // Built from code points (not literals) so the source stays ASCII — no raw bidi control to trip "trojan source"
+    // linters or alarm reviewers.
+    private fun hostileString(random: Random): String = when (random.nextInt(4)) {
+        0 -> RTL_OVERRIDE.repeat(random.nextInt(1, 8))
+
+        // U+202E right-to-left override runs
+        1 -> FIRE_EMOJI.repeat(random.nextInt(1, 64))
+
+        // astral emoji (surrogate pairs)
+        2 -> "A".repeat(random.nextInt(MAX_NAME_LEN))
+
+        // oversized name
+        else -> "" // empty
+    }
+
+    private val RTL_OVERRIDE = Char(0x202E).toString()
+    private val FIRE_EMOJI = "${Char(0xD83D)}${Char(0xDD25)}" // U+1F525 as a UTF-16 surrogate pair
+}

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/ReplayFuzzTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/ReplayFuzzTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.radio
+
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.repository.HandshakeConstants
+import org.meshtastic.core.repository.RadioTransportCallback
+import org.meshtastic.proto.FromRadio
+import org.meshtastic.proto.MeshPacket
+import org.meshtastic.proto.MyNodeInfo
+import org.meshtastic.proto.NodeInfo
+import org.meshtastic.proto.ToRadio
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Seeded fuzz suite for the replay ingestion path, built on [ReplayFuzz]. Each test states an invariant the
+ * untrusted-input boundary must hold and sweeps it over [ReplayFuzz.DEFAULT_ITERATIONS] deterministic seeds; a failure
+ * message carries the seed so it reproduces locally. These run in `allTests`, so the parse/decode boundary is fuzzed on
+ * every CI run at no app-size cost.
+ *
+ * Layers covered here are the self-contained ones with clean pass/fail oracles: the asset parser, the handshake input,
+ * and the protobuf decoder. The post-decode handler chain (the layer that is *not* exception-isolated) needs the full
+ * `MeshMessageProcessor` graph and a richer oracle — the [ReplayFuzz.adversarialFromRadio] corpus is built to feed that
+ * integration harness when it lands.
+ */
+class ReplayFuzzTest {
+
+    /** Collects relayed frames without decoding, so the oracle is the transport's behaviour, not the callback's. */
+    private class Sink : RadioTransportCallback {
+        val frames = mutableListOf<ByteArray>()
+
+        override fun onConnect() = Unit
+
+        override fun onDisconnect(isPermanent: Boolean, errorMessage: String?) = Unit
+
+        override fun handleFromRadio(bytes: ByteArray) {
+            frames += bytes
+        }
+    }
+
+    private val sampleConfig = listOf(FromRadio(my_info = MyNodeInfo(my_node_num = 1)))
+    private val sampleNodes = listOf(FromRadio(node_info = NodeInfo(num = 1)))
+    private val samplePackets = listOf(FromRadio(packet = MeshPacket(id = 1)))
+
+    private fun validAsset() = ReplayFuzz.asset(sampleConfig, sampleNodes, samplePackets)
+
+    /**
+     * A corrupt asset must fail fast and *only* as [IllegalArgumentException] — never OOM, hang, or leak okio errors.
+     */
+    @Test
+    fun `corrupt assets fail only with IllegalArgumentException`() = runTest {
+        ReplayFuzz.forSeeds { random, seed ->
+            val input = if (seed % 2 == 0) ReplayFuzz.mutate(random, validAsset()) else ReplayFuzz.randomBytes(random)
+            val error =
+                runCatching { ReplayRadioTransport(Sink(), this, address = "", frames = input, packetDelayMs = 0) }
+                    .exceptionOrNull()
+            assertTrue(
+                error == null || error is IllegalArgumentException,
+                "seed=$seed: parser raised ${error?.let { it::class.simpleName }}: ${error?.message}",
+            )
+        }
+    }
+
+    /** The transport must absorb any outbound bytes — undecodable [ToRadio] is dropped, not thrown. */
+    @Test
+    fun `handleSendToRadio tolerates arbitrary outbound bytes`() = runTest {
+        val transport = ReplayRadioTransport(Sink(), this, address = "", frames = validAsset(), packetDelayMs = 0)
+        ReplayFuzz.forSeeds { random, seed ->
+            val error =
+                runCatching {
+                    transport.handleSendToRadio(ReplayFuzz.mutate(random, ToRadio(want_config_id = 1).encode()))
+                    transport.handleSendToRadio(ReplayFuzz.randomBytes(random))
+                }
+                    .exceptionOrNull()
+            assertTrue(error == null, "seed=$seed: handleSendToRadio threw $error")
+        }
+        testScheduler.advanceUntilIdle()
+    }
+
+    /**
+     * Decoding a bit-flipped frame may throw, but only a catchable [Exception] — an [Error] (OOM/SOE) would be a DoS.
+     */
+    @Test
+    fun `decode of bit-flipped frames never raises an Error`() = runTest {
+        val seedFrame = FromRadio(node_info = NodeInfo(num = 7)).encode()
+        ReplayFuzz.forSeeds { random, seed ->
+            val mutated = ReplayFuzz.mutate(random, seedFrame)
+            val error = runCatching { FromRadio.ADAPTER.decode(mutated) }.exceptionOrNull()
+            assertTrue(error == null || error is Exception, "seed=$seed: decode raised $error")
+        }
+    }
+
+    /** Hostile-but-valid content must replay through the transport intact (every relayed frame still decodes). */
+    @Test
+    fun `adversarial frames replay through the transport without crashing it`() = runTest {
+        val sink = Sink()
+        val nodes = (0 until 25).map { FromRadio(node_info = ReplayFuzz.adversarialNode(Random(it))) }
+        val packets = (0 until 75).map { FromRadio(packet = ReplayFuzz.adversarialPacket(Random(it))) }
+        val transport =
+            ReplayRadioTransport(
+                callback = sink,
+                scope = this,
+                address = "",
+                frames = ReplayFuzz.asset(sampleConfig, nodes, packets),
+                packetDelayMs = 0,
+            )
+
+        transport.start()
+        transport.handleSendToRadio(ToRadio(want_config_id = HandshakeConstants.NODE_INFO_NONCE).encode())
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(sink.frames.isNotEmpty())
+        sink.frames.forEach { FromRadio.ADAPTER.decode(it) } // round-trip held under hostile field values
+    }
+}

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/ReplayRadioTransportTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.radio
+
+import kotlinx.coroutines.test.runTest
+import okio.Buffer
+import org.meshtastic.core.repository.HandshakeConstants
+import org.meshtastic.core.repository.RadioTransportCallback
+import org.meshtastic.proto.FromRadio
+import org.meshtastic.proto.MeshPacket
+import org.meshtastic.proto.MyNodeInfo
+import org.meshtastic.proto.NodeInfo
+import org.meshtastic.proto.ToRadio
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ReplayRadioTransportTest {
+
+    private val configFrames = listOf(FromRadio(my_info = MyNodeInfo(my_node_num = 1)))
+    private val nodeFrames =
+        listOf(FromRadio(node_info = NodeInfo(num = 42)), FromRadio(node_info = NodeInfo(num = 43)))
+    private val packetFrames = (1..3).map { FromRadio(packet = MeshPacket(id = it)) }
+
+    private class RecordingCallback : RadioTransportCallback {
+        var connects = 0
+        val received = mutableListOf<FromRadio>()
+
+        override fun onConnect() {
+            connects++
+        }
+
+        override fun onDisconnect(isPermanent: Boolean, errorMessage: String?) = Unit
+
+        override fun handleFromRadio(bytes: ByteArray) {
+            received.add(FromRadio.ADAPTER.decode(bytes))
+        }
+    }
+
+    /** Encodes the three sections in the `replay_server.py --export` asset format. */
+    private fun asset(
+        config: List<FromRadio> = configFrames,
+        nodes: List<FromRadio> = nodeFrames,
+        packets: List<FromRadio> = packetFrames,
+    ): ByteArray {
+        val buffer = Buffer()
+        fun writeFrames(frames: List<FromRadio>, withCount: Boolean) {
+            if (withCount) buffer.writeInt(frames.size)
+            frames.forEach {
+                val bytes = it.encode()
+                buffer.writeInt(bytes.size)
+                buffer.write(bytes)
+            }
+        }
+        writeFrames(config, withCount = true)
+        writeFrames(nodes, withCount = true)
+        writeFrames(packets, withCount = false)
+        return buffer.readByteArray()
+    }
+
+    @Test
+    fun `start signals onConnect without emitting frames`() = runTest {
+        val callback = RecordingCallback()
+        val transport = ReplayRadioTransport(callback, this, address = "", frames = asset(), packetDelayMs = 0)
+
+        transport.start()
+
+        assertEquals(1, callback.connects)
+        assertTrue(callback.received.isEmpty())
+    }
+
+    @Test
+    fun `config nonce is answered with config frames and the echoed nonce only`() = runTest {
+        val callback = RecordingCallback()
+        val transport = ReplayRadioTransport(callback, this, address = "", frames = asset(), packetDelayMs = 0)
+
+        transport.handleSendToRadio(ToRadio(want_config_id = HandshakeConstants.CONFIG_NONCE).encode())
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(configFrames + FromRadio(config_complete_id = HandshakeConstants.CONFIG_NONCE), callback.received)
+    }
+
+    @Test
+    fun `node nonce is answered with the node db then the packet stream`() = runTest {
+        val callback = RecordingCallback()
+        val transport = ReplayRadioTransport(callback, this, address = "", frames = asset(), packetDelayMs = 0)
+
+        transport.handleSendToRadio(ToRadio(want_config_id = HandshakeConstants.NODE_INFO_NONCE).encode())
+        testScheduler.advanceUntilIdle()
+
+        val expected = nodeFrames + FromRadio(config_complete_id = HandshakeConstants.NODE_INFO_NONCE) + packetFrames
+        assertEquals(expected, callback.received)
+    }
+
+    @Test
+    fun `a second node nonce does not restart the packet stream`() = runTest {
+        val callback = RecordingCallback()
+        val transport = ReplayRadioTransport(callback, this, address = "", frames = asset(), packetDelayMs = 0)
+
+        transport.handleSendToRadio(ToRadio(want_config_id = HandshakeConstants.NODE_INFO_NONCE).encode())
+        testScheduler.advanceUntilIdle()
+        transport.handleSendToRadio(ToRadio(want_config_id = HandshakeConstants.NODE_INFO_NONCE).encode())
+        testScheduler.advanceUntilIdle()
+
+        val packetsSent = callback.received.count { it.packet != null }
+        assertEquals(packetFrames.size, packetsSent)
+    }
+
+    @Test
+    fun `non-handshake traffic is ignored`() = runTest {
+        val callback = RecordingCallback()
+        val transport = ReplayRadioTransport(callback, this, address = "", frames = asset(), packetDelayMs = 0)
+
+        transport.handleSendToRadio(ToRadio(packet = MeshPacket(id = 99)).encode())
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(callback.received.isEmpty())
+    }
+
+    // ── Malformed-asset handling: the parser must fail fast with a clear error, never underflow or over-allocate. ──
+
+    /** Builds a raw asset body so we can craft deliberately-corrupt inputs the [asset] helper cannot. */
+    private fun rawAsset(block: Buffer.() -> Unit): ByteArray = Buffer().apply(block).readByteArray()
+
+    @Test
+    fun `truncated section count is rejected`() = runTest {
+        // Only two bytes — not enough for the leading u32 config count.
+        assertFailsWith<IllegalArgumentException> {
+            ReplayRadioTransport(RecordingCallback(), this, address = "", frames = byteArrayOf(0x00, 0x01))
+        }
+    }
+
+    @Test
+    fun `frame length exceeding remaining bytes is rejected`() = runTest {
+        val frames = rawAsset {
+            writeInt(1) // config: 1 frame…
+            writeInt(9_999) // …declaring 9999 bytes…
+            write(byteArrayOf(1, 2, 3)) // …but only 3 follow.
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ReplayRadioTransport(RecordingCallback(), this, address = "", frames = frames)
+        }
+    }
+
+    @Test
+    fun `counted section with fewer frames than declared is rejected`() = runTest {
+        val frames = rawAsset {
+            writeInt(3) // config: claims 3 frames…
+            writeInt(2)
+            write(byteArrayOf(1, 2)) // …but provides only 1, then EOF.
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ReplayRadioTransport(RecordingCallback(), this, address = "", frames = frames)
+        }
+    }
+
+    @Test
+    fun `empty config and node sections with no packets are valid`() = runTest {
+        val callback = RecordingCallback()
+        val frames = rawAsset {
+            writeInt(0) // 0 config frames
+            writeInt(0) // 0 node frames
+            // no packet bytes
+        }
+        val transport = ReplayRadioTransport(callback, this, address = "", frames = frames, packetDelayMs = 0)
+
+        transport.start()
+        transport.handleSendToRadio(ToRadio(want_config_id = HandshakeConstants.NODE_INFO_NONCE).encode())
+        testScheduler.advanceUntilIdle()
+
+        // Only the injected config_complete — no nodes, no packets — proves zero-length sections parse cleanly.
+        assertEquals(listOf(FromRadio(config_complete_id = HandshakeConstants.NODE_INFO_NONCE)), callback.received)
+    }
+}

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -327,6 +327,7 @@
     <string name="delivery_confirmed">Delivery confirmed</string>
     <string name="delivery_confirmed_reboot_warning">Your device may disconnect and reboot while settings are applied.</string>
     <string name="demo_mode">Demo Mode</string>
+    <string name="demo_mode_replay">Demo Mode (Replay)</string>
     <string name="desc_node_filter_clear">clear node filter</string>
     <string name="description">Description</string>
     <string name="desktop_notification_title">Meshtastic</string>

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
@@ -164,7 +164,12 @@ class MeshServiceOrchestrator(
             .launchIn(newScope)
 
         radioInterfaceService.receivedData
-            .onEach { bytes -> messageProcessor.handleFromRadio(bytes, nodeManager.myNodeNum.value) }
+            // This loop is the single lifeline for every inbound packet. handleFromRadio is already total, but guard
+            // here too so nothing — now or later — can cancel the collection and leave the radio permanently deaf.
+            .onEach { bytes ->
+                safeCatching { messageProcessor.handleFromRadio(bytes, nodeManager.myNodeNum.value) }
+                    .onFailure { Logger.e(it) { "Dropped inbound bytes after a receive-loop error" } }
+            }
             .launchIn(newScope)
 
         radioInterfaceService.connectionError

--- a/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
+++ b/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
@@ -33,6 +33,7 @@ import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.demo_mode
+import org.meshtastic.core.resources.demo_mode_replay
 import org.meshtastic.core.resources.meshtastic
 import org.meshtastic.feature.connections.model.AndroidUsbDeviceData
 import org.meshtastic.feature.connections.model.DeviceListEntry
@@ -154,9 +155,18 @@ class AndroidGetDiscoveredDevicesUseCase(
         usbDevices: List<DeviceListEntry.Usb>,
         showMock: Boolean,
         db: Map<Int, Node>,
-    ): List<DeviceListEntry> =
-        (usbDevices + if (showMock) listOf(DeviceListEntry.Mock(getString(Res.string.demo_mode))) else emptyList())
-            .map { entry ->
-                entry.copy(node = findNodeByNameSuffix(entry.name, entry.fullAddress, db, databaseManager))
+    ): List<DeviceListEntry> = (
+        usbDevices +
+            if (showMock) {
+                listOf(
+                    DeviceListEntry.Mock(getString(Res.string.demo_mode)),
+                    DeviceListEntry.Replay(getString(Res.string.demo_mode_replay)),
+                )
+            } else {
+                emptyList()
             }
+        )
+        .map { entry ->
+            entry.copy(node = findNodeByNameSuffix(entry.name, entry.fullAddress, db, databaseManager))
+        }
 }

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/Constants.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/Constants.kt
@@ -29,5 +29,8 @@ const val TCP_DEVICE_PREFIX: String = "t"
 /** One-char prefix / sentinel marking the mock (demo-mode) device's `fullAddress`. See [DeviceListEntry.Mock]. */
 const val MOCK_DEVICE_PREFIX: String = "m"
 
+/** One-char prefix / sentinel marking the capture-replay device's `fullAddress`. See [DeviceListEntry.Replay]. */
+const val REPLAY_DEVICE_PREFIX: String = "r"
+
 /** One-char prefix marking a BLE device's `fullAddress`. See [DeviceListEntry.Ble]. */
 const val BLE_DEVICE_PREFIX: String = "x"

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
@@ -338,6 +338,11 @@ open class ScannerViewModel(
                 changeDeviceAddress(entry.fullAddress)
                 true
             }
+
+            is DeviceListEntry.Replay -> {
+                changeDeviceAddress(entry.fullAddress)
+                true
+            }
         }
     }
 

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCase.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCase.kt
@@ -26,6 +26,7 @@ import org.meshtastic.core.network.repository.DiscoveredService
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.demo_mode
+import org.meshtastic.core.resources.demo_mode_replay
 import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.core.resources.meshtastic
 import org.meshtastic.feature.connections.model.DeviceListEntry
@@ -68,6 +69,10 @@ open class CommonGetDiscoveredDevicesUseCase(
                 if (showMock) {
                     val label = safeCatchingAll { getStringSuspend(Res.string.demo_mode) }.getOrDefault("Demo Mode")
                     add(DeviceListEntry.Mock(label))
+                    val replayLabel =
+                        safeCatchingAll { getStringSuspend(Res.string.demo_mode_replay) }
+                            .getOrDefault("Demo Mode (Replay)")
+                    add(DeviceListEntry.Replay(replayLabel))
                 }
             }
 

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/model/DeviceListEntry.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/model/DeviceListEntry.kt
@@ -72,6 +72,12 @@ sealed class DeviceListEntry(
         DeviceListEntry(name, "m", true, node) {
         override fun copy(node: Node?): Mock = copy(name = name, node = node)
     }
+
+    /** Debug-only virtual device that replays a bundled packet capture on-device (see `ReplayRadioTransport`). */
+    data class Replay(override val name: String, override val node: Node? = null) :
+        DeviceListEntry(name, "r", true, node) {
+        override fun copy(node: Node?): Replay = copy(name = name, node = node)
+    }
 }
 
 /** Matches names like Meshtastic_1234. */

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -70,6 +70,7 @@ import org.meshtastic.core.ui.viewmodel.ConnectionStatus
 import org.meshtastic.core.ui.viewmodel.ConnectionsViewModel
 import org.meshtastic.feature.connections.MOCK_DEVICE_PREFIX
 import org.meshtastic.feature.connections.NO_DEVICE_SELECTED
+import org.meshtastic.feature.connections.REPLAY_DEVICE_PREFIX
 import org.meshtastic.feature.connections.ScannerViewModel
 import org.meshtastic.feature.connections.TCP_DEVICE_PREFIX
 import org.meshtastic.feature.connections.model.DeviceListEntry
@@ -251,7 +252,8 @@ fun ConnectionsScreen(
                         if (
                             uiState == ConnectionUiState.CONNECTED_WITH_NODE &&
                             regionUnset &&
-                            selectedDevice != MOCK_DEVICE_PREFIX
+                            selectedDevice != MOCK_DEVICE_PREFIX &&
+                            selectedDevice != REPLAY_DEVICE_PREFIX
                         ) {
                             Spacer(modifier = Modifier.height(8.dp))
                             Card(modifier = Modifier.fillMaxWidth()) {

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/DeviceListItem.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/DeviceListItem.kt
@@ -108,6 +108,8 @@ fun DeviceListItem(
             is DeviceListEntry.Tcp -> MeshtasticIcons.Wifi
 
             is DeviceListEntry.Mock -> MeshtasticIcons.Add
+
+            is DeviceListEntry.Replay -> MeshtasticIcons.Add
         }
 
     val contentDescription =
@@ -116,6 +118,7 @@ fun DeviceListItem(
             is DeviceListEntry.Usb -> stringResource(Res.string.serial)
             is DeviceListEntry.Tcp -> stringResource(Res.string.network)
             is DeviceListEntry.Mock -> stringResource(Res.string.add)
+            is DeviceListEntry.Replay -> stringResource(Res.string.add)
         }
 
     val selectLabel = stringResource(Res.string.action_select_device)

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCaseTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCaseTest.kt
@@ -90,7 +90,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
         setUp()
         useCase.invoke(showMock = true, resolvedList = resolvedServicesFlow).test {
             val result = awaitItem()
-            result.usbDevices.size shouldBe 1
+            result.usbDevices.size shouldBe 2
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -239,7 +239,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
         setUp()
         useCase.invoke(showMock = true, resolvedList = flowOf(emptyList())).test {
             val result = awaitItem()
-            result.usbDevices.size shouldBe 1
+            result.usbDevices.size shouldBe 2
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
On-device packet-ingestion work needs a deterministic, radio-free way to drive realistic mesh traffic into the app, and assurance that the untrusted-input path can't be crashed by a malformed packet. This PR adds an on-device capture-replay transport, a seeded fuzz harness over the ingestion boundary, and the per-packet exception isolation that the fuzzing surfaced as missing.

### 🌟 New Features

- **`InterfaceId.REPLAY` — on-device capture-replay transport.** A debug/test-only **"Demo Mode (Replay)"** connection entry replays a pre-captured `FromRadio` frame stream entirely on-device — no network, no paired radio. It honours the two-phase `want_config` handshake (config → node DB → packet stream) and paces packets at a steady rate, giving a deterministic, self-contained traffic source for benchmarks, populated-UI tests, and manual QA. When the (gitignored) capture asset is absent it falls back to the existing synthetic `MockRadioTransport`, so the entry always works.

### 🛠️ Refactoring & Architecture

- **Hardened the replay interface.** The asset parser now validates every frame length against the bytes remaining and fails fast with `IllegalArgumentException` instead of an okio underflow or an oversized allocation; `handleSendToRadio` tolerates arbitrary inbound bytes (undecodable `ToRadio` is dropped, not thrown). The on-wire asset format is documented authoritatively in the `ReplayRadioTransport` KDoc.

### 🐛 Bug Fixes

- **Isolate per-packet failures in the receive pipeline.** The `FromRadio` *decode* boundary was already guarded, but the post-decode handler chain (`processFromRadio` → the per-variant handlers) and the orchestrator's receive loop (`receivedData.onEach { handleFromRadio }`) were not. A single malformed-but-decodable packet from any peer in radio range whose handler threw would cancel the `receivedData` collection and silently deafen the radio for the rest of the session — a remote DoS, and likely a crash on Android's default coroutine exception handler. Both layers now contain handler failures with `safeCatching` (which re-throws `CancellationException`, preserving structured concurrency), logging and dropping the offending packet.

### Testing Performed

- **`ReplayFuzz` + `ReplayFuzzTest`** (new, `core:network` `commonTest`): a seeded, deterministic fuzz harness over the ingestion boundary (random / mutated / structurally-valid-but-hostile inputs), asserting four invariants — corrupt assets fail *only* with `IllegalArgumentException`; `handleSendToRadio` never throws; a bit-flipped frame decodes to a catchable `Exception`, never an `Error`; adversarial-but-valid content replays intact. Runs under `allTests` at zero app-size cost, and every failure reproduces from its integer seed.
- **`ReplayRadioTransportTest`** (extended): added malformed-asset cases (truncated counts, oversized lengths, short/empty sections) alongside the handshake/stream tests — 9 total.
- **`MeshMessageProcessorImplTest`** (extended): added `a throwing handler does not propagate out of handleFromRadio`, which forces a downstream handler to throw and asserts the call returns normally — it fails without the fix above.
- Full local gate green on the current `main` (detekt `2.0.0-alpha.5`): `spotlessCheck detekt assembleGoogleDebug kmpSmokeCompile`, plus `:core:network`, `:core:data`, and `:core:service` `allTests`.
- The replay transport itself was verified on-device in earlier work: the two-phase handshake completes, a ~200-node DB lands, and packets decode through the normal ingestion pipeline.

> The capture asset (`burningmesh.fromradio`) is derived from a private mesh capture and is **gitignored** — it is never committed. Without it, the "Demo Mode (Replay)" entry runs against the synthetic 2-node mock.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
