### PR TITLE
chore(deps): bump meshtastic-protobufs to 2.7.26-aa53c96-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,7 +95,7 @@ mqttastic = "0.4.0"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
 takpacket-sdk = "0.7.0"
-meshtastic-protobufs = "2.7.26-032b7df-SNAPSHOT"
+meshtastic-protobufs = "2.7.26-aa53c96-SNAPSHOT"
 
 # Gradle Plugins
 develocity = "4.5.0"


### PR DESCRIPTION
## Summary
- Bumps the pinned `meshtastic-protobufs` snapshot from `2.7.26-032b7df-SNAPSHOT` to the latest published snapshot, `2.7.26-aa53c96-SNAPSHOT`.
- Upstream delta is additive only: adds `is_unmessagable` and `is_licensed` fields to `DeviceProfile` exports (meshtastic/protobufs#971).

## Test plan
- [x] `./gradlew assembleDebug` — new proto snapshot resolves and project compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)