### PR TITLE
refactor(settings): replace SimpleDateFormat with kotlinx-datetime

### DIFF
--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/SettingsScreen.kt
@@ -36,12 +36,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.eygraber.uri.toKmpUri
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
 import org.meshtastic.core.common.util.nowMillis
-import org.meshtastic.core.common.util.toDate
-import org.meshtastic.core.common.util.toInstant
 import org.meshtastic.core.navigation.DiscoveryRoute
 import org.meshtastic.core.navigation.Route
 import org.meshtastic.core.navigation.SettingsRoute
@@ -85,8 +87,7 @@ import org.meshtastic.feature.settings.radio.component.EditDeviceProfileDialog
 import org.meshtastic.feature.settings.util.LanguageUtils
 import org.meshtastic.feature.settings.util.LanguageUtils.languageMap
 import org.meshtastic.proto.DeviceProfile
-import java.text.SimpleDateFormat
-import java.util.Locale
+import kotlin.time.Instant.Companion.fromEpochMilliseconds
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
@@ -142,8 +143,16 @@ fun SettingsScreen(
                 } else {
                     deviceProfile = it
                     val nodeName = (it.short_name ?: "").ifBlank { "node" }
-                    val dateFormat = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
-                    val dateStr = dateFormat.format(nowMillis.toInstant().toDate())
+                    val dateStr =
+                        fromEpochMilliseconds(nowMillis)
+                            .toLocalDateTime(TimeZone.currentSystemDefault())
+                            .format(
+                                LocalDateTime.Format {
+                                    year()
+                                    monthNumber()
+                                    day()
+                                },
+                            )
                     val fileName = "Meshtastic_${nodeName}_${dateStr}_nodeConfig.cfg"
                     val intent =
                         Intent(Intent.ACTION_CREATE_DOCUMENT).apply {

--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/component/PersistenceSection.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/component/PersistenceSection.kt
@@ -23,10 +23,13 @@ import androidx.appcompat.app.AppCompatActivity.RESULT_OK
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.common.util.nowMillis
-import org.meshtastic.core.common.util.toDate
-import org.meshtastic.core.common.util.toInstant
 import org.meshtastic.core.database.DatabaseConstants
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.app_settings
@@ -39,8 +42,18 @@ import org.meshtastic.core.ui.component.ListItem
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Output
 import org.meshtastic.core.ui.theme.AppTheme
-import java.text.SimpleDateFormat
-import java.util.Locale
+import kotlin.time.Instant.Companion.fromEpochMilliseconds
+
+private val EXPORT_TIMESTAMP_FORMAT =
+    LocalDateTime.Format {
+        year()
+        monthNumber()
+        day()
+        char('_')
+        hour()
+        minute()
+        second()
+    }
 
 /** Section for settings related to data persistence and exports. */
 @Composable
@@ -50,7 +63,10 @@ fun PersistenceSection(
     nodeShortName: String,
     onExportData: (android.net.Uri) -> Unit,
 ) {
-    val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(nowMillis.toInstant().toDate())
+    val timestamp =
+        fromEpochMilliseconds(nowMillis)
+            .toLocalDateTime(TimeZone.currentSystemDefault())
+            .format(EXPORT_TIMESTAMP_FORMAT)
 
     val exportRangeTestLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {


### PR DESCRIPTION
## 🧹 Why

`:feature:settings` had the last two `java.text.SimpleDateFormat` usages in the app — Android-only JDK date formatting in a module that's otherwise KMP-friendly. This tidies them up to the `kotlinx-datetime` `LocalDateTime.Format` idiom already established in [`Debug.kt`](https://github.com/meshtastic/Meshtastic-Android/blob/main/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt).

## 🛠️ What changed

- `SettingsScreen.kt` — node-config export filename timestamp (`yyyyMMdd`).
- `PersistenceSection.kt` — range-test / data-log export filename timestamp (`yyyyMMdd_HHmmss`); the format descriptor is hoisted to a top-level `val` (keeps the composable under detekt's `LongMethod` limit).
- Dropped the now-unused `java.text.SimpleDateFormat`, `java.util.Locale`, and `toDate`/`toInstant` imports.

## Notes for reviewers

- **Behaviour preserved**: still device-local time (`TimeZone.currentSystemDefault()`) and the same date patterns, so exported filenames are unchanged. `Debug.kt` uses `TimeZone.UTC`; I deliberately did **not** match that here to avoid changing existing filename semantics — happy to switch if UTC is preferred.
- No shared helper across the two files — the patterns differ, so a common util wasn't worth it.

## Testing Performed

`./gradlew spotlessCheck detekt :feature:settings:compileAndroidMain` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)