### PR TITLE
fix(qr): Preserve incoming channels when adding from QR

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/qr/ScannedQrCodeDialog.kt
@@ -63,6 +63,7 @@ import org.meshtastic.core.resources.replace
 import org.meshtastic.core.resources.replace_channels_and_settings_description
 import org.meshtastic.core.ui.component.ChannelSelection
 import org.meshtastic.core.ui.theme.AppTheme
+import org.meshtastic.core.ui.util.mergeChannelSettingsForAdd
 import org.meshtastic.proto.ChannelSet
 
 @Composable
@@ -107,9 +108,7 @@ fun ScannedQrCodeDialog(
                     ),
                 )
             } else {
-                // To guarantee consistent ordering, using a LinkedHashSet which iterates through
-                // its entries according to the order an item was *first* inserted.
-                val result = (channels.settings + incoming.settings).distinct()
+                val result = mergeChannelSettingsForAdd(channels.settings, incoming.settings)
                 channels.copy(settings = result)
             }
         }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
@@ -154,3 +154,20 @@ suspend fun applyReplacementChannelSet(
     }
     radioConfigRepository.replaceAllSettings(channelSet.settings)
 }
+
+/**
+ * Builds the ADD-mode preview list for QR import. Existing channels are preserved at their positions; every incoming
+ * channel is appended in order without deduplication.
+ *
+ * Structural `.distinct()` was previously used here, but it silently dropped incoming channels that matched existing
+ * entries, shifting later channels to wrong indices and hiding them from the user. The caller (UI) lets the user select
+ * which incoming channels to keep.
+ *
+ * @param existing The current [ChannelSettings] list on the radio. Preserved in order.
+ * @param incoming The imported [ChannelSettings] list. Appended in order.
+ * @return The concatenated list `[existing..., incoming...]`.
+ */
+fun mergeChannelSettingsForAdd(
+    existing: List<ChannelSettings>,
+    incoming: List<ChannelSettings>,
+): List<ChannelSettings> = existing + incoming

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/ProtoExtensionsTest.kt
@@ -141,4 +141,75 @@ class ProtoExtensionsTest {
         assertEquals(2, result[2].index)
         assertEquals(secondaryB, result[2].settings)
     }
+
+    // --- mergeChannelSettingsForAdd tests ---
+
+    @Test
+    fun merge_preserves_all_existing_channels_in_order() {
+        val existing = listOf(ChannelSettings(name = "A"), ChannelSettings(name = "B"))
+
+        val result = mergeChannelSettingsForAdd(existing, incoming = emptyList())
+
+        assertEquals(2, result.size)
+        assertEquals("A", result[0].name)
+        assertEquals("B", result[1].name)
+    }
+
+    @Test
+    fun merge_appends_all_incoming_channels_in_order() {
+        val incoming = listOf(ChannelSettings(name = "C"), ChannelSettings(name = "D"))
+
+        val result = mergeChannelSettingsForAdd(existing = emptyList(), incoming)
+
+        assertEquals(2, result.size)
+        assertEquals("C", result[0].name)
+        assertEquals("D", result[1].name)
+    }
+
+    @Test
+    fun merge_preserves_structurally_equal_channels() {
+        val channel = ChannelSettings(name = "LongFast", psk = byteArrayOf(1).toByteString())
+
+        val result = mergeChannelSettingsForAdd(existing = listOf(channel), incoming = listOf(channel))
+
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun merge_preserves_same_name_different_psk() {
+        val existingChan = ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString())
+        val incomingChan = ChannelSettings(name = "A", psk = byteArrayOf(2).toByteString())
+
+        val result = mergeChannelSettingsForAdd(listOf(existingChan), listOf(incomingChan))
+
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun merge_preserves_same_psk_different_name() {
+        val psk = byteArrayOf(1, 2).toByteString()
+        val existingChan = ChannelSettings(name = "A", psk = psk)
+        val incomingChan = ChannelSettings(name = "B", psk = psk)
+
+        val result = mergeChannelSettingsForAdd(listOf(existingChan), listOf(incomingChan))
+
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun merge_preserves_duplicate_inside_incoming() {
+        val a = ChannelSettings(name = "A", psk = byteArrayOf(1).toByteString())
+        val b = ChannelSettings(name = "B", psk = byteArrayOf(2).toByteString())
+
+        val result = mergeChannelSettingsForAdd(existing = emptyList(), incoming = listOf(a, a, b))
+
+        assertEquals(3, result.size)
+    }
+
+    @Test
+    fun merge_both_empty_produces_empty_list() {
+        val result = mergeChannelSettingsForAdd(existing = emptyList(), incoming = emptyList())
+
+        assertTrue(result.isEmpty())
+    }
 }


### PR DESCRIPTION
## Overview

This PR fixes QR ADD-mode channel preview construction so incoming channels are not silently removed before the user can review them.

The previous ADD-mode flow merged existing and incoming channels with `.distinct()`. That used raw `ChannelSettings` structural equality, which could remove an incoming channel before it appeared in the import preview. When that happened, later incoming channels could shift positions and the user had no way to inspect or recover the dropped entry.

ADD mode should preserve the current radio channels and show incoming channels in scanned order. This change makes the preview construction explicit: existing channels stay first, and incoming channels are appended without automatic deduplication.

This follows the related QR replacement work in #5999. That PR made REPLACE imports authoritative and sequential; this PR keeps ADD-mode previews non-lossy.

## Key Changes

- Replaced raw structural `.distinct()` merging in QR ADD mode.
- Added explicit ADD-mode preview construction for existing and incoming channels.
- Preserved existing channels in their current order.
- Appended incoming channels in scanned order.
- Kept structurally equal incoming channels visible instead of silently dropping them.
- Left duplicate/conflict classification to a future follow-up.
- Left QR REPLACE behavior unchanged.
- Left channel write sequencing unchanged.

## Testing

- Added unit-test coverage for ADD-mode preview construction.
- Covered preserving existing channels, appending incoming channels, preserving duplicate-looking incoming entries, preserving same-name/different-PSK entries, preserving same-PSK/different-name entries, preserving duplicate entries inside incoming, and empty-list cases.
- Verified manually by deleting channels and re-adding them from QR/import flow.

## Migration Notes

- No user data migration is required.
- Existing channel data remains unchanged until the user imports channels.
- This only changes the QR ADD-mode preview behavior before the user accepts the import.