### PR TITLE
test: activate dead NodeInfoDao tests

### DIFF
--- a/core/database/src/androidHostTest/kotlin/org/meshtastic/core/database/dao/NodeInfoDaoTest.kt
+++ b/core/database/src/androidHostTest/kotlin/org/meshtastic/core/database/dao/NodeInfoDaoTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database.dao
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class NodeInfoDaoTest : CommonNodeInfoDaoTest()

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonNodeInfoDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonNodeInfoDaoTest.kt
@@ -23,6 +23,7 @@ import org.meshtastic.core.database.MeshtasticDatabase
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.entity.NodeEntity
 import org.meshtastic.core.database.getInMemoryDatabaseBuilder
+import org.meshtastic.core.testing.setupTestContext
 import org.meshtastic.proto.User
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -49,6 +50,7 @@ abstract class CommonNodeInfoDaoTest {
         )
 
     suspend fun createDb() {
+        setupTestContext()
         database = getInMemoryDatabaseBuilder().build()
         dao = database.nodeInfoDao()
         dao.setMyNodeInfo(myNodeInfo)
@@ -61,6 +63,7 @@ abstract class CommonNodeInfoDaoTest {
 
     @Test
     fun testGetMyNodeInfo() = runTest {
+        createDb()
         val info = dao.getMyNodeInfo().first()
         assertNotNull(info)
         assertEquals(myNodeInfo.myNodeNum, info.myNodeNum)
@@ -68,6 +71,7 @@ abstract class CommonNodeInfoDaoTest {
 
     @Test
     fun testUpsertNode() = runTest {
+        createDb()
         val node =
             NodeEntity(
                 num = 1234,
@@ -82,6 +86,7 @@ abstract class CommonNodeInfoDaoTest {
 
     @Test
     fun testNodeDBbyNum() = runTest {
+        createDb()
         val node1 = NodeEntity(num = 1, user = User(id = "!1"))
         val node2 = NodeEntity(num = 2, user = User(id = "!2"))
         dao.putAll(listOf(node1, node2))
@@ -94,6 +99,7 @@ abstract class CommonNodeInfoDaoTest {
 
     @Test
     fun testDeleteNode() = runTest {
+        createDb()
         val node = NodeEntity(num = 1, user = User(id = "!1"))
         dao.upsert(node)
         dao.deleteNode(1)
@@ -103,6 +109,7 @@ abstract class CommonNodeInfoDaoTest {
 
     @Test
     fun testClearNodeInfo() = runTest {
+        createDb()
         val node1 = NodeEntity(num = 1, user = User(id = "!1"), isFavorite = true)
         val node2 = NodeEntity(num = 2, user = User(id = "!2"), isFavorite = false)
         dao.putAll(listOf(node1, node2))


### PR DESCRIPTION
## Why

`CommonNodeInfoDaoTest` was an abstract test class that **never executed**, giving false coverage confidence for `NodeInfoDao`:

1. It had no concrete platform subclass (unlike `QuickChatActionDaoTest : CommonQuickChatActionDaoTest()`).
2. Its `@Test` methods used the `lateinit dao`/`database` fields without ever calling `createDb()`.

So `testGetMyNodeInfo`/`testUpsertNode`/`testNodeDBbyNum`/`testDeleteNode`/`testClearNodeInfo` compiled but never ran.

## 🛠️ What changed

Fix mirrors the existing QuickChat pattern:
- Added `setupTestContext()` to `createDb()`.
- Call `createDb()` at the top of each `@Test` method.
- Added a concrete `NodeInfoDaoTest : CommonNodeInfoDaoTest()` Robolectric subclass in `androidHostTest`.

## Testing Performed

`./gradlew :core:database:allTests --tests "*NodeInfoDaoTest*"` — all 5 tests now execute and pass (0 skipped, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database test setup so node info tests initialize the in-memory database correctly before running.
  * Fixed test ordering issues so node info checks run in the intended test, reducing flaky or misleading results.
  * Added Android test coverage for node info data access on newer Android/JVM test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->