### PR TITLE
feat(lora): gate region→preset map + TINY presets on firmware capability

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
@@ -69,6 +69,12 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
     val supportsEsp32Ota = atLeast(V2_7_18)
 
     /**
+     * Support for the LoRa region→preset compatibility map and TINY presets. Supported since firmware v2.8.0. Older
+     * firmware never sends the map, so the UI keeps the preset list unconstrained and hides the new presets.
+     */
+    val supportsLoraRegionPresetMap = atLeast(V2_8_0)
+
+    /**
      * Support for runtime lockdown mode (per-connection passphrase auth). Supported since firmware v2.8.0. Note:
      * lockdown is also hardware-gated (nRF52 only) — the device advertises real support by sending a `LockdownStatus`,
      * which is the authoritative signal and drives the actual UI state.

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -27,9 +27,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.model.Capabilities
 import org.meshtastic.core.model.Channel
 import org.meshtastic.core.model.ChannelOption
 import org.meshtastic.core.model.RegionInfo
+import org.meshtastic.core.model.RegionPresetConstraint
 import org.meshtastic.core.model.constraintFor
 import org.meshtastic.core.model.numChannels
 import org.meshtastic.core.model.repairPresetFor
@@ -67,9 +69,38 @@ import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.feature.settings.util.hopLimits
 import org.meshtastic.proto.Config
+import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
 
 private val SPREAD_FACTOR_RANGE = 7..12
 private val CODING_RATE_RANGE = 5..8
+
+/**
+ * Builds the modem-preset dropdown items: hide the 2.8-only TINY presets on firmware without
+ * [Capabilities.supportsLoraRegionPresetMap], restrict to the region's legal presets (R7), then always keep the current
+ * selection present (disabled) so the field is never blank when the device's preset is illegal for the region.
+ */
+private fun buildPresetItems(
+    presetConstraint: RegionPresetConstraint?,
+    presetsGated: Boolean,
+    selectedPreset: ModemPreset,
+    capabilities: Capabilities,
+): List<DropDownItem<ModemPreset>> {
+    val items =
+        ChannelOption.entries
+            .filter { option ->
+                capabilities.supportsLoraRegionPresetMap ||
+                    (option != ChannelOption.TINY_FAST && option != ChannelOption.TINY_SLOW)
+            }
+            .filter { option -> presetConstraint == null || option.modemPreset in presetConstraint.presets }
+            .map { option ->
+                DropDownItem(value = option.modemPreset, label = option.modemPreset.name, enabled = !presetsGated)
+            }
+    return if (items.any { it.value == selectedPreset }) {
+        items
+    } else {
+        items + DropDownItem(value = selectedPreset, label = selectedPreset.name, enabled = false)
+    }
+}
 
 @Composable
 fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
@@ -109,9 +140,13 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     ) {
         item {
             TitledCard(title = stringResource(Res.string.options)) {
-                // Region→preset legality map only constrains the locally connected device (R10); for remote admin
-                // there is no map for the remote node, so leave the preset list unconstrained.
-                val regionPresetMap = if (state.isLocal) state.loraRegionPresetMap else null
+                // The region→preset legality map is a function of firmware version + region, not of the device
+                // instance, so the locally-cached map (from our own handshake) is reused for remote admin too. Gated
+                // on the *target* node's firmware capability (metadata is per-target): pre-2.8 nodes don't get the
+                // map or the new TINY presets, which also keeps older remotes unconstrained.
+                val capabilities =
+                    remember(state.metadata?.firmware_version) { Capabilities(state.metadata?.firmware_version) }
+                val regionPresetMap = if (capabilities.supportsLoraRegionPresetMap) state.loraRegionPresetMap else null
                 val presetConstraint =
                     remember(regionPresetMap, formState.value.region) {
                         regionPresetMap.constraintFor(formState.value.region)
@@ -145,27 +180,8 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     // device is flagged as a licensed operator (R8).
                     val selectedPreset = formState.value.modem_preset
                     val presetItems =
-                        remember(presetConstraint, presetsGated, selectedPreset) {
-                            val items =
-                                ChannelOption.entries
-                                    .filter { option ->
-                                        presetConstraint == null || option.modemPreset in presetConstraint.presets
-                                    }
-                                    .map { option ->
-                                        DropDownItem(
-                                            value = option.modemPreset,
-                                            label = option.modemPreset.name,
-                                            enabled = !presetsGated,
-                                        )
-                                    }
-                            // Always keep the current selection present (disabled) so the field is never blank when
-                            // the device's preset is illegal for the selected region.
-                            if (items.any { it.value == selectedPreset }) {
-                                items
-                            } else {
-                                items +
-                                    DropDownItem(value = selectedPreset, label = selectedPreset.name, enabled = false)
-                            }
+                        remember(presetConstraint, presetsGated, selectedPreset, capabilities) {
+                            buildPresetItems(presetConstraint, presetsGated, selectedPreset, capabilities)
                         }
                     DropDownPreference(
                         title = stringResource(Res.string.modem_preset),


### PR DESCRIPTION
Firmware older than 2.8 has no concept of the LoRa region→preset legality map (protobufs #951) or the new `TINY_FAST`/`TINY_SLOW` presets. Surfacing them on a pre-2.8 node invites confusion — e.g. narrow presets appearing as legal options on the US region — so this gates both behind a firmware capability, per the follow-up discussed on Discord.

## 🌟 New Features
- Add `Capabilities.supportsLoraRegionPresetMap` (firmware ≥ 2.8.0) to centralize the gate alongside the other firmware feature flags.

## 🛠️ Refactoring & Architecture
- `LoRaConfigScreen`: apply the region→preset map and hide the `TINY_FAST`/`TINY_SLOW` presets only when the **target** node's firmware supports them. The capability is built from `state.metadata.firmware_version`, which is per-target, so remote admin is gated on the *remote* node's firmware rather than the locally-connected device.
- The legality map is a function of firmware version + region (not the device instance), so the locally-cached map is reused for remote admin once the remote node is known to support it — this drops the prior local-only gate, which was overly conservative.
- Extracted preset-list construction into a `buildPresetItems` helper to keep `LoRaConfigScreen` under the detekt cyclomatic-complexity limit.

### Behavior
- **Local or remote ≥ 2.8** → constrained preset list + TINY presets, using the cached legality map.
- **< 2.8, or target metadata not yet fetched** → unconstrained list, TINY hidden (conservative default; firmware still enforces its own rules).

## Testing Performed
No new tests — the change is a UI gate over existing logic. Verified locally:
- `:core:model:allTests` (32 tests) pass.
- `spotlessCheck`, `detekt`, and `:feature:settings:compileAndroidMain` pass.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->