### PR TITLE
fix(discovery): show disabled reason below Start Analysis button

### DIFF
--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/DiscoveryScanScreen.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/DiscoveryScanScreen.kt
@@ -373,6 +373,14 @@ private fun ScanButton(
             Icon(imageVector = MeshtasticIcons.PlayArrow, contentDescription = null)
             Text(stringResource(Res.string.discovery_start_scan), modifier = Modifier.padding(start = 8.dp))
         }
+        if (!isEnabled && disabledReason.isNotEmpty()) {
+            Text(
+                text = disabledReason,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
     }
 }
 

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/DiscoveryScanScreen.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/DiscoveryScanScreen.kt
@@ -365,21 +365,23 @@ private fun ScanButton(
         val disabledDescription = stringResource(Res.string.discovery_start_scan_disabled, disabledReason)
         val buttonModifier =
             if (!isEnabled) {
-                modifier.fillMaxWidth().semantics { contentDescription = disabledDescription }
+                Modifier.fillMaxWidth().semantics { contentDescription = disabledDescription }
             } else {
-                modifier.fillMaxWidth()
+                Modifier.fillMaxWidth()
             }
-        Button(onClick = onStart, enabled = isEnabled, modifier = buttonModifier) {
-            Icon(imageVector = MeshtasticIcons.PlayArrow, contentDescription = null)
-            Text(stringResource(Res.string.discovery_start_scan), modifier = Modifier.padding(start = 8.dp))
-        }
-        if (!isEnabled && disabledReason.isNotEmpty()) {
-            Text(
-                text = disabledReason,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 4.dp),
-            )
+        Column(modifier = modifier) {
+            Button(onClick = onStart, enabled = isEnabled, modifier = buttonModifier) {
+                Icon(imageVector = MeshtasticIcons.PlayArrow, contentDescription = null)
+                Text(stringResource(Res.string.discovery_start_scan), modifier = Modifier.padding(start = 8.dp))
+            }
+            if (!isEnabled && disabledReason.isNotEmpty()) {
+                Text(
+                    text = disabledReason,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

🐛 The \"Start Analysis\" button on the Local Mesh Discovery screen was disabled with no visible explanation. Users (including non-English speakers) had no idea why.

The `disabledReason` string was already computed for each blocking condition (`not connected`, `uses default key`, `no presets selected`, `2.4 GHz unsupported`) but was only set as a `contentDescription` — accessible to screen readers only, invisible to everyone else.

This renders the reason as `bodySmall` text below the button when it's disabled.

## Changes

- Wrap the `Button` + reason `Text` in a `Column` (required to satisfy the `MultipleEmitters` detekt rule)
- Show `disabledReason` as visible `onSurfaceVariant` text below the button when disabled and a reason exists
- No new strings — reuses existing `discovery_start_scan_reason_*` resources

## Testing Performed

- `detekt` passes clean on `:feature:discovery`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the scan button’s accessibility by showing a localized disabled description when the button can’t be used.
  * Added an on-screen reason below the scan button when it is disabled, helping users understand why scanning is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->