### PR TITLE
test(data): de-flake DeviceLinkRepositoryImplTest by running on the wall clock

### DIFF
--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/DeviceLinkRepositoryImplTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/DeviceLinkRepositoryImplTest.kt
@@ -16,8 +16,8 @@
  */
 package org.meshtastic.core.data.repository
 
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.meshtastic.core.data.datasource.DeviceLinkLocalDataSource
 import org.meshtastic.core.data.datasource.DeviceLinksJsonDataSource
 import org.meshtastic.core.di.CoroutineDispatchers
@@ -49,8 +49,13 @@ class DeviceLinkRepositoryImplTest {
         override fun loadDeviceLinksFromJsonAsset(): List<NetworkDeviceLink> = links
     }
 
-    private val dispatcher = UnconfinedTestDispatcher()
-    private val dispatchers = CoroutineDispatchers(main = dispatcher, io = dispatcher, default = dispatcher)
+    // Real dispatchers + runBlocking (per test), NOT runTest/UnconfinedTestDispatcher. reconcile() guards its network
+    // fetch with withTimeoutOrNull, whose deadline follows the calling coroutine's clock. Under runTest that clock is
+    // virtual and runTest fast-forwards it while the coroutine parks on Room's real IO dispatcher; under load the 5s
+    // budget "elapsed" in virtual time, so the fetch was treated as timed out, store() was skipped, and the cache kept
+    // stale rows (reconcilePrunes... flaked). On the wall clock the instant fake never times out.
+    private val unconfined = Dispatchers.Unconfined
+    private val dispatchers = CoroutineDispatchers(main = unconfined, io = unconfined, default = unconfined)
 
     private lateinit var dbProvider: FakeDatabaseProvider
     private lateinit var local: DeviceLinkLocalDataSource
