### PR TITLE
refactor(ui): migrate MapView dialog to Compose M3 + drop legacy material dependency

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -235,7 +235,7 @@ dependencies {
     implementation(libs.jetbrains.compose.material3.adaptive)
     implementation(libs.jetbrains.compose.material3.adaptive.layout)
     implementation(libs.jetbrains.compose.material3.adaptive.navigation)
-    implementation(libs.material)
+    implementation(libs.androidx.appcompat)
     implementation(libs.compose.multiplatform.animation)
     implementation(libs.compose.multiplatform.material3)
     implementation(libs.compose.multiplatform.ui.tooling.preview)

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -283,7 +283,6 @@ dependencies {
     googleImplementation(libs.dd.sdk.android.logs)
     googleImplementation(libs.dd.sdk.android.rum)
     googleImplementation(libs.dd.sdk.android.session.replay)
-    googleImplementation(libs.dd.sdk.android.session.replay.material)
     googleImplementation(libs.dd.sdk.android.timber)
     googleImplementation(libs.dd.sdk.android.trace)
     googleImplementation(libs.dd.sdk.android.trace.otel)

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -67,7 +67,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
@@ -229,6 +228,7 @@ fun MapView(
 
     var showDownloadButton: Boolean by remember { mutableStateOf(false) }
     var showEditWaypointDialog by remember { mutableStateOf<Waypoint?>(null) }
+    var showDeleteWaypointDialog by remember { mutableStateOf<Waypoint?>(null) }
     var showCacheManagerDialog by remember { mutableStateOf(false) }
     var showCurrentCacheInfo by remember { mutableStateOf(false) }
     var showPurgeTileSourceDialog by remember { mutableStateOf(false) }
@@ -393,39 +393,6 @@ fun MapView(
         }
     }
 
-    fun showDeleteMarkerDialog(waypoint: Waypoint) {
-        val builder = MaterialAlertDialogBuilder(context)
-        builder.setTitle(getString(Res.string.waypoint_delete))
-        builder.setNeutralButton(getString(Res.string.cancel)) { _, _ ->
-            Logger.d { "User canceled marker delete dialog" }
-        }
-        builder.setNegativeButton(getString(Res.string.delete_for_me)) { _, _ ->
-            Logger.d { "User deleted waypoint ${waypoint.id} for me" }
-            mapViewModel.deleteWaypoint(waypoint.id)
-        }
-        if (waypoint.locked_to in setOf(0, mapViewModel.myNodeNum ?: 0) && isConnected) {
-            builder.setPositiveButton(getString(Res.string.delete_for_everyone)) { _, _ ->
-                Logger.d { "User deleted waypoint ${waypoint.id} for everyone" }
-                mapViewModel.sendWaypoint(waypoint.copy(expire = 1))
-                mapViewModel.deleteWaypoint(waypoint.id)
-            }
-        }
-        val dialog = builder.show()
-        for (
-        button in
-        setOf(
-            androidx.appcompat.app.AlertDialog.BUTTON_NEUTRAL,
-            androidx.appcompat.app.AlertDialog.BUTTON_NEGATIVE,
-            androidx.appcompat.app.AlertDialog.BUTTON_POSITIVE,
-        )
-        ) {
-            with(dialog.getButton(button)) {
-                textSize = 12F
-                isAllCaps = false
-            }
-        }
-    }
-
     fun showMarkerLongPressDialog(id: Int) {
         performHapticFeedback()
         Logger.d { "marker long pressed id=$id" }
@@ -434,7 +401,7 @@ fun MapView(
         if (waypoint.locked_to in setOf(0, mapViewModel.myNodeNum ?: 0) && isConnected) {
             showEditWaypointDialog = waypoint
         } else {
-            showDeleteMarkerDialog(waypoint)
+            showDeleteWaypointDialog = waypoint
         }
     }
 
@@ -718,11 +685,59 @@ fun MapView(
             onDeleteClicked = { waypoint ->
                 Logger.d { "User clicked delete waypoint ${waypoint.id}" }
                 showEditWaypointDialog = null
-                showDeleteMarkerDialog(waypoint)
+                showDeleteWaypointDialog = waypoint
             },
             onDismissRequest = {
                 Logger.d { "User clicked cancel marker edit dialog" }
                 showEditWaypointDialog = null
+            },
+        )
+    }
+
+    if (showDeleteWaypointDialog != null) {
+        val waypoint = showDeleteWaypointDialog ?: return
+        val canDeleteForEveryone = waypoint.locked_to in setOf(0, mapViewModel.myNodeNum ?: 0) && isConnected
+        androidx.compose.material3.AlertDialog(
+            onDismissRequest = {
+                Logger.d { "User canceled marker delete dialog" }
+                showDeleteWaypointDialog = null
+            },
+            title = { Text(stringResource(Res.string.waypoint_delete)) },
+            // Both deletes are confirmations; Cancel is the dismiss action (mirrors the old neutral button).
+            confirmButton = {
+                Column {
+                    TextButton(
+                        onClick = {
+                            Logger.d { "User deleted waypoint ${waypoint.id} for me" }
+                            mapViewModel.deleteWaypoint(waypoint.id)
+                            showDeleteWaypointDialog = null
+                        },
+                    ) {
+                        Text(stringResource(Res.string.delete_for_me))
+                    }
+                    if (canDeleteForEveryone) {
+                        TextButton(
+                            onClick = {
+                                Logger.d { "User deleted waypoint ${waypoint.id} for everyone" }
+                                mapViewModel.sendWaypoint(waypoint.copy(expire = 1))
+                                mapViewModel.deleteWaypoint(waypoint.id)
+                                showDeleteWaypointDialog = null
+                            },
+                        ) {
+                            Text(stringResource(Res.string.delete_for_everyone))
+                        }
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        Logger.d { "User canceled marker delete dialog" }
+                        showDeleteWaypointDialog = null
+                    },
+                ) {
+                    Text(stringResource(Res.string.cancel))
+                }
             },
         )
     }

--- a/androidApp/src/main/res/values/styles.xml
+++ b/androidApp/src/main/res/values/styles.xml
@@ -24,7 +24,7 @@
         <!-- The splash screen icon -->
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_splash</item>
         <!-- The theme to switch to after the splash screen is dismissed -->
-        <item name="postSplashScreenTheme">@style/Theme.Material3.DynamicColors.DayNight.NoActionBar</item>
+        <item name="postSplashScreenTheme">@style/Theme.AppCompat.DayNight.NoActionBar</item>
     </style>
 
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -256,7 +256,6 @@ coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 dd-sdk-android-logs = { module = "com.datadoghq:dd-sdk-android-logs", version.ref = "dd-sdk-android" }
 dd-sdk-android-rum = { module = "com.datadoghq:dd-sdk-android-rum", version.ref = "dd-sdk-android" }
 dd-sdk-android-session-replay = { module = "com.datadoghq:dd-sdk-android-session-replay", version.ref = "dd-sdk-android" }
-dd-sdk-android-session-replay-material = { module = "com.datadoghq:dd-sdk-android-session-replay-material", version.ref = "dd-sdk-android" }
 dd-sdk-android-timber = { module = "com.datadoghq:dd-sdk-android-timber", version.ref = "dd-sdk-android" }
 dd-sdk-android-trace = { module = "com.datadoghq:dd-sdk-android-trace", version.ref = "dd-sdk-android" }
 dd-sdk-android-trace-otel = { module = "com.datadoghq:dd-sdk-android-trace-otel", version.ref = "dd-sdk-android" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -264,7 +264,6 @@ dokka-android-documentation-plugin = { module = "org.jetbrains.dokka:android-doc
 markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
 markdown-renderer-m3 = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 markdown-renderer-android = { module = "com.mikepenz:multiplatform-markdown-renderer-android", version.ref = "markdownRenderer" }
-material = { module = "com.google.android.material:material", version = "1.14.0" }
 
 kable-core = { module = "com.juul.kable:kable-core", version.ref = "kable" }
 # mqtt-client 0.4.0 split the monolith into a BOM + core + per-transport modules. The BOM pins the


### PR DESCRIPTION
Removes the maintenance-only `com.google.android.material:material` (1.14.0) View library, whose only remaining use was a single `MaterialAlertDialogBuilder` call in the F-Droid `MapView`. The app is otherwise fully Compose Multiplatform, so the legacy MDC dependency was pure dead weight. This purges `com.google.android.material` from **both** flavors' runtime classpaths.

### 🛠️ Refactoring & Architecture
- **Android View → Compose migration:** Replaced the `MaterialAlertDialogBuilder` delete-waypoint dialog in `MapView.kt` (F-Droid flavor) with a Compose Material 3 `AlertDialog`, driven by a new `showDeleteWaypointDialog` state (mirrors the existing `showEditWaypointDialog` pattern).
- Button parity preserved: **Cancel** (dismiss), **Delete for me**, and **Delete for everyone** — the last still gated on `locked_to`/connection exactly as before.
- Swapped the post-splash host theme from `Theme.Material3.DynamicColors.DayNight.NoActionBar` to `Theme.AppCompat.DayNight.NoActionBar`. The app is pure Compose (`setContent`), and dynamic color is already supplied by Compose's `dynamicColorScheme` — the XML theme only governs the splash→Compose window handoff.

### 🧹 Chores
- Removed `material` from `gradle/libs.versions.toml` and `androidApp/build.gradle.kts`.
- Declared `androidx.appcompat` directly in `androidApp` — `AppCompatActivity`/`AppCompatResources`/`AppCompatDelegate` were previously satisfied transitively *through* the material library.
- Dropped the unused `dd-sdk-android-session-replay-material` Datadog extension (google flavor): Session Replay never registered it (`addExtensionSupport(MaterialExtensionSupport())` was never called) and it pulled `com.google.android.material` back in transitively. Removing it purges the View library from `googleDebugRuntimeClasspath` entirely.

### Reviewer notes
- The theme swap is the only runtime-behavior change. Verified safe: `MainActivity` uses `setContent` with no `setContentView`/`LayoutInflater` under the activity theme, and the sole layout XML (a Glance widget preview, rendered outside the activity) references no `?attr/...` Material theme attributes — so nothing resolves Material3-only attrs at inflation time.
- Confirmed `com.google.android.material` no longer appears in `:androidApp:dependencies --configuration googleDebugRuntimeClasspath`.
- Baseline validation passed locally: `spotlessApply spotlessCheck detekt assembleDebug test allTests` (both google + fdroid flavors assemble; full KMP test suite green); `assembleGoogleDebug` re-verified after the Datadog change.