### PR TITLE
chore(deps): bump protobufs to 2.7.26-06d729a-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,7 +95,7 @@ mqttastic = "0.4.0"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
 takpacket-sdk = "0.7.0"
-meshtastic-protobufs = "2.7.26-21879a9-SNAPSHOT"
+meshtastic-protobufs = "2.7.26-06d729a-SNAPSHOT"
 
 # Gradle Plugins
 develocity = "4.4.3"


### PR DESCRIPTION
## Why

Keeps the proto pin current. Bumps `org.meshtastic:protobufs` from `21879a9` to `06d729a` — the latest snapshot on the maven-snapshots repo (uploaded 2026-06-29).

## 🧹 What changed

One-line bump in `gradle/libs.versions.toml`. New upstream content between the two SHAs is entirely **additive** — nothing removed, nothing wired into the app yet:

- **MeshBeacon** — new portnum, wire message, `ModuleConfig` + `LocalModuleConfig.mesh_beacon` field
- **Multi-target broadcast** support in `ModuleConfig`
- **Waypoint `notify_favorites_only`** (geofence)
- Kotlin 2.4.0 bump inside the proto repo (build-side only, no API impact)

## Testing Performed

- `:core:model` and `:core:network` compile clean on Android + JVM
- Dependency resolves across all targets (android, jvm, iosArm64, iosSimulatorArm64)
- `:core:model:allTests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)