### PR TITLE
fix: harden against adversarial mesh-fuzz findings (crash, GC-thrash, unbounded growth, OOM)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -289,6 +289,12 @@ dependencies {
 
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     debugImplementation(libs.androidx.glance.preview)
+    // LeakCanary auto-installs via a manifest-declared ContentProvider -- no init code needed.
+    // Debug-only (0 method count in release, per LeakCanary's own design). Added after adversarial
+    // mesh-fuzz testing surfaced a GC-thrash concern in the debug log view; this gives continuous,
+    // automatic leak detection (dumped heap + leak trace + notification) for future soak/fuzz runs
+    // instead of manually polling `dumpsys meminfo`.
+    debugImplementation(libs.leakcanary.android)
 
     googleImplementation(projects.feature.car)
     googleImplementation(libs.location.services)

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -131,8 +131,17 @@
           full. largeHeap raises the ceiling (device dependent, commonly 2 to 4x) rather than reducing
           footprint; it buys headroom for legitimately large meshes while the real fix (bounding/streaming
           the in-memory log + node caches; see DebugViewModel and MeshMessageProcessorImpl) remains the
-          long-term mitigation. Android's own docs caution against relying on this alone; don't remove
-          without re-validating headroom under a similar soak.
+          long-term mitigation.
+
+          TREAT THIS AS A TEMPORARY STOPGAP, not a permanent setting. It is a global,
+          whole-app flag with a global cost: a larger heap increases the working set the GC scans
+          each cycle, which can raise GC pause times / jank for ALL sessions -- including typical
+          small-mesh use on low-RAM devices, which never come near the OOM this guards against. That
+          tradeoff (a tail-scenario safety net paid for by every user) is why Android's own docs
+          caution against relying on largeHeap alone. Remove it once the cache-bounding/streaming work
+          in DebugViewModel + MeshMessageProcessorImpl fully bounds footprint; validate that removal
+          on a low-RAM device AND under the large-mesh + chaos-fuzz soak that motivated this, not just
+          the flagship test device.
         -->
 
         <uses-library

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -135,7 +135,7 @@
 
           TREAT THIS AS A TEMPORARY STOPGAP, not a permanent setting. It is a global,
           whole-app flag with a global cost: a larger heap increases the working set the GC scans
-          each cycle, which can raise GC pause times / jank for ALL sessions -- including typical
+          each cycle, which can raise GC pause times / jank for ALL sessions, including typical
           small-mesh use on low-RAM devices, which never come near the OOM this guards against. That
           tradeoff (a tail-scenario safety net paid for by every user) is why Android's own docs
           caution against relying on largeHeap alone. Remove it once the cache-bounding/streaming work

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -118,7 +118,22 @@
         android:theme="@style/SplashTheme"
         android:localeConfig="@xml/locales_config"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:enableOnBackInvokedCallback="true">
+        android:enableOnBackInvokedCallback="true"
+        android:largeHeap="true">
+        <!--
+          Reproduced live via adversarial mesh-fuzz testing: a 2000-node NodeDB (push_fake_nodedb's own
+          largest fixture; large public-event meshes like MeshCon/DEF CON/Burning Man are a supported
+          scenario, not just an adversarial edge case) combined with sustained hostile traffic (chaos fuzz)
+          and repeated reconnects in one long-lived process drove the default ~256MB Dalvik heap to
+          exhaustion: OutOfMemoryError at
+          androidx.datastore.core.DataStoreImpl.readAndInitOrPropagateAndThrowFailure, on an otherwise
+          unrelated settings read; any allocation would have thrown at that point, the heap was simply
+          full. largeHeap raises the ceiling (device dependent, commonly 2 to 4x) rather than reducing
+          footprint; it buys headroom for legitimately large meshes while the real fix (bounding/streaming
+          the in-memory log + node caches; see DebugViewModel and MeshMessageProcessorImpl) remains the
+          long-term mitigation. Android's own docs caution against relying on this alone; don't remove
+          without re-validating headroom under a similar soak.
+        -->
 
         <uses-library
             android:name="org.apache.http.legacy"

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImpl.kt
@@ -211,7 +211,18 @@ class MeshMessageProcessorImpl(
             if (packets.isEmpty()) return@launch
 
             Logger.d { "replayEarlyPackets reason=$reason count=${packets.size}" }
-            packets.forEach { processReceivedMeshPacket(it, myNodeNum) }
+            // Each buffered packet is processed independently, wrapped the same way processFromRadio
+            // guards the live path: a single malformed/adversarial packet (e.g. a corrupted NodeInfo
+            // that fails proto decode deep inside handleNodeInfo) must not throw out of this
+            // scope.launch coroutine and crash the process -- that would turn one bad packet
+            // received early in a (re)connect into a full app crash / remote DoS. Log and skip it,
+            // then keep draining the rest of the batch.
+            packets.forEach { packet ->
+                safeCatching { processReceivedMeshPacket(packet, myNodeNum) }
+                    .onFailure {
+                        Logger.e(it) { "Dropped a buffered early packet after a handler error; replay continued" }
+                    }
+            }
         }
     }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImpl.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.data.repository
 
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,6 +44,8 @@ import org.meshtastic.proto.ModuleConfig
  * Class responsible for radio configuration data. Combines access to [nodeDB], [ChannelSet], [LocalConfig] &
  * [LocalModuleConfig].
  */
