### PR TITLE
refactor(core:ui): drop redundant SinglePaneSceneStrategy from NavDisplay

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
@@ -40,7 +40,6 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.scene.DialogSceneStrategy
 import androidx.navigation3.scene.Scene
-import androidx.navigation3.scene.SinglePaneSceneStrategy
 import androidx.navigation3.ui.NavDisplay
 import org.meshtastic.core.navigation.MultiBackstack
 
@@ -129,13 +128,8 @@ fun MeshtasticNavDisplay(
                         backStack.removeLastOrNull()
                     }
                 },
-            sceneStrategies =
-            listOf(
-                DialogSceneStrategy(),
-                listDetailSceneStrategy,
-                supportingPaneSceneStrategy,
-                SinglePaneSceneStrategy(),
-            ),
+            // NavDisplay falls back to SinglePaneSceneStrategy automatically when none of these compute a Scene.
+            sceneStrategies = listOf(DialogSceneStrategy(), listDetailSceneStrategy, supportingPaneSceneStrategy),
             sharedTransitionScope = this@SharedTransitionLayout,
             transitionSpec = meshtasticTransitionSpec(),
             popTransitionSpec = meshtasticTransitionSpec(),


### PR DESCRIPTION
## Why

`MeshtasticNavDisplay` explicitly listed `SinglePaneSceneStrategy()` as the last entry in its `sceneStrategies` chain. Per the current [Navigation 3 scenes guidance](https://developer.android.com/guide/navigation/navigation-3/scenes), `NavDisplay` *already* falls back to `SinglePaneSceneStrategy` automatically when none of the supplied strategies compute a `Scene` (the `sceneStrategy` param defaults to it). The explicit entry — and its import — were therefore dead weight.

This came out of a best-practice audit of our Compose/Nav3/Material3 stack against the latest mid-2026 official docs. The rest of the audit found our nav code (the per-tab `MultiBackstack`, the entry-decorator wiring, the adaptive list-detail/supporting-pane strategies) already matches current official guidance, so this redundant strategy was the only actionable cleanup.

## 🧹 Cleanup

- Remove the explicit `SinglePaneSceneStrategy()` from the `sceneStrategies` list and its now-unused import.
- Add a one-line comment documenting the automatic fallback so it isn't reintroduced.

Behavior-preserving — the resolved strategy chain is unchanged.

## Testing Performed

- `:core:ui:detekt` — pass
- `:core:ui:allTests` — pass (185 tests)
- `:core:ui:spotlessCheck` — pass

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>
-->