@@ -90,19 +95,16 @@ class DeviceLinkRepositoryImplTest {
     @AfterTest fun tearDown() = dbProvider.close()
 
     @Test
-    fun seedsFromBundledJsonWhenEmptyAndDropsInternalLinks() = runTest(dispatcher) {
+    fun seedsFromBundledJsonWhenEmptyAndDropsInternalLinks() = runBlocking {
         seed.links =
-            listOf(
-                link("rak4631", targets = listOf("rak4631")),
-                link("github", type = NetworkDeviceLink.TYPE_INTERNAL),
-            )
+            listOf(link("rak4631", targets = listOf("rak4631")), link("github", type = NetworkDeviceLink.TYPE_INTERNAL))
         repository.ensureImported()
 
         assertEquals(setOf("rak4631"), local.getAll().map { it.shortCode }.toSet())
     }
 
     @Test
-    fun ensureImportedSeedsOnlyWhenEmpty() = runTest(dispatcher) {
+    fun ensureImportedSeedsOnlyWhenEmpty() = runBlocking {
         seed.links = listOf(link("rak4631", targets = listOf("rak4631")))
         repository.ensureImported()
         assertEquals(1, local.count())
@@ -114,7 +116,7 @@ class DeviceLinkRepositoryImplTest {
     }
 
     @Test
-    fun getLinksForTargetFiltersByTargetAndRegionVendorFirst() = runTest(dispatcher) {
+    fun getLinksForTargetFiltersByTargetAndRegionVendorFirst() = runBlocking {
         api.response =
             NetworkDeviceLinksResponse(
                 links =
@@ -145,13 +147,11 @@ class DeviceLinkRepositoryImplTest {
     }
 
     @Test
-    fun worldwideLinksShowRegardlessOfRegion() = runTest(dispatcher) {
+    fun worldwideLinksShowRegardlessOfRegion() = runBlocking {
         api.response =
             NetworkDeviceLinksResponse(
                 links =
-                listOf(
-                    link("ww", type = NetworkDeviceLink.TYPE_MARKETPLACE, targets = listOf("t"), regions = null),
-                ),
+                listOf(link("ww", type = NetworkDeviceLink.TYPE_MARKETPLACE, targets = listOf("t"), regions = null)),
             )
         repository.reconcile()
 
@@ -159,7 +159,7 @@ class DeviceLinkRepositoryImplTest {
     }
 
     @Test
-    fun reconcilePrunesShortCodesNoLongerInCatalog() = runTest(dispatcher) {
+    fun reconcilePrunesShortCodesNoLongerInCatalog() = runBlocking {
         api.response =
             NetworkDeviceLinksResponse(
                 links = listOf(link("a", targets = listOf("t")), link("b", targets = listOf("t"))),
@@ -173,7 +173,7 @@ class DeviceLinkRepositoryImplTest {
     }
 
     @Test
-    fun emptyResponseLeavesCacheUntouched() = runTest(dispatcher) {
+    fun emptyResponseLeavesCacheUntouched() = runBlocking {
         api.response = NetworkDeviceLinksResponse(links = listOf(link("a", targets = listOf("t"))))
         repository.reconcile()
         assertEquals(1, local.count())

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -153,10 +153,11 @@ abstract class MeshtasticDatabase : RoomDatabase() {
          * wedge: all reader connections report `Free` but `permits=0`, so every read acquisition times out
          * indefinitely. Forcing single-connection eliminates the separate reader permit pool entirely.
          *
-         * **In-memory databases MUST pass `false`** for deterministic read-after-write: a pooled reader connection can
-         * serve a snapshot older than the latest write on the writer connection, so a read immediately after a write
-         * may observe stale rows — making read-after-write assertions non-deterministically flaky (see
-         * `DeviceLinkRepositoryImplTest`). A single connection serializes reads behind writes.
+         * **In-memory databases (tests) pass `false`.** Room already serves an in-memory database (`name == null`) from
+         * a single connection regardless of the pool configuration, so this only makes the single-connection intent
+         * explicit and serializes the query dispatcher; it is not load-bearing for read-after-write.
+         * (`DeviceLinkRepositoryImplTest` is deterministic because it runs on the wall clock, not because of this flag;
+         * see that test's comments.)
          *
          * **JVM/iOS production uses `true`** (the default). Revisit if desktop/iOS field logs show similar
          * pool-exhaustion patterns under cancellation churn.


### PR DESCRIPTION
## Why

`DeviceLinkRepositoryImplTest.reconcilePrunesShortCodesNoLongerInCatalog` fails intermittently in CI. It is a test-harness flake, not a product bug — the repository logic is correct; the test mixed `runTest`'s virtual clock with Room's real dispatcher.

## Root cause

`reconcile()` guards its network fetch with `withTimeoutOrNull(5s)`, whose deadline is measured against the **calling coroutine's clock**. The test ran on `runTest` + `UnconfinedTestDispatcher` (virtual time), while Room executes its DB work on the real `ioDispatcher` — which `runTest` neither owns nor awaits. Each time the coroutine parked on a real IO thread, the test scheduler went idle and `runTest` **fast-forwarded virtual time**; under load it jumped past the 5s budget, so the fetch was reported as timed out, `store()` was skipped, and the cache kept the pre-prune rows `[a, b]` instead of `[a]`.

This is purely a test artifact: in production the timeout runs on the wall clock against a real network call, so it never misfires.

> The previously-added `multiConnection = false` for in-memory DBs was a separate — and on Room `3.0.0-rc01`, moot — mitigation: Room already forces a single connection for in-memory databases (`name == null`) regardless of the pool config, so it was never what made or broke this test.

## Changes

🐛 **Bug Fixes**
- Run `DeviceLinkRepositoryImplTest` on real dispatchers + `runBlocking` instead of `UnconfinedTestDispatcher` + `runTest`, so `reconcile()`'s `withTimeoutOrNull` is measured on the wall clock (matching production) and `runTest`'s virtual-clock fast-forward can no longer spuriously expire it.

🧹 **Chores**
- Correct the `configureCommon` KDoc: clarify that Room 3 always serves in-memory databases from a single connection regardless of the pool config, and that this test's determinism comes from the wall clock, not from `multiConnection`.

## Testing Performed

- The flake only surfaces under concurrent IO-pool contention (like CI), so a temporary 24-thread stress harness was used to reproduce it. On `main` it failed ~0.3% of runs, and the failure count exactly matched the `network refresh timed out` log count — confirming the timeout-misfire mechanism. With this change, **~18,000 concurrent + ~15,000 sequential runs completed with zero failures, `timedOut=0`**. The harness was removed before this PR.
- Full baseline: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — **BUILD SUCCESSFUL**; all 6 `DeviceLinkRepositoryImplTest` methods pass.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
