### PR TITLE
Prevent Range Test from running on public/default channel

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
@@ -53,7 +53,6 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
         enabled = state.connected,
         responseState = state.responseState,
         onDismissPacketResponse = viewModel::clearPacketResponse,
-        additionalDirtyCheck = { isPublicPrimaryChannel && formState.value.enabled },
         onSave = {
             val safeConfig = if (isPublicPrimaryChannel) it.copy(enabled = false) else it
             val config = ModuleConfig(range_test = safeConfig)
@@ -65,7 +64,7 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                 SwitchPreference(
                     title = stringResource(Res.string.range_test_enabled),
                     checked = formState.value.enabled,
-                    enabled = canConfigure,
+                    enabled = canConfigure || formState.value.enabled,
                     onCheckedChange = { formState.value = formState.value.copy(enabled = it) },
                     containerColor = CardDefaults.cardColors().containerColor,
                 )

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
@@ -43,9 +43,6 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val rangeTestConfig = state.moduleConfig.range_test ?: ModuleConfig.RangeTestConfig()
     val formState = rememberConfigState(initialValue = rangeTestConfig)
 
-    // A PSK shorter than 2 bytes means either cleartext (0 bytes) or the well-known default
-    // shortstring code (1 byte). Both are effectively public — Range Test must not run on them
-    // to avoid flooding the shared mesh. Use the CLI to override if intentional.
     val isPublicPrimaryChannel = (state.channelList.firstOrNull()?.psk?.size ?: 0) < 2
     val canConfigure = state.connected && !isPublicPrimaryChannel
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
@@ -43,6 +43,12 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val rangeTestConfig = state.moduleConfig.range_test ?: ModuleConfig.RangeTestConfig()
     val formState = rememberConfigState(initialValue = rangeTestConfig)
 
+    // A PSK shorter than 2 bytes means either cleartext (0 bytes) or the well-known default
+    // shortstring code (1 byte). Both are effectively public — Range Test must not run on them
+    // to avoid flooding the shared mesh. Use the CLI to override if intentional.
+    val isPublicPrimaryChannel = (state.channelList.firstOrNull()?.psk?.size ?: 0) < 2
+    val canConfigure = state.connected && !isPublicPrimaryChannel
+
     RadioConfigScreenList(
         title = stringResource(Res.string.range_test),
         onBack = onBack,
@@ -50,8 +56,10 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
         enabled = state.connected,
         responseState = state.responseState,
         onDismissPacketResponse = viewModel::clearPacketResponse,
+        additionalDirtyCheck = { isPublicPrimaryChannel && formState.value.enabled },
         onSave = {
-            val config = ModuleConfig(range_test = it)
+            val safeConfig = if (isPublicPrimaryChannel) it.copy(enabled = false) else it
+            val config = ModuleConfig(range_test = safeConfig)
             viewModel.setModuleConfig(config)
         },
     ) {
@@ -60,7 +68,7 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                 SwitchPreference(
                     title = stringResource(Res.string.range_test_enabled),
                     checked = formState.value.enabled,
-                    enabled = state.connected,
+                    enabled = canConfigure,
                     onCheckedChange = { formState.value = formState.value.copy(enabled = it) },
                     containerColor = CardDefaults.cardColors().containerColor,
                 )
@@ -69,7 +77,7 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                 DropDownPreference(
                     title = stringResource(Res.string.sender_message_interval_seconds),
                     selectedItem = (formState.value.sender).toLong(),
-                    enabled = state.connected,
+                    enabled = canConfigure,
                     items = rangeItems.map { it.value to it.toDisplayString() },
                     onItemSelected = { formState.value = formState.value.copy(sender = it.toInt()) },
                 )
@@ -77,7 +85,7 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                 SwitchPreference(
                     title = stringResource(Res.string.save_csv_in_storage_esp32_only),
                     checked = formState.value.save,
-                    enabled = state.connected,
+                    enabled = canConfigure,
                     onCheckedChange = { formState.value = formState.value.copy(save = it) },
                     containerColor = CardDefaults.cardColors().containerColor,
                 )


### PR DESCRIPTION
## Summary

- Blocks enabling Range Test in the app UI when the primary channel is unencrypted (empty PSK) or uses the well-known 1-byte default shortstring key. Both are effectively public channels that would flood the shared mesh with test traffic.
- Users who intentionally want Range Test on a public channel can still enable it via the Meshtastic CLI — this is by design, making it a deliberate power-user action rather than an accidental tap.
- Backend enforcement on save forces \enabled = false\ when a public channel is detected, so even a UI bypass cannot persist the setting.

## Changes from previous PR #3816

- **Deduplication:** Hoisted \state.connected && !isPublicPrimaryChannel\ into a single \canConfigure\ val — no repeated expression across 4 call sites
- **Already-enabled fix:** Kept screen-level \enabled = state.connected\ (not \canConfigure\) so the save footer remains reachable. Added \dditionalDirtyCheck = { isPublicPrimaryChannel && formState.value.enabled }\ — this surfaces the Save/Discard buttons when a device already has Range Test enabled on a public channel (e.g. set via CLI), letting the user push the corrective \enabled = false\ through the app.
- **Updated to current codebase:** Migrated to \src/commonMain\ path, \core.resources\ imports, Wire data-class \copy()\ syntax, and \ModuleConfig(range_test = ...)\ constructor — matches the KMP refactor that landed after #3816 was closed.

## Test plan

- [ ] On a device with default channel (1-byte PSK): Range Test controls are grayed out; Save does not appear unless Range Test was already enabled
- [ ] On a device with default channel and Range Test already enabled (set via CLI): Save/Discard footer appears; tapping Save pushes \enabled = false\ to device
- [ ] On a device with a private channel (PSK ≥ 2 bytes): Range Test controls work normally