### PR TITLE
fix(settings): gate Traffic Management config at firmware v2.8.0

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
@@ -52,8 +52,8 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
     /** Support for Status Message module. Supported since firmware v2.8.0. */
     val supportsStatusMessage = atLeast(V2_8_0)
 
-    /** Support for Traffic Management module. Supported since firmware v3.0.0. */
-    val supportsTrafficManagementConfig = atLeast(V3_0_0)
+    /** Support for Traffic Management module. Supported since firmware v2.8.0. */
+    val supportsTrafficManagementConfig = atLeast(V2_8_0)
 
     /** Support for TAK (ATAK) module configuration. Supported since firmware v2.7.19. */
     val supportsTakConfig = atLeast(V2_7_19)
@@ -79,7 +79,6 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
         private val V2_7_18 = DeviceVersion("2.7.18")
         private val V2_7_19 = DeviceVersion("2.7.19")
         private val V2_8_0 = DeviceVersion("2.8.0")
-        private val V3_0_0 = DeviceVersion("3.0.0")
         private val UNRELEASED = DeviceVersion("9.9.9")
     }
 }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
@@ -74,9 +74,9 @@ class CapabilitiesTest {
     }
 
     @Test
-    fun supportsTrafficManagementConfig_requires_V3_0_0() {
-        assertFalse(caps("2.7.18").supportsTrafficManagementConfig)
-        assertTrue(caps("3.0.0").supportsTrafficManagementConfig)
+    fun supportsTrafficManagementConfig_requires_V2_8_0() {
+        assertFalse(caps("2.7.21").supportsTrafficManagementConfig)
+        assertTrue(caps("2.8.0").supportsTrafficManagementConfig)
     }
 
     @Test


### PR DESCRIPTION
## 🐛 Why

The Traffic Management radio-config screen was gated at firmware **v3.0.0**, hiding a feature whose firmware support already ships on the **2.8** line. There is no v3.0.0 firmware, so the screen was effectively unreachable for every real device.

The v3.0.0 value was a placeholder introduced in #4671 ("upcoming support") and never reconciled once the firmware actually landed.

Firmware support is present on 2.8.0 (verified 2026-06-18):
- `src/modules/TrafficManagementModule.cpp` shipped on the 2.8 line (added 2026-05-09 via meshtastic/firmware#10413, "2.8: …").
- `AdminModule` handles `TRAFFICMANAGEMENT_CONFIG` and `Modules.cpp` instantiates the module.
- Firmware `version.properties` is `major=2 minor=8 build=0`.

## 🛠️ What

- Lower `supportsTrafficManagementConfig` from `atLeast(V3_0_0)` to `atLeast(V2_8_0)` — the same constant `supportsStatusMessage` already uses.
- Drop the now-unused `V3_0_0` constant.

## 🐛 Testing Performed

- Updated `CapabilitiesTest` to expect `false` below 2.8.0 and `true` at/above 2.8.0 (mirroring the StatusMessage test).
- `./gradlew :core:model:allTests` — pass.
- `./gradlew spotlessApply detekt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
