### PR TITLE
ci(docs): overlap Dokka and Jekyll builds to cut deploy wall-time

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -45,9 +45,6 @@ jobs:
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Build Dokka HTML documentation
-        run: ./gradlew dokkaGeneratePublicationHtml --no-configuration-cache
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -58,18 +55,23 @@ jobs:
       - name: Generate Docs Site
         run: ./gradlew generateDocsBundle validateDocsBundle publishDocsSite -Pdocs.channel=root -Pci=true
 
-      - name: Compile Jekyll Docs Site
+      # Dokka (Gradle) and Jekyll (Ruby) are independent — Dokka's output is only
+      # copied in afterwards — so run them concurrently to overlap the two slowest
+      # steps (~10 min Dokka vs ~5 min Jekyll) instead of summing them (~16 -> ~11 min).
+      - name: Build Dokka + Jekyll concurrently
         run: |
+          set -euo pipefail
           BUNDLE_GEMFILE=docs/Gemfile bundle exec jekyll build \
             --source build/_site \
             --destination build/jekyll_site \
-            --baseurl /${{ github.event.repository.name }}
+            --baseurl /${{ github.event.repository.name }} &
+          jekyll_pid=$!
+          ./gradlew dokkaGeneratePublicationHtml --no-configuration-cache
+          wait "$jekyll_pid"
           touch build/jekyll_site/.nojekyll
 
       - name: Assemble Pages artifact
-        run: |
-          # Copy Dokka output into compiled jekyll_site/api/
-          cp -r build/dokka/html build/jekyll_site/api
+        run: cp -r build/dokka/html build/jekyll_site/api  # Dokka HTML -> /api
 
       - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## Why

The `Deploy Documentation` workflow runs on nearly every push to `main` (scheduled updates, most merged PRs touch `*/src/**`). Its `build` job spent **~16 min** almost entirely in two steps run back-to-back:

| Step | Time |
|------|------|
| Build Dokka HTML | ~9–12 min (Gradle) |
| Compile Jekyll | ~5–6 min (Ruby) |
| everything else combined | <90s |

These two steps are **independent**: Jekyll builds from `build/_site` (produced by `generateDocsBundle`/`publishDocsSite`), and Dokka's output is only *copied into* `jekyll_site/api` afterwards. Nothing required them to be sequential.

## 🛠️ What changed

Run Jekyll in the background while Dokka runs in the foreground, then `wait` on the Jekyll PID before assembling the Pages artifact. Wall-time drops from ~16 min to the longer of the two steps (**~11 min**, Dokka-bound).

- `set -euo pipefail` + `wait "$jekyll_pid"` propagates Jekyll's exit code, so a Jekyll failure still fails the job. If Dokka fails first the script aborts and the orphaned Jekyll process is harmless (the runner is torn down).
- Kept in a **single job** deliberately: splitting into two parallel jobs would mean passing Dokka's thousands-of-files HTML tree between jobs as an artifact, and that upload/download overhead would likely eat the savings. The in-job overlap gets the same win with zero shuffling.

## Notes for reviewers

- Ruby setup was moved above the concurrent step (it must be ready before Jekyll launches). No behavioral change.
- The two processes' logs will interleave in the combined step — acceptable for a docs deploy. Happy to capture Jekyll output to a file and print it on failure if preferred.
- Dokka (~10 min) is now the floor; overlapping can't beat the longest step. Speeding up Dokka itself is out of scope here.
- Not touched but noticed: `docs/_config.yml` sets both a local `theme` gem and a `remote_theme` + `jekyll-remote-theme` plugin. Since this pipeline uploads a pre-built artifact (never uses GitHub's hosted Jekyll build), the remote-theme fetch may be dead weight inside the Jekyll step — left alone pending confirmation.

## Testing

CI-only change; verified by the next `Deploy Documentation` run. Output artifact is unchanged (same Dokka HTML + Jekyll site, same `/api` layout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing workflow to build site pages and API docs together, which should make doc releases more efficient.
  * Kept the published site structure intact, including API documentation placement and GitHub Pages deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->