### PR TITLE
fix(network): migrate to mqtt-client 0.4.0 (IP-literal TLS fix)

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
@@ -43,7 +43,10 @@ import org.meshtastic.mqtt.ConnectionState
 import org.meshtastic.mqtt.MqttClient
 import org.meshtastic.mqtt.MqttException
 import org.meshtastic.mqtt.ProbeResult
+import org.meshtastic.mqtt.plus
 import org.meshtastic.mqtt.probe
+import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
+import org.meshtastic.mqtt.transport.ws.WebSocketTransportFactory
 import org.meshtastic.proto.MqttClientProxyMessage
 import org.meshtastic.proto.ToRadio
 import kotlin.uuid.Uuid
@@ -136,6 +139,8 @@ class MqttManagerImpl(
         val endpoint = resolveEndpoint(address, tlsEnabled)
         val result =
             MqttClient.probe(endpoint = endpoint) {
+                // probe() requires a transportFactory in 0.4.0 (errors otherwise); mirror the live client.
+                transportFactory = TcpTransportFactory() + WebSocketTransportFactory()
                 // Per-connection random suffix: myId identifies the node (and is null →
                 // "unknown" before the node record loads), so two probes can collide on one
                 // client-id and evict each other (SESSION_TAKEN_OVER). See MQTTRepositoryImpl.

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -35,7 +35,15 @@ kotlin {
             implementation(projects.core.ble)
 
             implementation(libs.okio)
-            api(libs.meshtastic.mqtt.client)
+            // mqtt-client 0.4.0 splits into BOM + core + transport modules. `api` (not `implementation`)
+            // because :core:data and :desktopApp consume org.meshtastic.mqtt.* types transitively through
+            // this module. Both transports are registered: transport-tcp (tcp://-/ssl://, default) +
+            // transport-ws (user-entered ws://-/wss://), composed with `+` at the client config sites.
+            // No platform() on the KMP commonMain handler; reach the BOM through project.dependencies.
+            api(project.dependencies.platform(libs.meshtastic.mqtt.client.bom))
+            api(libs.meshtastic.mqtt.client.core)
+            api(libs.meshtastic.mqtt.client.transport.tcp)
+            api(libs.meshtastic.mqtt.client.transport.ws)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.atomicfu)
             implementation(libs.ktor.client.core)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -51,6 +51,9 @@ import org.meshtastic.mqtt.MqttLogLevel
 import org.meshtastic.mqtt.MqttMessage
 import org.meshtastic.mqtt.QoS
 import org.meshtastic.mqtt.packet.Subscription
+import org.meshtastic.mqtt.plus
+import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
+import org.meshtastic.mqtt.transport.ws.WebSocketTransportFactory
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.MqttClientProxyMessage
 import kotlin.concurrent.Volatile
@@ -321,6 +324,9 @@ private class DefaultMqttClientSession(private val delegate: MqttClient) : MqttC
 
 private fun defaultMqttClientFactory(setup: MqttClientSetup): MqttClientSession = DefaultMqttClientSession(
     MqttClient(setup.ownerId) {
+        // mqtt-client 0.4.0 makes transport a required SPI: the client throws at connect if unset.
+        // Register TCP/TLS (the default) + WebSocket (for user-entered ws://-/wss:// brokers).
+        transportFactory = TcpTransportFactory() + WebSocketTransportFactory()
         keepAliveSeconds = MQTT_KEEPALIVE_SECONDS
         autoReconnect = true
         username = setup.mqttConfig?.username

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,7 +95,7 @@ osmdroid-android = "6.1.20"
 spotless = "8.7.0"
 vico = "3.2.3"
 kable = "0.43.1"
-mqttastic = "0.3.8"
+mqttastic = "0.4.0"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
 takpacket-sdk = "0.7.0"
@@ -264,7 +264,13 @@ markdown-renderer-android = { module = "com.mikepenz:multiplatform-markdown-rend
 material = { module = "com.google.android.material:material", version = "1.14.0" }
 
 kable-core = { module = "com.juul.kable:kable-core", version.ref = "kable" }
-meshtastic-mqtt-client = { module = "org.meshtastic:mqtt-client", version.ref = "mqttastic" }
+# mqtt-client 0.4.0 split the monolith into a BOM + core + per-transport modules. The BOM pins the
+# versions, so core/transport stay versionless. Both transports are wired: transport-tcp (tcp://-/ssl://,
+# the default) and transport-ws (for user-entered ws://-/wss:// broker addresses).
+meshtastic-mqtt-client-bom = { module = "org.meshtastic:mqtt-client-bom", version.ref = "mqttastic" }
+meshtastic-mqtt-client-core = { module = "org.meshtastic:mqtt-client-core" }
+meshtastic-mqtt-client-transport-tcp = { module = "org.meshtastic:mqtt-client-transport-tcp" }
+meshtastic-mqtt-client-transport-ws = { module = "org.meshtastic:mqtt-client-transport-ws" }
 
 jserialcomm = { module = "com.fazecast:jSerialComm", version.ref = "jserialcomm" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }


### PR DESCRIPTION
mqtt-client **0.4.0** is a breaking release that splits the monolithic `org.meshtastic:mqtt-client` artifact into a BOM + core + per-transport modules and makes the transport a required public SPI. Bumping to it ships the upstream fix for TLS to a private MQTT broker addressed by an **IP literal**, which previously failed with `Domain specific configurations require that hostname aware checkServerTrusted(...) is used`.

Resolves #5894 — the fix landed upstream in meshtastic/MQTTastic-Client-KMP#67, released as [v0.4.0](https://github.com/meshtastic/MQTTastic-Client-KMP/releases/tag/v0.4.0).

### 🛠️ Refactoring & Architecture
- **Dependency split (breaking upstream):** replaced the single `org.meshtastic:mqtt-client` with `mqtt-client-bom` + `mqtt-client-core` + `mqtt-client-transport-tcp` + `mqtt-client-transport-ws` in `gradle/libs.versions.toml` (transports are versionless, pinned by the BOM).
- `core:network` consumes the BOM via `project.dependencies.platform(...)` because the KMP `commonMain` dependency handler doesn't expose `platform()`. Kept `api` (not `implementation`) so `:core:data` and `:desktopApp` keep resolving `org.meshtastic.mqtt.*` types transitively.
- Transport is now an explicit SPI. Both transports are registered and composed with the `+` combinator at each `MqttClient` config site — the live proxy client (`MQTTRepositoryImpl`) and the "Test connection" probe (`MqttManagerImpl`): `TcpTransportFactory()` (TCP/TLS, the default) `+` `WebSocketTransportFactory()` (covers user-entered `ws://`/`wss://` broker addresses). 0.4.0 throws at connect and at probe when the transport is unset.

### 🐛 Bug Fixes
- Connecting an MQTT proxy / running "Test connection" against a private broker by IP over TLS no longer fails the hostname-aware trust check (#5894).

### 🧹 Chores
- `mqttastic` 0.3.8 → 0.4.0.

### Testing Performed
Local baseline on JDK 21: `spotlessCheck`, `detekt`, `assembleDebug` (google + fdroid), and `kmpSmokeCompile` all green. The full `test` / `allTests` run on the base migration was also green apart from one **pre-existing** flake (`feature:messaging` → `MessageViewModelTest.testDeleteMessages`, the known Room-`ioDispatcher` / `runTest` timing race) which passes on isolated re-run and is unrelated to this change. The WebSocket-transport addition is additive (no test constructs a client/transport). No test files were modified.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
