### PR TITLE
fix(network): preserve TCP reconnect backoff on short sessions

### DIFF
--- a/core/network/src/jvmAndroidMain/kotlin/org/meshtastic/core/network/transport/TcpTransport.kt
+++ b/core/network/src/jvmAndroidMain/kotlin/org/meshtastic/core/network/transport/TcpTransport.kt
@@ -76,6 +76,14 @@ class TcpTransport(
         const val SOCKET_RETRIES = 18 // 18 * 5s = 90s inactivity before disconnect
         const val TIMEOUT_LOG_INTERVAL = 5
         private const val MILLIS_PER_SECOND = 1_000L
+
+        /**
+         * Minimum session duration for backoff to reset. Sessions shorter than this that ended in peer-EOF are treated
+         * as transient firmware-side disconnects (e.g., ESP32 light sleep closing the TCP PhoneAPI session after a
+         * config dump) and do NOT reset the backoff — the growing delay gives the radio time to recover between
+         * attempts instead of hammering it at 1 Hz.
+         */
+        const val SHORT_SESSION_THRESHOLD_MS = 30_000L
     }
 
     private val codec =
@@ -176,12 +184,18 @@ class TcpTransport(
                     false
                 }
 
-            // Reset backoff after a connection that successfully exchanged data,
-            // so transient firmware-side disconnects recover quickly.
-            if (hadData) {
-                Logger.d { "$logTag: [$address] Resetting backoff after successful data exchange" }
+            // Reset backoff only after a session that lasted long enough to indicate a real connection,
+            // not a short config-dump-then-EOF from a sleeping radio. Short sessions keep the backoff
+            // growing so the radio has time to recover between reconnect attempts.
+            val sessionUptime = if (connectionStartTime > 0) nowMillis - connectionStartTime else 0
+            if (hadData && sessionUptime >= SHORT_SESSION_THRESHOLD_MS) {
+                Logger.d { "$logTag: [$address] Resetting backoff after successful data exchange (${sessionUptime}ms)" }
                 retryCount = 1
                 backoff = MIN_BACKOFF_MILLIS
+            } else if (hadData) {
+                Logger.d {
+                    "$logTag: [$address] Short session (${sessionUptime}ms) — keeping backoff at ${backoff / MILLIS_PER_SECOND}s"
+                }
             }
 
             val delaySec = backoff / MILLIS_PER_SECOND

--- a/core/network/src/jvmAndroidMain/kotlin/org/meshtastic/core/network/transport/TcpTransport.kt
+++ b/core/network/src/jvmAndroidMain/kotlin/org/meshtastic/core/network/transport/TcpTransport.kt
@@ -36,6 +36,16 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
+ * Decides whether to reset the reconnect backoff based on session data and uptime.
+ *
+ * Only sessions that lasted at least [thresholdMs] with actual data exchange are considered stable enough to warrant a
+ * backoff reset. Short sessions — e.g., an ESP32 dumping config then closing the socket — keep the growing backoff so
+ * the radio has time to recover between attempts.
+ */
+internal fun shouldResetBackoff(hadData: Boolean, sessionUptimeMs: Long, thresholdMs: Long): Boolean =
+    hadData && sessionUptimeMs >= thresholdMs
+
+/**
  * Shared JVM TCP transport for Meshtastic radios.
  *
  * Manages the TCP socket lifecycle (connect, read loop, reconnect with backoff) and uses [StreamFrameCodec] for the
@@ -188,7 +198,7 @@ class TcpTransport(
             // not a short config-dump-then-EOF from a sleeping radio. Short sessions keep the backoff
             // growing so the radio has time to recover between reconnect attempts.
             val sessionUptime = if (connectionStartTime > 0) nowMillis - connectionStartTime else 0
-            if (hadData && sessionUptime >= SHORT_SESSION_THRESHOLD_MS) {
+            if (shouldResetBackoff(hadData, sessionUptime, SHORT_SESSION_THRESHOLD_MS)) {
                 Logger.d { "$logTag: [$address] Resetting backoff after successful data exchange (${sessionUptime}ms)" }
                 retryCount = 1
                 backoff = MIN_BACKOFF_MILLIS

--- a/core/network/src/jvmTest/kotlin/org/meshtastic/core/network/transport/ShouldResetBackoffTest.kt
+++ b/core/network/src/jvmTest/kotlin/org/meshtastic/core/network/transport/ShouldResetBackoffTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.transport
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ShouldResetBackoffTest {
+
+    private val threshold = 30_000L
+
+    @Test
+    fun `no data never resets backoff`() {
+        assertFalse(shouldResetBackoff(hadData = false, sessionUptimeMs = 0, thresholdMs = threshold))
+        assertFalse(shouldResetBackoff(hadData = false, sessionUptimeMs = 60_000, thresholdMs = threshold))
+    }
+
+    @Test
+    fun `data below threshold does not reset backoff`() {
+        assertFalse(shouldResetBackoff(hadData = true, sessionUptimeMs = 0, thresholdMs = threshold))
+        assertFalse(shouldResetBackoff(hadData = true, sessionUptimeMs = 1_000, thresholdMs = threshold))
+        assertFalse(shouldResetBackoff(hadData = true, sessionUptimeMs = 29_999, thresholdMs = threshold))
+    }
+
+    @Test
+    fun `data at exactly threshold resets backoff`() {
+        assertTrue(shouldResetBackoff(hadData = true, sessionUptimeMs = 30_000, thresholdMs = threshold))
+    }
+
+    @Test
+    fun `data above threshold resets backoff`() {
+        assertTrue(shouldResetBackoff(hadData = true, sessionUptimeMs = 30_001, thresholdMs = threshold))
+        assertTrue(shouldResetBackoff(hadData = true, sessionUptimeMs = 600_000, thresholdMs = threshold))
+    }
+}


### PR DESCRIPTION
## Overview

This PR fixes TCP reconnect behavior for radios that briefly accept a PhoneAPI TCP connection, send initial/config data, and then close the socket before the session is actually stable. Previously, any received data reset reconnect backoff to the 1-second floor, so repeated short sessions could hammer a sleeping or recovering radio at roughly 1 Hz. The fix only resets reconnect backoff after a data-bearing session has remained connected long enough to be treated as stable.

## Key Changes

### Fixes

- Preserved growing TCP reconnect backoff after short data-bearing sessions.
- Added a minimum stable-session threshold before resetting reconnect delay.
- Prevented config-dump-then-EOF sessions from repeatedly resetting backoff to 1 second.
- Kept fast recovery for genuinely stable sessions by still resetting backoff after data is exchanged and the session uptime meets the threshold.
- Left no-data failures on the existing exponential backoff path.

### Refactors

- Added `SHORT_SESSION_THRESHOLD_MS` to document the stable-session cutoff.
- Extracted the reconnect reset decision into `shouldResetBackoff(...)`.
- Moved reconnect reset logic from “any data received” to “data received and session uptime meets the stability threshold.”
- Expanded reconnect logging to distinguish stable sessions that reset backoff from short sessions that keep the current backoff.

### Testing

- Added JVM unit coverage for the reconnect backoff reset policy via `ShouldResetBackoffTest`.
- Covered the reset decision without socket/integration setup:
  - no data => no reset
  - data + uptime below threshold => no reset
  - data + uptime at threshold => reset
  - data + uptime above threshold => reset
- No socket/integration tests are included; the branch keeps transport-loop behavior unchanged apart from the tested reset decision.

## Breaking changes / migration

No breaking API or user-facing migration steps are required. Changes are internal to TCP transport reconnect behavior.