### PR TITLE
fix(ui): show Wi-Fi unavailable banner only during active network scan

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/NetworkTransportInfo.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/NetworkTransportInfo.kt
@@ -46,19 +46,17 @@ internal fun anyNetworkScanTransportAvailable(networks: List<NetworkTransportInf
 /**
  * Returns `true` when the "Wi-Fi unavailable" recovery banner should render in `ConnectionsScreen`.
  *
- * The banner surfaces "no usable transport for NSD/mDNS scan" only while the user is actually trying to use network
- * discovery: when the Network section is visible OR an active scan is in progress.
+ * Banner shows only while a network scan is actively running, local-network permission is granted, and WiFi is
+ * unavailable. The auto-scan case is covered because `isNetworkScanning` is true during auto-scan regardless of the
+ * user's transport-chip preference.
  *
- * The previous gate (`showNetworkTransport &&` alone) missed the auto-scan case — `LifecycleStartEffect` keys
- * `startNetworkScan()` off `networkAutoScan + permission`, not the section-visibility chip, so a user with the Network
- * filter chip toggled off but auto-scan on gets a running scan that can't find anything with the recovery banner
- * suppressed. Widening to `showNetworkTransport || isNetworkScanning` surfaces the hint whenever the user is actually
- * interacting with network discovery, without overlapping the permission-request flow on the scan toggle (still gated
- * by [localNetworkPermissionGranted]).
+ * Gating on the scan state (rather than the `showNetworkTransport` chip preference, which defaults to on) keeps the
+ * banner silent while discovery is idle — the user only needs the recovery hint at the moment a scan cannot find a
+ * usable transport. The [localNetworkPermissionGranted] guard keeps the banner from overlapping the permission-request
+ * flow on the scan toggle.
  */
 fun shouldShowWifiUnavailableBanner(
-    showNetworkTransport: Boolean,
     isNetworkScanning: Boolean,
     localNetworkPermissionGranted: Boolean,
     wifiUnavailable: Boolean,
-): Boolean = (showNetworkTransport || isNetworkScanning) && localNetworkPermissionGranted && wifiUnavailable
+): Boolean = isNetworkScanning && localNetworkPermissionGranted && wifiUnavailable

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/NetworkTransportInfo.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/NetworkTransportInfo.kt
@@ -46,17 +46,22 @@ internal fun anyNetworkScanTransportAvailable(networks: List<NetworkTransportInf
 /**
  * Returns `true` when the "Wi-Fi unavailable" recovery banner should render in `ConnectionsScreen`.
  *
- * Banner shows only while a network scan is actively running, local-network permission is granted, and WiFi is
- * unavailable. The auto-scan case is covered because `isNetworkScanning` is true during auto-scan regardless of the
- * user's transport-chip preference.
+ * Banner shows only while a network scan is actively running, local-network permission is granted, WiFi is unavailable,
+ * and the scan has not yet produced any discovered TCP nodes. The auto-scan case is covered because `isNetworkScanning`
+ * is true during auto-scan regardless of the user's transport-chip preference.
  *
  * Gating on the scan state (rather than the `showNetworkTransport` chip preference, which defaults to on) keeps the
  * banner silent while discovery is idle — the user only needs the recovery hint at the moment a scan cannot find a
  * usable transport. The [localNetworkPermissionGranted] guard keeps the banner from overlapping the permission-request
  * flow on the scan toggle.
+ *
+ * The banner is a recovery hint for the case where the user has started a network scan but no nodes have been
+ * discovered yet. Once the scan produces results, the user has found what they were looking for and the hint is no
+ * longer useful — so the banner is suppressed when the discovered-TCP list is non-empty.
  */
 fun shouldShowWifiUnavailableBanner(
     isNetworkScanning: Boolean,
     localNetworkPermissionGranted: Boolean,
     wifiUnavailable: Boolean,
-): Boolean = isNetworkScanning && localNetworkPermissionGranted && wifiUnavailable
+    discoveredTcpDevicesEmpty: Boolean,
+): Boolean = isNetworkScanning && localNetworkPermissionGranted && wifiUnavailable && discoveredTcpDevicesEmpty

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/NetworkTransportTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/NetworkTransportTest.kt
@@ -177,8 +177,10 @@ class NetworkTransportTest {
 
 /**
  * Coverage for the [shouldShowWifiUnavailableBanner] gate consumed by `ConnectionsScreen`. The banner surfaces "no
- * usable transport for NSD/mDNS scan" only while a network scan is actively running. Each case mirrors one of the
- * reported combinations of (scan-active) plus the permission and transport-availability guards.
+ * usable transport for NSD/mDNS scan" only while a network scan is actively running, and is suppressed once the scan
+ * has produced discovered TCP nodes — at that point the user has found what they were looking for and the recovery hint
+ * is no longer useful. Each case mirrors one of the reported combinations of (scan-active, results-empty) plus the
+ * permission and transport-availability guards.
  */
 class WifiUnavailableBannerTest {
     private fun transports(wifi: Boolean = false) =
@@ -195,6 +197,7 @@ class WifiUnavailableBannerTest {
                 isNetworkScanning = false,
                 localNetworkPermissionGranted = true,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(transports()),
+                discoveredTcpDevicesEmpty = true,
             ),
         )
     }
