### PR TITLE
chore(deps): bump protobufs to 2.7.26.90-gf55e85a-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -96,7 +96,7 @@ mqttastic = "0.4.0"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
 takpacket-sdk = "0.7.0"
-meshtastic-protobufs = "2.7.26-aa53c96-SNAPSHOT"
+meshtastic-protobufs = "2.7.26.90-gf55e85a-SNAPSHOT"
 
 # Gradle Plugins
 develocity = "4.5.0"


### PR DESCRIPTION
## Why

Renovate can't do this bump right now: Mend tripped **Maven Central rate limiting** (`Release interceptor failed for "maven"` on the repo dashboard), so its maven datasource is serving stale cached metadata and keeps offering the older `2.7.26-678281c-SNAPSHOT`. This bumps by hand to the actual newest published snapshot.

Also validates the new snapshot-versioning scheme end to end: this is the first snapshot published under the dot-count format from protobufs #977/#978 (`{tag}.{N}-g{sha}`), which sorts by recency so future Renovate picks land correctly once the rate limit clears.

## What

`org.meshtastic:protobufs`: `2.7.26-aa53c96-SNAPSHOT` → `2.7.26.90-gf55e85a-SNAPSHOT` (single line in `gradle/libs.versions.toml`).

## Risk

Proto delta between the two snapshots is **additive/cosmetic only** — no compile impact:
- `mesh.proto`: +15 lines — new Heltec RC board `HardwareModel` enum entries.
- `portnums.proto`: 1-line formatting change.

No app code consumes anything new; this just advances the pin. CI validates the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled protobuf library version reference to a newer snapshot build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->