### PR TITLE
chore(flatpak): drop unused openjdk17 SDK extension from desktop manifest

### DIFF
--- a/scripts/verify-flatpak/desktop-offline.yaml
+++ b/scripts/verify-flatpak/desktop-offline.yaml
@@ -11,7 +11,6 @@ runtime: org.freedesktop.Platform
 runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
   - org.freedesktop.Sdk.Extension.openjdk21
 command: meshtastic-wrapper.sh
 
@@ -76,7 +75,7 @@ modules:
       - sed -i 's|distributionUrl=.*|distributionUrl=gradle-all.zip|' gradle/wrapper/gradle-wrapper.properties
       - echo "org.gradle.java.installations.auto-detect=false" >> gradle.properties
       - echo "org.gradle.java.installations.auto-download=false" >> gradle.properties
-      - echo "org.gradle.java.installations.paths=/usr/lib/sdk/openjdk21/jvm/openjdk-21,/usr/lib/sdk/openjdk17/jvm/openjdk-17" >> gradle.properties
+      - echo "org.gradle.java.installations.paths=/usr/lib/sdk/openjdk21/jvm/openjdk-21" >> gradle.properties
       - >
         sed -i
         's/^\(\s*\)vendor\.set(JvmVendorSpec\.JETBRAINS)/\1\/\/ vendor.set(JvmVendorSpec.JETBRAINS)/'


### PR DESCRIPTION
## Why

The offline Flatpak verify manifest listed **both** `openjdk17` and `openjdk21` SDK extensions, but the desktop build never uses 17. Every toolchain/target in the repo is pinned to JDK 21:

- `desktopApp` toolchain `JavaLanguageVersion.of(21)` + `jvmTarget JVM_21`
- convention plugin `JDK_VERSION = 21` (`jvmToolchain(21)`, `source/targetCompatibility VERSION_21`)
- the manifest sets `JAVA_HOME=…/openjdk21` and bundles **JBR 21** for the runtime

Gradle never selects the 17 toolchain because nothing requests it — it was leftover from the generic Java-Flatpak template.

## 🧹 Cleanup

- Remove `org.freedesktop.Sdk.Extension.openjdk17` from `sdk-extensions`.
- Trim the dead `openjdk17` entry from `org.gradle.java.installations.paths`.

## Testing Performed

None — YAML-only change to the local verify manifest, no build/runtime impact. A `flatpak-builder` run to confirm needs Linux; not run here.

> Note: upstream `vidplace7/org.meshtastic.desktop` (the Flathub manifest) still carries the same two `openjdk17` lines and should get the same trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop offline build setup to use only the newer Java 21 runtime.
  * Streamlined the Java toolchain configuration for more consistent build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->