### PR TITLE
fix(logs): Allow access to DebugPanel Logs while disconnected

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfig.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfig.kt
@@ -80,6 +80,8 @@ fun RadioConfigItemList(
     onNavigate: (Route) -> Unit,
 ) {
     val enabled = state.connected && !state.responseState.isWaiting() && !isManaged
+    // ponytail: Debug Log/App Logs read local device data, not the radio, so they stay usable offline.
+    val debugPanelEnabled = !state.responseState.isWaiting() && !isManaged
 
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
         RadioConfigSection(isManaged, enabled, onRouteClick)
@@ -93,7 +95,7 @@ fun RadioConfigItemList(
         AdministrationSection(enabled, onNavigate)
 
         if (state.isLocal) {
-            AdvancedSection(isManaged, isOtaCapable, enabled, onNavigate)
+            AdvancedSection(isManaged, isOtaCapable, enabled, debugPanelEnabled, onNavigate)
         }
     }
 }
@@ -190,7 +192,13 @@ private fun AdministrationSection(enabled: Boolean, onNavigate: (Route) -> Unit)
 }
 
 @Composable
-private fun AdvancedSection(isManaged: Boolean, isOtaCapable: Boolean, enabled: Boolean, onNavigate: (Route) -> Unit) {
+private fun AdvancedSection(
+    isManaged: Boolean,
+    isOtaCapable: Boolean,
+    enabled: Boolean,
+    debugPanelEnabled: Boolean,
+    onNavigate: (Route) -> Unit,
+) {
     ExpressiveSection(title = stringResource(Res.string.advanced_title)) {
         if (isManaged) {
             ManagedMessage()
@@ -222,7 +230,7 @@ private fun AdvancedSection(isManaged: Boolean, isOtaCapable: Boolean, enabled: 
         ListItem(
             text = stringResource(Res.string.debug_panel),
             leadingIcon = MeshtasticIcons.BugReport,
-            enabled = enabled,
+            enabled = debugPanelEnabled,
             onClick = { onNavigate(SettingsRoute.DebugPanel) },
         )
     }


### PR DESCRIPTION
Allows access to device and app logs while disconnected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The debug panel is now disabled in situations where settings are still loading or managed, preventing users from opening it at the wrong time.
  * The advanced settings area now correctly reflects when the debug panel should be available, improving consistency in the radio configuration screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->