### PR TITLE
feat: offline-first event firmware metadata (JSON schema + bundled asset)

### DIFF
--- a/androidApp/src/main/assets/event_firmware.json
+++ b/androidApp/src/main/assets/event_firmware.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "generatedAt": "2026-06-23T00:00:00Z",
+  "source": "bundled",
+  "editions": [
+    {
+      "edition": "HAMVENTION",
+      "displayName": "Hamvention",
+      "welcomeMessage": "Welcome to Hamvention! 🍖📻",
+      "eventStart": "2026-05-15",
+      "eventEnd": "2026-05-17",
+      "timeZone": "America/New_York",
+      "location": "Xenia, Ohio, USA",
+      "iconUrl": null,
+      "accentColor": "#005DAA",
+      "links": [
+        { "label": "Event Website", "url": "https://hamvention.org" }
+      ]
+    },
+    {
+      "edition": "OPEN_SAUCE",
+      "displayName": "Open Sauce",
+      "welcomeMessage": "Welcome to Open Sauce! 🔧",
+      "eventStart": "2026-07-18",
+      "eventEnd": "2026-07-19",
+      "timeZone": "America/Los_Angeles",
+      "location": "San Mateo, California, USA",
+      "iconUrl": null,
+      "accentColor": "#E94F1D",
+      "links": [
+        { "label": "Event Website", "url": "https://opensauce.com" }
+      ]
+    },
+    {
+      "edition": "DEFCON",
+      "displayName": "DEFCON",
+      "welcomeMessage": "Welcome to DEFCON! 💀",
+      "eventStart": "2026-08-06",
+      "eventEnd": "2026-08-09",
+      "timeZone": "America/Los_Angeles",
+      "location": "Las Vegas, Nevada, USA",
+      "iconUrl": null,
+      "accentColor": "#C0392B",
+      "links": [
+        { "label": "Event Website", "url": "https://defcon.org" }
+      ]
+    },
+    {
+      "edition": "BURNING_MAN",
+      "displayName": "Burning Man",
+      "welcomeMessage": "Welcome to Burning Man! 🔥",
+      "eventStart": "2026-08-30",
+      "eventEnd": "2026-09-07",
+      "timeZone": "America/Los_Angeles",
+      "location": "Black Rock City, Nevada, USA",
+      "iconUrl": null,
+      "accentColor": "#E8552D",
+      "links": [
+        { "label": "Event Website", "url": "https://burningman.org" }
+      ]
+    }
+  ]
+}

--- a/schemas/event_firmware.schema.json
+++ b/schemas/event_firmware.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://meshtastic.org/schemas/event_firmware.schema.json",
+  "title": "Event Firmware Metadata",
+  "description": "Offline-first display metadata for event-specific firmware editions. The bundled androidApp/src/main/assets/event_firmware.json is a frozen copy of a future Meshtastic API response (planned GET /resource/eventFirmware); it shares the {version, generatedAt, source, <payload>[]} envelope used by device_links.json so the network layer can drop-in replace it. Keyed (within each record) by the FirmwareEdition proto enum name.",
+  "type": "object",
+  "required": ["version", "editions"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema/envelope version. Bump when the structure changes incompatibly."
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp the snapshot was generated."
+    },
+    "source": {
+      "type": "string",
+      "description": "Origin of this snapshot, e.g. \"bundled\" or the API URL it was frozen from."
+    },
+    "editions": {
+      "type": "array",
+      "description": "One record per event firmware edition.",
+      "items": { "$ref": "#/$defs/edition" }
+    }
+  },
+  "$defs": {
+    "edition": {
+      "type": "object",
+      "required": ["edition", "displayName", "welcomeMessage"],
+      "additionalProperties": false,
+      "properties": {
+        "edition": {
+          "type": "string",
+          "pattern": "^[A-Z0-9_]+$",
+          "description": "FirmwareEdition proto enum name, e.g. \"HAMVENTION\". A pattern (not a fixed enum list) so adding a new event needs no schema change."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable name shown in the UI, e.g. \"Hamvention\" (vs the enum name \"HAMVENTION\")."
+        },
+        "welcomeMessage": {
+          "type": "string",
+          "description": "Plain (English) welcome string. NOTE: this is intentionally NOT localized — moving it into this data file drops the Crowdin per-language translation the app's string resources previously provided. Revisit when an upstream API / localization strategy is added."
+        },
+        "eventStart": {
+          "type": ["string", "null"],
+          "format": "date",
+          "description": "ISO-8601 date (YYYY-MM-DD) the event begins, interpreted in timeZone. Seed values are best-effort and change yearly; the upstream sync is expected to own them."
+        },
+        "eventEnd": {
+          "type": ["string", "null"],
+          "format": "date",
+          "description": "ISO-8601 date (YYYY-MM-DD) the event ends, interpreted in timeZone."
+        },
+        "timeZone": {
+          "type": ["string", "null"],
+          "description": "IANA time zone id (e.g. \"America/New_York\") so eventStart/eventEnd resolve in the event's local time, not the device's."
+        },
+        "location": {
+          "type": ["string", "null"],
+          "description": "Free-text venue/city for display, e.g. \"Las Vegas, Nevada, USA\"."
+        },
+        "iconUrl": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "URL of the event branding icon. Null when no hosted icon exists yet."
+        },
+        "accentColor": {
+          "type": ["string", "null"],
+          "pattern": "^#[0-9A-Fa-f]{6}$",
+          "description": "Brand/accent color (#RRGGBB) for ambient event theming."
+        },
+        "links": {
+          "type": "array",
+          "description": "Labeled links for the event (website, schedule, map, …).",
+          "items": { "$ref": "#/$defs/link" }
+        }
+      }
+    },
+    "link": {
+      "type": "object",
+      "required": ["label", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "label": { "type": "string", "description": "Display text for the link." },
+        "url": { "type": "string", "format": "uri", "description": "Destination URL." }
+      }
+    }
+  }
+}