@@ -209,19 +212,22 @@ class WifiUnavailableBannerTest {
                 isNetworkScanning = true,
                 localNetworkPermissionGranted = true,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(transports()),
+                discoveredTcpDevicesEmpty = true,
             ),
         )
     }
 
     @Test
     fun scan_active_permission_granted_wifi_unavailable_then_banner_shows() {
-        // Clean positive case: scan actively running, permission granted, WiFi unavailable — banner
-        // fires. This is the only combination the banner is meant to surface.
+        // Clean positive case: scan actively running, permission granted, WiFi unavailable, no
+        // discovered nodes yet — banner fires. This is the only combination the banner is meant
+        // to surface.
         assertTrue(
             shouldShowWifiUnavailableBanner(
                 isNetworkScanning = true,
                 localNetworkPermissionGranted = true,
                 wifiUnavailable = true,
+                discoveredTcpDevicesEmpty = true,
             ),
         )
     }
@@ -234,6 +240,7 @@ class WifiUnavailableBannerTest {
                 isNetworkScanning = true,
                 localNetworkPermissionGranted = false,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(transports()),
+                discoveredTcpDevicesEmpty = true,
             ),
         )
     }
@@ -246,6 +253,7 @@ class WifiUnavailableBannerTest {
                 isNetworkScanning = true,
                 localNetworkPermissionGranted = true,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(transports(wifi = true)),
+                discoveredTcpDevicesEmpty = true,
             ),
         )
     }
