### PR TITLE
fix(build): pin compose-material via explicit dep so baseline-profile generation resolves

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -277,6 +277,9 @@ dependencies {
     googleImplementation(libs.maps.compose)
     googleImplementation(libs.maps.compose.utils)
     googleImplementation(libs.maps.compose.widgets)
+    // maps-compose-widgets requests androidx.compose.material:material version-less (expects a BOM
+    // we exclude). Name it with a version so the version is published in the app's graph metadata.
+    googleImplementation(libs.androidx.compose.material)
     googleImplementation(libs.dd.sdk.android.logs)
     googleImplementation(libs.dd.sdk.android.rum)
     googleImplementation(libs.dd.sdk.android.session.replay)

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/AndroidCompose.kt
@@ -43,17 +43,14 @@ internal fun Project.configureAndroidCompose(commonExtension: CommonExtension) {
             "androidx.compose.runtime",
             "androidx.compose.ui",
         )
-    // The BOM exclusion above strips the version from `androidx.compose.material:material`
-    // requested by maps-compose-widgets (google flavor). Pin only that artifact — the
-    // group also contains `material-ripple`, which CMP publishes at the bom-aligned
-    // version and must not be force-downgraded.
-    val materialVersion = libs.version("androidx-compose-material")
+    // `androidx.compose.material:material` is ALSO requested version-less by maps-compose-widgets,
+    // but it is pinned via an explicit versioned dependency in :androidApp rather than forced here —
+    // a force does not cross the project boundary, so consumers of the app's graph (e.g.
+    // :baselineprofile) would otherwise re-orphan it. Do not re-add a force for it here.
     configurations.configureEach {
         resolutionStrategy.eachDependency {
             if (requested.group in cmpAlignedGroups) {
                 useVersion(androidxComposeVersion)
-            } else if (requested.group == "androidx.compose.material" && requested.name == "material") {
-                useVersion(materialVersion)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -164,6 +164,9 @@ androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", versi
 # AndroidX Compose (explicit versions — BOM removed; CMP is the sole version authority)
 androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "androidx-compose-bom-aligned" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose-bom-aligned" } # Required by Robolectric Compose tests (registers ComponentActivity)
+# M2 `material`, version-less from maps-compose-widgets (google). Declared explicitly so the version
+# propagates to consumers of the app's graph (e.g. :baselineprofile); see androidApp/build.gradle.kts.
+androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-material" }
 
 # Compose Multiplatform
 compose-multiplatform-animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "compose-multiplatform" }


### PR DESCRIPTION
The scheduled `update_assets` workflow's baseline-profile step has been failing at dependency resolution. It emits a `::warning::` and skips rather than failing the job, so the job stays green while the profile is never regenerated. ([Failing run.](https://github.com/meshtastic/Meshtastic-Android/actions/runs/27957911000/job/82731130836))

**Root cause:** `com.google.maps.android:maps-compose-widgets` requests `androidx.compose.material:material` with **no version** (it expects a Compose BOM to supply one). `:androidApp` excludes that BOM globally so CMP remains the sole Compose version authority, then force-pins `material` in the `AndroidCompose.kt` convention plugin. But a `resolutionStrategy` force only applies within the module that declares it — it does **not** cross project boundaries. When `:baselineprofile` resolves the app's graph via its `*TestedApks` configuration, `material` is orphaned again:

```
Could not find androidx.compose.material:material:.
  Required by: :baselineprofile > :androidApp > com.google.maps.android:maps-compose-widgets
```

**Fix:** declare `material` as an explicit, versioned dependency. Real-dependency versions are published in the app's variant metadata and therefore propagate to every consumer of its graph, so `:baselineprofile` (and any future test/benchmark module) inherits `1.7.8` with no per-module workaround. The convention-plugin force becomes redundant and is removed. `:baselineprofile` itself needs no change.

### 🐛 Bug Fixes
- Fix scheduled baseline-profile generation failing to resolve `androidx.compose.material:material` in `:baselineprofile`.

### 🛠️ Refactoring & Architecture
- Replace the `resolutionStrategy` force for `androidx.compose.material:material` with an explicit `googleImplementation` dependency in `:androidApp`, so its version propagates across project boundaries instead of being re-pinned per consuming module.
- The `androidx.compose.{animation,foundation,runtime,ui}` alignment force in `AndroidCompose.kt` is intentionally **kept** — it overrides conflicting transitive versions *down* to the CMP-aligned tag, which a plain declaration cannot do.

### 🧹 Chores
- Add an `androidx-compose-material` library alias to the version catalog (the version ref already existed).

### Testing Performed
No test or runtime code changed. Verified locally:
- `./gradlew spotlessCheck detekt` — pass.
- `./gradlew assembleDebug` — both `google` and `fdroid` flavors build across all modules, confirming the removed convention-plugin force orphaned `material` in no module.
- `androidx.compose.material:material` resolves to `1.7.8` in both `:androidApp` (`googleDebugRuntimeClasspath`) and `:baselineprofile` (`googleNonMinifiedReleaseTestedApks`), with no empty-version error.

<!--
If you have screenshots or recordings to display your change, please include them!
-->
