### PR TITLE
fix(ci): rename skip_author to ignore_usernames in .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,7 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    skip_author:
+    ignore_usernames:
       - renovate
       - renovate[bot]
   # Stop reviewing once a PR is closed.


### PR DESCRIPTION
## Summary
- `skip_author` is not a valid CodeRabbit config key under `reviews.auto_review` — the correct key is `ignore_usernames`.
- The invalid key meant the `renovate` / `renovate[bot]` entries were silently a no-op, so those PRs were still being auto-reviewed by CodeRabbit.
- Same issue was flagged by CodeRabbit itself on [meshtastic/protobufs#973](https://github.com/meshtastic/protobufs/pull/973#discussion_r3510439742), applying the equivalent fix here.

## Testing Performed
- N/A — one-line CI config rename, no app code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)