### PR TITLE
fix(data): Persist TAK module config

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigHandlerImpl.kt
@@ -130,5 +130,6 @@ private fun ModuleConfig.summarize(): String = when {
     detection_sensor != null -> "detection_sensor"
     paxcounter != null -> "paxcounter"
     statusmessage != null -> "statusmessage"
+    tak != null -> "tak"
     else -> "unknown"
 }

--- a/core/datastore/src/commonMain/kotlin/org/meshtastic/core/datastore/ModuleConfigDataSource.kt
+++ b/core/datastore/src/commonMain/kotlin/org/meshtastic/core/datastore/ModuleConfigDataSource.kt
@@ -47,6 +47,7 @@ class ModuleConfigDataSource(
     }
 
     /** Updates [LocalModuleConfig] from each [ModuleConfig] oneOf. */
+    @Suppress("CyclomaticComplexMethod")
     suspend fun setLocalModuleConfig(config: ModuleConfig) = moduleConfigStore.updateData { current ->
         when {
             config.mqtt != null -> current.copy(mqtt = config.mqtt)
@@ -77,6 +78,8 @@ class ModuleConfigDataSource(
             config.paxcounter != null -> current.copy(paxcounter = config.paxcounter)
 
             config.statusmessage != null -> current.copy(statusmessage = config.statusmessage)
+
+            config.tak != null -> current.copy(tak = config.tak)
 
             else -> current
         }


### PR DESCRIPTION
## Overview

This pull request fixes TAK module configuration persistence.

Received TAK module configs were handled by the generated protobuf model, but `ModuleConfigDataSource.setLocalModuleConfig(...)` did not copy the TAK branch into `LocalModuleConfig`. As a result, TAK config updates could be received but not persisted locally. The module-config debug summary also did not recognize TAK configs and reported them as `unknown`.

## Key Changes

- Persist `config.tak` into `LocalModuleConfig`.
- Label TAK module configs as `tak` in `MeshConfigHandlerImpl` summaries.
- Add the required cyclomatic-complexity suppression to match the existing oneOf branch structure.

## Testing

- This mirrors the existing type-safe per-variant persistence branches.
- The change is compiler-checked against the generated protobuf accessors.
- Existing CI coverage is sufficient for this small persistence fix.

## Migration Notes

- No protobuf changes.
- No generated files changed.
- No DataStore migration required.