### PR TITLE
fix(messages): Refresh channel placeholders after updates

### DIFF
--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
@@ -146,8 +146,8 @@ fun ContactsScreen(
     // Create channel placeholders (always show broadcast contacts, even when empty)
     val channels by viewModel.channels.collectAsStateWithLifecycle()
     val channelPlaceholders =
-        remember(channels.settings.size) {
-            (0 until channels.settings.size).map { ch ->
+        remember(channels) {
+            channels.settings.mapIndexed { ch, _ ->
                 Contact(
                     contactKey = "$ch^all",
                     shortName = "$ch",


### PR DESCRIPTION
## Overview

This PR fixes stale channel placeholder rows in the Contacts/Messages list.

Previously, channel placeholders were remembered only by `channels.settings.size`. If channel settings changed without changing the number of channels, placeholder rows could keep stale names or default labels until a broader refresh.

This change keys the placeholder computation on the full `ChannelSet`, so placeholder contacts are recomputed when channel content changes, not only when the channel count changes.

## Key Changes

* Recomputed channel placeholder contacts when the full channel set changes.
* Replaced the index-range loop with `channels.settings.mapIndexed`.
* Kept placeholder contact keys and display behavior unchanged.

## Testing

* Verified the diff is limited to channel placeholder recomputation.
* Verified `git diff --check` passes.
* Manually tested by updating channel settings without changing the channel count and confirmed that placeholder names update correctly.

## Migration Notes

* No user data migration is required.
* This only affects how channel placeholder contacts are remembered and refreshed in the UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how broadcast/channel placeholder contacts are generated, with no expected change to the visible contact list or contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->