### PR TITLE
ci: publish rolling -SNAPSHOT build of main to a GitHub prerelease

### DIFF
--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           fetch-depth: 0 # git rev-list --count needs full history for the versionCode
           token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+          persist-credentials: false # no git push here; gh does the authed work via GH_TOKEN
 
       - name: Download debug APKs
         uses: actions/download-artifact@v8
@@ -67,24 +68,22 @@ jobs:
           done
           ls -l upload
 
-      # Delete the previous snapshot release AND its tag, then let action-gh-release recreate
-      # both at HEAD. This prunes the now-stale (differently-named) APKs so they don't pile up,
-      # and sidesteps the Releases API refusing to retarget an already-existing tag.
+      # Delete the previous snapshot release AND its tag, then recreate both at HEAD. This
+      # prunes the now-stale (differently-named) APKs so they don't pile up, and sidesteps the
+      # Releases API refusing to retarget an already-existing tag.
       - name: Remove previous snapshot release
         run: gh release delete snapshot --yes --cleanup-tag || true
 
       - name: Publish snapshot release
-        uses: softprops/action-gh-release@v3
-        with:
-          token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
-          tag_name: snapshot
-          name: Snapshot ${{ env.VERSION_CODE }} (${{ github.sha }})
-          target_commitish: ${{ github.sha }}
-          body: |
-            Automated debug build from the latest commit on `main` (${{ github.sha }}), versionCode ${{ env.VERSION_CODE }}.
-            Unsigned/debug-keyed, F-Droid and Google flavors. Not for production use — this release is replaced on every push to main.
+        run: |
+          cat > notes.md <<EOF
+          Automated debug build from the latest commit on \`main\` ($GITHUB_SHA), versionCode $VERSION_CODE.
+          Unsigned/debug-keyed, F-Droid and Google flavors. Not for production use — this release is replaced on every push to main.
 
-            **Obtainium:** enable *Include prereleases*. Each build's APK filename carries the versionCode, so updates are detected.
-          files: upload/*.apk
-          prerelease: true
-          generate_release_notes: false
+          **Obtainium:** enable *Include prereleases*. Each build's APK filename carries the versionCode, so updates are detected.
+          EOF
+          gh release create snapshot upload/*.apk \
+            --title "Snapshot $VERSION_CODE ($GITHUB_SHA)" \
+            --target "$GITHUB_SHA" \
+            --prerelease \
+            --notes-file notes.md

--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -23,3 +23,68 @@ jobs:
       run_unit_tests: false
       upload_artifacts: true
     secrets: inherit
+
+  # Republishes the debug APKs validate-and-build already produced as a rolling "snapshot"
+  # prerelease that moves to HEAD on every push to main, so testers get a stable download
+  # link instead of digging through Actions artifacts (which require a GitHub login and
+  # expire after 7 days).
+  publish-snapshot:
+    needs: validate-and-build
+    if: github.repository == 'meshtastic/Meshtastic-Android'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+    env:
+      # CROWDIN_GITHUB_TOKEN (a PAT), not the default GITHUB_TOKEN, because the repo's tag
+      # rulesets block the default token from creating/deleting tags — same token every other
+      # tag-touching workflow here uses.
+      GH_TOKEN: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0 # git rev-list --count needs full history for the versionCode
+          token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+
+      - name: Download debug APKs
+        uses: actions/download-artifact@v8
+        with:
+          name: app-debug-apks
+          path: artifacts
+
+      # A moving tag reuses the same release URL forever, and Obtainium fingerprints the
+      # asset URL — so without a changing filename it would never detect a new build.
+      # Embed the (monotonic) versionCode in each APK name; same formula the app build uses.
+      - name: Rename APKs with versionCode
+        run: |
+          COMMIT_COUNT=$(git rev-list --count HEAD)
+          OFFSET=$(grep '^VERSION_CODE_OFFSET=' config.properties | cut -d'=' -f2)
+          VERSION_CODE=$((COMMIT_COUNT + OFFSET))
+          echo "VERSION_CODE=$VERSION_CODE" >> "$GITHUB_ENV"
+          mkdir -p upload
+          find artifacts -name '*.apk' | while read -r f; do
+            cp "$f" "upload/$(basename "$f" .apk)-${VERSION_CODE}.apk"
+          done
+          ls -l upload
+
+      # Delete the previous snapshot release AND its tag, then let action-gh-release recreate
+      # both at HEAD. This prunes the now-stale (differently-named) APKs so they don't pile up,
+      # and sidesteps the Releases API refusing to retarget an already-existing tag.
+      - name: Remove previous snapshot release
+        run: gh release delete snapshot --yes --cleanup-tag || true
+
+      - name: Publish snapshot release
+        uses: softprops/action-gh-release@v3
+        with:
+          token: ${{ secrets.CROWDIN_GITHUB_TOKEN }}
+          tag_name: snapshot
+          name: Snapshot ${{ env.VERSION_CODE }} (${{ github.sha }})
+          target_commitish: ${{ github.sha }}
+          body: |
+            Automated debug build from the latest commit on `main` (${{ github.sha }}), versionCode ${{ env.VERSION_CODE }}.
+            Unsigned/debug-keyed, F-Droid and Google flavors. Not for production use — this release is replaced on every push to main.
+
+            **Obtainium:** enable *Include prereleases*. Each build's APK filename carries the versionCode, so updates are detected.
+          files: upload/*.apk
+          prerelease: true
+          generate_release_notes: false

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -488,6 +488,14 @@ jobs:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache_read_only: ${{ needs.setup.outputs.cache_read_only }}
 
+      # ponytail: -SNAPSHOT only on main pushes, so PR/merge-queue debug builds keep the plain
+      # base version. Publishing the resulting APKs is main-check.yml's job, not this one.
+      - name: Tag main-branch builds as -SNAPSHOT
+        if: github.event_name == 'push'
+        run: |
+          BASE=$(grep '^VERSION_NAME_BASE=' config.properties | cut -d'=' -f2)
+          echo "VERSION_NAME=${BASE}-SNAPSHOT" >> "$GITHUB_ENV"
+
       - name: Build Android APKs
         run: ./gradlew androidApp:assembleFdroidDebug androidApp:assembleGoogleDebug -Pci=true --parallel --configuration-cache --continue
 

--- a/obtainium-test-builds.md
+++ b/obtainium-test-builds.md
@@ -23,12 +23,21 @@ release is published (un-drafted) when a build is promoted to closed or higher.
 | **stable** | Production | published, marked *Latest* | ✅ Yes |
 | **open** beta | Beta (Open) | published prerelease, tag `vX.Y.Z-open.N` | ✅ Yes |
 | **closed** beta | Alpha (Closed) | published prerelease, tag `vX.Y.Z-closed.N` | ✅ Yes |
+| **snapshot** | — (not on Play) | rolling prerelease, tag `snapshot` | ✅ Yes |
 
-Only **one** test build is "live" on GitHub at a time: as a build is promoted,
-its release object moves forward (its tag changes from `-closed.N` to `-open.N`
-to the clean production tag). So a `-closed`/`-open` build is installable only
-while it is currently parked in that channel — once promoted onward, the old
-channel tag no longer has a release.
+Only **one** promoted test build is "live" on GitHub at a time: as a build is
+promoted, its release object moves forward (its tag changes from `-closed.N` to
+`-open.N` to the clean production tag). So a `-closed`/`-open` build is
+installable only while it is currently parked in that channel — once promoted
+onward, the old channel tag no longer has a release.
+
+**Snapshot** is different: it's an automated debug build of the latest commit on
+`main`, rebuilt and re-published under the single moving `snapshot` tag on every
+push. It never goes to Play. Because debug builds use a `.debug` application-ID
+suffix (`com.geeksville.mesh.fdroid.debug` / `com.geeksville.mesh.google.debug`)
+and the debug signing key, a snapshot installs as its **own separate app** — it
+sits alongside a Play/stable/beta install, so the uninstall-first warning above
+does **not** apply to it.
 
 ## Setup
 
@@ -60,14 +69,34 @@ channel tag no longer has a release.
 - **Filter release titles by regular expression:** `-closed\.`
 - **Filter APKs by regular expression:** see [Picking the APK](#picking-the-apk)
 
-### Bleeding edge (newest test build, any channel)
+### Bleeding edge (newest promoted test build, any channel)
 
 - **Include prereleases:** on
-- *(no release-title filter)*
+- **Filter release titles by regular expression:** `-(closed|open)\.`
 - **Filter APKs by regular expression:** see [Picking the APK](#picking-the-apk)
 
-Obtainium installs the newest published prerelease — whatever is currently in
-open or closed.
+Obtainium installs the newest promoted prerelease — whatever is currently in
+open or closed. The title filter is required to skip the always-newer `snapshot`
+prerelease; without it Obtainium would follow snapshot instead.
+
+### Snapshot (latest commit on `main`)
+
+- **Include prereleases:** on
+- **Filter release titles by regular expression:** `^Snapshot`
+- **Filter APKs by regular expression:** debug-signed names, see below
+
+Follows `main` directly — updates on every push. These are **debug builds**
+(`.debug` package, debug key), so they install as a separate app and won't
+disturb a stable/beta install. The APKs are named `…-debug-<versionCode>.apk`
+(not `-release.apk`), so use debug-suffixed filters:
+
+| You want | Regex |
+|---|---|
+| Google flavor, most phones (arm64) | `google-arm64-v8a-debug-\d+\.apk` |
+| fdroid flavor, most phones (arm64) | `fdroid-arm64-v8a-debug-\d+\.apk` |
+| fdroid flavor, one-size-fits-all | `fdroid-universal-debug-\d+\.apk` |
+
+Snapshot releases attach only the debug APKs — no `.aab` or desktop installers.
 
 > **If your channel filter finds nothing:** when no build is parked in that
 > exact channel, the title filter matches no current release (old channel tags


### PR DESCRIPTION
## Why

There's currently no easy way to grab a build of the very latest `main` — testers have to dig through Actions artifacts, which require a GitHub login and expire after 7 days. This adds a rolling `snapshot` prerelease that tracks `main` and gives testers (and Obtainium) a stable download link, at essentially zero extra CI cost since it reuses the debug APKs the pipeline already builds.

## Changes

### 🌟 New Features
- **Rolling `snapshot` prerelease.** New `publish-snapshot` job in `main-check.yml` runs on every push to `main`, republishing the existing debug APKs as a GitHub prerelease under the moving `snapshot` tag. No new build steps, no new secrets, no Play/Firebase channel.
- **`-SNAPSHOT` versionName** stamped on main-branch builds only (`reusable-check.yml`); PR and merge-queue builds keep the plain base version.

### 🛠️ Architecture / mechanics
- APK filenames embed the monotonic `versionCode` (`…-debug-<versionCode>.apk`). A moving tag reuses the same asset URL forever, and Obtainium fingerprints that URL — so without a changing filename it would never detect a new build.
- The job **delete+recreates** the release and tag at `HEAD` rather than updating in place. This prunes stale, differently-named assets (which would otherwise accumulate) and sidesteps the Releases API refusing to retarget an already-existing tag.
- Uses `CROWDIN_GITHUB_TOKEN` for the tag delete/create — the same token every other tag-touching workflow uses, since the default `GITHUB_TOKEN` is blocked by the repo's tag rulesets.

### 🧹 Chores (docs)
- `obtainium-test-builds.md`: documented the new snapshot channel — notably it installs as a **separate `.debug` package**, so the uninstall-the-Play-version dance doesn't apply. Also fixed the "bleeding edge" instructions, which would otherwise now follow `snapshot` (always the newest prerelease) instead of the newest open/closed beta.

## Reviewer notes
- **Nothing else is triggered by the tag.** `docs-release.yml` only fires on `v*.*.*` (snapshot doesn't match), and the real release pipeline is `workflow_dispatch`/`workflow_call` only.
- The exact split-APK filenames in the Obtainium doc (`androidApp-google-arm64-v8a-debug-<vc>.apk`) are derived from the build config; the first real snapshot run is the cheap way to confirm the documented regexes match.
- Design intentionally stayed with GitHub Releases + debug signing (per discussion) rather than Firebase App Distribution / a dedicated nightly key / a separate applicationId — the `.debug` suffix already isolates snapshot installs from production.

## Testing Performed
Workflow-only change; validated both YAML files parse. Full behavior is exercised by the first push to `main` after merge (build → rename → delete/recreate release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated snapshot releases for Android debug APKs, simplifying installation of the latest test builds.
  * Push builds are now marked with a distinct “SNAPSHOT” version label to clearly separate them from promoted builds.

* **Documentation**
  * Updated Obtainium channel guidance to include a snapshot channel and explain snapshot-specific behavior.
  * Expanded “Bleeding edge” and “Snapshot” setup instructions with improved filtering and notes about debug-only artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->