### PR TITLE
chore: migrate kotlinx-collections-immutable to participial method names

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/NodeManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/NodeManagerImpl.kt
@@ -71,19 +71,19 @@ class NodeManagerImpl(
             var nextById = byId
             // If the user.id changed (e.g. firmware reassigned the hex id) drop the stale id entry.
             if (previous != null && previous.user.id.isNotEmpty() && previous.user.id != node.user.id) {
-                nextById = nextById.remove(previous.user.id)
+                nextById = nextById.removing(previous.user.id)
             }
             if (node.user.id.isNotEmpty()) {
-                nextById = nextById.put(node.user.id, node)
+                nextById = nextById.putting(node.user.id, node)
             }
-            return NodeIndex(byNum = byNum.put(num, node), byId = nextById)
+            return NodeIndex(byNum = byNum.putting(num, node), byId = nextById)
         }
 
         fun remove(num: Int): NodeIndex {
             val previous = byNum[num] ?: return this
             return NodeIndex(
-                byNum = byNum.remove(num),
-                byId = if (previous.user.id.isNotEmpty()) byId.remove(previous.user.id) else byId,
+                byNum = byNum.removing(num),
+                byId = if (previous.user.id.isNotEmpty()) byId.removing(previous.user.id) else byId,
             )
         }
 
@@ -92,8 +92,8 @@ class NodeManagerImpl(
                 var byNum = persistentMapOf<Int, Node>()
                 var byId = persistentMapOf<String, Node>()
                 for ((num, node) in nodes) {
-                    byNum = byNum.put(num, node)
-                    if (node.user.id.isNotEmpty()) byId = byId.put(node.user.id, node)
+                    byNum = byNum.putting(num, node)
+                    if (node.user.id.isNotEmpty()) byId = byId.putting(node.user.id, node)
                 }
                 return NodeIndex(byNum, byId)
             }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/RequestTimer.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/RequestTimer.kt
@@ -37,7 +37,7 @@ internal class RequestTimer {
 
     /** Records the start time for [requestId]. */
     fun start(requestId: Int) {
-        startTimes.update { it.put(requestId, nowMillis) }
+        startTimes.update { it.putting(requestId, nowMillis) }
     }
 
     /**
@@ -46,7 +46,7 @@ internal class RequestTimer {
      */
     fun appendDuration(requestId: Int, text: String, logLabel: String): String {
         val start = startTimes.value[requestId]
-        startTimes.update { it.remove(requestId) }
+        startTimes.update { it.removing(requestId) }
         if (start == null) return text
         val seconds = (nowMillis - start) / MILLIS_PER_SECOND
         Logger.i { "$logLabel $requestId complete in $seconds s" }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/SessionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/SessionManagerImpl.kt
@@ -63,7 +63,7 @@ class SessionManagerImpl(private val clock: Clock) : SessionManager {
     override fun recordSession(srcNodeNum: Int, passkey: ByteString) {
         if (passkey.size == 0) return
         val now = clock.now()
-        entries.update { it.put(srcNodeNum, SessionEntry(passkey, now)) }
+        entries.update { it.putting(srcNodeNum, SessionEntry(passkey, now)) }
         Logger.d { "Recorded session refresh from $srcNodeNum (${passkey.size} bytes)" }
         refreshFlow.tryEmit(srcNodeNum)
     }

--- a/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/FlowCache.kt
+++ b/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/FlowCache.kt
@@ -42,7 +42,7 @@ internal inline fun <K, V> cachedFlow(
         current[key]?.let {
             return it.value
         }
-        if (cache.compareAndSet(current, current.put(key, newLazy))) {
+        if (cache.compareAndSet(current, current.putting(key, newLazy))) {
             return newLazy.value
         }
     }


### PR DESCRIPTION
## Why

`kotlinx-collections-immutable` 0.5.0 (our pinned version) deprecates the imperative copy-returning methods on the persistent collections (`put`, `remove`, …) at `WARNING` level, renaming them to participial forms per [KEEP-0459](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0459-naming-conventions-for-copy-returning-operations.md). At **0.6.0 these old names become compile errors** (and are removed at 0.7.0). Migrating now keeps us forward-safe and clears the deprecation warnings.

## 🧹 What changed

Pure call-site rename on `PersistentMap` receivers — same parameters, order, and return type, only the name changes:

- `put(k, v)` → `putting(k, v)`
- `remove(k)` → `removing(k)`

Touched sites:
- `core/prefs/FlowCache.kt` — `putting` in the atomic CAS insert loop
- `core/data/RequestTimer.kt` — `putting`/`removing` for per-request start times
- `core/data/NodeManagerImpl.kt` — `putting`/`removing` across the `byNum`/`byId` node indices
- `core/data/SessionManagerImpl.kt` — `putting` in `recordSession`

No new imports (these are `PersistentMap` members), no behavioral change, no reformatting of untouched lines.

## Testing Performed

`./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green (2505 tests pass).

## Notes for reviewer

- Version stays pinned at `0.5.0` — it's the latest published release (no 0.6.0 on Maven Central yet), and the participial names already exist there, so this compiles cleanly today and is ready for the eventual 0.6.0 break.