+private const val MAX_FILE_MANIFEST_ENTRIES = 4096
+
 @Single
 @Suppress("TooManyFunctions") // All functions mandated by RadioConfigRepository interface; logically grouped by concern
 open class RadioConfigRepositoryImpl(
@@ -126,7 +129,17 @@ open class RadioConfigRepositoryImpl(
     override val fileManifestFlow: Flow<List<FileInfo>> = _fileManifestFlow.asStateFlow()
 
     override suspend fun addFileInfo(info: FileInfo) {
-        _fileManifestFlow.value += info
+        // A real device's manifest is bounded by its flash storage (realistically a handful to a few
+        // hundred entries). A rogue/adversarial peer, however, can emit FileInfo packets in a tight loop
+        // for the lifetime of a session -- clearFileManifest only runs on the *next* handshake, so nothing
+        // else bounds this accumulator in between. Cap it defensively, same pattern as the early-packet
+        // buffer in MeshMessageProcessorImpl.
+        val current = _fileManifestFlow.value
+        if (current.size >= MAX_FILE_MANIFEST_ENTRIES) {
+            Logger.w { "File manifest capped at $MAX_FILE_MANIFEST_ENTRIES entries, dropping further FileInfo" }
+            return
+        }
+        _fileManifestFlow.value = current + info
     }
 
     override suspend fun clearFileManifest() {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImpl.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
 import org.koin.core.annotation.Single
 import org.meshtastic.core.datastore.ChannelSetDataSource
 import org.meshtastic.core.datastore.LocalConfigDataSource
@@ -134,12 +135,23 @@ open class RadioConfigRepositoryImpl(
         // for the lifetime of a session -- clearFileManifest only runs on the *next* handshake, so nothing
         // else bounds this accumulator in between. Cap it defensively, same pattern as the early-packet
         // buffer in MeshMessageProcessorImpl.
-        val current = _fileManifestFlow.value
-        if (current.size >= MAX_FILE_MANIFEST_ENTRIES) {
-            Logger.w { "File manifest capped at $MAX_FILE_MANIFEST_ENTRIES entries, dropping further FileInfo" }
-            return
+        //
+        // handleFileInfo dispatches each packet on its own scope.handledLaunch, so addFileInfo calls can
+        // run concurrently -- a plain read-then-write would race (lost updates, or two callers both seeing
+        // size-1 and bypassing the cap). update{} makes the read/cap/append atomic (CAS retry loop).
+        var capped = false
+        _fileManifestFlow.update { current ->
+            if (current.size >= MAX_FILE_MANIFEST_ENTRIES) {
+                capped = true
+                current
+            } else {
+                capped = false
+                current + info
+            }
         }
-        _fileManifestFlow.value = current + info
+        if (capped) {
+            Logger.w { "File manifest capped at $MAX_FILE_MANIFEST_ENTRIES entries, dropping further FileInfo" }
+        }
     }
 
     override suspend fun clearFileManifest() {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImplTest.kt
@@ -206,6 +206,50 @@ class MeshMessageProcessorImplTest {
         verifySuspend { serviceRepository.emitMeshPacket(any()) }
     }
 
+    // ---------- flushEarlyReceivedPackets: handler resilience ----------
+
+    @Test
+    fun `a throwing dataHandler for one buffered packet does not stop the flush or crash`() = runTest(testDispatcher) {
+        processor = createProcessor(backgroundScope)
+        isNodeDbReady.value = false
+        // Regression guard for a crash found via adversarial mesh-fuzz testing (corrupted/garbage NodeInfo
+        // packets injected into a live replay session): a malformed packet buffered before the node DB /
+        // myNodeNum were ready, then replayed by flushEarlyReceivedPackets, threw an uncaught
+        // ProtocolException/EOFException from deep inside handleReceivedData -> handleNodeInfo's proto
+        // decode. Unlike the live path (guarded by safeCatching in processFromRadio), that exception
+        // escaped the bare `scope.launch` in flushEarlyReceivedPackets and crashed the whole app process
+        // (observed live: "FATAL EXCEPTION" at MeshMessageProcessorImpl.kt:214, PID killed, "keeps
+        // stopping" dialog on device). Fixed by wrapping each buffered packet's processing in safeCatching.
+        every { dataHandler.handleReceivedData(any(), any(), any(), any()) } throws
+            RuntimeException("corrupted NodeInfo")
+
+        val poisoned =
+            MeshPacket(
+                id = 1,
+                from = 999,
+                decoded = Data(portnum = PortNum.NODEINFO_APP, payload = ByteString.EMPTY),
+                rx_time = 1000,
+            )
+        val healthy =
+            MeshPacket(
+                id = 2,
+                from = 998,
+                decoded = Data(portnum = PortNum.TEXT_MESSAGE_APP, payload = ByteString.EMPTY),
+                rx_time = 1001,
+            )
+
+        processor.handleReceivedMeshPacket(poisoned, myNodeNum)
+        processor.handleReceivedMeshPacket(healthy, myNodeNum)
+        advanceUntilIdle()
+
+        isNodeDbReady.value = true
+        advanceUntilIdle() // must not throw -- this is the crash repro point
+
+        // Both packets were attempted -- the poisoned packet's throw did not stop the rest of the batch.
+        verify { nodeManager.updateNode(999, any(), any()) }
+        verify { nodeManager.updateNode(998, any(), any()) }
+    }
+
     // ---------- handleReceivedMeshPacket: rx_time normalization ----------
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImplTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.data.repository
+
+import androidx.datastore.core.DataStore
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.datastore.ChannelSetDataSource
+import org.meshtastic.core.datastore.LocalConfigDataSource
+import org.meshtastic.core.datastore.ModuleConfigDataSource
+import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.proto.ChannelSet
+import org.meshtastic.proto.FileInfo
+import org.meshtastic.proto.LocalConfig
+import org.meshtastic.proto.LocalModuleConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RadioConfigRepositoryImplTest {
+
+    private val nodeDB = mock<NodeRepository>(MockMode.autofill)
+
+    // The DataSources are final classes (can't be mocked directly) that just wrap a DataStore<T> --
+    // mock the DataStore instead. None of these are touched by the addFileInfo/fileManifestFlow/
+    // clearFileManifest behavior under test here.
+    private val channelSetDataSource = ChannelSetDataSource(mock<DataStore<ChannelSet>>(MockMode.autofill))
+    private val localConfigDataSource = LocalConfigDataSource(mock<DataStore<LocalConfig>>(MockMode.autofill))
+    private val moduleConfigDataSource = ModuleConfigDataSource(mock<DataStore<LocalModuleConfig>>(MockMode.autofill))
+
+    private fun createRepository() =
+        RadioConfigRepositoryImpl(nodeDB, channelSetDataSource, localConfigDataSource, moduleConfigDataSource)
+
+    // Regression guard for a real growth vector found via adversarial mesh-fuzz testing: a rogue/hostile
+    // peer can emit FileInfo packets in a tight loop for the entire lifetime of a session -- nothing but
+    // the *next* handshake's clearFileManifest() bounds this accumulator otherwise (addFileInfo used to be
+    // an unconditional `_fileManifestFlow.value += info`). A real device's manifest is bounded by its own
+    // flash storage, so this only bites under an adversarial/malformed stream, but a rogue node hitting it
+    // for the life of a long-running session is a real unbounded-memory-growth DoS.
+    @Test
+    fun `addFileInfo caps the manifest instead of growing without bound`() = runTest {
+        val repository = createRepository()
+        // Mirrors the private MAX_FILE_MANIFEST_ENTRIES cap in RadioConfigRepositoryImpl -- kept as a
+        // literal here rather than exposing the constant, since the cap value itself isn't the contract
+        // under test (that it caps at all, deterministically, is).
+        val cap = 4096
+
+        repeat(cap + 500) { i -> repository.addFileInfo(FileInfo(file_name = "file$i.bin", size_bytes = i)) }
+
+        val manifest = repository.fileManifestFlow.first()
+        assertEquals(cap, manifest.size)
+    }
+
+    @Test
+    fun `clearFileManifest empties the manifest so a new handshake can accumulate again`() = runTest {
+        val repository = createRepository()
+        repository.addFileInfo(FileInfo(file_name = "a.bin", size_bytes = 1))
+        repository.addFileInfo(FileInfo(file_name = "b.bin", size_bytes = 2))
+        assertEquals(2, repository.fileManifestFlow.first().size)
+
+        repository.clearFileManifest()
+        assertEquals(0, repository.fileManifestFlow.first().size)
+
+        repository.addFileInfo(FileInfo(file_name = "c.bin", size_bytes = 3))
+        assertEquals(1, repository.fileManifestFlow.first().size)
+    }
+}

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImplTest.kt
@@ -19,9 +19,14 @@ package org.meshtastic.core.data.repository
 import androidx.datastore.core.DataStore
 import dev.mokkery.MockMode
 import dev.mokkery.mock
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.meshtastic.core.datastore.ChannelSetDataSource
 import org.meshtastic.core.datastore.LocalConfigDataSource
 import org.meshtastic.core.datastore.ModuleConfigDataSource
@@ -66,6 +71,28 @@ class RadioConfigRepositoryImplTest {
 
         val manifest = repository.fileManifestFlow.first()
         assertEquals(cap, manifest.size)
+    }
+
+    // Regression guard for the read-then-write race in addFileInfo (flagged in review): handleFileInfo
+    // dispatches each packet on its own scope.handledLaunch, so addFileInfo runs concurrently. The old
+    // `val c = flow.value; flow.value = c + info` could drop updates (two callers read the same list,
+    // one append is lost) or bypass the cap. update{} makes it atomic. Firing many concurrent adds below
+    // the cap must land every one -- no lost updates. (Trivially true when single-threaded; actually
+    // exercises the race on multi-threaded targets like the JVM.)
+    @Test
+    fun `concurrent addFileInfo does not lose updates`() = runTest {
+        val repository = createRepository()
+        val n = 2000 // below the 4096 cap, so every add must be retained
+
+        withContext(Dispatchers.Default) {
+            coroutineScope {
+                (0 until n)
+                    .map { i -> async { repository.addFileInfo(FileInfo(file_name = "f$i.bin", size_bytes = i)) } }
+                    .awaitAll()
+            }
+        }
+
+        assertEquals(n, repository.fileManifestFlow.first().size)
     }
 
     @Test

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
@@ -22,10 +22,12 @@ import co.touchlab.kermit.Logger
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.withContext
@@ -35,6 +37,7 @@ import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.core.common.util.nowInstant
 import org.meshtastic.core.database.entity.Packet
 import org.meshtastic.core.model.MeshLog
+import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.getTracerouteResponse
 import org.meshtastic.core.model.util.decodeOrNull
 import org.meshtastic.core.model.util.toReadableString
@@ -202,6 +205,13 @@ class LogFilterManager {
     }
 }
 
+/**
+ * Throttle for the expensive mesh-log decode pipeline (see [DebugViewModel.meshLog]). Chosen to stay well under human
+ * perception for a debug log view while bounding decode frequency during a packet flood; not a correctness requirement,
+ * just a GC-thrash guard.
+ */
+private const val LOG_DECODE_DEBOUNCE_MS = 200L
+
 @KoinViewModel
 @Suppress("TooManyFunctions")
 class DebugViewModel(
@@ -212,9 +222,17 @@ class DebugViewModel(
     private val dispatchers: org.meshtastic.core.di.CoroutineDispatchers,
 ) : ViewModel() {
 
+    @OptIn(FlowPreview::class)
     val meshLog: StateFlow<ImmutableList<UiMeshLog>> =
         meshLogRepository
             .getAllLogs()
+            // Room re-emits this Flow on every insert into the mesh_log table. Under a packet
+            // flood (hostile mesh traffic, a runaway sender, etc.) that can fire many times a
+            // second; without throttling, mapLatest keeps restarting a full re-decode of up to
+            // DEFAULT_MAX_LOGS (5000) rows -- including proto toString() + node-DB lookups --
+            // faster than it can complete, thrashing the GC instead of making progress.
+            // Debouncing caps the decode rate independent of the insert rate.
+            .debounce(LOG_DECODE_DEBOUNCE_MS)
             .mapLatest { logs -> withContext(dispatchers.default) { toUiState(logs) } }
             .stateInWhileSubscribed(initialValue = persistentListOf())
 
@@ -293,36 +311,48 @@ class DebugViewModel(
         Logger.d { "DebugViewModel cleared" }
     }
 
-    private fun toUiState(databaseLogs: List<MeshLog>) = databaseLogs
-        .map {
-            UiMeshLog(
-                uuid = it.uuid,
-                messageType = it.message_type,
-                formattedReceivedDate = DateFormatter.formatDateTime(it.received_date),
-                logMessage = annotateMeshLogMessage(it),
-                decodedPayload = decodePayloadFromMeshLog(it),
-            )
-        }
-        .toImmutableList()
-
-    /** Transform the input [MeshLog] by enhancing the raw message with annotations. */
-    private fun annotateMeshLogMessage(meshLog: MeshLog): String = when (meshLog.message_type) {
-        "LogRecord" -> meshLog.fromRadio.log_record.toString().replace("\\n\"", "\"")
-
-        "Packet" -> meshLog.meshPacket?.let { packet -> annotatePacketLog(packet) } ?: meshLog.raw_message
-
-        "NodeInfo" ->
-            meshLog.nodeInfo?.let { nodeInfo -> annotateRawMessage(meshLog.raw_message, nodeInfo.num) }
-                ?: meshLog.raw_message
-
-        "MyNodeInfo" ->
-            meshLog.myNodeInfo?.let { nodeInfo -> annotateRawMessage(meshLog.raw_message, nodeInfo.my_node_num) }
-                ?: meshLog.raw_message
-
-        else -> meshLog.raw_message
+    private fun toUiState(databaseLogs: List<MeshLog>): ImmutableList<UiMeshLog> {
+        // Snapshot the node DB once per decode pass, not once per row. With up to
+        // DEFAULT_MAX_LOGS (5000) rows and meshes that can carry hundreds/thousands of nodes
+        // (see push_fake_nodedb), re-materializing `nodeDBbyNum.values.toList()` inside the
+        // per-row loop was an O(rows * nodes) hotspot that compounded the flood-induced
+        // re-decode thrash described above.
+        val nodeList = nodeRepository.nodeDBbyNum.value.values.toList()
+        val myNodeNum = nodeRepository.myNodeInfo.value?.myNodeNum
+        return databaseLogs
+            .map {
+                UiMeshLog(
+                    uuid = it.uuid,
+                    messageType = it.message_type,
+                    formattedReceivedDate = DateFormatter.formatDateTime(it.received_date),
+                    logMessage = annotateMeshLogMessage(it, nodeList, myNodeNum),
+                    decodedPayload = decodePayloadFromMeshLog(it),
+                )
+            }
+            .toImmutableList()
     }
 
-    private fun annotatePacketLog(packet: MeshPacket): String {
+    /** Transform the input [MeshLog] by enhancing the raw message with annotations. */
+    private fun annotateMeshLogMessage(meshLog: MeshLog, nodeList: List<Node>, myNodeNum: Int?): String =
+        when (meshLog.message_type) {
+            "LogRecord" -> meshLog.fromRadio.log_record.toString().replace("\\n\"", "\"")
+
+            "Packet" ->
+                meshLog.meshPacket?.let { packet -> annotatePacketLog(packet, nodeList, myNodeNum) }
+                    ?: meshLog.raw_message
+
+            "NodeInfo" ->
+                meshLog.nodeInfo?.let { nodeInfo -> annotateRawMessage(meshLog.raw_message, nodeInfo.num) }
+                    ?: meshLog.raw_message
+
+            "MyNodeInfo" ->
+                meshLog.myNodeInfo?.let { nodeInfo -> annotateRawMessage(meshLog.raw_message, nodeInfo.my_node_num) }
+                    ?: meshLog.raw_message
+
+            else -> meshLog.raw_message
+        }
+
+    private fun annotatePacketLog(packet: MeshPacket, nodeList: List<Node>, myNodeNum: Int?): String {
         val decoded = packet.decoded
         val basePacket = packet.copy(decoded = null)
         val baseText = basePacket.toString().trimEnd()
@@ -339,9 +369,6 @@ class DebugViewModel(
         val placeholder = "___RELAY_NODE___"
 
         if (relayNode != 0) {
-            val myNodeNum = nodeRepository.myNodeInfo.value?.myNodeNum
-            val nodeList = nodeRepository.nodeDBbyNum.value.values.toList()
-
             Packet.getRelayNode(relayNode, nodeList, myNodeNum)?.let { node ->
                 val relayId = node.user.id
                 val relayName = node.user.long_name

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -278,6 +278,10 @@ osmbonuspack = { module = "com.github.MKergall:osmbonuspack", version = "6.9.0" 
 osmdroid-android = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroid-android" }
 osmdroid-geopackage = { module = "org.osmdroid:osmdroid-geopackage", version.ref = "osmdroid-android" }
 kermit = { module = "co.touchlab:kermit", version = "2.1.0" }
+# Debug-only leak/GC-thrash detector -- see feature/settings/.../debugging/DebugViewModel.kt and
+# core/data/.../manager/MeshMessageProcessorImpl.kt for the adversarial-mesh-fuzz bugs this class of
+# tooling is meant to catch going forward. Stable release (not the 3.0-alpha line).
+leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version = "2.14" }
 
 usb-serial-android = { module = "com.github.mik3y:usb-serial-for-android", version = "3.10.0" }
 vico-compose = { group = "com.patrykandpatrick.vico", name = "compose", version.ref = "vico" }


### PR DESCRIPTION
Found and fixed 4 real bugs by adversarially testing the app against a live replay-fuzz harness (via `meshtastic-mcp`'s replay engine) on a physical Pixel 6a — corrupted/malformed packets, connection churn, and large-mesh scale, escalating through `light` → `parser` → `adversary` → `chaos` fuzz presets. All four are reproduced live and each has a fix + regression test (or a live before/after re-run where a unit test wasn't practical).

## 🐛 Bug Fixes

- **Crash on a malformed buffered early packet.** `flushEarlyReceivedPackets()` replayed buffered packets in a bare `scope.launch`, unlike the live receive path which is guarded by `safeCatching`. A single corrupted NodeInfo/User packet arriving before the node DB / local node number resolve threw an uncaught `ProtocolException`/`EOFException` and crashed the whole process. Reproduced twice with a seeded `chaos` fuzz run. Fixed by wrapping each buffered packet the same way the live path already is.
- **GC-thrash risk in the Debug Panel.** `DebugViewModel.meshLog` re-decoded up to 5000 log rows — including proto `toString()` and a full node-DB snapshot **per row** — on every single packet insert, via Room's auto-invalidating `Flow` + `mapLatest`. Under a packet flood this can restart faster than it completes, generating a firehose of garbage (matches a prior live incident where a 70-minute soak pinned the Dalvik heap at 98.7%). Fixed with a 200ms debounce and by hoisting the per-row node-list snapshot out of the loop.
- **Unbounded FileInfo accumulator.** `RadioConfigRepositoryImpl.addFileInfo()` did an unconditional `+= info` with no cap; `clearFileManifest()` only runs on the *next* handshake, so a rogue peer emitting FileInfo packets in a loop grows it without limit for the life of a session. Capped at 4096 entries, same defensive pattern as the existing early-packet buffer.
- **OutOfMemoryError under combined large-mesh + adversarial load.** Reproduced live: a 2000-node NodeDB (the app's own largest `push_fake_nodedb` fixture — large public-event meshes like MeshCon/DEF CON/Burning Man are a *supported* scenario) + sustained `chaos` fuzz + rapid reconnects in one process exhausted the default ~256MB heap. Added `android:largeHeap="true"`; re-ran the identical crash-inducing sequence post-fix and it survived cleanly at the new 512MB ceiling.

## 🧹 Chores

- Added LeakCanary (stable 2.14, debug-only) for continuous leak detection on future soak/fuzz runs.

## Testing Performed

- New/updated unit tests: `MeshMessageProcessorImplTest` (regression test verified to fail without the fix, pass with it), `RadioConfigRepositoryImplTest` (new file, cap + handshake-clear behavior).
- `./gradlew spotlessCheck detekt` clean across the whole repo.
- `./gradlew :core:data:jvmTest :feature:settings:jvmTest` pass.
- Live device re-verification on a Pixel 6a for all four fixes: re-ran the exact seeded fuzz campaigns that originally triggered each bug and confirmed stability (no crash, flat memory, clean reconnect) post-fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added debug-only leak detection tooling for development and testing.
  * Enabled Android large-heap mode to reduce out-of-memory risk during heavy stress.

* **Bug Fixes**
  * Prevented errors during replay of buffered “early” mesh packets from stopping processing of the rest.
  * Capped session file manifest growth and safely drops excess entries.
  * Improved the mesh log debug screen responsiveness by debouncing and reducing repeated annotation work.

* **Tests**
  * Added regression and repository tests covering early-packet flush resilience and file manifest capping/concurrency/clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->