### PR TITLE
fix(ui): prevent duplicate LazyColumn keys in node metrics logs

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetrics.kt
@@ -168,7 +168,7 @@ fun AirQualityMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Uni
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
                 itemsIndexed(
                     data,
-                    key = { _, telemetry -> telemetry.time },
+                    key = { index, telemetry -> "${telemetry.time}_$index" },
                     contentType = { _, _ -> "air_quality_metrics" },
                 ) { _, telemetry ->
                     AirQualityMetricsCard(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/DeviceMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/DeviceMetrics.kt
@@ -193,7 +193,7 @@ fun DeviceMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
                 itemsIndexed(
                     data,
-                    key = { _, telemetry -> telemetry.time },
+                    key = { index, telemetry -> "${telemetry.time}_$index" },
                     contentType = { _, _ -> "device_metrics" },
                 ) { _, telemetry ->
                     DeviceMetricsCard(
@@ -566,7 +566,7 @@ private fun DeviceMetricsScreenPreview() {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     itemsIndexed(
                         telemetries,
-                        key = { _, telemetry -> telemetry.time },
+                        key = { index, telemetry -> "${telemetry.time}_$index" },
                         contentType = { _, _ -> "device_metrics" },
                     ) { _, telemetry ->
                         DeviceMetricsCard(telemetry = telemetry, isSelected = false, onClick = {})

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
@@ -117,7 +117,7 @@ fun EnvironmentMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Un
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
                 itemsIndexed(
                     filteredTelemetries,
-                    key = { _, telemetry -> telemetry.time },
+                    key = { index, telemetry -> "${telemetry.time}_$index" },
                     contentType = { _, _ -> "environment_metrics" },
                 ) { _, telemetry ->
                     EnvironmentMetricsCard(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogScreens.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogScreens.kt
@@ -72,7 +72,7 @@ fun PositionLogScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
                 itemsIndexed(
                     positions,
-                    key = { _, position -> position.time },
+                    key = { index, position -> "${position.time}_$index" },
                     contentType = { _, _ -> "position_log" },
                 ) { _, position ->
                     PositionCard(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
@@ -161,7 +161,7 @@ fun PowerMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
             LazyColumn(modifier = modifier.fillMaxSize(), state = lazyListState) {
                 itemsIndexed(
                     data,
-                    key = { _, telemetry -> telemetry.time },
+                    key = { index, telemetry -> "${telemetry.time}_$index" },
                     contentType = { _, _ -> "power_metrics" },
                 ) { _, telemetry ->
                     PowerMetricsCard(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/SignalMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/SignalMetrics.kt
@@ -120,9 +120,11 @@ private sealed interface SignalLogEntry {
     /** Distinguishes the two card layouts so Compose can reuse compositions per type. */
     val contentType: Any
 
-    data class LocalStatsEntry(val telemetry: Telemetry) : SignalLogEntry {
+    data class LocalStatsEntry(val telemetry: Telemetry, val index: Int) : SignalLogEntry {
         override val timeSeconds: Int = telemetry.time
-        override val key: Any = "local_stats_${telemetry.time}"
+
+        // Local stats telemetry is an id-less proto; the source-list index disambiguates same-second samples.
+        override val key: Any = "local_stats_${telemetry.time}_$index"
         override val contentType: Any = "local_stats"
     }
 
@@ -145,7 +147,7 @@ fun SignalMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit, m
     val data =
         remember(signalData, localStatsData) {
             (
-                localStatsData.map { SignalLogEntry.LocalStatsEntry(it) } +
+                localStatsData.mapIndexed { index, telemetry -> SignalLogEntry.LocalStatsEntry(telemetry, index) } +
                     signalData.map { SignalLogEntry.PacketEntry(it) }
                 )
                 .sortedByDescending { it.timeSeconds }


### PR DESCRIPTION
The node-detail metrics screens crash with `IllegalArgumentException: Key "<timestamp>" was already used` when a node reports two telemetry or position samples in the same wall-clock second. Several `LazyColumn`s keyed their items on a bare second-resolution timestamp, so same-second samples collide and Compose tears the screen down. Observed on the 2.8.0 internal track (versionCode 29321164); the crash recurs across versions.

### 🐛 Bug Fixes
- Fixed the duplicate-key crash in the node metrics log lists by giving each `LazyColumn` item a guaranteed-unique key. The Device, Environment, Power, Air Quality, and Position logs now key on `"${time}_$index"` (the pattern `HostMetricsLog` already used) instead of the bare `telemetry.time` / `position.time`.
- Fixed the same latent defect in `SignalMetrics.LocalStatsEntry` (its key was `"local_stats_${time}"`); it now threads the source-list index so two local-stats samples in the same second can't collide. The sibling `PacketEntry` keeps its real packet-id key (`"packet_${meshPacket.id}"`).

### 🛠️ Refactoring & Architecture
- Standardized item keys across the whole `feature/node` metrics module on two patterns: a **real unique id** (`uuid` / packet `id`) where the list element carries one, and **`"${time}_$index"`** for the id-less `Telemetry` / `Position` protos. No bare-timestamp keys remain.

### Why not a real id everywhere?
The data layer does have a unique id for every one of these lists (each `Telemetry` is parsed from a `MeshLog` with a `uuid`; positions come from a `MeshPacket` with `.id`), but those ids are discarded when the rows are mapped to bare protos before reaching the UI state. Threading them through to a single `key = { it.uuid }` idiom would be a data-model refactor (changing `MetricsState`'s list types and rippling through the use case, charts, and CSV exporters), so it's out of scope for this crash fix and noted as a possible follow-up.

### Testing Performed
- `./gradlew spotlessApply spotlessCheck detekt :feature:node:allTests kmpSmokeCompile` — all green (722 tests pass; Spotless and detekt clean).
- No test changes: this is a Compose key-stability fix with no behavioral change to the rendered cards or the selection/highlight logic.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
