### PR TITLE
fix(car): notification-only car messaging for production; park templated behind flag

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -43,8 +43,23 @@ if (keystorePropertiesFile.exists()) {
     keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
 }
 
+// The templated Android Auto experience (CarAppService + HomeScreen) is a Google "templated
+// messaging" beta feature that is publishable only to Closed/Internal tracks — Open/Production
+// submissions are auto-rejected (https://developer.android.com/training/cars/communication/templated-messaging).
+// Default builds therefore ship *notification-only* car messaging, which is GA and production-safe.
+// Build a Closed-track templated AAB with: -PenableCarTemplates=true
+// ponytail: gated by a gradle property + res override, not a full build flavor — templated is
+// parked until it leaves Google's beta. Promote to a flavor dimension only if CI must ship both.
+val enableCarTemplates = (findProperty("enableCarTemplates") as String?)?.toBoolean() ?: false
+
 configure<ApplicationExtension> {
     namespace = "org.meshtastic.app"
+
+    // When templates are enabled, this res dir overrides feature:car's notification-only
+    // automotive_app_desc.xml with one that also declares <uses name="template" />.
+    if (enableCarTemplates) {
+        sourceSets.getByName("google").res.srcDir("src/googleCarTemplates/res")
+    }
 
     signingConfigs {
         create("release") {
@@ -114,6 +129,10 @@ configure<ApplicationExtension> {
             )
         }
         ndk { abiFilters += listOf("armeabi-v7a", "arm64-v8a") }
+
+        // Activates the (google-only) CarAppService. Off by default so production builds ship
+        // notification-only car messaging; flipped on by -PenableCarTemplates=true for Closed tracks.
+        manifestPlaceholders["carTemplatesEnabled"] = enableCarTemplates.toString()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/androidApp/src/googleCarTemplates/res/xml/automotive_app_desc.xml
+++ b/androidApp/src/googleCarTemplates/res/xml/automotive_app_desc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Templated Android Auto declaration, included ONLY when building with -PenableCarTemplates=true
+  (wired in androidApp/build.gradle.kts). Being an app-module resource, it overrides feature:car's
+  notification-only automotive_app_desc.xml in the merge, adding <uses name="template" /> so Android
+  Auto recognizes and launches the CarAppService/HomeScreen. Closed/Internal tracks only — Google
+  auto-rejects templated-messaging builds submitted to Open/Production.
+-->
+<automotiveApp>
+    <uses name="notification" />
+    <uses name="template" />
+</automotiveApp>

--- a/feature/car/build.gradle.kts
+++ b/feature/car/build.gradle.kts
@@ -30,6 +30,11 @@ android {
     defaultConfig {
         minSdk = 23
         consumerProguardFiles("proguard-rules.pro")
+        // The CarAppService is disabled unless -PenableCarTemplates=true. feature:car resolves the
+        // placeholder in its OWN manifest, so it must read the property directly (the app's value does
+        // not override a library's own placeholder). Default false → production ships it disabled.
+        manifestPlaceholders["carTemplatesEnabled"] =
+            ((findProperty("enableCarTemplates") as String?)?.toBoolean() ?: false).toString()
     }
 
     // Robolectric provides the Android context that androidx.car.app TestCarContext/ScreenController need.

--- a/feature/car/src/main/AndroidManifest.xml
+++ b/feature/car/src/main/AndroidManifest.xml
@@ -2,8 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
+        <!-- enabled is gated by the app's `carTemplatesEnabled` manifest placeholder: off by default
+             (production ships notification-only car messaging), on for -PenableCarTemplates=true builds.
+             The decisive gate is automotive_app_desc's <uses name="template" /> (see res/xml); this is
+             defense-in-depth so the templated service can't be bound in production. -->
         <service
             android:name="org.meshtastic.feature.car.service.MeshtasticCarAppService"
+            android:enabled="${carTemplatesEnabled}"
             android:exported="true"
             android:permission="androidx.car.app.CarAppService">
             <intent-filter>

--- a/feature/car/src/main/kotlin/org/meshtastic/feature/car/screens/HomeScreen.kt
+++ b/feature/car/src/main/kotlin/org/meshtastic/feature/car/screens/HomeScreen.kt
@@ -144,8 +144,22 @@ class HomeScreen(
         carContext.getCarService(AppManager::class.java).showAlert(alert)
     }
 
+    // Any exception thrown out of onGetTemplate() crashes the Android Auto host ("content not able to
+    // load") and fails Play's Auto review. Degrade to a safe template instead and log for diagnosis.
+    // NOTE: this guards exceptions in OUR build path; a host-side template-contract rejection (e.g. the
+    // messaging surface must be a ListTemplate/SectionedItemTemplate of ConversationItems, not this
+    // TabTemplate dashboard) would not throw here — confirm against the Play pre-launch stack before
+    // promoting templated builds. See -PenableCarTemplates in androidApp/build.gradle.kts.
+    @Suppress("TooGenericExceptionCaught")
+    override fun onGetTemplate(): Template = try {
+        buildHomeTemplate()
+    } catch (e: Exception) {
+        Logger.e(tag = "HomeScreen", throwable = e) { "onGetTemplate failed; showing fallback template" }
+        buildDisconnectedTemplate()
+    }
+
     @Suppress("ReturnCount")
-    override fun onGetTemplate(): Template {
+    private fun buildHomeTemplate(): Template {
         val connectionStatus = stateCoordinator.sessionState.value.connectionStatus
         if (connectionStatus == ConnectionState.Disconnected || connectionStatus == ConnectionState.DeviceSleep) {
             return buildDisconnectedTemplate()

--- a/feature/car/src/main/res/xml/automotive_app_desc.xml
+++ b/feature/car/src/main/res/xml/automotive_app_desc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Default (production) declaration: notification-only car messaging. This is GA and ships to any
+  Play track. The templated experience (<uses name="template" />) is a Google beta restricted to
+  Closed/Internal tracks, so it is added ONLY by androidApp/src/googleCarTemplates/res when built
+  with -PenableCarTemplates=true (that override replaces this file in the merge).
+-->
 <automotiveApp>
-    <uses name="template" />
     <uses name="notification" />
 </automotiveApp>


### PR DESCRIPTION
## Why

Google rejected **v2.8.0-closed.2** (versionCode 29321269) — *"App crashes / the content of your application is not able to load"* under the Auto App Quality Guidelines.

Root cause: the car app is a **"templated messaging experience"** (CarAppService `MESSAGING` + MessagingStyle notifications + `<uses name="template" />`). Per [Google's docs](https://developer.android.com/training/cars/communication/templated-messaging), templated messaging is **beta — publishable to Internal/Closed tracks only; Open/Production submissions are auto-rejected** regardless of correctness. The crash is in the templated surface (launched by tapping a message notification → renders `HomeScreen`). The [#5997](https://github.com/meshtastic/Meshtastic-Android/pull/5997) `TabTemplate` fix was already in the rejected build — it crashed anyway, and adding the `com.google.android.gms.car.application` meta-data there is what first exposed the templated app to review.

Reproduction is blocked locally: the DHU (2.1) can't launch sideloaded apps (`CAR.VALIDATOR: Package DENIED; failed all other checks` for every non-Google app, even with unknown-sources on), and Auto-host crashes don't reach Crashlytics/Datadog. R8 code-strip and resource-shrink were **ruled out** (all car code/resources survive the minified release build).

So this design can never reach Production. This PR makes the **default build notification-only** (GA, production-safe) and **parks the templated experience behind a flag** for Closed-track builds.

## 🌟 Production: notification-only car messaging
- Default `googleRelease` ships notification-only: `CarAppService` is `android:enabled=false` and `automotive_app_desc` declares only `<uses name="notification" />`. It is therefore **not a templated Auto app** and is not subject to the Auto templated review.
- Hands-free reply / mark-as-read keep working — that notification code lives in `core:service`, which is in every build.

## 🛠️ Templated dashboard parked behind `-PenableCarTemplates`
```
./gradlew :androidApp:bundleGoogleRelease                            # Production (notification-only)
./gradlew :androidApp:bundleGoogleRelease -PenableCarTemplates=true  # Closed track (+ templated)
```
- The flag adds `androidApp/src/googleCarTemplates/res`, whose `automotive_app_desc` override declares `<uses name="template" />`, and enables the service.
- `feature:car` stays compiled (`FlavorModule` references `FeatureCarModule`). It resolves the `enabled` placeholder from the same property, because a library's own manifest placeholder is **not** overridden by the app's value.

## 🐛 Crash hardening
- `HomeScreen.onGetTemplate()` now degrades to a safe template instead of throwing out to the Android Auto host (which crashes it = Play rejection). NOTE: a host-side template-contract rejection wouldn't throw here — the suspected `TabTemplate`-vs-`ListTemplate`/`SectionedItemTemplate`-of-`ConversationItem` contract issue still needs the Play Console pre-launch stack to confirm. Templated is parked until then.

## Testing Performed
- **aapt-verified the packaged manifest + `automotive_app_desc`**: flag-off → service `enabled=false` + notification-only; flag-on → service `enabled=true` + `<uses template>`.
- `spotlessCheck`, `detekt`, `assembleDebug` (google + fdroid), `:feature:car:test` (`CarScreensTest`: disconnected→PaneTemplate and connected→TabTemplate both pass).

## Follow-ups (not in this PR)
- Root-cause the templated crash from the Play pre-launch report; likely make the messaging surface a `ListTemplate`/`SectionedItemTemplate` of `ConversationItem`s rather than a `TabTemplate` dashboard.
- The nodes/status dashboard is a better fit for a future generally-available **IOT/POI** templated app (separate investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional templated Android Auto experience in specific builds.
  * Improved build-time controls so the car experience can switch between notification-only and templated modes.

* **Bug Fixes**
  * Prevented Android Auto template errors from crashing the host by falling back safely when template generation fails.
  * Kept the car experience disabled by default for production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->