### PR TITLE
fix(settings): crash opening Position radio-config screen

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/PositionConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/PositionConfigScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalFocusManager
@@ -71,6 +72,34 @@ expect fun DeviceLocationButton(
     onLocationReceived: (Position) -> Unit,
 )
 
+private val PositionStateSaver =
+    listSaver<Position, Any>(
+        save = {
+            listOf(
+                it.latitude,
+                it.longitude,
+                it.altitude,
+                it.time,
+                it.satellitesInView,
+                it.groundSpeed,
+                it.groundTrack,
+                it.precisionBits,
+            )
+        },
+        restore = {
+            Position(
+                latitude = it[0] as Double,
+                longitude = it[1] as Double,
+                altitude = it[2] as Int,
+                time = it[3] as Int,
+                satellitesInView = it[4] as Int,
+                groundSpeed = it[5] as Int,
+                groundTrack = it[6] as Int,
+                precisionBits = it[7] as Int,
+            )
+        },
+    )
+
 @Composable
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 fun PositionConfigScreenCommon(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
@@ -102,7 +131,9 @@ fun PositionConfigScreenCommon(viewModel: RadioConfigViewModel, onBack: () -> Un
             updated
         }
     val formState = rememberConfigState(initialValue = sanitizedPositionConfig)
-    var locationInput by rememberSaveable(currentPosition) { mutableStateOf(currentPosition) }
+    // Position is not Bundle-storable, so persist it through a custom Saver of its primitive fields.
+    var locationInput by
+        rememberSaveable(currentPosition, stateSaver = PositionStateSaver) { mutableStateOf(currentPosition) }
 
     val focusManager = LocalFocusManager.current
     RadioConfigScreenList(


### PR DESCRIPTION
## Why

Tapping **Location** in radio config crashed the app instantly (reproduced on a Pixel 9 Pro via logcat):

```
java.lang.IllegalArgumentException: MutableState containing Position(lat=…, lon=…, alt=…, time=1)
cannot be saved using the current SaveableStateRegistry. The default implementation only
supports types which can be stored inside the Bundle.
    at androidx.compose.runtime.saveable.RememberSaveableKt.requireCanBeSaved(RememberSaveable.kt:355)
```

`PositionConfigScreen` used `rememberSaveable { mutableStateOf(currentPosition) }` with no `stateSaver`. `Position` is a plain `core.model` data class (not `Parcelable`/Bundle-storable), so `rememberSaveable` fell back to the default Bundle saver and threw on the main thread the moment the screen composed — the crash happened on entry, not on any interaction.

## What changed

- Added a `listSaver` over `Position`'s primitive fields and passed it as `stateSaver` to the `rememberSaveable`. All fields are `Double`/`Int`, so the saver is KMP/Bundle-safe.
- All eight fields are round-tripped so the `additionalDirtyCheck { locationInput != currentPosition }` equality comparison stays correct.

## Testing Performed

- `./gradlew :feature:settings:assemble spotlessCheck detekt` — all pass.
- Crash confirmed in device logcat before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)