### PR TITLE
perf(node): add stable keys and contentType to telemetry chart lists

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
@@ -202,7 +202,10 @@ fun ScannedQrCodeDialog(
                     )
                 }
 
-                itemsIndexed(channelSet.settings) { index, channel ->
+                itemsIndexed(channelSet.settings, key = { index, _ -> index }, contentType = { _, _ -> "channel" }) {
+                        index,
+                        channel,
+                    ->
                     val isExisting = !shouldReplace && index < channels.settings.size
                     val channelObj = Channel(channel, channelSet.lora_config ?: Channel.default.loraConfig)
                     ChannelSelection(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetrics.kt
@@ -166,7 +166,11 @@ fun AirQualityMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Uni
         },
         listPart = { modifier, selectedX, lazyListState, onCardClick ->
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
-                itemsIndexed(data) { _, telemetry ->
+                itemsIndexed(
+                    data,
+                    key = { _, telemetry -> telemetry.time },
+                    contentType = { _, _ -> "air_quality_metrics" },
+                ) { _, telemetry ->
                     AirQualityMetricsCard(
                         telemetry = telemetry,
                         isSelected = telemetry.time.toDouble() == selectedX,

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/DeviceMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/DeviceMetrics.kt
@@ -191,7 +191,11 @@ fun DeviceMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
         },
         listPart = { modifier, selectedX, lazyListState, onCardClick ->
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
-                itemsIndexed(data) { _, telemetry ->
+                itemsIndexed(
+                    data,
+                    key = { _, telemetry -> telemetry.time },
+                    contentType = { _, _ -> "device_metrics" },
+                ) { _, telemetry ->
                     DeviceMetricsCard(
                         telemetry = telemetry,
                         isSelected = telemetry.time.toDouble() == selectedX,
@@ -560,7 +564,11 @@ private fun DeviceMetricsScreenPreview() {
 
                 /* Device Metric Cards */
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    itemsIndexed(telemetries) { _, telemetry ->
+                    itemsIndexed(
+                        telemetries,
+                        key = { _, telemetry -> telemetry.time },
+                        contentType = { _, _ -> "device_metrics" },
+                    ) { _, telemetry ->
                         DeviceMetricsCard(telemetry = telemetry, isSelected = false, onClick = {})
                     }
                 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
@@ -115,7 +115,11 @@ fun EnvironmentMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Un
         },
         listPart = { modifier, selectedX, lazyListState, onCardClick ->
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
-                itemsIndexed(filteredTelemetries) { _, telemetry ->
+                itemsIndexed(
+                    filteredTelemetries,
+                    key = { _, telemetry -> telemetry.time },
+                    contentType = { _, _ -> "environment_metrics" },
+                ) { _, telemetry ->
                     EnvironmentMetricsCard(
                         telemetry = telemetry,
                         environmentDisplayFahrenheit = state.isFahrenheit,

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PaxMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PaxMetrics.kt
@@ -231,7 +231,11 @@ fun PaxMetricsScreen(metricsViewModel: MetricsViewModel, onNavigateUp: () -> Uni
                     state = lazyListState,
                     contentPadding = PaddingValues(horizontal = 16.dp),
                 ) {
-                    itemsIndexed(paxMetrics) { _, (log, pax) ->
+                    itemsIndexed(
+                        paxMetrics,
+                        key = { _, (log, _) -> log.uuid },
+                        contentType = { _, _ -> "pax_metrics" },
+                    ) { _, (log, pax) ->
                         PaxMetricsItem(
                             log = log,
                             pax = pax,

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogScreens.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogScreens.kt
@@ -70,7 +70,11 @@ fun PositionLogScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
         },
         listPart = { modifier, selectedX, lazyListState, onCardClick ->
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
-                itemsIndexed(positions) { _, position ->
+                itemsIndexed(
+                    positions,
+                    key = { _, position -> position.time },
+                    contentType = { _, _ -> "position_log" },
+                ) { _, position ->
                     PositionCard(
                         position = position,
                         displayUnits = state.displayUnits,

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
@@ -159,7 +159,11 @@ fun PowerMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
         },
         listPart = { modifier, selectedX, lazyListState, onCardClick ->
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
-                itemsIndexed(data) { _, telemetry ->
+                itemsIndexed(
+                    data,
+                    key = { _, telemetry -> telemetry.time },
+                    contentType = { _, _ -> "power_metrics" },
+                ) { _, telemetry ->
                     PowerMetricsCard(
                         telemetry = telemetry,
                         isSelected = telemetry.time.toDouble() == selectedX,

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/SignalMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/SignalMetrics.kt
@@ -114,12 +114,22 @@ private val LEGEND_DATA =
 private sealed interface SignalLogEntry {
     val timeSeconds: Int
 
+    /** Stable, collision-free identity for use as a LazyColumn item key across both entry types. */
+    val key: Any
+
+    /** Distinguishes the two card layouts so Compose can reuse compositions per type. */
+    val contentType: Any
+
     data class LocalStatsEntry(val telemetry: Telemetry) : SignalLogEntry {
         override val timeSeconds: Int = telemetry.time
+        override val key: Any = "local_stats_${telemetry.time}"
+        override val contentType: Any = "local_stats"
     }
 
     data class PacketEntry(val meshPacket: MeshPacket) : SignalLogEntry {
         override val timeSeconds: Int = meshPacket.rx_time
+        override val key: Any = "packet_${meshPacket.id}"
+        override val contentType: Any = "signal_packet"
     }
 }
 
@@ -204,7 +214,11 @@ fun SignalMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit, m
                 }
             } else {
                 LazyColumn(modifier = contentModifier.fillMaxSize(), state = lazyListState) {
-                    itemsIndexed(data) { _, entry ->
+                    itemsIndexed(
+                        data,
+                        key = { _, entry -> entry.key },
+                        contentType = { _, entry -> entry.contentType },
+                    ) { _, entry ->
                         when (entry) {
                             is SignalLogEntry.LocalStatsEntry ->
                                 LocalStatsCard(


### PR DESCRIPTION
## Why

The telemetry/log lists in the node metrics screens rendered with bare `itemsIndexed(data) { ... }` — no `key` and no `contentType`. Without a stable key, Compose uses positional identity, so when a row is inserted or reordered (new telemetry arrives at the top of these time-sorted lists) the whole list is re-laid-out and `animateItem` can't run. This adds stable identities and content types so only the affected rows recompose.

## 🛠️ Changes

- **Stable item keys** on every previously-unkeyed `itemsIndexed` in the metrics screens:
  - `DeviceMetrics` (both lists), `AirQualityMetrics`, `PowerMetrics`, `EnvironmentMetrics` → key on `telemetry.time`.
  - `PositionLogScreens` → key on `position.time`.
  - `PaxMetrics` → key on the `MeshLog.uuid` primary key (not `received_date`, which isn't guaranteed unique).
  - `ScannedQrCodeDialog` → key on the channel slot index (the identity already used for selection state).
- **Constant `contentType`** added to each list so Compose can pool/reuse compositions per type. This matters most in the heterogeneous `LazyColumn`s (`ScannedQrCodeDialog` interleaves description text, channel rows, LoRa-change blocks, and buttons; `SignalMetrics` mixes two card types).
- **`SignalMetrics` heterogeneous list:** its `LazyColumn` holds both `LocalStatsEntry` and `PacketEntry`, where a bare timestamp could collide across the two subtypes. Added type-prefixed `key`/`contentType` members to the `SignalLogEntry` sealed interface (`"local_stats_<time>"` vs `"packet_<meshPacket.id>"`) so keys stay collision-free and the two card layouts get distinct content types.

`TracerouteLog` and `HostMetricsLog` already had keys and were left untouched.

## Note for reviewers

The timestamp-based keys assume `time` is unique within each list. This matches the screens' existing selection logic, which already treats `time` as each card's identity (`telemetry.time.toDouble() == selectedX`) — so duplicate timestamps would already have broken selection highlighting, independent of this change.

## Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt assembleDebug` — all pass.
- `./gradlew :feature:node:allTests` — all pass (JVM unit tests; iOS simulator compilation succeeds).

No test changes were required — this is a list-rendering/identity change with no behavioral surface in the existing unit tests.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
