### PR TITLE
fix(metrics): air-quality chart legend follows plotted data, not selection

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetrics.kt
@@ -97,6 +97,14 @@ internal enum class AirQuality(val labelRes: StringResource, val unit: String, v
     }
 }
 
+/**
+ * The subset of [candidates] with at least one reading in [telemetries]. The chart only draws series that have data, so
+ * the legend must use this rather than the raw selection — otherwise a default-selected series (PM2.5) shows a legend
+ * entry on nodes that never report it (issue #5873). Internal so it can be unit-tested.
+ */
+internal fun metricsWithData(candidates: List<AirQuality>, telemetries: List<Telemetry>): List<AirQuality> =
+    candidates.filter { metric -> telemetries.any { metric.getValue(it) != null } }
+
 private val LEGEND_DATA =
     AirQuality.entries.map { metric -> LegendData(nameRes = metric.labelRes, color = metric.color, isLine = true) }
 
@@ -193,10 +201,11 @@ private fun AirQualityChart(
     modifier: Modifier = Modifier,
 ) {
     val activeMetrics = AirQuality.entries.filter { it in selectedMetrics }
+    val drawnMetrics = metricsWithData(activeMetrics, telemetries)
     val metricLabels = activeMetrics.associateWith { stringResource(it.labelRes) }
     MetricChartScaffold(
         isEmpty = telemetries.isEmpty() || activeMetrics.isEmpty(),
-        legendData = LEGEND_DATA.filter { ld -> activeMetrics.any { it.labelRes == ld.nameRes } },
+        legendData = LEGEND_DATA.filter { ld -> drawnMetrics.any { it.labelRes == ld.nameRes } },
         modifier = modifier,
     ) { modelProducer, chartModifier ->
         val marker =

--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetricsTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/metrics/AirQualityMetricsTest.kt
@@ -69,4 +69,21 @@ class AirQualityMetricsTest {
             assertNull(it.getValue(t), "${it.name} should be null without air_quality_metrics")
         }
     }
+
+    @Test
+    fun `metricsWithData drops selected series that have no reading so the legend is not ever-present`() {
+        // Issue 5873, CO2-only node: PM2.5 is default-selected but never reported, so it must not survive into the
+        // legend.
+        val co2Only = listOf(telemetry(AirQualityMetrics(co2 = 450)))
+        assertEquals(listOf(AirQuality.CO2), metricsWithData(listOf(AirQuality.PM2_5, AirQuality.CO2), co2Only))
+    }
+
+    @Test
+    fun `metricsWithData keeps a series once it has any reading in the frame`() {
+        val mixed = listOf(telemetry(AirQualityMetrics(co2 = 450)), telemetry(AirQualityMetrics(pm25_standard = 8)))
+        assertEquals(
+            listOf(AirQuality.PM2_5, AirQuality.CO2),
+            metricsWithData(listOf(AirQuality.PM2_5, AirQuality.CO2), mixed),
+        )
+    }
 }


### PR DESCRIPTION
## Why

On the air-quality metrics screen, `selectedMetrics` defaults to `{PM2.5, CO2}` and the chart legend was built from that selection. On a node that never reports PM2.5 (e.g. a CO₂-only sensor), the chart correctly drew no PM2.5 line — but the legend still rendered a PM2.5 entry. That's the *ever-present PM2.5 legend* @DaneEvans flagged on #5873.

## What changed

🐛 The legend now follows the series that are **actually plotted** in the current time frame, not the raw selection. Added a small `internal fun metricsWithData(candidates, telemetries)` (the metrics with ≥1 reading in the frame — the same set the chart already uses to draw its lines) and drive `legendData` off it. Nodes that *do* report PM2.5 are unaffected; the fix only removes legend entries for series with no data.

Scoped to the legend/selection only — the CO₂/temp-humidity card work on this issue is untouched.

## Testing performed

- Added 2 regression tests to `AirQualityMetricsTest`: a CO₂-only node drops PM2.5 from the legend set; a series survives once it has any reading in the frame.
- `./gradlew :feature:node:allTests` — pass (incl. iOS simulator compile)
- `./gradlew :feature:node:detekt spotlessCheck` — clean

Refs #5873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved air-quality chart legends so they only show metrics that actually have data.
  * Prevented selected but unavailable readings from appearing in the chart legend, reducing confusion when some series aren’t reported.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->