### PR TITLE
ci: split scheduled updates into hourly light + daily heavy jobs

### DIFF
--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -1,0 +1,124 @@
+name: Scheduled Baseline Profile & Graphs
+
+on:
+  schedule:
+    # Once a day. Baseline-profile regeneration needs a booted emulator (~14 min)
+    # and the profile/graphs rarely change, so this is decoupled from the frequent
+    # firmware/hardware/translation job in scheduled-updates.yml.
+    - cron: '0 0 * * *'
+  workflow_dispatch:       # Allow manual triggering
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'meshtastic/Meshtastic-Android'
+    permissions:
+      contents: write      # To commit files and push branches
+      pull-requests: write # To create pull requests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+        with:
+          token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+
+      - name: Gradle Setup
+        uses: ./.github/actions/gradle-setup
+        with:
+          gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          cache_read_only: 'false'
+
+      - name: Update Graphs
+        run: ./gradlew graphUpdate
+        continue-on-error: true
+
+      # ── Baseline Profile regeneration ───────────────────────────────────
+      # Generation needs a booted emulator; continue-on-error keeps flakiness
+      # from blocking the graphs PR.
+      - name: Enable KVM (for the emulator)
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Generate Baseline Profile
+        id: generate_baseline
+        continue-on-error: true # Emulator flakiness must not block the graphs PR.
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis # google flavor needs GMS (Maps) on the device image
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          # Writes androidApp/src/google/generated/baselineProfiles/ via the androidx.baselineprofile plugin.
+          # --no-configuration-cache: the underlying connectedGoogleNonMinifiedReleaseAndroidTest task is not
+          # config-cache serializable (SeparateTestModuleTestData / ResolutionBackedFileCollection), and the
+          # project enables org.gradle.configuration-cache by default — same workaround used in reusable-check.yml.
+          script: ./gradlew :androidApp:generateGoogleReleaseBaselineProfile -Pci=true --no-configuration-cache
+
+      - name: Detect baseline profile changes
+        id: baseline
+        run: |
+          profile_dir="androidApp/src/google/generated/baselineProfiles"
+          outcome="${{ steps.generate_baseline.outcome }}"
+          if [ "$outcome" != "success" ]; then
+            echo "::warning::Baseline profile generation failed (outcome: $outcome). Skipping."
+            echo "status=error" >> "$GITHUB_OUTPUT"
+          elif [ -n "$(git status --porcelain "$profile_dir" 2>/dev/null)" ]; then
+            echo "status=updated" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=unchanged" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build PR body
+        id: pr_body
+        run: |
+          baseline_status="${{ steps.baseline.outputs.status }}"
+
+          body="This PR includes automated updates from the scheduled workflow:"
+          body+=$'\n'
+
+          case "$baseline_status" in
+            updated)   body+=$'\n'"- ✅ \`androidApp\` baseline profile regenerated on an emulator." ;;
+            unchanged) body+=$'\n'"- ✔️ \`androidApp\` baseline profile regenerated — no changes detected." ;;
+            error)     body+=$'\n'"- ⚠️ \`androidApp\` baseline profile generation failed — skipped (see workflow logs)." ;;
+            *)         body+=$'\n'"- ❓ \`androidApp\` baseline profile — unknown status." ;;
+          esac
+
+          body+=$'\n'"- Updated module dependency graphs in README.md files (if changed)."
+          body+=$'\n'
+          body+=$'\n'"Please review the changes."
+
+          {
+            echo "content<<PREOF"
+            echo "$body"
+            echo "PREOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request if changes occurred
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+          commit-message: |
+            chore: Scheduled updates (Graphs, Baseline Profile)
+
+            Automated updates for:
+            - Module dependency graphs
+            - androidApp baseline profile
+          title: 'chore: Scheduled updates (Graphs, Baseline Profile)'
+          body: ${{ steps.pr_body.outputs.content }}
+          branch: 'scheduled-baseline'
+          base: 'main'
+          delete-branch: true
+          # Only stage the baseline-profile dir when generation actually produced changes. When the emulator
+          # boots far enough for Gradle to create an *empty* baselineProfiles/ dir but generation then fails,
+          # `git add <glob>` aborts with "pathspec did not match any files", which would hard-fail this step
+          # and defeat the continue-on-error on the generation step above.
+          add-paths: |
+            ${{ steps.baseline.outputs.status == 'updated' && 'androidApp/src/google/generated/baselineProfiles/**' || '' }}
+            **/README.md
+          labels: |
+            automation

--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -2,7 +2,9 @@ name: Scheduled Updates (Firmware, Hardware, Translations)
 
 on:
   schedule:
-    - cron: '0 */6 * * *' # Run every 6 hours (raised from 4h to absorb the added baseline-profile step)
+    # Hourly. This job is cheap (curl + Crowdin + PR, no build) — the slow
+    # emulator/graph work lives in scheduled-baseline.yml on a daily cron.
+    - cron: '0 * * * *'
   workflow_dispatch:       # Allow manual triggering
 
 jobs:
@@ -102,66 +104,12 @@ jobs:
         run: sudo chown -R $USER:$USER .
 
       # Early warning for overlength store-listing translations just pulled from
-      # Crowdin. Non-blocking on purpose: a hard failure here would abort the
-      # firmware/hardware/graphs job and stop the PR from being created. The
-      # hard gate is the check-metadata job in pull-request.yml, which runs
-      # against the PR this workflow opens.
+      # Crowdin. Non-blocking on purpose: a hard failure here would abort the job
+      # and stop the PR from being created. The hard gate is the check-metadata
+      # job in pull-request.yml, which runs against the PR this workflow opens.
       - name: Check store metadata lengths
         continue-on-error: true
         run: python3 scripts/check-metadata-length.py
-
-      - name: Gradle Setup
-        uses: ./.github/actions/gradle-setup
-        with:
-          gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache_read_only: 'false'
-
-      - name: Update Graphs
-        run: ./gradlew graphUpdate
-        continue-on-error: true
-
-      # ── Baseline Profile regeneration ───────────────────────────────────
-      # Runs on every scheduled tick (and manual dispatch). Generation needs a booted emulator
-      # (~10 min); continue-on-error keeps flakiness from blocking the firmware/translation PR.
-      - name: Enable KVM (for the emulator)
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: Generate Baseline Profile
-        id: generate_baseline
-        continue-on-error: true # Emulator flakiness must not block the firmware/translation PR.
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          target: google_apis # google flavor needs GMS (Maps) on the device image
-          arch: x86_64
-          profile: pixel_6
-          disable-animations: true
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          # Writes androidApp/src/google/generated/baselineProfiles/ via the androidx.baselineprofile plugin.
-          # --no-configuration-cache: the underlying connectedGoogleNonMinifiedReleaseAndroidTest task is not
-          # config-cache serializable (SeparateTestModuleTestData / ResolutionBackedFileCollection), and the
-          # project enables org.gradle.configuration-cache by default — same workaround used in reusable-check.yml.
-          script: ./gradlew :androidApp:generateGoogleReleaseBaselineProfile -Pci=true --no-configuration-cache
-
-      - name: Detect baseline profile changes
-        id: baseline
-        run: |
-          profile_dir="androidApp/src/google/generated/baselineProfiles"
-          outcome="${{ steps.generate_baseline.outcome }}"
-          if [ "$outcome" = "skipped" ]; then
-            echo "status=skipped" >> "$GITHUB_OUTPUT"
-          elif [ "$outcome" != "success" ]; then
-            echo "::warning::Baseline profile generation failed (outcome: $outcome). Skipping."
-            echo "status=error" >> "$GITHUB_OUTPUT"
-          elif [ -n "$(git status --porcelain "$profile_dir" 2>/dev/null)" ]; then
-            echo "status=updated" >> "$GITHUB_OUTPUT"
-          else
-            echo "status=unchanged" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Build PR body
         id: pr_body
@@ -170,7 +118,6 @@ jobs:
           firmware_detail="${{ steps.firmware.outputs.detail }}"
           hardware_status="${{ steps.hardware.outputs.status }}"
           hardware_detail="${{ steps.hardware.outputs.detail }}"
-          baseline_status="${{ steps.baseline.outputs.status }}"
 
           body="This PR includes automated updates from the scheduled workflow:"
           body+=$'\n'
@@ -191,19 +138,9 @@ jobs:
             *)         body+=$'\n'"- ❓ \`device_hardware.json\` — unknown status." ;;
           esac
 
