### PR TITLE
fix(ci): align auto-labeler and PR-label check with real GitHub labels

### DIFF
--- a/.github/workflows/pr_enforce_labels.yml
+++ b/.github/workflows/pr_enforce_labels.yml
@@ -2,7 +2,7 @@ name: Check PR Labels
 
 on:
   pull_request:
-    types: [edited, labeled]
+    types: [opened, synchronize, edited, labeled, unlabeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -25,11 +25,11 @@ jobs:
           const labels = new Set();
 
           // Match branch prefix (e.g. feat/..., fix/..., chore-something)
-          // Also parse conventional-commit-style PR titles as a fallback
+          // Also parse conventional-commit-style PR titles as a fallback: type(scope): subject
           const branchPrefix = branch.split(/[\/\-_]/)[0].toLowerCase();
-          const titlePrefix = (title.match(/^(\w+)[\(:]/) || [])[1]?.toLowerCase();
-
-          const prefix = branchPrefix || titlePrefix;
+          const titleMatch = title.match(/^(\w+)(?:\(([^)]+)\))?:/);
+          const titlePrefix = titleMatch?.[1]?.toLowerCase();
+          const titleScope = titleMatch?.[2]?.toLowerCase();
 
           // Map prefixes to changelog-aligned labels
           const prefixMap = {
@@ -53,6 +53,11 @@ jobs:
             'release':  'release',
           };
 
+          // Map conventional-commit scopes to labels not derivable from the type alone
+          const scopeMap = {
+            'desktop': 'desktop',
+          };
+
           // Label from branch prefix
           if (prefixMap[branchPrefix]) labels.add(prefixMap[branchPrefix]);
 
@@ -61,16 +66,25 @@ jobs:
             labels.add(prefixMap[titlePrefix]);
           }
 
-          // Also label 'repo' if .github/ or build-logic/ files were changed
-          if (!labels.has('repo') && !labels.has('ci') && !labels.has('build')) {
+          // Label from PR title scope, e.g. "feat(desktop): ..."
+          if (titleScope && scopeMap[titleScope]) labels.add(scopeMap[titleScope]);
+
+          // Path-based labels from changed files
+          const pathLabels = [
+            { prefix: '.github/', label: 'repo' },
+            { prefix: 'build-logic/', label: 'build' },
+            { prefix: 'desktopApp/', label: 'desktop' },
+          ].filter(({ label }) => !labels.has(label));
+          if (pathLabels.length > 0) {
             try {
               const files = await github.paginate(
                 github.rest.pulls.listFiles,
                 { owner: context.repo.owner, repo: context.repo.repo, pull_number: context.payload.pull_request.number, per_page: 100 },
                 (res) => res.data.map(f => f.filename)
               );
-              if (files.some(f => f.startsWith('.github/'))) labels.add('repo');
-              if (files.some(f => f.startsWith('build-logic/'))) labels.add('build');
+              for (const { prefix, label } of pathLabels) {
+                if (files.some(f => f.startsWith(prefix))) labels.add(label);
+              }
             } catch (e) {
               core.warning(`Could not list PR files (rate limited?): ${e.message}`);
             }


### PR DESCRIPTION
## Summary
- `Check PR Labels` (pr_enforce_labels.yml) only triggered on `edited`/`labeled`. If a PR's branch/title matched none of the auto-labeler's prefixes, no label was ever applied and the check never ran at all — silently missing rather than failing. Now triggers on `opened`/`synchronize` (matching the auto-labeler's own triggers) plus `unlabeled`, so it always runs and also catches a required label being removed later.
- The auto-labeler (pull-request-target.yml) could never produce the `desktop` label, despite it being a real, required label with an established `feat(desktop): ...` commit-title convention and a dedicated `desktopApp/` module. Added conventional-commit scope parsing (`type(scope): subject`) and a `desktopApp/` changed-file path check, generalizing the existing `.github/` → `repo` / `build-logic/` → `build` path-based detection into a small table.
- Removed an unused `const prefix = branchPrefix || titlePrefix` line left over in the labeler script.
- Verified via `gh label list` that every label referenced by either workflow (`bugfix`, `enhancement`, `automation`, `dependencies`, `repo`, `release`, `refactor`, `desktop`, `chore`, `ci`, `build`, `testing`, `documentation`) actually exists in the repo.

## Testing Performed
- Read-only verification: diffed the auto-labeler's producible label set against the `check-label` required-label set and against `gh label list` output; no code path to execute locally (these are `pull_request`/`pull_request_target` GitHub Actions workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request label checks so they run for more PR activity types, helping labels stay accurate after updates and edits.
  * Enhanced automatic label assignment by better recognizing commit/title patterns and applying labels more consistently based on changed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->