### PR TITLE
fix(ble): Stop transport connect after failed bonding

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RadioNotConnectedException.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RadioNotConnectedException.kt
@@ -17,4 +17,5 @@
 package org.meshtastic.core.model
 
 /** Exception thrown when an operation is attempted while not connected to a mesh radio. */
-open class RadioNotConnectedException(message: String = "Not connected to radio") : Exception(message)
+open class RadioNotConnectedException(message: String = "Not connected to radio", cause: Throwable? = null) :
+    Exception(message, cause)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -358,21 +358,7 @@ class BleRadioTransport(
 
         val device = findDevice()
 
-        // Bond before connecting: firmware may require an encrypted link,
-        // and without a bond Android fails with status 5 or 133.
-        // No-op on Desktop/JVM where the OS handles pairing automatically.
-        if (!bluetoothRepository.isBonded(address)) {
-            Logger.i { "[$address] Device not bonded, initiating bonding" }
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                bluetoothRepository.bond(device)
-                Logger.i { "[$address] Bonding successful" }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Logger.w(e) { "[$address] Bonding failed, attempting connection anyway" }
-            }
-        }
+        bondDeviceBeforeConnect(device)
 
         val state = bleConnection.connectAndAwait(device, CONNECTION_TIMEOUT)
 
@@ -468,6 +454,30 @@ class BleRadioTransport(
         }
 
         return BleReconnectPolicy.Outcome.Disconnected(wasStable = wasStable, wasIntentional = wasIntentional)
