### PR TITLE
fix(ble): Handle scan registration failure

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -117,6 +117,7 @@ bluetooth_feature_config_description
 bluetooth_feature_discovery
 bluetooth_feature_discovery_description
 bluetooth_permission
+bluetooth_scan_start_failed
 bold_heading
 bonding_failed_permissions
 bonding_failed_retry

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleScanStartException.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleScanStartException.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ble
+
+/** Known reasons a BLE discovery scan failed before Android registered the scanner. */
+enum class BleScanStartFailureReason(val androidCode: String, val description: String) {
+    ApplicationRegistrationFailed(
+        androidCode = "SCAN_FAILED_APPLICATION_REGISTRATION_FAILED(2)",
+        description = "Android could not register the app for BLE scanning",
+    ),
+}
+
+/** A discovery scan-start failure. No advertisements can be delivered until a future scan starts successfully. */
+class BleScanStartException(val reason: BleScanStartFailureReason, cause: Throwable) :
+    IllegalStateException("BLE scan could not start: ${reason.androidCode}", cause)

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.ble
 
 import com.juul.kable.Advertisement
 import com.juul.kable.Scanner
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collect
@@ -26,6 +27,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
 import kotlin.time.Duration
 import kotlin.uuid.Uuid
+
+private const val MAX_SCAN_START_FAILURE_CAUSE_DEPTH = 10
 
 internal sealed interface KableScanFilter {
     data object None : KableScanFilter
@@ -67,16 +70,43 @@ open class KableBleScanner(private val loggingConfig: BleLoggingConfig) : BleSca
         // By wrapping it in a channelFlow with a timeout, we enforce the BleScanner contract cleanly.
         return channelFlow {
             withTimeoutOrNull(timeout) {
-                advertisements(filter).collect { advertisement ->
-                    send(
-                        MeshtasticBleDevice(
-                            address = advertisement.identifier,
-                            name = advertisement.name,
-                            advertisement = advertisement.advertisement,
-                        ),
-                    )
+                try {
+                    advertisements(filter).collect { advertisement ->
+                        send(
+                            MeshtasticBleDevice(
+                                address = advertisement.identifier,
+                                name = advertisement.name,
+                                advertisement = advertisement.advertisement,
+                            ),
+                        )
+                    }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: IllegalStateException) {
+                    throw ex.asBleScanStartExceptionOrNull() ?: ex
                 }
             }
         }
     }
 }
