### PR TITLE
fix(ci): make docs-governance fork-PR safe under actions/checkout v7

### DIFF
--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -1,6 +1,17 @@
 name: UI & Docs Governance
 
+# Split by trust level:
+# - pull_request (fork context, read-only token, NO secrets) runs the `validate`
+#   job, which checks out and EXECUTES fork-supplied code (node scripts/*.js). This
+#   is safe only because the token is read-only and secrets are unavailable.
+# - pull_request_target (base context, write token) runs the comment-posting
+#   staleness jobs. They MUST NOT check out or execute fork code — they read the
+#   changed-file list via the API instead. (actions/checkout@v7 also refuses a fork
+#   checkout under pull_request_target, which is what surfaced this.)
 on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
   pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
@@ -17,24 +28,21 @@ jobs:
   staleness:
     name: Docs staleness check
     runs-on: ubuntu-24.04-arm
+    # pull_request_target only: needs the write token to post advisory comments.
+    # Reads the changed-file list via the API — no fork checkout, no fork code run.
     if: >-
-      github.event.pull_request != null
+      github.event_name == 'pull_request_target'
+      && github.event.pull_request != null
       && !contains(github.event.pull_request.labels.*.name, 'skip-docs-check')
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
       - name: Detect changed files
         id: changed
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
-
-          changed=$(git diff --name-only "$BASE" "$HEAD")
+          changed=$(gh pr diff "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --name-only)
 
           views_changed=$(echo "$changed" | grep -E \
             '^feature/.*/src/commonMain/.*/(ui|component|screen)/|^feature/.*/src/androidMain/.*/ui/|^core/ui/src/commonMain/' \
@@ -158,6 +166,12 @@ jobs:
   validate:
     name: Docs quality gates
     runs-on: ubuntu-24.04-arm
+    # Runs on pull_request (fork context, read-only token, no secrets) — never on
+    # pull_request_target — because it checks out and executes fork-supplied code
+    # (node scripts/*.js). The pull_request event makes that execution safe; the
+    # pull_request_target instance is skipped to avoid the pwn-request RCE and the
+    # actions/checkout@v7 fork-checkout refusal.
+    if: github.event_name != 'pull_request_target'
 
     steps:
       - name: Checkout
@@ -204,24 +218,21 @@ jobs:
   preview-staleness:
     name: Preview staleness check
     runs-on: ubuntu-24.04-arm
+    # pull_request_target only: needs the write token to post advisory comments.
+    # Reads the changed-file list via the API — no fork checkout, no fork code run.
     if: >-
-      github.event.pull_request != null
+      github.event_name == 'pull_request_target'
+      && github.event.pull_request != null
       && !contains(github.event.pull_request.labels.*.name, 'skip-preview-check')
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
       - name: Detect changed files
         id: changed
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
-
-          changed=$(git diff --name-only "$BASE" "$HEAD")
+          changed=$(gh pr diff "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --name-only)
 
           # UI composables changed (screens, components — excluding tests and previews)
           ui_changed=$(echo "$changed" | grep -E \


### PR DESCRIPTION
## Why

`actions/checkout@v7` refuses to check out fork PR code from a `pull_request_target` workflow (the "pwn request" guard). `docs-governance.yml` runs all three of its jobs on `pull_request_target` and checks out the fork's `head.sha`, so every fork PR now fails the **Docs quality gates** check at the checkout step (e.g. #5856). The two staleness jobs are currently masked only because they're dismissed by `skip-docs-check` / `skip-preview-check` labels — they carry the same latent failure.

## 🛠️ What

Split the workflow by trust level instead of opting into the unsafe flag:

- **`validate` (Docs quality gates)** now runs on **`pull_request`**. It must check out and execute fork-supplied code (`node scripts/*.js`); under `pull_request` the token is read-only and secrets are unavailable, so that execution is safe. It is skipped on `pull_request_target`.
- **`staleness` / `preview-staleness`** stay on **`pull_request_target`** (they need the write token to post advisory comments) but **no longer check out fork code** — they read the changed-file list via `gh pr diff --name-only`. No fork code is fetched or executed.

This deliberately avoids `allow-unsafe-pr-checkout: true`, which would run fork-controlled scripts with the base write token and secrets (RCE).

## Notes

- Effect is realized once merged to `main`: `pull_request_target` jobs use the base workflow immediately; the `validate` check runs for a fork PR after it next merges `main` (the `pull_request` trigger comes from the PR head's copy).
- `validate`'s doc checks never actually ran before (they died at checkout); this lets them run. Any real doc-link/coverage failures they surface are separate from this infra fix.

## Testing Performed

- `actionlint` passes (only a pre-existing SC2129 shellcheck style note in untouched code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
