### PR TITLE
chore(deps): track androidx.compose.material (M2) with the CMP-aligned compose ref

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -62,7 +62,8 @@
       "matchPackageNames": [
         "/^org\\.jetbrains\\.compose/",
         "androidx.compose.runtime:runtime-tracing",
-        "androidx.compose.ui:ui-test-manifest"
+        "androidx.compose.ui:ui-test-manifest",
+        "androidx.compose.material:material"
       ]
     },
     {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,10 +57,6 @@ compose-multiplatform-material3 = "1.11.0-alpha07"
 # AndroidCompose.kt's resolutionStrategy force-aligns these groups to *this* version
 # at resolution time, so it is the source of truth for the Android target.
 androidx-compose-bom-aligned = "1.11.3"
-# `androidx-compose-material` (M2) is independent of CMP. Pinned because
-# maps-compose-widgets requests `androidx.compose.material:material` without
-# a version (relying on a BOM that we exclude). M2 is frozen at 1.7.8.
-androidx-compose-material = "1.7.8"
 jetbrains-adaptive = "1.3.0-beta02"
 
 # Google
@@ -164,9 +160,11 @@ androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", versi
 # AndroidX Compose (explicit versions — BOM removed; CMP is the sole version authority)
 androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "androidx-compose-bom-aligned" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose-bom-aligned" } # Required by Robolectric Compose tests (registers ComponentActivity)
-# M2 `material`, version-less from maps-compose-widgets (google). Declared explicitly so the version
-# propagates to consumers of the app's graph (e.g. :baselineprofile); see androidApp/build.gradle.kts.
-androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-material" }
+# M2 `material` rides the same AndroidX train as the bom-aligned compose artifacts, so it shares
+# that ref (stays aligned; Renovate bumps it with the compose group). Requested version-less by
+# maps-compose-widgets (google), declared explicitly so the version propagates to consumers of the
+# app's graph (e.g. :baselineprofile); see androidApp/build.gradle.kts.
+androidx-compose-material = { module = "androidx.compose.material:material", version.ref = "androidx-compose-bom-aligned" }
 
 # Compose Multiplatform
 compose-multiplatform-animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "compose-multiplatform" }


### PR DESCRIPTION
M2 `androidx.compose.material:material` rides the same AndroidX version train as the bom-aligned compose artifacts (`foundation`/`ui`/`runtime`/`animation`), which `AndroidCompose.kt` force-aligns to `1.11.3`. But `material` was held on a **separate `1.7.8` ref** — so the app shipped `material:1.7.8` running against `ui`/`foundation:1.11.3` (a 4-minor skew), and because it was a standalone version key with no Renovate rule, the bot kept opening lone bump PRs for it (e.g. #5901).

This points the catalog library at the existing `androidx-compose-bom-aligned` ref and deletes the dedicated `androidx-compose-material` version. `material` now tracks the rest of the compose stack automatically (resolving to `1.11.3`), removing the skew. It's also added to the Renovate `compose-multiplatform` group so future bumps ride with the train instead of arriving as separate PRs.

Follow-on to #5899 (which made `material` an explicit dependency so its version propagates across project boundaries). **Supersedes #5901** — that lone bump becomes unnecessary once `material` shares the aligned ref.

### 🧹 Chores
- Delete the standalone `androidx-compose-material = "1.7.8"` version ref; the catalog library now uses `version.ref = "androidx-compose-bom-aligned"`.
- Add `androidx.compose.material:material` to the `compose-multiplatform` Renovate group so it bumps with the CMP-aligned artifacts.

### 🛠️ Refactoring & Architecture
- M2 `material` now stays aligned with `foundation`/`ui`/`runtime` (`1.11.3`) instead of lagging at `1.7.8`, eliminating the mixed-version Compose graph the app previously shipped.

### Testing Performed
No test or runtime code changed. Verified locally on this branch:
- `./gradlew spotlessCheck detekt` — pass.
- `./gradlew assembleDebug` — both `google` and `fdroid` flavors build across all modules.
- `androidx.compose.material:material` resolves to `1.11.3` in both `:androidApp` (`googleDebugRuntimeClasspath`) and `:baselineprofile` (`googleNonMinifiedReleaseTestedApks`), with no resolution errors.

<!--
If you have screenshots or recordings to display your change, please include them!
-->
