### PR TITLE
feat(firmware): link OTAFIX bootloader from slow-DFU success screen

### DIFF
--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
@@ -112,6 +112,7 @@ import org.meshtastic.core.resources.firmware_update_release_notes
 import org.meshtastic.core.resources.firmware_update_retry
 import org.meshtastic.core.resources.firmware_update_save_dfu_file
 import org.meshtastic.core.resources.firmware_update_select_file
+import org.meshtastic.core.resources.firmware_update_slow_bootloader_hint
 import org.meshtastic.core.resources.firmware_update_source_local
 import org.meshtastic.core.resources.firmware_update_stable
 import org.meshtastic.core.resources.firmware_update_success
@@ -149,6 +150,14 @@ import org.meshtastic.core.ui.util.rememberOpenUrl
 import org.meshtastic.core.ui.util.rememberSaveFileLauncher
 
 private const val CYCLE_DELAY_MS = 4500L
+
+/**
+ * Flashing instructions for the OTAFIX 2.1 bootloader, which lifts the BLE DFU MTU cap (20-byte → 244-byte packets,
+ * ~10× faster updates). Offered on the Success screen after a low-speed transfer — never mid-upload, where leaving the
+ * app could drop the DFU link and brick the device.
+ */
+private const val OTAFIX_BOOTLOADER_URL =
+    "https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX#changes-in-otafix-21"
 
 @Composable
 @Suppress("LongMethod")
@@ -328,7 +337,8 @@ private fun FirmwareUpdateContent(
 
             is FirmwareUpdateState.Error -> ErrorState(error = state.error, onRetry = actions.onRetry)
 
-            is FirmwareUpdateState.Success -> SuccessState(onDone = actions.onDone)
+            is FirmwareUpdateState.Success ->
+                SuccessState(onDone = actions.onDone, wasLowSpeedTransfer = state.wasLowSpeedTransfer)
 
             is FirmwareUpdateState.AwaitingFileSave -> AwaitingFileSaveState(state, actions.onSaveFile)
         }
@@ -866,8 +876,9 @@ internal fun ErrorState(error: UiText, onRetry: () -> Unit) {
 }
 
 @Composable
