### PR TITLE
docs: second-pass audit of docs/en — fix drift and document new features

### DIFF
--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -34,6 +34,10 @@ Things that trip up first-time contributors — check these before requesting re
 Keep the last 5–8 entries and trim older ones from the bottom.
 -->
 
+**July 2026** — Map layer stack (`MapLayer.kt`, `MapLayersManager`, GeoJSON/KML import, Site Planner) extracted from the Google flavor into shared `androidApp/src/main` source (#6148) — F-Droid now renders imported overlays via a new OSMdroid-based renderer, so both flavors compile one implementation.
+
+**July 2026** — [Persistence](developer/persistence) — Local Mesh Discovery sessions and cached `msh.to` device links now persist to Room (`DiscoverySessionEntity`, `DiscoveryPresetResultEntity`, `DiscoveredNodeEntity`, `DeviceLinkEntity`).
+
 **June 2026** — [Architecture](developer/architecture) / [Codebase](developer/codebase) — Protos migrated from the `core/proto` git submodule to the `org.meshtastic:protobufs` Maven artifact; there is no longer a local proto module to build or sync.
 
 **June 2026** — AIDL/`IMeshService` removed (#5586). The mesh service is now in-process only, driven entirely through `RadioController` — no cross-process binder, no `aidl` stubs.
@@ -45,10 +49,6 @@ Keep the last 5–8 entries and trim older ones from the bottom.
 **June 2026** — [Testing](developer/testing) — Added the `:baselineprofile` module (#5735): a Macrobenchmark cold-start journey generates a Baseline Profile for `:androidApp` to AOT-compile hot startup paths.
 
 **June 2026** — [Persistence](developer/persistence) — FTS5 full-text message search (#5373): a `PacketFts` virtual table mirrors `Packet.messageText`, kept in sync by Room-managed triggers.
-
-**May 2026** — [Measurement & Formatting](developer/measurement) — New page documenting the `MetricFormatter` API, locale-aware unit conversion patterns, and how to add new measurement types.
-
-**May 2026** — [Testing](developer/testing) — Compose Preview Screenshot Testing (CST) integrated: `screenshot-tests/` module, `@PreviewTest` wrappers, CI validation, docs asset pipeline.
 
 <!-- DEV_WHATS_NEW_END -->
 

--- a/docs/en/developer/adding-a-feature-module.md
+++ b/docs/en/developer/adding-a-feature-module.md
@@ -2,7 +2,7 @@
 title: Adding a Feature Module
 parent: Developer Guide
 nav_order: 3
-last_updated: 2026-05-13
+last_updated: 2026-07-08
 aliases:
   - new-module
   - feature-module
@@ -27,7 +27,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary { withHostTest { } }
+    android { withHostTest { isIncludeAndroidResources = true } }
 
     sourceSets {
         commonMain.dependencies {

--- a/docs/en/developer/codebase.md
+++ b/docs/en/developer/codebase.md
@@ -2,7 +2,7 @@
 title: Codebase
 parent: Developer Guide
 nav_order: 2
-last_updated: 2026-06-11
+last_updated: 2026-07-08
 aliases:
   - repository-layout
   - project-structure
@@ -60,10 +60,9 @@ Meshtastic-Android/
 ├── screenshot-tests/       # Compose Preview screenshot tests (visual-regression gate)
 ├── docs-screenshots/       # Doc-framed composition screenshots (generate-only, not CI-gated)
 ├── build-logic/            # Convention plugins and build helpers
-│   ├── convention/
-│   └── flatpak/
+│   └── convention/
 ├── docs/                   # Documentation source (markdown)
-│   └── en/                 # English sources (translations land in docs/{lang}/)
+│   └── en/                 # English source; other locales live under docs/<locale>/user/
 │       ├── user/
 │       └── developer/
 ├── gradle/                 # Gradle wrapper and version catalog
@@ -96,7 +95,7 @@ All build files use Kotlin DSL (`.gradle.kts`). Configuration:
 
 ### Convention Plugins
 
-Located in `build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/`:
+Located in `build-logic/convention/src/main/kotlin/`:
 
 | Plugin | Purpose |
 |--------|---------|

--- a/docs/en/developer/contributing.md
+++ b/docs/en/developer/contributing.md
@@ -2,7 +2,7 @@
 title: Contributing
 parent: Developer Guide
 nav_order: 8
-last_updated: 2026-05-13
+last_updated: 2026-07-08
 aliases:
   - contributing
   - pull-request
@@ -29,12 +29,12 @@ Branches use conventional-commit style prefixes:
 | `test/<scope>` | Test additions or fixes |
 | `deps/<scope>` | Dependency updates |
 
-Numeric spec prefixes (e.g., `003-app-docs-markdown`) are also valid for spec-driven work.
+Timestamp-based spec prefixes (`YYYYMMDD-HHMMSS-feature-name`, as created by `/speckit.git.feature`) are also valid for spec-driven work.
 
 Examples:
 - `feat/desktop-ble-transport`
 - `fix/bluetooth-reconnect`
-- `003-app-docs-markdown`
+- `20260601-074653-air-quality-telemetry`
 
 ## Development Workflow
 

--- a/docs/en/developer/measurement.md
+++ b/docs/en/developer/measurement.md
@@ -148,6 +148,7 @@ Date and time formatting uses the `DateFormatter` `expect object` with platform-
 | `formatTime()` | "2:30 PM" |
 | `formatTimeWithSeconds()` | "2:30:45 PM" |
 | `formatDate()` | "2026-05-13" |
+| `formatDateTimeShort()` | "5/13/26 2:30 PM" |
 
 Unlike `MetricFormatter`, `DateFormatter` is declared with `expect`/`actual` (an `expect object` in `commonMain`, an `actual object` per platform) because date formatting inherently depends on platform locale APIs.
 

--- a/docs/en/developer/navigation-and-deep-links.md
+++ b/docs/en/developer/navigation-and-deep-links.md
@@ -2,7 +2,7 @@
 title: Navigation & Deep Links
 parent: Developer Guide
 nav_order: 4
-last_updated: 2026-07-01
+last_updated: 2026-07-08
 aliases:
   - deeplinks
   - navigation-3
@@ -57,8 +57,9 @@ https://meshtastic.org/{path}       # App Link, android:autoVerify — also open
 `adb shell am start -a android.intent.action.VIEW -d "meshtastic://meshtastic/{path}"` is the fastest way to
 trigger any route below from a shell or automation script without touching the UI.
 
-**Source of truth:** the exhaustive, always-current list of segments lives as KDoc on
+**Source of truth:** the always-current list of segments lives in the `when` block in
 [`DeepLinkRouter.route()`](../../../core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/DeepLinkRouter.kt)
+(the class-level KDoc above it is illustrative, not exhaustive)
 and as executable spec in
 [`DeepLinkRouterTest.kt`](../../../core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/DeepLinkRouterTest.kt).
 The table below is a snapshot for quick reference — check those two files if it looks out of date.
@@ -76,6 +77,7 @@ The table below is a snapshot for quick reference — check those two files if i
 | `/settings/helpDocs` | `SettingsRoute.HelpDocs` | Docs browser |
 | `/settings/helpDocs/{pageId}` | `SettingsRoute.HelpDocPage(pageId)` | Specific doc page |
 | `/settings/help-docs` | `SettingsRoute.HelpDocs` | Compatibility alias |
+| `/discovery` | `DiscoveryRoute.DiscoveryGraph` | Local Mesh Discovery entry point |
 | `/settings/local-mesh-discovery/session/{sessionId}` | `DiscoveryRoute.DiscoverySummary(sessionId)` | Discovery session result |
 | `/nodes` | `NodesRoute.Nodes` | Node list |
 | `/nodes/{destNum}` | `NodesRoute.NodeDetail(destNum)` | Node detail |

--- a/docs/en/developer/persistence.md
+++ b/docs/en/developer/persistence.md
@@ -2,7 +2,7 @@
 title: Persistence
 parent: Developer Guide
 nav_order: 6
-last_updated: 2026-06-11
+last_updated: 2026-07-08
 aliases:
   - room
   - database
@@ -49,6 +49,10 @@ The primary structured data store:
 | `DeviceHardwareEntity` | Cached device hardware catalog |
 | `FirmwareReleaseEntity` | Cached firmware release info |
 | `TracerouteNodePositionEntity` | Traceroute hop position data |
+| `DiscoverySessionEntity` | A Local Mesh Discovery scan session (timestamp, presets scanned, home preset) |
+| `DiscoveryPresetResultEntity` | Per-preset result within a discovery session |
+| `DiscoveredNodeEntity` | Nodes found during a discovery preset scan |
+| `DeviceLinkEntity` | Cached `msh.to` device links from the Meshtastic API |
 
 > 💡 **Note:** Waypoints, telemetry, and channel data are stored within the `Packet` entity (using the `port_num` field to distinguish packet types) rather than in separate tables.
 

--- a/docs/en/developer/transport.md
+++ b/docs/en/developer/transport.md
@@ -57,7 +57,7 @@ Serial communication over USB:
 ## TCP/IP
 
 **Module:** `core:network`  
-**Platforms:** Android, Desktop, iOS
+**Platforms:** Android, Desktop (iOS: code compiles, but there's no iOS app target or `RadioTransportFactory` yet — see Transport Factory below)
 
 Network-based transport for WiFi-enabled radios:
 - TCP socket connection to radio's IP address

--- a/docs/en/user.md
+++ b/docs/en/user.md
@@ -19,6 +19,12 @@ Documentation for using the Meshtastic Android and Desktop app.
 Keep the last 5–8 entries and archive older ones by removing them.
 -->
 
+**July 2026** — [Map & Waypoints](user/map-and-waypoints) — Waypoints can now define a geofence: get notified when nodes enter or leave an area. Creator-only by default, with a per-geofence opt-in for others.
+
+**July 2026** — [Map & Waypoints](user/map-and-waypoints) — Map Layers (import your own `.kml`/`.kmz`/GeoJSON overlays) and Site Planner (RF coverage estimation) are now available on F-Droid, not just Google Play.
+
+**July 2026** — [Nodes](user/nodes) — Added a "Nodes per Hop" histogram showing how many nodes sit at each hop distance, filterable to a last-heard time window.
+
 **July 2026** — [Messages & Channels](user/messages-and-channels) — Documented tap-to-open `@mentions` and on-device message translation (Google Play build only).
 
 **July 2026** — [Node Metrics](user/node-metrics) — Air Quality now shows an EPA NowCast AQI reading and the CO₂ sensor's own temperature & humidity.
@@ -28,12 +34,6 @@ Keep the last 5–8 entries and archive older ones by removing them.
 **June 2026** — [Help & In-App Docs](user/help-and-docs) — New page covering the in-app documentation browser, search, and the on-device Chirpy AI assistant.
 
 **June 2026** — [Home Screen Widget](user/widget) — New page covering the Android home screen widget that shows your connected radio's local stats at a glance.
-
-**June 2026** — [Discovery](user/discovery) — Added the Local Mesh Discovery scanner: a dedicated mode that cycles your radio through LoRa presets, dwells on each to collect packets, and ranks which preset works best at your location.
-
-**June 2026** — [Node Metrics](user/node-metrics) — Added Air Quality metrics (PM1.0, PM2.5, PM10, and CO₂ with severity color bands), a separate view from the BME680 IAQ reading.
-
-**June 2026** — [Messages & Channels](user/messages-and-channels) — Added full-text message search within a conversation, with a result counter and previous/next navigation.
 
 <!-- WHATS_NEW_END -->
 

--- a/docs/en/user/connections.md
+++ b/docs/en/user/connections.md
@@ -2,7 +2,7 @@
 title: Connections
 parent: User Guide
 nav_order: 2
-last_updated: 2026-06-25
+last_updated: 2026-07-08
 description: Connect your phone or desktop to a Meshtastic radio via Bluetooth, USB, or TCP/IP.
 aliases:
   - bluetooth
@@ -79,8 +79,8 @@ Some Meshtastic radios support WiFi/Ethernet connectivity, allowing TCP-based co
 1. Make sure the radio is on the same local network as your phone/desktop.
 2. On the Connect screen, select the **Network** transport filter.
 3. Choose the radio one of two ways:
-   - **Scan Network Devices** — toggle this on to auto-discover radios that advertise themselves on the local network (mDNS / `_meshtastic._tcp`). Discovered devices appear in the list; tap one to connect.
-   - **Add Network Device Manually** — enter the radio's IP address (or hostname) and port (default: `4403`).
+   - **Scan for network devices** — toggle this on to auto-discover radios that advertise themselves on the local network (mDNS / `_meshtastic._tcp`). Discovered devices appear in the list; tap one to connect.
+   - **Add device manually…** — enter the radio's IP address (or hostname) and port (default: `4403`).
 4. Previously-used network addresses are remembered under **Recent Network Devices** for quick reconnection (long-press to remove one).
 
 > 💡 **Tip:** Network discovery uses mDNS, which only works when both devices are on the same subnet. On Android 17+ the app needs the local-network permission for scanning; if discovery finds nothing, add the device manually by IP.

--- a/docs/en/user/debug-logs.md
+++ b/docs/en/user/debug-logs.md
@@ -2,7 +2,7 @@
 title: Debug Logs
 parent: User Guide
 nav_order: 22
-last_updated: 2026-07-01
+last_updated: 2026-07-08
 description: View and export the app's own debug logs from inside the app, and attach a capture to a GitHub issue to help diagnose bugs — no adb required.
 aliases:
   - debug-logs
@@ -44,7 +44,7 @@ Tap the **download** icon to save the current logs to a file. You choose where i
 
 Attach that file to your GitHub issue.
 
-> 🔒 **Privacy:** Exports automatically **redact** sensitive values such as channel keys and admin/session keys before writing the file. Even so, logs can contain node names, positions, and other identifying details — glance through the file before sharing it publicly, and share privately if you have any doubt.
+> 🔒 **Privacy:** Exports automatically **redact** private keys, admin keys, and session passkeys before writing the file. Channel PSKs are **not** redacted, and logs can also contain node names, positions, and other identifying details — glance through the file before sharing it publicly, and share privately if you have any doubt.
 
 ## Desktop
 

--- a/docs/en/user/desktop.md
+++ b/docs/en/user/desktop.md
@@ -67,7 +67,7 @@ Bluetooth Low Energy is supported on Desktop via the [Kable](https://github.com/
 | Map | ✓ | ◐ | Map tab exists on desktop, but the interactive map view is Android-only |
 | Settings | ✓ | ✓ | Full parity |
 | Bluetooth (BLE) | ✓ | ✓ | Via Kable on desktop |
-| Firmware Update | ✓ | ◐ | Desktop supports in-app USB firmware update; BLE/Wi-Fi OTA is Android-only |
+| Firmware Update | ✓ | ✓ | In-app USB, BLE, and Wi-Fi (ESP32) update all work the same as Android |
 | Notifications | ✓ | ✓ | Native OS notifications |
 | Widgets | ✓ | ✗ | Android-only |
 | Android Auto | ✓ | ✗ | Android-only — not available on Desktop or iOS |
@@ -135,7 +135,6 @@ Requirements:
 
 ## Known Limitations
 
-- Firmware updates over the air (BLE/Wi-Fi) are Android-only; on desktop, use the in-app USB update or the [Web Flasher](https://flasher.meshtastic.org)
 - The interactive map view is Android-only — the Map tab is present but does not render a map on desktop
 - Some Android-specific features (widgets, specific notification channels) are unavailable
 - Performance may vary on low-spec hardware running Compose Desktop
@@ -144,7 +143,7 @@ Requirements:
 ## Related Topics
 
 - [Connections](connections) — connection methods overview
-- [Firmware Updates](firmware) — in-app USB update on desktop, or the [Web Flasher](https://flasher.meshtastic.org)
+- [Firmware Updates](firmware) — USB, BLE, and Wi-Fi update all work the same as on Android
 
 ---
 

--- a/docs/en/user/discovery.md
+++ b/docs/en/user/discovery.md
@@ -2,7 +2,7 @@
 title: Discovery
 parent: User Guide
 nav_order: 12
-last_updated: 2026-06-11
+last_updated: 2026-07-08
 description: Explore your mesh network — the Local Mesh Discovery scanner, traceroute paths, neighbor maps, and node discovery tools.
 aliases:
   - mesh-discovery
@@ -115,8 +115,8 @@ Each hop represents a relay node that forwarded the message. The SNR and RSSI va
 
 | What to look for | What it means |
 |------------------|---------------|
-| All hops show Good SNR (> 5 dB) | Healthy path — messages flow reliably |
-| One hop shows Bad SNR (< 0 dB) | Weak link — this relay segment is fragile |
+| All hops show Good SNR (≥ −7 dB, green) | Healthy path — messages flow reliably |
+| One hop shows Bad SNR (< −15 dB, red) | Weak link — this relay segment is fragile |
 | Many hops (4+) | Long path — consider repositioning a node to shorten it |
 | Different path on retry | Mesh is adapting — multiple routes exist (this is good!) |
 

--- a/docs/en/user/firmware.md
+++ b/docs/en/user/firmware.md
@@ -17,7 +17,7 @@ Keep your Meshtastic radio up to date with the latest firmware for new features,
 
 ## Checking for Updates
 
-1. Open the connected radio's configuration and, under **Advanced**, tap **Firmware Update** — or tap the firmware notification if one is shown. The entry appears only for OTA-capable devices.
+1. Open the connected radio's configuration and, under **Advanced**, tap **Firmware Update**. The entry appears only for OTA-capable devices.
 2. The app checks for available firmware versions.
 3. Available updates show the version number and changelog summary.
 

--- a/docs/en/user/map-and-waypoints.md
+++ b/docs/en/user/map-and-waypoints.md
@@ -2,13 +2,17 @@
 title: Map & Waypoints
 parent: User Guide
 nav_order: 6
-last_updated: 2026-06-25
-description: View node positions on the map, create and share waypoints, and manage position sharing and privacy.
+last_updated: 2026-07-08
+description: View node positions on the map, create and share waypoints, manage map layers and Site Planner, and control position sharing and privacy.
 aliases:
   - map
   - waypoints
   - gps
   - location
+  - site-planner
+  - map-layers
+  - geojson
+  - kml
 ---
 
 # Map & Waypoints
@@ -52,19 +56,30 @@ Waypoints are shared geographic points of interest that all mesh members can see
 
 | Property | Description |
 |----------|-------------|
-| Name | Short identifier (max 30 characters) |
+| Name | Short identifier (max 29 characters) |
 | Description | Optional longer description |
 | Icon | Visual marker emoji on the map |
 | Locked | If locked, only the creator can edit or delete |
-| Expiration | Optional auto-remove time |
+| Expiration | Optional auto-remove date and time |
+| Geofence | Optional enter/exit alert area — see below |
 
 ### Waypoint Expiration
 
 Waypoints can be set to expire automatically:
 - **Never** (default) — waypoint remains until manually deleted
-- **Timed** — waypoint is automatically removed after the specified duration (e.g., "remove after 2 hours"). Useful for temporary markers like rally points, hazards, or meeting locations.
+- **Timed** — pick a specific date and time; the waypoint is automatically removed once that time passes. Useful for temporary markers like rally points, hazards, or meeting locations.
 
-Expired waypoints are automatically hidden from the map so they don't clutter the display. The expiration countdown begins when the waypoint is created, not when other nodes receive it.
+Expired waypoints are automatically hidden from the map so they don't clutter the display. The expiration countdown is based on the absolute time you picked, not a duration from when the waypoint was created or received.
+
+### Waypoint Geofences
+
+Any waypoint can also define a **geofence** — an alert area — so you or others get notified when a node enters or leaves it:
+
+1. Set a **geofence radius** from the preset chips (or **Off** to disable), or tap **Set area on map** to draw a custom rectangular area instead.
+2. Once a region is set, toggle **Notify on enter** and/or **Notify on exit**.
+3. Optionally enable **Favorites only** to limit alerts to your favorited nodes.
+
+Since waypoints (and their geofences) are broadcast to the whole mesh, only the **creator** is alerted by default. If someone else shares a geofenced waypoint with you, its detail view offers a **"Notify me of crossings"** opt-in so you can also receive enter/exit alerts for it.
 
 ### Managing Waypoints
 
@@ -72,6 +87,14 @@ Expired waypoints are automatically hidden from the map so they don't clutter th
 - Edit or delete waypoints you created
 - **Locked waypoints** cannot be modified or deleted by other nodes — only the original creator can change them
 - Unlocked waypoints can be edited by any mesh member
+
+## Map Layers
+
+Tap the layers icon on the map to open **Manage Map Layers**, where you can import your own overlays in `.kml`, `.kmz`, or GeoJSON format — either by opening a file with Meshtastic or sharing it into the app from another app. Imported layers are listed with a toggle to show/hide each one and an option to remove it. This is available on both the Google Play and F-Droid builds.
+
+### Site Planner
+
+**Site Planner** estimates RF coverage for a transmitter and draws it on the map as a color-coded overlay. Open it from a map control, or from a node's detail page via **Estimate coverage** (shown only for nodes with a known position). Configure the transmitter (location, frequency, TX power, antenna gain and height), the receiver (sensitivity, height), and simulation options (max range, high-resolution terrain, color palette), then run the estimate. Like map layers, Site Planner works on both the Google Play and F-Droid builds.
 
 ## Position Sharing
 

--- a/docs/en/user/messages-and-channels.md
+++ b/docs/en/user/messages-and-channels.md
@@ -2,7 +2,7 @@
 title: Messages & Channels
 parent: User Guide
 nav_order: 3
-last_updated: 2026-06-25
+last_updated: 2026-07-08
 description: Send and receive messages, manage channels, configure encryption, search conversations, and use quick chat, reactions, and message actions.
 aliases:
   - channels
@@ -57,15 +57,17 @@ Direct messages (DMs) are point-to-point encrypted communications between two sp
 
 ### Message States
 
-| State | Icon | Meaning |
-|-------|------|---------|
-| Queued | ⏳ | Message waiting to be sent |
-| En route | ✓ | Delivered to the radio, awaiting acknowledgment |
-| Delivered | ✓✓ | Acknowledgment received from recipient |
-| Received | ✓ | Message received from the mesh (incoming) |
-| S&F Routing | 🔗 | Store & Forward: message being routed through an S&F node |
-| S&F Confirmed | 🔗 | Store & Forward: delivery confirmed via S&F node |
-| Error | ✗ | Delivery failed after retries |
+A status label appears under **your own** outgoing messages only (incoming messages from others show no status label):
+
+| State | Meaning |
+|-------|---------|
+| Sending… | Queued or already handed to the radio, not yet resolved either way (queued and en-route both show this same text) |
+| Delivered to recipient | The strongest confirmation for a direct message — an acknowledgment came back |
+| Delivered to mesh | For a channel broadcast, the message reached the mesh (broadcasts have no per-recipient ack) |
+| Relayed, not confirmed by recipient | For a direct message, shown in a warning color — the message was relayed but no acknowledgment has come back yet |
+| Routing via SF++ chain… | Being routed/buffered by the Store & Forward Plus Plus chain |
+| Confirmed on SF++ chain | Confirmed delivered via the SF++ chain |
+| Error | Delivery failed — tap the status for the specific reason (see Delivery Errors below) |
 
 ### Delivery Errors
 

--- a/docs/en/user/node-metrics.md
+++ b/docs/en/user/node-metrics.md
@@ -2,7 +2,7 @@
 title: Node Metrics
 parent: User Guide
 nav_order: 5
-last_updated: 2026-06-25
+last_updated: 2026-07-08
 description: Telemetry dashboards for each mesh node — device health, environment sensors, air quality, signal quality, power, traceroute, and position history.
 aliases:
   - metrics
@@ -104,8 +104,8 @@ Signal quality is rated from **SNR relative to the active LoRa modem preset's de
 | Quality | Criteria |
 |---------|----------|
 | Good | SNR above the preset's limit |
-| Fair | up to 5.5 dB below the limit |
-| Bad | between 5.5 dB and 7.5 dB below the limit |
+| Fair | less than 5.5 dB below the limit |
+| Bad | 5.5 dB to 7.5 dB below the limit |
 | None | more than 7.5 dB below the limit |
 
 See [Understanding the Signal Meter](signal-meter) for the full explanation.

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -2,12 +2,13 @@
 title: Nodes
 parent: User Guide
 nav_order: 4
-last_updated: 2026-06-25
+last_updated: 2026-07-08
 description: Browse, filter, and sort mesh nodes — view details, signal quality, roles, and quick actions.
 aliases:
   - node-list
   - mesh-nodes
   - peers
+  - hop-histogram
 ---
 
 # Nodes
@@ -120,6 +121,10 @@ Type in the search field to filter nodes by name or short name. The filter updat
 | **Channel** | Grouped by channel index |
 | **Via MQTT** | Grouped by MQTT vs. radio-heard |
 | **Favorites** | Favorited nodes first |
+
+## Nodes per Hop
+
+Tap the hop-histogram icon in the node list's app bar to open a bar chart of how many nodes sit at each hop distance (0 = direct, 1 = one relay away, and so on). Filter the chart to a **last heard** window — All time, 1 hour, 8 hours, or 24 hours — to see how the mesh looks right now versus over a longer period. It's a quick way to gauge how busy and spread out your local mesh is.
 
 ## Node Detail
 

--- a/docs/en/user/onboarding.md
+++ b/docs/en/user/onboarding.md
@@ -2,7 +2,7 @@
 title: Getting Started
 parent: User Guide
 nav_order: 1
-last_updated: 2026-05-13
+last_updated: 2026-07-08
 description: First-launch setup — permissions, onboarding flow, and next steps after connecting your radio.
 aliases:
   - first-launch
@@ -60,10 +60,10 @@ If denied, Bluetooth scanning will not function and your node will not report a 
 
 Notifications alert you to:
 - Incoming messages from channels and direct messages
-- Connection status changes (connected, disconnected, reconnecting)
-- Firmware update availability
+- New nodes joining the mesh
+- Low battery on a remote node
 
-> 💡 **Tip:** You can fine-tune notification preferences later in Android system settings. The app creates separate notification channels for messages, connection events, and background service status.
+> 💡 **Tip:** You can fine-tune notification preferences later in Android system settings — the app creates a separate notification channel per category (plus a few internal ones, like the background service), so you can enable or silence them individually.
 
 ### Critical Alerts Permission
 

--- a/docs/en/user/settings-module-admin.md
+++ b/docs/en/user/settings-module-admin.md
@@ -2,7 +2,7 @@
 title: Settings — Modules & Admin
 parent: User Guide
 nav_order: 8
-last_updated: 2026-05-20
+last_updated: 2026-07-08
 description: Configure optional feature modules (MQTT, telemetry, canned messages, TAK, and more) and perform device administration.
 aliases:
   - modules
@@ -81,10 +81,11 @@ Buffers messages for nodes that were temporarily offline, then replays them when
 | Setting | Description |
 |---------|-------------|
 | Enabled | Activate store and forward |
-| Heartbeat (s) | Announcement interval |
+| Heartbeat | Periodically announce this node's store-and-forward capability |
 | Records | Maximum stored messages |
 | History Return (max) | Max messages to replay |
 | History Return (window) | Time window for replay |
+| Server | Act as a store-and-forward server for the mesh (requires ample memory, e.g. ESP32 with PSRAM) |
 
 > 💡 **Tip:** Store and Forward works best on nodes with ample memory (ESP32 with PSRAM). Router nodes are ideal candidates since they're typically always-on.
 
@@ -145,6 +146,7 @@ GPIO control over the mesh network. Allows a remote node to read or write GPIO p
 |---------|-------------|
 | Enabled | Activate remote GPIO access |
 | Allow Undefined Pins | Allow access to any GPIO pin (security risk) |
+| Available Pins | Up to 4 GPIO pins this node exposes for remote read/write |
 
 > ⚠️ **Warning:** Enabling "Allow Undefined Pins" gives remote nodes access to all GPIO pins, which could interfere with the radio's own hardware. Only enable on dedicated GPIO nodes.
 
@@ -156,6 +158,7 @@ Broadcasts information about directly heard neighbors, enabling mesh topology ma
 |---------|-------------|
 | Enabled | Activate neighbor broadcasting |
 | Update Interval (s) | How often to broadcast neighbor list |
+| Transmit Over LoRa | Also broadcast neighbor info over LoRa, not just MQTT/phone. Unavailable on a channel using the default key and name |
 
 See [Discovery](discovery) for how to use neighbor data for mesh topology exploration.
 
@@ -165,8 +168,8 @@ Controls onboard NeoPixel or other addressable RGB LEDs on supported hardware. C
 
 | Setting | Description |
 |---------|-------------|
-| Enabled | Activate LED control |
-| LED State | On, Off, or set specific color |
+| LED State | Turn the LED on or off |
+| Current | LED current limit (0–31) |
 | Red / Green / Blue | Individual color channel values (0–255) |
 
 ### Detection Sensor Module
@@ -177,7 +180,8 @@ Turns your node into a motion or door sensor alert system. When a GPIO pin detec
 |---------|-------------|
 | Enabled | Activate detection sensor |
 | Monitor Pin | GPIO pin connected to sensor |
-| Detection Triggered High | Trigger when pin goes high (vs. low) |
+| Detection Trigger Type | How the pin's state maps to a detection event (e.g. active high/low, edge-triggered) |
+| Use Input Pullup Mode | Enable the pin's internal pull-up resistor |
 | Minimum Broadcast (s) | Minimum time between alert broadcasts |
 | State Broadcast (s) | Periodic state broadcast interval |
 | Send Bell | Include bell character in alerts |
@@ -225,10 +229,7 @@ Remotely reboot a connected or administered node.
 
 ### Debug Panel
 
-View detailed diagnostic information:
-- Protocol buffers debug output
-- Mesh packet log
-- Connection state details
+Opens the **Packets** and **App logs** tabs for viewing, filtering, and exporting diagnostic output. See [Debug Logs](debug-logs) for the full walkthrough.
 
 ### Troubleshooting Remote Admin
 

--- a/docs/en/user/settings-radio-user.md
+++ b/docs/en/user/settings-radio-user.md
@@ -2,7 +2,7 @@
 title: Settings — Radio & User
 parent: User Guide
 nav_order: 7
-last_updated: 2026-05-20
+last_updated: 2026-07-08
 description: Configure your radio hardware, LoRa presets, user profile, position sharing, power management, and security.
 aliases:
   - settings
@@ -59,19 +59,19 @@ After modifying settings, tap **Save** to write the configuration to your radio.
 
 | Preset | Range | Speed | SNR Limit | Best For |
 |--------|-------|-------|-----------|----------|
-| Short Turbo | ~1 km | 21.9 kbps | −5 dB | Dense urban with line-of-sight; data-heavy applications |
+| Short Turbo | ~1 km | 21.9 kbps | −7.5 dB | Dense urban with line-of-sight; data-heavy applications |
 | Short Fast | ~3 km | 10.9 kbps | −7.5 dB | Urban neighborhoods; buildings within a few blocks |
 | Short Slow | ~5 km | 5.5 kbps | −10 dB | Suburban short-range; moderate building density |
-| Medium Fast | ~5 km | 5.5 kbps | −10 dB | Suburban areas; moderate building density |
-| Medium Slow | ~8 km | 1.1 kbps | −12.5 dB | Suburban/rural; moderate range with slower speed |
-| Long Turbo | ~10 km | 4.4 kbps | −10 dB | Similar range to Long Fast but with 500 kHz bandwidth; faster throughput |
-| Long Fast | ~10 km | 1.1 kbps | −12.5 dB | **General use (default)** — balanced range and speed |
-| Long Moderate | ~20 km | 0.34 kbps | −15 dB | Rural with some terrain; occasional use |
-| Lite Fast | ~5 km | 5.5 kbps | −10 dB | EU 866 MHz SRD band (125 kHz BW); comparable to Medium Fast |
-| Lite Slow | ~10 km | 1.1 kbps | −12.5 dB | EU 866 MHz SRD band (125 kHz BW); comparable to Long Fast |
+| Medium Fast | ~5 km | 5.5 kbps | −12.5 dB | Suburban areas; moderate building density |
+| Medium Slow | ~8 km | 1.1 kbps | −15 dB | Suburban/rural; moderate range with slower speed |
+| Long Turbo | ~10 km | 4.4 kbps | −12.5 dB | Similar range to Long Fast but with 500 kHz bandwidth; faster throughput |
+| Long Fast | ~10 km | 1.1 kbps | −17.5 dB | **General use (default)** — balanced range and speed |
+| Long Moderate | ~20 km | 0.34 kbps | −17.5 dB | Rural with some terrain; occasional use |
+| Lite Fast | ~5 km | 5.5 kbps | −12.5 dB | EU 866 MHz SRD band (125 kHz BW); comparable to Medium Fast |
+| Lite Slow | ~10 km | 1.1 kbps | −15 dB | EU 866 MHz SRD band (125 kHz BW); comparable to Long Fast |
 | Narrow Fast | ~5 km | 2.7 kbps | −10 dB | EU 868 MHz band (62.5 kHz BW); avoids interference with other devices |
 | Narrow Slow | ~10 km | 1.1 kbps | −12.5 dB | EU 868 MHz band (62.5 kHz BW); comparable to Long Fast |
-| ~~Long Slow~~ | ~30 km | 0.18 kbps | −17.5 dB | ⚠️ **Deprecated** — still selectable but may be removed in a future firmware release |
+| ~~Long Slow~~ | ~30 km | 0.18 kbps | −20 dB | ⚠️ **Deprecated** — still selectable but may be removed in a future firmware release |
 | ~~Very Long Slow~~ | ~40+ km | 0.09 kbps | −20 dB | ⚠️ **Deprecated** — still selectable but may be removed in a future firmware release |
 
 > ℹ️ **Note:** This table uses the common short names. In the app's preset dropdown they read as **Short Range - Fast**, **Long Range - Fast**, **Lite - Fast**, **Narrow - Fast**, and so on.

--- a/docs/en/user/signal-meter.md
+++ b/docs/en/user/signal-meter.md
@@ -2,7 +2,7 @@
 title: How the Meshtastic Signal Meter Works
 parent: User Guide
 nav_order: 15
-last_updated: 2026-06-25
+last_updated: 2026-07-08
 description: How the signal meter rates quality from SNR relative to the LoRa modem preset — spread spectrum, presets, and what the bars really mean.
 aliases:
   - signal
@@ -54,8 +54,8 @@ Because the rating is relative to the preset limit, the *same* SNR can rate diff
 | Level | Bars | Criteria | Meaning |
 |-------|------|----------|---------|
 | Good | 3 | SNR **above** the preset's `limit` | Signal is comfortably above the demodulation floor — healthy connection. |
-| Fair | 2 | up to `5.5 dB` below the `limit` | Decodable, but getting close to the floor. |
-| Bad | 1 | between `5.5 dB` and `7.5 dB` below the `limit` | At the very edge of what the preset can recover. |
+| Fair | 2 | less than `5.5 dB` below the `limit` | Decodable, but getting close to the floor. |
+| Bad | 1 | `5.5 dB` to `7.5 dB` below the `limit` | At the very edge of what the preset can recover. |
 | None | 0 | more than `7.5 dB` below the `limit` | Below the floor — transmission lost to noise. |
 
 > **Note:** The fixed SNR thresholds you may have seen elsewhere (`-7 dB` / `-15 dB`) are now only used for coloring individual hops in traceroute results — not for the per-node signal meter described here.

--- a/docs/en/user/tak.md
+++ b/docs/en/user/tak.md
@@ -2,7 +2,7 @@
 title: TAK Integration
 parent: User Guide
 nav_order: 10
-last_updated: 2026-05-13
+last_updated: 2026-07-08
 description: Interoperate with ATAK and WinTAK — CoT position sharing, TAK roles, and plugin setup.
 aliases:
   - tak
@@ -78,24 +78,23 @@ When using TAK roles, your node broadcasts identity information that appears on 
 
 | Setting | Description |
 |---------|-------------|
-| Team | Your team color on the TAK map (e.g., Blue, Red, Cyan, Green) |
-| Role | Your operational role (Team Member, Team Lead, HQ, Medic, RTO, etc.) |
-| Callsign | Your TAK callsign (defaults to your Meshtastic long name) |
+| Team Color | Your team color on the TAK map (e.g., Blue, Red, Cyan, Green) |
+| Member Role | Your operational role (Team Member, Team Lead, HQ, Medic, RTO, etc.) |
 
-These settings appear in **Settings → Module Config → TAK** when the TAK module is enabled.
+These settings appear in **Settings → Module Config → TAK** when the TAK module is enabled. Your TAK callsign isn't a separate setting — it's derived automatically from your Meshtastic node name.
 
 > 💡 **Tip:** Team/role colors are the standard TAK affiliation colors. Coordinate with your TAK team to use consistent team assignments.
 
 ## Wire Format (V1 / V2)
 
-Meshtastic supports two TAK wire formats:
+Meshtastic supports two TAK wire formats, chosen automatically based on the connected radio's firmware — no manual configuration needed:
 
 | Format | Compatibility | Features |
 |--------|--------------|----------|
-| V1 (Legacy) | ATAK Plugin v1.x, older firmware | Basic CoT position sharing only |
-| V2 (Current) | ATAK Plugin v2.x, firmware 2.3+ | Full CoT support including chat, routes, zstd compression |
+| V1 (Legacy) | Firmware 2.7.x and older | Bare protobuf encoding on port 72. Supports position sharing (PLI) and chat (GeoChat) only — shapes, markers, routes, and other typed CoT events are dropped |
+| V2 (Current) | Firmware 2.8.0+ | Compact, zstd-compressed encoding on port 78. Adds shapes, markers, routes, aircraft, casevac, emergency, and task CoT types on top of everything V1 supports |
 
-The app automatically selects V2 when both sides support it. No manual configuration needed — the TAK module negotiates format based on firmware capabilities.
+A node still relays legacy V1 packets from older nodes even while running V2 itself, so mixed-firmware meshes keep working.
 
 ## Usage with ATAK
 
@@ -114,7 +113,7 @@ Once configured:
 | Node doesn't appear on ATAK map | TAK module disabled or wrong role | Verify TAK module is enabled and node role is TAK or TAK Tracker |
 | Position updates are stale | GPS fix lost or interval too long | Check GPS status; reduce position broadcast interval in Position Config |
 | ATAK plugin shows "disconnected" | BLE connection lost or plugin crashed | Reconnect Bluetooth in Meshtastic app, then restart ATAK plugin |
-| Chat messages not bridging | V1 format doesn't support chat | Ensure both nodes run firmware 2.3+ for V2 wire format |
+| Shapes, markers, or routes not bridging | Sending node is on legacy V1 (firmware 2.7.x or older) | Update the sending node's firmware to 2.8.0+ for V2 wire format |
 | CoT data not flowing | Channel mismatch | All TAK nodes must be on the same channel with matching encryption |
 
 ## Security Considerations

--- a/docs/en/user/units-and-locale.md
+++ b/docs/en/user/units-and-locale.md
@@ -2,7 +2,7 @@
 title: Units, Measurement & Locale
 parent: User Guide
 nav_order: 16
-last_updated: 2026-05-12
+last_updated: 2026-07-08
 description: How the app formats temperature, distance, speed, and other measurements based on your device locale.
 ---
 
@@ -14,7 +14,7 @@ The Meshtastic app automatically displays temperatures, distances, speeds, and t
 
 ## How It Works
 
-Meshtastic radios always transmit data in **metric units** (meters, °C, km/h, hPa, etc.). When the app receives this data, it converts and displays values in whatever unit system your device's locale specifies.
+Meshtastic radios always transmit data in **metric units** (meters, °C, m/s, hPa, etc.). When the app receives this data, it converts and displays values in whatever unit system your device's locale specifies.
 
 On Android, your measurement preferences are determined by your system **Language & Region** settings. On Desktop (JVM), the app uses the JVM's default `Locale`.
 


### PR DESCRIPTION
## Why

Follow-up to #6150 (the first docs/en audit). Two things prompted a second pass: several features shipped without doc updates in the days around that PR, and — caught while re-verifying — **the squash-merge on GitHub silently dropped that PR's CodeRabbit-review follow-up commit**. `signal-meter.md`, `node-metrics.md`, `units-and-locale.md`, and `codebase.md` had reverted to their pre-review wording on `main` even though the review threads show resolved. All four are reapplied here, plus a fresh audit of everything else.

Every claim below was verified against the current source (grep/read, not assumed) before editing — three independent fresh audit passes ran in parallel, then each finding was cross-checked against the actual code, strings, and Compose UI before I touched a file.

## 🐛 Corrections — factual errors

- `settings-radio-user.md` — Modem Preset SNR Limit table was wrong on **9 of 14 presets, including the default** (Long Fast: doc said −12.5 dB, code says −17.5 dB). Verified against `ChannelOption.kt`.
- `debug-logs.md` — privacy note claimed channel keys are redacted from log exports; they aren't (only `private_key`/`admin_key`/`session_passkey` are — verified against `LogFormatter.kt`). Softened the claim so it doesn't overpromise.
- `adding-a-feature-module.md` — the copy-paste `build.gradle.kts` example used `androidLibrary { withHostTest {} }`, a DSL block that exists nowhere in the repo; every real feature module uses `android { withHostTest { isIncludeAndroidResources = true } }`.
- `codebase.md` — convention-plugin classes live in `build-logic/convention/src/main/kotlin/` (default package), not the documented subpackage; the tree also showed a `build-logic/flatpak/` directory deleted back in #5619.
- `tak.md` — wire-format table said V2 needs firmware "2.3+" (actually 2.8.0, per `Capabilities.supportsTakV2`); said V1 doesn't support chat (it does — GeoChat, per `TAKMeshIntegration.kt`); documented a "Callsign" module setting that doesn't exist in the UI (it's auto-derived from the node name).
- `onboarding.md` — notification-permission blurb described "connection status" and "firmware update" notification categories that don't exist; the real three are messages/new nodes/low battery (`NotificationsScreen.kt`).
- `messages-and-channels.md` — Message States table rewritten: queued and en-route render identical "Sending…" text, "Delivered" means something different for a direct message vs. a channel broadcast, and the status label only appears on your own outgoing messages, never on incoming ones (verified against `Message.kt`/`MessageItem.kt`).
- `settings-module-admin.md` — five module-config tables had drifted from the current Compose UI (Store & Forward, Remote Hardware, Neighbor Info, Ambient Lighting, Detection Sensor) — missing fields, and one boolean documented as if it were a numeric interval.
- `desktop.md` — my own claim from the first audit round that BLE/Wi-Fi OTA firmware update is Android-only was itself wrong; traced `DefaultFirmwareUpdateManager`'s dispatch logic and it's fully cross-platform with no desktop gating anywhere in the stack.

## 🌟 Newly documented (shipped, previously undocumented)

- "Nodes per Hop" histogram on the node list app bar → `nodes.md`
- Map Layers (import your own GeoJSON/KML/KMZ overlays) + Site Planner (RF coverage estimation), now on F-Droid as well as Google Play (#6148) → `map-and-waypoints.md`
- Waypoint geofences — enter/exit alerts, creator-only by default with a per-geofence opt-in for others → `map-and-waypoints.md`
- `@mentions` (tap to jump to a node) and on-device message translation (Google Play only) → `messages-and-channels.md`

## 🧹 Smaller corrections

Waypoint name limit is 29 characters not 30; added the missing `formatDateTimeShort()` to the `DateFormatter` reference; added 4 Room entities from Discovery/device-links that were missing from the persistence table; fixed a stale numeric spec-prefix example (specs now use timestamp-based names); added a `/discovery` row to the deep-link table; fixed a couple of button-label mismatches; refreshed both "What's New" lists (kept at the 8-entry cap).

## For reviewers

Given the squash-merge issue on #6150, it's worth merging this one with a regular merge commit, or double-checking the squash captures the final pushed state rather than the branch's first commit.

## Testing

Content-only Markdown edits, scoped entirely to `docs/en/`. No frontmatter schema or link-structure changes beyond what's described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for map layers, Site Planner overlays, geofences, hop histogram charts, and improved message status details.
  * Expanded guidance for discovery, TAK integration, firmware updates, and desktop firmware parity.
* **Bug Fixes**
  * Clarified signal-quality thresholds, modem preset limits, and deep link/navigation references for more accurate in-app guidance.
* **Documentation**
  * Updated several user and developer guides, including onboarding, persistence, transport, and contribution instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->