### PR TITLE
feat(testing): debug-only skip_onboarding intent extra for AI/CI tooling

### DIFF
--- a/.skills/testing-ci/SKILL.md
+++ b/.skills/testing-ci/SKILL.md
@@ -77,6 +77,20 @@ Compose Preview Screenshot Testing (AGP/layoutlib) is split into two modules —
 
 Rendering is **host-deterministic** (layoutlib): a local `update` produces references byte-identical to CI, so locally-recorded goldens pass `validate`. `copyDocsScreenshots` overwrites a stale committed `nodes_detail_local.png` each run — `git checkout` it. Public previews consumed cross-module by a wrapper need a `detekt-baseline.xml` entry (PreviewPublic). New screenshot? Pick the module by purpose; see `docs/assets/screenshots/README.md`.
 
+## 3c) Fresh-install manual/agent testing: skip onboarding
+
+Debug builds accept an intent extra to skip the intro flow (`MainActivity.kt`, `BuildConfig.DEBUG`-gated — never reaches release/Play builds). Pair with `pm grant` (native Android, no app code) to pre-accept runtime permissions:
+
+```bash
+adb shell pm grant <pkg> android.permission.BLUETOOTH_SCAN
+adb shell pm grant <pkg> android.permission.BLUETOOTH_CONNECT
+adb shell pm grant <pkg> android.permission.ACCESS_FINE_LOCATION
+adb shell pm grant <pkg> android.permission.POST_NOTIFICATIONS   # API 33+
+adb shell am start -n <pkg>/org.meshtastic.app.MainActivity --ez skip_onboarding true
+```
+
+Use this whenever driving the app from a fresh install/uninstall (screenshot tests, UI automation, agent-driven exploration) instead of clicking through the intro screens.
+
 ## 4) CI Pipeline Architecture
 
 CI is defined in `.github/workflows/reusable-check.yml` and structured as parallel job groups:

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
@@ -105,6 +105,13 @@ class MainActivity : AppCompatActivity() {
 
         super.onCreate(savedInstanceState)
 
+        // ponytail: debug-only test affordance so CI/agent tooling can skip onboarding on a fresh
+        // install: `adb shell am start -n <pkg>/.MainActivity --ez skip_onboarding true`. Pair with
+        // `adb shell pm grant <pkg> <permission>` to pre-grant runtime permissions (native, no app code).
+        if (BuildConfig.DEBUG && intent.getBooleanExtra(EXTRA_SKIP_ONBOARDING, false)) {
+            model.onAppIntroCompleted()
+        }
+
         enableEdgeToEdge()
 
         // Explicitly set the cutout mode to ALWAYS for Android 15+ to satisfy Play Console recommendations.
@@ -327,5 +334,9 @@ class MainActivity : AppCompatActivity() {
         if (!selectedAddress.isNullOrBlank() && selectedAddress != NO_DEVICE_SELECTED) return
 
         handleMeshtasticUri("$DEEP_LINK_BASE_URI/connections".toUri())
+    }
+
+    private companion object {
+        const val EXTRA_SKIP_ONBOARDING = "skip_onboarding"
     }
 }


### PR DESCRIPTION
## Summary
- Adds a `BuildConfig.DEBUG`-gated check in `MainActivity.onCreate` that calls `onAppIntroCompleted()` when launched with `--ez skip_onboarding true`, letting AI/CI tooling drive the app past the intro flow on a fresh install without clicking through it.
- Documents the full recipe (this extra + `adb shell pm grant` for runtime permissions) in `.skills/testing-ci/SKILL.md` so it's discoverable for future agent sessions.

## Testing Performed
- `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green.
- Manual clean-install verification on the `medium_phone` emulator: uninstalled `com.geeksville.mesh.fdroid.debug`, reinstalled, ran `pm grant` for BLUETOOTH_SCAN/BLUETOOTH_CONNECT/ACCESS_FINE_LOCATION/POST_NOTIFICATIONS, launched with `am start --ez skip_onboarding true`. App landed directly on the main Connection screen (no intro screens), and `dumpsys package` confirmed all four permissions `granted=true`.
- Confirmed the flag is `BuildConfig.DEBUG`-gated so it cannot reach release/Play builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for fresh-install testing that explains how to bypass the intro flow in debug builds.
  * Included setup steps for permissions and launching the app with the skip option enabled.

* **New Features**
  * Added a debug-only way to skip onboarding during test installs, making repeated setup and validation faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->