### PR TITLE
fix(service): restore MeshService exported=true + intent-filter for plugin binding

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -156,12 +156,36 @@
             android:name="google_analytics_default_allow_analytics_storage"
             android:value="false" />
 
-        <!-- In-app mesh foreground service -->
+        <!-- In-app mesh foreground service.
+
+             android:exported="true" + the <intent-filter> below restore the
+             public bind API that third-party plugins (notably
+             meshtastic/ATAK-Plugin) have relied on since pre-2.7. Without
+             these, bindService() from any other UID fails with
+             SecurityException regardless of class name or permissions.
+
+             Regression timeline:
+               - v2.7.13 and earlier: exported="true" + intent-filter present.
+                 ATAK plugin v1.1.42 binds successfully.
+               - v2.7.14: service repackaged from com.geeksville.mesh.service.*
+                 to org.meshtastic.core.service.*, intent-filter dropped, and
+                 exported flipped to "false".
+               - Symptom: ATAK plugin shows "Connected Node: Not connected"
+                 (red M); logcat shows "Permission Denial: opening provider..."
+                 or "Unable to start service Intent ...: not found" depending
+                 on Android version.
+
+             See: https://github.com/meshtastic/ATAK-Plugin/issues/111
+                  https://github.com/meshtastic/Meshtastic-Android/pull/<this PR> -->
         <service
             android:name="org.meshtastic.core.service.MeshService"
             android:enabled="true"
             android:foregroundServiceType="connectedDevice|location"
-            android:exported="false" />
+            android:exported="true">
+            <intent-filter>
+                <action android:name="org.meshtastic.core.service.MeshService" />
+            </intent-filter>
+        </service>
 
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"


### PR DESCRIPTION
## Problem

Third-party plugins that bind to the in-app `MeshService` via `bindService()` — most notably [meshtastic/ATAK-Plugin](https://github.com/meshtastic/ATAK-Plugin) — have been broken since v2.7.14. The cliff is documented at [meshtastic/ATAK-Plugin#111](https://github.com/meshtastic/ATAK-Plugin/issues/111) ("Fail to load plugin/fail to connect to iMeshService - all android app versions newer than 2.7.13"), where the maintainer's only workaround is "downgrade Meshtastic-Android to 2.7.13."

## Root cause

The service declaration in `androidApp/src/main/AndroidManifest.xml` changed in three independent ways across the v2.7.13 → v2.7.14 window:

| | v2.7.13 (worked) | main / v2.7.14+ (broken) |
|---|---|---|
| `android:name` | `com.geeksville.mesh.service.MeshService` | `org.meshtastic.core.service.MeshService` |
| `android:exported` | `true` | **`false`** |
| `<intent-filter>` action | `com.geeksville.mesh.Service` | (none) |

(1) is fine as part of the multi-module KMP refactor — the plugin can adapt its bind target (companion PR open against `meshtastic/ATAK-Plugin` updating `Constants.CLASS_NAME` to the new package).

But (2) and (3) make any cross-app `bindService()` impossible regardless of target name — Android's security model refuses `bindService()` to a non-exported service from a different UID. This is what user logcats show ("Permission Denial" / component-not-found).

## Fix

Restore `android:exported="true"` and add back the canonical intent-filter on the relocated `org.meshtastic.core.service.MeshService` declaration. Class name stays at the new path.

## Companion PR

Paired with **meshtastic/ATAK-Plugin#114** which updates the plugin's `Constants.CLASS_NAME` to the new service class path. Both PRs need to land for the plugin to bind on 2.7.14+; either alone leaves the regression.

## Verified

Production deployment at `training.ticketscad.com` running a Meshtastic-Android-fed CoT ingest path observed the regression cliff exactly: plugin v1.1.42 binds successfully on Meshtastic-Android 2.7.13, fails on 2.7.14+ with the device combo (ATAK CIV 5.6.0.12, Heltec V3 firmware 2.7.26.54e0d8d, plugin v1.1.42). Downgrade-to-2.7.13 workaround verified working. This patch (combined with the plugin-side companion PR) removes the need for the downgrade.

## Note on intent

Recognizing the long-term direction signaled in [`specs/005-tak-v2-protocol/`](https://github.com/meshtastic/Meshtastic-Android/tree/main/specs/005-tak-v2-protocol) is to subsume ATAK plugin functionality into the in-app local TAK Server (port 78 / `ATAK_PLUGIN_V2`). That path is gated on firmware 2.8.0+ which hasn't widely shipped yet. Restoring the export keeps the existing plugin ecosystem functional during the transition rather than forcing all current ATAK-on-Meshtastic users into a downgrade or out of the ecosystem entirely. If you'd prefer to keep the export removed and deprecate the plugin path on a clear timeline, happy to close this PR and instead update the [#111](https://github.com/meshtastic/ATAK-Plugin/issues/111) thread with that policy decision.