### PR TITLE
refactor(ble): Make Kable connect fallback explicitly bounded

### DIFF
--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -85,9 +85,10 @@ class KableBleService(private val peripheral: Peripheral, private val serviceUui
  *
  * Manages peripheral lifecycle, connection state tracking, and GATT service profile access.
  *
- * Connection attempts follow Kable's recommended pattern from the SensorTag sample: try a direct connect first, then
- * fall back to `autoConnect = true` on failure. Only two attempts are made per [connect] call — the caller
- * ([BleRadioTransport]) owns the macro-level retry/backoff loop.
+ * Connection attempts follow Kable's recommended pattern from the SensorTag sample: use a direct connect when a fresh
+ * advertisement is available, then fall back to `autoConnect = true` on failure. Advertisement-less devices start on
+ * the `autoConnect` path. At most two attempts are made per [connect] call — the caller ([BleRadioTransport]) owns the
+ * macro-level retry/backoff loop.
  */
 class KableBleConnection(private val scope: CoroutineScope, private val loggingConfig: BleLoggingConfig) :
     BleConnection {
@@ -113,7 +114,7 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
         MutableStateFlow<BleConnectionState>(BleConnectionState.Disconnected(DisconnectReason.Unknown))
     override val connectionState: StateFlow<BleConnectionState> = _connectionState.asStateFlow()
 
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod", "ThrowsCount")
     override suspend fun connect(device: BleDevice) {
         val meshtasticDevice = device as? MeshtasticBleDevice ?: error("Unsupported BleDevice type: ${device::class}")
         var autoConnect = meshtasticDevice.advertisement == null
@@ -161,7 +162,11 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
                 }
                 .launchIn(scope)
 
-        while (p.state.value !is State.Connected) {
+        // Bounded to at most two attempts: direct connect, then autoConnect fallback when a fresh
+        // advertisement was available. Advertisement-less devices start on the autoConnect path.
+        // The outer reconnect loop (BleRadioTransport) owns the macro retry budget — see class kdoc.
+        repeat(2) {
+            if (p.state.value is State.Connected) return
             autoConnect =
                 try {
                     connectionScope?.let { oldScope ->
@@ -186,6 +191,16 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
                     delay(AUTOCONNECT_FALLBACK_DELAY)
                     true
                 }
+        }
+        // Bounded loop may exit without reaching Connected if both connect() calls
+        // returned without throwing but state hasn't settled. The original while loop
+        // would have kept iterating; the bounded loop defers to the outer reconnect policy.
+        // Guard against false-positive Connected by verifying state here.
+        if (p.state.value !is State.Connected) {
+            _connectionState.emit(BleConnectionState.Disconnected(DisconnectReason.ConnectionFailed))
+            throw NotConnectedException(
+                "Failed to establish connection after bounded attempts (state=${p.state.value})",
+            )
         }
     }
 

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleReconnectPolicyTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleReconnectPolicyTest.kt
@@ -245,6 +245,63 @@ class BleReconnectPolicyTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
+    fun `execute reaches recovery after repeated inner connect failures`() = runTest {
+        val failedInnerCyclesBeforeRecovery = 5
+        val maxFailuresAfterRecovery = 7
+        val policy =
+            BleReconnectPolicy(
+                maxFailures = maxFailuresAfterRecovery,
+                failureThreshold = 3,
+                settleDelay = 1.milliseconds,
+                backoffStrategy = { 1.milliseconds },
+            )
+        var attemptCount = 0
+        var reachedRecoveryAttempt = false
+        var transientBeforeRecovery = 0
+        var transientAfterRecovery = 0
+        var permanentCalled = false
+
+        policy.execute(
+            attempt = {
+                attemptCount++
+                when {
+                    attemptCount <= failedInnerCyclesBeforeRecovery ->
+                        BleReconnectPolicy.Outcome.Failed(
+                            RuntimeException("bounded inner Kable cycle #$attemptCount failed"),
+                        )
+
+                    !reachedRecoveryAttempt -> {
+                        reachedRecoveryAttempt = true
+                        BleReconnectPolicy.Outcome.Disconnected(wasStable = true, wasIntentional = false)
+                    }
+
+                    else -> BleReconnectPolicy.Outcome.Failed(RuntimeException("post-recovery failure"))
+                }
+            },
+            onTransientDisconnect = {
+                if (reachedRecoveryAttempt) {
+                    transientAfterRecovery++
+                } else {
+                    transientBeforeRecovery++
+                }
+            },
+            onPermanentDisconnect = { permanentCalled = true },
+        )
+
+        assertTrue(reachedRecoveryAttempt, "outer reconnect must reach a later successful connection attempt")
+        assertEquals(
+            failedInnerCyclesBeforeRecovery + 1 + maxFailuresAfterRecovery,
+            attemptCount,
+            "outer reconnect should continue through failed inner cycles before and after recovery",
+        )
+        assertEquals(3, transientBeforeRecovery, "failures at threshold and above should signal transient state")
+        assertEquals(4, transientAfterRecovery, "stable recovery should reset the failure threshold")
+        assertTrue(permanentCalled, "finite maxFailures is used only to terminate this test")
+        assertEquals(maxFailuresAfterRecovery, policy.consecutiveFailures)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
     fun `execute stops when coroutine is cancelled`() = runTest {
         var attemptCount = 0
         val policy =


### PR DESCRIPTION
## Overview

This pull request makes the BLE Kable connection fallback policy explicit inside `KableBleConnection.connect(...)`.

Before this change, the direct-connect → autoConnect fallback behavior was encoded as a `while (state != Connected)` loop with an internal `autoConnect` flag flip. The intended behavior was bounded, but a reader had to trace mutable state to verify that each `connect(...)` call only attempts the direct path and then the autoConnect fallback.

This change makes that invariant structural: each `connect(...)` call performs at most two inner Kable attempts, while `BleRadioTransport` remains responsible for the outer reconnect/backoff loop.

## Key Changes

- Replaced the implicit `while (state != Connected)` retry structure with an explicit bounded loop.
- Preserved the existing connection order:
  - direct connect first when a fresh advertisement is available,
  - autoConnect fallback second,
  - advertisement-less devices start on the autoConnect path.
- Added a final state check so `connect(...)` cannot report success unless Kable reached `Connected`.
- Kept macro reconnect/backoff ownership in `BleRadioTransport`.
- Updated `KableBleConnection` documentation to describe the inner fallback policy.
- Added focused coverage proving repeated bounded inner failures do not stop the outer reconnect policy from reaching a later successful attempt.

## Testing

- Added `BleReconnectPolicyTest` coverage for repeated connection failures followed by recovery.
- Verified the outer reconnect policy continues after repeated failed inner connection attempts.

## Migration Notes

- No user data migration is required.
- No BLE address format changes are introduced.
- The outer BLE reconnect/backoff policy remains unchanged.