### PR TITLE
feat(node): label power channels and fix pressure axis scale

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/NodeInfoWriteDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/NodeInfoWriteDataSource.kt
@@ -39,5 +39,7 @@ interface NodeInfoWriteDataSource {
 
     suspend fun setNodeNotes(num: Int, notes: String)
 
+    suspend fun setPowerChannelLabels(num: Int, labels: List<String>)
+
     suspend fun backfillDenormalizedNames()
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/NodeInfoWriteDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/NodeInfoWriteDataSource.kt
@@ -39,7 +39,7 @@ interface NodeInfoWriteDataSource {
 
     suspend fun setNodeNotes(num: Int, notes: String)
 
-    suspend fun setPowerChannelLabels(num: Int, labels: List<String>)
+    suspend fun updatePowerChannelLabel(num: Int, channelIndex: Int, label: String)
 
     suspend fun backfillDenormalizedNames()
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoWriteDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoWriteDataSource.kt
@@ -66,8 +66,10 @@ class SwitchingNodeInfoWriteDataSource(
         withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().setNodeNotes(num, notes) } }
     }
 
-    override suspend fun setPowerChannelLabels(num: Int, labels: List<String>) {
-        withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().setPowerChannelLabels(num, labels) } }
+    override suspend fun updatePowerChannelLabel(num: Int, channelIndex: Int, label: String) {
+        withContext(dispatchers.io) {
+            dbManager.withDb { it.nodeInfoDao().updatePowerChannelLabel(num, channelIndex, label) }
+        }
     }
 
     override suspend fun backfillDenormalizedNames() {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoWriteDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoWriteDataSource.kt
@@ -66,6 +66,10 @@ class SwitchingNodeInfoWriteDataSource(
         withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().setNodeNotes(num, notes) } }
     }
 
+    override suspend fun setPowerChannelLabels(num: Int, labels: List<String>) {
+        withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().setPowerChannelLabels(num, labels) } }
+    }
+
     override suspend fun backfillDenormalizedNames() {
         withContext(dispatchers.io) { dbManager.withDb { it.nodeInfoDao().backfillDenormalizedNames() } }
     }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/NodeRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/NodeRepositoryImpl.kt
