### PR TITLE
fix(firmware): render chirpy mascot via painterResource in update dialog

### DIFF
--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
@@ -21,6 +21,7 @@ package org.meshtastic.feature.firmware
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
@@ -79,6 +80,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.mikepenz.markdown.m3.Markdown
 import kotlinx.coroutines.delay
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.common.util.CommonUri
 import org.meshtastic.core.database.entity.FirmwareRelease
@@ -531,12 +533,8 @@ private fun ChirpyCard() {
                 horizontalArrangement = spacedBy(4.dp),
             ) {
                 Text(text = "🪜", modifier = Modifier.size(48.dp), style = MaterialTheme.typography.headlineLarge)
-                AsyncImage(
-                    model =
-                    ImageRequest.Builder(LocalPlatformContext.current)
-                        .data(Res.drawable.img_chirpy)
-                        .crossfade(true)
-                        .build(),
+                Image(
+                    painter = painterResource(Res.drawable.img_chirpy),
                     contentScale = ContentScale.Fit,
                     contentDescription = stringResource(Res.string.chirpy),
                     modifier = Modifier.size(48.dp),


### PR DESCRIPTION
## Why

The "don't forget your ladder" dialog shown before a BLE firmware update displayed no chirpy mascot — the spot next to the 🪜 emoji was just blank. Root cause: `ChirpyCard` fed the bundled `img_chirpy` vector drawable to **Coil's `AsyncImage`**. Coil is a network/disk image loader and has no decoder for a Compose Multiplatform `DrawableResource` (an Android Vector `.xml` that compiles to an `ImageVector`), so it silently rendered nothing on every platform.

## Changes

🐛 **Bug Fixes**
- `FirmwareUpdateScreen.ChirpyCard`: render the bundled mascot with `Image(painterResource(Res.drawable.img_chirpy))` instead of `Coil AsyncImage`. This matches how the docs feature (`ChirpyFab`, `ChirpyAssistantSheet`) already renders the exact same asset, and `painterResource` handles the compiled vector drawable on **all platforms** (Android/Desktop/iOS) with no `ImageLoader` involved.

🧹 **Chores**
- Re-recorded the `ScreenshotFirmwareDisclaimer` Light/Dark CST baselines (and the `firmware_disclaimer.png` docs copy). The old baselines captured the blank chirpy from the broken Coil path; now that chirpy renders, the reference images are updated to match.

## Notes for reviewers

- Coil is **not** removed — it stays correct for the network path right below, where `DeviceHardwareImage` loads real `.svg` device images from `flasher.meshtastic.org` (`SvgDecoder.Factory` is registered on Android and Desktop). The four Coil imports are still in use by that composable.
- Swept the repo: this was the only place a bundled Compose `DrawableResource` was routed through Coil.

## Testing Performed

- `:feature:firmware:spotlessCheck`, `:feature:firmware:detekt`, `:feature:firmware:assemble` pass.
- `:screenshot-tests:validateDebugScreenshotTest`: failed on `ScreenshotFirmwareDisclaimer_{Light,Dark}` before the baseline re-record (chirpy now draws where the baseline was blank), passes after (246 tests, 0 failures). Verified the regenerated baseline visually shows chirpy beside the ladder.

<!--
If you have screenshots or recordings to display your change, please include them!

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->
