### PR TITLE
docs(mqtt): correct probe() tlsEnabled KDoc transport scheme

### DIFF
--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MqttManager.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MqttManager.kt
@@ -47,7 +47,8 @@ interface MqttManager {
      * "Test Connection" affordances.
      *
      * @param address Raw broker address as the user would type it (host, host:port, or full URL).
-     * @param tlsEnabled `true` to upgrade bare addresses to `wss://` (ignored when [address] already has a scheme).
+     * @param tlsEnabled `true` upgrades bare addresses to `ssl://` (TLS, port 8883) instead of `tcp://` (plaintext,
+     *   port 1883); ignored when [address] already has a scheme.
      * @param username Optional MQTT username.
      * @param password Optional MQTT password.
      */


### PR DESCRIPTION
## Why

The KDoc for `MqttManager.probe(...)` misstated the MQTT transport. It claimed `tlsEnabled` upgrades bare addresses to `wss://`, implying a WebSocket transport. The app does not use WebSocket for MQTT — `resolveEndpoint(...)` in `MQTTRepositoryImpl` upgrades bare addresses to `ssl://` (TLS, port 8883) or `tcp://` (plaintext, port 1883). The doc actively misled readers about the default transport.

## Changes

🐛 **Bug Fixes**
- Corrected the `@param tlsEnabled` KDoc on [`MqttManager.probe(...)`](https://github.com/meshtastic/Meshtastic-Android/blob/main/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MqttManager.kt) to describe the real schemes/ports (`ssl://` TLS:8883 vs `tcp://` plaintext:1883), matching `resolveEndpoint(...)`.

## Notes for reviewers

- Pure documentation change — no behavior, signatures, or logic touched.
- The `ws://`/`wss://` literals in `MQTTRepositoryImplTest` were checked and left as-is: they test the *explicit-scheme* branch (a user typing `ws://` is parsed verbatim), which is correct and unrelated to the default-transport upgrade this KDoc describes.
- Validation: `./gradlew spotlessApply spotlessCheck detekt` — all clean (spotless rewrapped the KDoc line to the standard hanging-indent form).

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->