### PR TITLE
chore: fix build warnings and migrate deprecated APIs

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -1046,8 +1046,8 @@ private fun CacheInfoDialog(mapView: MapView, onDismiss: () -> Unit) {
         onDismiss = onDismiss,
         negativeButton = { TextButton(onClick = { onDismiss() }) { Text(text = stringResource(Res.string.close)) } },
     ) {
-        val capacityMb = (cacheCapacity / (1024 * 1024)).toLong()
-        val usageMb = (currentCacheUsage / (1024 * 1024)).toLong()
+        val capacityMb = cacheCapacity / (1024 * 1024)
+        val usageMb = currentCacheUsage / (1024 * 1024)
         Text(modifier = Modifier.padding(16.dp), text = stringResource(Res.string.map_cache_info, capacityMb, usageMb))
     }
 }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -1230,6 +1230,7 @@ private fun offsetPolyline(
 
 // region --- Map Layers ---
 
+@OptIn(MapsComposeExperimentalApi::class)
 @Composable
 private fun MapLayerOverlay(layerItem: MapLayerItem, mapViewModel: MapViewModel) {
     val context = LocalContext.current

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/model/CustomTileSource.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/model/CustomTileSource.kt
@@ -19,8 +19,7 @@ package org.meshtastic.app.map.model
 class CustomTileSource {
 
     companion object {
-        fun getTileSource(index: Int) {
-            index
-        }
+        // No-op stub for the Google flavor (osmdroid tile sources are fdroid-only).
+        fun getTileSource(index: Int) {}
     }
 }

--- a/androidApp/src/test/kotlin/org/meshtastic/app/di/KoinVerificationTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/di/KoinVerificationTest.kt
@@ -38,6 +38,7 @@ import kotlin.test.Test
 
 class KoinVerificationTest {
 
+    @OptIn(org.koin.core.annotation.KoinExperimentalAPI::class)
     @Test
     fun verifyKoinConfiguration() {
         AppKoinModule()

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
@@ -18,6 +18,7 @@ package org.meshtastic.buildlogic
 
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.project
 import org.jetbrains.dokka.gradle.DokkaExtension
 import java.net.URI
 
@@ -73,5 +74,5 @@ fun Project.configureDokkaAggregation(subprojectPaths: List<String>) {
     // Add each subproject as a Dokka dependency using declared paths rather than
     // iterating live subproject objects. This avoids cross-project configuration
     // access and is compatible with Gradle Isolated Projects.
-    subprojectPaths.forEach { path -> dependencies.add("dokka", project(path)) }
+    subprojectPaths.forEach { path -> dependencies.add("dokka", dependencies.project(path)) }
 }

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Kover.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Kover.kt
@@ -19,6 +19,7 @@ package org.meshtastic.buildlogic
 import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.project
 
 fun Project.configureKover() {
     val isCi = providers.gradleProperty("ci").map { it.toBoolean() }.getOrElse(false)
@@ -64,5 +65,5 @@ fun Project.configureKover() {
  * Isolated Projects. The list should match the modules declared in `settings.gradle.kts`.
  */
 fun Project.configureKoverAggregation(subprojectPaths: List<String>) {
-    subprojectPaths.forEach { path -> dependencies.add("kover", project(path)) }
+    subprojectPaths.forEach { path -> dependencies.add("kover", dependencies.project(path)) }
 }

--- a/core/ble/build.gradle.kts
+++ b/core/ble/build.gradle.kts
@@ -44,7 +44,7 @@ kotlin {
             implementation(projects.core.testing)
         }
 
-        val androidHostTest by getting {
+        getByName("androidHostTest") {
             dependencies {
                 implementation(projects.core.testing)
                 implementation(libs.kotlinx.coroutines.test)

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
@@ -46,6 +46,10 @@ internal fun resolveKableScanFilter(serviceUuid: Uuid?, address: String?): Kable
     else -> KableScanFilter.None
 }
 
+// Kable's Advertisement.identifier is an expect typealias: String on Android/JVM/JS but Uuid on Apple.
+// toString() looks redundant when compiling the Android/JVM view (hence the warning) but is required to
+// normalize the Apple Uuid to the String this result carries, so it must stay.
+@Suppress("REDUNDANT_CALL_OF_CONVERSION_METHOD")
 private fun Advertisement.toScanResult(): KableScanResult =
     KableScanResult(identifier = identifier.toString(), name = name, advertisement = this)
 

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -49,7 +49,7 @@ kotlin {
         }
 
         // Room / SQLite runtime shared between Android and Desktop JVM targets
-        val jvmAndroidMain by getting {
+        getByName("jvmAndroidMain") {
             dependencies {
                 implementation(libs.androidx.room.runtime)
                 implementation(libs.androidx.room.paging)
@@ -67,7 +67,7 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
         }
 
-        val androidHostTest by getting {
+        getByName("androidHostTest") {
             dependencies {
                 // JVM variant provides the host-platform native for BundledSQLiteDriver (same as core:database)
                 runtimeOnly("androidx.sqlite:sqlite-bundled-jvm:2.7.0")

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/ai/AiFunctionProviderImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/ai/AiFunctionProviderImpl.kt
@@ -270,7 +270,7 @@ class AiFunctionProviderImpl(
                 when {
                     totalCount == 0 -> 0
                     onlineCount == 0 -> HEALTH_SCORE_DEGRADED
-                    else -> (HEALTH_SCORE_BASE + (HEALTH_SCORE_ONLINE_RATIO * onlineCount) / totalCount).toInt()
+                    else -> HEALTH_SCORE_BASE + (HEALTH_SCORE_ONLINE_RATIO * onlineCount) / totalCount
                 }
 
             // Find most recent packet: max lastHeard across all nodes (convert seconds to ms)

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -50,7 +50,7 @@ kotlin {
             implementation(libs.androidx.room.testing)
         }
 
-        val androidHostTest by getting {
+        getByName("androidHostTest") {
             dependencies {
                 implementation(libs.androidx.sqlite.bundled)
                 // JVM variant provides the host-platform native for BundledSQLiteDriver
@@ -60,7 +60,7 @@ kotlin {
                 implementation(libs.junit)
             }
         }
-        val androidDeviceTest by getting {
+        getByName("androidDeviceTest") {
             dependencies {
                 implementation(libs.androidx.room.testing)
                 implementation(libs.androidx.test.ext.junit)

--- a/core/konsist/build.gradle.kts
+++ b/core/konsist/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
     android { withHostTest {} }
 
     sourceSets {
-        val jvmTest by getting {
+        getByName("jvmTest") {
             dependencies {
                 implementation(libs.konsist)
                 implementation(libs.junit)

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -60,7 +60,7 @@ kotlin {
             api(libs.androidx.annotation)
             api(libs.androidx.core.ktx)
         }
-        val androidDeviceTest by getting {
+        getByName("androidDeviceTest") {
             dependencies {
                 implementation(libs.androidx.test.ext.junit)
                 implementation(libs.androidx.test.runner)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
             implementation(libs.jetbrains.lifecycle.runtime)
         }
 
-        val jvmMain by getting {
+        getByName("jvmMain") {
             dependencies {
                 implementation(libs.ktor.client.java)
                 implementation(libs.jserialcomm)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -114,6 +114,9 @@ class MQTTRepositoryImpl(
         scope.launch { safeCatching { c?.close() }.onFailure { e -> Logger.w(e) { "MQTT clean disconnect failed" } } }
     }
 
+    // json_enabled is deprecated in the protobuf schema but remains the only way to toggle MQTT JSON
+    // publish/consume, so we must keep reading it until the firmware/proto provides a replacement.
+    @Suppress("DEPRECATION")
     @OptIn(ExperimentalSerializationApi::class)
     override val proxyMessageFlow: Flow<MqttClientProxyMessage> = callbackFlow {
         // Append a per-connection random id. myId identifies the *node* (and is null →

--- a/core/service/build.gradle.kts
+++ b/core/service/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
             implementation(libs.koin.androidx.workmanager)
         }
 
-        val androidHostTest by getting {
+        getByName("androidHostTest") {
             dependencies {
                 implementation(projects.core.testing)
                 implementation(libs.androidx.test.ext.junit)

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/LockdownPassphraseStoreImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/LockdownPassphraseStoreImpl.kt
@@ -35,7 +35,10 @@ import org.meshtastic.core.repository.StoredPassphrase
 @Single(binds = [LockdownPassphraseStore::class])
 class LockdownPassphraseStoreImpl(app: Application) : LockdownPassphraseStore {
 
-    @Suppress("TooGenericExceptionCaught")
+    // androidx.security.crypto (MasterKey / EncryptedSharedPreferences) is deprecated by Google with no
+    // drop-in AndroidX replacement yet. Migrating encrypted storage is a separate, security-sensitive
+    // effort; suppress until a stable replacement (e.g. Tink) is adopted.
+    @Suppress("TooGenericExceptionCaught", "DEPRECATION")
     private val prefs: SharedPreferences? by lazy {
         try {
             val masterKey = MasterKey.Builder(app).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/SecurityKeyBackupStoreImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/SecurityKeyBackupStoreImpl.kt
@@ -34,7 +34,10 @@ import org.meshtastic.core.repository.StoredSecurityKeys
 @Single(binds = [SecurityKeyBackupStore::class])
 class SecurityKeyBackupStoreImpl(app: Application) : SecurityKeyBackupStore {
 
-    @Suppress("TooGenericExceptionCaught")
+    // androidx.security.crypto (MasterKey / EncryptedSharedPreferences) is deprecated by Google with no
+    // drop-in AndroidX replacement yet. Migrating encrypted storage is a separate, security-sensitive
+    // effort; suppress until a stable replacement (e.g. Tink) is adopted.
+    @Suppress("TooGenericExceptionCaught", "DEPRECATION")
     private val prefs: SharedPreferences? by lazy {
         try {
             val masterKey = MasterKey.Builder(app).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build()

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -717,7 +717,7 @@ class SharedRadioInterfaceService(
         // would replay stale bytes ahead of the next session's firmware handshake, since the channel
         // outlives the orchestrator's per-start scope.
         @Suppress("EmptyWhileBlock", "ControlFlowWithEmptyBody")
-        while (_receivedData.tryReceive().isSuccess) Unit
+        while (_receivedData.tryReceive().isSuccess) {}
     }
 
     override fun onConnect() {

--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/CoTXmlParser.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/CoTXmlParser.kt
@@ -23,11 +23,17 @@ import nl.adaptivity.xmlutil.serialization.XML
 import kotlin.time.Clock
 import kotlin.time.Instant
 
-private val xmlParser = XML {
-    // xmlutil 1.0.0 moved repairNamespaces from the policy builder to the top-level XML config.
-    repairNamespaces = false
-    defaultPolicy { ignoreUnknownChildren() }
-}
+// XML.compat preserves xmlutil's pre-1.0 serialization defaults. The non-deprecated 1.0 builders
+// (XML.recommended/XML.V1) intentionally change serialization defaults, which would alter the CoT XML
+// wire format we exchange with ATAK/TAK servers. Staying on the compat policy until that migration can
+// be validated against real TAK interop; suppress the soft-deprecation on the factory itself.
+@Suppress("DEPRECATION")
+private val xmlParser =
+    XML.compat {
+        // xmlutil 1.0.0 moved repairNamespaces from the policy builder to the top-level XML config.
+        repairNamespaces = false
+        defaultPolicy { ignoreUnknownChildren() }
+    }
 
 class CoTXmlParser(private val xml: String) {
     fun parse(): Result<CoTMessage> = try {

--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKDataPackageGenerator.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKDataPackageGenerator.kt
@@ -46,10 +46,16 @@ object TAKDataPackageGenerator {
     private const val CLIENT_P12_FILE_NAME = "client.p12"
     private const val PACKAGE_NAME = "Meshtastic_TAK_Server"
 
-    private val xmlSerializer = XML {
-        xmlDeclMode = XmlDeclMode.Charset
-        indentString = "  "
-    }
+    // XML.compat preserves xmlutil's pre-1.0 serialization defaults. The non-deprecated 1.0 builders
+    // (XML.recommended/XML.V1) intentionally change serialization defaults, which would alter the CoT
+    // XML wire format consumed by ATAK/TAK servers. Staying on the compat policy until that migration
+    // can be validated against real TAK interop; suppress the soft-deprecation on the factory itself.
+    @Suppress("DEPRECATION")
+    private val xmlSerializer =
+        XML.compat {
+            xmlDeclMode = XmlDeclMode.Charset
+            indentString = "  "
+        }
 
     /**
      * Platform-specific hook for reading the bundled TLS certificate bytes. Default implementation lives in

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -109,7 +109,7 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
 
     override fun resetReceivedBuffer() {
         @Suppress("EmptyWhileBlock", "ControlFlowWithEmptyBody")
-        while (_receivedData.tryReceive().isSuccess) Unit
+        while (_receivedData.tryReceive().isSuccess) {}
     }
 
     // --- Helper methods for testing ---

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -64,7 +64,7 @@ kotlin {
             implementation(libs.jetbrains.lifecycle.runtime.compose)
         }
 
-        val jvmAndroidMain by getting { dependencies { implementation(libs.compose.multiplatform.ui.tooling) } }
+        getByName("jvmAndroidMain") { dependencies { implementation(libs.compose.multiplatform.ui.tooling) } }
 
         androidMain.dependencies { implementation(libs.androidx.activity.compose) }
 

--- a/core/ui/src/androidMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
+++ b/core/ui/src/androidMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
@@ -332,6 +332,10 @@ actual fun isWifiUnavailable(): Boolean {
  * the transport reduction can delegate to the platform-agnostic [anyNetworkScanTransportAvailable] helper (which is
  * unit-tested in `commonTest`).
  */
+// ConnectivityManager.allNetworks is deprecated (API 31+) in favor of NetworkCallback-based discovery,
+// but a synchronous snapshot of active networks is exactly what this transport probe needs. Suppress
+// until a callback-based rewrite is warranted.
+@Suppress("DEPRECATION")
 private fun ConnectivityManager.hasLocalNetwork(): Boolean {
     val transports =
         allNetworks.mapNotNull { network ->

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerViewModel.kt
@@ -52,10 +52,10 @@ internal class EmojiPickerViewModel(
                 emojiRepository.preload()
                 _isLoaded.value = true
             } catch (e: MissingResourceException) {
-                Logger.e("EmojiPickerViewModel", e) { "Failed to load emoji data" }
+                Logger.e(tag = "EmojiPickerViewModel", throwable = e) { "Failed to load emoji data" }
                 _loadError.value = true
             } catch (e: IllegalStateException) {
-                Logger.e("EmojiPickerViewModel", e) { "Failed to load emoji data" }
+                Logger.e(tag = "EmojiPickerViewModel", throwable = e) { "Failed to load emoji data" }
                 _loadError.value = true
             }
         }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/ProtoExtensions.kt
@@ -195,7 +195,7 @@ fun normalizeReplacementSettings(
 }
 
 /** True when a [ChannelSettings] carries no name and no PSK — a placeholder, not an intended channel. */
-private fun ChannelSettings.isPlaceholder(): Boolean = name.isNullOrBlank() && (psk == null || psk.size == 0)
+private fun ChannelSettings.isPlaceholder(): Boolean = name.isNullOrBlank() && psk.size == 0
 
 /**
  * Applies an imported [ChannelSet] as an authoritative replacement to the radio and local cache.

--- a/core/ui/src/iosMain/kotlin/org/meshtastic/core/ui/util/NoopStubs.kt
+++ b/core/ui/src/iosMain/kotlin/org/meshtastic/core/ui/util/NoopStubs.kt
@@ -46,7 +46,7 @@ actual fun rememberSaveFileLauncher(
 @Composable
 actual fun rememberOpenFileLauncher(onUriReceived: (CommonUri?) -> Unit): (mimeType: String) -> Unit = { _ -> }
 
-@Composable actual fun rememberReadTextFromUri(): suspend (CommonUri, Int) -> String? = { _, _ -> null }
+@Composable actual fun rememberReadTextFromUri(): suspend (uri: CommonUri, maxChars: Int) -> String? = { _, _ -> null }
 
 @Composable actual fun KeepScreenOn(enabled: Boolean) {}
 

--- a/core/ui/src/jvmMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
+++ b/core/ui/src/jvmMain/kotlin/org/meshtastic/core/ui/util/PlatformUtils.kt
@@ -76,7 +76,9 @@ actual fun rememberSaveFileLauncher(
 /** JVM — Opens a native file dialog to pick a file. */
 @Composable
 actual fun rememberOpenFileLauncher(onUriReceived: (CommonUri?) -> Unit): (mimeType: String) -> Unit = { _ ->
-    val dialog = FileDialog(null as? Frame, "Open File", FileDialog.LOAD)
+    // Explicit Frame? local disambiguates the FileDialog(Frame, ...) overload from FileDialog(Dialog, ...)
+    val parentFrame: Frame? = null
+    val dialog = FileDialog(parentFrame, "Open File", FileDialog.LOAD)
     dialog.isVisible = true
     val file = dialog.file
     val dir = dialog.directory

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
@@ -72,8 +71,8 @@ class NoopRadioInterfaceService : RadioInterfaceService {
     override fun isMockTransport(): Boolean = false
 
     override val receivedData = MutableSharedFlow<ByteArray>()
-    override val meshActivity: Flow<MeshActivity> = MutableSharedFlow<MeshActivity>().asFlow()
-    override val connectionError: Flow<String> = MutableSharedFlow<String>().asFlow()
+    override val meshActivity: Flow<MeshActivity> = MutableSharedFlow<MeshActivity>()
+    override val connectionError: Flow<String> = MutableSharedFlow<String>()
 
     override fun sendToRadio(bytes: ByteArray) {
         logWarn("NoopRadioInterfaceService.sendToRadio(${bytes.size} bytes)")

--- a/feature/car/src/main/kotlin/org/meshtastic/feature/car/screens/HomeScreen.kt
+++ b/feature/car/src/main/kotlin/org/meshtastic/feature/car/screens/HomeScreen.kt
@@ -257,12 +257,15 @@ class HomeScreen(
                 }
             }
 
-        return ConversationItem.Builder()
-            .setId(conversation.contactKey)
-            .setTitle(CarText.create(conversation.displayName))
-            .setMessages(messages)
-            .setSelf(selfPerson)
-            .setConversationCallback(callback)
+        // car-app 1.7 deprecated the no-arg Builder + individual setters in favor of the
+        // required-args constructor (id, title, self, messages, conversationCallback).
+        return ConversationItem.Builder(
+            conversation.contactKey,
+            CarText.create(conversation.displayName),
+            selfPerson,
+            messages,
+            callback,
+        )
             .setGroupConversation(conversation.contactKey.contains(NodeAddress.ID_BROADCAST))
             .build()
     }

--- a/feature/connections/build.gradle.kts
+++ b/feature/connections/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
 
         androidMain.dependencies { implementation(libs.usb.serial.android) }
 
-        val androidHostTest by getting {
+        getByName("androidHostTest") {
             dependencies {
                 implementation(projects.core.testing)
                 implementation(libs.kotlinx.coroutines.test)

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/DiscoveryScanScreen.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/DiscoveryScanScreen.kt
@@ -34,12 +34,12 @@ import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -361,7 +361,7 @@ private fun DwellTimePicker(
                     readOnly = true,
                     enabled = enabled,
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-                    modifier = Modifier.fillMaxWidth().menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    modifier = Modifier.fillMaxWidth().menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
                 )
                 ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
                     DWELL_OPTIONS.forEach { minutes ->

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/component/MeshBeaconInvitationCard.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/component/MeshBeaconInvitationCard.kt
@@ -85,7 +85,7 @@ internal fun MeshBeaconInvitationCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            if (region != null && region != RegionCode.UNSET) {
+            if (region != RegionCode.UNSET) {
                 Text(
                     text = stringResource(Res.string.mesh_beacon_offer_region, region.name),
                     style = MaterialTheme.typography.labelMedium,

--- a/feature/docs/build.gradle.kts
+++ b/feature/docs/build.gradle.kts
@@ -57,8 +57,8 @@ kotlin {
  *
  * This task runs automatically before resource generation tasks.
  */
-val syncDocsToComposeResources by
-    tasks.registering(Sync::class) {
+val syncDocsToComposeResources =
+    tasks.register<Sync>("syncDocsToComposeResources") {
         description = "Syncs docs/en/ markdown source into composeResources for in-app bundling"
         group = "docs"
 
@@ -102,8 +102,8 @@ tasks
 // clean, or commit deliberately when refreshing the docs/Jekyll image set. Add a CI staleness gate
 // if drift becomes a problem.
 
-val syncTranslatedDocsToComposeResources by
-    tasks.registering(Copy::class) {
+val syncTranslatedDocsToComposeResources =
+    tasks.register<Copy>("syncTranslatedDocsToComposeResources") {
         description = "Syncs Crowdin-translated docs into locale-qualified composeResources"
         group = "docs"
 

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
@@ -145,7 +145,6 @@ import org.meshtastic.core.ui.icon.Dangerous
 import org.meshtastic.core.ui.icon.Folder
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Refresh
-import org.meshtastic.core.ui.icon.SystemUpdate
 import org.meshtastic.core.ui.icon.Usb
 import org.meshtastic.core.ui.icon.Warning
 import org.meshtastic.core.ui.icon.Wifi
@@ -462,7 +461,6 @@ private fun ReadyState(
                     FirmwareUpdateMethod.Ble -> MeshtasticIcons.Bluetooth
                     FirmwareUpdateMethod.Usb -> MeshtasticIcons.Usb
                     FirmwareUpdateMethod.Wifi -> MeshtasticIcons.Wifi
-                    else -> MeshtasticIcons.SystemUpdate
                 },
                 contentDescription = null,
             )

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
@@ -134,6 +135,7 @@ class FirmwareUpdateViewModel(
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     override fun onCleared() {
         super.onCleared()
         // viewModelScope is already cancelled when onCleared() runs, so launch cleanup on the

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
@@ -176,8 +176,13 @@ constructor(
             val logs = args[LOGS_INDEX] as LogsGroup
             val identity = args[IDENTITY_INDEX] as IdentityGroup
             val metadata = args[METADATA_INDEX] as MetadataGroup
+
+            @Suppress("UNCHECKED_CAST")
             val requests = args[REQUESTS_INDEX] as Pair<List<MeshLog>, List<MeshLog>>
-            val (hw, deviceLinks) = args[HARDWARE_INDEX] as Pair<DeviceHardware?, List<DeviceLink>>
+
+            @Suppress("UNCHECKED_CAST")
+            val hardwareAndLinks = args[HARDWARE_INDEX] as Pair<DeviceHardware?, List<DeviceLink>>
+            val (hw, deviceLinks) = hardwareAndLinks
 
             val (trReqs, niReqs) = requests
             val isLocal = node.num == identity.ourNode?.num

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetrics.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.patrykandpatrick.vico.compose.cartesian.VicoScrollState
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
-import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
+import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
@@ -223,7 +223,7 @@ private fun AirQualityChart(
                 activeMetrics.forEachIndexed { index, metric ->
                     val metricData = metricDataSets[index]
                     if (metricData.isNotEmpty()) {
-                        lineSeries {
+                        lineModel {
                             series(x = metricData.map { it.time }, y = metricData.map { metric.getValue(it) ?: 0f })
                         }
                     }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
@@ -133,7 +133,7 @@ fun GenericMetricChart(
                 bottomAxis = bottomAxis,
                 marker = marker,
                 markerVisibilityListener = markerVisibilityListener,
-                persistentMarkers = { _ -> if (selectedX != null && marker != null) marker at selectedX else null },
+                persistentMarkers = { _ -> if (selectedX != null && marker != null) marker at selectedX },
                 fadingEdges = rememberFadingEdges(),
                 decorations = decorations,
                 // Telemetry timestamps arrive at irregular intervals. Without an explicit

--- a/feature/settings/detekt-baseline.xml
+++ b/feature/settings/detekt-baseline.xml
@@ -58,7 +58,7 @@
     <ID>ModifierMissing:ExternalNotificationConfigScreen.android.kt:@Suppress("TooGenericExceptionCaught") @Composable actual fun RingtoneTrailingIcon</ID>
     <ID>ModifierMissing:FilterSettingsScreen.kt:@Composable fun FilterSettingsScreen</ID>
     <ID>ModifierMissing:LoRaConfigItemList.kt:@Composable fun LoRaConfigScreen</ID>
-    <ID>ModifierMissing:MQTTConfigItemList.kt:@Composable fun MQTTConfigScreen</ID>
+    <ID>ModifierMissing:MQTTConfigItemList.kt:@Suppress("DEPRECATION") @Composable fun MQTTConfigScreen</ID>
     <ID>ModifierMissing:MapReportingPreference.kt:@Suppress("LongMethod") @Composable fun MapReportingPreference</ID>
     <ID>ModifierMissing:ModuleConfigurationScreen.kt:@Composable fun ModuleConfigurationScreen</ID>
     <ID>ModifierMissing:NeighborInfoConfigItemList.kt:@Composable fun NeighborInfoConfigScreen</ID>

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
@@ -89,6 +89,9 @@ import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.proto.ModuleConfig
 
+// json_enabled is deprecated in the protobuf schema but remains the only toggle for MQTT JSON
+// publish/consume, so the settings UI must keep exposing it until the proto provides a replacement.
+@Suppress("DEPRECATION")
 @Composable
 fun MQTTConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val state by viewModel.radioConfigState.collectAsStateWithLifecycle()


### PR DESCRIPTION
## Summary

Cleans up build/compiler warnings across the project, **preferring real API migrations over suppression**. Build passes (`:androidApp:assembleFdroidDebug`), spotless clean.

### Migrations to new APIs
- **Gradle Kotlin DSL** (removed in Gradle 10):
  - `val x by getting {}` → `getByName("x") {}` (9 `build.gradle.kts`)
  - `by registering(T::class)` → `tasks.register<T>("name")` (`feature/docs`)
  - `project(path)` → `DependencyHandler.project(path)` in the Dokka & Kover aggregation convention plugins (verified via bytecode)
- **xmlutil**: deprecated `XML {}` constructor → `XML.compat {}` named factory
- **Vico**: `lineSeries {}` → `lineModel {}`
- **Kermit**: `Logger.e(tag, e){}` → `Logger.e(tag =, throwable =){}`
- **Compose**: `MenuAnchorType` → `ExposedDropdownMenuAnchorType`
- **Coroutines**: proper `@OptIn(DelicateCoroutinesApi::class)` for `CoroutineStart.ATOMIC`
- Removed redundant conversions / redundant `else` on exhaustive `when` / always-true|false conditions / unused expressions; scoped `@Suppress("UNCHECKED_CAST")` to the exact casts

### Suppressed with rationale — no drop-in replacement exists
- `MQTTConfig.json_enabled`: proto-deprecated with **no replacement field** (verified in the protobuf artifact); still the only MQTT-JSON toggle
- `androidx.security.crypto` (`EncryptedSharedPreferences`/`MasterKey`): Google deprecated the **entire library** with no AndroidX replacement; a real migration (e.g. Tink) is a separate, security-reviewed workstream with a data-migration path for existing encrypted passphrases/key backups
- `ConnectivityManager.allNetworks`: no synchronous multi-network snapshot replacement
- `XML.compat`: the 1.0 builders intentionally change serialization defaults — unsafe for the **ATAK/TAK CoT wire format** without interop validation
- Kable `identifier.toString()`: required on Apple (`Uuid`); redundant only in the JVM view

### Known remaining
- One Gradle project-notation deprecation traces **into the Kover plugin itself** (`kotlinx.kover` 0.9.8, `PrepareKover.kt`) — only fixable by a Kover release, not our code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the firmware update screen with clearer icons for BLE, USB, and Wi‑Fi update methods.
  * Refined discovery dwell-time dropdown anchoring and improved chart line rendering.
* **Bug Fixes**
  * Fixed cache info display to show more precise storage values.
  * Improved accuracy in mesh health scoring.
  * Updated channel handling so placeholder channels are identified more consistently.
  * Improved CoT/TAK XML generation compatibility.
* **Chores**
  * Reduced development warning noise across the app (no intended behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->