### PR TITLE
fix(ble): retrigger connection when bonding is interrupted

### DIFF
--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -142,10 +142,31 @@ class AndroidBluetoothRepository(
             }
 
             if (!remoteDevice.createBond()) {
-                try {
-                    context.unregisterReceiver(receiver)
-                } catch (ignored: Exception) {}
-                if (cont.isActive) cont.resumeWith(Result.failure(Exception("Failed to initiate bonding")))
+                // createBond() returns false when a bond is already in flight (initiated by the OS or
+                // triggered by a GATT operation hitting a secured characteristic) or already established.
+                // The ACTION_BOND_STATE_CHANGED broadcast is unreliable on some devices (see Kable #111),
+                // so re-check bondState directly rather than failing the whole flow.
+                when (remoteDevice.bondState) {
+                    android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                        try {
+                            context.unregisterReceiver(receiver)
+                        } catch (ignored: Exception) {}
+                        if (cont.isActive) cont.resume(Unit)
+                    }
+
+                    android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                        // Bond already in progress; leave the receiver registered to resolve it on the
+                        // terminal BOND_BONDED / BOND_NONE transition instead of treating this as a failure.
+                        Logger.d { "createBond() returned false but bonding is already in progress" }
+                    }
+
+                    else -> {
+                        try {
+                            context.unregisterReceiver(receiver)
+                        } catch (ignored: Exception) {}
+                        if (cont.isActive) cont.resumeWith(Result.failure(Exception("Failed to initiate bonding")))
+                    }
+                }
             }
         }
         updateBluetoothState()

--- a/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModel.kt
+++ b/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModel.kt
@@ -68,26 +68,34 @@ class AndroidScannerViewModel(
         Logger.i { "Starting bonding for ${entry.device.address.anonymize}" }
         viewModelScope.launch {
             @Suppress("TooGenericExceptionCaught")
-            try {
-                bluetoothRepository.bond(entry.device)
-                Logger.i { "Bonding complete for ${entry.device.address.anonymize}, selecting device..." }
-                changeDeviceAddress(entry.fullAddress)
-            } catch (ex: SecurityException) {
-                Logger.w(ex) { "Bonding failed for ${entry.device.address.anonymize} Permissions not granted" }
-                serviceRepository.setErrorMessage(
-                    text = "Bonding failed: ${ex.message} Permissions not granted",
-                    severity = Severity.Warn,
-                )
-            } catch (ex: Exception) {
-                // Bonding is often flaky and can fail for many reasons (timeout, user cancel, etc)
-                val message = ex.message ?: ""
-                if (message.contains("Received bond state changed 11")) {
-                    // This is a known issue where bonding is still in progress, ignore as error
-                    Logger.d { "Bonding still in progress for ${entry.device.address.anonymize}" }
-                } else {
-                    Logger.w(ex) { "Bonding failed for ${entry.device.address.anonymize}" }
-                    serviceRepository.setErrorMessage(text = "Bonding failed: ${ex.message}", severity = Severity.Warn)
+            val armTransport =
+                try {
+                    bluetoothRepository.bond(entry.device)
+                    Logger.i { "Bonding complete for ${entry.device.address.anonymize}, selecting device..." }
+                    true
+                } catch (ex: SecurityException) {
+                    // No BLUETOOTH_CONNECT permission — connecting would fail the same way, so surface the
+                    // error and do not arm the transport.
+                    Logger.w(ex) { "Bonding failed for ${entry.device.address.anonymize} Permissions not granted" }
+                    serviceRepository.setErrorMessage(
+                        text = "Bonding failed: ${ex.message} Permissions not granted",
+                        severity = Severity.Warn,
+                    )
+                    false
+                } catch (ex: Exception) {
+                    // Bonding is flaky and can fail for many reasons: user cancel/timeout, an unreliable
+                    // ACTION_BOND_STATE_CHANGED broadcast, or an OS/GATT-initiated bond already in flight
+                    // (see Kable #111). Don't treat any of these as terminal — arm the transport anyway so
+                    // its persistent reconnect loop (which bonds on demand and retries with backoff) can
+                    // converge, instead of leaving the device inert until the user re-selects it.
+                    Logger.w(ex) {
+                        "Bonding did not complete cleanly for ${entry.device.address.anonymize}; " +
+                            "arming transport to retry"
+                    }
+                    true
                 }
+            if (armTransport) {
+                changeDeviceAddress(entry.fullAddress)
             }
         }
     }


### PR DESCRIPTION
## Why

Selecting an **unbonded** node and having the bonding flow get interrupted left the device inert — the user had to re-select the node to retrigger a connection.

Root cause: the transport's reconnect loop is persistent and bonds on demand, but it only starts once `changeDeviceAddress()` runs. For an unbonded device that call was gated behind a **clean** `bond()` success, so any bonding hiccup (user-cancel/timeout, an unreliable `ACTION_BOND_STATE_CHANGED` broadcast, or an OS/GATT-initiated bond already in flight) skipped it and the persistent reconnect loop was never armed.

## Changes

### 🐛 Bug Fixes
- **`AndroidScannerViewModel.requestBonding`** — arm the transport on **every** bonding outcome except a permissions `SecurityException`. A flaky or interrupted bond now hands off to the transport's reconnect+backoff loop (which bonds on demand and retries) instead of stranding the device until a manual re-select.
- **`AndroidBluetoothRepository.bond`** — when `createBond()` returns `false`, re-check `bondState` instead of failing outright:
  - `BOND_BONDED` → resume immediately
  - `BOND_BONDING` → keep waiting on the receiver for the terminal transition
  - otherwise → fail as before

  This handles the in-flight-bond collision and unreliable bond-state broadcast documented upstream in [Kable #111](https://github.com/JuulLabs/kable/issues/111).

## Reviewer notes
- **No automated coverage added.** Both files are `androidMain` classes touching `BluetoothDevice` / `BroadcastReceiver`, and neither module has a Robolectric / `androidUnitTest` harness today. Standing one up is a larger, separate effort.
- **Needs real-hardware verification.** This is a behavioral BLE change; the meaningful test is selecting an unbonded node, interrupting bonding, and confirming the connection retriggers without re-selecting.
- Kable itself provides no bonding API (it's intentionally unsupported), so bonding remains entirely app-owned here — the fix leans on the existing transport reconnect loop rather than adding a new mechanism.

## Validation
- `./gradlew spotlessApply spotlessCheck` — pass
- `./gradlew detekt` — pass
- `compileAndroidMain` for `:core:ble` and `:feature:connections` (with `--rerun-tasks`) — pass

<!--
If you have screenshots or recordings to display your change, please include them!
-->
