### PR TITLE
fix(messaging): use stored contact_key to avoid duplicate LazyColumn key crash (#6131)

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
@@ -61,7 +61,7 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         .flatMapLatest { db -> db.packetDao().getContactKeys() }
         .map { map -> map.mapValues { it.value.data } }
 
-    override fun getContactsPaged(): Flow<PagingData<DataPacket>> = Pager(
+    override fun getContactsPaged(): Flow<PagingData<Pair<String, DataPacket>>> = Pager(
         config =
         PagingConfig(
             pageSize = CONTACTS_PAGE_SIZE,
@@ -71,7 +71,7 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         pagingSourceFactory = { dbManager.currentDb.value.packetDao().getContactKeysPaged() },
     )
         .flow
-        .map { pagingData -> pagingData.map { it.data } }
+        .map { pagingData -> pagingData.map { it.contact_key to it.data } }
 
     override suspend fun getMessageCount(contact: String): Int =
         withContext(dispatchers.io) { dbManager.currentDb.value.packetDao().getMessageCount(contact) }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketRepository.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketRepository.kt
@@ -40,8 +40,8 @@ interface PacketRepository {
     /** Reactive flow of all conversation contacts, keyed by their contact identifier. */
     fun getContacts(): Flow<Map<String, DataPacket>>
 
-    /** Reactive paged flow of conversation contacts. */
-    fun getContactsPaged(): Flow<PagingData<DataPacket>>
+    /** Reactive paged flow of conversation contacts, each paired with its stored contact key. */
+    fun getContactsPaged(): Flow<PagingData<Pair<String, DataPacket>>>
 
     /** Returns the total number of messages in a conversation. */
     suspend fun getMessageCount(contact: String): Int

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModel.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModel.kt
@@ -142,16 +142,12 @@ class ContactsViewModel(
                 val myNodeNum = params.myNodeNum
 
                 packetRepository.getContactsPaged().map { pagingData ->
-                    pagingData.map { packetData: DataPacket ->
-                        // Determine if this is my message (originated on this device)
+                    pagingData.map { (contactKey, packetData) ->
+                        // Use the stored contact_key as the identity. Recomputing it here from a
+                        // possibly-null myNodeNum collapses distinct conversations onto one key and
+                        // crashes the LazyColumn with a duplicate-key error (#6131).
                         val fromLocal = packetData.isFromLocal(myNodeNum)
                         val toBroadcast = packetData.isBroadcast
-
-                        // Reconstruct contactKey exactly as rememberDataPacket() computes it:
-                        // For outgoing or broadcast: use the "to" field (recipient / ^all)
-                        // For incoming DMs: use the "from" field (the other party)
-                        val contactId = if (fromLocal || toBroadcast) packetData.to else packetData.from
-                        val contactKey = "${packetData.channel}$contactId"
 
                         // grab usernames from NodeInfo
                         val userId = if (fromLocal) packetData.to else packetData.from


### PR DESCRIPTION
## Why

Fixes #6131. Opening the Messages screen could crash with:

> Key "8!xxxxxxxx" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.

The paged contacts DAO query already dedupes with `GROUP BY contact_key`, returning exactly one row per conversation. But `ContactsViewModel` discarded that stored key and **recomputed** the conversation key from the `DataPacket` using a nullable `myNodeNum`. When `myNodeNum` is null at display time (startup, disconnected, or `my_node` not yet populated), `isFromLocal()` returns `false` for every message the user sent, so the recomputed `contactId` becomes the user's *own* node id. Every DM conversation whose latest message the user sent then collapses onto the identical key `"8!<myOwnNodeHex>"` (`8` = the PKI-DM channel index) — a duplicate `LazyColumn` key, which crashes the screen. Reported on Desktop, but the code is shared `commonMain` so it affects all platforms.

## 🐛 What changed

- Thread the authoritative stored `contact_key` through the paged flow (`getContactsPaged()` now emits `Pair<String, DataPacket>`) and use it directly as the conversation identity, instead of recomputing it.
- As a bonus, this also corrects the unread-count, message-count, and mute-settings lookups in the same block, which previously used the same wrong recomputed key when `myNodeNum` was null.

Three files, net −4 lines:
- `core/repository/.../PacketRepository.kt` — interface return type
- `core/data/.../PacketRepositoryImpl.kt` — map `it.contact_key to it.data`
- `feature/messaging/.../ContactsViewModel.kt` — use stored key, drop recompute

## Testing performed

- `detekt` clean; `spotless` clean on the touched modules.
- Compiles for JVM + iOS (`compileKotlinJvm` + `compileKotlinIosSimulatorArm64`) on all three modules.

No new unit test added: conversation-key uniqueness is a SQL `GROUP BY contact_key` guarantee, not Kotlin logic, so a mock-based ViewModel test would only exercise the fake. Worth adding an `asSnapshot` paging test if `androidx.paging:paging-testing` gets pulled into the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact list paging so conversations are kept separate even when they share similar message details.
  * Prevented duplicate or merged contact entries in the conversation list, making scrolling and loading more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->