### PR TITLE
Promote CO2 temperatures to summary if no other temp is present.

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
@@ -364,8 +364,7 @@ private fun gatherSensors(node: Node, tempInFahrenheit: Boolean, contentColor: C
     if ((env.temperature ?: 0f) != 0f) {
         val temp = MetricFormatter.temperature(env.temperature ?: 0f, tempInFahrenheit)
         items.add { TemperatureInfo(temp = temp, contentColor = contentColor) }
-    }
-    else if ((aq.co2_temperature?: 0f) != 0f) {
+    } else if ((aq.co2_temperature ?: 0f) != 0f) {
         val temp = MetricFormatter.temperature(aq.co2_temperature ?: 0f, tempInFahrenheit)
         items.add { TemperatureInfo(temp = temp, contentColor = contentColor) }
     }
@@ -374,8 +373,7 @@ private fun gatherSensors(node: Node, tempInFahrenheit: Boolean, contentColor: C
         items.add {
             HumidityInfo(humidity = MetricFormatter.humidity(env.relative_humidity ?: 0f), contentColor = contentColor)
         }
-    }
-    else if ((aq.co2_humidity?: 0f) != 0f) {
+    } else if ((aq.co2_humidity ?: 0f) != 0f) {
         items.add {
             HumidityInfo(humidity = MetricFormatter.humidity(aq.co2_humidity ?: 0f), contentColor = contentColor)
         }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
@@ -354,7 +354,6 @@ private fun NodeSignalRow(thatNode: Node, isThisNode: Boolean, contentColor: Col
 private fun gatherSensors(node: Node, tempInFahrenheit: Boolean, contentColor: Color): List<@Composable () -> Unit> {
     val items = mutableListOf<@Composable () -> Unit>()
     val env = node.environmentMetrics
-    val aq = node.airQualityMetrics
     val pax = node.paxcounter
 
     if (pax.ble != 0 || pax.wifi != 0) {
@@ -365,22 +364,11 @@ private fun gatherSensors(node: Node, tempInFahrenheit: Boolean, contentColor: C
         val temp = MetricFormatter.temperature(env.temperature ?: 0f, tempInFahrenheit)
         items.add { TemperatureInfo(temp = temp, contentColor = contentColor) }
     }
-    else if ((aq.co2_temperature?: 0f) != 0f) {
-        val temp = MetricFormatter.temperature(aq.co2_temperature ?: 0f, tempInFahrenheit)
-        items.add { TemperatureInfo(temp = temp, contentColor = contentColor) }
-    }
-
     if ((env.relative_humidity ?: 0f) != 0f) {
         items.add {
             HumidityInfo(humidity = MetricFormatter.humidity(env.relative_humidity ?: 0f), contentColor = contentColor)
         }
     }
-    else if ((aq.co2_humidity?: 0f) != 0f) {
-        items.add {
-            HumidityInfo(humidity = MetricFormatter.humidity(aq.co2_humidity ?: 0f), contentColor = contentColor)
-        }
-    }
-
     if ((env.barometric_pressure ?: 0f) != 0f) {
         items.add {
             PressureInfo(

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
@@ -354,6 +354,7 @@ private fun NodeSignalRow(thatNode: Node, isThisNode: Boolean, contentColor: Col
 private fun gatherSensors(node: Node, tempInFahrenheit: Boolean, contentColor: Color): List<@Composable () -> Unit> {
     val items = mutableListOf<@Composable () -> Unit>()
     val env = node.environmentMetrics
+    val aq = node.airQualityMetrics
     val pax = node.paxcounter
 
     if (pax.ble != 0 || pax.wifi != 0) {
@@ -364,11 +365,22 @@ private fun gatherSensors(node: Node, tempInFahrenheit: Boolean, contentColor: C
         val temp = MetricFormatter.temperature(env.temperature ?: 0f, tempInFahrenheit)
         items.add { TemperatureInfo(temp = temp, contentColor = contentColor) }
     }
+    else if ((aq.co2_temperature?: 0f) != 0f) {
+        val temp = MetricFormatter.temperature(aq.co2_temperature ?: 0f, tempInFahrenheit)
+        items.add { TemperatureInfo(temp = temp, contentColor = contentColor) }
+    }
+
     if ((env.relative_humidity ?: 0f) != 0f) {
         items.add {
             HumidityInfo(humidity = MetricFormatter.humidity(env.relative_humidity ?: 0f), contentColor = contentColor)
         }
     }
+    else if ((aq.co2_humidity?: 0f) != 0f) {
+        items.add {
+            HumidityInfo(humidity = MetricFormatter.humidity(aq.co2_humidity ?: 0f), contentColor = contentColor)
+        }
+    }
+
     if ((env.barometric_pressure ?: 0f) != 0f) {
         items.add {
             PressureInfo(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor readings shown in the UI by falling back to alternate air quality data when primary temperature or humidity values are unavailable.
  * Temperature and humidity displays now stay populated more often, reducing empty or missing sensor fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->