@@ -250,6 +250,9 @@ class NodeRepositoryImpl(
     override suspend fun setNodeNotes(num: Int, notes: String) =
         withContext(dispatchers.io) { nodeInfoWriteDataSource.setNodeNotes(num, notes) }
 
+    override suspend fun setPowerChannelLabels(num: Int, labels: List<String>) =
+        withContext(dispatchers.io) { nodeInfoWriteDataSource.setPowerChannelLabels(num, labels) }
+
     private fun MyNodeInfo.toEntity() = MyNodeEntity(
         myNodeNum = myNodeNum,
         model = model,

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/NodeRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/NodeRepositoryImpl.kt
@@ -250,8 +250,8 @@ class NodeRepositoryImpl(
     override suspend fun setNodeNotes(num: Int, notes: String) =
         withContext(dispatchers.io) { nodeInfoWriteDataSource.setNodeNotes(num, notes) }
 
-    override suspend fun setPowerChannelLabels(num: Int, labels: List<String>) =
-        withContext(dispatchers.io) { nodeInfoWriteDataSource.setPowerChannelLabels(num, labels) }
+    override suspend fun updatePowerChannelLabel(num: Int, channelIndex: Int, label: String) =
+        withContext(dispatchers.io) { nodeInfoWriteDataSource.updatePowerChannelLabel(num, channelIndex, label) }
 
     private fun MyNodeInfo.toEntity() = MyNodeEntity(
         myNodeNum = myNodeNum,

--- a/core/database/schemas/org.meshtastic.core.database.MeshtasticDatabase/46.json
+++ b/core/database/schemas/org.meshtastic.core.database.MeshtasticDatabase/46.json
@@ -1,0 +1,1607 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 46,
+    "identityHash": "470de736ff2302f94798591820a516dd",
+    "entities": [
+      {
+        "tableName": "my_node",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`myNodeNum` INTEGER NOT NULL, `model` TEXT, `firmwareVersion` TEXT, `couldUpdate` INTEGER NOT NULL, `shouldUpdate` INTEGER NOT NULL, `currentPacketId` INTEGER NOT NULL, `messageTimeoutMsec` INTEGER NOT NULL, `minAppVersion` INTEGER NOT NULL, `maxChannels` INTEGER NOT NULL, `hasWifi` INTEGER NOT NULL, `deviceId` TEXT, `pioEnv` TEXT, PRIMARY KEY(`myNodeNum`))",
+        "fields": [
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "firmwareVersion",
+            "columnName": "firmwareVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "couldUpdate",
+            "columnName": "couldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldUpdate",
+            "columnName": "shouldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPacketId",
+            "columnName": "currentPacketId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageTimeoutMsec",
+            "columnName": "messageTimeoutMsec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxChannels",
+            "columnName": "maxChannels",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasWifi",
+            "columnName": "hasWifi",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pioEnv",
+            "columnName": "pioEnv",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "myNodeNum"
+          ]
+        }
+      },
+      {
+        "tableName": "nodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `user` BLOB NOT NULL, `long_name` TEXT, `short_name` TEXT, `position` BLOB NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `snr` REAL NOT NULL, `rssi` INTEGER NOT NULL, `last_heard` INTEGER NOT NULL, `device_metrics` BLOB NOT NULL, `channel` INTEGER NOT NULL, `via_mqtt` INTEGER NOT NULL, `hops_away` INTEGER NOT NULL, `is_favorite` INTEGER NOT NULL, `is_ignored` INTEGER NOT NULL DEFAULT 0, `is_muted` INTEGER NOT NULL DEFAULT 0, `environment_metrics` BLOB NOT NULL, `power_metrics` BLOB NOT NULL, `air_quality_metrics` BLOB NOT NULL DEFAULT x'', `paxcounter` BLOB NOT NULL, `public_key` BLOB, `notes` TEXT NOT NULL DEFAULT '', `power_channel_labels` TEXT NOT NULL DEFAULT '[]', `manually_verified` INTEGER NOT NULL DEFAULT 0, `node_status` TEXT, `last_transport` INTEGER NOT NULL DEFAULT 0, `has_xeddsa_signed` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`num`))",
+        "fields": [
+          {
+            "fieldPath": "num",
+            "columnName": "num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user",
+            "columnName": "user",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeard",
+            "columnName": "last_heard",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceTelemetry",
+            "columnName": "device_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viaMqtt",
+            "columnName": "via_mqtt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hops_away",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIgnored",
+            "columnName": "is_ignored",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isMuted",
+            "columnName": "is_muted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "environmentTelemetry",
+            "columnName": "environment_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "powerTelemetry",
+            "columnName": "power_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "airQualityTelemetry",
+            "columnName": "air_quality_metrics",
+            "affinity": "BLOB",
+            "notNull": true,
+            "defaultValue": "x''"
+          },
+          {
+            "fieldPath": "paxcounter",
+            "columnName": "paxcounter",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "public_key",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "powerChannelLabels",
+            "columnName": "power_channel_labels",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "manuallyVerified",
+            "columnName": "manually_verified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "nodeStatus",
+            "columnName": "node_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastTransport",
+            "columnName": "last_transport",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "signsPackets",
+            "columnName": "has_xeddsa_signed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "num"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nodes_last_heard",
+            "unique": false,
+            "columnNames": [
+              "last_heard"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_last_heard` ON `${TABLE_NAME}` (`last_heard`)"
+          },
+          {
+            "name": "index_nodes_short_name",
+            "unique": false,
+            "columnNames": [
+              "short_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_short_name` ON `${TABLE_NAME}` (`short_name`)"
+          },
+          {
+            "name": "index_nodes_long_name",
+            "unique": false,
+            "columnNames": [
+              "long_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_long_name` ON `${TABLE_NAME}` (`long_name`)"
+          },
+          {
+            "name": "index_nodes_hops_away",
+            "unique": false,
+            "columnNames": [
+              "hops_away"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_hops_away` ON `${TABLE_NAME}` (`hops_away`)"
+          },
+          {
+            "name": "index_nodes_is_favorite",
+            "unique": false,
+            "columnNames": [
+              "is_favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_is_favorite` ON `${TABLE_NAME}` (`is_favorite`)"
+          },
+          {
+            "name": "index_nodes_last_heard_is_favorite",
+            "unique": false,
+            "columnNames": [
+              "last_heard",
+              "is_favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_last_heard_is_favorite` ON `${TABLE_NAME}` (`last_heard`, `is_favorite`)"
+          },
+          {
+            "name": "index_nodes_public_key",
+            "unique": false,
+            "columnNames": [
+              "public_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_public_key` ON `${TABLE_NAME}` (`public_key`)"
+          }
+        ]
+      },
+      {
+        "tableName": "packet",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `myNodeNum` INTEGER NOT NULL DEFAULT 0, `port_num` INTEGER NOT NULL, `contact_key` TEXT NOT NULL, `received_time` INTEGER NOT NULL, `read` INTEGER NOT NULL DEFAULT 1, `data` TEXT NOT NULL, `packet_id` INTEGER NOT NULL DEFAULT 0, `routing_error` INTEGER NOT NULL DEFAULT -1, `snr` REAL NOT NULL DEFAULT 0, `rssi` INTEGER NOT NULL DEFAULT 0, `hopsAway` INTEGER NOT NULL DEFAULT -1, `sfpp_hash` BLOB, `filtered` INTEGER NOT NULL DEFAULT 0, `message_text` TEXT NOT NULL DEFAULT '', `translated_text` TEXT, `show_translated` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "port_num",
+            "columnName": "port_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_time",
+            "columnName": "received_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetId",
+            "columnName": "packet_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "routingError",
+            "columnName": "routing_error",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hopsAway",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "sfpp_hash",
+            "columnName": "sfpp_hash",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "filtered",
+            "columnName": "filtered",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "messageText",
+            "columnName": "message_text",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "translatedText",
+            "columnName": "translated_text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showTranslated",
+            "columnName": "show_translated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_packet_myNodeNum",
+            "unique": false,
+            "columnNames": [
+              "myNodeNum"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_myNodeNum` ON `${TABLE_NAME}` (`myNodeNum`)"
+          },
+          {
+            "name": "index_packet_port_num",
+            "unique": false,
+            "columnNames": [
+              "port_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_port_num` ON `${TABLE_NAME}` (`port_num`)"
+          },
+          {
+            "name": "index_packet_contact_key",
+            "unique": false,
+            "columnNames": [
+              "contact_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_contact_key` ON `${TABLE_NAME}` (`contact_key`)"
+          },
+          {
+            "name": "index_packet_contact_key_port_num_received_time",
+            "unique": false,
+            "columnNames": [
+              "contact_key",
+              "port_num",
+              "received_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_contact_key_port_num_received_time` ON `${TABLE_NAME}` (`contact_key`, `port_num`, `received_time`)"
+          },
+          {
+            "name": "index_packet_packet_id",
+            "unique": false,
+            "columnNames": [
+              "packet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_packet_id` ON `${TABLE_NAME}` (`packet_id`)"
+          },
+          {
+            "name": "index_packet_received_time",
+            "unique": false,
+            "columnNames": [
+              "received_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_received_time` ON `${TABLE_NAME}` (`received_time`)"
+          },
+          {
+            "name": "index_packet_filtered",
+            "unique": false,
+            "columnNames": [
+              "filtered"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_filtered` ON `${TABLE_NAME}` (`filtered`)"
+          },
+          {
+            "name": "index_packet_read",
+            "unique": false,
+            "columnNames": [
+              "read"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_read` ON `${TABLE_NAME}` (`read`)"
+          }
+        ]
+      },
+      {
+        "tableName": "packet_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS5(`message_text`, tokenize=`unicode61`, content=`packet`)",
+        "fields": [
+          {
+            "fieldPath": "messageText",
+            "columnName": "message_text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS5",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "packet",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC",
+          "contentRowId": "",
+          "columnSize": true,
+          "detail": "FULL"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_BEFORE_UPDATE BEFORE UPDATE ON `packet` BEGIN DELETE FROM `packet_fts` WHERE `rowid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_BEFORE_DELETE BEFORE DELETE ON `packet` BEGIN DELETE FROM `packet_fts` WHERE `rowid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_AFTER_UPDATE AFTER UPDATE ON `packet` BEGIN INSERT INTO `packet_fts`(`rowid`, `message_text`) VALUES (NEW.`rowid`, NEW.`message_text`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_AFTER_INSERT AFTER INSERT ON `packet` BEGIN INSERT INTO `packet_fts`(`rowid`, `message_text`) VALUES (NEW.`rowid`, NEW.`message_text`); END"
+        ]
+      },
+      {
+        "tableName": "contact_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contact_key` TEXT NOT NULL, `muteUntil` INTEGER NOT NULL, `last_read_message_uuid` INTEGER, `last_read_message_timestamp` INTEGER, `filtering_disabled` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`contact_key`))",
+        "fields": [
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muteUntil",
+            "columnName": "muteUntil",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadMessageUuid",
+            "columnName": "last_read_message_uuid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastReadMessageTimestamp",
+            "columnName": "last_read_message_timestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "filteringDisabled",
+            "columnName": "filtering_disabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contact_key"
+          ]
+        }
+      },
+      {
+        "tableName": "log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `type` TEXT NOT NULL, `received_date` INTEGER NOT NULL, `message` TEXT NOT NULL, `from_num` INTEGER NOT NULL DEFAULT 0, `port_num` INTEGER NOT NULL DEFAULT 0, `from_radio` BLOB NOT NULL DEFAULT x'', PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message_type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_date",
+            "columnName": "received_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raw_message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromNum",
+            "columnName": "from_num",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "portNum",
+            "columnName": "port_num",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fromRadio",
+            "columnName": "from_radio",
+            "affinity": "BLOB",
+            "notNull": true,
+            "defaultValue": "x''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_log_from_num",
+            "unique": false,
+            "columnNames": [
+              "from_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_log_from_num` ON `${TABLE_NAME}` (`from_num`)"
+          },
+          {
+            "name": "index_log_port_num",
+            "unique": false,
+            "columnNames": [
+              "port_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_log_port_num` ON `${TABLE_NAME}` (`port_num`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quick_chat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `message` TEXT NOT NULL, `mode` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mode",
+            "columnName": "mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "reactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`myNodeNum` INTEGER NOT NULL DEFAULT 0, `reply_id` INTEGER NOT NULL, `user_id` TEXT NOT NULL, `emoji` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `snr` REAL NOT NULL DEFAULT 0, `rssi` INTEGER NOT NULL DEFAULT 0, `hopsAway` INTEGER NOT NULL DEFAULT -1, `packet_id` INTEGER NOT NULL DEFAULT 0, `status` INTEGER NOT NULL DEFAULT 0, `routing_error` INTEGER NOT NULL DEFAULT 0, `relays` INTEGER NOT NULL DEFAULT 0, `relay_node` INTEGER, `to` TEXT, `channel` INTEGER NOT NULL DEFAULT 0, `sfpp_hash` BLOB, PRIMARY KEY(`myNodeNum`, `reply_id`, `user_id`, `emoji`))",
+        "fields": [
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "replyId",
+            "columnName": "reply_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hopsAway",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "packetId",
+            "columnName": "packet_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "routingError",
+            "columnName": "routing_error",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "relays",
+            "columnName": "relays",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "relayNode",
+            "columnName": "relay_node",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "to",
+            "columnName": "to",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sfpp_hash",
+            "columnName": "sfpp_hash",
+            "affinity": "BLOB"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "myNodeNum",
+            "reply_id",
+            "user_id",
+            "emoji"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reactions_reply_id",
+            "unique": false,
+            "columnNames": [
+              "reply_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reactions_reply_id` ON `${TABLE_NAME}` (`reply_id`)"
+          },
+          {
+            "name": "index_reactions_packet_id",
+            "unique": false,
+            "columnNames": [
+              "packet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reactions_packet_id` ON `${TABLE_NAME}` (`packet_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `proto` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`num`))",
+        "fields": [
+          {
+            "fieldPath": "num",
+            "columnName": "num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proto",
+            "columnName": "proto",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "num"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_num",
+            "unique": false,
+            "columnNames": [
+              "num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_num` ON `${TABLE_NAME}` (`num`)"
+          }
+        ]
+      },
+      {
+        "tableName": "device_hardware",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`actively_supported` INTEGER NOT NULL, `architecture` TEXT NOT NULL, `display_name` TEXT NOT NULL, `has_ink_hud` INTEGER, `has_mui` INTEGER, `hwModel` INTEGER NOT NULL, `hw_model_slug` TEXT NOT NULL, `images` TEXT, `last_updated` INTEGER NOT NULL, `partition_scheme` TEXT, `platformio_target` TEXT NOT NULL, `requires_dfu` INTEGER, `support_level` INTEGER, `tags` TEXT, PRIMARY KEY(`platformio_target`))",
+        "fields": [
+          {
+            "fieldPath": "activelySupported",
+            "columnName": "actively_supported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "architecture",
+            "columnName": "architecture",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasInkHud",
+            "columnName": "has_ink_hud",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasMui",
+            "columnName": "has_mui",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hwModel",
+            "columnName": "hwModel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hwModelSlug",
+            "columnName": "hw_model_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "images",
+            "columnName": "images",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partitionScheme",
+            "columnName": "partition_scheme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platformioTarget",
+            "columnName": "platformio_target",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requiresDfu",
+            "columnName": "requires_dfu",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportLevel",
+            "columnName": "support_level",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platformio_target"
+          ]
+        }
+      },
+      {
+        "tableName": "device_link",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`short_code` TEXT NOT NULL, `link_description` TEXT, `is_vendor` INTEGER NOT NULL, `regions` TEXT, `targets` TEXT, PRIMARY KEY(`short_code`))",
+        "fields": [
+          {
+            "fieldPath": "shortCode",
+            "columnName": "short_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkDescription",
+            "columnName": "link_description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isVendor",
+            "columnName": "is_vendor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regions",
+            "columnName": "regions",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "targets",
+            "columnName": "targets",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "short_code"
+          ]
+        }
+      },
+      {
+        "tableName": "firmware_release",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page_url` TEXT NOT NULL, `release_notes` TEXT NOT NULL, `title` TEXT NOT NULL, `zip_url` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `release_type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageUrl",
+            "columnName": "page_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseNotes",
+            "columnName": "release_notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zipUrl",
+            "columnName": "zip_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseType",
+            "columnName": "release_type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "traceroute_node_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`log_uuid` TEXT NOT NULL, `request_id` INTEGER NOT NULL, `node_num` INTEGER NOT NULL, `position` BLOB NOT NULL, PRIMARY KEY(`log_uuid`, `node_num`), FOREIGN KEY(`log_uuid`) REFERENCES `log`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "logUuid",
+            "columnName": "log_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestId",
+            "columnName": "request_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeNum",
+            "columnName": "node_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "log_uuid",
+            "node_num"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traceroute_node_position_log_uuid",
+            "unique": false,
+            "columnNames": [
+              "log_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traceroute_node_position_log_uuid` ON `${TABLE_NAME}` (`log_uuid`)"
+          },
+          {
+            "name": "index_traceroute_node_position_request_id",
+            "unique": false,
+            "columnNames": [
+              "request_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traceroute_node_position_request_id` ON `${TABLE_NAME}` (`request_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "log",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "log_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovery_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `presets_scanned` TEXT NOT NULL, `home_preset` TEXT NOT NULL, `total_unique_nodes` INTEGER NOT NULL DEFAULT 0, `avg_channel_utilization` REAL NOT NULL DEFAULT 0.0, `total_messages` INTEGER NOT NULL DEFAULT 0, `total_sensor_packets` INTEGER NOT NULL DEFAULT 0, `furthest_node_distance` REAL NOT NULL DEFAULT 0.0, `completion_status` TEXT NOT NULL DEFAULT 'complete', `ai_summary` TEXT, `user_latitude` REAL NOT NULL DEFAULT 0.0, `user_longitude` REAL NOT NULL DEFAULT 0.0, `total_dwell_seconds` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetsScanned",
+            "columnName": "presets_scanned",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homePreset",
+            "columnName": "home_preset",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalUniqueNodes",
+            "columnName": "total_unique_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avgChannelUtilization",
+            "columnName": "avg_channel_utilization",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "totalMessages",
+            "columnName": "total_messages",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "totalSensorPackets",
+            "columnName": "total_sensor_packets",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "furthestNodeDistance",
+            "columnName": "furthest_node_distance",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "completionStatus",
+            "columnName": "completion_status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'complete'"
+          },
+          {
+            "fieldPath": "aiSummary",
+            "columnName": "ai_summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLatitude",
+            "columnName": "user_latitude",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "userLongitude",
+            "columnName": "user_longitude",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "totalDwellSeconds",
+            "columnName": "total_dwell_seconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "discovery_preset_result",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `session_id` INTEGER NOT NULL, `preset_name` TEXT NOT NULL, `dwell_duration_seconds` INTEGER NOT NULL DEFAULT 0, `unique_nodes` INTEGER NOT NULL DEFAULT 0, `direct_neighbor_count` INTEGER NOT NULL DEFAULT 0, `mesh_neighbor_count` INTEGER NOT NULL DEFAULT 0, `infrastructure_node_count` INTEGER NOT NULL DEFAULT 0, `message_count` INTEGER NOT NULL DEFAULT 0, `sensor_packet_count` INTEGER NOT NULL DEFAULT 0, `avg_channel_utilization` REAL NOT NULL DEFAULT 0.0, `avg_airtime_rate` REAL NOT NULL DEFAULT 0.0, `packet_success_rate` REAL NOT NULL DEFAULT 0.0, `packet_failure_rate` REAL NOT NULL DEFAULT 0.0, `ai_summary` TEXT, `num_packets_tx` INTEGER NOT NULL DEFAULT 0, `num_packets_rx` INTEGER NOT NULL DEFAULT 0, `num_packets_rx_bad` INTEGER NOT NULL DEFAULT 0, `num_rx_dupe` INTEGER NOT NULL DEFAULT 0, `num_tx_relay` INTEGER NOT NULL DEFAULT 0, `num_tx_relay_canceled` INTEGER NOT NULL DEFAULT 0, `num_online_nodes` INTEGER NOT NULL DEFAULT 0, `num_total_nodes` INTEGER NOT NULL DEFAULT 0, `uptime_seconds` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`session_id`) REFERENCES `discovery_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetName",
+            "columnName": "preset_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dwellDurationSeconds",
+            "columnName": "dwell_duration_seconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "uniqueNodes",
+            "columnName": "unique_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "directNeighborCount",
+            "columnName": "direct_neighbor_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "meshNeighborCount",
+            "columnName": "mesh_neighbor_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "infrastructureNodeCount",
+            "columnName": "infrastructure_node_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "messageCount",
+            "columnName": "message_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sensorPacketCount",
+            "columnName": "sensor_packet_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avgChannelUtilization",
+            "columnName": "avg_channel_utilization",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "avgAirtimeRate",
+            "columnName": "avg_airtime_rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "packetSuccessRate",
+            "columnName": "packet_success_rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "packetFailureRate",
+            "columnName": "packet_failure_rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "aiSummary",
+            "columnName": "ai_summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numPacketsTx",
+            "columnName": "num_packets_tx",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numPacketsRx",
+            "columnName": "num_packets_rx",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numPacketsRxBad",
+            "columnName": "num_packets_rx_bad",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numRxDupe",
+            "columnName": "num_rx_dupe",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numTxRelay",
+            "columnName": "num_tx_relay",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numTxRelayCanceled",
+            "columnName": "num_tx_relay_canceled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numOnlineNodes",
+            "columnName": "num_online_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numTotalNodes",
+            "columnName": "num_total_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "uptimeSeconds",
+            "columnName": "uptime_seconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovery_preset_result_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_preset_result_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "discovery_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovered_node",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `preset_result_id` INTEGER NOT NULL, `node_num` INTEGER NOT NULL, `short_name` TEXT, `long_name` TEXT, `neighbor_type` TEXT NOT NULL DEFAULT 'direct', `latitude` REAL, `longitude` REAL, `distance_from_user` REAL, `hop_count` INTEGER NOT NULL DEFAULT 0, `snr` REAL NOT NULL DEFAULT 0, `rssi` INTEGER NOT NULL DEFAULT 0, `message_count` INTEGER NOT NULL DEFAULT 0, `sensor_packet_count` INTEGER NOT NULL DEFAULT 0, `is_infrastructure` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`preset_result_id`) REFERENCES `discovery_preset_result`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetResultId",
+            "columnName": "preset_result_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeNum",
+            "columnName": "node_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "neighborType",
+            "columnName": "neighbor_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'direct'"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceFromUser",
+            "columnName": "distance_from_user",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "hopCount",
+            "columnName": "hop_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "messageCount",
+            "columnName": "message_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sensorPacketCount",
+            "columnName": "sensor_packet_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInfrastructure",
+            "columnName": "is_infrastructure",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovered_node_preset_result_id",
+            "unique": false,
+            "columnNames": [
+              "preset_result_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovered_node_preset_result_id` ON `${TABLE_NAME}` (`preset_result_id`)"
+          },
+          {
+            "name": "index_discovered_node_node_num",
+            "unique": false,
+            "columnNames": [
+              "node_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovered_node_node_num` ON `${TABLE_NAME}` (`node_num`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "discovery_preset_result",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "preset_result_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '470de736ff2302f94798591820a516dd')"
+    ]
+  }
+}

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -115,8 +115,9 @@ import org.meshtastic.core.database.entity.TracerouteNodePositionEntity
         AutoMigration(from = 42, to = 43, spec = AutoMigration42to43::class),
         AutoMigration(from = 43, to = 44),
         AutoMigration(from = 44, to = 45),
+        AutoMigration(from = 45, to = 46),
     ],
-    version = 45,
+    version = 46,
     exportSchema = true,
 )
 @androidx.room3.ConstructedBy(MeshtasticDatabaseConstructor::class)

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
@@ -27,6 +27,7 @@ import org.meshtastic.core.database.entity.MetadataEntity
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.entity.NodeEntity
 import org.meshtastic.core.database.entity.NodeWithRelations
+import org.meshtastic.core.model.mergePowerChannelLabel
 import org.meshtastic.proto.HardwareModel
 
 @Suppress("TooManyFunctions")
@@ -329,10 +330,8 @@ interface NodeInfoDao {
      */
     @Transaction
     suspend fun updatePowerChannelLabel(num: Int, channelIndex: Int, label: String) {
-        val labels = (getNodeByNum(num)?.node?.powerChannelLabels ?: emptyList()).toMutableList()
-        while (labels.size <= channelIndex) labels.add("")
-        labels[channelIndex] = label.trim()
-        setPowerChannelLabels(num, labels.dropLastWhile { it.isBlank() })
+        val existing = getNodeByNum(num)?.node?.powerChannelLabels ?: emptyList()
+        setPowerChannelLabels(num, mergePowerChannelLabel(existing, channelIndex, label))
     }
 
     /**

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
@@ -144,6 +144,7 @@ interface NodeInfoDao {
     @Suppress("CyclomaticComplexMethod", "MagicNumber")
     private fun handleExistingNodeUpsertValidation(existingNode: NodeEntity, incomingNode: NodeEntity): NodeEntity {
         val resolvedNotes = incomingNode.notes.ifBlank { existingNode.notes }
+        val resolvedPowerChannelLabels = incomingNode.powerChannelLabels.ifEmpty { existingNode.powerChannelLabels }
 
         val isPlaceholder = incomingNode.user.hw_model == HardwareModel.UNSET
         val hasExistingUser = existingNode.user.hw_model != HardwareModel.UNSET
@@ -157,6 +158,7 @@ interface NodeInfoDao {
                 shortName = existingNode.shortName,
                 manuallyVerified = existingNode.manuallyVerified,
                 notes = resolvedNotes,
+                powerChannelLabels = resolvedPowerChannelLabels,
             )
         }
 
@@ -166,6 +168,7 @@ interface NodeInfoDao {
             user = incomingNode.user.copy(public_key = resolvedKey ?: ByteString.EMPTY),
             publicKey = resolvedKey,
             notes = resolvedNotes,
+            powerChannelLabels = resolvedPowerChannelLabels,
         )
     }
 
@@ -312,6 +315,9 @@ interface NodeInfoDao {
 
     @Query("UPDATE nodes SET notes = :notes WHERE num = :num")
     suspend fun setNodeNotes(num: Int, notes: String)
+
+    @Query("UPDATE nodes SET power_channel_labels = :labels WHERE num = :num")
+    suspend fun setPowerChannelLabels(num: Int, labels: List<String>)
 
     /**
      * Batch version of [getVerifiedNodeForUpsert]. Pre-fetches all existing nodes and public-key conflicts in two

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
@@ -320,6 +320,22 @@ interface NodeInfoDao {
     suspend fun setPowerChannelLabels(num: Int, labels: List<String>)
 
     /**
+     * Sets a single power-channel [label] (0-based [channelIndex]) atomically: the read-modify-write runs inside a
+     * transaction that reads the current labels from the DB, so concurrent edits to different channels can't clobber
+     * each other via a stale read. Earlier channels keep their slot (blank padding); trailing blanks are dropped.
+     *
+     * Reads via [getNodeByNum] rather than a scalar `SELECT power_channel_labels`: Room reads a `List<String>` query
+     * result as one String per row (returning the raw JSON text), not as the column's converted `List<String>`.
+     */
+    @Transaction
+    suspend fun updatePowerChannelLabel(num: Int, channelIndex: Int, label: String) {
+        val labels = (getNodeByNum(num)?.node?.powerChannelLabels ?: emptyList()).toMutableList()
+        while (labels.size <= channelIndex) labels.add("")
+        labels[channelIndex] = label.trim()
+        setPowerChannelLabels(num, labels.dropLastWhile { it.isBlank() })
+    }
+
+    /**
      * Batch version of [getVerifiedNodeForUpsert]. Pre-fetches all existing nodes and public-key conflicts in two
      * queries instead of N individual queries, then processes each node in memory.
      */

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/NodeEntity.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/NodeEntity.kt
@@ -63,6 +63,7 @@ data class NodeWithRelations(
         paxcounter = node.paxcounter,
         publicKey = node.publicKey ?: node.user.public_key,
         notes = node.notes,
+        powerChannelLabels = node.powerChannelLabels,
         nodeStatus = node.nodeStatus,
         lastTransport = node.lastTransport,
         metadata = metadata?.proto,
@@ -91,6 +92,7 @@ data class NodeWithRelations(
             paxcounter = paxcounter,
             publicKey = publicKey ?: user.public_key,
             notes = notes,
+            powerChannelLabels = powerChannelLabels,
             manuallyVerified = manuallyVerified,
             nodeStatus = nodeStatus,
             lastTransport = lastTransport,
@@ -146,6 +148,7 @@ data class NodeEntity(
     @ColumnInfo(typeAffinity = ColumnInfo.BLOB) var paxcounter: Paxcount = Paxcount(),
     @ColumnInfo(name = "public_key") var publicKey: ByteString? = null,
     @ColumnInfo(name = "notes", defaultValue = "") var notes: String = "",
+    @ColumnInfo(name = "power_channel_labels", defaultValue = "[]") var powerChannelLabels: List<String> = emptyList(),
     @ColumnInfo(name = "manually_verified", defaultValue = "0")
     var manuallyVerified: Boolean = false, // ONLY set true when scanned/imported manually
     @ColumnInfo(name = "node_status") var nodeStatus: String? = null,
@@ -215,6 +218,7 @@ data class NodeEntity(
         paxcounter = paxcounter,
         publicKey = publicKey ?: user.public_key,
         notes = notes,
+        powerChannelLabels = powerChannelLabels,
         nodeStatus = nodeStatus,
         lastTransport = lastTransport,
         signsPackets = signsPackets,

--- a/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/dao/PowerChannelLabelsDaoTest.kt
+++ b/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/dao/PowerChannelLabelsDaoTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database.dao
+
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.database.MeshtasticDatabase
+import org.meshtastic.core.database.entity.NodeEntity
+import org.meshtastic.core.database.getInMemoryDatabaseBuilder
+import org.meshtastic.proto.HardwareModel
+import org.meshtastic.proto.User
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Covers the local-only power-channel labels: the direct setter round-trips through the [List]<[String]> column
+ * converter, and a routine device-sync upsert (which never carries labels) must not clobber the user's saved labels.
+ *
+ * JVM-only: the preservation case re-`upsert`s an existing row, and that nested suspend `@Transaction` (upsert reading
+ * back a `@Relation` row) throws a bare SQLException under Robolectric's SQLite; the logic itself is pure Kotlin.
+ */
+class PowerChannelLabelsDaoTest {
+
+    private val database: MeshtasticDatabase = getInMemoryDatabaseBuilder().build()
+    private val dao: NodeInfoDao = database.nodeInfoDao()
+
+    @AfterTest
+    fun tearDown() = database.close()
+
+    private fun node(num: Int, labels: List<String> = emptyList()) = NodeEntity(
+        num = num,
+        user = User(id = "!$num", long_name = "Node $num", hw_model = HardwareModel.TBEAM),
+        powerChannelLabels = labels,
+    )
+
+    @Test
+    fun setterRoundTripsThroughConverter() = runTest {
+        dao.upsert(node(7))
+        dao.setPowerChannelLabels(7, listOf("Solar", "Battery"))
+
+        assertEquals(listOf("Solar", "Battery"), dao.getNodeByNum(7)?.node?.powerChannelLabels)
+    }
+
+    @Test
+    fun upsertWithoutLabelsPreservesExisting() = runTest {
+        dao.upsert(node(8, labels = listOf("Solar", "Battery")))
+        // A device-sync update carries no labels; re-upserting must keep the user's saved ones.
+        dao.upsert(node(8))
+
+        val result = dao.getNodeByNum(8)
+        assertNotNull(result)
+        assertEquals(listOf("Solar", "Battery"), result.node.powerChannelLabels)
+    }
+}

--- a/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/dao/PowerChannelLabelsDaoTest.kt
+++ b/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/dao/PowerChannelLabelsDaoTest.kt
@@ -39,8 +39,7 @@ class PowerChannelLabelsDaoTest {
     private val database: MeshtasticDatabase = getInMemoryDatabaseBuilder().build()
     private val dao: NodeInfoDao = database.nodeInfoDao()
 
-    @AfterTest
-    fun tearDown() = database.close()
+    @AfterTest fun tearDown() = database.close()
 
     private fun node(num: Int, labels: List<String> = emptyList()) = NodeEntity(
         num = num,

--- a/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/dao/PowerChannelLabelsDaoTest.kt
+++ b/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/dao/PowerChannelLabelsDaoTest.kt
@@ -65,4 +65,26 @@ class PowerChannelLabelsDaoTest {
         assertNotNull(result)
         assertEquals(listOf("Solar", "Battery"), result.node.powerChannelLabels)
     }
+
+    @Test
+    fun updateMergesFreshFromDbSoChannelsDontClobber() = runTest {
+        dao.upsert(node(9))
+        // Each call reads the current labels from the DB inside its transaction, so setting a second
+        // channel keeps the first — the race the read-modify-write in the ViewModel used to allow.
+        dao.updatePowerChannelLabel(9, channelIndex = 0, label = "Solar")
+        dao.updatePowerChannelLabel(9, channelIndex = 1, label = "Battery")
+
+        assertEquals(listOf("Solar", "Battery"), dao.getNodeByNum(9)?.node?.powerChannelLabels)
+    }
+
+    @Test
+    fun updatePadsTrimsAndDropsTrailingBlanks() = runTest {
+        dao.upsert(node(10))
+        dao.updatePowerChannelLabel(10, channelIndex = 2, label = "  Load  ")
+        assertEquals(listOf("", "", "Load"), dao.getNodeByNum(10)?.node?.powerChannelLabels)
+
+        // Clearing the last label shrinks the stored list rather than leaving trailing blanks.
+        dao.updatePowerChannelLabel(10, channelIndex = 2, label = "")
+        assertEquals(emptyList(), dao.getNodeByNum(10)?.node?.powerChannelLabels)
+    }
 }

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Node.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Node.kt
@@ -63,6 +63,8 @@ data class Node(
     val paxcounter: Paxcount = Paxcount(),
     val publicKey: ByteString? = null,
     val notes: String = "",
+    /** User-editable labels per power-metrics channel (e.g. "Solar", "Battery"), indexed by channel - 1. */
+    val powerChannelLabels: List<String> = emptyList(),
     val manuallyVerified: Boolean = false,
     /** True when this node signs its broadcasts via XEdDSA (NodeInfo.has_xeddsa_signed). Automatic trust. */
     val signsPackets: Boolean = false,

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/PowerChannelLabels.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/PowerChannelLabels.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model
+
+/**
+ * Merges a user-editable power-channel [label] into [existing] at the 0-based [channelIndex].
+ *
+ * Earlier channels keep their slot via blank padding, the label is trimmed, and trailing blanks are dropped so clearing
+ * a label shrinks the list. Shared by the DB write path and test fakes so the rule can't drift between them.
+ */
+fun mergePowerChannelLabel(existing: List<String>, channelIndex: Int, label: String): List<String> {
+    val labels = existing.toMutableList()
+    while (labels.size <= channelIndex) labels.add("")
+    labels[channelIndex] = label.trim()
+    return labels.dropLastWhile { it.isBlank() }
+}

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/MergePowerChannelLabelTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/MergePowerChannelLabelTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MergePowerChannelLabelTest {
+
+    @Test
+    fun setsLabelAndTrims() {
+        assertEquals(listOf("Solar"), mergePowerChannelLabel(emptyList(), channelIndex = 0, label = "  Solar  "))
+    }
+
+    @Test
+    fun padsEarlierChannelsWithBlanks() {
+        assertEquals(listOf("", "", "Load"), mergePowerChannelLabel(emptyList(), channelIndex = 2, label = "Load"))
+    }
+
+    @Test
+    fun keepsExistingChannelsWhenSettingAnother() {
+        assertEquals(
+            listOf("Solar", "Battery"),
+            mergePowerChannelLabel(listOf("Solar"), channelIndex = 1, label = "Battery"),
+        )
+    }
+
+    @Test
+    fun clearingLastLabelDropsTrailingBlanks() {
+        assertEquals(listOf("Solar"), mergePowerChannelLabel(listOf("Solar", "Battery"), channelIndex = 1, label = ""))
+        assertEquals(emptyList(), mergePowerChannelLabel(listOf("Load"), channelIndex = 0, label = ""))
+    }
+
+    @Test
+    fun clearingAMiddleLabelKeepsLaterOnesAsBlankSlots() {
+        assertEquals(
+            listOf("", "Battery"),
+            mergePowerChannelLabel(listOf("Solar", "Battery"), channelIndex = 0, label = ""),
+        )
+    }
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRepository.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRepository.kt
@@ -154,6 +154,14 @@ interface NodeRepository {
     suspend fun setNodeNotes(num: Int, notes: String)
 
     /**
+     * Updates the user-editable power-channel labels for a node (e.g. "Solar", "Battery"), indexed by channel - 1.
+     *
+     * @param num The node number.
+     * @param labels The labels to persist.
+     */
+    suspend fun setPowerChannelLabels(num: Int, labels: List<String>)
+
+    /**
      * Upserts a [Node] into the persistent database.
      *
      * @param node The [Node] model to save.

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRepository.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRepository.kt
@@ -154,12 +154,14 @@ interface NodeRepository {
     suspend fun setNodeNotes(num: Int, notes: String)
 
     /**
-     * Updates the user-editable power-channel labels for a node (e.g. "Solar", "Battery"), indexed by channel - 1.
+     * Sets one user-editable power-channel label (e.g. "Solar", "Battery"). The read-modify-write is atomic, so
+     * concurrent edits to different channels don't clobber each other.
      *
      * @param num The node number.
-     * @param labels The labels to persist.
+     * @param channelIndex The 0-based power channel index.
+     * @param label The label to persist (blank clears it).
      */
-    suspend fun setPowerChannelLabels(num: Int, labels: List<String>)
+    suspend fun updatePowerChannelLabel(num: Int, channelIndex: Int, label: String)
 
     /**
      * Upserts a [Node] into the persistent database.

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
@@ -325,6 +325,8 @@ class TAKMeshIntegrationTest {
         override suspend fun installConfig(mi: MyNodeInfo, nodes: List<Node>) {}
 
         override suspend fun insertMetadata(nodeNum: Int, metadata: DeviceMetadata) {}
+
+        override suspend fun setPowerChannelLabels(num: Int, labels: List<String>) {}
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
@@ -326,7 +326,7 @@ class TAKMeshIntegrationTest {
 
         override suspend fun insertMetadata(nodeNum: Int, metadata: DeviceMetadata) {}
 
-        override suspend fun setPowerChannelLabels(num: Int, labels: List<String>) {}
+        override suspend fun updatePowerChannelLabel(num: Int, channelIndex: Int, label: String) {}
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeNodeRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeNodeRepository.kt
@@ -155,9 +155,13 @@ class FakeNodeRepository :
         _nodeDBbyNum.value = _nodeDBbyNum.value + (num to node.copy(notes = notes))
     }
 
-    override suspend fun setPowerChannelLabels(num: Int, labels: List<String>) {
+    override suspend fun updatePowerChannelLabel(num: Int, channelIndex: Int, label: String) {
         val node = _nodeDBbyNum.value[num] ?: return
-        _nodeDBbyNum.value = _nodeDBbyNum.value + (num to node.copy(powerChannelLabels = labels))
+        val labels = node.powerChannelLabels.toMutableList()
+        while (labels.size <= channelIndex) labels.add("")
+        labels[channelIndex] = label.trim()
+        _nodeDBbyNum.value =
+            _nodeDBbyNum.value + (num to node.copy(powerChannelLabels = labels.dropLastWhile { it.isBlank() }))
     }
 
     override suspend fun upsert(node: Node) {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeNodeRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeNodeRepository.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.map
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeSortOption
+import org.meshtastic.core.model.mergePowerChannelLabel
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.proto.DeviceMetadata
 import org.meshtastic.proto.LocalStats
@@ -157,11 +158,8 @@ class FakeNodeRepository :
 
     override suspend fun updatePowerChannelLabel(num: Int, channelIndex: Int, label: String) {
         val node = _nodeDBbyNum.value[num] ?: return
-        val labels = node.powerChannelLabels.toMutableList()
-        while (labels.size <= channelIndex) labels.add("")
-        labels[channelIndex] = label.trim()
-        _nodeDBbyNum.value =
-            _nodeDBbyNum.value + (num to node.copy(powerChannelLabels = labels.dropLastWhile { it.isBlank() }))
+        val merged = mergePowerChannelLabel(node.powerChannelLabels, channelIndex, label)
+        _nodeDBbyNum.value = _nodeDBbyNum.value + (num to node.copy(powerChannelLabels = merged))
     }
 
     override suspend fun upsert(node: Node) {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeNodeRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeNodeRepository.kt
@@ -155,6 +155,11 @@ class FakeNodeRepository :
         _nodeDBbyNum.value = _nodeDBbyNum.value + (num to node.copy(notes = notes))
     }
 
+    override suspend fun setPowerChannelLabels(num: Int, labels: List<String>) {
+        val node = _nodeDBbyNum.value[num] ?: return
+        _nodeDBbyNum.value = _nodeDBbyNum.value + (num to node.copy(powerChannelLabels = labels))
+    }
+
     override suspend fun upsert(node: Node) {
         _nodeDBbyNum.value = _nodeDBbyNum.value + (node.num to node)
     }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentCharts.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentCharts.kt
@@ -233,7 +233,9 @@ fun EnvironmentMetricsChart(
                 },
             )
 
-        val pressureRangeProvider = remember { CartesianLayerRangeProvider.fixed(minY = 700.0, maxY = 1200.0) }
+        // Fixed sea-level-relative domain (design#53) so small real pressure changes are visually
+        // comparable across sessions/nodes instead of being swamped by a 700-1200 hPa altitude range.
+        val pressureRangeProvider = remember { CartesianLayerRangeProvider.fixed(minY = 950.0, maxY = 1050.0) }
         val layers = mutableListOf<LineCartesianLayer>()
         if (showPressure && pressureData.isNotEmpty()) {
             layers.add(
@@ -244,7 +246,7 @@ fun EnvironmentMetricsChart(
                     ),
                     verticalAxisPosition = Axis.Position.Vertical.Start,
                     // Fixed range per Oscar's UX guidance: barometric pressure should NOT autoscale,
-                    // otherwise trends (storms) are invisible. 700-1200 hPa covers sea-level to altitude.
+                    // otherwise trends (storms) are invisible.
                     rangeProvider = pressureRangeProvider,
                 ),
             )

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentCharts.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentCharts.kt
@@ -35,6 +35,7 @@ import com.patrykandpatrick.vico.compose.cartesian.data.CartesianLayerRangeProvi
 import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
+import com.patrykandpatrick.vico.compose.common.data.ExtraStore
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.common.util.formatString
 import org.meshtastic.core.resources.Res
@@ -133,6 +134,25 @@ private val LEGEND_DATA_4 =
                 metricKey = entry,
             )
         }
+
+private const val PRESSURE_DEFAULT_MIN = 950.0
+private const val PRESSURE_DEFAULT_MAX = 1050.0
+private const val PRESSURE_WINDOW_HPA = PRESSURE_DEFAULT_MAX - PRESSURE_DEFAULT_MIN
+
+/**
+ * Y-axis bounds for the barometric-pressure layer, given the plotted data's [dataMin]/[dataMax].
+ *
+ * Uses a fixed [PRESSURE_WINDOW_HPA]-wide window so a given pressure change is always the same visual size (design#53's
+ * "consistent scale"). Near sea level this is the standard [PRESSURE_DEFAULT_MIN]–[PRESSURE_DEFAULT_MAX]; for a node at
+ * altitude (lower station pressure) the same-width window slides down so readings aren't clipped. It only widens past
+ * the fixed width if a single node's readings genuinely span more than the window.
+ */
+internal fun pressureAxisRange(dataMin: Double, dataMax: Double): Pair<Double, Double> = when {
+    dataMax - dataMin > PRESSURE_WINDOW_HPA -> dataMin to dataMax
+    dataMin < PRESSURE_DEFAULT_MIN -> dataMin to (dataMin + PRESSURE_WINDOW_HPA)
+    dataMax > PRESSURE_DEFAULT_MAX -> (dataMax - PRESSURE_WINDOW_HPA) to dataMax
+    else -> PRESSURE_DEFAULT_MIN to PRESSURE_DEFAULT_MAX
+}
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
@@ -233,9 +253,17 @@ fun EnvironmentMetricsChart(
                 },
             )
 
-        // Fixed sea-level-relative domain (design#53) so small real pressure changes are visually
-        // comparable across sessions/nodes instead of being swamped by a 700-1200 hPa altitude range.
-        val pressureRangeProvider = remember { CartesianLayerRangeProvider.fixed(minY = 950.0, maxY = 1050.0) }
+        // Fixed-width pressure window (design#53) so a given change is always the same visual size,
+        // sliding to the node's elevation so high-altitude readings aren't clipped. See [pressureAxisRange].
+        val pressureRangeProvider = remember {
+            object : CartesianLayerRangeProvider {
+                override fun getMinY(minY: Double, maxY: Double, extraStore: ExtraStore) =
+                    pressureAxisRange(minY, maxY).first
+
+                override fun getMaxY(minY: Double, maxY: Double, extraStore: ExtraStore) =
+                    pressureAxisRange(minY, maxY).second
+            }
+        }
         val layers = mutableListOf<LineCartesianLayer>()
         if (showPressure && pressureData.isNotEmpty()) {
             layers.add(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
@@ -187,12 +187,9 @@ open class MetricsViewModel(
     /** Persists a user-editable label (e.g. "Solar", "Battery") for a power-metrics channel (0-based index). */
     fun setPowerChannelLabel(nodeNum: Int, channelIndex: Int, label: String) =
         safeLaunch(context = dispatchers.io, tag = "setPowerChannelLabel") {
-            val labels = (state.value.node?.powerChannelLabels ?: emptyList()).toMutableList()
-            // Pad with blank placeholders so earlier channels keep their index; trailing blanks are dropped below.
-            while (labels.size <= channelIndex) labels.add("")
-            labels[channelIndex] = label.trim()
-            // Keep the stored list minimal so clearing a label shrinks it instead of leaving trailing blanks.
-            nodeRepository.setPowerChannelLabels(nodeNum, labels.dropLastWhile { it.isBlank() })
+            // Atomic in the DAO: reads current labels from the DB (not stale ViewModel state) so quick successive
+            // saves to different channels can't clobber each other.
+            nodeRepository.updatePowerChannelLabel(nodeNum, channelIndex, label)
         }
 
     fun deleteLog(uuid: String) =

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
@@ -184,6 +184,17 @@ open class MetricsViewModel(
 
     fun getUser(nodeNum: Int) = nodeRepository.getUser(nodeNum)
 
+    /** Persists a user-editable label (e.g. "Solar", "Battery") for a power-metrics channel (0-based index). */
+    fun setPowerChannelLabel(nodeNum: Int, channelIndex: Int, label: String) =
+        safeLaunch(context = dispatchers.io, tag = "setPowerChannelLabel") {
+            val labels = (state.value.node?.powerChannelLabels ?: emptyList()).toMutableList()
+            // Pad with blank placeholders so earlier channels keep their index; trailing blanks are dropped below.
+            while (labels.size <= channelIndex) labels.add("")
+            labels[channelIndex] = label.trim()
+            // Keep the stored list minimal so clearing a label shrinks it instead of leaving trailing blanks.
+            nodeRepository.setPowerChannelLabels(nodeNum, labels.dropLastWhile { it.isBlank() })
+        }
+
     fun deleteLog(uuid: String) =
         safeLaunch(context = dispatchers.io, tag = "deleteLog") { meshLogRepository.deleteLog(uuid) }
 

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
@@ -30,8 +30,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -42,7 +47,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
@@ -68,7 +75,10 @@ import org.meshtastic.core.resources.channel_7
 import org.meshtastic.core.resources.channel_8
 import org.meshtastic.core.resources.current
 import org.meshtastic.core.resources.power_metrics_log
+import org.meshtastic.core.resources.save
 import org.meshtastic.core.resources.voltage
+import org.meshtastic.core.ui.icon.MeshtasticIcons
+import org.meshtastic.core.ui.icon.Save
 import org.meshtastic.core.ui.theme.GraphColors.Gold
 import org.meshtastic.core.ui.theme.GraphColors.InfantryBlue
 import org.meshtastic.core.ui.util.rememberSaveFileLauncher
@@ -113,6 +123,7 @@ fun PowerMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
             }
         }
     var selectedChannel by rememberSaveable { mutableStateOf(PowerChannel.ONE) }
+    val channelLabels = state.node?.powerChannelLabels.orEmpty()
 
     BaseMetricScreen(
         onNavigateUp = onNavigateUp,
@@ -138,12 +149,23 @@ fun PowerMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     availableChannels.forEach { channel ->
+                        val customLabel = channelLabels.getOrNull(channel.ordinal).orEmpty()
                         FilterChip(
                             selected = selectedChannel == channel,
                             onClick = { selectedChannel = channel },
-                            label = { Text(stringResource(channel.strRes)) },
+                            label = { Text(customLabel.ifBlank { stringResource(channel.strRes) }) },
                         )
                     }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                val nodeNum = state.node?.num
+                if (nodeNum != null) {
+                    PowerChannelLabelEditor(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        currentLabel = channelLabels.getOrNull(selectedChannel.ordinal).orEmpty(),
+                        placeholder = stringResource(selectedChannel.strRes),
+                        onSave = { label -> viewModel.setPowerChannelLabel(nodeNum, selectedChannel.ordinal, label) },
+                    )
                 }
             }
         },
@@ -166,12 +188,44 @@ fun PowerMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
                 ) { _, telemetry ->
                     PowerMetricsCard(
                         telemetry = telemetry,
+                        channelLabels = channelLabels,
                         isSelected = telemetry.time.toDouble() == selectedX,
                         onClick = { onCardClick(telemetry.time.toDouble()) },
                     )
                 }
             }
         },
+    )
+}
+
+/** Lets the user assign a role/name (e.g. "Solar", "Battery") to the currently selected power channel. */
+@Composable
+private fun PowerChannelLabelEditor(
+    currentLabel: String,
+    placeholder: String,
+    onSave: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var label by remember(currentLabel) { mutableStateOf(currentLabel) }
+    val edited = label.trim() != currentLabel.trim()
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val save: () -> Unit = {
+        onSave(label.trim())
+        keyboardController?.hide()
+    }
+    OutlinedTextField(
+        value = label,
+        onValueChange = { label = it },
+        modifier = modifier.fillMaxWidth(),
+        placeholder = { Text(placeholder) },
+        singleLine = true,
+        trailingIcon = {
+            IconButton(onClick = save, enabled = edited) {
+                Icon(imageVector = MeshtasticIcons.Save, contentDescription = stringResource(Res.string.save))
+            }
+        },
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { save() }),
     )
 }
 
@@ -284,7 +338,12 @@ private fun PowerMetricsChart(
 
 @Composable
 @Suppress("CyclomaticComplexMethod", "LongMethod")
-private fun PowerMetricsCard(telemetry: Telemetry, isSelected: Boolean, onClick: () -> Unit) {
+private fun PowerMetricsCard(
+    telemetry: Telemetry,
+    channelLabels: List<String>,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
     val time = telemetry.time.toLong() * MS_PER_SEC
     SelectableMetricCard(isSelected = isSelected, onClick = onClick) {
         Row(modifier = Modifier.fillMaxWidth()) {
@@ -302,8 +361,8 @@ private fun PowerMetricsCard(telemetry: Telemetry, isSelected: Boolean, onClick:
 
                 val pm = telemetry.power_metrics
                 if (pm != null) {
-                    PowerChannelsRow1(pm)
-                    PowerChannelsExtraRows(pm)
+                    PowerChannelsRow1(pm, channelLabels)
+                    PowerChannelsExtraRows(pm, channelLabels)
                 }
             }
         }
@@ -311,23 +370,38 @@ private fun PowerMetricsCard(telemetry: Telemetry, isSelected: Boolean, onClick:
 }
 
 @Composable
-private fun PowerChannelsRow1(pm: org.meshtastic.proto.PowerMetrics) {
+private fun PowerChannelsRow1(pm: org.meshtastic.proto.PowerMetrics, channelLabels: List<String>) {
     Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
         if (pm.ch1_current != null || pm.ch1_voltage != null) {
-            PowerChannelColumn(Res.string.channel_1, pm.ch1_voltage ?: 0f, pm.ch1_current ?: 0f)
+            PowerChannelColumn(
+                Res.string.channel_1,
+                channelLabels.getOrNull(PowerChannel.ONE.ordinal),
+                pm.ch1_voltage ?: 0f,
+                pm.ch1_current ?: 0f,
+            )
         }
         if (pm.ch2_current != null || pm.ch2_voltage != null) {
-            PowerChannelColumn(Res.string.channel_2, pm.ch2_voltage ?: 0f, pm.ch2_current ?: 0f)
+            PowerChannelColumn(
+                Res.string.channel_2,
+                channelLabels.getOrNull(PowerChannel.TWO.ordinal),
+                pm.ch2_voltage ?: 0f,
+                pm.ch2_current ?: 0f,
+            )
         }
         if (pm.ch3_current != null || pm.ch3_voltage != null) {
-            PowerChannelColumn(Res.string.channel_3, pm.ch3_voltage ?: 0f, pm.ch3_current ?: 0f)
+            PowerChannelColumn(
+                Res.string.channel_3,
+                channelLabels.getOrNull(PowerChannel.THREE.ordinal),
+                pm.ch3_voltage ?: 0f,
+                pm.ch3_current ?: 0f,
+            )
         }
     }
 }
 
 @Composable
 @Suppress("CyclomaticComplexMethod")
-private fun PowerChannelsExtraRows(pm: org.meshtastic.proto.PowerMetrics) {
+private fun PowerChannelsExtraRows(pm: org.meshtastic.proto.PowerMetrics, channelLabels: List<String>) {
     val hasCh456 =
         hasChannelData(pm.ch4_voltage, pm.ch4_current) ||
             hasChannelData(pm.ch5_voltage, pm.ch5_current) ||
@@ -338,13 +412,28 @@ private fun PowerChannelsExtraRows(pm: org.meshtastic.proto.PowerMetrics) {
         Spacer(modifier = Modifier.height(4.dp))
         Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
             if (hasChannelData(pm.ch4_voltage, pm.ch4_current)) {
-                PowerChannelColumn(Res.string.channel_4, pm.ch4_voltage ?: 0f, pm.ch4_current ?: 0f)
+                PowerChannelColumn(
+                    Res.string.channel_4,
+                    channelLabels.getOrNull(PowerChannel.FOUR.ordinal),
+                    pm.ch4_voltage ?: 0f,
+                    pm.ch4_current ?: 0f,
+                )
             }
             if (hasChannelData(pm.ch5_voltage, pm.ch5_current)) {
-                PowerChannelColumn(Res.string.channel_5, pm.ch5_voltage ?: 0f, pm.ch5_current ?: 0f)
+                PowerChannelColumn(
+                    Res.string.channel_5,
+                    channelLabels.getOrNull(PowerChannel.FIVE.ordinal),
+                    pm.ch5_voltage ?: 0f,
+                    pm.ch5_current ?: 0f,
+                )
             }
             if (hasChannelData(pm.ch6_voltage, pm.ch6_current)) {
-                PowerChannelColumn(Res.string.channel_6, pm.ch6_voltage ?: 0f, pm.ch6_current ?: 0f)
+                PowerChannelColumn(
+                    Res.string.channel_6,
+                    channelLabels.getOrNull(PowerChannel.SIX.ordinal),
+                    pm.ch6_voltage ?: 0f,
+                    pm.ch6_current ?: 0f,
+                )
             }
         }
     }
@@ -352,10 +441,20 @@ private fun PowerChannelsExtraRows(pm: org.meshtastic.proto.PowerMetrics) {
         Spacer(modifier = Modifier.height(4.dp))
         Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
             if (hasChannelData(pm.ch7_voltage, pm.ch7_current)) {
-                PowerChannelColumn(Res.string.channel_7, pm.ch7_voltage ?: 0f, pm.ch7_current ?: 0f)
+                PowerChannelColumn(
+                    Res.string.channel_7,
+                    channelLabels.getOrNull(PowerChannel.SEVEN.ordinal),
+                    pm.ch7_voltage ?: 0f,
+                    pm.ch7_current ?: 0f,
+                )
             }
             if (hasChannelData(pm.ch8_voltage, pm.ch8_current)) {
-                PowerChannelColumn(Res.string.channel_8, pm.ch8_voltage ?: 0f, pm.ch8_current ?: 0f)
+                PowerChannelColumn(
+                    Res.string.channel_8,
+                    channelLabels.getOrNull(PowerChannel.EIGHT.ordinal),
+                    pm.ch8_voltage ?: 0f,
+                    pm.ch8_current ?: 0f,
+                )
             }
         }
     }
@@ -364,9 +463,13 @@ private fun PowerChannelsExtraRows(pm: org.meshtastic.proto.PowerMetrics) {
 private fun hasChannelData(voltage: Float?, current: Float?): Boolean = voltage != null || current != null
 
 @Composable
-private fun PowerChannelColumn(titleRes: StringResource, voltage: Float, current: Float) {
+private fun PowerChannelColumn(titleRes: StringResource, customLabel: String?, voltage: Float, current: Float) {
     Column {
-        Text(text = stringResource(titleRes), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
+        Text(
+            text = customLabel?.takeIf { it.isNotBlank() } ?: stringResource(titleRes),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+        )
         MetricValueRow(color = PowerMetric.VOLTAGE.color, text = MetricFormatter.voltage(voltage))
         MetricValueRow(color = PowerMetric.CURRENT.color, text = MetricFormatter.current(current))
     }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
@@ -163,7 +163,7 @@ fun PowerMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
                     PowerChannelLabelEditor(
                         modifier = Modifier.padding(horizontal = 16.dp),
                         currentLabel = channelLabels.getOrNull(selectedChannel.ordinal).orEmpty(),
-                        placeholder = stringResource(selectedChannel.strRes),
+                        channelName = stringResource(selectedChannel.strRes),
                         onSave = { label -> viewModel.setPowerChannelLabel(nodeNum, selectedChannel.ordinal, label) },
                     )
                 }
@@ -202,7 +202,7 @@ fun PowerMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
 @Composable
 private fun PowerChannelLabelEditor(
     currentLabel: String,
-    placeholder: String,
+    channelName: String,
     onSave: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -217,7 +217,8 @@ private fun PowerChannelLabelEditor(
         value = label,
         onValueChange = { label = it },
         modifier = modifier.fillMaxWidth(),
-        placeholder = { Text(placeholder) },
+        // Floating label (not a placeholder) so the channel stays identifiable after a custom name is typed.
+        label = { Text(channelName) },
         singleLine = true,
         trailingIcon = {
             IconButton(onClick = save, enabled = edited) {

--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/metrics/PressureAxisRangeTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/metrics/PressureAxisRangeTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.metrics
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PressureAxisRangeTest {
+
+    @Test
+    fun nearSeaLevelUsesStandardWindow() {
+        // Typical readings sit inside 950-1050, so the axis stays comparable across sessions/nodes.
+        assertEquals(950.0 to 1050.0, pressureAxisRange(dataMin = 1005.0, dataMax = 1020.0))
+    }
+
+    @Test
+    fun windowIsAlwaysTheSameWidthWhenNotOverflowing() {
+        listOf(1005.0 to 1020.0, 835.0 to 848.0, 1042.0 to 1061.0).forEach { (min, max) ->
+            val (lo, hi) = pressureAxisRange(min, max)
+            assertEquals(100.0, hi - lo, 1e-9, "fixed window width for $min..$max")
+        }
+    }
+
+    @Test
+    fun highAltitudeWindowSlidesDownToContainReadings() {
+        // Station pressure at altitude (~1500 m) reads well below 950; window slides down instead of clipping.
+        val (lo, hi) = pressureAxisRange(dataMin = 835.0, dataMax = 848.0)
+        assertEquals(835.0 to 935.0, lo to hi)
+        assertTrue(835.0 >= lo && 848.0 <= hi, "readings fit inside the window")
+    }
+
+    @Test
+    fun highPressureWindowSlidesUpToContainReadings() {
+        val (lo, hi) = pressureAxisRange(dataMin = 1042.0, dataMax = 1061.0)
+        assertEquals(961.0 to 1061.0, lo to hi)
+    }
+
+    @Test
+    fun spanWiderThanWindowFallsBackToExactRange() {
+        // A node that moved thousands of metres can span more than the fixed width; show it all rather than clip.
+        assertEquals(830.0 to 1015.0, pressureAxisRange(dataMin = 830.0, dataMax = 1015.0))
+    }
+
+    @Test
+    fun singleReadingStillGetsTheStandardWindow() {
+        assertEquals(950.0 to 1050.0, pressureAxisRange(dataMin = 1013.0, dataMax = 1013.0))
+    }
+}


### PR DESCRIPTION
## Why

Closes #6099. Per [meshtastic/design#53](https://github.com/meshtastic/design/issues/53), sensor/telemetry display should be aligned across clients. This closes the two remaining Android gaps (the AQI slice already shipped separately as #6092):

## 🛠️ Changes

- **Power channel identity/role**: Add a simple user-editable text label per power-metrics channel (e.g. "Solar", "Battery"), stored locally per node (new `power_channel_labels` Room column, DB v45→v46) and preserved across device-sync upserts the same way `notes` already is. Surfaced in the channel-selector chips and in the telemetry log cards. Coordinates loosely with the iOS counterpart ([Meshtastic-Apple#2046](https://github.com/meshtastic/Meshtastic-Apple/issues/2046)) on concept (a per-channel, user-settable label) without blocking on it.
- **Fixed pressure axis**: The barometric-pressure axis was already separated from temp/humidity/IAQ onto its own axis, which is correct — but it autoscaled from data min/max (700–1200 hPa). Changed to a fixed sea-level-relative domain (950–1050 hPa) so small real pressure changes are visually comparable across sessions/nodes.

## Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green.
- New Room schema (`46.json`) generated via KSP AutoMigration; no manual migration code needed (pure column addition).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable per-node power-channel labels, displayed on the power metrics screen.
  * Users can now edit a channel’s label directly from the metrics view.
* **Bug Fixes**
  * Prevented existing labels from being overwritten when updating without new label content.
  * Ensured label updates merge correctly across channels and persist across reloads.
* **Tests**
  * Added coverage for setting, merging, trimming, and update semantics for power-channel labels.
* **Refactor**
  * Improved barometric pressure chart scaling to keep trends readable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->