+
+private fun Throwable.asBleScanStartExceptionOrNull(): BleScanStartException? {
+    var current: Throwable? = this
+    var depth = 0
+    while (current != null && depth < MAX_SCAN_START_FAILURE_CAUSE_DEPTH) {
+        if (current.isApplicationRegistrationFailure()) {
+            return BleScanStartException(BleScanStartFailureReason.ApplicationRegistrationFailed, current)
+        }
+        current = current.cause
+        depth++
+    }
+    return null
+}
+
+// Kable exposes Android scan-start registration failure as an IllegalStateException message,
+// so keep this matcher narrow and local to the scanner adapter.
+private fun Throwable.isApplicationRegistrationFailure(): Boolean = this is IllegalStateException &&
+    message?.let { failureMessage ->
+        failureMessage.contains("app cannot be registered", ignoreCase = true) ||
+            failureMessage.contains("SCAN_FAILED_APPLICATION_REGISTRATION_FAILED", ignoreCase = true)
+    } == true

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
@@ -95,7 +95,7 @@ private fun Throwable.asBleScanStartExceptionOrNull(): BleScanStartException? {
     var depth = 0
     while (current != null && depth < MAX_SCAN_START_FAILURE_CAUSE_DEPTH) {
         if (current.isApplicationRegistrationFailure()) {
-            return BleScanStartException(BleScanStartFailureReason.ApplicationRegistrationFailed, current)
+            return BleScanStartException(BleScanStartFailureReason.ApplicationRegistrationFailed, this)
         }
         current = current.cause
         depth++

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -119,6 +120,39 @@ class KableBleConnectionTest {
         scanner.scan(timeout = 1.seconds, serviceUuid = serviceUuid, address = "AA:BB:CC:DD:EE:FF").toList()
 
         assertEquals(KableScanFilter.Address("AA:BB:CC:DD:EE:FF"), scanner.lastFilter)
+    }
+
+    @Test
+    fun `scan wraps Android scanner registration failure`() = runTest {
+        val scanner =
+            TestKableBleScanner(
+                scanResults = flow { throw IllegalStateException("Failed to start scan as app cannot be registered") },
+            )
+
+        val failure = assertFailsWith<BleScanStartException> { scanner.scan(timeout = 1.seconds).toList() }
+
+        assertEquals(BleScanStartFailureReason.ApplicationRegistrationFailed, failure.reason)
+    }
+
+    @Test
+    fun `scan wraps nested scanner registration failure`() = runTest {
+        val innerCause = IllegalStateException("Failed to start scan as app cannot be registered")
+        val scanner =
+            TestKableBleScanner(scanResults = flow { throw IllegalStateException("Outer scanner failure", innerCause) })
+
+        val failure = assertFailsWith<BleScanStartException> { scanner.scan(timeout = 1.seconds).toList() }
+
+        assertEquals(BleScanStartFailureReason.ApplicationRegistrationFailed, failure.reason)
+    }
+
+    @Test
+    fun `scan preserves unrelated illegal state failure`() = runTest {
+        val scanner =
+            TestKableBleScanner(scanResults = flow { throw IllegalStateException("Unexpected scanner state") })
+
+        val failure = assertFailsWith<IllegalStateException> { scanner.scan(timeout = 1.seconds).toList() }
+
+        assertEquals("Unexpected scanner state", failure.message)
     }
 
     private class TestKableBleScanner(private val scanResults: Flow<KableScanResult>) :

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -135,6 +135,7 @@
     <string name="bluetooth_feature_discovery">Discovery</string>
     <string name="bluetooth_feature_discovery_description">Find and identify Meshtastic devices near you.</string>
     <string name="bluetooth_permission">Bluetooth</string>
+    <string name="bluetooth_scan_start_failed">Bluetooth scan couldn't start. Try again, or toggle Bluetooth if the problem continues.</string>
     <string name="bold_heading">Bold Heading</string>
     <string name="bonding_failed_permissions">Pairing failed. Grant nearby device permissions and try again.</string>
     <string name="bonding_failed_retry">Pairing did not complete. Try pairing again.</string>

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
@@ -19,7 +19,9 @@ package org.meshtastic.feature.connections
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -34,9 +36,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import org.meshtastic.core.ble.BleDevice
+import org.meshtastic.core.ble.BleScanStartException
 import org.meshtastic.core.ble.BleScanner
 import org.meshtastic.core.ble.MeshtasticBleConstants
+import org.meshtastic.core.common.util.safeCatchingAll
 import org.meshtastic.core.datastore.RecentAddressesDataSource
 import org.meshtastic.core.datastore.model.RecentAddress
 import org.meshtastic.core.di.CoroutineDispatchers
@@ -49,12 +54,20 @@ import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.RadioPrefs
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.core.repository.UiPrefs
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.bluetooth_scan_start_failed
+import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.feature.connections.model.DeviceListEntry
 import org.meshtastic.feature.connections.model.DiscoveredDevices
 import org.meshtastic.feature.connections.model.GetDiscoveredDevicesUseCase
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+internal val BLE_SCAN_START_FAILURE_RETRY_COOLDOWN = 15.seconds
+private const val BLE_SCAN_START_FAILURE_MESSAGE_FALLBACK =
+    "Bluetooth scan couldn't start. Try again, or toggle Bluetooth if the problem continues."
 
 /**
  * Platform-neutral ViewModel that drives the Connections screen: device discovery (BLE/USB/TCP), scan state, current
@@ -107,6 +120,9 @@ open class ScannerViewModel(
     private val scannedBleDevices = MutableStateFlow<Map<String, BleDevice>>(emptyMap())
     private val discoveryOrder = MutableStateFlow<List<String>>(emptyList())
     private var scanJob: Job? = null
+    private var scanStartFailureCooldownJob: Job? = null
+    private val scanStartFailureCooldownActive = MutableStateFlow(false)
+    private var scanStartFailureCooldownGeneration = 0
 
     // Generation counter that owns the `_isBleScanning` flag's cleanup. The scan coroutine's `finally` block may run
     // asynchronously on the IO dispatcher after a stop+restart has already kicked off a new scan; without this guard
@@ -272,7 +288,7 @@ open class ScannerViewModel(
      * prior scan cannot reset the flag on this new scan's state.
      */
     fun startBleScan() {
-        if (_isBleScanning.value || bleScanner == null) return
+        if (_isBleScanning.value || bleScanner == null || scanStartFailureCooldownActive.value) return
         // Cancel the other scan first so only one flag is ever true. Both stop methods are idempotent.
         stopNetworkScan()
 
@@ -301,8 +317,13 @@ open class ScannerViewModel(
                                 discoveryOrder.update { it + device.address }
                             }
                         }
+                } catch (ex: BleScanStartException) {
+                    handleBleScanStartFailure(ex, generation)
                 } finally {
-                    if (scanGeneration.value == generation) _isBleScanning.value = false
+                    if (scanGeneration.value == generation) {
+                        _isBleScanning.value = false
+                        scanJob = null
+                    }
                 }
             }
     }
