### PR TITLE
chore(deps): re-pin protobufs to v-less snapshot 2.7.26-4b8d665-SNAPSHOT, drop resolution override

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,27 +59,3 @@ plugins.withId("org.meshtastic.flatpak.sources") {
 dependencies {
     dokkaPlugin(libs.dokka.android.documentation.plugin)
 }
-
-// ─── TEMPORARY: protobufs commit-pinned snapshot preview (PR #5834) ──────────────────────────────
-// We track the unreleased protobufs snapshot v2.7.26-497cd88-SNAPSHOT for the LoRa region→preset map (#951).
-// protobufs #959 switched RB snapshot publishing to immutable per-commit vX.Y.Z-{shorthash}-SNAPSHOT
-// coordinates; pin the exact one rather than the moving develop-SNAPSHOT.
-// takpacket-sdk:0.7.0 STILL transitively pins protobufs:2.7.25 (verified against its POM), and
-// Gradle ranks 2.7.25 > v2.7.26-…-SNAPSHOT (the numeric "2" outranks the "v2" string qualifier).
-// That downgrades the test *runtime* classpath to 2.7.25 while the common-metadata *compile* uses
-// the snapshot, yielding NoSuchFieldError/NoSuchMethodError on the proto-generated classes at test
-// runtime (assembleDebug/detekt don't catch it; test/allTests do). Force every protobufs* variant
-// to the snapshot so compile and runtime agree. Safe because atak.proto is unchanged, so takpacket's
-// own message ABI stays compatible with the newer protobufs.
-// REMOVE once protobufs cuts a tagged release containing #951 (re-pin the catalog to it) — and,
-// ideally, once takpacket-sdk is republished against that release.
-allprojects {
-    configurations.all {
-        resolutionStrategy.eachDependency {
-            if (requested.group == "org.meshtastic" && requested.name.startsWith("protobufs")) {
-                useVersion("v2.7.26-497cd88-SNAPSHOT")
-                because("preview #5834: override takpacket transitive protobufs:2.7.25 pin")
-            }
-        }
-    }
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,7 +95,7 @@ mqttastic = "0.4.0"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
 takpacket-sdk = "0.7.0"
-meshtastic-protobufs = "v2.7.26-497cd88-SNAPSHOT"
+meshtastic-protobufs = "2.7.26-4b8d665-SNAPSHOT"
 
 # Gradle Plugins
 develocity = "4.4.3"


### PR DESCRIPTION
protobufs [#960](https://github.com/meshtastic/protobufs/pull/960) dropped the leading `v` from per-commit KMP snapshot coordinates, fixing a Maven/Gradle version-ordering problem in how this app consumed the snapshot. This PR re-pins to the corrected coordinate and removes the workaround that the broken ordering required.

## Why

The old pin `v2.7.26-497cd88-SNAPSHOT` had a leading `v`, which Maven/Gradle treat as a non-numeric qualifier — so the whole string sorted *below* every numeric release. Two consequences:

- Renovate proposed a **downgrade** to the latest plain release `2.7.25` (#5938).
- takpacket-sdk's transitive `protobufs:2.7.25` outranked the snapshot on the test *runtime* classpath, which required a `resolutionStrategy` override in `build.gradle.kts` to keep the compile and runtime proto ABI in sync.

protobufs #960 publishes the v-less form `2.7.26-4b8d665-SNAPSHOT`. The short-SHA is a build qualifier that Maven/Gradle sort *above* the base release, so it now ranks above `2.7.25` and the override is no longer needed.

## 🧹 Chores

- Re-pin `org.meshtastic:protobufs` → `2.7.26-4b8d665-SNAPSHOT` (`gradle/libs.versions.toml`). Same proto content as the prior pin — `4b8d665` is `497cd88` plus #960's CI/README-only change.
- Remove the now-redundant `resolutionStrategy.eachDependency` override from `build.gradle.kts` (−24 lines); Gradle selects the snapshot over takpacket's transitive `2.7.25` natively.

Follow-on: this makes Renovate PR #5938 a no-op (the v-less coordinate sorts above `2.7.25`), so it can be closed.

## Testing Performed

- `dependencyInsight` on `core:model` (the sole takpacket consumer): test runtime resolves `protobufs-jvm` → `2.7.26-4b8d665-SNAPSHOT`, not `2.7.25`.
- `:core:model:allTests` — green, no `NoSuchField`/`NoSuchMethod` ABI errors.
- Full baseline `spotlessApply spotlessCheck detekt assembleDebug test allTests` — BUILD SUCCESSFUL.

<!--
If you have screenshots or recordings to display your change, please include them!

<img src="" width="300"/>
-->
