### PR TITLE
fix: derive phone-UI units from OS locale, not radio display config

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -143,7 +143,6 @@ import org.meshtastic.feature.map.LastHeardFilter
 import org.meshtastic.feature.map.component.EditWaypointDialog
 import org.meshtastic.feature.map.component.MapButton
 import org.meshtastic.feature.map.component.MapControlsOverlay
-import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
 import org.meshtastic.proto.Waypoint
 import org.osmdroid.bonuspack.utils.BonusPackHelper.getBitmapFromVectorDrawable
 import org.osmdroid.config.Configuration
@@ -372,7 +371,6 @@ fun MapView(
     fun MapView.onNodesChanged(nodes: Collection<Node>): List<MarkerWithLabel> {
         val nodesWithPosition = nodes.filter { it.validPosition != null }
         val ourNode = mapViewModel.ourNodeInfo.value
-        val displayUnits = mapViewModel.config.display?.units ?: DisplayUnits.METRIC
         val mapFilterStateValue = mapViewModel.mapFilterStateFlow.value // Access mapFilterState directly
         return nodesWithPosition.mapNotNull { node ->
             if (mapFilterStateValue.onlyFavorites && !node.isFavorite && !node.equals(ourNode)) {

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -27,9 +27,7 @@ import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
-import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.feature.map.BaseMapViewModel
-import org.meshtastic.proto.LocalConfig
 
 @Suppress("LongParameterList")
 @KoinViewModel
@@ -57,11 +55,6 @@ class MapViewModel(
         set(value) {
             mapPrefs.setMapStyle(value)
         }
-
-    val localConfig = radioConfigRepository.localConfigFlow.stateInWhileSubscribed(initialValue = LocalConfig())
-
-    val config
-        get() = localConfig.value
 
     val applicationId = buildConfigProvider.applicationId
 }

--- a/core/common/src/androidMain/kotlin/org/meshtastic/core/common/util/LocaleUtils.android.kt
+++ b/core/common/src/androidMain/kotlin/org/meshtastic/core/common/util/LocaleUtils.android.kt
@@ -35,25 +35,6 @@ actual fun currentLocaleQualifier(): String {
 actual fun getSystemMeasurementSystem(): MeasurementSystem {
     val locale = Locale.getDefault()
 
-    // Android 14+ (API 34) introduced user-settable locale preferences.
-    if (Build.VERSION.SDK_INT >= 34) {
-        try {
-            val localePrefsClass = Class.forName("androidx.core.text.util.LocalePreferences")
-            val getMeasurementSystemMethod =
-                localePrefsClass.getMethod("getMeasurementSystem", Locale::class.java, Boolean::class.javaPrimitiveType)
-            val result = getMeasurementSystemMethod.invoke(null, locale, true) as String
-            return when (result) {
-                "us",
-                "uk",
-                -> MeasurementSystem.IMPERIAL
-
-                else -> MeasurementSystem.METRIC
-            }
-        } catch (@Suppress("TooGenericExceptionCaught") ignored: Exception) {
-            // Fallback
-        }
-    }
-
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         when (LocaleData.getMeasurementSystem(ULocale.forLocale(locale))) {
             LocaleData.MeasurementSystem.SI -> MeasurementSystem.METRIC

--- a/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/MetricFormatter.kt
+++ b/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/MetricFormatter.kt
@@ -49,12 +49,20 @@ object MetricFormatter {
 
     fun rssi(value: Int): String = "$value dBm"
 
-    fun windSpeed(metersPerSecond: Float, decimalPlaces: Int = 1): String =
-        "${NumberFormatter.format(metersPerSecond, decimalPlaces)} m/s"
+    fun windSpeed(metersPerSecond: Float, isImperial: Boolean, decimalPlaces: Int = 1): String {
+        val value = if (isImperial) metersPerSecond * MPH_PER_MPS else metersPerSecond
+        val unit = if (isImperial) "mph" else "m/s"
+        return "${NumberFormatter.format(value, decimalPlaces)} $unit"
+    }
 
-    fun rainfall(millimeters: Float, decimalPlaces: Int = 1): String =
-        "${NumberFormatter.format(millimeters, decimalPlaces)} mm"
+    fun rainfall(millimeters: Float, isImperial: Boolean, decimalPlaces: Int = 1): String {
+        val value = if (isImperial) millimeters / MM_PER_INCH else millimeters
+        val unit = if (isImperial) "in" else "mm"
+        return "${NumberFormatter.format(value, decimalPlaces)} $unit"
+    }
 }
 
 private const val FAHRENHEIT_SCALE = 1.8f
 private const val FAHRENHEIT_OFFSET = 32
+private const val MPH_PER_MPS = 2.23694f
+private const val MM_PER_INCH = 25.4f

--- a/core/common/src/commonTest/kotlin/org/meshtastic/core/common/util/MetricFormatterTest.kt
+++ b/core/common/src/commonTest/kotlin/org/meshtastic/core/common/util/MetricFormatterTest.kt
@@ -123,21 +123,31 @@ class MetricFormatterTest {
 
     @Test
     fun windSpeed() {
-        assertEquals("12.3 m/s", MetricFormatter.windSpeed(12.34f))
+        assertEquals("12.3 m/s", MetricFormatter.windSpeed(12.34f, isImperial = false))
     }
 
     @Test
     fun windSpeedZero() {
-        assertEquals("0.0 m/s", MetricFormatter.windSpeed(0.0f))
+        assertEquals("0.0 m/s", MetricFormatter.windSpeed(0.0f, isImperial = false))
+    }
+
+    @Test
+    fun windSpeedImperial() {
+        assertEquals("27.6 mph", MetricFormatter.windSpeed(12.34f, isImperial = true))
     }
 
     @Test
     fun rainfall() {
-        assertEquals("2.5 mm", MetricFormatter.rainfall(2.54f))
+        assertEquals("2.5 mm", MetricFormatter.rainfall(2.54f, isImperial = false))
     }
 
     @Test
     fun rainfallZero() {
-        assertEquals("0.0 mm", MetricFormatter.rainfall(0.0f))
+        assertEquals("0.0 mm", MetricFormatter.rainfall(0.0f, isImperial = false))
+    }
+
+    @Test
+    fun rainfallImperial() {
+        assertEquals("0.10 in", MetricFormatter.rainfall(2.54f, isImperial = true, decimalPlaces = 2))
     }
 }

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
@@ -67,7 +67,11 @@ open class BaseMapViewModel(
 
     val myNodeInfo = nodeRepository.myNodeInfo
 
-    /** OS locale display units (metric/imperial) for distance/altitude/speed formatting across map surfaces. */
+    /**
+     * OS locale display units (metric/imperial) for distance/altitude/speed formatting across map surfaces. StateFlow
+     * kept for the existing collectAsState call sites; value is a one-time snapshot at construction and does not react
+     * to a mid-session locale change (ViewModel survives config changes).
+     */
     val displayUnits: StateFlow<DisplayUnits> = MutableStateFlow(DistanceUnit.getFromLocale()).asStateFlow()
 
     val ourNodeInfo = nodeRepository.ourNodeInfo

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
@@ -32,6 +32,7 @@ import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.TracerouteOverlay
 import org.meshtastic.core.model.geofence.activeWaypointPackets
+import org.meshtastic.core.model.util.DistanceUnit
 import org.meshtastic.core.repository.MapPrefs
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketRepository
@@ -66,11 +67,8 @@ open class BaseMapViewModel(
 
     val myNodeInfo = nodeRepository.myNodeInfo
 
-    /** Device display units (metric/imperial) for distance/altitude/speed formatting across map surfaces. */
-    val displayUnits: StateFlow<DisplayUnits> =
-        radioConfigRepository.localConfigFlow
-            .map { it.display?.units ?: DisplayUnits.METRIC }
-            .stateInWhileSubscribed(initialValue = DisplayUnits.METRIC)
+    /** OS locale display units (metric/imperial) for distance/altitude/speed formatting across map surfaces. */
+    val displayUnits: StateFlow<DisplayUnits> = MutableStateFlow(DistanceUnit.getFromLocale()).asStateFlow()
 
     val ourNodeInfo = nodeRepository.ourNodeInfo
 

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
@@ -33,7 +33,6 @@ import org.meshtastic.core.model.DeviceLink
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
-import org.meshtastic.core.model.util.DistanceUnit
 import org.meshtastic.core.model.util.hasValidEnvironmentMetrics
 import org.meshtastic.core.model.util.isDirectSignal
 import org.meshtastic.core.repository.DeviceHardwareRepository
@@ -51,6 +50,7 @@ import org.meshtastic.feature.node.detail.NodeRequestActions
 import org.meshtastic.feature.node.metrics.EnvironmentMetricsState
 import org.meshtastic.feature.node.model.LogsType
 import org.meshtastic.feature.node.model.MetricsState
+import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
 import org.meshtastic.proto.DeviceProfile
 import org.meshtastic.proto.FirmwareEdition
 import org.meshtastic.proto.MeshPacket
@@ -184,7 +184,7 @@ constructor(
             val isLocal = node.num == identity.ourNode?.num
             val pioEnv = if (isLocal) identity.myInfo?.pioEnv else null
 
-            val displayUnits = DistanceUnit.getFromLocale()
+            val isImperial = getSystemMeasurementSystem() == MeasurementSystem.IMPERIAL
 
             val metricsState =
                 MetricsState(
@@ -194,8 +194,8 @@ constructor(
                     deviceLinks = deviceLinks,
                     reportedTarget = pioEnv,
                     isManaged = identity.profile.config?.security?.is_managed ?: false,
-                    isFahrenheit = getSystemMeasurementSystem() == MeasurementSystem.IMPERIAL,
-                    displayUnits = displayUnits,
+                    isFahrenheit = isImperial,
+                    displayUnits = if (isImperial) DisplayUnits.IMPERIAL else DisplayUnits.METRIC,
                     deviceMetrics = logs.telemetry.filter { it.device_metrics != null },
                     localStats = logs.telemetry.filter { it.local_stats != null },
                     powerMetrics = logs.telemetry.filter { it.power_metrics != null },

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
@@ -25,14 +25,13 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import org.koin.core.annotation.Single
-import org.meshtastic.core.common.util.MeasurementSystem
-import org.meshtastic.core.common.util.getSystemMeasurementSystem
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.model.DeviceLink
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
+import org.meshtastic.core.model.util.DistanceUnit
 import org.meshtastic.core.model.util.hasValidEnvironmentMetrics
 import org.meshtastic.core.model.util.isDirectSignal
 import org.meshtastic.core.repository.DeviceHardwareRepository
@@ -184,7 +183,7 @@ constructor(
             val isLocal = node.num == identity.ourNode?.num
             val pioEnv = if (isLocal) identity.myInfo?.pioEnv else null
 
-            val isImperial = getSystemMeasurementSystem() == MeasurementSystem.IMPERIAL
+            val displayUnits = DistanceUnit.getFromLocale()
 
             val metricsState =
                 MetricsState(
@@ -194,8 +193,8 @@ constructor(
                     deviceLinks = deviceLinks,
                     reportedTarget = pioEnv,
                     isManaged = identity.profile.config?.security?.is_managed ?: false,
-                    isFahrenheit = isImperial,
-                    displayUnits = if (isImperial) DisplayUnits.IMPERIAL else DisplayUnits.METRIC,
+                    isFahrenheit = displayUnits == DisplayUnits.IMPERIAL,
+                    displayUnits = displayUnits,
                     deviceMetrics = logs.telemetry.filter { it.device_metrics != null },
                     localStats = logs.telemetry.filter { it.local_stats != null },
                     powerMetrics = logs.telemetry.filter { it.power_metrics != null },

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
@@ -25,12 +25,15 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import org.koin.core.annotation.Single
+import org.meshtastic.core.common.util.MeasurementSystem
+import org.meshtastic.core.common.util.getSystemMeasurementSystem
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.model.DeviceLink
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
+import org.meshtastic.core.model.util.DistanceUnit
 import org.meshtastic.core.model.util.hasValidEnvironmentMetrics
 import org.meshtastic.core.model.util.isDirectSignal
 import org.meshtastic.core.repository.DeviceHardwareRepository
@@ -48,7 +51,6 @@ import org.meshtastic.feature.node.detail.NodeRequestActions
 import org.meshtastic.feature.node.metrics.EnvironmentMetricsState
 import org.meshtastic.feature.node.model.LogsType
 import org.meshtastic.feature.node.model.MetricsState
-import org.meshtastic.proto.Config
 import org.meshtastic.proto.DeviceProfile
 import org.meshtastic.proto.FirmwareEdition
 import org.meshtastic.proto.MeshPacket
@@ -182,8 +184,7 @@ constructor(
             val isLocal = node.num == identity.ourNode?.num
             val pioEnv = if (isLocal) identity.myInfo?.pioEnv else null
 
-            val moduleConfig = identity.profile.module_config
-            val displayUnits = identity.profile.config?.display?.units ?: Config.DisplayConfig.DisplayUnits.METRIC
+            val displayUnits = DistanceUnit.getFromLocale()
 
             val metricsState =
                 MetricsState(
@@ -193,9 +194,7 @@ constructor(
                     deviceLinks = deviceLinks,
                     reportedTarget = pioEnv,
                     isManaged = identity.profile.config?.security?.is_managed ?: false,
-                    isFahrenheit =
-                    moduleConfig?.telemetry?.environment_display_fahrenheit == true ||
-                        (displayUnits == Config.DisplayConfig.DisplayUnits.IMPERIAL),
+                    isFahrenheit = getSystemMeasurementSystem() == MeasurementSystem.IMPERIAL,
                     displayUnits = displayUnits,
                     deviceMetrics = logs.telemetry.filter { it.device_metrics != null },
                     localStats = logs.telemetry.filter { it.local_stats != null },

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
@@ -28,11 +28,14 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
+import org.meshtastic.core.common.util.MeasurementSystem
+import org.meshtastic.core.common.util.getSystemMeasurementSystem
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.NodeListDensity
 import org.meshtastic.core.model.NodeSortOption
+import org.meshtastic.core.model.util.DistanceUnit
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.DeviceHardwareRepository
@@ -128,12 +131,12 @@ class NodeListViewModel(
             )
         }
     val nodesUiState: StateFlow<NodesUiState> =
-        combine(nodeSortOption, nodeFilter, radioConfigRepository.deviceProfileFlow) { sort, nodeFilter, profile ->
+        combine(nodeSortOption, nodeFilter) { sort, nodeFilter ->
             NodesUiState(
                 sort = sort,
                 filter = nodeFilter,
-                distanceUnits = profile.config?.display?.units?.value ?: 0,
-                tempInFahrenheit = profile.module_config?.telemetry?.environment_display_fahrenheit ?: false,
+                distanceUnits = DistanceUnit.getFromLocale().value,
+                tempInFahrenheit = getSystemMeasurementSystem() == MeasurementSystem.IMPERIAL,
             )
         }
             .stateInWhileSubscribed(initialValue = NodesUiState())

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
@@ -130,13 +130,17 @@ class NodeListViewModel(
                 excludeMqtt = excludeMqtt,
             )
         }
+
+    // OS locale rarely changes mid-session; snapshot once instead of per filter/sort emission.
+    private val distanceUnits = DistanceUnit.getFromLocale().value
+    private val tempInFahrenheit = getSystemMeasurementSystem() == MeasurementSystem.IMPERIAL
     val nodesUiState: StateFlow<NodesUiState> =
         combine(nodeSortOption, nodeFilter) { sort, nodeFilter ->
             NodesUiState(
                 sort = sort,
                 filter = nodeFilter,
-                distanceUnits = DistanceUnit.getFromLocale().value,
-                tempInFahrenheit = getSystemMeasurementSystem() == MeasurementSystem.IMPERIAL,
+                distanceUnits = distanceUnits,
+                tempInFahrenheit = tempInFahrenheit,
             )
         }
             .stateInWhileSubscribed(initialValue = NodesUiState())

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
@@ -123,6 +123,8 @@ fun EnvironmentMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Un
                     EnvironmentMetricsCard(
                         telemetry = telemetry,
                         environmentDisplayFahrenheit = state.isFahrenheit,
+                        isImperial =
+                        state.displayUnits == org.meshtastic.proto.Config.DisplayConfig.DisplayUnits.IMPERIAL,
                         isSelected = telemetry.time.toDouble() == selectedX,
                         onClick = { onCardClick(telemetry.time.toDouble()) },
                     )
@@ -511,11 +513,12 @@ private fun OneWireTemperatureDisplay(
 private fun EnvironmentMetricsCard(
     telemetry: Telemetry,
     environmentDisplayFahrenheit: Boolean,
+    isImperial: Boolean,
     isSelected: Boolean,
     onClick: () -> Unit,
 ) {
     SelectableMetricCard(isSelected = isSelected, onClick = onClick) {
-        EnvironmentMetricsContent(telemetry, environmentDisplayFahrenheit)
+        EnvironmentMetricsContent(telemetry, environmentDisplayFahrenheit, isImperial)
     }
 }
 
@@ -523,6 +526,7 @@ private fun EnvironmentMetricsCard(
 private fun EnvironmentMetricsContent(
     telemetry: Telemetry,
     environmentDisplayFahrenheit: Boolean,
+    isImperial: Boolean,
     timeTextOverride: String? = null,
 ) {
     val envMetrics = telemetry.environment_metrics ?: org.meshtastic.proto.EnvironmentMetrics()
@@ -550,11 +554,8 @@ private fun EnvironmentMetricsContent(
 
         VoltageCurrentDisplay(envMetrics)
         RadiationDisplay(envMetrics)
-        // ponytail: environmentDisplayFahrenheit == (displayUnits == IMPERIAL) — both derive from the same
-        // getSystemMeasurementSystem(), so it doubles as the imperial flag for wind/rainfall. Thread a separate
-        // flag only if temperature and distance units are ever sourced independently (e.g. UK Celsius + miles).
-        WindDisplay(envMetrics, environmentDisplayFahrenheit)
-        RainfallDisplay(envMetrics, environmentDisplayFahrenheit)
+        WindDisplay(envMetrics, isImperial)
+        RainfallDisplay(envMetrics, isImperial)
         OneWireTemperatureDisplay(envMetrics, environmentDisplayFahrenheit)
     }
 }
@@ -590,6 +591,7 @@ fun PreviewEnvironmentMetricsContent() {
             EnvironmentMetricsContent(
                 telemetry = fakeTelemetry,
                 environmentDisplayFahrenheit = false,
+                isImperial = false,
                 timeTextOverride = "2023-11-14 22:13",
             )
         }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
@@ -368,21 +368,21 @@ private fun RadiationDisplay(envMetrics: org.meshtastic.proto.EnvironmentMetrics
 }
 
 @Composable
-private fun WindDisplay(envMetrics: org.meshtastic.proto.EnvironmentMetrics) {
+private fun WindDisplay(envMetrics: org.meshtastic.proto.EnvironmentMetrics, isImperial: Boolean) {
     val hasSpeed = envMetrics.wind_speed != null && !envMetrics.wind_speed!!.isNaN()
     val hasGust = envMetrics.wind_gust != null && !envMetrics.wind_gust!!.isNaN()
     val hasLull = envMetrics.wind_lull != null && !envMetrics.wind_lull!!.isNaN()
 
     if (hasSpeed || hasGust || hasLull) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            if (hasSpeed) WindSpeedRow(envMetrics)
-            if (hasGust || hasLull) WindGustLullRow(envMetrics, hasGust, hasLull)
+            if (hasSpeed) WindSpeedRow(envMetrics, isImperial)
+            if (hasGust || hasLull) WindGustLullRow(envMetrics, isImperial, hasGust, hasLull)
         }
     }
 }
 
 @Composable
-private fun WindSpeedRow(envMetrics: org.meshtastic.proto.EnvironmentMetrics) {
+private fun WindSpeedRow(envMetrics: org.meshtastic.proto.EnvironmentMetrics, isImperial: Boolean) {
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             MetricIndicator(Environment.WIND_SPEED.color)
@@ -390,9 +390,9 @@ private fun WindSpeedRow(envMetrics: org.meshtastic.proto.EnvironmentMetrics) {
             val dirText =
                 if (envMetrics.wind_direction != null) {
                     formatString(
-                        "%s %.1f m/s (%s %d°)",
+                        "%s %s (%s %d°)",
                         stringResource(Res.string.wind_speed),
-                        envMetrics.wind_speed!!,
+                        MetricFormatter.windSpeed(envMetrics.wind_speed!!, isImperial),
                         stringResource(Res.string.wind_direction),
                         envMetrics.wind_direction!!,
                     )
@@ -400,7 +400,7 @@ private fun WindSpeedRow(envMetrics: org.meshtastic.proto.EnvironmentMetrics) {
                     formatString(
                         "%s %s",
                         stringResource(Res.string.wind_speed),
-                        MetricFormatter.windSpeed(envMetrics.wind_speed!!),
+                        MetricFormatter.windSpeed(envMetrics.wind_speed!!, isImperial),
                     )
                 }
             Text(
@@ -413,18 +413,29 @@ private fun WindSpeedRow(envMetrics: org.meshtastic.proto.EnvironmentMetrics) {
 }
 
 @Composable
-private fun WindGustLullRow(envMetrics: org.meshtastic.proto.EnvironmentMetrics, hasGust: Boolean, hasLull: Boolean) {
+private fun WindGustLullRow(
+    envMetrics: org.meshtastic.proto.EnvironmentMetrics,
+    isImperial: Boolean,
+    hasGust: Boolean,
+    hasLull: Boolean,
+) {
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
         if (hasGust) {
             Text(
-                text = "${stringResource(Res.string.wind_gust)} ${MetricFormatter.windSpeed(envMetrics.wind_gust!!)}",
+                text =
+                "${stringResource(Res.string.wind_gust)} ${
+                    MetricFormatter.windSpeed(envMetrics.wind_gust!!, isImperial)
+                }",
                 color = MaterialTheme.colorScheme.onSurface,
                 fontSize = MaterialTheme.typography.labelLarge.fontSize,
             )
         }
         if (hasLull) {
             Text(
-                text = "${stringResource(Res.string.wind_lull)} ${MetricFormatter.windSpeed(envMetrics.wind_lull!!)}",
+                text =
+                "${stringResource(Res.string.wind_lull)} ${
+                    MetricFormatter.windSpeed(envMetrics.wind_lull!!, isImperial)
+                }",
                 color = MaterialTheme.colorScheme.onSurface,
                 fontSize = MaterialTheme.typography.labelLarge.fontSize,
             )
@@ -433,7 +444,7 @@ private fun WindGustLullRow(envMetrics: org.meshtastic.proto.EnvironmentMetrics,
 }
 
 @Composable
-private fun RainfallDisplay(envMetrics: org.meshtastic.proto.EnvironmentMetrics) {
+private fun RainfallDisplay(envMetrics: org.meshtastic.proto.EnvironmentMetrics, isImperial: Boolean) {
     val has1h = envMetrics.rainfall_1h != null && !envMetrics.rainfall_1h!!.isNaN()
     val has24h = envMetrics.rainfall_24h != null && !envMetrics.rainfall_24h!!.isNaN()
 
@@ -444,7 +455,7 @@ private fun RainfallDisplay(envMetrics: org.meshtastic.proto.EnvironmentMetrics)
                     text =
                     "${stringResource(
                         Res.string.rainfall_1h,
-                    )} ${MetricFormatter.rainfall(envMetrics.rainfall_1h!!)}",
+                    )} ${MetricFormatter.rainfall(envMetrics.rainfall_1h!!, isImperial)}",
                     color = MaterialTheme.colorScheme.onSurface,
                     fontSize = MaterialTheme.typography.labelLarge.fontSize,
                 )
@@ -454,7 +465,7 @@ private fun RainfallDisplay(envMetrics: org.meshtastic.proto.EnvironmentMetrics)
                     text =
                     "${stringResource(
                         Res.string.rainfall_24h,
-                    )} ${MetricFormatter.rainfall(envMetrics.rainfall_24h!!)}",
+                    )} ${MetricFormatter.rainfall(envMetrics.rainfall_24h!!, isImperial)}",
                     color = MaterialTheme.colorScheme.onSurface,
                     fontSize = MaterialTheme.typography.labelLarge.fontSize,
                 )
@@ -539,8 +550,8 @@ private fun EnvironmentMetricsContent(
 
         VoltageCurrentDisplay(envMetrics)
         RadiationDisplay(envMetrics)
-        WindDisplay(envMetrics)
-        RainfallDisplay(envMetrics)
+        WindDisplay(envMetrics, environmentDisplayFahrenheit)
+        RainfallDisplay(envMetrics, environmentDisplayFahrenheit)
         OneWireTemperatureDisplay(envMetrics, environmentDisplayFahrenheit)
     }
 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
@@ -550,6 +550,9 @@ private fun EnvironmentMetricsContent(
 
         VoltageCurrentDisplay(envMetrics)
         RadiationDisplay(envMetrics)
+        // ponytail: environmentDisplayFahrenheit == (displayUnits == IMPERIAL) — both derive from the same
+        // getSystemMeasurementSystem(), so it doubles as the imperial flag for wind/rainfall. Thread a separate
+        // flag only if temperature and distance units are ever sourced independently (e.g. UK Celsius + miles).
         WindDisplay(envMetrics, environmentDisplayFahrenheit)
         RainfallDisplay(envMetrics, environmentDisplayFahrenheit)
         OneWireTemperatureDisplay(envMetrics, environmentDisplayFahrenheit)


### PR DESCRIPTION
## Summary
- 🐛 The app's own UI (node list, node details, map) rendered distance/temperature/wind-speed/rainfall units from the *connected radio's* `DisplayConfig`/telemetry settings instead of the phone's OS locale, so units could mismatch what the phone owner actually expects (e.g. a US phone paired to a metric-configured radio, or vice versa).
- 🛠️ Repointed `NodeListViewModel`, `CommonGetNodeDetailsUseCase`, `BaseMapViewModel`, and fdroid `MapView`/`MapViewModel` to derive `distanceUnits`/`tempInFahrenheit`/`displayUnits` from `getSystemMeasurementSystem()` / `DistanceUnit.getFromLocale()` instead of reading the device's own display config. The radio-config screen that legitimately *writes* those fields to the physical device (`TelemetryConfigItemList`) is untouched.
- 🛠️ Made `MetricFormatter.windSpeed()`/`rainfall()` locale-aware the same way `temperature()` already was (mph/in vs m/s/mm), and threaded the flag through the environment-metrics screen.
- 🧹 Removed a dead reflection hack in `getSystemMeasurementSystem()`: it called `androidx.core.text.util.LocalePreferences.getMeasurementSystem` via `Class.forName`/reflection, but `androidx.core:core-ktx` 1.19.0 (the version this module already depends on) has no such method — the reflective lookup always threw `NoSuchMethodException` and silently fell through to the existing ICU/legacy fallback on every device, on every API level. Deleted the always-failing branch; behavior is unchanged since it never actually executed.

Fixes #6090. Per meshtastic/design#99 (units/locale alignment standard); iOS is already compliant, this is Android-only.

## Testing Performed
- `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green (1,359 tests, 0 failures)
- Added `windSpeedImperial`/`rainfallImperial` cases to `MetricFormatterTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment metrics now switch between imperial and metric for wind (speed/direction) and rainfall.
  * Map and node distance/temperature units now follow the device’s locale measurement system for more consistent display.
* **Bug Fixes**
  * Improved map marker text and node filtering behavior to stay aligned with the active display units.
  * Correct wind/rainfall unit formatting across the app (mph/in vs m/s/mm).
  * Improved system measurement-system detection on newer Android versions.
* **Tests**
  * Updated unit-formatting test coverage for imperial outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->