### PR TITLE
fix(firmware): repair nRF USB firmware update and post-update reconnect

### DIFF
--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/ProbeTableProvider.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/ProbeTableProvider.kt
@@ -30,9 +30,11 @@ import org.koin.core.annotation.Single
 @Single
 class ProbeTableProvider {
     fun get(): ProbeTable = UsbSerialProber.getDefaultProbeTable().apply {
-        // RAK 4631:
+        // RAK 4631 (0x239A / 0x8029):
         addProduct(9114, 32809, CdcAcmSerialDriver::class.java)
         // LilyGo TBeam v1.1:
         addProduct(6790, 21972, CdcAcmSerialDriver::class.java)
+        // Elecrow ThinkNode M3 / M4 / M6 and LilyGo T-Echo (0x239A / 0x4405) — native nRF52840 USB CDC:
+        addProduct(9114, 17413, CdcAcmSerialDriver::class.java)
     }
 }

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/UsbRepository.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/UsbRepository.kt
@@ -54,7 +54,17 @@ class UsbRepository(
         _serialDevices
             .mapLatest { serialDevices ->
                 val serialProber = usbSerialProberLazy.value
-                buildMap { serialDevices.forEach { (k, v) -> serialProber.probeDevice(v)?.let { put(k, it) } } }
+                // Key by a stable identity, NOT the raw deviceList key (the /dev/bus/usb/BBB/DDD path). Android
+                // reassigns that path on every re-enumeration — each reboot or replug bumps it (…/002 → …/008) — so a
+                // path-keyed map can't recognise the same physical node across a firmware-update reboot, and the
+                // auto-reconnect in SharedRadioInterfaceService (which matches the saved address against these keys)
+                // never re-arms. usbSerialStableKey() survives re-enumeration.
+                buildMap {
+                    serialDevices.values.forEach { device ->
+                        val driver = serialProber.probeDevice(device) ?: return@forEach
+                        put(driver.device.usbSerialStableKey(), driver)
+                    }
+                }
             }
             .stateIn(processLifecycle.coroutineScope, SharingStarted.Eagerly, emptyMap())
 
@@ -90,3 +100,18 @@ class UsbRepository(
         _serialDevices.emit(devices)
     }
 }
+
+/**
+ * Stable identity for a USB serial device that survives re-enumeration.
+ *
+ * Uses vendor + product id, which is permission-free and identical before and after a reboot/replug (and before vs
+ * after the firmware-update DFU bounce, since the app firmware re-enumerates with the same VID/PID). Deliberately does
+ * NOT use [UsbDevice.getSerialNumber] — that requires an active USB permission grant, which is exactly what is missing
+ * immediately after a re-enumeration, so a serial-based key would read back null mid-recovery and break the very
+ * reconnect this is meant to enable.
+ *
+ * ponytail: vendor:product collides if two *identical* boards are attached at once (last one wins in the map). Append
+ * getSerialNumber() — gated on usbManager.hasPermission(device) — only if multi-identical-device support is ever
+ * needed.
+ */
+internal fun UsbDevice.usbSerialStableKey(): String = "$vendorId-$productId"

