### PR TITLE
fix(docs): stop builds from churning tracked docs screenshots

### DIFF
--- a/feature/docs/build.gradle.kts
+++ b/feature/docs/build.gradle.kts
@@ -95,8 +95,12 @@ tasks
     }
     .configureEach { dependsOn(syncDocsToComposeResources) }
 
-// FR-038: Ensure screenshots are generated before syncing docs resources
-syncDocsToComposeResources.configure { dependsOn(":screenshot-tests:copyDocsScreenshots") }
+// ponytail: do NOT wire copyDocsScreenshots into the build. It writes into the tracked
+// docs/assets/screenshots/, so a build-time dependsOn rewrote those PNGs on every assemble/test
+// run and churned the working tree. The app bundles the committed copies as-is; regenerate on
+// demand for local viewing (./gradlew :screenshot-tests:copyDocsScreenshots) and `git checkout` to
+// clean, or commit deliberately when refreshing the docs/Jekyll image set. Add a CI staleness gate
+// if drift becomes a problem.
 
 val syncTranslatedDocsToComposeResources by
     tasks.registering(Copy::class) {


### PR DESCRIPTION
## 🐛 Bug Fix

Builds repeatedly dirtied the tracked `docs/assets/screenshots/*.png`, forcing a `git checkout` before every commit.

### Why
`syncDocsToComposeResources` carried a build-time `dependsOn(":screenshot-tests:copyDocsScreenshots")`. `copyDocsScreenshots` is a `Copy` task that writes into the **git-tracked** `docs/assets/screenshots/`. So **every** `assembleDebug`/`test` run that built `:feature:docs` rewrote those PNGs from the CST reference goldens. Because the committed copies had drifted from the current references, the working tree showed them modified on every build.

Rendering is deterministic (layoutlib), so this was never a host/machine issue — it was a generated artifact wired into the build graph against a tracked source path.

### Fix
Drop the `dependsOn`. The app still bundles the committed screenshots as-is via `syncDocsToComposeResources`. Refresh them on demand instead:

```
./gradlew :screenshot-tests:copyDocsScreenshots   # regenerate for local viewing
git checkout -- docs/assets/screenshots           # clean up after viewing
```

…or commit the result deliberately when you actually intend to refresh the docs/Jekyll image set.

No CI task regenerates or gates these images, so removing the build-time refresh changes **no CI behavior**.

## Testing Performed
- `./gradlew :feature:docs:syncDocsToComposeResources --dry-run` — confirms `:screenshot-tests:copyDocsScreenshots` is no longer in the task graph.
- `./gradlew :feature:docs:syncDocsToComposeResources` — BUILD SUCCESSFUL.
- `git status --porcelain docs/assets/screenshots/` — empty after the build (PNGs no longer touched).

## Notes
A `ponytail:` comment at the change site documents the new workflow. If committed doc images ever drift, the follow-up is a CI staleness gate (run `copyDocsScreenshots` + `git diff --exit-code`), not re-wiring the build.