### PR TITLE
fix(settings): Apply manual channel writes in order

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.jetbrains.compose.resources.StringResource
 import org.koin.core.annotation.InjectedParam
 import org.koin.core.annotation.KoinViewModel
@@ -221,6 +223,7 @@ open class RadioConfigViewModel(
     val mqttProbeStatus: StateFlow<MqttProbeStatus?> = _mqttProbeStatus.asStateFlow()
 
     private var probeJob: Job? = null
+    private val channelUpdateMutex = Mutex()
 
     /**
      * Run a one-shot reachability/credentials probe against an MQTT broker. Cancels any in-flight probe before starting
@@ -412,18 +415,21 @@ open class RadioConfigViewModel(
         safeLaunch(tag = "setRemoteChannels") {
             // Manual channel saves are an ordered batch: only update canonical local state after every write request is
             // enqueued. If any enqueue fails, safeLaunch reports it and leaves the saved state unchanged instead of
-            // blessing a partial delete/reorder result.
-            applyManualChannelUpdatePlan(
-                updatePlan = updatePlan,
-                writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
-                registerRequestId = ::registerRequestId,
-            )
+            // blessing a partial delete/reorder result. Serialize batches so two ordered write plans cannot interleave
+            // on the radio link.
+            channelUpdateMutex.withLock {
+                applyManualChannelUpdatePlan(
+                    updatePlan = updatePlan,
+                    writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
+                    registerRequestId = ::registerRequestId,
+                )
 
-            if (destNum == myNodeNum) {
-                packetRepository.migrateChannelsByPSK(old, new)
-                radioConfigRepository.replaceAllSettings(new)
+                if (destNum == myNodeNum) {
+                    packetRepository.migrateChannelsByPSK(old, new)
+                    radioConfigRepository.replaceAllSettings(new)
+                }
+                _radioConfigState.update { it.copy(channelList = new) }
             }
-            _radioConfigState.update { it.copy(channelList = new) }
         }
     }
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -427,6 +427,7 @@ open class RadioConfigViewModel(
                 val updatePlan = getManualChannelUpdatePlan(new, current)
                 if (updatePlan.isEmpty()) return@withLock
                 if (!beginManualChannelBatch(updatePlan.size)) return@withLock
+                val batchRequestIds = mutableSetOf<Int>()
 
                 try {
                     applyManualChannelUpdatePlan(
@@ -434,7 +435,10 @@ open class RadioConfigViewModel(
                         currentSettings = current,
                         finalSettings = new,
                         writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
-                        registerRequestId = ::registerManualChannelBatchRequestId,
+                        registerRequestId = { packetId ->
+                            batchRequestIds.add(packetId)
+                            registerManualChannelBatchRequestId(packetId)
+                        },
                         onInterrupted = { result ->
                             reconcileInterruptedManualChannelUpdate(
                                 destNum = destNum,
@@ -446,10 +450,10 @@ open class RadioConfigViewModel(
                     commitManualChannelSettings(destNum = destNum, oldSettings = current, newSettings = new)
                     finishManualChannelBatch()
                 } catch (e: CancellationException) {
-                    abortManualChannelBatch()
+                    abortManualChannelBatch(batchRequestIds)
                     throw e
                 } catch (e: Throwable) {
-                    abortManualChannelBatch()
+                    abortManualChannelBatch(batchRequestIds)
                     Logger.w(e) { "Manual channel update failed after enqueue" }
                     e.message?.let(::sendError) ?: sendError(Res.string.unknown_error)
                 }
@@ -811,11 +815,10 @@ open class RadioConfigViewModel(
     }
 
     private fun beginManualChannelBatch(total: Int): Boolean {
-        if (requestIds.value.isNotEmpty() || radioConfigState.value.responseState is ResponseState.Loading) {
+        if (hasUnrelatedPendingRequest() || hasPendingRequestRegistration()) {
             Logger.w { "Manual channel update skipped while another radio request is pending" }
             return false
         }
-        manualChannelBatchRequestIds.clear()
         manualChannelBatchEnqueueing = true
         _radioConfigState.update { state ->
             state.copy(route = "", responseState = ResponseState.Loading(total = total))
@@ -826,14 +829,13 @@ open class RadioConfigViewModel(
     private fun finishManualChannelBatch() {
         manualChannelBatchEnqueueing = false
         if (requestIds.value.isEmpty()) {
-            manualChannelBatchRequestIds.clear()
             setResponseStateSuccess()
         }
     }
 
-    private fun abortManualChannelBatch() {
+    private fun abortManualChannelBatch(batchRequestIds: Set<Int>) {
         manualChannelBatchEnqueueing = false
-        removeManualChannelBatchRequestIds()
+        removeRequestIds(batchRequestIds)
     }
 
     private fun completeSetRequestOrProgressBatch() {
@@ -908,6 +910,12 @@ open class RadioConfigViewModel(
         registerRequestId(packetId)
     }
 
+    private fun hasUnrelatedPendingRequest(): Boolean = requestIds.value.any { it !in manualChannelBatchRequestIds }
+
+    private fun hasPendingRequestRegistration(): Boolean = requestIds.value.isEmpty() &&
+        manualChannelBatchRequestIds.isEmpty() &&
+        radioConfigState.value.responseState is ResponseState.Loading
+
     private fun clearRequestIds() {
         requestTimeoutJobs.values.forEach { it.cancel() }
         requestTimeoutJobs.clear()
@@ -921,10 +929,9 @@ open class RadioConfigViewModel(
         requestIds.update { it.withoutPacketId(packetId) }
     }
 
-    private fun removeManualChannelBatchRequestIds() {
-        val packetIds = manualChannelBatchRequestIds.toSet()
+    private fun removeRequestIds(packetIds: Set<Int>) {
         packetIds.forEach { requestTimeoutJobs.remove(it)?.cancel() }
-        manualChannelBatchRequestIds.clear()
+        manualChannelBatchRequestIds.removeAll(packetIds)
         requestIds.update { ids -> ids.withoutPacketIds(packetIds) }
     }
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -403,21 +403,25 @@ open class RadioConfigViewModel(
 
     fun updateChannels(new: List<ChannelSettings>, old: List<ChannelSettings>) {
         val destNum = destNum ?: destNode.value?.num ?: return
-        getChannelList(new, old).forEach { channel ->
-            safeLaunch(tag = "setRemoteChannel") {
+
+        val updatePlan = getManualChannelUpdatePlan(new, old)
+        if (updatePlan.isEmpty()) return
+        safeLaunch(tag = "setRemoteChannels") {
+            for (channel in updatePlan) {
                 val packetId = radioConfigUseCase.setRemoteChannel(destNum, channel)
                 registerRequestId(packetId)
             }
-        }
 
-        if (destNum == myNodeNum) {
-            safeLaunch(tag = "migrateChannels") {
+            if (destNum == myNodeNum) {
                 packetRepository.migrateChannelsByPSK(old, new)
                 radioConfigRepository.replaceAllSettings(new)
             }
+            _radioConfigState.update { it.copy(channelList = new) }
         }
-        _radioConfigState.update { it.copy(channelList = new) }
     }
+
+    private fun getManualChannelUpdatePlan(new: List<ChannelSettings>, old: List<ChannelSettings>): List<Channel> =
+        getChannelList(new, old).sortedBy { it.index }
 
     fun setConfig(config: Config) {
         val destNum = destNum ?: destNode.value?.num ?: return

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -410,6 +410,9 @@ open class RadioConfigViewModel(
         val updatePlan = getManualChannelUpdatePlan(new, old)
         if (updatePlan.isEmpty()) return
         safeLaunch(tag = "setRemoteChannels") {
+            // Manual channel saves are an ordered batch: only update canonical local state after every write request is
+            // enqueued. If any enqueue fails, safeLaunch reports it and leaves the saved state unchanged instead of
+            // blessing a partial delete/reorder result.
             applyManualChannelUpdatePlan(
                 updatePlan = updatePlan,
                 writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
@@ -958,18 +961,23 @@ open class RadioConfigViewModel(
     }
 }
 
+internal data class ManualChannelUpdateResult(val packetIds: List<Int>)
+
 internal suspend fun applyManualChannelUpdatePlan(
     updatePlan: List<Channel>,
     writeChannel: suspend (Channel) -> Int,
     registerRequestId: (Int) -> Unit,
     writeDelay: Duration = MANUAL_CHANNEL_WRITE_DELAY,
     delayFn: suspend (Duration) -> Unit = { delay(it) },
-) {
+): ManualChannelUpdateResult {
+    val packetIds = mutableListOf<Int>()
     for ((index, channel) in updatePlan.withIndex()) {
         val packetId = writeChannel(channel)
+        packetIds.add(packetId)
         registerRequestId(packetId)
         if (index < updatePlan.lastIndex) {
             delayFn(writeDelay)
         }
     }
+    return ManualChannelUpdateResult(packetIds)
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -19,7 +19,9 @@ package org.meshtastic.feature.settings.radio
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -35,6 +37,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.StringResource
 import org.koin.core.annotation.InjectedParam
 import org.koin.core.annotation.KoinViewModel
@@ -79,6 +82,7 @@ import org.meshtastic.core.resources.key_backup_restored
 import org.meshtastic.core.resources.key_backup_saved
 import org.meshtastic.core.resources.timeout
 import org.meshtastic.core.ui.util.SnackbarManager
+import org.meshtastic.core.resources.unknown_error
 import org.meshtastic.core.ui.util.getChannelList
 import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.feature.settings.navigation.ConfigRoute
@@ -224,6 +228,7 @@ open class RadioConfigViewModel(
 
     private var probeJob: Job? = null
     private val channelUpdateMutex = Mutex()
+    private var manualChannelBatchEnqueueing = false
 
     /**
      * Run a one-shot reachability/credentials probe against an MQTT broker. Cancels any in-flight probe before starting
@@ -410,31 +415,76 @@ open class RadioConfigViewModel(
     fun updateChannels(new: List<ChannelSettings>, old: List<ChannelSettings>) {
         val destNum = destNum ?: destNode.value?.num ?: return
 
-        val updatePlan = getManualChannelUpdatePlan(new, old)
-        if (updatePlan.isEmpty()) return
         safeLaunch(tag = "setRemoteChannels") {
             // Manual channel saves are an ordered batch: only update canonical local state after every write request is
-            // enqueued. If any enqueue fails, safeLaunch reports it and leaves the saved state unchanged instead of
-            // blessing a partial delete/reorder result. Serialize batches so two ordered write plans cannot interleave
-            // on the radio link.
+            // enqueued. Serialize batches so two ordered write plans cannot interleave on the radio link, and diff
+            // each queued save against the canonical list at the moment it starts.
             channelUpdateMutex.withLock {
-                applyManualChannelUpdatePlan(
-                    updatePlan = updatePlan,
-                    writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
-                    registerRequestId = ::registerRequestId,
-                )
+                val current = radioConfigState.value.channelList.ifEmpty { old }
+                val updatePlan = getManualChannelUpdatePlan(new, current)
+                if (updatePlan.isEmpty()) return@withLock
+                beginManualChannelBatch(updatePlan.size)
 
-                if (destNum == myNodeNum) {
-                    packetRepository.migrateChannelsByPSK(old, new)
-                    radioConfigRepository.replaceAllSettings(new)
+                try {
+                    applyManualChannelUpdatePlan(
+                        updatePlan = updatePlan,
+                        currentSettings = current,
+                        finalSettings = new,
+                        writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
+                        registerRequestId = ::registerRequestId,
+                        onInterrupted = { result ->
+                            reconcileInterruptedManualChannelUpdate(
+                                destNum = destNum,
+                                oldSettings = current,
+                                appliedSettings = result.appliedSettings,
+                            )
+                        },
+                    )
+                    commitManualChannelSettings(destNum = destNum, oldSettings = current, newSettings = new)
+                    finishManualChannelBatch()
+                } catch (e: CancellationException) {
+                    abortManualChannelBatch()
+                    throw e
+                } catch (e: Throwable) {
+                    abortManualChannelBatch()
+                    Logger.w(e) { "Manual channel update failed after enqueue" }
+                    e.message?.let(::sendError) ?: sendError(Res.string.unknown_error)
                 }
-                _radioConfigState.update { it.copy(channelList = new) }
             }
         }
     }
 
     private fun getManualChannelUpdatePlan(new: List<ChannelSettings>, old: List<ChannelSettings>): List<Channel> =
         getChannelList(new, old).sortedBy { it.index }
+
+    private suspend fun commitManualChannelSettings(
+        destNum: Int,
+        oldSettings: List<ChannelSettings>,
+        newSettings: List<ChannelSettings>,
+    ) {
+        withContext(NonCancellable) {
+            if (destNum == myNodeNum) {
+                packetRepository.migrateChannelsByPSK(oldSettings, newSettings)
+                radioConfigRepository.replaceAllSettings(newSettings)
+            }
+            _radioConfigState.update { it.copy(channelList = newSettings) }
+        }
+    }
+
+    private suspend fun reconcileInterruptedManualChannelUpdate(
+        destNum: Int,
+        oldSettings: List<ChannelSettings>,
+        appliedSettings: List<ChannelSettings>,
+    ) {
+        withContext(NonCancellable) {
+            Logger.w { "Reconciling interrupted manual channel update appliedSettings=${appliedSettings.size}" }
+            if (destNum == myNodeNum) {
+                packetRepository.migrateChannelsByPSK(oldSettings, appliedSettings)
+                radioConfigRepository.replaceAllSettings(appliedSettings)
+            }
+            _radioConfigState.update { it.copy(channelList = appliedSettings) }
+        }
+    }
 
     fun setConfig(config: Config) {
         val destNum = destNum ?: destNode.value?.num ?: return
@@ -757,6 +807,33 @@ open class RadioConfigViewModel(
         }
     }
 
+    private fun beginManualChannelBatch(total: Int) {
+        manualChannelBatchEnqueueing = true
+        _radioConfigState.update { state ->
+            state.copy(route = "", responseState = ResponseState.Loading(total = total))
+        }
+    }
+
+    private fun finishManualChannelBatch() {
+        manualChannelBatchEnqueueing = false
+        if (requestIds.value.isEmpty()) {
+            setResponseStateSuccess()
+        }
+    }
+
+    private fun abortManualChannelBatch() {
+        manualChannelBatchEnqueueing = false
+        requestIds.value = hashSetOf()
+    }
+
+    private fun completeSetRequestOrProgressBatch() {
+        if (manualChannelBatchEnqueueing) {
+            incrementCompleted()
+        } else {
+            setResponseStateSuccess()
+        }
+    }
+
     protected fun setResponseStateSuccess() {
         _radioConfigState.update { state ->
             if (state.responseState is ResponseState.Loading) {
@@ -832,7 +909,7 @@ open class RadioConfigViewModel(
                     val data = packet.decoded!!
                     requestIds.update { it.apply { remove(data.request_id) } }
                     if (requestIds.value.isEmpty()) {
-                        setResponseStateSuccess()
+                        completeSetRequestOrProgressBatch()
                     } else {
                         incrementCompleted()
                     }
@@ -961,29 +1038,66 @@ open class RadioConfigViewModel(
             if (route.isNotEmpty() && !AdminRoute.entries.any { it.name == route }) {
                 clearPacketResponse()
             } else if (route.isEmpty()) {
-                setResponseStateSuccess()
+                completeSetRequestOrProgressBatch()
             }
         }
     }
 }
 
-internal data class ManualChannelUpdateResult(val packetIds: List<Int>)
+internal data class ManualChannelUpdateResult(val packetIds: List<Int>, val appliedSettings: List<ChannelSettings>)
+
+internal data class InterruptedManualChannelUpdate(
+    val appliedSettings: List<ChannelSettings>,
+    val appliedWriteCount: Int,
+)
 
 internal suspend fun applyManualChannelUpdatePlan(
     updatePlan: List<Channel>,
+    currentSettings: List<ChannelSettings>,
+    finalSettings: List<ChannelSettings>,
     writeChannel: suspend (Channel) -> Int,
     registerRequestId: (Int) -> Unit,
+    onInterrupted: suspend (InterruptedManualChannelUpdate) -> Unit = {},
     writeDelay: Duration = MANUAL_CHANNEL_WRITE_DELAY,
     delayFn: suspend (Duration) -> Unit = { delay(it) },
 ): ManualChannelUpdateResult {
     val packetIds = mutableListOf<Int>()
-    for ((index, channel) in updatePlan.withIndex()) {
-        val packetId = writeChannel(channel)
-        packetIds.add(packetId)
-        registerRequestId(packetId)
-        if (index < updatePlan.lastIndex) {
-            delayFn(writeDelay)
+    val appliedSettings = currentSettings.toMutableList()
+    var appliedWriteCount = 0
+    var updateComplete = false
+    try {
+        for ((index, channel) in updatePlan.withIndex()) {
+            val packetId = writeChannel(channel)
+            packetIds.add(packetId)
+            registerRequestId(packetId)
+            appliedSettings.applyManualChannelWrite(channel)
+            appliedWriteCount++
+            if (index < updatePlan.lastIndex) {
+                delayFn(writeDelay)
+            }
+        }
+        updateComplete = true
+    } finally {
+        if (!updateComplete && appliedWriteCount > 0) {
+            onInterrupted(
+                InterruptedManualChannelUpdate(
+                    appliedSettings = appliedSettings.toList(),
+                    appliedWriteCount = appliedWriteCount,
+                ),
+            )
         }
     }
-    return ManualChannelUpdateResult(packetIds)
+    return ManualChannelUpdateResult(packetIds = packetIds, appliedSettings = finalSettings)
+}
+
+private fun MutableList<ChannelSettings>.applyManualChannelWrite(channel: Channel) {
+    while (size <= channel.index) {
+        add(ChannelSettings())
+    }
+    this[channel.index] =
+        if (channel.role == Channel.Role.DISABLED) {
+            ChannelSettings()
+        } else {
+            channel.settings ?: ChannelSettings()
+        }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -98,7 +98,10 @@ import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.User
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+
+internal val MANUAL_CHANNEL_WRITE_DELAY: Duration = 1.seconds
 
 /** Data class that represents the current RadioConfig state. */
 data class RadioConfigState(
@@ -407,10 +410,11 @@ open class RadioConfigViewModel(
         val updatePlan = getManualChannelUpdatePlan(new, old)
         if (updatePlan.isEmpty()) return
         safeLaunch(tag = "setRemoteChannels") {
-            for (channel in updatePlan) {
-                val packetId = radioConfigUseCase.setRemoteChannel(destNum, channel)
-                registerRequestId(packetId)
-            }
+            applyManualChannelUpdatePlan(
+                updatePlan = updatePlan,
+                writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
+                registerRequestId = ::registerRequestId,
+            )
 
             if (destNum == myNodeNum) {
                 packetRepository.migrateChannelsByPSK(old, new)
@@ -950,6 +954,22 @@ open class RadioConfigViewModel(
             } else if (route.isEmpty()) {
                 setResponseStateSuccess()
             }
+        }
+    }
+}
+
+internal suspend fun applyManualChannelUpdatePlan(
+    updatePlan: List<Channel>,
+    writeChannel: suspend (Channel) -> Int,
+    registerRequestId: (Int) -> Unit,
+    writeDelay: Duration = MANUAL_CHANNEL_WRITE_DELAY,
+    delayFn: suspend (Duration) -> Unit = { delay(it) },
+) {
+    for ((index, channel) in updatePlan.withIndex()) {
+        val packetId = writeChannel(channel)
+        registerRequestId(packetId)
+        if (index < updatePlan.lastIndex) {
+            delayFn(writeDelay)
         }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -1045,7 +1045,7 @@ open class RadioConfigViewModel(
     }
 }
 
-internal data class ManualChannelUpdateResult(val packetIds: List<Int>, val appliedSettings: List<ChannelSettings>)
+internal data class ManualChannelUpdateResult(val packetIds: List<Int>, val finalSettings: List<ChannelSettings>)
 
 internal data class InterruptedManualChannelUpdate(
     val appliedSettings: List<ChannelSettings>,
@@ -1088,7 +1088,7 @@ internal suspend fun applyManualChannelUpdatePlan(
             )
         }
     }
-    return ManualChannelUpdateResult(packetIds = packetIds, appliedSettings = finalSettings)
+    return ManualChannelUpdateResult(packetIds = packetIds, finalSettings = finalSettings)
 }
 
 private fun MutableList<ChannelSettings>.applyManualChannelWrite(channel: Channel) {

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -81,8 +81,8 @@ import org.meshtastic.core.resources.key_backup_restore_failed
 import org.meshtastic.core.resources.key_backup_restored
 import org.meshtastic.core.resources.key_backup_saved
 import org.meshtastic.core.resources.timeout
-import org.meshtastic.core.ui.util.SnackbarManager
 import org.meshtastic.core.resources.unknown_error
+import org.meshtastic.core.ui.util.SnackbarManager
 import org.meshtastic.core.ui.util.getChannelList
 import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.feature.settings.navigation.ConfigRoute
@@ -412,6 +412,7 @@ open class RadioConfigViewModel(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     fun updateChannels(new: List<ChannelSettings>, old: List<ChannelSettings>) {
         val destNum = destNum ?: destNode.value?.num ?: return
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -229,6 +229,7 @@ open class RadioConfigViewModel(
     private var probeJob: Job? = null
     private val channelUpdateMutex = Mutex()
     private var manualChannelBatchEnqueueing = false
+    private val manualChannelBatchRequestIds = mutableSetOf<Int>()
 
     /**
      * Run a one-shot reachability/credentials probe against an MQTT broker. Cancels any in-flight probe before starting
@@ -260,6 +261,7 @@ open class RadioConfigViewModel(
         get() = _destNode
 
     private val requestIds = MutableStateFlow(hashSetOf<Int>())
+    private val requestTimeoutJobs = mutableMapOf<Int, Job>()
     private val _radioConfigState = MutableStateFlow(RadioConfigState())
     val radioConfigState: StateFlow<RadioConfigState> = _radioConfigState
 
@@ -424,7 +426,7 @@ open class RadioConfigViewModel(
                 val current = radioConfigState.value.channelList.ifEmpty { old }
                 val updatePlan = getManualChannelUpdatePlan(new, current)
                 if (updatePlan.isEmpty()) return@withLock
-                beginManualChannelBatch(updatePlan.size)
+                if (!beginManualChannelBatch(updatePlan.size)) return@withLock
 
                 try {
                     applyManualChannelUpdatePlan(
@@ -432,7 +434,7 @@ open class RadioConfigViewModel(
                         currentSettings = current,
                         finalSettings = new,
                         writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
-                        registerRequestId = ::registerRequestId,
+                        registerRequestId = ::registerManualChannelBatchRequestId,
                         onInterrupted = { result ->
                             reconcileInterruptedManualChannelUpdate(
                                 destNum = destNum,
@@ -696,7 +698,7 @@ open class RadioConfigViewModel(
     }
 
     fun clearPacketResponse() {
-        requestIds.value = hashSetOf()
+        clearRequestIds()
         _radioConfigState.update { it.copy(responseState = ResponseState.Empty) }
     }
 
@@ -808,23 +810,30 @@ open class RadioConfigViewModel(
         }
     }
 
-    private fun beginManualChannelBatch(total: Int) {
+    private fun beginManualChannelBatch(total: Int): Boolean {
+        if (requestIds.value.isNotEmpty() || radioConfigState.value.responseState is ResponseState.Loading) {
+            Logger.w { "Manual channel update skipped while another radio request is pending" }
+            return false
+        }
+        manualChannelBatchRequestIds.clear()
         manualChannelBatchEnqueueing = true
         _radioConfigState.update { state ->
             state.copy(route = "", responseState = ResponseState.Loading(total = total))
         }
+        return true
     }
 
     private fun finishManualChannelBatch() {
         manualChannelBatchEnqueueing = false
         if (requestIds.value.isEmpty()) {
+            manualChannelBatchRequestIds.clear()
             setResponseStateSuccess()
         }
     }
 
     private fun abortManualChannelBatch() {
         manualChannelBatchEnqueueing = false
-        requestIds.value = hashSetOf()
+        removeManualChannelBatchRequestIds()
     }
 
     private fun completeSetRequestOrProgressBatch() {
@@ -867,7 +876,8 @@ open class RadioConfigViewModel(
     }
 
     private fun registerRequestId(packetId: Int) {
-        requestIds.update { it.apply { add(packetId) } }
+        requestTimeoutJobs.remove(packetId)?.cancel()
+        requestIds.update { it.withPacketId(packetId) }
         _radioConfigState.update { state ->
             if (state.responseState is ResponseState.Loading) {
                 val total = maxOf(requestIds.value.size, state.responseState.total)
@@ -881,15 +891,41 @@ open class RadioConfigViewModel(
         }
 
         val requestTimeout = 30.seconds
-        safeLaunch(tag = "requestTimeout") {
-            delay(requestTimeout)
-            if (requestIds.value.contains(packetId)) {
-                requestIds.update { it.apply { remove(packetId) } }
-                if (requestIds.value.isEmpty()) {
-                    sendError(Res.string.timeout)
+        requestTimeoutJobs[packetId] =
+            safeLaunch(tag = "requestTimeout") {
+                delay(requestTimeout)
+                if (requestIds.value.contains(packetId)) {
+                    removeRequestId(packetId)
+                    if (requestIds.value.isEmpty()) {
+                        sendError(Res.string.timeout)
+                    }
                 }
             }
-        }
+    }
+
+    private fun registerManualChannelBatchRequestId(packetId: Int) {
+        manualChannelBatchRequestIds.add(packetId)
+        registerRequestId(packetId)
+    }
+
+    private fun clearRequestIds() {
+        requestTimeoutJobs.values.forEach { it.cancel() }
+        requestTimeoutJobs.clear()
+        manualChannelBatchRequestIds.clear()
+        requestIds.value = hashSetOf()
+    }
+
+    private fun removeRequestId(packetId: Int) {
+        requestTimeoutJobs.remove(packetId)?.cancel()
+        manualChannelBatchRequestIds.remove(packetId)
+        requestIds.update { it.withoutPacketId(packetId) }
+    }
+
+    private fun removeManualChannelBatchRequestIds() {
+        val packetIds = manualChannelBatchRequestIds.toSet()
+        packetIds.forEach { requestTimeoutJobs.remove(it)?.cancel() }
+        manualChannelBatchRequestIds.clear()
+        requestIds.update { ids -> ids.withoutPacketIds(packetIds) }
     }
 
     private fun processPacketResponse(packet: MeshPacket) {
@@ -908,7 +944,7 @@ open class RadioConfigViewModel(
             is RadioResponseResult.Success -> {
                 if (route.isEmpty()) {
                     val data = packet.decoded!!
-                    requestIds.update { it.apply { remove(data.request_id) } }
+                    removeRequestId(data.request_id)
                     if (requestIds.value.isEmpty()) {
                         completeSetRequestOrProgressBatch()
                     } else {
@@ -1033,7 +1069,7 @@ open class RadioConfigViewModel(
         }
 
         val requestId = packet.decoded?.request_id ?: return
-        requestIds.update { it.apply { remove(requestId) } }
+        removeRequestId(requestId)
 
         if (requestIds.value.isEmpty()) {
             if (route.isNotEmpty() && !AdminRoute.entries.any { it.name == route }) {
@@ -1102,3 +1138,10 @@ private fun MutableList<ChannelSettings>.applyManualChannelWrite(channel: Channe
             channel.settings ?: ChannelSettings()
         }
 }
+
+private fun HashSet<Int>.withPacketId(packetId: Int): HashSet<Int> = HashSet(this).apply { add(packetId) }
+
+private fun HashSet<Int>.withoutPacketId(packetId: Int): HashSet<Int> = HashSet(this).apply { remove(packetId) }
+
+private fun HashSet<Int>.withoutPacketIds(packetIds: Set<Int>): HashSet<Int> =
+    HashSet(this).apply { removeAll(packetIds) }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -1093,6 +1093,7 @@ class RadioConfigViewModelTest {
 
         verifySuspend { radioConfigUseCase.setConfig(123, Config(security = decoded)) }
     }
+
     private fun fourChannelFixture() = listOf(
         ChannelSettings(name = "A"),
         ChannelSettings(name = "B"),

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -508,6 +508,109 @@ class RadioConfigViewModelTest {
     }
 
     @Test
+    fun `updateChannels does not start manual batch while another radio request is pending`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+
+        val old = listOf(ChannelSettings(name = "Old"))
+        val new = listOf(ChannelSettings(name = "New"))
+
+        everySuspend { radioConfigUseCase.getOwner(any()) } calls
+            {
+                delay(10_000)
+                42
+            }
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } returns 100
+
+        viewModel.setResponseStateLoading(ConfigRoute.USER)
+        runCurrent()
+
+        viewModel.updateChannels(new, old)
+        runCurrent()
+
+        assertEquals(ConfigRoute.USER.name, viewModel.radioConfigState.value.route)
+        assertTrue(viewModel.radioConfigState.value.responseState is ResponseState.Loading)
+        verifySuspend(exactly(0)) { radioConfigUseCase.setRemoteChannel(any(), any()) }
+
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `aborted manual batch preserves unrelated pending request`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        val packetFlow = MutableSharedFlow<MeshPacket>()
+        val old = fourChannelFixture()
+        val (channelA, _, _, channelD) = old
+        val new = listOf(channelA, channelD)
+        val owner = User(id = "!123", long_name = "Updated")
+        var writeCount = 0
+
+        every { serviceRepository.meshPacketFlow } returns packetFlow
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+
+        everySuspend { radioConfigUseCase.getOwner(any()) } returns 42
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+            {
+                writeCount++
+                if (writeCount == 2) {
+                    viewModel.setResponseStateLoading(ConfigRoute.USER)
+                    throw IllegalStateException("boom")
+                }
+                100
+            }
+        every { processRadioResponseUseCase(any(), 123, any()) } calls
+            {
+                val pendingRequestIds = it.args[2] as Set<Int>
+                if (42 in pendingRequestIds) RadioResponseResult.Owner(owner) else null
+            }
+
+        viewModel.updateChannels(new, old)
+        runCurrent()
+        advanceTimeBy(MANUAL_CHANNEL_WRITE_DELAY.inWholeMilliseconds)
+        runCurrent()
+
+        packetFlow.emit(MeshPacket(decoded = Data(request_id = 42)))
+        runCurrent()
+
+        assertEquals(owner, viewModel.radioConfigState.value.userConfig)
+    }
+
+    @Test
+    fun `aborted manual batch cancels batch timeout before packet id reuse`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        val old = fourChannelFixture()
+        val (channelA, _, _, channelD) = old
+        val new = listOf(channelA, channelD)
+        var writeCount = 0
+
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+            {
+                writeCount++
+                if (writeCount == 2) throw IllegalStateException("boom")
+                100
+            }
+        everySuspend { radioConfigUseCase.getOwner(any()) } returns 100
+
+        viewModel.updateChannels(new, old)
+        runCurrent()
+        advanceTimeBy(MANUAL_CHANNEL_WRITE_DELAY.inWholeMilliseconds)
+        runCurrent()
+
+        viewModel.setResponseStateLoading(ConfigRoute.USER)
+        runCurrent()
+
+        advanceTimeBy(29_500)
+        runCurrent()
+
+        assertTrue(viewModel.radioConfigState.value.responseState is ResponseState.Loading)
+    }
+
+    @Test
     fun `applyManualChannelUpdatePlan paces writes except after final channel`() = runTest {
         val channelA = Channel(index = 1, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "A"))
         val channelB = Channel(index = 2, role = Channel.Role.DISABLED, settings = ChannelSettings())

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -82,6 +82,7 @@ import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.User
+import kotlin.time.Duration
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -394,6 +395,30 @@ class RadioConfigViewModelTest {
         assertEquals(1, maxConcurrentWrites)
         assertEquals(new, viewModel.radioConfigState.value.channelList)
         verifySuspend(exactly(2)) { radioConfigUseCase.setRemoteChannel(123, any()) }
+    }
+
+    @Test
+    fun `applyManualChannelUpdatePlan paces writes except after final channel`() = runTest {
+        val channelA = Channel(index = 1, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "A"))
+        val channelB = Channel(index = 2, role = Channel.Role.DISABLED, settings = ChannelSettings())
+        val channelC = Channel(index = 3, role = Channel.Role.DISABLED, settings = ChannelSettings())
+        val writtenIndexes = mutableListOf<Int>()
+        val registeredRequestIds = mutableListOf<Int>()
+        val delays = mutableListOf<Duration>()
+
+        applyManualChannelUpdatePlan(
+            updatePlan = listOf(channelA, channelB, channelC),
+            writeChannel = { channel ->
+                writtenIndexes.add(channel.index)
+                channel.index + 100
+            },
+            registerRequestId = { registeredRequestIds.add(it) },
+            delayFn = { delays.add(it) },
+        )
+
+        assertEquals(listOf(1, 2, 3), writtenIndexes)
+        assertEquals(listOf(101, 102, 103), registeredRequestIds)
+        assertEquals(listOf(MANUAL_CHANNEL_WRITE_DELAY, MANUAL_CHANNEL_WRITE_DELAY), delays)
     }
 
     @Test

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -400,11 +400,8 @@ class RadioConfigViewModelTest {
     @Test
     fun `updateChannels keeps canonical channel list unchanged when ordered write fails`() = runTest {
         val node = Node(num = 123, user = User(id = "!123"))
-        val channelA = ChannelSettings(name = "A")
-        val channelB = ChannelSettings(name = "B")
-        val channelC = ChannelSettings(name = "C")
-        val channelD = ChannelSettings(name = "D")
-        val old = listOf(channelA, channelB, channelC, channelD)
+        val old = fourChannelFixture()
+        val (channelA, _, _, channelD) = old
         val new = listOf(channelA, channelD)
         val writtenIndexes = mutableListOf<Int>()
 
@@ -436,11 +433,8 @@ class RadioConfigViewModelTest {
     @Test
     fun `updateChannels serializes overlapping channel saves`() = runTest {
         val node = Node(num = 123, user = User(id = "!123"))
-        val channelA = ChannelSettings(name = "A")
-        val channelB = ChannelSettings(name = "B")
-        val channelC = ChannelSettings(name = "C")
-        val channelD = ChannelSettings(name = "D")
-        val old = listOf(channelA, channelB, channelC, channelD)
+        val old = fourChannelFixture()
+        val (channelA, _, channelC, channelD) = old
         val firstNew = listOf(channelA, channelD)
         val secondNew = listOf(channelA, channelC)
         val writtenChannels = mutableListOf<String>()
@@ -1059,6 +1053,12 @@ class RadioConfigViewModelTest {
 
         verifySuspend { radioConfigUseCase.setConfig(123, Config(security = decoded)) }
     }
+    private fun fourChannelFixture() = listOf(
+        ChannelSettings(name = "A"),
+        ChannelSettings(name = "B"),
+        ChannelSettings(name = "C"),
+        ChannelSettings(name = "D"),
+    )
 
     private fun myNodeInfo(myNodeNum: Int) = MyNodeInfo(
         myNodeNum = myNodeNum,

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -82,13 +82,13 @@ import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.User
-import kotlin.time.Duration
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RadioConfigViewModelTest {
@@ -398,6 +398,41 @@ class RadioConfigViewModelTest {
     }
 
     @Test
+    fun `updateChannels keeps canonical channel list unchanged when ordered write fails`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        val channelA = ChannelSettings(name = "A")
+        val channelB = ChannelSettings(name = "B")
+        val channelC = ChannelSettings(name = "C")
+        val channelD = ChannelSettings(name = "D")
+        val old = listOf(channelA, channelB, channelC, channelD)
+        val new = listOf(channelA, channelD)
+        val writtenIndexes = mutableListOf<Int>()
+
+        every { radioConfigRepository.channelSetFlow } returns MutableStateFlow(ChannelSet(settings = old))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+        runCurrent()
+
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+            {
+                val channel = it.args[1] as Channel
+                writtenIndexes.add(channel.index)
+                if (writtenIndexes.size == 2) {
+                    throw IllegalStateException("boom")
+                }
+                channel.index + 100
+            }
+
+        viewModel.updateChannels(new, old)
+        advanceUntilIdle()
+
+        assertEquals(listOf(1, 2), writtenIndexes)
+        assertEquals(old, viewModel.radioConfigState.value.channelList)
+        verifySuspend(exactly(0)) { packetRepository.migrateChannelsByPSK(any(), any()) }
+        verifySuspend(exactly(0)) { radioConfigRepository.replaceAllSettings(any()) }
+    }
+
+    @Test
     fun `applyManualChannelUpdatePlan paces writes except after final channel`() = runTest {
         val channelA = Channel(index = 1, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "A"))
         val channelB = Channel(index = 2, role = Channel.Role.DISABLED, settings = ChannelSettings())
@@ -406,17 +441,19 @@ class RadioConfigViewModelTest {
         val registeredRequestIds = mutableListOf<Int>()
         val delays = mutableListOf<Duration>()
 
-        applyManualChannelUpdatePlan(
-            updatePlan = listOf(channelA, channelB, channelC),
-            writeChannel = { channel ->
-                writtenIndexes.add(channel.index)
-                channel.index + 100
-            },
-            registerRequestId = { registeredRequestIds.add(it) },
-            delayFn = { delays.add(it) },
-        )
+        val result =
+            applyManualChannelUpdatePlan(
+                updatePlan = listOf(channelA, channelB, channelC),
+                writeChannel = { channel ->
+                    writtenIndexes.add(channel.index)
+                    channel.index + 100
+                },
+                registerRequestId = { registeredRequestIds.add(it) },
+                delayFn = { delays.add(it) },
+            )
 
         assertEquals(listOf(1, 2, 3), writtenIndexes)
+        assertEquals(listOf(101, 102, 103), result.packetIds)
         assertEquals(listOf(101, 102, 103), registeredRequestIds)
         assertEquals(listOf(MANUAL_CHANNEL_WRITE_DELAY, MANUAL_CHANNEL_WRITE_DELAY), delays)
     }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -86,7 +86,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 
@@ -529,9 +531,43 @@ class RadioConfigViewModelTest {
 
         assertEquals(listOf(1, 2, 3), writtenIndexes)
         assertEquals(listOf(101, 102, 103), result.packetIds)
-        assertEquals(listOf(ChannelSettings(name = "new")), result.appliedSettings)
+        assertEquals(listOf(ChannelSettings(name = "new")), result.finalSettings)
         assertEquals(listOf(101, 102, 103), registeredRequestIds)
         assertEquals(listOf(MANUAL_CHANNEL_WRITE_DELAY, MANUAL_CHANNEL_WRITE_DELAY), delays)
+    }
+
+    @Test
+    fun `applyManualChannelUpdatePlan invokes onInterrupted when writeChannel fails mid-plan`() = runTest {
+        val channelA = Channel(index = 1, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "A"))
+        val channelB = Channel(index = 2, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "B"))
+        val channelC = Channel(index = 3, role = Channel.Role.SECONDARY, settings = ChannelSettings(name = "C"))
+        val writtenIndexes = mutableListOf<Int>()
+
+        var interrupted: InterruptedManualChannelUpdate? = null
+
+        val error =
+            assertFailsWith<IllegalStateException> {
+                applyManualChannelUpdatePlan(
+                    updatePlan = listOf(channelA, channelB, channelC),
+                    currentSettings = listOf(ChannelSettings(name = "old")),
+                    finalSettings = listOf(ChannelSettings(name = "new")),
+                    writeChannel = { channel ->
+                        writtenIndexes.add(channel.index)
+                        if (channel.index == 2) throw IllegalStateException("boom")
+                        channel.index + 100
+                    },
+                    registerRequestId = {},
+                    onInterrupted = { interrupted = it },
+                    delayFn = {},
+                )
+            }
+
+        assertEquals("boom", error.message)
+        // Channel A (index 1) completed before channel B (index 2) threw.
+        assertEquals(listOf(1, 2), writtenIndexes)
+        assertNotNull(interrupted)
+        assertEquals(1, interrupted!!.appliedWriteCount)
+        assertEquals("A", interrupted!!.appliedSettings[1].name)
     }
 
     @Test

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -410,6 +410,7 @@ class RadioConfigViewModelTest {
 
         every { radioConfigRepository.channelSetFlow } returns MutableStateFlow(ChannelSet(settings = old))
         nodeRepository.setNodes(listOf(node))
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 123))
         viewModel = createViewModel()
         runCurrent()
 
@@ -430,6 +431,47 @@ class RadioConfigViewModelTest {
         assertEquals(old, viewModel.radioConfigState.value.channelList)
         verifySuspend(exactly(0)) { packetRepository.migrateChannelsByPSK(any(), any()) }
         verifySuspend(exactly(0)) { radioConfigRepository.replaceAllSettings(any()) }
+    }
+
+    @Test
+    fun `updateChannels serializes overlapping channel saves`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        val channelA = ChannelSettings(name = "A")
+        val channelB = ChannelSettings(name = "B")
+        val channelC = ChannelSettings(name = "C")
+        val channelD = ChannelSettings(name = "D")
+        val old = listOf(channelA, channelB, channelC, channelD)
+        val firstNew = listOf(channelA, channelD)
+        val secondNew = listOf(channelA, channelC)
+        val writtenChannels = mutableListOf<String>()
+        var firstWrite = true
+
+        every { radioConfigRepository.channelSetFlow } returns MutableStateFlow(ChannelSet(settings = old))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+        runCurrent()
+
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+            {
+                val channel = it.args[1] as Channel
+                writtenChannels.add("${channel.index}:${channel.role}:${channel.settings?.name.orEmpty()}")
+                if (firstWrite) {
+                    firstWrite = false
+                    delay(10_000)
+                }
+                writtenChannels.size
+            }
+
+        viewModel.updateChannels(firstNew, old)
+        runCurrent()
+        viewModel.updateChannels(secondNew, old)
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf("1:SECONDARY:D", "2:DISABLED:", "3:DISABLED:", "1:SECONDARY:C", "2:DISABLED:", "3:DISABLED:"),
+            writtenChannels,
+        )
+        assertEquals(secondNew, viewModel.radioConfigState.value.channelList)
     }
 
     @Test

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -67,6 +68,7 @@ import org.meshtastic.core.testing.FakeLockdownCoordinator
 import org.meshtastic.core.testing.FakeNodeRepository
 import org.meshtastic.core.ui.util.SnackbarManager
 import org.meshtastic.feature.settings.navigation.ConfigRoute
+import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.Config
@@ -357,6 +359,41 @@ class RadioConfigViewModelTest {
 
         verifySuspend { radioConfigUseCase.setRemoteChannel(123, any()) }
         assertEquals(new, viewModel.radioConfigState.value.channelList)
+    }
+
+    @Test
+    fun `updateChannels writes changed channels sequentially in index order`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+
+        val channelA = ChannelSettings(name = "A")
+        val channelB = ChannelSettings(name = "B")
+        val channelC = ChannelSettings(name = "C")
+        val old = listOf(channelA, channelB, channelC)
+        val new = listOf(channelA, channelC, channelB)
+        val writtenIndexes = mutableListOf<Int>()
+        var activeWrites = 0
+        var maxConcurrentWrites = 0
+
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+            {
+                val channel = it.args[1] as Channel
+                activeWrites++
+                maxConcurrentWrites = maxOf(maxConcurrentWrites, activeWrites)
+                writtenIndexes.add(channel.index)
+                delay(1)
+                activeWrites--
+                writtenIndexes.size
+            }
+
+        viewModel.updateChannels(new, old)
+        advanceUntilIdle()
+
+        assertEquals(listOf(1, 2), writtenIndexes)
+        assertEquals(1, maxConcurrentWrites)
+        assertEquals(new, viewModel.radioConfigState.value.channelList)
+        verifySuspend(exactly(2)) { radioConfigUseCase.setRemoteChannel(123, any()) }
     }
 
     @Test

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -398,11 +398,50 @@ class RadioConfigViewModelTest {
     }
 
     @Test
-    fun `updateChannels keeps canonical channel list unchanged when ordered write fails`() = runTest {
+    fun `updateChannels waits for all ordered writes before success`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        val packetFlow = MutableSharedFlow<MeshPacket>()
+        every { serviceRepository.meshPacketFlow } returns packetFlow
+        every { processRadioResponseUseCase(any(), 123, any()) } returns RadioResponseResult.Success
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+
+        val channelA = ChannelSettings(name = "A")
+        val channelB = ChannelSettings(name = "B")
+        val channelC = ChannelSettings(name = "C")
+        val old = listOf(channelA, channelB, channelC)
+        val new = listOf(channelA, channelC, channelB)
+        var nextPacketId = 40
+
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls { ++nextPacketId }
+
+        viewModel.updateChannels(new, old)
+        runCurrent()
+
+        packetFlow.emit(MeshPacket(decoded = Data(request_id = 41)))
+        runCurrent()
+
+        val midBatchState = viewModel.radioConfigState.value.responseState
+        assertTrue(midBatchState is ResponseState.Loading)
+        assertEquals(2, midBatchState.total)
+        assertEquals(1, midBatchState.completed)
+
+        advanceTimeBy(MANUAL_CHANNEL_WRITE_DELAY.inWholeMilliseconds)
+        runCurrent()
+
+        packetFlow.emit(MeshPacket(decoded = Data(request_id = 42)))
+        runCurrent()
+
+        assertTrue(viewModel.radioConfigState.value.responseState is ResponseState.Success)
+    }
+
+    @Test
+    fun `updateChannels reconciles applied channel writes when ordered write fails`() = runTest {
         val node = Node(num = 123, user = User(id = "!123"))
         val old = fourChannelFixture()
         val (channelA, _, _, channelD) = old
         val new = listOf(channelA, channelD)
+        val partiallyApplied = listOf(channelA, channelD, old[2], old[3])
         val writtenIndexes = mutableListOf<Int>()
 
         every { radioConfigRepository.channelSetFlow } returns MutableStateFlow(ChannelSet(settings = old))
@@ -425,9 +464,10 @@ class RadioConfigViewModelTest {
         advanceUntilIdle()
 
         assertEquals(listOf(1, 2), writtenIndexes)
-        assertEquals(old, viewModel.radioConfigState.value.channelList)
-        verifySuspend(exactly(0)) { packetRepository.migrateChannelsByPSK(any(), any()) }
-        verifySuspend(exactly(0)) { radioConfigRepository.replaceAllSettings(any()) }
+        assertEquals(partiallyApplied, viewModel.radioConfigState.value.channelList)
+        assertTrue(viewModel.radioConfigState.value.responseState is ResponseState.Error)
+        verifySuspend { packetRepository.migrateChannelsByPSK(old, partiallyApplied) }
+        verifySuspend { radioConfigRepository.replaceAllSettings(partiallyApplied) }
     }
 
     @Test
@@ -461,10 +501,7 @@ class RadioConfigViewModelTest {
         viewModel.updateChannels(secondNew, old)
         advanceUntilIdle()
 
-        assertEquals(
-            listOf("1:SECONDARY:D", "2:DISABLED:", "3:DISABLED:", "1:SECONDARY:C", "2:DISABLED:", "3:DISABLED:"),
-            writtenChannels,
-        )
+        assertEquals(listOf("1:SECONDARY:D", "2:DISABLED:", "3:DISABLED:", "1:SECONDARY:C"), writtenChannels)
         assertEquals(secondNew, viewModel.radioConfigState.value.channelList)
     }
 
@@ -480,6 +517,8 @@ class RadioConfigViewModelTest {
         val result =
             applyManualChannelUpdatePlan(
                 updatePlan = listOf(channelA, channelB, channelC),
+                currentSettings = listOf(ChannelSettings(name = "old")),
+                finalSettings = listOf(ChannelSettings(name = "new")),
                 writeChannel = { channel ->
                     writtenIndexes.add(channel.index)
                     channel.index + 100
@@ -490,6 +529,7 @@ class RadioConfigViewModelTest {
 
         assertEquals(listOf(1, 2, 3), writtenIndexes)
         assertEquals(listOf(101, 102, 103), result.packetIds)
+        assertEquals(listOf(ChannelSettings(name = "new")), result.appliedSettings)
         assertEquals(listOf(101, 102, 103), registeredRequestIds)
         assertEquals(listOf(MANUAL_CHANNEL_WRITE_DELAY, MANUAL_CHANNEL_WRITE_DELAY), delays)
     }


### PR DESCRIPTION
## Overview

This PR makes manual channel saves deterministic by writing channel changes in order instead of allowing overlapping write batches.

Previously, multi-channel edits could enqueue several radio writes without pacing or serialization. On constrained links, that made save, delete, and reorder flows more fragile and allowed overlapping saves to interleave.

This change builds an ordered channel update plan, applies writes sequentially, keeps the response state tied to the full batch, and reconciles already-enqueued writes if a batch is interrupted.

## Key Changes

* Built manual channel update plans in channel index order.
* Applied manual channel writes sequentially.
* Added pacing between channel writes.
* Serialized overlapping manual channel save batches.
* Computed queued save plans inside the mutex against the current canonical channel list.
* Kept batch success from firing while paced writes are still being enqueued.
* Surfaced enqueue failures as user-visible errors.
* Reconciled already-enqueued channel writes if a batch is interrupted or cancelled mid-plan.
* Updated local channel state only after ordered write requests are enqueued.
* Avoided committing partial final state when a write enqueue fails mid-plan.
* Preserved local channel migration behavior for the local node path.
* Added focused coverage for ordering, pacing, serialization, interrupted batches, and partial failures.

## Testing

* Added coverage proving channel writes are ordered by index.
* Added coverage proving overlapping saves do not interleave.
* Added coverage proving pacing happens between writes.
* Added coverage proving no delay is added after the final write.
* Added coverage proving batch success is held until enqueueing completes.
* Added coverage proving enqueue failure surfaces an error.
* Added coverage proving interrupted writes reconcile already-applied channel settings.
* Added coverage proving queued saves diff against current canonical state.
* Verified `git diff --check` passes.

## Migration Notes

* No user data migration is required.
* Existing channel data is unchanged until the user edits and saves channels.
* This only changes the ordering, pacing, and recovery behavior of manual channel save writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Channel updates are now written as a single ordered batch, ensuring consistent results when multiple channels change together.
  * Channel-save progress is more accurate during the batch lifecycle, including pacing between writes.

* **Bug Fixes**
  * Prevents overlapping channel-save operations from interleaving, improving reliability.
  * Improved partial-failure handling: if a batch fails mid-sequence, settings are reconciled to the already-applied channels to keep state consistent.

* **Tests**
  * Expanded coroutine and timing assertions to verify ordered write behavior, progress transitions, and interruption recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->