### PR TITLE
fix(network): retry transient connection/IO failures to api.meshtastic.org

### DIFF
--- a/androidApp/src/main/kotlin/org/meshtastic/app/di/NetworkModule.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/di/NetworkModule.kt
@@ -48,6 +48,7 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.common.BuildConfigProvider
 import org.meshtastic.core.network.HttpClientDefaults
 import org.meshtastic.core.network.KermitHttpLogger
+import org.meshtastic.core.network.configureDefaultRetry
 
 private const val DISK_CACHE_PERCENT = 0.02
 private const val MEMORY_CACHE_PERCENT = 0.25
@@ -104,10 +105,7 @@ class NetworkModule {
                 connectTimeoutMillis = HttpClientDefaults.TIMEOUT_MS
                 socketTimeoutMillis = HttpClientDefaults.TIMEOUT_MS
             }
-            install(plugin = HttpRequestRetry) {
-                retryOnServerErrors(maxRetries = HttpClientDefaults.MAX_RETRIES)
-                exponentialDelay()
-            }
+            install(plugin = HttpRequestRetry) { configureDefaultRetry() }
             if (buildConfigProvider.isDebug) {
                 install(plugin = Logging) {
                     logger = KermitHttpLogger

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
@@ -16,8 +16,10 @@
  */
 package org.meshtastic.core.network
 
+import io.ktor.client.plugins.HttpRequestRetryConfig
+
 /**
- * Shared HTTP client configuration constants used by both Android and Desktop Ktor `HttpClient` setups.
+ * Shared HTTP client configuration used by both Android and Desktop Ktor `HttpClient` setups.
  *
  * These values are consumed by the platform-specific Koin modules (`NetworkModule` on Android, `DesktopKoinModule` on
  * Desktop) when installing [io.ktor.client.plugins.HttpTimeout] and [io.ktor.client.plugins.HttpRequestRetry].
@@ -26,9 +28,22 @@ object HttpClientDefaults {
     /** Timeout in milliseconds for connect, request, and socket operations. */
     const val TIMEOUT_MS = 30_000L
 
-    /** Maximum number of automatic retries on server errors (5xx). */
+    /** Maximum number of automatic retries on server errors (5xx) and transient connection/IO failures. */
     const val MAX_RETRIES = 3
 
     /** Base URL for the Meshtastic public API. Installed via the `DefaultRequest` plugin. */
     const val API_BASE_URL = "https://api.meshtastic.org/"
+}
+
+/**
+ * Shared [io.ktor.client.plugins.HttpRequestRetry] policy for both engines.
+ *
+ * Retries on 5xx server errors and on transient connection/IO failures (dropped sockets, DNS blips, read timeouts) —
+ * the common failure mode on flaky cellular — with exponential backoff. [HttpClientDefaults.MAX_RETRIES] applies to
+ * both rules.
+ */
+fun HttpRequestRetryConfig.configureDefaultRetry() {
+    retryOnServerErrors(maxRetries = HttpClientDefaults.MAX_RETRIES)
+    retryOnException(maxRetries = HttpClientDefaults.MAX_RETRIES, retryOnTimeout = true)
+    exponentialDelay()
 }

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/di/DesktopKoinModule.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/di/DesktopKoinModule.kt
@@ -44,6 +44,7 @@ import org.meshtastic.core.model.NetworkDeviceLink
 import org.meshtastic.core.model.NetworkFirmwareReleases
 import org.meshtastic.core.network.HttpClientDefaults
 import org.meshtastic.core.network.KermitHttpLogger
+import org.meshtastic.core.network.configureDefaultRetry
 import org.meshtastic.core.network.repository.MQTTRepository
 import org.meshtastic.core.network.service.ApiService
 import org.meshtastic.core.network.service.ApiServiceImpl
@@ -245,10 +246,7 @@ private fun desktopPlatformStubsModule() = module {
                 connectTimeoutMillis = HttpClientDefaults.TIMEOUT_MS
                 socketTimeoutMillis = HttpClientDefaults.TIMEOUT_MS
             }
-            install(HttpRequestRetry) {
-                retryOnServerErrors(maxRetries = HttpClientDefaults.MAX_RETRIES)
-                exponentialDelay()
-            }
+            install(HttpRequestRetry) { configureDefaultRetry() }
             if (DesktopBuildConfig.IS_DEBUG) {
                 install(Logging) {
                     logger = KermitHttpLogger


### PR DESCRIPTION
## Why

Both Ktor `HttpClient` configs (Android engine on mobile, Java engine on desktop) installed `HttpRequestRetry` with only `retryOnServerErrors(maxRetries = 3)` + `exponentialDelay()`. Transient **connection/IO** failures to `api.meshtastic.org` — DNS blips, dropped sockets, read timeouts — were therefore **not** retried and surfaced immediately as failures. That is the common failure mode on flaky cellular, where a single retry would usually succeed.

Ktor's Java-engine `IOException` retry became reliable in 3.1/3.2 ([KTOR-6770](https://youtrack.jetbrains.com/issue/KTOR-6770)) and this repo is on Ktor 3.5.0, so enabling exception retry is now safe on both engines.

## Changes

### 🐛 Bug Fixes
- Add `retryOnException(maxRetries = 3, retryOnTimeout = true)` alongside the existing `retryOnServerErrors` rule so transient connection/IO/timeout failures are retried with the same backoff. `maxRetries` reuses the existing `HttpClientDefaults.MAX_RETRIES`, so it stays in lockstep with the server-error rule.

### 🛠️ Refactoring & Architecture
- Centralize the retry policy as a single `HttpRequestRetryConfig.configureDefaultRetry()` extension in `core/network`'s `HttpClientDefaults` — where the shared timeout/retry constants already live — and call it from both engines. Previously each engine duplicated the `install(HttpRequestRetry) { … }` block; now there is one definition, so the two clients can't drift.

**Files**
- `core/network/.../HttpClientDefaults.kt` — new `configureDefaultRetry()` extension (commonMain; `ktor-client-core` is already a commonMain dep)
- `androidApp/.../di/NetworkModule.kt` — call site now `install(plugin = HttpRequestRetry) { configureDefaultRetry() }`
- `desktopApp/.../di/DesktopKoinModule.kt` — call site now `install(HttpRequestRetry) { configureDefaultRetry() }`

## Testing Performed
Baseline verification run locally (worktree):
- `./gradlew spotlessApply` ✅
- `./gradlew detekt` ✅
- `./gradlew assembleDebug` ✅
- `./gradlew :core:network:allTests` ✅ (56 tests)
- `./gradlew :desktopApp:compileKotlin` ✅ (verifies the Java-engine call site compiles)

No behavioral change beyond retry coverage; no new tests added (the change is wiring on the Ktor plugin config).

<!--
If you have screenshots or recordings to display your change, please include them!
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)