### PR TITLE
fix(discovery): ship a fresh LoRaConfig when switching to a beacon's preset

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
@@ -148,20 +148,18 @@ fun MeshBeacon.toJoinChannelSet(option: BeaconJoinOption, currentLora: LoRaConfi
         BeaconJoinOption.ADD -> ChannelSet(settings = listOf(offerChannel))
 
         BeaconJoinOption.SWITCH -> {
-            // Ship a fresh LoRaConfig rather than a copy of the current one: any stale RF pin on the connected radio
+            // Start from the shared device default ([Channel.default] — use_preset=true, hop_limit/tx_enabled set,
+            // every RF field blank) rather than a copy of the current config: any stale RF pin on the connected radio
             // — an explicit channel_num, override_frequency, or manual bandwidth/spread_factor/coding_rate — would
             // otherwise strand it on the old slot. use_preset + the default (zero) channel_num/override_frequency lets
             // firmware re-derive the frequency from the offered channel name (Apple FR-006). This is sent as a full
-            // LoRaConfig replacement, so carry region (a zero region disables transmit) and set the standard
-            // hop_limit/tx_enabled defaults; the beacon proto advertises no other RF fields.
+            // LoRaConfig replacement, so carry region (a zero region disables transmit); the beacon proto advertises
+            // no other RF fields.
             val base = currentLora ?: LoRaConfig()
             val loraConfig =
-                LoRaConfig(
-                    use_preset = true,
+                Channel.default.loraConfig.copy(
                     modem_preset = offer_preset ?: base.modem_preset,
                     region = if (offer_region != RegionCode.UNSET) offer_region else base.region,
-                    hop_limit = 3,
-                    tx_enabled = true,
                 )
             ChannelSet(settings = listOf(offerChannel), lora_config = loraConfig)
         }

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
@@ -128,16 +128,19 @@ fun MeshBeacon.beaconJoinOption(currentLora: LoRaConfig?, currentChannels: List<
  * Builds the [ChannelSet] to hand the QR channel-import dialog for a given [option].
  *
  * [ADD][BeaconJoinOption.ADD] omits `lora_config` so the dialog merges the offered channel into a free secondary slot
- * with no reboot. [SWITCH][BeaconJoinOption.SWITCH] carries a `lora_config` derived from [currentLora] with only the
- * advertised preset+region applied and `channel_num` reset to 0 (firmware derives the frequency from the offered
- * channel name — Apple FR-006). Every other radio setting (`hop_limit`, `tx_power`, `tx_enabled`, …) is preserved from
- * [currentLora], so joining never silently zeroes them — the beacon proto advertises no such fields. Returns `null` for
+ * with no reboot. [SWITCH][BeaconJoinOption.SWITCH] carries a **fresh** `lora_config` (not a copy of [currentLora])
+ * with `use_preset = true`, the advertised preset+region applied, and every RF field left at its default — notably
+ * `channel_num`/`override_frequency` zeroed so firmware re-derives the frequency from the offered channel name (Apple
+ * FR-006). Starting blank guarantees no stale slot/frequency pin (`channel_num`, `override_frequency`, manual
+ * bandwidth/spread_factor/coding_rate) from the old mesh survives the retune. Only `region` is carried from
+ * [currentLora] when the beacon doesn't advertise one — this config is sent as a full LoRaConfig replacement, and a
+ * zero region disables transmit; `hop_limit`/`tx_enabled` fall back to the app's standard defaults. Returns `null` for
  * [NONE][BeaconJoinOption.NONE] or a beacon with no offered channel.
  *
  * Both paths strip position sharing from the offered channel ([withoutPositionSharing]) so joining a stranger's mesh
  * never leaks our location — matching Apple's `joinBeaconMesh`/`addBeaconChannel`.
  *
- * @param currentLora The radio's current [LoRaConfig]; a switch alters only preset/region/channel_num.
+ * @param currentLora The radio's current [LoRaConfig]; a switch reuses only its region/preset as fallbacks.
  */
 fun MeshBeacon.toJoinChannelSet(option: BeaconJoinOption, currentLora: LoRaConfig?): ChannelSet? {
     val offerChannel = (offer_channel ?: return null).withoutPositionSharing()
@@ -145,18 +148,20 @@ fun MeshBeacon.toJoinChannelSet(option: BeaconJoinOption, currentLora: LoRaConfi
         BeaconJoinOption.ADD -> ChannelSet(settings = listOf(offerChannel))
 
         BeaconJoinOption.SWITCH -> {
-            // Always ship a LoRaConfig so channel_num resets to 0 and firmware re-derives the frequency from the
-            // offered
-            // channel name (Apple FR-006) — even when no preset is offered (else an explicit channel_num override would
-            // strand the radio on the old slot). Preserve every current field; override only the advertised
-            // preset/region.
+            // Ship a fresh LoRaConfig rather than a copy of the current one: any stale RF pin on the connected radio
+            // — an explicit channel_num, override_frequency, or manual bandwidth/spread_factor/coding_rate — would
+            // otherwise strand it on the old slot. use_preset + the default (zero) channel_num/override_frequency lets
+            // firmware re-derive the frequency from the offered channel name (Apple FR-006). This is sent as a full
+            // LoRaConfig replacement, so carry region (a zero region disables transmit) and set the standard
+            // hop_limit/tx_enabled defaults; the beacon proto advertises no other RF fields.
             val base = currentLora ?: LoRaConfig()
             val loraConfig =
-                base.copy(
+                LoRaConfig(
                     use_preset = true,
-                    channel_num = 0,
                     modem_preset = offer_preset ?: base.modem_preset,
                     region = if (offer_region != RegionCode.UNSET) offer_region else base.region,
+                    hop_limit = 3,
+                    tx_enabled = true,
                 )
             ChannelSet(settings = listOf(offerChannel), lora_config = loraConfig)
         }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/MeshBeaconOfferTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/MeshBeaconOfferTest.kt
@@ -112,16 +112,18 @@ class MeshBeaconOfferTest {
     }
 
     @Test
-    fun `SWITCH preserves current lora fields and only overrides preset region and channel_num`() {
-        // Regression: the beacon proto advertises no hop_limit/tx_power/tx_enabled — a switch must not zero them.
+    fun `SWITCH ships a fresh lora config so stale RF pins never survive the retune`() {
+        // The join must NOT copy the current config: a stale channel_num / override / manual preset would strand the
+        // radio on the old slot. use_preset is set, the offered preset+region applied, and every RF field left blank.
         val current =
             radioLora.copy(
                 modem_preset = ModemPreset.MEDIUM_FAST,
                 region = RegionCode.EU_868,
-                hop_limit = 3,
+                hop_limit = 7,
                 tx_power = 27,
                 tx_enabled = true,
                 channel_num = 5,
+                override_frequency = 915.5f,
             )
         val beacon =
             MeshBeacon(
@@ -131,24 +133,26 @@ class MeshBeaconOfferTest {
             )
         val lora = beacon.toJoinChannelSet(BeaconJoinOption.SWITCH, current)?.lora_config
         assertNotNull(lora)
-        assertEquals(3, lora.hop_limit, "hop_limit must be preserved, not zeroed")
-        assertEquals(27, lora.tx_power, "tx_power must be preserved")
-        assertEquals(true, lora.tx_enabled, "tx_enabled must be preserved")
+        assertEquals(true, lora.use_preset, "use_preset must be set")
         assertEquals(ModemPreset.LONG_FAST, lora.modem_preset, "offered preset applied")
         assertEquals(RegionCode.US, lora.region, "offered region applied")
         assertEquals(0, lora.channel_num, "channel_num reset to 0 for frequency derivation")
+        assertEquals(0f, lora.override_frequency, "stale override_frequency dropped — firmware re-derives it")
+        assertEquals(0, lora.tx_power, "stale tx_power dropped — firmware picks the region max")
+        assertEquals(3, lora.hop_limit, "hop_limit falls back to the standard default, not the stale value")
     }
 
     @Test
-    fun `SWITCH without an offered preset still resets channel_num and keeps the current preset`() {
+    fun `SWITCH without an offered preset keeps the current preset and region and resets channel_num`() {
         // A channel-only beacon (no preset) must still reset channel_num=0 so firmware re-derives the frequency from
-        // the new primary name — otherwise a radio with an explicit channel_num override lands on the wrong slot.
+        // the new primary name, keep the current preset, and carry the current region (a zero region disables TX).
         val current = radioLora.copy(modem_preset = ModemPreset.MEDIUM_FAST, channel_num = 5)
         val beacon = MeshBeacon(offer_channel = ChannelSettings(name = "PartyNet"))
         val lora = beacon.toJoinChannelSet(BeaconJoinOption.SWITCH, current)?.lora_config
         assertNotNull(lora, "SWITCH must always carry lora so channel_num resets")
         assertEquals(0, lora.channel_num, "channel_num reset to 0 even without an offered preset")
         assertEquals(ModemPreset.MEDIUM_FAST, lora.modem_preset, "current preset kept when none offered")
+        assertEquals(RegionCode.US, lora.region, "current region carried when none offered")
     }
 
     @Test


### PR DESCRIPTION
## Why

Joining a Mesh Beacon via **SWITCH** copied the connected radio's *current* `LoRaConfig` and overrode only preset/region/`channel_num`. On the firmware side `use_preset = true` **only** gates `bandwidth`/`spread_factor`/`coding_rate` — every other RF field stays live. So any stale `channel_num`, `override_frequency`, or manual `bandwidth`/`spread_factor`/`coding_rate` on the radio carried over into the join and could strand it on the *old* mesh's slot instead of the offered one.

## 🐛 Fix

`MeshBeacon.toJoinChannelSet(SWITCH)` now builds a **fresh** `LoRaConfig` instead of copying the current one:

- `use_preset = true` + the advertised preset+region applied
- `channel_num` / `override_frequency` left at their zero defaults, so firmware re-derives the frequency from the offered channel name (Apple `014-mesh-beacons` FR-006)
- stale manual `bandwidth`/`spread_factor`/`coding_rate` and `tx_power` dropped

The config is applied as a **full LoRaConfig replacement** (`setLocalConfig(Config(lora = ...))`), so a truly-blank config would disable transmit. To stay safe, the fresh config still:

- carries `region` from the current config when the beacon doesn't advertise one (a zero region disables TX)
- sets the app's standard `hop_limit = 3` / `tx_enabled = true` defaults rather than zeroing them

ADD and NONE paths are unchanged. The temporary scan-dwell retune in `DiscoveryScanEngine` is intentionally left preserving the base config (it's a short-lived tune-back, documented in-place) and is out of scope here.

## Testing Performed

`./gradlew :core:model:allTests spotlessCheck detekt` — all green (13 `MeshBeaconOfferTest` cases).

Rewrote two SWITCH tests to lock in the new behavior:
- `SWITCH ships a fresh lora config so stale RF pins never survive the retune` — asserts `use_preset`, offered preset/region applied, and `channel_num`/`override_frequency`/`tx_power` all dropped from a config that had them set.
- `SWITCH without an offered preset keeps the current preset and region and resets channel_num` — asserts the region-carry fallback and preset preservation for a channel-only beacon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel switching so a join now uses a fresh radio configuration rather than reusing older settings.
  * Prevented stale RF fields (including frequency/channel overrides and related RF controls) from being carried over during a switch.
  * For switches without an offered preset, the channel is reset while the current region behavior remains consistent.
  * Updated validation to match the new “clean config” switch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->