### PR TITLE
fix(usb): Suppress expected serial close warnings

### DIFF
--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
@@ -121,6 +121,14 @@ class SerialRadioTransport(
                         }
 
                         override fun onDisconnected(thrown: Exception?) {
+                            // Skip the disconnect callback when the reader-thread termination is the
+                            // direct result of an explicit close() — the caller owns the post-close
+                            // notification, and the expected close must not emit warning-log noise.
+                            // USB unplug / cable error is the only path that should log + forward a
+                            // transient disconnect here.
+                            if (explicitCloseInProgress.get()) {
+                                return
+                            }
                             val uptime =
                                 if (connectionStartTime > 0) {
                                     nowMillis - connectionStartTime
@@ -136,13 +144,6 @@ class SerialRadioTransport(
                                     "Device: $device, " +
                                     "Uptime: ${uptime}ms, " +
                                     "Packets RX: $packetsReceived ($bytesReceived bytes)"
-                            }
-                            // Skip the disconnect callback when the reader-thread termination is the
-                            // direct result of an explicit close() — the caller owns the post-close
-                            // notification. USB unplug / cable error is the only path that should
-                            // forward a transient disconnect here.
-                            if (explicitCloseInProgress.get()) {
-                                return
                             }
                             // USB unplug / cable error is transient — the transport will reconnect when
                             // the device is replugged or the OS re-enumerates the port. Only an explicit


### PR DESCRIPTION
## Overview

This pull request suppresses warning-log noise from expected USB serial closes.

After the USB replug recovery work, explicit serial transport shutdown correctly suppresses disconnect propagation, but the serial reader callback could still log scary warning messages before checking whether the disconnect was caused by an explicit `close()`. That made normal teardown look like an unexpected USB/cable failure.

This change moves the explicit-close guard to the top of `SerialRadioTransport.onDisconnected(...)`, before uptime calculation and warning logging.

## Key Changes

- Return early from `SerialRadioTransport.onDisconnected(...)` when `explicitCloseInProgress` is set.
- Avoid warning logs for expected reader-thread termination during explicit `close()`.
- Preserve warning logs and transient disconnect forwarding for real USB unplug, cable, or I/O failures.
- Keep service-layer close semantics unchanged.

## Testing

- Existing USB recovery behavior remains unchanged.

## Migration Notes

- No API changes.
- No behavior change for unexpected USB disconnects.
- This PR should land before a USB permission-denial follow-up, which touches the same callback path.