### PR TITLE
fix(docs): preserve #anchor when rewriting sibling links for Docusaurus

### DIFF
--- a/scripts/sync-android-docs.js
+++ b/scripts/sync-android-docs.js
@@ -127,8 +127,16 @@ function rewriteSiblingLinks(content, section, isIndex = false) {
     return content.replace(
         /\[([^\]]*)\]\((?!https?:\/\/)(?!#)([^)]+)\)/g,
         (match, text, link) => {
+            // Split off a trailing #anchor (or ?query) so it survives the .md rewrite.
+            // Source links like `node-metrics#air-quality-metrics` must become
+            // `node-metrics.md#air-quality-metrics`, else Docusaurus resolves the slug
+            // as a sub-path of the current page and the build fails on a broken link.
+            const splitIdx = link.search(/[#?]/);
+            const linkPath = splitIdx >= 0 ? link.slice(0, splitIdx) : link;
+            const suffix = splitIdx >= 0 ? link.slice(splitIdx) : "";
+
             // Skip if already has .md extension or is an image
-            if (link.endsWith(".md") || IMAGE_EXTENSIONS.has(path.extname(link).toLowerCase())) {
+            if (linkPath.endsWith(".md") || IMAGE_EXTENSIONS.has(path.extname(linkPath).toLowerCase())) {
                 return match;
             }
 
@@ -136,26 +144,26 @@ function rewriteSiblingLinks(content, section, isIndex = false) {
             // user.md/developer.md sit beside the section dir, so they link to children
             // as "user/onboarding". From index.md inside that dir, strip the prefix.
             if (isIndex) {
-                const sameSection = link.match(new RegExp(`^${section}/(.+)`));
+                const sameSection = linkPath.match(new RegExp(`^${section}/(.+)`));
                 if (sameSection && slugs.has(sameSection[1])) {
-                    return `[${text}](${sameSection[1]}.md)`;
+                    return `[${text}](${sameSection[1]}.md${suffix})`;
                 }
             }
 
             // Check for cross-section links like ../developer/testing
-            const crossMatch = link.match(/^\.\.\/(\w+)\/(.+)/);
+            const crossMatch = linkPath.match(/^\.\.\/(\w+)\/(.+)/);
             if (crossMatch) {
                 const [, targetSection, slug] = crossMatch;
                 const targetSlugs = targetSection === "user" ? KNOWN_USER_SLUGS : KNOWN_DEV_SLUGS;
                 if (targetSlugs.has(slug)) {
-                    return `[${text}](../${targetSection}/${slug}.md)`;
+                    return `[${text}](../${targetSection}/${slug}.md${suffix})`;
                 }
             }
 
             // Check for sibling links
-            const bare = link.replace(/^\.\//, "");
+            const bare = linkPath.replace(/^\.\//, "");
             if (slugs.has(bare)) {
-                return `[${text}](${bare}.md)`;
+                return `[${text}](${bare}.md${suffix})`;
             }
 
             return match;


### PR DESCRIPTION
## Problem
`scripts/sync-android-docs.js` rewrites bare sibling slugs to `.md` so Docusaurus resolves them as pages. But `rewriteSiblingLinks` matched the **whole** link against the known-slug set, so a link with an anchor — `node-metrics#air-quality-metrics` (in `docs/en/user/telemetry-and-sensors.md`) — never matched and kept its bare slug.

Docusaurus then resolved it as a sub-path of the current page (`.../telemetry-and-sensors/node-metrics/#air-quality-metrics`) and **failed the meshtastic.org docs build** with a broken link (`onBrokenLinks: throw`). This breaks the auto-generated sync PR every time.

## Fix
Split off a trailing `#anchor` / `?query` before the slug lookups, then re-append it after inserting `.md`:

```
node-metrics#air-quality-metrics → node-metrics.md#air-quality-metrics
```

Covers all three link forms the rewriter handles (index landing, cross-section `../developer/x`, and sibling).

## Verification
Re-ran the sync against current `main` docs: the link now emits `.md#air-quality-metrics`, and a sweep finds no remaining slug-with-anchor links missing `.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)