### PR TITLE
drop internal builds - not currently in use anyway

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ on:
         required: false
       GRADLE_CACHE_PASSWORD:
         required: false
+      INTERNAL_BUILDS_HOST:
+        required: false
+      INTERNAL_BUILDS_HOST_PAT:
+        required: false
       APPLE_SIGNING_IDENTITY:
         required: false
       APPLE_ID:
@@ -441,6 +445,8 @@ jobs:
       - release-fdroid
       - release-desktop
       - release-flatpak-src
+    env:
+      INTERNAL_BUILDS_HOST: ${{ secrets.INTERNAL_BUILDS_HOST }}
     permissions:
       contents: write
       id-token: write
@@ -468,4 +474,18 @@ jobs:
           generate_release_notes: true
           files: ./artifacts/**/*
           draft: true
+          prerelease: true
+
+      - name: Create or Update internal GitHub Release
+        continue-on-error: true
+        if: ${{ env.INTERNAL_BUILDS_HOST != '' }}
+        uses: softprops/action-gh-release@v3
+        with:
+          repository: ${{ secrets.INTERNAL_BUILDS_HOST }}
+          token: ${{ secrets.INTERNAL_BUILDS_HOST_PAT }}
+          tag_name: ${{ inputs.tag_name }}
+          name: ${{ inputs.tag_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})
+          generate_release_notes: false
+          files: ./artifacts/**/*
+          draft: false
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,6 @@ on:
         required: false
       GRADLE_CACHE_PASSWORD:
         required: false
-      INTERNAL_BUILDS_HOST:
-        required: false
-      INTERNAL_BUILDS_HOST_PAT:
-        required: false
       APPLE_SIGNING_IDENTITY:
         required: false
       APPLE_ID:
@@ -445,8 +441,6 @@ jobs:
       - release-fdroid
       - release-desktop
       - release-flatpak-src
-    env:
-      INTERNAL_BUILDS_HOST: ${{ secrets.INTERNAL_BUILDS_HOST }}
     permissions:
       contents: write
       id-token: write
@@ -474,18 +468,4 @@ jobs:
           generate_release_notes: true
           files: ./artifacts/**/*
           draft: true
-          prerelease: true
-
-      - name: Create or Update internal GitHub Release
-        continue-on-error: true
-        if: ${{ env.INTERNAL_BUILDS_HOST != '' }}
-        uses: softprops/action-gh-release@v3
-        with:
-          repository: ${{ secrets.INTERNAL_BUILDS_HOST }}
-          token: ${{ secrets.INTERNAL_BUILDS_HOST_PAT }}
-          tag_name: ${{ inputs.tag_name }}
-          name: ${{ inputs.tag_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})
-          generate_release_notes: false
-          files: ./artifacts/**/*
-          draft: false
           prerelease: true


### PR DESCRIPTION
Delete the push to the internal builds repo - it wasn't in use, and was a bit of maintainance overhead. 
I can add it again if we need to run invisible builds again for a major overhaul. 

Secrets have already been deleted. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified the release workflow by removing the option to publish a separate internal release and the related secret wiring.
  * Updated the bundled protocol definitions dependency to a newer revision (via an updated recorded submodule commit).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->