### PR TITLE
docs(ai): instruct PR agents to include screenshots for UI changes

### DIFF
--- a/.github/copilot-pull-request-instructions.md
+++ b/.github/copilot-pull-request-instructions.md
@@ -14,5 +14,12 @@ You are an expert open-source maintainer. Your goal is to write clear, professio
    - 🧹 **Chores** (Dependencies, formatting, docs)
 4. **Architecture Callouts:** If the diff includes moving files from `androidMain` to `commonMain`, or migrating from Android Views to Compose, highlight this as a "KMP Migration Milestone".
 5. **Testing Callouts:** If the diff includes changes to `commonTest` or mentions tests, add a section called "Testing Performed" and list the tests that were added/modified.
-6. **No "Magic" Text:** Do not invent URLs or insert fake image placeholders. Leave the HTML comment block for images intact so the user can manually add their screenshots.
+6. **Screenshots for UI changes:** If the change affects the UI (Compose composables, layouts, theming, navigation, or anything under `feature/**` / `core/ui/**`), add a **Screenshots** section when real images are available — for example generated `:screenshot-tests` reference PNGs committed in the PR, or images captured from a device/emulator. Prefer a **Before / After** table for visual changes and fixes:
+
+   | Before | After |
+   |--------|-------|
+   | <img src="<url>" width="300"/> | <img src="<url>" width="300"/> |
+
+   Reference committed images with a stable **commit-SHA** raw URL (`https://raw.githubusercontent.com/<owner>/<repo>/<sha>/<path>`, URL-encoding spaces as `%20`) so the links survive branch deletion, or use a GitHub-uploaded attachment. Only embed images that actually exist.
+7. **No "Magic" Text:** Never invent URLs or insert fake/placeholder images. If no real screenshot is available for a UI change, leave the template's HTML image comment block intact so the author can add one — do not fabricate.
 </instructions>


### PR DESCRIPTION
## Why

The AI PR-description instructions (`.github/copilot-pull-request-instructions.md`) currently tell agents **not** to add images — rule #6 says *"Leave the HTML comment block for images intact so the user can manually add their screenshots."* But for UI-affecting changes we usually **do** have real images available (generated `:screenshot-tests` reference PNGs committed in the PR, or device/emulator captures), and a Before/After table makes visual fixes far easier to review.

## Changes

🧹 **Docs / tooling**
- Add a **"Screenshots for UI changes"** instruction: when a change touches the UI (Compose, layouts, theming, navigation, `feature/**` or `core/ui/**`) and real images exist, add a **Screenshots** section — prefer a **Before / After** table.
- Recommend referencing committed images with a stable **commit-SHA raw URL** (URL-encoding spaces) so links survive branch deletion, or a GitHub-uploaded attachment.
- Keep the anti-fabrication guardrail (now rule #7): only embed images that actually exist; never invent URLs or placeholders — if none exist, leave the template's image comment block for the author.

Docs-only; no code or behavior change. The human `PULL_REQUEST_TEMPLATE.md` already has a screenshots/Before-After comment block — this aligns the agent instructions with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for including screenshots when making UI changes.
  * Introduced a simple **Before / After** table format for visual comparisons.
  * Clarified how to link images reliably so screenshots remain viewable over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->