-internal fun SuccessState(onDone: () -> Unit) {
+internal fun SuccessState(wasLowSpeedTransfer: Boolean = false, onDone: () -> Unit) {
     val haptic = LocalHapticFeedback.current
+    val openUrl = rememberOpenUrl()
     LaunchedEffect(Unit) { haptic.performHapticFeedback(HapticFeedbackType.LongPress) }
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -884,6 +895,18 @@ internal fun SuccessState(onDone: () -> Unit) {
             style = MaterialTheme.typography.headlineLarge,
             textAlign = TextAlign.Center,
         )
+        // The just-finished transfer was MTU-capped (stock bootloader). Now that the device is back and it's safe to
+        // leave the app, offer a one-time OTAFIX upgrade tip for faster future updates.
+        if (wasLowSpeedTransfer) {
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = stringResource(Res.string.firmware_update_slow_bootloader_hint),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            TextButton(onClick = { openUrl(OTAFIX_BOOTLOADER_URL) }) { Text(stringResource(Res.string.learn_more)) }
+        }
         Spacer(Modifier.height(32.dp))
         @OptIn(ExperimentalMaterial3ExpressiveApi::class)
         val largeHeight = ButtonDefaults.LargeContainerHeight

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateState.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateState.kt
@@ -72,8 +72,13 @@ sealed interface FirmwareUpdateState {
     /** An error occurred at any stage of the update pipeline. */
     data class Error(val error: UiText) : FirmwareUpdateState
 
-    /** The firmware update completed and the device reconnected successfully. */
-    data object Success : FirmwareUpdateState
+    /**
+     * The firmware update completed and the device reconnected successfully.
+     *
+     * @property wasLowSpeedTransfer True if the upload ran at the MTU-capped low speed (stock bootloader), so the
+     *   Success screen can offer a one-time OTAFIX upgrade tip for faster future updates.
+     */
+    data class Success(val wasLowSpeedTransfer: Boolean = false) : FirmwareUpdateState
 
     /** UF2 file is ready; waiting for the user to choose a save location (USB flow). */
     data class AwaitingFileSave(val uf2Artifact: FirmwareArtifact, val fileName: String) : FirmwareUpdateState

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -237,8 +237,9 @@ class FirmwareUpdateViewModel(
                                     updateState = { _state.value = it },
                                 )
 
-                            when (_state.value) {
-                                is FirmwareUpdateState.Success -> verifyUpdateResult(originalDeviceAddress)
+                            when (val finalState = _state.value) {
+                                is FirmwareUpdateState.Success ->
+                                    verifyUpdateResult(originalDeviceAddress, finalState.wasLowSpeedTransfer)
 
                                 is FirmwareUpdateState.Error -> {
                                     tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
@@ -325,8 +326,9 @@ class FirmwareUpdateViewModel(
                         )
                     tempFirmwareFile = updateArtifact ?: extractedFile
 
-                    when (_state.value) {
-                        is FirmwareUpdateState.Success -> verifyUpdateResult(originalDeviceAddress)
+                    when (val finalState = _state.value) {
+                        is FirmwareUpdateState.Success ->
+                            verifyUpdateResult(originalDeviceAddress, finalState.wasLowSpeedTransfer)
 
                         is FirmwareUpdateState.Error -> {
                             tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
@@ -355,7 +357,7 @@ class FirmwareUpdateViewModel(
         }
     }
 
-    private suspend fun verifyUpdateResult(address: String?) {
+    private suspend fun verifyUpdateResult(address: String?, wasLowSpeedTransfer: Boolean = false) {
         _state.value = FirmwareUpdateState.Verifying
 
         // Trigger a fresh connection attempt by MeshService using the original prefixed address
@@ -378,7 +380,7 @@ class FirmwareUpdateViewModel(
             Logger.w { "Post-update verification timed out for $address" }
             _state.value = FirmwareUpdateState.VerificationFailed
         } else {
-            _state.value = FirmwareUpdateState.Success
+            _state.value = FirmwareUpdateState.Success(wasLowSpeedTransfer)
         }
     }
 

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/Esp32OtaUpdateHandler.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/Esp32OtaUpdateHandler.kt
@@ -351,6 +351,6 @@ class Esp32OtaUpdateHandler(
             .getOrThrow()
         Logger.i { "ESP32 OTA: Firmware stream completed" }
 
-        updateState(FirmwareUpdateState.Success)
+        updateState(FirmwareUpdateState.Success())
     }
 }

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuHandler.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuHandler.kt
@@ -208,7 +208,7 @@ class SecureDfuHandler(
                     )
 
                     completed = true
-                    updateState(FirmwareUpdateState.Success)
+                    updateState(FirmwareUpdateState.Success(wasLowSpeedTransfer = transport.isLowSpeedTransfer))
                     zipFile
                 } finally {
                     // Send ABORT if cancelled mid-transfer, then always clean up.

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateIntegrationTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateIntegrationTest.kt
@@ -129,7 +129,7 @@ class FirmwareUpdateIntegrationTest {
                 @Suppress("UNCHECKED_CAST")
                 val updateState = it.args[3] as (FirmwareUpdateState) -> Unit
                 updateState(FirmwareUpdateState.Updating(ProgressState()))
-                updateState(FirmwareUpdateState.Success)
+                updateState(FirmwareUpdateState.Success())
                 null
             }
 

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
@@ -187,7 +187,7 @@ class FirmwareUpdateViewModelTest {
             .calls {
                 @Suppress("UNCHECKED_CAST")
                 val updateState = it.args[3] as (FirmwareUpdateState) -> Unit
-                updateState(FirmwareUpdateState.Success)
+                updateState(FirmwareUpdateState.Success())
                 null
             }
 

--- a/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
+++ b/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
@@ -197,7 +197,7 @@ class FirmwareUpdateViewModelFileTest {
             .calls {
                 @Suppress("UNCHECKED_CAST")
                 val updateState = it.args[3] as (FirmwareUpdateState) -> Unit
-                updateState(FirmwareUpdateState.Success)
+                updateState(FirmwareUpdateState.Success())
                 null
             }
 
@@ -257,7 +257,7 @@ class FirmwareUpdateViewModelFileTest {
             .calls {
                 @Suppress("UNCHECKED_CAST")
                 val updateState = it.args[3] as (FirmwareUpdateState) -> Unit
-                updateState(FirmwareUpdateState.Success)
+                updateState(FirmwareUpdateState.Success())
                 null
             }
 


### PR DESCRIPTION
## Why

[#5915](https://github.com/meshtastic/Meshtastic-Android/pull/5915) detects a low-speed (MTU-capped) nRF52 BLE DFU transfer — a stock Adafruit bootloader negotiates only ATT MTU 23, capping Legacy DFU at 20-byte packets (~3.7 KB/s; a ~785 KB image takes ~3.5 min). It shows an in-upload hint naming the **OTAFIX** bootloader, which grants a high MTU (244-byte packets, ~10× faster). But that hint had no link, so users had no actionable path to the fix.

A link can't live on the upload screen: opening a browser backgrounds the app mid-DFU, which can drop the BLE link and brick a half-written image (the screen runs `KeepScreenOn` and traps back-nav for exactly this reason), and you can't flash a new bootloader mid-transfer anyway. So the actionable **"Learn more"** link lives on the **Success** screen — shown only when the just-finished transfer was low-speed, once it's safe to leave the app and the user has just felt the slowness.

## Changes

🌟 The firmware-update **Success** screen now offers a one-time OTAFIX upgrade tip with a **"Learn more"** link, but only after a slow (MTU-capped) DFU transfer.

🛠️ `FirmwareUpdateState.Success` now carries a `wasLowSpeedTransfer` flag, set from `transport.isLowSpeedTransfer` in `SecureDfuHandler` and threaded through `verifyUpdateResult`. The tip follows the **actual negotiated MTU** rather than a static per-device guess (a board already running OTAFIX isn't slow), so no new device flag was added. Reuses the existing `firmware_update_slow_bootloader_hint` and `learn_more` strings — no new string resources.

The link points at the [OTAFIX README](https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX#changes-in-otafix-21) because meshtastic.org's nRF52 docs don't yet document OTAFIX or the bootloader-dependent transfer speed (a docs PR upstream would let this point at meshtastic.org later).

## Testing Performed

- `./gradlew spotlessCheck detekt assembleDebug test allTests` — all pass.
- Updated the 3 firmware tests that construct `FirmwareUpdateState.Success` for the new data-class constructor; existing post-success state-transition assertions still pass.
- The new tip is a single `if (wasLowSpeedTransfer)` branch in `SuccessState` (not separately screenshot-tested). **Not yet verified on real OTAFIX 2.1 hardware** — only a stock-bootloader RAK4631 was available; confirming the high-MTU path engages on an OTAFIX unit remains a follow-up.

<!--
Screenshots welcome. Single image:
<img src="" width="300"/>

Before / after:
| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