-          # Baseline profile (daily / manual only)
-          case "$baseline_status" in
-            updated)   body+=$'\n'"- ✅ \`androidApp\` baseline profile regenerated on an emulator." ;;
-            unchanged) body+=$'\n'"- ✔️ \`androidApp\` baseline profile regenerated — no changes detected." ;;
-            error)     body+=$'\n'"- ⚠️ \`androidApp\` baseline profile generation failed — skipped (see workflow logs)." ;;
-            skipped)   ;; # Not a daily/manual run — omit the line entirely.
-            *)         ;;
-          esac
-
-          # Crowdin & graphs (always attempted)
+          # Crowdin (always attempted)
           body+=$'\n'"- Source strings were uploaded to Crowdin."
           body+=$'\n'"- Latest translations were downloaded from Crowdin (if available)."
-          body+=$'\n'"- Updated module dependency graphs in README.md files (if changed)."
           body+=$'\n'
           body+=$'\n'"Please review the changes."
 
@@ -219,48 +156,26 @@ jobs:
         with:
           token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
           commit-message: |
-            chore: Scheduled updates (Firmware, Hardware, Translations, Graphs, Baseline)
+            chore: Scheduled updates (Firmware, Hardware, Translations)
 
             Automated updates for:
             - Firmware releases list
             - Device hardware list
             - Crowdin source string uploads
             - Crowdin translation downloads
