### PR TITLE
fix(settings): Generate fresh PSK for named manual channels

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -70,6 +71,7 @@ import org.meshtastic.feature.settings.radio.channel.component.ChannelCard
 import org.meshtastic.feature.settings.radio.channel.component.ChannelConfigHeader
 import org.meshtastic.feature.settings.radio.channel.component.ChannelLegend
 import org.meshtastic.feature.settings.radio.channel.component.ChannelLegendDialog
+import org.meshtastic.feature.settings.radio.channel.component.ChannelPskEditState
 import org.meshtastic.feature.settings.radio.channel.component.EditChannelDialog
 import org.meshtastic.feature.settings.radio.component.LoadingOverlay
 import org.meshtastic.feature.settings.radio.component.PacketResponseStateDialog
@@ -122,12 +124,17 @@ private fun ChannelConfigScreen(
         rememberSaveable(saver = listSaver(save = { it.toList() }, restore = { it.toMutableStateList() })) {
             settingsList.toMutableStateList()
         }
+    val pskEditStatesInput =
+        rememberSaveable(saver = channelPskEditStatesSaver) {
+            List(settingsList.size) { ChannelPskEditState() }.toMutableStateList()
+        }
 
     val listState = rememberLazyListState()
     val dragDropState =
         rememberDragDropState(listState) { fromIndex, toIndex ->
             if (toIndex in settingsListInput.indices && fromIndex in settingsListInput.indices) {
-                settingsListInput.apply { add(toIndex, removeAt(fromIndex)) }
+                settingsListInput.move(fromIndex, toIndex)
+                pskEditStatesInput.move(fromIndex, toIndex)
             }
         }
 
@@ -143,11 +150,14 @@ private fun ChannelConfigScreen(
         EditChannelDialog(
             channelSettings = settingsListInput.getOrNull(index) ?: ChannelSettings(),
             modemPresetName = modemPresetName,
-            onAddClick = {
+            initialPskEditState = pskEditStatesInput.getOrElse(index) { ChannelPskEditState() },
+            onAddClick = { settings, pskEditState ->
                 if (settingsListInput.size > index) {
-                    settingsListInput[index] = it
+                    settingsListInput[index] = settings
+                    pskEditStatesInput[index] = pskEditState
                 } else {
-                    settingsListInput.add(it)
+                    settingsListInput.add(settings)
+                    pskEditStatesInput.add(pskEditState)
                 }
                 showEditChannelDialog = null
             },
@@ -177,6 +187,7 @@ private fun ChannelConfigScreen(
                     onClick = {
                         if (maxChannels > settingsListInput.size) {
                             settingsListInput.add(newUnnamedManualChannelSettings())
+                            pskEditStatesInput.add(ChannelPskEditState(canGeneratePskForName = true))
                             showEditChannelDialog = settingsListInput.lastIndex
                         }
                     },
@@ -231,7 +242,10 @@ private fun ChannelConfigScreen(
                             channelSettings = channel,
                             loraConfig = loraConfig,
                             onEditClick = { showEditChannelDialog = index },
-                            onDeleteClick = { settingsListInput.removeAt(index) },
+                            onDeleteClick = {
+                                settingsListInput.removeAt(index)
+                                pskEditStatesInput.removeAt(index)
+                            },
                             sharesLocation = locationChannel == index,
                         )
                     }
@@ -244,6 +258,7 @@ private fun ChannelConfigScreen(
                                 focusManager.clearFocus()
                                 settingsListInput.clear()
                                 settingsListInput.addAll(settingsList)
+                                pskEditStatesInput.replaceAll(settingsList.size, ChannelPskEditState())
                             },
                             positiveText = stringResource(Res.string.send),
                             onPositiveClicked = {
@@ -273,7 +288,40 @@ private fun ChannelConfigScreen(
     }
 }
 
-private fun newUnnamedManualChannelSettings(): ChannelSettings = ChannelSettings(psk = Channel.default.settings.psk)
+private fun newUnnamedManualChannelSettings(): ChannelSettings = Channel.default.settings
+
+private val channelPskEditStatesSaver =
+    listSaver<SnapshotStateList<ChannelPskEditState>, Int>(
+        save = { states -> states.map { it.toSaveableFlags() } },
+        restore = { flags -> flags.map { it.toChannelPskEditState() }.toMutableStateList() },
+    )
+
+private fun <T> MutableList<T>.move(fromIndex: Int, toIndex: Int) {
+    add(toIndex, removeAt(fromIndex))
+}
+
+private fun MutableList<ChannelPskEditState>.replaceAll(size: Int, value: ChannelPskEditState) {
+    clear()
+    repeat(size) { add(value) }
+}
+
+private fun ChannelPskEditState.toSaveableFlags(): Int {
+    var flags = 0
+    if (canGeneratePskForName) flags = flags or CAN_GENERATE_PSK_FOR_NAME_FLAG
+    if (generatedPskForName) flags = flags or GENERATED_PSK_FOR_NAME_FLAG
+    if (pskExplicitlyEdited) flags = flags or PSK_EXPLICITLY_EDITED_FLAG
+    return flags
+}
+
+private fun Int.toChannelPskEditState(): ChannelPskEditState = ChannelPskEditState(
+    canGeneratePskForName = this and CAN_GENERATE_PSK_FOR_NAME_FLAG != 0,
+    generatedPskForName = this and GENERATED_PSK_FOR_NAME_FLAG != 0,
+    pskExplicitlyEdited = this and PSK_EXPLICITLY_EDITED_FLAG != 0,
+)
+
+private const val CAN_GENERATE_PSK_FOR_NAME_FLAG = 1
+private const val GENERATED_PSK_FOR_NAME_FLAG = 1 shl 1
+private const val PSK_EXPLICITLY_EDITED_FLAG = 1 shl 2
 
 /**
  * Determines what [Channel] if any is enabled to conduct automatic location sharing.

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
@@ -126,7 +126,7 @@ private fun ChannelConfigScreen(
         }
     val pskEditStatesInput =
         rememberSaveable(saver = channelPskEditStatesSaver) {
-            List(settingsList.size) { ChannelPskEditState() }.toMutableStateList()
+            List(settingsListInput.size) { ChannelPskEditState() }.toMutableStateList()
         }
 
     val listState = rememberLazyListState()
@@ -296,16 +296,16 @@ private val channelPskEditStatesSaver =
         restore = { flags -> flags.map { it.toChannelPskEditState() }.toMutableStateList() },
     )
 
-private fun <T> MutableList<T>.move(fromIndex: Int, toIndex: Int) {
+internal fun <T> MutableList<T>.move(fromIndex: Int, toIndex: Int) {
     add(toIndex, removeAt(fromIndex))
 }
 
-private fun MutableList<ChannelPskEditState>.replaceAll(size: Int, value: ChannelPskEditState) {
+internal fun MutableList<ChannelPskEditState>.replaceAll(size: Int, value: ChannelPskEditState) {
     clear()
     repeat(size) { add(value) }
 }
 
-private fun ChannelPskEditState.toSaveableFlags(): Int {
+internal fun ChannelPskEditState.toSaveableFlags(): Int {
     var flags = 0
     if (canGeneratePskForName) flags = flags or CAN_GENERATE_PSK_FOR_NAME_FLAG
     if (generatedPskForName) flags = flags or GENERATED_PSK_FOR_NAME_FLAG
@@ -313,7 +313,7 @@ private fun ChannelPskEditState.toSaveableFlags(): Int {
     return flags
 }
 
-private fun Int.toChannelPskEditState(): ChannelPskEditState = ChannelPskEditState(
+internal fun Int.toChannelPskEditState(): ChannelPskEditState = ChannelPskEditState(
     canGeneratePskForName = this and CAN_GENERATE_PSK_FOR_NAME_FLAG != 0,
     generatedPskForName = this and GENERATED_PSK_FOR_NAME_FLAG != 0,
     pskExplicitlyEdited = this and PSK_EXPLICITLY_EDITED_FLAG != 0,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
@@ -176,7 +176,7 @@ private fun ChannelConfigScreen(
                 FloatingActionButton(
                     onClick = {
                         if (maxChannels > settingsListInput.size) {
-                            settingsListInput.add(ChannelSettings(psk = Channel.default.settings.psk))
+                            settingsListInput.add(newUnnamedManualChannelSettings())
                             showEditChannelDialog = settingsListInput.lastIndex
                         }
                     },
@@ -272,6 +272,8 @@ private fun ChannelConfigScreen(
         }
     }
 }
+
+private fun newUnnamedManualChannelSettings(): ChannelSettings = ChannelSettings(psk = Channel.default.settings.psk)
 
 /**
  * Determines what [Channel] if any is enabled to conduct automatic location sharing.

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
@@ -186,7 +186,7 @@ private fun ChannelConfigScreen(
                 FloatingActionButton(
                     onClick = {
                         if (maxChannels > settingsListInput.size) {
-                            settingsListInput.add(newUnnamedManualChannelSettings())
+                            settingsListInput.add(Channel.default.settings)
                             pskEditStatesInput.add(ChannelPskEditState(canGeneratePskForName = true))
                             showEditChannelDialog = settingsListInput.lastIndex
                         }
@@ -256,14 +256,16 @@ private fun ChannelConfigScreen(
                             negativeText = stringResource(Res.string.cancel),
                             onNegativeClicked = {
                                 focusManager.clearFocus()
-                                settingsListInput.clear()
-                                settingsListInput.addAll(settingsList)
+                                settingsListInput.replaceWith(settingsList)
                                 pskEditStatesInput.replaceAll(settingsList.size, ChannelPskEditState())
                             },
                             positiveText = stringResource(Res.string.send),
                             onPositiveClicked = {
                                 focusManager.clearFocus()
-                                onPositiveClicked(settingsListInput)
+                                val committedSettings = settingsListInput.toList()
+                                onPositiveClicked(committedSettings)
+                                settingsListInput.replaceWith(committedSettings)
+                                pskEditStatesInput.replaceAll(committedSettings.size, ChannelPskEditState())
                             },
                         )
                     }
@@ -288,8 +290,6 @@ private fun ChannelConfigScreen(
     }
 }
 
-private fun newUnnamedManualChannelSettings(): ChannelSettings = Channel.default.settings
-
 private val channelPskEditStatesSaver =
     listSaver<SnapshotStateList<ChannelPskEditState>, Int>(
         save = { states -> states.map { it.toSaveableFlags() } },
@@ -298,6 +298,11 @@ private val channelPskEditStatesSaver =
 
 internal fun <T> MutableList<T>.move(fromIndex: Int, toIndex: Int) {
     add(toIndex, removeAt(fromIndex))
+}
+
+internal fun <T> MutableList<T>.replaceWith(values: List<T>) {
+    clear()
+    addAll(values)
 }
 
 internal fun MutableList<ChannelPskEditState>.replaceAll(size: Int, value: ChannelPskEditState) {

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/component/EditChannelDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/component/EditChannelDialog.kt
@@ -53,22 +53,23 @@ import org.meshtastic.proto.ModuleSettings
 @Composable
 fun EditChannelDialog(
     channelSettings: ChannelSettings,
-    onAddClick: (ChannelSettings) -> Unit,
+    onAddClick: (ChannelSettings, ChannelPskEditState) -> Unit,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     modemPresetName: String = stringResource(Res.string.default_),
+    initialPskEditState: ChannelPskEditState = ChannelPskEditState(),
 ) {
     val focusManager = LocalFocusManager.current
     var isFocused by remember { mutableStateOf(false) }
 
     var channelInput by remember(channelSettings) { mutableStateOf(channelSettings) }
-    var generatedPskForName by remember(channelSettings) { mutableStateOf(false) }
+    var pskEditState by remember(channelSettings, initialPskEditState) { mutableStateOf(initialPskEditState) }
 
     MeshtasticDialog(
         onDismiss = onDismissRequest,
         dismissText = stringResource(Res.string.cancel),
         confirmText = stringResource(Res.string.save),
-        onConfirm = { onAddClick(channelInput) },
+        onConfirm = { onAddClick(channelInput, pskEditState) },
         modifier = modifier,
         title = "", // Title is handled internally by specific items if needed, or we could add one
         text = {
@@ -88,9 +89,9 @@ fun EditChannelDialog(
                     KeyboardOptions.Default.copy(keyboardType = KeyboardType.Text, imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                     onValueChanged = {
-                        val update = channelInput.withUpdatedName(it, generatedPskForName)
+                        val update = channelInput.applyChannelNameEdit(it, pskEditState)
                         channelInput = update.settings
-                        generatedPskForName = update.generatedPskForName
+                        pskEditState = update.pskEditState
                     },
                     onFocusChanged = { isFocused = it.isFocused },
                 )
@@ -103,12 +104,12 @@ fun EditChannelDialog(
                     onValueChange = {
                         val fullPsk = Channel(ChannelSettings(psk = it)).psk
                         if (fullPsk.size in setOf(0, 16, 32)) {
-                            generatedPskForName = false
+                            pskEditState = pskEditState.copy(generatedPskForName = false, pskExplicitlyEdited = true)
                             channelInput = channelInput.copy(psk = it)
                         }
                     },
                     onGenerateKey = {
-                        generatedPskForName = false
+                        pskEditState = pskEditState.copy(generatedPskForName = false, pskExplicitlyEdited = true)
                         channelInput = channelInput.copy(psk = Channel.getRandomKey())
                     },
                 )
@@ -143,13 +144,26 @@ fun EditChannelDialog(
     )
 }
 
-private data class ChannelNameUpdate(val settings: ChannelSettings, val generatedPskForName: Boolean)
+data class ChannelPskEditState(
+    val canGeneratePskForName: Boolean = false,
+    val generatedPskForName: Boolean = false,
+    val pskExplicitlyEdited: Boolean = false,
+)
 
-private fun ChannelSettings.withUpdatedName(nameInput: String, generatedPskForName: Boolean): ChannelNameUpdate {
+internal data class ChannelNameUpdate(val settings: ChannelSettings, val pskEditState: ChannelPskEditState)
+
+internal fun ChannelSettings.applyChannelNameEdit(
+    nameInput: String,
+    pskEditState: ChannelPskEditState,
+): ChannelNameUpdate {
     val name = nameInput.trim()
     val defaultPsk = Channel.default.settings.psk
-    val clearGeneratedPsk = name.isBlank() && generatedPskForName
-    val generateNamedPsk = name.isNotBlank() && psk == defaultPsk
+    val clearGeneratedPsk = name.isBlank() && pskEditState.generatedPskForName && !pskEditState.pskExplicitlyEdited
+    val generateNamedPsk =
+        name.isNotBlank() &&
+            psk == defaultPsk &&
+            pskEditState.canGeneratePskForName &&
+            !pskEditState.pskExplicitlyEdited
     val nextPsk =
         when {
             clearGeneratedPsk -> defaultPsk
@@ -160,7 +174,10 @@ private fun ChannelSettings.withUpdatedName(nameInput: String, generatedPskForNa
         when {
             clearGeneratedPsk -> false
             generateNamedPsk -> true
-            else -> generatedPskForName
+            else -> pskEditState.generatedPskForName
         }
-    return ChannelNameUpdate(settings = copy(name = name, psk = nextPsk), generatedPskForName = nextGeneratedPskForName)
+    return ChannelNameUpdate(
+        settings = copy(name = name, psk = nextPsk),
+        pskEditState = pskEditState.copy(generatedPskForName = nextGeneratedPskForName),
+    )
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/component/EditChannelDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/component/EditChannelDialog.kt
@@ -62,6 +62,7 @@ fun EditChannelDialog(
     var isFocused by remember { mutableStateOf(false) }
 
     var channelInput by remember(channelSettings) { mutableStateOf(channelSettings) }
+    var generatedPskForName by remember(channelSettings) { mutableStateOf(false) }
 
     MeshtasticDialog(
         onDismiss = onDismissRequest,
@@ -87,14 +88,9 @@ fun EditChannelDialog(
                     KeyboardOptions.Default.copy(keyboardType = KeyboardType.Text, imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
                     onValueChanged = {
-                        val defaultPsk = Channel.default.settings.psk
-                        val newPsk =
-                            if (channelInput.psk == defaultPsk) {
-                                Channel.getRandomKey()
-                            } else {
-                                channelInput.psk
-                            }
-                        channelInput = channelInput.copy(name = it.trim(), psk = newPsk)
+                        val update = channelInput.withUpdatedName(it, generatedPskForName)
+                        channelInput = update.settings
+                        generatedPskForName = update.generatedPskForName
                     },
                     onFocusChanged = { isFocused = it.isFocused },
                 )
@@ -107,10 +103,14 @@ fun EditChannelDialog(
                     onValueChange = {
                         val fullPsk = Channel(ChannelSettings(psk = it)).psk
                         if (fullPsk.size in setOf(0, 16, 32)) {
+                            generatedPskForName = false
                             channelInput = channelInput.copy(psk = it)
                         }
                     },
-                    onGenerateKey = { channelInput = channelInput.copy(psk = Channel.getRandomKey()) },
+                    onGenerateKey = {
+                        generatedPskForName = false
+                        channelInput = channelInput.copy(psk = Channel.getRandomKey())
+                    },
                 )
 
                 SwitchPreference(
@@ -141,4 +141,26 @@ fun EditChannelDialog(
             }
         },
     )
+}
+
+private data class ChannelNameUpdate(val settings: ChannelSettings, val generatedPskForName: Boolean)
+
+private fun ChannelSettings.withUpdatedName(nameInput: String, generatedPskForName: Boolean): ChannelNameUpdate {
+    val name = nameInput.trim()
+    val defaultPsk = Channel.default.settings.psk
+    val clearGeneratedPsk = name.isBlank() && generatedPskForName
+    val generateNamedPsk = name.isNotBlank() && psk == defaultPsk
+    val nextPsk =
+        when {
+            clearGeneratedPsk -> defaultPsk
+            generateNamedPsk -> Channel.getRandomKey()
+            else -> psk
+        }
+    val nextGeneratedPskForName =
+        when {
+            clearGeneratedPsk -> false
+            generateNamedPsk -> true
+            else -> generatedPskForName
+        }
+    return ChannelNameUpdate(settings = copy(name = name, psk = nextPsk), generatedPskForName = nextGeneratedPskForName)
 }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreenTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreenTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio.channel
+
+import org.meshtastic.feature.settings.radio.channel.component.ChannelPskEditState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ChannelConfigScreenTest {
+    @Test
+    fun `psk edit state round-trips through saveable flags for all boolean combinations`() {
+        for (canGenerate in listOf(false, true)) {
+            for (generated in listOf(false, true)) {
+                for (edited in listOf(false, true)) {
+                    val original =
+                        ChannelPskEditState(
+                            canGeneratePskForName = canGenerate,
+                            generatedPskForName = generated,
+                            pskExplicitlyEdited = edited,
+                        )
+                    val restored = original.toSaveableFlags().toChannelPskEditState()
+                    assertEquals(original, restored)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `move forward shifts element to higher index`() {
+        val list = mutableListOf("A", "B", "C", "D")
+        list.move(fromIndex = 1, toIndex = 3)
+        assertEquals(listOf("A", "C", "D", "B"), list)
+    }
+
+    @Test
+    fun `move backward shifts element to lower index`() {
+        val list = mutableListOf("A", "B", "C", "D")
+        list.move(fromIndex = 3, toIndex = 1)
+        assertEquals(listOf("A", "D", "B", "C"), list)
+    }
+
+    @Test
+    fun `replaceAll clears and refills with given size and value`() {
+        val list =
+            mutableListOf(
+                ChannelPskEditState(canGeneratePskForName = true),
+                ChannelPskEditState(generatedPskForName = true),
+            )
+        val fillValue = ChannelPskEditState(pskExplicitlyEdited = true)
+        list.replaceAll(size = 3, value = fillValue)
+        assertEquals(3, list.size)
+        assertTrue(list.all { it == fillValue })
+    }
+}

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreenTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreenTest.kt
@@ -66,4 +66,22 @@ class ChannelConfigScreenTest {
         assertEquals(3, list.size)
         assertTrue(list.all { it == fillValue })
     }
+
+    @Test
+    fun `replaceWith clears and refills with committed values`() {
+        val list = mutableListOf("draft", "stale")
+
+        list.replaceWith(listOf("committed"))
+
+        assertEquals(listOf("committed"), list)
+    }
+
+    @Test
+    fun `replaceAll clears committed channel psk generation eligibility`() {
+        val list = mutableListOf(ChannelPskEditState(canGeneratePskForName = true, generatedPskForName = true))
+
+        list.replaceAll(size = 1, value = ChannelPskEditState())
+
+        assertEquals(listOf(ChannelPskEditState()), list)
+    }
 }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/channel/component/EditChannelDialogTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/channel/component/EditChannelDialogTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio.channel.component
+
+import org.meshtastic.core.model.Channel
+import org.meshtastic.proto.ChannelSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class EditChannelDialogTest {
+    @Test
+    fun `new named manual channel generates fresh psk`() {
+        val update =
+            Channel.default.settings.applyChannelNameEdit(
+                nameInput = "custom",
+                pskEditState = ChannelPskEditState(canGeneratePskForName = true),
+            )
+
+        assertEquals("custom", update.settings.name)
+        assertNotEquals(Channel.default.settings.psk, update.settings.psk)
+        assertTrue(update.pskEditState.generatedPskForName)
+        assertFalse(update.pskEditState.pskExplicitlyEdited)
+    }
+
+    @Test
+    fun `explicitly entered default marker is preserved when naming channel`() {
+        val update =
+            Channel.default.settings.applyChannelNameEdit(
+                nameInput = "custom",
+                pskEditState = ChannelPskEditState(canGeneratePskForName = true, pskExplicitlyEdited = true),
+            )
+
+        assertEquals("custom", update.settings.name)
+        assertEquals(Channel.default.settings.psk, update.settings.psk)
+        assertFalse(update.pskEditState.generatedPskForName)
+    }
+
+    @Test
+    fun `existing default psk channel is not rotated when renamed`() {
+        val update =
+            Channel.default.settings.applyChannelNameEdit(
+                nameInput = "custom",
+                pskEditState = ChannelPskEditState(canGeneratePskForName = false),
+            )
+
+        assertEquals("custom", update.settings.name)
+        assertEquals(Channel.default.settings.psk, update.settings.psk)
+        assertFalse(update.pskEditState.generatedPskForName)
+    }
+
+    @Test
+    fun `generated name psk is restored to default when name is cleared after reopen`() {
+        val generatedSettings = ChannelSettings(name = "custom", psk = Channel.getRandomKey())
+
+        val update =
+            generatedSettings.applyChannelNameEdit(
+                nameInput = "",
+                pskEditState = ChannelPskEditState(canGeneratePskForName = true, generatedPskForName = true),
+            )
+
+        assertEquals("", update.settings.name)
+        assertEquals(Channel.default.settings.psk, update.settings.psk)
+        assertFalse(update.pskEditState.generatedPskForName)
+    }
+}


### PR DESCRIPTION
## Overview

This PR prevents newly created named manual channels from silently keeping the shared default PSK marker.

When a user adds a new manual channel and gives it a non-blank custom name, the dialog now generates a fresh random PSK only while that new channel is still eligible for name-based key generation. Existing channels and explicit user key choices are preserved.

This keeps default/unnamed channel behavior intact while avoiding delete/re-add flows that create a custom-named channel with shared-default key behavior.

## Key Changes

* Started newly added manual channels from `Channel.default.settings`.
* Tracked which newly added channels are eligible for name-based key generation.
* Generated a fresh random PSK when a new eligible channel is given a non-blank name and the current key is still default.
* Preserved explicitly entered PSKs, including the default marker.
* Preserved explicitly generated keys.
* Avoided rotating keys when renaming existing channels.
* Preserved generated-key state during the current edit flow so clearing an auto-named channel can restore the default key.
* Added focused dialog coverage for new-channel generation, explicit-key preservation, existing-channel preservation, and clear-name behavior.

## Testing

* Added coverage proving a newly named manual channel generates a fresh key.
* Added coverage proving an explicitly entered default marker is preserved.
* Added coverage proving existing default-PSK channels are not rotated when renamed.
* Added coverage for clearing an auto-generated key during the current edit flow.
* Verified `git diff --check` passes.

## Migration Notes

* No user data migration is required.
* Existing channels are unchanged.
* This only changes the default behavior for newly added manual channels while they are being named.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved channel editing to keep PSK generation/restore behavior consistently tied to channel name changes.
  * Added per-channel PSK edit-state handling when adding new channels and after reordering.

* **Bug Fixes**
  * Prevented PSK edit state from drifting out of sync during drag-and-drop, cancel, or delete.
  * Renaming now preserves explicit/default PSKs and avoids unintended PSK regeneration when key generation is disabled.

* **Tests**
  * Expanded test coverage for PSK/name edit-state transitions and list move/replace helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->