### PR TITLE
chore(coderabbit): skip auto-review for Renovate PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,9 +9,13 @@ reviews:
   high_level_summary: true
   poem: false
   # Don't burn reviews on WIP. This repo opens lots of draft PRs; review on "ready".
+  # Skip Renovate dependency updates — CI gates dependencies; we review for substance, not every bump.
   auto_review:
     enabled: true
     drafts: false
+    skip_author:
+      - renovate
+      - renovate[bot]
   # Stop reviewing once a PR is closed.
   abort_on_close: true
 


### PR DESCRIPTION
## Summary
Skip CodeRabbit auto-review for Renovate dependency updates to reduce token burn. CI already gates lint/tests/detekt; CodeRabbit is for substance, not every dependency bump.

## Testing Performed
Verified `.coderabbit.yaml` syntax and `skip_author` filter applies to both `renovate` and `renovate[bot]` authors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review settings to skip Renovate-generated pull requests.
  * Left existing review behavior unchanged for all other updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->