--- a/schemas/event_firmware.schema.json
+++ b/schemas/event_firmware.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://meshtastic.org/schemas/event_firmware.schema.json",
   "title": "Event Firmware Metadata",
-  "description": "Offline-first display metadata for event-specific firmware editions. The bundled androidApp/src/main/assets/event_firmware.json is a frozen copy of a future Meshtastic API response (planned GET /resource/eventFirmware); it shares the {version, generatedAt, source, <payload>[]} envelope used by device_links.json so the network layer can drop-in replace it. Keyed (within each record) by the FirmwareEdition proto enum name.",
+  "description": "Offline-first display metadata for event-specific firmware editions. The bundled androidApp/src/main/assets/event_firmware.json shares the {version, generatedAt, source, <payload>[]} envelope used by device_links.json so a future Meshtastic API (planned GET /resource/eventFirmware) can reuse the same shape. Each record identifies its edition by the FirmwareEdition proto enum name in the `edition` field. This schema is the authoring contract for the bundled file and is bumped as the shape evolves; the runtime JSON parser is independently tolerant of unknown fields.",
   "type": "object",
   "required": ["version", "editions"],
   "additionalProperties": false,


### PR DESCRIPTION
Defines the offline-first data contract for event-specific firmware editions (Hamvention, Open Sauce, DEFCON, Burning Man), so the app can later drive event-specific UI/UX from data instead of the hardcoded `EventEdition.kt` mapping. **This PR is the contract only** — no app wiring and no upstream API endpoint yet (both deliberately follow-up).

🌟 **New Features**
- `schemas/event_firmware.schema.json` — JSON Schema (draft 2020-12) defining the contract: a `{version, generatedAt, source, editions[]}` envelope (mirroring `device_links.json`) where each record carries `edition` (the `FirmwareEdition` proto enum name), `displayName`, `welcomeMessage`, plus optional `eventStart`/`eventEnd`, `timeZone`, `location`, `iconUrl`, `accentColor`, and labeled `links`.
- `androidApp/src/main/assets/event_firmware.json` — bundled seed data for the 4 current editions. `displayName`/`welcomeMessage` reuse today's values; `eventStart`/`eventEnd`/`accentColor` are best-effort seed placeholders (events recur yearly — the upstream sync will own them); `iconUrl` is `null` (no hosted icons yet).

**Design notes**
- **Array-of-records**, not a map keyed by enum name, so the bundled file matches the shape a future `GET /resource/eventFirmware` response will use and deserializes cleanly into a `@Serializable` model later.
- `edition` is a regex `pattern`, not a fixed enum list, so adding a new event needs no schema change.
- `welcomeMessage` is a plain English string — this intentionally drops the Crowdin per-language localization the string resources provided; documented in the schema, to be revisited with the upstream API.

**Not in this PR (follow-ups)**
- Wiring the file into the app (model + loader + repository, migrating `EventEdition.kt`) and the upstream REST endpoint.
- A DRY-up of the repeated offline-first asset-loading boilerplate (a `BundledAssetReader` seam) — split into its own task, to land before the event-API wiring.
- Relaxing `additionalProperties`/`required` strictness once a real API + CI snapshot validation exist.

🧹 **Testing Performed**
- Validated the seed asset against the schema with `ajv` (draft 2020-12); a negative control (typo'd key) is correctly rejected by `additionalProperties:false`.
- Confirmed via `jq` that the 4 `edition` keys are real `FirmwareEdition` names and all fields are present.

<!--
If you have screenshots or recordings to display your change, please include them!
<img src="" width="300"/>
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)