### PR TITLE
fix(firmware): Keep bundled release discovery available

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
@@ -122,14 +122,17 @@ open class FirmwareReleaseRepositoryImpl(
 
             val bundled = bundledSnapshot?.releases ?: return
 
-            // Re-evaluate against the current active DB on every call — it may have switched devices.
-            val toApply =
-                listOf(FirmwareReleaseType.STABLE to bundled.stable, FirmwareReleaseType.ALPHA to bundled.alpha)
-                    .filter { (type, releases) -> isBundleNewerFor(type, releases) }
-                    .toMap()
-            if (toApply.isNotEmpty()) {
-                Logger.i { "FirmwareReleaseRepository: applying bundled snapshot for ${toApply.keys}" }
-                localDataSource.replaceFirmwareReleases(toApply)
+            refreshMutex.withLock {
+                // Re-evaluate against the current active DB under the same lock as network refresh so an older bundled
+                // snapshot cannot overwrite fresher data that just arrived from the API.
+                val toApply =
+                    listOf(FirmwareReleaseType.STABLE to bundled.stable, FirmwareReleaseType.ALPHA to bundled.alpha)
+                        .filter { (type, releases) -> isBundleNewerFor(type, releases) }
+                        .toMap()
+                if (toApply.isNotEmpty()) {
+                    Logger.i { "FirmwareReleaseRepository: applying bundled snapshot for ${toApply.keys}" }
+                    localDataSource.replaceFirmwareReleases(toApply)
+                }
             }
         }
     }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