@@ -259,6 +267,22 @@ class WifiUnavailableBannerTest {
                 isNetworkScanning = true,
                 localNetworkPermissionGranted = true,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(vpnOnly),
+                discoveredTcpDevicesEmpty = true,
+            ),
+        )
+    }
+
+    @Test
+    fun scan_active_permission_granted_wifi_unavailable_results_found_then_banner_hidden() {
+        // Once the live scan has produced discovered TCP nodes, the recovery hint is no longer
+        // useful — the user has found what they were looking for. Banner stays hidden even though
+        // scan is active, permission is granted, and WiFi is reported unavailable.
+        assertFalse(
+            shouldShowWifiUnavailableBanner(
+                isNetworkScanning = true,
+                localNetworkPermissionGranted = true,
+                wifiUnavailable = true,
+                discoveredTcpDevicesEmpty = false,
             ),
         )
     }

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/NetworkTransportTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/NetworkTransportTest.kt
@@ -177,9 +177,8 @@ class NetworkTransportTest {
 
 /**
  * Coverage for the [shouldShowWifiUnavailableBanner] gate consumed by `ConnectionsScreen`. The banner surfaces "no
- * usable transport for NSD/mDNS scan" only while the user is actually trying to use network discovery. Each case
- * mirrors one of the four reported combinations of (section-visible, scan-active) plus the permission and
- * transport-availability guards.
+ * usable transport for NSD/mDNS scan" only while a network scan is actively running. Each case mirrors one of the
+ * reported combinations of (scan-active) plus the permission and transport-availability guards.
  */
 class WifiUnavailableBannerTest {
     private fun transports(wifi: Boolean = false) =
@@ -187,11 +186,12 @@ class WifiUnavailableBannerTest {
         listOf(NetworkTransportInfo(hasWifi = wifi, hasEthernet = false, hasVpn = false))
 
     @Test
-    fun section_visible_permission_granted_cellular_only_then_banner_shows() {
-        // Baseline: Network chip visible, permission granted, cellular-only — banner shows.
-        assertTrue(
+    fun scan_inactive_permission_granted_cellular_only_then_banner_hidden() {
+        // Pins the user-reported bug: no scan is running, permission granted, cellular-only
+        // transport. The banner must NOT render — the user is not actively trying to discover, so
+        // the recovery hint is noise.
+        assertFalse(
             shouldShowWifiUnavailableBanner(
-                showNetworkTransport = true,
                 isNetworkScanning = false,
                 localNetworkPermissionGranted = true,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(transports()),
@@ -200,12 +200,12 @@ class WifiUnavailableBannerTest {
     }
 
     @Test
-    fun scan_active_section_hidden_cellular_only_then_banner_shows() {
-        // The user-reported regression: Network chip toggled off but auto-scan running in the background,
-        // cellular-only transport. The pre-fix gate (`showNetworkTransport &&` alone) suppressed this case.
+    fun scan_active_permission_granted_cellular_only_then_banner_shows() {
+        // The auto-scan case: scan running in the background with cellular-only transport. Chip
+        // visibility no longer gates this surface — `isNetworkScanning` is the only activity
+        // signal — so the banner surfaces the missing-transport hint to the user.
         assertTrue(
             shouldShowWifiUnavailableBanner(
-                showNetworkTransport = false,
                 isNetworkScanning = true,
                 localNetworkPermissionGranted = true,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(transports()),
@@ -214,14 +214,14 @@ class WifiUnavailableBannerTest {
     }
 
     @Test
-    fun section_hidden_and_scan_inactive_then_banner_hidden() {
-        // User is not interacting with network discovery at all — banner suppressed even on cellular-only.
-        assertFalse(
+    fun scan_active_permission_granted_wifi_unavailable_then_banner_shows() {
+        // Clean positive case: scan actively running, permission granted, WiFi unavailable — banner
+        // fires. This is the only combination the banner is meant to surface.
+        assertTrue(
             shouldShowWifiUnavailableBanner(
-                showNetworkTransport = false,
-                isNetworkScanning = false,
+                isNetworkScanning = true,
                 localNetworkPermissionGranted = true,
-                wifiUnavailable = !anyNetworkScanTransportAvailable(transports()),
+                wifiUnavailable = true,
             ),
         )
     }
@@ -231,7 +231,6 @@ class WifiUnavailableBannerTest {
         // Permission-recovery flow on the scan toggle owns this surface; banner must not overlap.
         assertFalse(
             shouldShowWifiUnavailableBanner(
-                showNetworkTransport = true,
                 isNetworkScanning = true,
                 localNetworkPermissionGranted = false,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(transports()),
@@ -244,7 +243,6 @@ class WifiUnavailableBannerTest {
         // VPN off + Wi-Fi on + scanning → no banner (preserves the existing "transport available" outcome).
         assertFalse(
             shouldShowWifiUnavailableBanner(
-                showNetworkTransport = true,
                 isNetworkScanning = true,
                 localNetworkPermissionGranted = true,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(transports(wifi = true)),
@@ -258,7 +256,6 @@ class WifiUnavailableBannerTest {
         val vpnOnly = listOf(NetworkTransportInfo(hasWifi = false, hasEthernet = false, hasVpn = true))
         assertFalse(
             shouldShowWifiUnavailableBanner(
-                showNetworkTransport = true,
                 isNetworkScanning = true,
                 localNetworkPermissionGranted = true,
                 wifiUnavailable = !anyNetworkScanTransportAvailable(vpnOnly),

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -300,9 +300,9 @@ fun ConnectionsScreen(
 
                         // Adapter-off hints: shown only when the relevant permission is granted but the radio/network
                         // is unavailable, so they don't overlap the permission-recovery flow on the scan toggles.
-                        // The Wi-Fi banner gate includes `isNetworkScanning` because `LifecycleStartEffect` keys the
-                        // auto-scan off `permission status`, not the section-visibility chip — a user with the Network
-                        // filter off but auto-scan on still has a running scan that needs the hint.
+                        // The WiFi-unavailable banner only renders while a network scan is actively running —
+                        // discovery is the only moment the user needs to know WiFi is missing. The auto-scan case is
+                        // covered because `isNetworkScanning` is true during auto-scan regardless of chip state.
                         if (showBleTransport && bluetoothPermission.isGranted && bluetoothDisabled) {
                             RecoveryCard(
                                 message = stringResource(Res.string.bluetooth_disabled),
@@ -313,7 +313,6 @@ fun ConnectionsScreen(
                         }
                         if (
                             shouldShowWifiUnavailableBanner(
-                                showNetworkTransport = showNetworkTransport,
                                 isNetworkScanning = isNetworkScanning,
                                 localNetworkPermissionGranted = localNetworkPermission.isGranted,
                                 wifiUnavailable = wifiUnavailable,

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -316,6 +316,7 @@ fun ConnectionsScreen(
                                 isNetworkScanning = isNetworkScanning,
                                 localNetworkPermissionGranted = localNetworkPermission.isGranted,
                                 wifiUnavailable = wifiUnavailable,
+                                discoveredTcpDevicesEmpty = discoveredTcpDevices.isEmpty(),
                             )
                         ) {
                             RecoveryCard(


### PR DESCRIPTION
## Overview

This PR fixes Connections screen Wi-Fi recovery banner behavior so the banner appears only when it is useful: during an active network scan, after local-network permission has been granted, when no Wi-Fi/VPN/Ethernet scan transport is available, and before any TCP devices have been discovered. This prevents the banner from appearing just because the Network section is visible, and hides it once discovery has produced usable results.

This PR is related to the scan lifecycle coordination PR (#5887) and should land after it. That PR makes `isNetworkScanning` a more reliable runtime signal; this PR then uses that signal as the banner’s user-intent gate. Because both PRs touch nearby `ConnectionsScreen.kt` code, this branch may need a small rebase after the scan lifecycle PR lands.

## Key Changes

### Fixes

- Banner no longer displays when no network scan is actively running, eliminating false-positive idle states.
- Banner automatically hides once discovered TCP devices appear in the list.
- Auto-scan scenarios still show the banner when appropriate because the gate uses `isNetworkScanning`, not the Network section visibility chip.
- Permission-denied, Wi-Fi-available, and VPN-available states continue to suppress the banner.

### Refactors

- Updated `shouldShowWifiUnavailableBanner()` to use scan/result state instead of transport chip visibility:
  - Removed `showNetworkTransport`.
  - Added `isNetworkScanning`.
  - Added `discoveredTcpDevicesEmpty`.
  - Retained `localNetworkPermissionGranted` and `wifiUnavailable`.
- Simplified the `ConnectionsScreen` call site to pass active scan state, permission state, transport availability, and whether the discovered TCP list is empty.
- Removed dependence on the Network section visibility chip, which defaults to visible and is not a reliable signal of user discovery intent.
- Updated predicate documentation to describe the recovery-hint behavior and result-based suppression.

### Testing

- Expanded common test coverage for:
  - scan inactive + cellular-only transport => banner hidden.
  - scan active + cellular-only transport => banner shown.
  - scan active + permission denied => banner hidden.
  - scan active + Wi-Fi available => banner hidden.
  - scan active + VPN available => banner hidden.
  - scan active + Wi-Fi unavailable + TCP results found => banner hidden.
- Static call-site review confirms the old `showNetworkTransport` predicate argument is removed from touched files.

## Breaking Changes

The internal `shouldShowWifiUnavailableBanner()` helper signature changed.

Removed:
- `showNetworkTransport: Boolean`

Added:
- `isNetworkScanning: Boolean`
- `discoveredTcpDevicesEmpty: Boolean`

Retained:
- `localNetworkPermissionGranted: Boolean`
- `wifiUnavailable: Boolean`

No user-facing migration is required.