### PR TITLE
fix(build): remove -Xbackend-threads=0 to stop parallel codegen crashes

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
@@ -223,7 +223,7 @@ private val SHARED_COMPILER_ARGS =
     listOf(
         "-Xexpect-actual-classes",
         "-Xskip-prerelease-check",
-        "-Xbackend-threads=0",
+        // No -Xbackend-threads: parallel codegen races and crashes release builds (KT-83578).
     )
 
 private const val JDK_VERSION = 21


### PR DESCRIPTION
## 🛠️ Why

The `v2.8.0-internal.14` google release build has now choked repeatedly on `:feature:car:compileGoogleReleaseKotlin` with an internal Kotlin compiler error:

```
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
  at java.util.ArrayList.add
  at org.jetbrains.kotlin.backend.jvm.JvmIrCodegenFactory.invokeCodegen$lambda$0
```

This is [KT-83578](https://youtrack.jetbrains.com/issue/KT-83578): the compiler's **experimental** parallel JVM backend has a race where multiple codegen threads append to an unsynchronized `ArrayList`. It only triggers when `-Xbackend-threads=0` (use all cores) is explicitly set — which we do in `build-logic` `SHARED_COMPILER_ARGS` since #5311. It's timing-dependent, so it passes locally and randomly bombs CI; in run [28586561770](https://github.com/meshtastic/Meshtastic-Android/actions/runs/28586561770) it failed on the daemon **and** the no-daemon fallback, blocking the release.

## 🐛 What

Remove the `-Xbackend-threads=0` compiler arg (the workaround recommended on the YouTrack issue), restoring the default single-threaded backend. Codegen is a small slice of total build time; deterministic releases beat the speedup.

We can reintroduce the flag once KT-83578 is fixed upstream (reportedly not reproducible on 2.4.20-dev builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)