### PR TITLE
feat(lora): default US region to LongTurbo preset

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
@@ -73,3 +73,16 @@ fun LoRaRegionPresetMap?.repairPresetFor(region: RegionCode, current: ModemPrese
         else -> constraint.presets.firstOrNull() ?: current
     }
 }
+
+/**
+ * The app's built-in default modem presets for regions whose default differs from the global [ChannelOption.DEFAULT].
+ * Mirrors the per-region defaults newer firmware advertises in [LoRaRegionPresetMap], so the default channel and a
+ * fresh setup over old firmware (which sends no map) land on the same preset a new node would.
+ */
+private val REGION_DEFAULT_PRESETS = mapOf(RegionCode.US to ModemPreset.LONG_TURBO)
+
+/**
+ * The app's preferred default preset for [region], or `null` when it has no region-specific default and the caller
+ * should fall back to [ChannelOption.DEFAULT] / the current preset.
+ */
+fun defaultPresetFor(region: RegionCode): ModemPreset? = REGION_DEFAULT_PRESETS[region]

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
@@ -138,4 +138,10 @@ class LoRaRegionPresetsTest {
             )
         assertEquals(ModemPreset.MEDIUM_FAST, oddMap.repairPresetFor(RegionCode.US, ModemPreset.SHORT_FAST))
     }
+
+    @Test
+    fun `region default preset is LongTurbo for US and absent for other regions`() {
+        assertEquals(ModemPreset.LONG_TURBO, defaultPresetFor(RegionCode.US))
+        assertNull(defaultPresetFor(RegionCode.EU_868))
+    }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
@@ -63,6 +63,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.meshtastic.core.model.Channel
 import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.defaultPresetFor
 import org.meshtastic.core.model.util.getChannelUrl
 import org.meshtastic.core.navigation.Route
 import org.meshtastic.core.resources.Res
@@ -199,8 +200,15 @@ fun ChannelScreen(
             messageRes = Res.string.are_you_sure_change_default,
             onConfirm = {
                 Logger.d { "Switching back to default channel" }
+                // The default channel takes the region's preferred preset (e.g. US -> LongTurbo) so its derived name,
+                // hash, and frequency match what a freshly-set-up node in that region would use.
+                val preset = defaultPresetFor(viewModel.region) ?: Channel.default.loraConfig.modem_preset
                 val lora =
-                    (Channel.default.loraConfig).copy(region = viewModel.region, tx_enabled = viewModel.txEnabled)
+                    Channel.default.loraConfig.copy(
+                        region = viewModel.region,
+                        modem_preset = preset,
+                        tx_enabled = viewModel.txEnabled,
+                    )
                 installSettings(Channel.default.settings, lora)
                 showResetDialog = false
             },

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -33,6 +33,7 @@ import org.meshtastic.core.model.ChannelOption
 import org.meshtastic.core.model.RegionInfo
 import org.meshtastic.core.model.RegionPresetConstraint
 import org.meshtastic.core.model.constraintFor
+import org.meshtastic.core.model.defaultPresetFor
 import org.meshtastic.core.model.numChannels
 import org.meshtastic.core.model.repairPresetFor
 import org.meshtastic.core.resources.Res
@@ -70,6 +71,7 @@ import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.feature.settings.util.hopLimits
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
+import org.meshtastic.proto.Config.LoRaConfig.RegionCode
 
 private val SPREAD_FACTOR_RANGE = 7..12
 private val CODING_RATE_RANGE = 5..8
@@ -159,10 +161,22 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     items = RegionInfo.entries.map { it.regionCode to it.description },
                     selectedItem = formState.value.region,
                     onItemSelected = { region ->
+                        val freshSetup = formState.value.region == RegionCode.UNSET
                         // When the region changes, snap the preset to the region's default if the current one is
                         // no longer legal there (R7); a no-op when the region is unconstrained.
                         val repaired = regionPresetMap.repairPresetFor(region, formState.value.modem_preset)
-                        formState.value = formState.value.copy(region = region, modem_preset = repaired)
+                        // At fresh setup (region was UNSET) adopt the region's advertised default rather than keeping
+                        // a merely-legal preset: the firmware map's default when present, else the app's built-in
+                        // default (e.g. US -> LongTurbo on pre-2.8 firmware that sends no map).
+                        val preset =
+                            if (freshSetup) {
+                                regionPresetMap.constraintFor(region)?.defaultPreset
+                                    ?: defaultPresetFor(region)
+                                    ?: repaired
+                            } else {
+                                repaired
+                            }
+                        formState.value = formState.value.copy(region = region, modem_preset = preset)
                     },
                 )
                 HorizontalDivider()


### PR DESCRIPTION
## Why

The US LoRa region's default modem preset should be **LongTurbo**, not LongFast. Newer firmware (2.8+) advertises per-region defaults via `LoRaRegionPresetMap`, but the app never actually applied that advertised default at fresh setup — it kept any *legal* preset, so a US node reporting the proto-zero `LONG_FAST` stayed on LongFast. Older firmware (pre-2.8) sends no map at all, and the app's default channel was hardcoded to LongFast regardless of region.

## What changed

🌟 The US region now defaults to **LongTurbo** consistently across every setup path:

- **LoRa config form — fresh setup** (`region` going `UNSET` → a region): adopt the region's advertised default rather than keeping a merely-legal preset — the firmware map's `default_preset` when present, else the app's built-in default, else the existing legality-repaired preset. A deliberate later preset change in an already-configured region is untouched.
- **Default channel (reset-to-defaults):** the rebuilt default channel now takes the region's preferred preset, so its derived name (`"LongTurbo"`), channel hash, and frequency match what a freshly-set-up node in that region would use.

🛠️ Added a shared `defaultPresetFor(region)` in `core:model` backed by a small `US → LONG_TURBO` table, mirroring the per-region defaults newer firmware advertises in the map. Both call sites use it, so there's a single source of truth.

## Notes for reviewers

- The fresh-setup seed is gated on the previous region being `UNSET`, so it only fires during genuine first-time setup and never clobbers a deliberate preset chosen later.
- `defaultPresetFor` returns `null` for regions with no app-specific opinion; callers fall back to `ChannelOption.DEFAULT` / the current preset, so behavior for every non-US region is unchanged.

## Testing Performed

- `:core:model:allTests` — added a unit test asserting `defaultPresetFor(US) == LONG_TURBO` and `null` for other regions.
- `:feature:settings:allTests` (204 tests) and `:core:model` / `:feature:settings` `detekt` — all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Region settings now use a more appropriate default radio preset for supported regions, with improved handling during fresh setup.
  * Resetting channel settings now also restores the region-specific preset when available.

* **Bug Fixes**
  * Prevents region changes from leaving channels on a less suitable preset when a better default exists.
  * Improves consistency between selected region and modem configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->