@@ -310,9 +331,6 @@ open class ScannerViewModel(
     /**
      * Starts BLE scanning for screen-entry auto-scan only when no device is already selected. Manual scan toggles call
      * [startBleScan] directly so users can still discover/switch devices while connected.
-     *
-     * This controls only Connections-screen discovery. Selected-device reconnect still performs its fresh-advertisement
-     * scan in `BleRadioTransport.findDevice` before connecting.
      */
     fun startBleAutoScan() {
         if (activeTransport.value != DeviceType.BLE) return
@@ -352,6 +370,41 @@ open class ScannerViewModel(
                 uiPrefs.setNetworkAutoScan(false)
             }
         }
+    }
+
+    private suspend fun handleBleScanStartFailure(exception: BleScanStartException, generation: Int) {
+        if (scanGeneration.value != generation) return
+
+        scanGeneration.value = generation + 1
+        scanJob = null
+        _isBleScanning.value = false
+        uiPrefs.setBleAutoScan(false)
+        startBleScanRetryCooldown()
+
+        Logger.w(exception) {
+            "BLE scan could not start: ${exception.reason.androidCode} (${exception.reason.description})"
+        }
+        val errorMessage =
+            safeCatchingAll { getStringSuspend(Res.string.bluetooth_scan_start_failed) }
+                .getOrDefault(BLE_SCAN_START_FAILURE_MESSAGE_FALLBACK)
+        serviceRepository.setErrorMessage(text = errorMessage, severity = Severity.Warn)
+    }
+
+    private fun startBleScanRetryCooldown() {
+        val generation = ++scanStartFailureCooldownGeneration
+        scanStartFailureCooldownActive.value = true
+        scanStartFailureCooldownJob?.cancel()
+        scanStartFailureCooldownJob =
+            viewModelScope.launch {
+                try {
+                    delay(BLE_SCAN_START_FAILURE_RETRY_COOLDOWN)
+                } finally {
+                    if (scanStartFailureCooldownGeneration == generation) {
+                        scanStartFailureCooldownActive.value = false
+                        scanStartFailureCooldownJob = null
+                    }
+                }
+            }
     }
 
     /**

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
@@ -23,9 +23,13 @@ import dev.mokkery.matcher.any
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.meshtastic.core.ble.BleDevice
+import org.meshtastic.core.ble.BleScanStartException
+import org.meshtastic.core.ble.BleScanStartFailureReason
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.network.repository.DiscoveredService
@@ -103,6 +107,57 @@ class ScannerViewModelTest {
             assertEquals(false, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `scan startup failure clears scanning state disables auto-scan and surfaces error`() = runTest {
+        harness.uiPrefs.setBleAutoScan(true)
+        every { bleScanner.scan(any(), any()) } returns failingScanFlow()
+
+        viewModel.startBleScan()
+
+        assertEquals(false, viewModel.isBleScanning.value)
+        assertEquals(false, viewModel.bleAutoScan.value)
+        assertEquals(
+            "Bluetooth scan couldn't start. Try again, or toggle Bluetooth if the problem continues.",
+            serviceRepository.errorMessage.value,
+        )
+    }
+
+    @Test
+    fun `scan startup failure cooldown prevents immediate retry and allows later manual retry`() = runTest {
+        var scanAttempts = 0
+        every { bleScanner.scan(any(), any()) } returns
+            flow {
+                scanAttempts += 1
+                throw BleScanStartException(
+                    reason = BleScanStartFailureReason.ApplicationRegistrationFailed,
+                    cause = IllegalStateException("Failed to start scan as app cannot be registered"),
+                )
+            }
+
+        viewModel.startBleScan()
+        assertEquals(1, scanAttempts)
+        assertEquals(false, viewModel.isBleScanning.value)
+
+        viewModel.startBleScan()
+        assertEquals(1, scanAttempts)
+
+        harness.testDispatcher.scheduler.advanceTimeBy(BLE_SCAN_START_FAILURE_RETRY_COOLDOWN.inWholeMilliseconds + 1)
+        viewModel.startBleScan()
+
+        assertEquals(2, scanAttempts)
+    }
+
+    @Test
+    fun `stopBleScan is idempotent after failed startup`() = runTest {
+        every { bleScanner.scan(any(), any()) } returns failingScanFlow()
+
+        viewModel.startBleScan()
+        viewModel.stopBleScan()
+        viewModel.stopBleScan()
+
+        assertEquals(false, viewModel.isBleScanning.value)
     }
 
     @Test
@@ -205,7 +260,7 @@ class ScannerViewModelTest {
         val bondedBle = FakeBleDevice(address = "0D:0E:0F:10:11:12", name = "Bonded C", rssi = null)
         val bondedDevice = DeviceListEntry.Ble(device = bondedBle, bonded = true)
 
-        val scanFlow = MutableStateFlow<org.meshtastic.core.ble.BleDevice?>(null)
+        val scanFlow = MutableStateFlow<BleDevice?>(null)
         every { bleScanner.scan(any(), any()) } returns scanFlow.filterNotNull()
 
         viewModel.bleDevicesForUi.test {
@@ -275,7 +330,7 @@ class ScannerViewModelTest {
     @Test
     fun `stopBleScan does not clear scanned devices`() = runTest {
         val device = FakeBleDevice(address = "01:02:03:04:05:06", name = "Node", rssi = -50)
-        val scanFlow = MutableStateFlow<org.meshtastic.core.ble.BleDevice?>(null)
+        val scanFlow = MutableStateFlow<BleDevice?>(null)
         every { bleScanner.scan(any(), any()) } returns scanFlow.filterNotNull()
 
         viewModel.bleDevicesForUi.test {
@@ -578,5 +633,12 @@ class ScannerViewModelTest {
 
         assertEquals(false, viewModel.isNetworkScanning.value)
         assertEquals("t192.168.1.99", radioController.lastSetDeviceAddress)
+    }
+
+    private fun failingScanFlow() = flow<BleDevice> {
+        throw BleScanStartException(
+            reason = BleScanStartFailureReason.ApplicationRegistrationFailed,
+            cause = IllegalStateException("Failed to start scan as app cannot be registered"),
+        )
     }
 }


### PR DESCRIPTION
## Overview

This pull request handles an Android BLE scan startup failure observed in field logs.

In that failure path, Android rejected BLE scanner registration with `SCAN_FAILED_APPLICATION_REGISTRATION_FAILED`. That means the discovery scan never actually started: there were no advertisements to wait for and no device-discovery result to recover from. The adapter was enabled and there was no permission exception, but Android reported that the app could not be registered for scanning.

Before this change, that failure escaped from the scan coroutine as a generic `[startBleScan]` unhandled exception. The scan state reset, and the app could immediately try again, creating repeated scanner-registration failures without a useful recovery message.

This change makes that scan-start failure explicit: the app classifies it near the scanner adapter, clears scan state, disables immediate BLE auto-scan retry, shows a recovery warning, and allows manual retry after a short cooldown.

## Key Changes

- Added a typed BLE scan startup failure for Android scanner registration failure.
- Wrapped Kable scanner-registration failures as `BleScanStartException`.
- Kept the Android/Kable message matching narrow and local to the scanner adapter.
- Preserved cancellation and unrelated scanner exceptions.
- Stopped treating scan startup failure as a generic `[startBleScan]` unhandled exception.
- Ensured failed scan startup clears scanning state and scan job state.
- Disabled BLE auto-scan after scan-start failure to avoid immediate retry loops.
- Added a short retry cooldown before allowing another BLE discovery scan.
- Surfaced a user-facing recovery message.
- Preserved BLE/Network scan mutual exclusion.

## Testing

- Added coverage for direct Android scanner registration failure wrapping.
- Added coverage for wrapped cause-chain scanner registration failure wrapping.
- Added coverage proving unrelated `IllegalStateException` failures are preserved.
- Added coverage proving scan startup failure clears scanning state.
- Added coverage proving scan startup failure disables BLE auto-scan and surfaces an error.
- Added coverage proving immediate retry is blocked during cooldown and manual retry is allowed after cooldown.
- Added coverage proving `stopBleScan()` remains idempotent after failed startup.
- Verified in a normal field run that BLE discovery, selection, connection setup, radio session readiness, and mesh handshake still complete successfully.

## Migration Notes

- No user data migration is required.
- Existing BLE addresses and OS bonds are unchanged.
- This only changes handling of Android BLE discovery scan startup failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user-facing message for Bluetooth scan start failures.
  * Improved Bluetooth scanning to handle startup failures more gracefully, with automatic retry cooldowns.

* **Bug Fixes**
  * Scan start errors are now detected and surfaced instead of failing silently.
  * Bluetooth auto-scan is disabled temporarily after repeated startup failures to prevent rapid retries.
  * Scanning state is now cleared correctly after a failed scan start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->