@@ -54,10 +54,19 @@ open class FirmwareReleaseRepositoryImpl(
     /** Single-flight guard so concurrent collectors share one network refresh. */
     private val refreshMutex = Mutex()
 
-    /** Guards [seedChecked] so concurrent collectors decode the bundled snapshot at most once per process. */
+    /**
+     * Guards [bundledSnapshot] decode so concurrent collectors decode the bundled JSON at most once per process. The
+     * apply/skip decision itself is re-evaluated every time against the CURRENT active DB — the active Room database
+     * switches per selected device, so a one-shot seed gate would miss a freshly activated DB whose `firmware_release`
+     * rows are empty.
+     */
     private val seedMutex = Mutex()
 
-    @Volatile private var seedChecked = false
+    /** Decoded bundled snapshot cached for the process lifetime; the asset file never changes between launches. */
+    @Volatile private var bundledSnapshot: NetworkFirmwareReleases? = null
+
+    /** Set when the bundled asset is missing or un-decodable, so we don't retry on every collection. */
+    @Volatile private var bundleDecodeFailed = false
 
     override val stableRelease: Flow<FirmwareRelease?> = getLatestFirmware(FirmwareReleaseType.STABLE)
 
@@ -87,34 +96,41 @@ open class FirmwareReleaseRepositoryImpl(
     /**
      * Applies the bundled snapshot per release type whenever it is newer than what is cached for that type — not just
      * when the cache is empty. The bundle is refreshed weekly in CI, so an app update carries fresh data even for users
-     * whose network path to api.meshtastic.org chronically fails. Checked once per process; a cache that is already
-     * newer (from a successful network refresh) is never regressed, and a type the bundle doesn't ship is left
-     * untouched.
+     * whose network path to api.meshtastic.org chronically fails. The decoded snapshot is cached for the process; the
+     * apply/skip decision is re-evaluated every call against the CURRENT active DB, because that DB switches per
+     * selected device and a one-shot seed gate would skip a freshly activated DB whose `firmware_release` rows are
+     * empty. A cache that is already newer (from a successful network refresh) is never regressed, and a type the
+     * bundle doesn't ship is left untouched.
      */
     private suspend fun ensureSeeded() {
-        if (seedChecked) return
+        if (bundleDecodeFailed) return // don't retry the bundled asset on every collection once it has failed
         seedMutex.withLock {
-            if (seedChecked) return
-            safeCatching {
-                val bundled = assetReader.decode<NetworkFirmwareReleases>("firmware_releases.json", json)?.releases
-                if (bundled == null) {
-                    Logger.w { "FirmwareReleaseRepository: no bundled releases available to seed from" }
-                } else {
-                    val toApply =
-                        listOf(
-                            FirmwareReleaseType.STABLE to bundled.stable,
-                            FirmwareReleaseType.ALPHA to bundled.alpha,
-                        )
-                            .filter { (type, releases) -> isBundleNewerFor(type, releases) }
-                            .toMap()
-                    if (toApply.isNotEmpty()) {
-                        Logger.i { "FirmwareReleaseRepository: applying bundled snapshot for ${toApply.keys}" }
-                        localDataSource.replaceFirmwareReleases(toApply)
+            // Decode the bundled JSON once per process; the asset never changes between launches.
+            if (bundledSnapshot == null && !bundleDecodeFailed) {
+                safeCatching { assetReader.decode<NetworkFirmwareReleases>("firmware_releases.json", json) }
+                    .onSuccess { snapshot -> bundledSnapshot = snapshot }
+                    .onFailure { e ->
+                        Logger.w(e) { "FirmwareReleaseRepository: failed to decode bundled JSON" }
+                        bundleDecodeFailed = true
                     }
+                // Decode returning null (asset missing) also stops further retries.
+                if (bundledSnapshot == null && !bundleDecodeFailed) {
+                    Logger.w { "FirmwareReleaseRepository: no bundled releases available to seed from" }
+                    bundleDecodeFailed = true
                 }
             }
-                .onSuccess { seedChecked = true }
-                .onFailure { e -> Logger.w(e) { "FirmwareReleaseRepository: failed to seed cache from bundled JSON" } }
+
+            val bundled = bundledSnapshot?.releases ?: return
+
+            // Re-evaluate against the current active DB on every call — it may have switched devices.
+            val toApply =
+                listOf(FirmwareReleaseType.STABLE to bundled.stable, FirmwareReleaseType.ALPHA to bundled.alpha)
+                    .filter { (type, releases) -> isBundleNewerFor(type, releases) }
+                    .toMap()
+            if (toApply.isNotEmpty()) {
+                Logger.i { "FirmwareReleaseRepository: applying bundled snapshot for ${toApply.keys}" }
+                localDataSource.replaceFirmwareReleases(toApply)
+            }
         }
     }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
@@ -113,8 +113,8 @@ open class FirmwareReleaseRepositoryImpl(
                     }
                 }
             }
+                .onSuccess { seedChecked = true }
                 .onFailure { e -> Logger.w(e) { "FirmwareReleaseRepository: failed to seed cache from bundled JSON" } }
-            seedChecked = true
         }
     }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
@@ -104,27 +104,31 @@ open class FirmwareReleaseRepositoryImpl(
      */
     private suspend fun ensureSeeded() {
         if (bundleDecodeFailed) return // don't retry the bundled asset on every collection once it has failed
-        seedMutex.withLock {
-            // Decode the bundled JSON once per process; the asset never changes between launches.
-            if (bundledSnapshot == null && !bundleDecodeFailed) {
-                safeCatching { assetReader.decode<NetworkFirmwareReleases>("firmware_releases.json", json) }
-                    .onSuccess { snapshot -> bundledSnapshot = snapshot }
-                    .onFailure { e ->
-                        Logger.w(e) { "FirmwareReleaseRepository: failed to decode bundled JSON" }
+
+        // seedMutex guards only the decode + snapshot cache; the DB apply runs outside it (so concurrent
+        // collectors don't block on a Room write or on refreshMutex) and under refreshMutex (so it can't
+        // race singleFlightRefresh and overwrite fresher data that just arrived from the API).
+        val bundled =
+            seedMutex.withLock {
+                // Decode the bundled JSON once per process; the asset never changes between launches.
+                if (bundledSnapshot == null && !bundleDecodeFailed) {
+                    safeCatching { assetReader.decode<NetworkFirmwareReleases>("firmware_releases.json", json) }
+                        .onSuccess { snapshot -> bundledSnapshot = snapshot }
+                        .onFailure { e ->
+                            Logger.w(e) { "FirmwareReleaseRepository: failed to decode bundled JSON" }
+                            bundleDecodeFailed = true
+                        }
+                    // Decode returning null (asset missing) also stops further retries.
+                    if (bundledSnapshot == null && !bundleDecodeFailed) {
+                        Logger.w { "FirmwareReleaseRepository: no bundled releases available to seed from" }
                         bundleDecodeFailed = true
                     }
-                // Decode returning null (asset missing) also stops further retries.
-                if (bundledSnapshot == null && !bundleDecodeFailed) {
-                    Logger.w { "FirmwareReleaseRepository: no bundled releases available to seed from" }
-                    bundleDecodeFailed = true
                 }
-            }
+                bundledSnapshot?.releases
+            } ?: return
 
-            val bundled = bundledSnapshot?.releases ?: return
-
+        safeCatching {
             refreshMutex.withLock {
-                // Re-evaluate against the current active DB under the same lock as network refresh so an older bundled
-                // snapshot cannot overwrite fresher data that just arrived from the API.
                 val toApply =
                     listOf(FirmwareReleaseType.STABLE to bundled.stable, FirmwareReleaseType.ALPHA to bundled.alpha)
                         .filter { (type, releases) -> isBundleNewerFor(type, releases) }
@@ -135,6 +139,7 @@ open class FirmwareReleaseRepositoryImpl(
                 }
             }
         }
+            .onFailure { e -> Logger.w(e) { "FirmwareReleaseRepository: failed to apply bundled snapshot" } }
     }
 
     /** True when [bundled] contains a release newer than anything cached for [type]. */

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/util/StaleWhileRevalidateFlow.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/util/StaleWhileRevalidateFlow.kt
@@ -54,7 +54,10 @@ internal fun <T : Any> staleWhileRevalidateFlow(
     networkTimeoutMs: Long? = DEFAULT_NETWORK_TIMEOUT_MS,
     tag: String = "StaleWhileRevalidate",
 ): Flow<T?> = flow {
-    val cached = loadFromCache()
+    val cached =
+        safeCatching { loadFromCache() }
+            .onFailure { e -> Logger.w(e) { "$tag: cache read failed" } }
+            .getOrNull()
     emit(cached)
 
     if (!shouldFetch(cached)) return@flow
@@ -78,7 +81,10 @@ internal fun <T : Any> staleWhileRevalidateFlow(
         Logger.w { "$tag: network fetch timed out after ${networkTimeoutMs}ms" }
     }
 
-    val fresh = loadFromCache()
+    val fresh =
+        safeCatching { loadFromCache() }
+            .onFailure { e -> Logger.w(e) { "$tag: cache reload failed after fetch" } }
+            .getOrNull()
     if (fresh != cached) {
         emit(fresh)
     }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/util/StaleWhileRevalidateFlow.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/util/StaleWhileRevalidateFlow.kt
@@ -84,7 +84,7 @@ internal fun <T : Any> staleWhileRevalidateFlow(
     val fresh =
         safeCatching { loadFromCache() }
             .onFailure { e -> Logger.w(e) { "$tag: cache reload failed after fetch" } }
-            .getOrNull()
+            .getOrElse { cached }
     if (fresh != cached) {
         emit(fresh)
     }

--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImplTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImplTest.kt
@@ -161,17 +161,40 @@ class FirmwareReleaseRepositoryImplTest {
     }
 
     @Test
-    fun failedBundledSeedIsRetriedOnNextCollection() = runBlocking {
+    fun failedBundledDecodeIsNotRetried() = runBlocking {
+        // A broken bundled asset is a permanent failure — retrying on every collection just burns I/O.
         seed.failuresBeforeSuccess = 1
         seed.bundled = Releases(stable = listOf(release("v2.7.15.567b8ea")))
         api.response = NetworkFirmwareReleases()
 
         val initialEmissions = repository.stableRelease.toList()
-
+        // Subsequent collection must NOT retry the decode (the second call would succeed if it did).
         val emissions = repository.stableRelease.toList()
 
         assertEquals(null, initialEmissions.first())
-        assertEquals("v2.7.15.567b8ea", emissions.first()?.id)
+        assertEquals(null, emissions.first(), "failed bundled decode is permanent; no retry on subsequent collections")
+    }
+
+    @Test
+    fun reSeedsWhenActiveDatabaseSwitches() = runBlocking {
+        // Reproduces the original bug: the active Room DB switches per selected device. A process-wide
+        // seed gate set during the first collection (against the default DB) skipped seeding the newly
+        // activated device DB, leaving the firmware picker empty.
+        seed.bundled = Releases(stable = listOf(release("v2.7.15.567b8ea")))
+        api.response = NetworkFirmwareReleases()
+
+        val firstEmissions = repository.stableRelease.toList()
+        assertEquals("v2.7.15.567b8ea", firstEmissions.first()?.id, "first collection seeds DB-A")
+
+        // The selected device's DB becomes active — it has no firmware_release rows.
+        dbProvider.switchToNewDatabase()
+
+        val secondEmissions = repository.stableRelease.toList()
+        assertEquals(
+            "v2.7.15.567b8ea",
+            secondEmissions.first()?.id,
+            "DB switch re-evaluates the bundled snapshot against the now-empty active DB and re-seeds it",
+        )
     }
 
     @Test

--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImplTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImplTest.kt
@@ -54,7 +54,13 @@ class FirmwareReleaseRepositoryImplTest {
 
     /** Serves `firmware_releases.json` from [bundled] via the real decode path, or nothing when null. */
     private class FakeBundledAssetReader(var bundled: Releases? = null) : BundledAssetReader {
+        var failuresBeforeSuccess = 0
+
         override fun open(name: String): Source? {
+            if (failuresBeforeSuccess > 0) {
+                failuresBeforeSuccess -= 1
+                error("Bundled asset read failed")
+            }
             val releases = bundled ?: return null
             if (name != "firmware_releases.json") return null
             val bytes = Json.encodeToString(NetworkFirmwareReleases(releases = releases)).encodeToByteArray()
@@ -152,6 +158,20 @@ class FirmwareReleaseRepositoryImplTest {
 
         assertEquals("v2.7.15.567b8ea", emissions.first()?.id)
         assertEquals(listOf("v2.7.25.104df5f"), dao.getReleasesByType(FirmwareReleaseType.ALPHA).map { it.id })
+    }
+
+    @Test
+    fun failedBundledSeedIsRetriedOnNextCollection() = runBlocking {
+        seed.failuresBeforeSuccess = 1
+        seed.bundled = Releases(stable = listOf(release("v2.7.15.567b8ea")))
+        api.response = NetworkFirmwareReleases()
+
+        val initialEmissions = repository.stableRelease.toList()
+
+        val emissions = repository.stableRelease.toList()
+
+        assertEquals(null, initialEmissions.first())
+        assertEquals("v2.7.15.567b8ea", emissions.first()?.id)
     }
 
     @Test

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDatabaseProvider.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDatabaseProvider.kt
@@ -21,14 +21,26 @@ import kotlinx.coroutines.flow.StateFlow
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.MeshtasticDatabase
 import org.meshtastic.core.database.getInMemoryDatabaseBuilder
+import kotlin.concurrent.Volatile
 
 /** A real [DatabaseProvider] that uses an in-memory database for testing. */
 class FakeDatabaseProvider : DatabaseProvider {
-    private val db: MeshtasticDatabase = getInMemoryDatabaseBuilder().build()
+    @Volatile private var db: MeshtasticDatabase = getInMemoryDatabaseBuilder().build()
     private val _currentDb = MutableStateFlow(db)
     override val currentDb: StateFlow<MeshtasticDatabase> = _currentDb
 
     override suspend fun <T> withDb(block: suspend (MeshtasticDatabase) -> T): T? = block(db)
+
+    /**
+     * Simulates the active-DB switch that happens when the app selects a different device — the new DB has no rows, so
+     * any cache that lived only in the previous DB is gone. Closes the prior DB to free its resources.
+     */
+    fun switchToNewDatabase() {
+        val previous = db
+        db = getInMemoryDatabaseBuilder().build()
+        _currentDb.value = db
+        previous.close()
+    }
 
     fun close() {
         db.close()

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -172,22 +172,18 @@ class FirmwareUpdateViewModel(
                         enterRecoveryModeOrError()
                         return@launch
                     }
+                    val deviceHardware = getDeviceHardware(ourNode) ?: return@launch
+                    _deviceHardware.value = deviceHardware
+                    _currentFirmwareVersion.value = ourNode.firmwareVersion
+
                     val releaseFlow =
                         if (_selectedReleaseType.value == FirmwareReleaseType.LOCAL) {
                             flowOf(null)
                         } else {
                             firmwareReleaseRepository.getReleaseFlow(_selectedReleaseType.value)
                         }
-
-                    val deviceHardware = getDeviceHardware(ourNode)
-                    if (deviceHardware != null) {
-                        _deviceHardware.value = deviceHardware
-                        _currentFirmwareVersion.value = ourNode.firmwareVersion
-                    }
-
                     releaseFlow.collectLatest { release ->
                         _selectedRelease.value = release
-                        if (deviceHardware == null) return@collectLatest
 
                         val dismissed = bootloaderWarningDataSource.isDismissed(address)
                         val firmwareUpdateMethod =
@@ -247,12 +243,14 @@ class FirmwareUpdateViewModel(
     private suspend fun enterRecoveryModeOrError() {
         val recovery = firmwareRecoveryDataSource.pending.first()
         if (recovery == null) {
+            clearDeviceMetadata()
             _state.value = FirmwareUpdateState.Error(UiText.Resource(Res.string.firmware_update_no_device))
             return
         }
         pendingRecovery = recovery
         val hardware =
             deviceHardwareRepository.getDeviceHardwareByModel(recovery.hwModel, recovery.pioEnv).getOrElse {
+                clearDeviceMetadata()
                 _state.value =
                     FirmwareUpdateState.Error(
                         UiText.Resource(Res.string.firmware_update_unknown_hardware, recovery.hwModel),
@@ -587,6 +585,7 @@ class FirmwareUpdateViewModel(
     }
 
     private fun clearDeviceMetadata() {
+        _selectedRelease.value = null
         _deviceHardware.value = null
         _currentFirmwareVersion.value = null
     }

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -179,11 +179,15 @@ class FirmwareUpdateViewModel(
                             firmwareReleaseRepository.getReleaseFlow(_selectedReleaseType.value)
                         }
 
-                    releaseFlow.collectLatest { release ->
-                        _selectedRelease.value = release
-                        val deviceHardware = getDeviceHardware(ourNode) ?: return@collectLatest
+                    val deviceHardware = getDeviceHardware(ourNode)
+                    if (deviceHardware != null) {
                         _deviceHardware.value = deviceHardware
                         _currentFirmwareVersion.value = ourNode.firmwareVersion
+                    }
+
+                    releaseFlow.collectLatest { release ->
+                        _selectedRelease.value = release
+                        if (deviceHardware == null) return@collectLatest
 
                         val dismissed = bootloaderWarningDataSource.isDismissed(address)
                         val firmwareUpdateMethod =
@@ -570,14 +574,21 @@ class FirmwareUpdateViewModel(
 
         return if (hwModelInt != null) {
             deviceHardwareRepository.getDeviceHardwareByModel(hwModelInt, target).getOrElse {
+                clearDeviceMetadata()
                 _state.value =
                     FirmwareUpdateState.Error(UiText.Resource(Res.string.firmware_update_unknown_hardware, hwModelInt))
                 null
             }
         } else {
+            clearDeviceMetadata()
             _state.value = FirmwareUpdateState.Error(UiText.Resource(Res.string.firmware_update_node_info_missing))
             null
         }
+    }
+
+    private fun clearDeviceMetadata() {
+        _deviceHardware.value = null
+        _currentFirmwareVersion.value = null
     }
 }
 

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -172,57 +172,56 @@ class FirmwareUpdateViewModel(
                         enterRecoveryModeOrError()
                         return@launch
                     }
-                    getDeviceHardware(ourNode)?.let { deviceHardware ->
+                    val releaseFlow =
+                        if (_selectedReleaseType.value == FirmwareReleaseType.LOCAL) {
+                            flowOf(null)
+                        } else {
+                            firmwareReleaseRepository.getReleaseFlow(_selectedReleaseType.value)
+                        }
+
+                    releaseFlow.collectLatest { release ->
+                        _selectedRelease.value = release
+                        val deviceHardware = getDeviceHardware(ourNode) ?: return@collectLatest
                         _deviceHardware.value = deviceHardware
                         _currentFirmwareVersion.value = ourNode.firmwareVersion
 
-                        val releaseFlow =
-                            if (_selectedReleaseType.value == FirmwareReleaseType.LOCAL) {
-                                flowOf(null)
-                            } else {
-                                firmwareReleaseRepository.getReleaseFlow(_selectedReleaseType.value)
-                            }
-
-                        releaseFlow.collectLatest { release ->
-                            _selectedRelease.value = release
-                            val dismissed = bootloaderWarningDataSource.isDismissed(address)
-                            val firmwareUpdateMethod =
-                                when {
-                                    radioPrefs.isSerial() -> {
-                                        // Serial OTA is not yet supported for ESP32 — only nRF52/RP2040 UF2.
-                                        if (deviceHardware.isEsp32Arc) {
-                                            FirmwareUpdateMethod.Unknown
-                                        } else {
-                                            FirmwareUpdateMethod.Usb
-                                        }
+                        val dismissed = bootloaderWarningDataSource.isDismissed(address)
+                        val firmwareUpdateMethod =
+                            when {
+                                radioPrefs.isSerial() -> {
+                                    // Serial OTA is not yet supported for ESP32 — only nRF52/RP2040 UF2.
+                                    if (deviceHardware.isEsp32Arc) {
+                                        FirmwareUpdateMethod.Unknown
+                                    } else {
+                                        FirmwareUpdateMethod.Usb
                                     }
-
-                                    radioPrefs.isBle() -> FirmwareUpdateMethod.Ble
-
-                                    radioPrefs.isTcp() -> {
-                                        // WiFi OTA is ESP32-only; nRF52/RP2040 have no TCP update path.
-                                        if (deviceHardware.isEsp32Arc) {
-                                            FirmwareUpdateMethod.Wifi
-                                        } else {
-                                            FirmwareUpdateMethod.Unknown
-                                        }
-                                    }
-
-                                    else -> FirmwareUpdateMethod.Unknown
                                 }
-                            _state.value =
-                                FirmwareUpdateState.Ready(
-                                    release = release,
-                                    deviceHardware = deviceHardware,
-                                    address = address,
-                                    showBootloaderWarning =
-                                    deviceHardware.requiresBootloaderUpgradeForOta == true &&
-                                        !dismissed &&
-                                        radioPrefs.isBle(),
-                                    updateMethod = firmwareUpdateMethod,
-                                    currentFirmwareVersion = ourNode.firmwareVersion,
-                                )
-                        }
+
+                                radioPrefs.isBle() -> FirmwareUpdateMethod.Ble
+
+                                radioPrefs.isTcp() -> {
+                                    // WiFi OTA is ESP32-only; nRF52/RP2040 have no TCP update path.
+                                    if (deviceHardware.isEsp32Arc) {
+                                        FirmwareUpdateMethod.Wifi
+                                    } else {
+                                        FirmwareUpdateMethod.Unknown
+                                    }
+                                }
+
+                                else -> FirmwareUpdateMethod.Unknown
+                            }
+                        _state.value =
+                            FirmwareUpdateState.Ready(
+                                release = release,
+                                deviceHardware = deviceHardware,
+                                address = address,
+                                showBootloaderWarning =
+                                deviceHardware.requiresBootloaderUpgradeForOta == true &&
+                                    !dismissed &&
+                                    radioPrefs.isBle(),
+                                updateMethod = firmwareUpdateMethod,
+                                currentFirmwareVersion = ourNode.firmwareVersion,
+                            )
                     }
                 }
                     .onFailure { e ->

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
@@ -309,15 +309,22 @@ class FirmwareUpdateViewModelTest {
 
     @Test
     fun `checkForUpdates sets error when hardware lookup fails`() = runTest {
+        advanceUntilIdle()
+        assertIs<FirmwareUpdateState.Ready>(viewModel.state.value)
+        assertIs<DeviceHardware>(viewModel.deviceHardware.value)
+        assertEquals("0.9.0", viewModel.currentFirmwareVersion.value)
+
         val release = FirmwareRelease(id = "2", title = "2.0.0", zipUrl = "url", releaseNotes = "notes")
         every { firmwareReleaseRepository.stableRelease } returns flowOf(release)
         everySuspend { deviceHardwareRepository.getDeviceHardwareByModel(any(), any()) } returns
             Result.failure(IllegalStateException("Unknown hardware"))
 
-        viewModel = createViewModel()
+        viewModel.checkForUpdates()
         advanceUntilIdle()
 
         assertEquals(release, viewModel.selectedRelease.value)
+        assertEquals(null, viewModel.deviceHardware.value)
+        assertEquals(null, viewModel.currentFirmwareVersion.value)
         assertIs<FirmwareUpdateState.Error>(viewModel.state.value)
     }
 

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
@@ -26,6 +26,7 @@ import dev.mokkery.mock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -44,6 +45,7 @@ import org.meshtastic.core.repository.RadioPrefs
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.UiText
 import org.meshtastic.core.resources.firmware_update_battery_low
+import org.meshtastic.core.resources.firmware_update_unknown_hardware
 import org.meshtastic.core.testing.FakeNodeRepository
 import org.meshtastic.core.testing.FakeRadioController
 import org.meshtastic.core.testing.TestDataFactory
@@ -311,21 +313,23 @@ class FirmwareUpdateViewModelTest {
     fun `checkForUpdates sets error when hardware lookup fails`() = runTest {
         advanceUntilIdle()
         assertIs<FirmwareUpdateState.Ready>(viewModel.state.value)
+        assertEquals("1.0.0", viewModel.selectedRelease.value?.title)
         assertIs<DeviceHardware>(viewModel.deviceHardware.value)
         assertEquals("0.9.0", viewModel.currentFirmwareVersion.value)
 
-        val release = FirmwareRelease(id = "2", title = "2.0.0", zipUrl = "url", releaseNotes = "notes")
-        every { firmwareReleaseRepository.stableRelease } returns flowOf(release)
+        every { firmwareReleaseRepository.stableRelease } returns flow { error("cache read failed") }
         everySuspend { deviceHardwareRepository.getDeviceHardwareByModel(any(), any()) } returns
             Result.failure(IllegalStateException("Unknown hardware"))
 
         viewModel.checkForUpdates()
         advanceUntilIdle()
 
-        assertEquals(release, viewModel.selectedRelease.value)
+        assertEquals(null, viewModel.selectedRelease.value)
         assertEquals(null, viewModel.deviceHardware.value)
         assertEquals(null, viewModel.currentFirmwareVersion.value)
-        assertIs<FirmwareUpdateState.Error>(viewModel.state.value)
+        val errorState = assertIs<FirmwareUpdateState.Error>(viewModel.state.value)
+        val error = assertIs<UiText.Resource>(errorState.error)
+        assertEquals(Res.string.firmware_update_unknown_hardware, error.res)
     }
 
     @Test
@@ -438,5 +442,38 @@ class FirmwareUpdateViewModelTest {
         assertTrue(state.isRecovery, "Expected recovery Ready but was $state")
         assertEquals("1234abcd", state.address) // fullAddress.drop(1)
         assertIs<FirmwareUpdateMethod.Ble>(state.updateMethod)
+    }
+
+    @Test
+    fun `recovery hardware lookup failure clears stale device metadata`() = runTest {
+        advanceUntilIdle()
+        assertIs<FirmwareUpdateState.Ready>(viewModel.state.value)
+        assertEquals("1.0.0", viewModel.selectedRelease.value?.title)
+        assertIs<DeviceHardware>(viewModel.deviceHardware.value)
+        assertEquals("0.9.0", viewModel.currentFirmwareVersion.value)
+
+        every { radioPrefs.devAddr } returns MutableStateFlow(null)
+        every { firmwareRecoveryDataSource.pending } returns
+            flowOf(
+                PendingFirmwareRecovery(
+                    fullAddress = "x1234abcd",
+                    hwModel = 999,
+                    pioEnv = "unknown",
+                    releaseType = "STABLE",
+                    deviceName = "Stale Node",
+                ),
+            )
+        everySuspend { deviceHardwareRepository.getDeviceHardwareByModel(any(), any()) } returns
+            Result.failure(IllegalStateException("Unknown hardware"))
+
+        viewModel.checkForUpdates()
+        advanceUntilIdle()
+
+        assertEquals(null, viewModel.selectedRelease.value)
+        assertEquals(null, viewModel.deviceHardware.value)
+        assertEquals(null, viewModel.currentFirmwareVersion.value)
+        val errorState = assertIs<FirmwareUpdateState.Error>(viewModel.state.value)
+        val error = assertIs<UiText.Resource>(errorState.error)
+        assertEquals(Res.string.firmware_update_unknown_hardware, error.res)
     }
 }

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
@@ -309,12 +309,15 @@ class FirmwareUpdateViewModelTest {
 
     @Test
     fun `checkForUpdates sets error when hardware lookup fails`() = runTest {
+        val release = FirmwareRelease(id = "2", title = "2.0.0", zipUrl = "url", releaseNotes = "notes")
+        every { firmwareReleaseRepository.stableRelease } returns flowOf(release)
         everySuspend { deviceHardwareRepository.getDeviceHardwareByModel(any(), any()) } returns
             Result.failure(IllegalStateException("Unknown hardware"))
 
         viewModel = createViewModel()
         advanceUntilIdle()
 
+        assertEquals(release, viewModel.selectedRelease.value)
         assertIs<FirmwareUpdateState.Error>(viewModel.state.value)
     }
 


### PR DESCRIPTION
## Overview

This PR fixes firmware release discovery when the app needs bundled release metadata.

F-Droid builds do not use the Meshtastic firmware release API, so bundled release metadata needs to remain available for the firmware update screen. The app also uses per-device databases, which means a bundled release snapshot seeded into one active database is not enough for later selected-device databases.

This change keeps bundled release discovery available for the current active database while still preventing unknown hardware from becoming flashable.

## Key Changes

* Cached the decoded bundled release snapshot for the current process.
* Re-evaluated bundled release seeding against the current active database.
* Seeded newly active or empty device databases from the bundled release snapshot.
* Preserved newer cached release data instead of regressing it with older bundled data.
* Kept partial bundled snapshots from deleting release types they do not contain.
* Marked bundled release data unavailable only when the bundled asset cannot be read or decoded.
* Applied bundled snapshots as a best-effort path so apply failures do not poison release discovery.
* Avoided holding the bundled decode mutex while waiting on the refresh/apply mutex.
* Preserved selected release state when hardware lookup fails.
* Cleared stale device metadata when hardware lookup fails.
* Kept the Ready state gated on resolved device hardware.
* Added focused coverage for active database switching, bundled seeding behavior, error handling, and selected-release preservation.

## Testing

* Added coverage proving an empty cache seeds from the bundled snapshot.
* Added coverage proving a newly active database is seeded after a previous database was already seeded.
* Added coverage proving newer bundled data replaces older cached release data.
* Added coverage proving older bundled data does not regress newer cached release data.
* Added coverage proving partial bundled snapshots leave missing release types untouched.
* Added coverage proving selected release state can populate when hardware lookup fails.
* Added coverage proving unknown hardware remains non-flashable.
* Verified `git diff --check` passes.

## Migration Notes

* No user data migration is required.
* Unknown hardware remains blocked from flashing.
* This only changes firmware release discovery and update-screen state initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Firmware releases now re-seed/refresh correctly when the active local database changes, rather than relying on a single one-time seed.
  * Bundled firmware data issues (missing/unreadable/invalid content) are treated as permanent, preventing repeated retry attempts.
  * Firmware update checks now clear stale device-related info when hardware lookup fails, ensuring the correct error state is shown.
  * Cache reads in stale-while-revalidate are more robust, avoiding unexpected failures when local data can’t be loaded.
* **Tests**
  * Added coverage for permanent bundled decode failure, reseeding on database switches, and stale-metadata clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->