### PR TITLE
fix(car): suppress INVISIBLE_MEMBER in CarScreensTest for fdroid build

### DIFF
--- a/feature/car/src/test/kotlin/org/meshtastic/feature/car/CarScreensTest.kt
+++ b/feature/car/src/test/kotlin/org/meshtastic/feature/car/CarScreensTest.kt
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
 package org.meshtastic.feature.car
 
 import androidx.car.app.model.PaneTemplate


### PR DESCRIPTION
## 🐛 Bug Fix

`:feature:car:testFdroidDebugUnitTest` failed to **compile** (the google variant passed). `CarScreensTest.kt` calls `CarStateCoordinator.setStateForTest(...)`, which is `internal` in production code, so the fdroid unit-test compilation reported:

> Cannot access 'fun setStateForTest(...)': it is internal

### Why
The sibling test in the same directory, `CarScreenDataBuilderTest.kt`, already works around this with a file-level `@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")`. `CarScreensTest.kt` was missing it — a pre-existing regression introduced by #5997, unrelated to the work where it was discovered.

### Fix
Add the matching `@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")` above the package declaration in `CarScreensTest.kt`.

## Testing Performed
Both variants now compile and pass (43 tests each):
```
./gradlew :feature:car:testFdroidDebugUnitTest :feature:car:testGoogleDebugUnitTest
```