### PR TITLE
fix(desktop): terminate process on exit; quit on close when no tray

### DIFF
--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.application
+import androidx.compose.ui.window.isTraySupported
 import androidx.compose.ui.window.rememberTrayState
 import androidx.compose.ui.window.rememberWindowState
 import co.touchlab.kermit.Logger
@@ -112,7 +113,7 @@ private fun svgPainterResource(path: String, density: Density): Painter = rememb
 }
 
 @OptIn(ExperimentalCoilApi::class)
-fun main(args: Array<String>) = application(exitProcessOnExit = false) {
+fun main(args: Array<String>) = application {
     val koinApp = remember {
         Logger.i { "Meshtastic Desktop — Starting" }
         startKoin { modules(desktopPlatformModule(), desktopModule()) }
@@ -228,7 +229,16 @@ private fun ApplicationScope.MeshtasticDesktopApp(uiViewModel: UIViewModel, isDa
     )
 
     if (isWindowReady && isAppVisible) {
-        MeshtasticWindow(uiViewModel, isDarkTheme, appIcon, windowState) { isAppVisible = false }
+        MeshtasticWindow(uiViewModel, isDarkTheme, appIcon, windowState) {
+            // Minimize to the tray on close — but only where a tray exists. On platforms without a
+            // system tray (e.g. some Linux desktop environments) there's nowhere to minimize to, so
+            // quit instead; otherwise the process would be stranded with no window and no tray icon.
+            if (isTraySupported) {
+                isAppVisible = false
+            } else {
+                exitApplication()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closing the Meshtastic Desktop app left the process running with no window and no reliable way to quit. This restores normal exit behavior and adds a safety net for desktop environments that have no system tray.

Fixes #5857

### 🐛 Bug Fixes
- **Terminate the JVM on exit.** `main()` passed `exitProcessOnExit = false` to `application()`. Compose Desktop relies on AWT, whose shutdown thread is non-daemon, so the JVM only exits when `exitProcess(0)` runs — which `application()` skips when that flag is `false`. As a result `exitApplication()` (tray **Quit** and **Super/Cmd+Q**) ended the composition but never killed the process. Removed the flag to restore the documented default (`true`). Per the `application()` KDoc, `false` is only for running code *after* the `application{}` block, which this expression-body `main` does not.
- **Quit on window-close when no tray exists.** Window-close minimizes to the tray by design (so background mesh notifications keep arriving). On platforms without a system tray (e.g. some Linux desktop environments) there is nowhere to minimize to, which would strand a windowless, icon-less process. Window-close now falls back to `exitApplication()` when `isTraySupported` is `false`.

Resulting behavior:

| Action | Tray available | No tray (e.g. some Linux DEs) |
|---|---|---|
| Window close (X) | Minimize to tray | Quit |
| Tray "Quit" / Super+Q | Quit | n/a |

Where a tray exists, window-close still minimizes to it (unchanged); the tray **Quit** item and **Super/Cmd+Q** now genuinely terminate the process.

### Verification
`./gradlew :desktopApp:compileKotlin :desktopApp:spotlessCheck :desktopApp:detekt` — all pass. The change is isolated to the desktop host shell (`desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt`); no tests reference it and no other module depends on it, so the module-scoped checks are the complete relevant gate.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
