### PR TITLE
chore: add CodeRabbit config tuned for this repo

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit config — see https://docs.coderabbit.ai/getting-started/yaml-configuration
+language: en-US
+
+reviews:
+  # chill = fewer nitpicks. CI already gates detekt/spotless/tests, and the
+  # maintainers are experienced — we want CodeRabbit for substance, not lint noise.
+  profile: chill
+  high_level_summary: true
+  poem: false
+  # Don't burn reviews on WIP. This repo opens lots of draft PRs; review on "ready".
+  auto_review:
+    enabled: true
+    drafts: false
+  # Stop reviewing once a PR is closed.
+  abort_on_close: true
+
+  path_filters:
+    # Generated / huge / non-source — don't review, just noise + token burn.
+    - "!**/build/**"
+    - "!**/*.png"
+    - "!**/*.webp"
+    - "!**/firmware_releases.json"
+    - "!**/emoji-data.json"
+    - "!**/flatpak-sources.json"
+    # Crowdin-managed translations — owned upstream, not hand-edited here.
+    - "!**/values-*/strings.xml"
+
+  path_instructions:
+    - path: "**/commonMain/**"
+      instructions: >
+        KMP common code. Flag any import of java.* or android.* — these break
+        non-Android targets. Expect KMP equivalents instead (Okio, kotlinx
+        Mutex/atomicfu, NumberFormatter.format() for floats).
+    - path: "**/*.kt"
+      instructions: >
+        Flag leftover // ... existing code ... placeholders, and any logging of
+        PII, location, or cryptographic keys.
+    - path: "**/src/**/strings.xml"
+      instructions: >
+        New string resources must be alphabetically sorted (scripts/sort-strings.py).
+        Flag out-of-order additions.
+
+  # CI is the source of truth for detekt + spotless (Zero Lint Tolerance gate),
+  # so disable detekt here to avoid duplicate comments. Keep the security/CI/shell
+  # scanners CI doesn't run inline.
+  tools:
+    detekt:
+      enabled: false


### PR DESCRIPTION
## Why

CodeRabbit was just enabled org-wide for automated PR reviews. Without a repo config it runs on defaults — duplicating the detekt/spotless/test gates CI already enforces, reviewing WIP draft PRs, and burning tokens on generated/locale files. This adds a `.coderabbit.yaml` tuned to how this project actually works.

## 🧹 Chores

- **`profile: chill`** — CI already gates detekt/spotless/tests with zero tolerance; we want CodeRabbit for logic/architecture, not duplicate lint nitpicks.
- **`auto_review.drafts: false`** — this repo opens lots of draft PRs; review on *ready for review*, not WIP.
- **`tools.detekt.enabled: false`** — CI is the source of truth for detekt; disabling here avoids double-reporting the same findings inline.
- **`path_filters`** — skip generated/large/Crowdin-managed files already guarded elsewhere: `build/`, `*.png`/`*.webp`, `firmware_releases.json`, `emoji-data.json`, `flatpak-sources.json`, `values-*/strings.xml`.
- **`path_instructions`** — encode AGENTS.md rules a generic reviewer would miss: no `java.*`/`android.*` in `commonMain`, no PII/location/key logging, alphabetically-sorted string resources.

## Notes for reviewers

- Config-only; no code or build changes, so the Gradle baseline isn't affected.
- The repo `.coderabbit.yaml` overrides dashboard settings, so this file (not the dashboard) is the source of truth for review behavior.
- Pointing CodeRabbit's knowledge base at `AGENTS.md` is a dashboard-side step that can't live in this file — worth doing separately.
- Easy to tune later; intentionally minimal to start (skipped `request_changes_workflow`, knowledge_base, labeling_instructions until we've seen real reviews land).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository review settings to improve automated checks on new changes.
  * Updated review rules to better handle generated files, translation resources, and platform-specific compatibility issues.
  * Refined automation so reviews run only when appropriate and stop cleanly when a pull request is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->