### PR TITLE
test(settings): fix flaky DebugViewModelTest presetFilters date assertion

### DIFF
--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModelTest.kt
@@ -143,15 +143,27 @@ class DebugViewModelTest {
     fun `presetFilters includes my node ID and broadcast`() {
         nodeRepository.setMyNodeInfo(org.meshtastic.core.testing.TestDataFactory.createMyNodeInfo(myNodeNum = 12345678))
 
+        // presetFilters reads the real wall clock (nowInstant) for its date element, so bracket that
+        // read: the instant the VM used lies between `before` and `after`, meaning its short-date must
+        // equal one of the two bounds. Keeps the assertion deterministic even when the wall clock
+        // crosses a minute boundary between the VM's read and the test's.
+        val before = org.meshtastic.core.common.util.nowInstant.toEpochMilliseconds()
         val filters = viewModel.presetFilters
+        val after = org.meshtastic.core.common.util.nowInstant.toEpochMilliseconds()
+
+        val validDates =
+            setOf(
+                org.meshtastic.core.common.util.DateFormatter.formatShortDate(before),
+                org.meshtastic.core.common.util.DateFormatter.formatShortDate(after),
+            )
+        (filters[3] in validDates) shouldBe true
+
         filters.shouldBe(
             listOf(
                 "!00bc614e",
                 "!ffffffff",
                 "decoded",
-                org.meshtastic.core.common.util.DateFormatter.formatShortDate(
-                    org.meshtastic.core.common.util.nowInstant.toEpochMilliseconds(),
-                ),
+                filters[3], // validated above against the bracketed wall-clock reads
             ) + org.meshtastic.proto.PortNum.entries.map { it.name },
         )
     }


### PR DESCRIPTION
## Why

`DebugViewModelTest.\`presetFilters includes my node ID and broadcast\`` fails ~1-in-60 CI runs. `DebugViewModel.presetFilters` is a computed getter that reads the real wall clock (`nowInstant`) for its short-date element. The test recomputed `DateFormatter.formatShortDate(nowInstant.toEpochMilliseconds())` at assertion time, so when the wall clock crossed a minute boundary between the ViewModel's read and the test's read, the two short-dates differed (e.g. `"3:15 PM"` vs `"3:16 PM"`) and the equality assertion failed. `nowInstant` is real wall-clock (`Clock.System.now()`), not frozen.

## 🐛 Fix

Bracket the ViewModel's clock read between two `nowInstant` reads in the test. The instant the ViewModel used necessarily lies within `[before, after]`, so its short-date must equal `formatShortDate` of one of the two bounds. The test now:

- validates the date element (index `[3]`) against that 2-element set of bounding short-dates, and
- keeps the full-list equality for everything else (node-id hex, broadcast, `decoded`, and the `PortNum` tail), reusing the already-validated `filters[3]` for the date slot.

Test-only change — **no production code touched**.

### Why not inject a `Clock`?

`nowInstant` is a top-level `val` backed by `Clock.System.now()`; making it injectable would mean adding a `Clock` to the `DebugViewModel` constructor plus DI wiring. The bracketing approach fixes the flake with zero production change.

## Testing Performed

Ran the JVM variant 5× with cache disabled — all green, no flakiness:

```
./gradlew :feature:settings:jvmTest --tests "*DebugViewModelTest*" --rerun-tasks
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Made a date-related test more reliable by allowing for small timing differences when checking the displayed date.
  * Updated the expected filter values to keep the validation stable across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->