### PR TITLE
fix(ble): Fail bonding promptly when polled state returns none

### DIFF
--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -289,6 +289,7 @@ class AndroidBluetoothRepositoryBondTest {
             val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
             val failure = launchBond(repo, mac)
+            deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
             advanceTimeBy(499L)
             assertFalse(failure.isCompleted, "bond() should still be waiting before the initial grace poll")
             advanceTimeBy(2L)

--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -281,11 +281,7 @@ class AndroidBluetoothRepositoryBondTest {
             val mac = "AA:BB:CC:DD:EE:0E"
             RobolectricBleBonding.grantBluetoothConnectPermission()
             val deviceShadow =
-                RobolectricBleBonding.primeBond(
-                    mac,
-                    bondState = BluetoothDevice.BOND_NONE,
-                    createBondReturns = true,
-                )
+                RobolectricBleBonding.primeBond(mac, bondState = BluetoothDevice.BOND_NONE, createBondReturns = true)
             val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
             val failure = launchBond(repo, mac)

--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -168,7 +168,7 @@ class AndroidBluetoothRepositoryBondTest {
             previousState = BluetoothDevice.BOND_BONDING,
         )
 
-        assertEquals("Bonding failed or rejected", failure.await()?.message)
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
     }
 
     @Test
@@ -272,7 +272,7 @@ class AndroidBluetoothRepositoryBondTest {
         deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
         advanceTimeBy(2L)
 
-        assertEquals("Bonding failed or rejected", failure.await()?.message)
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
     }
 
     @Test
@@ -285,11 +285,14 @@ class AndroidBluetoothRepositoryBondTest {
             val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
 
             val failure = launchBond(repo, mac)
+            // Robolectric synchronously marks createBond() as BONDED here; reset it to model
+            // Android's async BOND_NONE -> BOND_BONDING transition.
             deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
             advanceTimeBy(499L)
             assertFalse(failure.isCompleted, "bond() should still be waiting before the initial grace poll")
             advanceTimeBy(2L)
-            assertFalse(failure.isCompleted, "a newly initiated bond gets one poll before BOND_NONE is terminal")
+            assertFalse(failure.isCompleted, "a newly initiated bond should tolerate initial BOND_NONE")
+            // The same wait must still recover if Android later reports BONDING and then BONDED.
             deviceShadow.setBondState(BluetoothDevice.BOND_BONDING)
             advanceTimeBy(500L)
             assertFalse(failure.isCompleted, "BOND_BONDING should keep the bond wait active")
@@ -298,6 +301,79 @@ class AndroidBluetoothRepositoryBondTest {
 
             assertNull(failure.await(), "bond() should complete once Android reports BOND_BONDED")
         }
+
+    @Test
+    fun `createBond true fails on the BOND_NONE poll after grace is exhausted`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:0F"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        val deviceShadow =
+            RobolectricBleBonding.primeBond(mac, bondState = BluetoothDevice.BOND_NONE, createBondReturns = true)
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        // Robolectric synchronously marks createBond() as BONDED here; reset it to model
+        // Android's async BOND_NONE -> BOND_BONDING transition.
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(499L)
+        assertFalse(failure.isCompleted, "bond() should still be waiting before the initial grace poll")
+        advanceTimeBy(2L)
+        assertFalse(failure.isCompleted, "the first BOND_NONE poll should still be within the grace")
+        advanceTimeBy(500L)
+        assertFalse(failure.isCompleted, "the second BOND_NONE poll should consume the grace")
+        advanceTimeBy(500L)
+
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
+    }
+
+    @Test
+    fun `createBond true fails when polled bonding later returns none`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:10"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        val deviceShadow =
+            RobolectricBleBonding.primeBond(mac, bondState = BluetoothDevice.BOND_NONE, createBondReturns = true)
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        // Robolectric synchronously marks createBond() as BONDED here; reset it to model
+        // Android's async BOND_NONE -> BOND_BONDING transition.
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(501L)
+        assertFalse(failure.isCompleted, "initial BOND_NONE should not fail before bonding is observed")
+        // Covers the missed failure broadcast after polling observes BOND_BONDING. The createBond=false
+        // BOND_BONDING test pins the already-in-flight start path.
+        deviceShadow.setBondState(BluetoothDevice.BOND_BONDING)
+        advanceTimeBy(500L)
+        assertFalse(failure.isCompleted, "polled BOND_BONDING should keep the bond wait active")
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(500L)
+
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
+    }
+
+    @Test
+    fun `spurious none broadcast is ignored but later polled none fails`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:11"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        val deviceShadow =
+            RobolectricBleBonding.primeBond(
+                mac,
+                bondState = BluetoothDevice.BOND_BONDING,
+                createBondReturns = false,
+            )
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        RobolectricBleBonding.sendBondStateChanged(
+            mac,
+            newState = BluetoothDevice.BOND_NONE,
+            previousState = BluetoothDevice.BOND_NONE,
+        )
+        assertFalse(failure.isCompleted, "a spurious BOND_NONE broadcast must not resolve the bond")
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(500L)
+
+        assertEquals(BOND_FAILED_OR_REJECTED_MESSAGE, failure.await()?.message)
+    }
 
     @Test
     fun `bond succeeds when bond state becomes bonded at timeout boundary`() = runTest(UnconfinedTestDispatcher()) {

--- a/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
+++ b/core/ble/src/androidHostTest/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepositoryBondTest.kt
@@ -255,6 +255,54 @@ class AndroidBluetoothRepositoryBondTest {
         }
 
     @Test
+    fun `bond fails early when bond state returns none without broadcast`() = runTest(UnconfinedTestDispatcher()) {
+        val mac = "AA:BB:CC:DD:EE:0D"
+        RobolectricBleBonding.grantBluetoothConnectPermission()
+        val deviceShadow =
+            RobolectricBleBonding.primeBond(
+                mac,
+                bondState = BluetoothDevice.BOND_BONDING,
+                createBondReturns = false,
+            )
+        val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+        val failure = launchBond(repo, mac)
+        advanceTimeBy(499L)
+        assertFalse(failure.isCompleted, "bond() should still be waiting before the poll interval")
+        deviceShadow.setBondState(BluetoothDevice.BOND_NONE)
+        advanceTimeBy(2L)
+
+        assertEquals("Bonding failed or rejected", failure.await()?.message)
+    }
+
+    @Test
+    fun `createBond true does not fail immediately while bond state is initially none`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val mac = "AA:BB:CC:DD:EE:0E"
+            RobolectricBleBonding.grantBluetoothConnectPermission()
+            val deviceShadow =
+                RobolectricBleBonding.primeBond(
+                    mac,
+                    bondState = BluetoothDevice.BOND_NONE,
+                    createBondReturns = true,
+                )
+            val repo = newRepository(UnconfinedTestDispatcher(testScheduler))
+
+            val failure = launchBond(repo, mac)
+            advanceTimeBy(499L)
+            assertFalse(failure.isCompleted, "bond() should still be waiting before the initial grace poll")
+            advanceTimeBy(2L)
+            assertFalse(failure.isCompleted, "a newly initiated bond gets one poll before BOND_NONE is terminal")
+            deviceShadow.setBondState(BluetoothDevice.BOND_BONDING)
+            advanceTimeBy(500L)
+            assertFalse(failure.isCompleted, "BOND_BONDING should keep the bond wait active")
+            deviceShadow.setBondState(BluetoothDevice.BOND_BONDED)
+            advanceTimeBy(500L)
+
+            assertNull(failure.await(), "bond() should complete once Android reports BOND_BONDED")
+        }
+
+    @Test
     fun `bond succeeds when bond state becomes bonded at timeout boundary`() = runTest(UnconfinedTestDispatcher()) {
         val mac = "AA:BB:CC:DD:EE:0C"
         RobolectricBleBonding.grantBluetoothConnectPermission()

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -41,6 +41,7 @@ import kotlin.time.Duration.Companion.seconds
 
 private val BOND_TIMEOUT = 30.seconds
 private val BOND_STATE_POLL_INTERVAL = 500.milliseconds
+private const val CREATED_BOND_NONE_GRACE_POLLS = 1
 
 /** Android implementation of [BluetoothRepository]. */
 @Single
@@ -103,8 +104,8 @@ class AndroidBluetoothRepository(
                     ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
 
                     try {
-                        startOrObserveBond(remoteDevice, result)
-                        awaitBondResult(remoteDevice, result)
+                        val start = startOrObserveBond(remoteDevice, result)
+                        awaitBondResult(remoteDevice, result, start)
                     } finally {
                         unregisterBondReceiver(receiver)
                     }
@@ -122,44 +123,78 @@ class AndroidBluetoothRepository(
 
     @Suppress("TooGenericExceptionCaught")
     @SuppressLint("MissingPermission")
-    private fun startOrObserveBond(remoteDevice: android.bluetooth.BluetoothDevice, result: CompletableDeferred<Unit>) {
+    private fun startOrObserveBond(
+        remoteDevice: android.bluetooth.BluetoothDevice,
+        result: CompletableDeferred<Unit>,
+    ): BondWaitStart {
+        var start = BondWaitStart()
         try {
-            if (result.isCompleted) return
-
-            if (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
-                result.complete(Unit)
-            } else if (!remoteDevice.createBond()) {
-                // createBond() returns false when a bond is already in flight, triggered by a GATT
-                // operation hitting a secured characteristic, or already established.
-                // ACTION_BOND_STATE_CHANGED is unreliable on some devices (see Kable #111), so
-                // re-check bondState directly rather than failing the whole flow.
-                when (remoteDevice.bondState) {
-                    android.bluetooth.BluetoothDevice.BOND_BONDED -> {
-                        result.complete(Unit)
-                    }
-
-                    android.bluetooth.BluetoothDevice.BOND_BONDING -> {
-                        // Bond already in progress; leave the receiver registered to resolve it on
-                        // the terminal BOND_BONDED / BOND_NONE transition instead of treating this
-                        // as a failure.
-                        Logger.d { "createBond() returned false but bonding is already in progress" }
-                    }
-
-                    else -> {
-                        result.completeExceptionally(Exception("Failed to initiate bonding"))
-                    }
+            if (!result.isCompleted) {
+                if (remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
+                    result.complete(Unit)
+                } else if (remoteDevice.createBond()) {
+                    start = BondWaitStart(createdBond = true)
+                } else {
+                    start = observeExistingBond(remoteDevice, result)
                 }
             }
         } catch (e: Exception) {
             result.completeExceptionally(e)
         }
+        return start
     }
+
+    @SuppressLint("MissingPermission")
+    private fun observeExistingBond(
+        remoteDevice: android.bluetooth.BluetoothDevice,
+        result: CompletableDeferred<Unit>,
+    ): BondWaitStart {
+        // createBond() returns false when a bond is already in flight, triggered by a GATT
+        // operation hitting a secured characteristic, or already established.
+        // ACTION_BOND_STATE_CHANGED is unreliable on some devices (see Kable #111), so
+        // re-check bondState directly rather than failing the whole flow.
+        return when (remoteDevice.bondState) {
+            android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                result.complete(Unit)
+                BondWaitStart()
+            }
+
+            android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                // Bond already in progress; leave the receiver registered to resolve it on
+                // the terminal BOND_BONDED / BOND_NONE transition instead of treating this
+                // as a failure.
+                Logger.d { "createBond() returned false but bonding is already in progress" }
+                BondWaitStart(bondingObserved = true)
+            }
+
+            else -> {
+                result.completeExceptionally(Exception("Failed to initiate bonding"))
+                BondWaitStart()
+            }
+        }
+    }
+
+    private data class BondWaitStart(
+        val bondingObserved: Boolean = false,
+        val createdBond: Boolean = false,
+    )
 
     @SuppressLint("MissingPermission")
     private suspend fun awaitBondResult(
         remoteDevice: android.bluetooth.BluetoothDevice,
         result: CompletableDeferred<Unit>,
+        start: BondWaitStart,
     ) {
+        var bondingWasInFlight = start.bondingObserved
+        // createBond() can return before Android reports BOND_BONDING; avoid treating
+        // that initial BOND_NONE state as a terminal failure.
+        var bondNoneGracePolls =
+            if (start.createdBond && !bondingWasInFlight) {
+                CREATED_BOND_NONE_GRACE_POLLS
+            } else {
+                0
+            }
+
         while (!result.isCompleted) {
             val completedFromReceiver =
                 withTimeoutOrNull(BOND_STATE_POLL_INTERVAL) {
@@ -167,8 +202,26 @@ class AndroidBluetoothRepository(
                     true
                 } == true
 
-            if (!completedFromReceiver && remoteDevice.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED) {
-                result.complete(Unit)
+            if (!completedFromReceiver) {
+                when (remoteDevice.bondState) {
+                    android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                        result.complete(Unit)
+                    }
+
+                    android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                        bondingWasInFlight = true
+                        bondNoneGracePolls = 0
+                    }
+
+                    android.bluetooth.BluetoothDevice.BOND_NONE -> {
+                        if (bondingWasInFlight) {
+                            result.completeExceptionally(Exception("Bonding failed or rejected"))
+                        } else if (bondNoneGracePolls > 0) {
+                            bondNoneGracePolls--
+                            bondingWasInFlight = bondNoneGracePolls == 0
+                        }
+                    }
+                }
             }
         }
         result.await()

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -135,7 +135,27 @@ class AndroidBluetoothRepository(
                 } else if (remoteDevice.createBond()) {
                     start = BondWaitStart(createdBond = true)
                 } else {
-                    start = observeExistingBond(remoteDevice, result)
+                    // createBond() returns false when a bond is already in flight, triggered by a GATT
+                    // operation hitting a secured characteristic, or already established.
+                    // ACTION_BOND_STATE_CHANGED is unreliable on some devices (see Kable #111), so
+                    // re-check bondState directly rather than failing the whole flow.
+                    when (remoteDevice.bondState) {
+                        android.bluetooth.BluetoothDevice.BOND_BONDED -> {
+                            result.complete(Unit)
+                        }
+
+                        android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                            // Bond already in progress; leave the receiver registered to resolve it on
+                            // the terminal BOND_BONDED / BOND_NONE transition instead of treating this
+                            // as a failure.
+                            Logger.d { "createBond() returned false but bonding is already in progress" }
+                            start = BondWaitStart(bondingObserved = true)
+                        }
+
+                        else -> {
+                            result.completeExceptionally(Exception("Failed to initiate bonding"))
+                        }
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -144,40 +164,7 @@ class AndroidBluetoothRepository(
         return start
     }
 
-    @SuppressLint("MissingPermission")
-    private fun observeExistingBond(
-        remoteDevice: android.bluetooth.BluetoothDevice,
-        result: CompletableDeferred<Unit>,
-    ): BondWaitStart {
-        // createBond() returns false when a bond is already in flight, triggered by a GATT
-        // operation hitting a secured characteristic, or already established.
-        // ACTION_BOND_STATE_CHANGED is unreliable on some devices (see Kable #111), so
-        // re-check bondState directly rather than failing the whole flow.
-        return when (remoteDevice.bondState) {
-            android.bluetooth.BluetoothDevice.BOND_BONDED -> {
-                result.complete(Unit)
-                BondWaitStart()
-            }
-
-            android.bluetooth.BluetoothDevice.BOND_BONDING -> {
-                // Bond already in progress; leave the receiver registered to resolve it on
-                // the terminal BOND_BONDED / BOND_NONE transition instead of treating this
-                // as a failure.
-                Logger.d { "createBond() returned false but bonding is already in progress" }
-                BondWaitStart(bondingObserved = true)
-            }
-
-            else -> {
-                result.completeExceptionally(Exception("Failed to initiate bonding"))
-                BondWaitStart()
-            }
-        }
-    }
-
-    private data class BondWaitStart(
-        val bondingObserved: Boolean = false,
-        val createdBond: Boolean = false,
-    )
+    private data class BondWaitStart(val bondingObserved: Boolean = false, val createdBond: Boolean = false)
 
     @SuppressLint("MissingPermission")
     private suspend fun awaitBondResult(

--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/AndroidBluetoothRepository.kt
@@ -36,12 +36,17 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.di.CoroutineDispatchers
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private val BOND_TIMEOUT = 30.seconds
 private val BOND_STATE_POLL_INTERVAL = 500.milliseconds
-private const val CREATED_BOND_NONE_GRACE_POLLS = 1
+
+// Fixed two-poll grace for slow BOND_NONE -> BOND_BONDING transitions after createBond() returns true.
+// Tune this or track observed transition latency if a specific OEM needs a longer window.
+private val CREATED_BOND_NONE_GRACE = BOND_STATE_POLL_INTERVAL + BOND_STATE_POLL_INTERVAL
+internal const val BOND_FAILED_OR_REJECTED_MESSAGE = "Bonding failed or rejected"
 
 /** Android implementation of [BluetoothRepository]. */
 @Single
@@ -173,13 +178,13 @@ class AndroidBluetoothRepository(
         start: BondWaitStart,
     ) {
         var bondingWasInFlight = start.bondingObserved
-        // createBond() can return before Android reports BOND_BONDING; avoid treating
-        // that initial BOND_NONE state as a terminal failure.
-        var bondNoneGracePolls =
-            if (start.createdBond && !bondingWasInFlight) {
-                CREATED_BOND_NONE_GRACE_POLLS
+        // createBond() can return true before Android reports BOND_BONDING. Tolerate two polled
+        // BOND_NONE samples (polls 1-2), then fail on the third persistent BOND_NONE.
+        var createdBondNoneGraceRemaining =
+            if (start.createdBond) {
+                CREATED_BOND_NONE_GRACE
             } else {
-                0
+                Duration.ZERO
             }
 
         while (!result.isCompleted) {
@@ -196,16 +201,32 @@ class AndroidBluetoothRepository(
                     }
 
                     android.bluetooth.BluetoothDevice.BOND_BONDING -> {
+                        // Once polling observes BOND_BONDING, a later BOND_NONE is terminal. Keep this
+                        // defensive for any path that observes in-flight bonding outside the start state.
                         bondingWasInFlight = true
-                        bondNoneGracePolls = 0
+                        createdBondNoneGraceRemaining = Duration.ZERO
                     }
 
                     android.bluetooth.BluetoothDevice.BOND_NONE -> {
-                        if (bondingWasInFlight) {
-                            result.completeExceptionally(Exception("Bonding failed or rejected"))
-                        } else if (bondNoneGracePolls > 0) {
-                            bondNoneGracePolls--
-                            bondingWasInFlight = bondNoneGracePolls == 0
+                        // Invariant: if start.createdBond is false, startOrObserveBond either completed
+                        // result or observed BOND_BONDING, which is represented by bondingWasInFlight.
+                        val pollFailureDetails =
+                            "bond poll failed: bondingWasInFlight=$bondingWasInFlight " +
+                                "createdBond=${start.createdBond} graceRemaining=$createdBondNoneGraceRemaining"
+                        when {
+                            bondingWasInFlight -> {
+                                Logger.d { pollFailureDetails }
+                                result.completeExceptionally(Exception(BOND_FAILED_OR_REJECTED_MESSAGE))
+                            }
+
+                            createdBondNoneGraceRemaining > Duration.ZERO -> {
+                                createdBondNoneGraceRemaining -= BOND_STATE_POLL_INTERVAL
+                            }
+
+                            start.createdBond -> {
+                                Logger.d { pollFailureDetails }
+                                result.completeExceptionally(Exception(BOND_FAILED_OR_REJECTED_MESSAGE))
+                            }
                         }
                     }
                 }
@@ -246,7 +267,7 @@ class AndroidBluetoothRepository(
                 state == android.bluetooth.BluetoothDevice.BOND_NONE &&
                 prevState == android.bluetooth.BluetoothDevice.BOND_BONDING
             ) {
-                result.completeExceptionally(Exception("Bonding failed or rejected"))
+                result.completeExceptionally(Exception(BOND_FAILED_OR_REJECTED_MESSAGE))
             }
         }
     }


### PR DESCRIPTION
## Overview

This pull request makes Android BLE bonding fail promptly when the platform bond state returns to `BOND_NONE` after bonding was observed in progress, even if Android does not deliver the terminal bond-state broadcast.

This builds on the recent BLE bonding work in #5967, #5969, and #5973: bonding waits are now finite, failed user-facing pairing waits for an explicit retry instead of immediately arming the transport, and the BLE transport no longer continues into GATT setup after failed bonding when Android still reports the device as not bonded.

This change handles the remaining app-side wait case. Android may already know bonding failed, but the app may miss the terminal `ACTION_BOND_STATE_CHANGED` failure broadcast. Before this change, the polling path only completed early when Android reported `BOND_BONDED`. If pairing failed and polling saw `BOND_NONE`, the app could still wait until the full bonding timeout before surfacing the failure.

With this change, polling can now also fail the bond early when it is safe to treat `BOND_NONE` as terminal.

## Key Changes

- Preserved the receiver-based bonding path.
- Preserved the 30-second upper bound around Android bonding.
- Preserved early success when polling sees `BOND_BONDED`.
- Added early failure when polling sees terminal `BOND_NONE` after bonding was observed in progress.
- Added a short grace window after `createBond()` returns true so a slow `BOND_NONE -> BOND_BONDING` transition is not failed immediately.
- Avoided treating the initial pre-bond `BOND_NONE` state as an immediate failure.
- Reused the same bonding failure message for receiver-based and polling-based terminal failures.
- Added timeout diagnostics so field logs can show what bond state Android exposed when no terminal state arrived.
- Added Android host-test coverage for missed terminal failure broadcasts and grace handling.

## Testing

- Added coverage proving a missed terminal failure broadcast fails before the full bonding timeout.
- Added coverage proving a newly initiated bond does not fail immediately while Android still reports initial `BOND_NONE`.
- Added coverage proving persistent `BOND_NONE` after the grace window fails.
- Added coverage proving `BOND_BONDING` followed by polled `BOND_NONE` fails.
- Added coverage proving a spurious `BOND_NONE` broadcast is ignored while a later polled terminal `BOND_NONE` still fails.
- Preserved coverage for missed successful terminal broadcasts.
- Preserved coverage for timeout when no terminal bond state is observed.
- Preserved coverage for timeout-boundary success when Android reports `BOND_BONDED`.

## Migration Notes

- No user data migration is required.
- Existing BLE addresses and OS bonds are unchanged.
- Bluetooth permission behavior is unchanged.
- This only makes the app-side bond wait fail faster when Android already reports that bonding has ended unsuccessfully, and improves diagnostics when Android does not expose that terminal state.