--- a/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
+++ b/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
@@ -76,14 +76,16 @@ class AndroidGetDiscoveredDevicesUseCase(
 
         val usbDevicesFlow =
             usbRepository.serialDevices.map { usb ->
-                usb.map { (_, d) ->
+                usb.map { (stableKey, d) ->
                     DeviceListEntry.Usb(
                         usbData = AndroidUsbDeviceData(d),
                         name = d.device.deviceName,
+                        // Address must be the stable map key, not the device path: the path (deviceName) is reassigned
+                        // on every re-enumeration, so a path-based saved address can't survive a reboot/replug.
                         fullAddress =
                         radioInterfaceService.toInterfaceAddress(
                             org.meshtastic.core.model.InterfaceId.SERIAL,
-                            d.device.deviceName,
+                            stableKey,
                         ),
                         bonded = usbManagerLazy.value.hasPermission(d.device),
                     )

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -46,6 +46,7 @@ import org.meshtastic.core.datastore.BootloaderWarningDataSource
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.model.MyNodeInfo
+import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.repository.DeviceHardwareRepository
 import org.meshtastic.core.repository.FirmwareReleaseRepository
 import org.meshtastic.core.repository.NodeRepository
@@ -385,9 +386,9 @@ class FirmwareUpdateViewModel(
         // (stable-keyed) address. BLE/TCP have no such hot-plug recovery, so they still need the explicit re-address.
         address?.let { fullAddr ->
             if (radioPrefs.isSerial()) {
-                Logger.i { "Post-update: leaving USB reconnect to USB auto-recovery for $fullAddr" }
+                Logger.i { "Post-update: leaving USB reconnect to USB auto-recovery for ${fullAddr.anonymize}" }
             } else {
-                Logger.i { "Post-update: Requesting MeshService to reconnect to $fullAddr" }
+                Logger.i { "Post-update: Requesting MeshService to reconnect to ${fullAddr.anonymize}" }
                 radioController.setDeviceAddress(fullAddr)
             }
         }

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -248,6 +248,11 @@ class FirmwareUpdateViewModel(
                                 is FirmwareUpdateState.Success ->
                                     verifyUpdateResult(originalDeviceAddress, finalState.wasLowSpeedTransfer)
 
+                                // USB/UF2 path intentionally pauses here: the UI launches the file picker and
+                                // saveDfuFile() resumes the flow. Leave the state intact (tempFirmwareFile holds
+                                // the artifact for cleanup after the copy completes).
+                                is FirmwareUpdateState.AwaitingFileSave -> Unit
+
                                 is FirmwareUpdateState.Error -> {
                                     tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
                                 }
@@ -337,6 +342,9 @@ class FirmwareUpdateViewModel(
                         is FirmwareUpdateState.Success ->
                             verifyUpdateResult(originalDeviceAddress, finalState.wasLowSpeedTransfer)
 
+                        // USB/UF2 path pauses here for the user to pick a save location; saveDfuFile() resumes it.
+                        is FirmwareUpdateState.AwaitingFileSave -> Unit
+
                         is FirmwareUpdateState.Error -> {
                             tempFirmwareFile = cleanupTemporaryFiles(fileHandler, tempFirmwareFile)
                         }
@@ -367,10 +375,21 @@ class FirmwareUpdateViewModel(
     private suspend fun verifyUpdateResult(address: String?, wasLowSpeedTransfer: Boolean = false) {
         _state.value = FirmwareUpdateState.Verifying
 
-        // Trigger a fresh connection attempt by MeshService using the original prefixed address
+        // Trigger a fresh connection attempt by MeshService using the original prefixed address.
+        //
+        // For USB/serial, do NOT force this: a USB node re-enumerates several times through the bootloader over
+        // ~20s, so a one-shot setDeviceAddress fires into an enumeration gap, fails ("Serial device not found"),
+        // and lands the transport in Disconnected — which preempts the dedicated USB auto-recovery in
+        // SharedRadioInterfaceService (observeUsbRecoveryTriggers), since that only arms from DeviceSleep. Leaving
+        // the transport in DeviceSleep lets that recovery reconnect the moment the device re-attaches on its new
+        // (stable-keyed) address. BLE/TCP have no such hot-plug recovery, so they still need the explicit re-address.
         address?.let { fullAddr ->
-            Logger.i { "Post-update: Requesting MeshService to reconnect to $fullAddr" }
-            radioController.setDeviceAddress(fullAddr)
+            if (radioPrefs.isSerial()) {
+                Logger.i { "Post-update: leaving USB reconnect to USB auto-recovery for $fullAddr" }
+            } else {
+                Logger.i { "Post-update: Requesting MeshService to reconnect to $fullAddr" }
+                radioController.setDeviceAddress(fullAddr)
+            }
         }
 
         // Wait for device to reconnect and settle

--- a/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
+++ b/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
@@ -293,6 +293,68 @@ class FirmwareUpdateViewModelFileTest {
     }
 
     @Test
+    fun `startUpdate keeps AwaitingFileSave state for USB path`() = runTest {
+        // Regression: the UF2/USB flow ends at AwaitingFileSave — a deliberate pause for the file picker, not a
+        // missing terminal state. startUpdate() must leave it intact; previously it fell into the else branch and
+        // clobbered it to Error, so tapping "Update via USB File Transfer" always failed.
+        every { radioPrefs.devAddr } returns MutableStateFlow("s/dev/ttyUSB0")
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        val ready = viewModel.state.value
+        assertIs<FirmwareUpdateState.Ready>(ready)
+        assertIs<FirmwareUpdateMethod.Usb>(ready.updateMethod)
+
+        val artifact =
+            FirmwareArtifact(
+                uri = CommonUri.parse("file:///tmp/firmware.uf2"),
+                fileName = "firmware.uf2",
+                isTemporary = true,
+            )
+        everySuspend { firmwareUpdateManager.startUpdate(any(), any(), any(), any()) }
+            .calls {
+                @Suppress("UNCHECKED_CAST")
+                val updateState = it.args[3] as (FirmwareUpdateState) -> Unit
+                updateState(FirmwareUpdateState.AwaitingFileSave(artifact, "firmware.uf2"))
+                artifact
+            }
+
+        viewModel.startUpdate()
+        advanceUntilIdle()
+
+        assertIs<FirmwareUpdateState.AwaitingFileSave>(viewModel.state.value)
+    }
+
+    @Test
+    fun `startUpdateFromFile keeps AwaitingFileSave state for USB path`() = runTest {
+        every { radioPrefs.devAddr } returns MutableStateFlow("s/dev/ttyUSB0")
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+        assertIs<FirmwareUpdateMethod.Usb>((viewModel.state.value as FirmwareUpdateState.Ready).updateMethod)
+
+        val artifact =
+            FirmwareArtifact(
+                uri = CommonUri.parse("file:///tmp/extracted.uf2"),
+                fileName = "extracted.uf2",
+                isTemporary = true,
+            )
+        everySuspend { fileHandler.extractFirmware(any(), any(), any()) } returns artifact
+        everySuspend { firmwareUpdateManager.startUpdate(any(), any(), any(), any(), any()) }
+            .calls {
+                @Suppress("UNCHECKED_CAST")
+                val updateState = it.args[3] as (FirmwareUpdateState) -> Unit
+                updateState(FirmwareUpdateState.AwaitingFileSave(artifact, "extracted.uf2"))
+                artifact
+            }
+
+        viewModel.startUpdateFromFile(CommonUri.parse("file:///downloads/firmware.zip"))
+        advanceUntilIdle()
+
+        assertIs<FirmwareUpdateState.AwaitingFileSave>(viewModel.state.value)
+    }
+
+    @Test
     fun `startUpdateFromFile cleans up on manager error state`() = runTest {
         every { radioPrefs.devAddr } returns MutableStateFlow("s/dev/ttyUSB0")
 


### PR DESCRIPTION
## Why

A community report ("can we do USB DFU for nRF nodes? I'm only seeing OTA") turned out not to be a missing feature — the USB (UF2) firmware-update path for nRF52 already exists, but it was **broken end-to-end**. Tapping **Update via USB File Transfer** always failed, and even when it flashed, the app couldn't reconnect afterward. This fixes the whole flow. Verified on a RAK4631 over USB.

## 🐛 Bug fixes

- **USB update never started.** `performUsbUpdate` sets state to `AwaitingFileSave` — the deliberate pause where the UI launches the SAF file picker and `saveDfuFile()` resumes the flow. But `FirmwareUpdateViewModel.startUpdate()` / `startUpdateFromFile()` only handled `Success`/`Error`, so `AwaitingFileSave` fell into the `else` "defense-in-depth" branch and was overwritten with `Error`. Symptom in logcat: `Firmware update returned without terminal state: AwaitingFileSave(...)`. Added an explicit `AwaitingFileSave` branch to both `when` blocks.

- **Post-update reconnect race.** `verifyUpdateResult` forced a one-shot `setDeviceAddress` ~5s after reboot. A USB node re-enumerates through the bootloader over ~20s, so the forced reconnect fired into the enumeration gap, failed (`Serial device not found`), and landed the transport in `Disconnected` — which preempts the dedicated USB auto-recovery (`observeUsbRecoveryTriggers`, which only arms from `DeviceSleep`). Now we skip the forced reconnect for serial and let auto-recovery own it. BLE/TCP still force it (they have no hot-plug presence and the address is set to `"n"` during the update, so the explicit re-address is load-bearing there).

## 🛠️ Improvements

- **Stable USB serial identity.** Devices were keyed by `UsbDevice.deviceName` (the `/dev/bus/usb/BBB/DDD` path), which Android reassigns on every re-enumeration — so after the post-update reboot the saved address no longer matched and auto-reconnect couldn't recognise the node. Now keyed by a stable `vendorId-productId` (`UsbDevice.usbSerialStableKey()`) in `UsbRepository`, and the saved `SERIAL` address is built from that key in `AndroidGetDiscoveredDevicesUseCase` (it previously baked in the path). Deliberately **not** the USB serial number — `getSerialNumber()` needs a permission grant that's missing right after re-enumeration, which would defeat the recovery. (Trade-off: two *identical* boards collide; documented in-code with the upgrade path.)

- **Recognise more nRF boards over USB.** Registered `0x239A/0x4405` in `ProbeTableProvider` so Elecrow ThinkNode M3/M4/M6 and LilyGo T-Echo are detected as USB CDC serial devices at all (previously only RAK4631 `0x8029` was). ⚠️ **Unverified on hardware** — I don't have an M3/M4/M6/T-Echo to test the connect path; the vid:pid is confirmed against the firmware board JSONs (`build.hwids[0]`). Happy to split this into its own PR if reviewers prefer to keep this one all-verified.

## Testing performed

- `:feature:firmware:jvmTest` — green (19 tests, incl. 2 new regression tests asserting `startUpdate`/`startUpdateFromFile` keep `AwaitingFileSave` instead of clobbering it to `Error`).
- `spotlessCheck` + `detekt` — clean.
- **On-device (RAK4631, Pixel 6a, googleDebug):** full USB update → file picker → flash → reboot → **automatic** reconnect with no manual replug. Logcat confirms `DeviceSleep` preserved → `Post-update: leaving USB reconnect to USB auto-recovery` → `Serial device connected in 23ms` → `Connected`. The device's stable key (`9114-32809`) held across the path churn (`/002 → … → /011`).

## Reviewer notes

- The per-transport split in `verifyUpdateResult` is intentional and asymmetric: USB skips the forced reconnect (auto-recovery handles it), BLE/WiFi keep it (no presence signal; address is `"n"` post-update). See the in-code comment for the rationale.
- Remaining known Android limitation (out of scope): USB permission is granted per `UsbDevice` instance and re-prompts on re-enumeration unless the user checked "always open this app" via the `device_filter.xml` attach dialog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved USB device detection with expanded support for additional known VID/PID devices.

* **Bug Fixes**
  * More reliable tracking of connected devices after re-enumeration (unplug/replug or reboot) by using a stable device identity for saved addressing.
  * USB firmware updates now preserve the “save file” step correctly and avoid unnecessary forced reconnects on Serial/USB while keeping reconnect behavior for other transports.

* **Tests**
  * Added regression coverage for USB firmware update state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->