-            - Module dependency graphs
-            - androidApp baseline profile
-          title: 'chore: Scheduled updates (Firmware, Hardware, Translations, Graphs, Baseline)'
+          title: 'chore: Scheduled updates (Firmware, Hardware, Translations)'
           body: ${{ steps.pr_body.outputs.content }}
           branch: 'scheduled-updates'
           base: 'main'
           delete-branch: true
-          # Only stage the baseline-profile dir when generation actually produced changes. When the emulator
-          # boots far enough for Gradle to create an *empty* baselineProfiles/ dir but generation then fails,
-          # `git add <glob>` aborts with "pathspec did not match any files", which would hard-fail this step
-          # and defeat the continue-on-error on the generation step above.
           add-paths: |
             androidApp/src/main/assets/firmware_releases.json
             androidApp/src/main/assets/device_hardware.json
-            ${{ steps.baseline.outputs.status == 'updated' && 'androidApp/src/google/generated/baselineProfiles/**' || '' }}
             fastlane/metadata/android/**
             **/strings.xml
-            **/README.md
             docs/**/*.md
           labels: |
             automation
             l10n
             firmware
             hardware
-
-  check-workflow-status:
-    name: Check Workflow Status
-    runs-on: ubuntu-24.04-arm
-    permissions: {}
-    needs:
-        - update_assets
-    if: always()
-    steps:
-      - name: Check Workflow Status
-        if: "contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')"
-        run: |
-          echo "One of the dependent jobs failed or was cancelled. Failing the workflow."
-          exit 1


### PR DESCRIPTION
## Why

The scheduled-updates workflow was doing two very different kinds of work in one job on one cadence, and the slow half dominated:

- The firmware/hardware/translation refresh is the point of the workflow and takes **seconds** (curl + Crowdin).
- The baseline-profile regeneration needs a booted emulator and takes **~14 min** — ~90% of every run — yet the profile rarely changes.

Run timings confirmed this. Every 6h tick spent ~14–15 min in `Generate Baseline Profile` while everything else was noise. The PR-body code even had a dead `skipped` branch assuming baseline was "daily/manual only" — but no gate was ever added, so it ran 4×/day.

On top of that, the `check-workflow-status` job spun up a **separate `ubuntu-24.04-arm` runner** just to `exit 1` when `update_assets` failed — which already reddens the workflow. In practice it was always skipped and added **~9 min of trailing queue** to every run (e.g. [run 28824178741](https://github.com/meshtastic/Meshtastic-Android/actions/runs/28824178741): real work done 22:10, run held open until 22:19 for a skipped step).

## What

🛠️ Split into two single-purpose workflows:

| Workflow | Cron | Work | Runtime |
|---|---|---|---|
| `scheduled-updates.yml` | hourly | firmware + hardware curl, Crowdin, PR | ~1–2 min, **no Gradle/JDK** |
| `scheduled-baseline.yml` (new) | daily `0 0 * * *` | module graphs + baseline profile, PR | ~16 min, once/day |

🧹 Details:
- The light path is now **Gradle-free** — dropped `gradle-setup`, `graphUpdate`, KVM, the emulator, and the cache save/restore. Cadence dropped to **hourly** (the `6h` was only raised to absorb the baseline step per its own comment).
- Graphs (`**/README.md`) + baseline moved to the daily file. `docs/**/*.md` and `**/strings.xml` are Crowdin output, so they correctly stay with the light job.
- Removed the redundant `check-workflow-status` job.
- Dropped the now-unreachable `skipped` branch in baseline detection.

**Behavior change:** two independent PRs now (`scheduled-updates`, `scheduled-baseline`) instead of one combined PR. The frequent firmware/hardware PR no longer waits on the emulator.

## Testing performed

Both workflow files validated with a YAML parser. No app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated daily baseline profile and dependency graph update process, with manual run support.
  * Increased scheduled update checks to run hourly for faster refreshes.

* **Bug Fixes**
  * Improved how update pull request summaries are assembled, with clearer status reporting.
  * Simplified staged changes so update PRs include only relevant app, translation, and documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->