+    }
+
+    private suspend fun bondDeviceBeforeConnect(device: BleDevice) {
+        if (bluetoothRepository.isBonded(address)) return
+
+        // Bond before connecting: firmware may require an encrypted link, and without a bond Android fails with
+        // status 5 or 133. Non-Android targets use repository-specific no-op behavior.
+        Logger.i { "[$address] Device not bonded, initiating bonding" }
+        try {
+            bluetoothRepository.bond(device)
+            Logger.i { "[$address] Bonding successful" }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // bond() failed. Android may still have recorded the bond, in which case we can safely continue into GATT
+            // setup. If the device is still not bonded, continuing would fail later with a cryptic status (5/133), so
+            // stop now and let BleReconnectPolicy own the retry/backoff.
+            if (bluetoothRepository.isBonded(address)) {
+                Logger.w(e) { "[$address] Bonding reported failure but device is bonded; continuing" }
+            } else {
+                Logger.w(e) { "[$address] Bonding failed and device is still not bonded; stopping connection attempt" }
+                throw RadioNotConnectedException("Bonding failed and device is still not bonded", e)
+            }
+        }
     }
 
     private suspend fun onConnected() {

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -23,6 +23,7 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
@@ -37,6 +38,8 @@ import org.meshtastic.core.testing.FakeBleConnectionFactory
 import org.meshtastic.core.testing.FakeBleDevice
 import org.meshtastic.core.testing.FakeBleScanner
 import org.meshtastic.core.testing.FakeBluetoothRepository
+import org.meshtastic.core.testing.failBondAfterRecording
+import org.meshtastic.core.testing.failBondWith
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -259,6 +262,129 @@ class BleRadioTransportTest {
             assertNotNull(scanner.lastScanServiceUuid, "scan must include serviceUuid")
             assertEquals(SERVICE_UUID, scanner.lastScanServiceUuid)
             assertEquals(address, scanner.lastScanAddress)
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    // --- Transport-side bond failure handling ---
+
+    @Test
+    fun `bond succeeds then connectAndAwait is called`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        scanner.emitDevice(device)
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        try {
+            advanceTimeBy(3_001)
+            assertEquals(1, bluetoothRepository.bondCalls.size, "bond() must be called before connecting")
+            assertEquals(1, connection.connectAndAwaitCalls, "connectAndAwait must be called after successful bond")
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    @Test
+    fun `bond throws but device is bonded then connectAndAwait is still called`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        scanner.emitDevice(device)
+        bluetoothRepository.failBondAfterRecording(Exception("bond flaked"))
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        try {
+            advanceTimeBy(3_001)
+            assertEquals(1, bluetoothRepository.bondCalls.size, "bond() must be attempted before connecting")
+            assertEquals(
+                1,
+                connection.connectAndAwaitCalls,
+                "connectAndAwait must be called when bond flaked but device is bonded",
+            )
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    @Test
+    fun `bond throws and device not bonded then connectAndAwait is not called`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        scanner.emitDevice(device)
+        bluetoothRepository.failBondWith(Exception("bond rejected"))
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        try {
+            // Advance past one failed bond attempt and retry backoff, but before the next bond attempt.
+            advanceTimeBy(10_001)
+            assertEquals(
+                0,
+                connection.connectAndAwaitCalls,
+                "connectAndAwait must not be called when bond failed and device is not bonded",
+            )
+            assertEquals(1, bluetoothRepository.bondCalls.size, "bond() must have been attempted once")
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    /**
+     * When [bluetoothRepository.bond] throws a [CancellationException], it must propagate as coroutine cancellation —
+     * NOT be swallowed into a generic [BleReconnectPolicy.Outcome.Failed].
+     *
+     * Discriminator: with the `catch (CancellationException) { throw e }` guard present, the job is cancelled and bond
+     * is called exactly once. If the guard were removed, the CE would be caught by `catch (Exception)`, converted to
+     * `RadioNotConnectedException`, become `Outcome.Failed`, and the policy would retry — making `bondCalls.size > 1`.
+     */
+    @Test
+    fun `CancellationException from bond cancels the connection job without retrying`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        scanner.emitDevice(device)
+        bluetoothRepository.bondOutcome =
+            FakeBluetoothRepository.BondOutcome.Fail(CancellationException("simulated cancel"))
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.start()
+        try {
+            advanceTimeBy(12_000)
+            assertEquals(
+                1,
+                bluetoothRepository.bondCalls.size,
+                "bond() must be called exactly once — cancellation, not retry",
+            )
+            assertEquals(0, connection.connectAndAwaitCalls, "connectAndAwait must not be called after cancellation")
         } finally {
             bleTransport.close()
         }


### PR DESCRIPTION
## Overview

This pull request stops the BLE transport from continuing into GATT setup after transport-side bonding fails and Android still reports the device as not bonded.

This is the third change in the related BLE bonding cleanup. #5967 made Android bonding waits finite and re-checked final bond state before failing. #5969 changed the user-facing pairing path so failed pairing waits for an explicit retry instead of immediately arming the transport. This PR handles the remaining transport-side case.

If `bond()` fails but Android now reports the device as bonded, the transport still continues. That preserves the late or flaky terminal-bond case where Android recorded the bond even though the app-side bond call reported an error.

If `bond()` fails and Android still reports the device as not bonded, the transport now stops that connection attempt before calling `connectAndAwait()`. The existing reconnect policy remains responsible for any later retry/backoff.

## Key Changes

* Re-checked `isBonded(address)` after transport-side `bond()` failure.
* Continued into GATT setup when Android reports the device is bonded after a flaky bond result.
* Stopped the current connection attempt when bonding fails and the device is still not bonded.
* Avoided continuing into GATT setup after a failed bond that cannot produce an encrypted connection.
* Preserved coroutine cancellation behavior.
* Preserved the original bond failure as the cause on `RadioNotConnectedException`.
* Added focused transport tests for the new bond-failure gate.

## Testing

* Added coverage proving successful bonding still proceeds to `connectAndAwait()`.
* Added coverage proving a flaky bond result still attempts bonding and proceeds when Android reports the device bonded.
* Added coverage proving a failed bond does not call `connectAndAwait()` when Android still reports not bonded.
* Added coverage proving `CancellationException` from bonding cancels rather than becoming a retryable generic failure.

## Migration Notes

* No user data migration is required.
* Existing BLE addresses and OS bonds are unchanged.
* Bluetooth permission behavior is unchanged.
* This only changes the transport-side handling of failed bonding before GATT setup.
