### PR TITLE
fix(ble): refresh GATT cache around ESP32 OTA profile changes

### DIFF
--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KableGattCacheRefresh.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KableGattCacheRefresh.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ble
+
+import android.bluetooth.BluetoothGatt
+import co.touchlab.kermit.Logger
+import com.juul.kable.Peripheral
+import kotlinx.coroutines.flow.StateFlow
+
+@Suppress("ReturnCount")
+internal actual fun Peripheral.refreshGattCache(): Boolean {
+    // Direct 2-hop reflection on Kable 0.43.1 internals.
+    // Path: BluetoothDeviceAndroidPeripheral.connection (MutableStateFlow<Connection?>) → .value → Connection.gatt
+    // Re-verify field names on Kable version bumps.
+    val gatt =
+        try {
+            extractBluetoothGatt()
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.w(e) { "refreshGattCache: BluetoothGatt extraction failed (${this.javaClass.name})" }
+            null
+        }
+            ?: run {
+                Logger.w { "refreshGattCache: BluetoothGatt unreachable via Kable internals (${this.javaClass.name})" }
+                return false
+            }
+    return try {
+        val refreshMethod = gatt.javaClass.getDeclaredMethod("refresh").apply { isAccessible = true }
+        val result = refreshMethod.invoke(gatt) as? Boolean ?: false
+        Logger.i { "refreshGattCache: refresh() returned $result" }
+        result
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Logger.w(e) { "refreshGattCache: refresh() invocation failed" }
+        false
+    }
+}
+
+/**
+ * Extracts the [BluetoothGatt] from Kable's internal object graph via a 2-hop field lookup.
+ *
+ * Hop 1: `Peripheral` → field `"connection"` (`MutableStateFlow<Connection?>`) → `.value` → `Connection` Hop 2:
+ * `Connection` → field `"gatt"` → `BluetoothGatt`
+ *
+ * Returns `null` if either hop fails (e.g., Kable internals changed between versions).
+ */
+@Suppress("ReturnCount")
+private fun Peripheral.extractBluetoothGatt(): BluetoothGatt? {
+    // Hop 1: Read "connection" field from the concrete Peripheral class (BluetoothDeviceAndroidPeripheral)
+    val connectionField = readDeclaredField("connection") ?: return null
+    val connectionStateFlow = connectionField as? StateFlow<*> ?: return null
+    val connection = connectionStateFlow.value ?: return null
+
+    // Hop 2: Read "gatt" field from the Connection class
+    return connection.readDeclaredFieldAs<BluetoothGatt>("gatt")
+}
+
+private fun Any.readDeclaredField(name: String): Any? {
+    var clazz: Class<*>? = javaClass
+    while (clazz != null && clazz != Any::class.java) {
+        try {
+            val field = clazz.getDeclaredField(name)
+            field.isAccessible = true
+            return field.get(this)
+        } catch (_: NoSuchFieldException) {
+            clazz = clazz.superclass
+        }
+    }
+    return null
+}
+
+private inline fun <reified T> Any.readDeclaredFieldAs(name: String): T? = readDeclaredField(name) as? T

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/BleConnection.kt
@@ -89,6 +89,13 @@ interface BleConnection {
      * returns `false` for platforms that don't support it.
      */
     fun requestBalancedConnectionPriority(): Boolean = false
+
+    /**
+     * Clears the platform's cached GATT service table for the connected peripheral. Necessary when a device reboots
+     * into a different GATT profile (e.g., ESP32 OTA loader) on the same BLE MAC. Returns `true` if the cache was
+     * invalidated. Default implementation returns `false` for platforms without a service cache.
+     */
+    fun invalidateServiceCache(): Boolean = false
 }
 
 /** Represents a BLE service for commonMain. */
@@ -98,6 +105,9 @@ interface BleService {
 
     /** Returns true when the characteristic is present on the connected device. */
     fun hasCharacteristic(characteristic: BleCharacteristic): Boolean
+
+    /** Returns the UUIDs of all characteristics discovered for this service. Empty for non-Kable platforms. */
+    fun discoveredCharacteristicUuids(): List<Uuid> = emptyList()
 
     /** Observes notifications/indications from the characteristic. */
     fun observe(characteristic: BleCharacteristic): Flow<ByteArray>

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleConnection.kt
@@ -54,6 +54,11 @@ class KableBleService(private val peripheral: Peripheral, private val serviceUui
         svc.serviceUuid == serviceUuid && svc.characteristics.any { it.characteristicUuid == characteristic.uuid }
     } == true
 
+    override fun discoveredCharacteristicUuids(): List<Uuid> = peripheral.services.value
+        ?.find { it.serviceUuid == serviceUuid }
+        ?.characteristics
+        ?.map { it.characteristicUuid } ?: emptyList()
+
     override fun observe(characteristic: BleCharacteristic) =
         peripheral.observe(characteristicOf(serviceUuid, characteristic.uuid))
 
@@ -294,6 +299,8 @@ class KableBleConnection(private val scope: CoroutineScope, private val loggingC
     override fun requestHighConnectionPriority(): Boolean = peripheral?.requestHighConnectionPriority() == true
 
     override fun requestBalancedConnectionPriority(): Boolean = peripheral?.requestBalancedConnectionPriority() == true
+
+    override fun invalidateServiceCache(): Boolean = peripheral?.refreshGattCache() == true
 
     /** Ensures the previous peripheral's GATT resources are fully released. */
     private suspend fun cleanUpPeripheral(tag: String) {

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -44,3 +44,17 @@ internal expect fun Peripheral.requestHighConnectionPriority(): Boolean
  * operations complete. On platforms without an equivalent API (JVM/iOS) this is a no-op.
  */
 internal expect fun Peripheral.requestBalancedConnectionPriority(): Boolean
+
+/**
+ * Clears the platform's cached GATT service table for the connected [Peripheral].
+ *
+ * Kable keeps Android's `BluetoothGatt` on an internal connection object owned by the peripheral. This extension
+ * searches the peripheral and its active connection for that field, then invokes the hidden `refresh()` API to clear
+ * the per-device service cache.
+ *
+ * Necessary when a device reboots into a different GATT profile (e.g., ESP32 OTA loader) using the same BLE MAC.
+ *
+ * Returns `true` if the cache was invalidated. On platforms without a cache (JVM/iOS) this is a no-op returning
+ * `false`.
+ */
+internal expect fun Peripheral.refreshGattCache(): Boolean

--- a/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
+++ b/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
@@ -32,3 +32,5 @@ internal actual fun Peripheral.negotiatedMaxWriteLength(): Int? = null
 internal actual fun Peripheral.requestHighConnectionPriority(): Boolean = false
 
 internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean = false
+
+internal actual fun Peripheral.refreshGattCache(): Boolean = false

--- a/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -35,4 +35,6 @@ internal actual fun Peripheral.requestHighConnectionPriority(): Boolean = false
 
 internal actual fun Peripheral.requestBalancedConnectionPriority(): Boolean = false
 
+internal actual fun Peripheral.refreshGattCache(): Boolean = false
+
 private const val DEFAULT_JVM_MTU = 512

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -56,6 +56,7 @@ import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.model.RadioNotConnectedException
 import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.network.transport.HeartbeatSender
+import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.RadioTransport
 import org.meshtastic.core.repository.RadioTransportCallback
 import kotlin.concurrent.Volatile
@@ -119,6 +120,12 @@ private val SUBSCRIPTION_READY_TIMEOUT = 5.seconds
  * significantly increases battery draw on both the phone and the radio.
  */
 private val PRIORITY_DOWNGRADE_DELAY = 30.seconds
+
+/**
+ * Settle delay after disconnecting to let the BLE stack release GATT resources before reconnecting post cache
+ * invalidation.
+ */
+private val POST_INVALIDATION_RECONNECT_DELAY = 500.milliseconds
 
 /**
  * A [RadioTransport] implementation for BLE devices using the common BLE abstractions (which are powered by Kable).
@@ -364,6 +371,29 @@ class BleRadioTransport(
 
         if (state !is BleConnectionState.Connected) {
             throw RadioNotConnectedException("Failed to connect to device at address $address")
+        }
+
+        // Post-OTA GATT cache invalidation: the device rebooted with potentially different
+        // BLE service table handles. Refresh Android's cache and reconnect to force fresh
+        // service discovery before proceeding with profile setup.
+        val radioServiceForCache = callback as? RadioInterfaceService
+        if (radioServiceForCache?.consumeGattCacheInvalidationRequest() == true) {
+            val invalidated = bleConnection.invalidateServiceCache()
+            Logger.d { "[${address.anonymize()}] Post-OTA GATT cache invalidation requested: $invalidated" }
+            if (invalidated) {
+                Logger.i {
+                    "[${address.anonymize()}] Reconnecting after GATT cache refresh to force service rediscovery"
+                }
+                bleConnection.disconnect()
+                delay(POST_INVALIDATION_RECONNECT_DELAY)
+                val reconnectState = bleConnection.connectAndAwait(device, CONNECTION_TIMEOUT)
+                if (reconnectState !is BleConnectionState.Connected) {
+                    throw RadioNotConnectedException(
+                        "Failed to reconnect after post-OTA GATT cache refresh (state=$reconnectState)",
+                    )
+                }
+                Logger.i { "[${address.anonymize()}] Reconnected after GATT cache refresh" }
+            }
         }
 
         val gattConnectedAt = nowMillis

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -38,12 +38,15 @@ import org.meshtastic.core.testing.FakeBleConnectionFactory
 import org.meshtastic.core.testing.FakeBleDevice
 import org.meshtastic.core.testing.FakeBleScanner
 import org.meshtastic.core.testing.FakeBluetoothRepository
+import org.meshtastic.core.testing.FakeRadioInterfaceService
 import org.meshtastic.core.testing.failBondAfterRecording
 import org.meshtastic.core.testing.failBondWith
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BleRadioTransportTest {
@@ -385,6 +388,60 @@ class BleRadioTransportTest {
                 "bond() must be called exactly once — cancellation, not retry",
             )
             assertEquals(0, connection.connectAndAwaitCalls, "connectAndAwait must not be called after cancellation")
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    /**
+     * Post-OTA GATT cache invalidation: when the service-layer one-shot flag is armed
+     * ([RadioInterfaceService.requestGattCacheInvalidationOnNextConnect]), [BleRadioTransport.attemptConnection] must
+     * consume it and call [BleConnection.invalidateServiceCache]. When the cache refresh succeeds it disconnects and
+     * reconnects once to force fresh service discovery.
+     *
+     * Uses [FakeRadioInterfaceService] as the callback so the flag's real atomic getAndSet semantics drive the
+     * consume-once behavior under test.
+     */
+    @Test
+    fun `post-OTA cache invalidation flag is consumed during connect and triggers reconnect`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        bluetoothRepository.bond(device)
+        scanner.emitDevice(device)
+        connection.service.addCharacteristic(FROMNUM_CHARACTERISTIC)
+        connection.service.addCharacteristic(FROMRADIO_CHARACTERISTIC)
+        connection.invalidateServiceCacheResult = true
+
+        val radioService = FakeRadioInterfaceService()
+        radioService.requestGattCacheInvalidationOnNextConnect()
+
+        val bleTransport =
+            BleRadioTransport(
+                scope = this,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = radioService,
+                address = address,
+            )
+        bleTransport.start()
+        try {
+            // 3s settle + connectAndAwait + 500ms reconnect delay + reconnect connectAndAwait, then profile setup
+            // bounded by CONNECTED_GATE_TIMEOUT / SUBSCRIPTION_READY_TIMEOUT (5s each).
+            advanceTimeBy(20_000)
+
+            // The transport consumed the flag during its first connect cycle: a second consume must return false.
+            assertFalse(
+                radioService.consumeGattCacheInvalidationRequest(),
+                "GATT cache invalidation flag must have been consumed by the transport",
+            )
+            assertTrue(
+                connection.invalidateServiceCacheCalls >= 1,
+                "invalidateServiceCache must be called after consuming the flag",
+            )
+            assertTrue(
+                connection.connectAndAwaitCalls >= 2,
+                "transport must reconnect after cache invalidation (got ${connection.connectAndAwaitCalls} calls)",
+            )
         } finally {
             bleTransport.close()
         }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioController.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioController.kt
@@ -74,4 +74,10 @@ interface RadioController :
      * @param address The new device identifier.
      */
     suspend fun setDeviceAddress(address: String)
+
+    /**
+     * Requests that the next BLE connection invalidates Android's GATT service cache. Call before [setDeviceAddress]
+     * when reconnecting after a firmware update.
+     */
+    fun requestGattCacheInvalidationOnNextConnect()
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -130,6 +130,23 @@ interface RadioInterfaceService : RadioTransportCallback {
      */
     suspend fun restartTransport()
 
+    /**
+     * Requests that the next BLE transport connection invalidates Android's GATT service cache before service
+     * discovery. Used after OTA firmware updates where the device reboots with a potentially different BLE service
+     * table on the same MAC address.
+     *
+     * The flag is one-shot: consumed on the first connect after being set.
+     */
+    fun requestGattCacheInvalidationOnNextConnect()
+
+    /**
+     * Consumes and returns the GATT cache invalidation request. Returns `true` exactly once after
+     * [requestGattCacheInvalidationOnNextConnect] was called, then resets to `false`.
+     *
+     * Intended to be called by the BLE transport during connection setup.
+     */
+    fun consumeGattCacheInvalidationRequest(): Boolean
+
     /** Returns the current device address. */
     fun getDeviceAddress(): String?
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/RadioControllerImpl.kt
@@ -134,6 +134,10 @@ class RadioControllerImpl(
         onDeviceAddressChanged?.invoke()
     }
 
+    override fun requestGattCacheInvalidationOnNextConnect() {
+        radioInterfaceService.requestGattCacheInvalidationOnNextConnect()
+    }
+
     private suspend fun switchDevice(deviceAddr: String) {
         val currentAddr = meshPrefs.deviceAddress.value
         if (deviceAddr != currentAddr) {

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -202,6 +202,8 @@ class SharedRadioInterfaceService(
      */
     @Volatile private var connectionRequested = false
 
+    private val gattCacheInvalidationRequested = atomic(false)
+
     /** Prevents concurrent liveness-induced transport restarts from stacking. */
     private val isRestarting = atomic(false)
 
@@ -466,6 +468,13 @@ class SharedRadioInterfaceService(
             isRestarting.value = false
         }
     }
+
+    override fun requestGattCacheInvalidationOnNextConnect() {
+        gattCacheInvalidationRequested.value = true
+        Logger.d { "GATT cache invalidation requested for next BLE connect" }
+    }
+
+    override fun consumeGattCacheInvalidationRequest(): Boolean = gattCacheInvalidationRequested.getAndSet(false)
 
     override fun isMockTransport(): Boolean = transportFactory.isMockTransport()
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -391,6 +391,7 @@ class SharedRadioInterfaceService(
             // Tear the gate down BEFORE stopTransportLocked() so a concurrent state-listener
             // emission arriving while we wait for the mutex cannot re-start the transport.
             connectionRequested = false
+            gattCacheInvalidationRequested.value = false
             ignoreExceptionSuspend { stopTransportLocked() }
         }
     }
@@ -500,6 +501,8 @@ class SharedRadioInterfaceService(
             return false
         }
 
+        val previousAddress = getBondedDeviceAddress()
+
         analytics.track("mesh_bond")
 
         Logger.d { "Setting bonded device to ${sanitized?.anonymize}" }
@@ -515,6 +518,9 @@ class SharedRadioInterfaceService(
                 // transport for a device the user explicitly tore down. Only start a fresh
                 // transport when an address was actually selected.
                 connectionRequested = sanitized != null
+                if (sanitized != null && previousAddress != null && sanitized != previousAddress) {
+                    gattCacheInvalidationRequested.value = false
+                }
                 ignoreExceptionSuspend { stopTransportLocked() }
                 if (sanitized != null) {
                     startTransportLocked()

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/SharedRadioInterfaceServiceLivenessTest.kt
@@ -1683,4 +1683,127 @@ class SharedRadioInterfaceServiceLivenessTest {
             advanceTimeBy(1_000L)
         }
     }
+
+    // ─── Post-OTA GATT cache invalidation flag lifecycle ───────────────────────────────────────
+
+    /**
+     * The one-shot cache-invalidation flag is armed by
+     * [SharedRadioInterfaceService.requestGattCacheInvalidationOnNextConnect] and consumed exactly once by
+     * [SharedRadioInterfaceService.consumeGattCacheInvalidationRequest] (atomic getAndSet).
+     * [SharedRadioInterfaceService.disconnect] must clear any still-pending flag so a later reconnect does not silently
+     * trigger a stale invalidation.
+     */
+    @Test
+    fun `gatt cache invalidation flag is consumed once and cleared on disconnect`() = runTest(testDispatcher) {
+        val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+        try {
+            assertFalse(
+                service.consumeGattCacheInvalidationRequest(),
+                "flag must default to unset before any request",
+            )
+
+            service.requestGattCacheInvalidationOnNextConnect()
+            assertTrue(
+                service.consumeGattCacheInvalidationRequest(),
+                "first consume after request must return true",
+            )
+            assertFalse(
+                service.consumeGattCacheInvalidationRequest(),
+                "second consume must return false (one-shot getAndSet)",
+            )
+
+            // Re-arm; disconnect below must clear it.
+            service.requestGattCacheInvalidationOnNextConnect()
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+
+        assertFalse(
+            service.consumeGattCacheInvalidationRequest(),
+            "disconnect must clear the pending GATT cache invalidation flag",
+        )
+    }
+
+    /**
+     * Rebinding to a DIFFERENT device address must drop the pending flag — the cache invalidation was requested for the
+     * previous device's post-OTA reboot and must not bleed into the new device's connection.
+     * ([SharedRadioInterfaceService.setDeviceAddress] clears `gattCacheInvalidationRequested` when the address
+     * changes.)
+     */
+    @Test
+    fun `setDeviceAddress with a different address clears the pending gatt cache invalidation flag`() =
+        runTest(testDispatcher) {
+            val service = createConnectedService("xAA:BB:CC:DD:EE:FF")
+            try {
+                service.requestGattCacheInvalidationOnNextConnect()
+
+                assertTrue(service.setDeviceAddress("xBB:11:22:33:44:55"), "setDeviceAddress must accept a new address")
+                // The clear happens inside the launched transportMutex.withLock; flush it.
+                testDispatcher.scheduler.runCurrent()
+                advanceTimeBy(1_000L)
+
+                assertFalse(
+                    service.consumeGattCacheInvalidationRequest(),
+                    "switching to a different device address must clear the pending flag",
+                )
+            } finally {
+                service.disconnect()
+                advanceTimeBy(1_000L)
+            }
+        }
+
+    /**
+     * Counterpart: rebinding to the SAME address is a documented no-op ([SharedRadioInterfaceService.setDeviceAddress]
+     * early-returns when already Connected to that address), so it must NOT touch the pending flag.
+     */
+    @Test
+    fun `setDeviceAddress with the same address preserves the pending gatt cache invalidation flag`() =
+        runTest(testDispatcher) {
+            val address = "xAA:BB:CC:DD:EE:FF"
+            val service = createConnectedService(address)
+            try {
+                service.requestGattCacheInvalidationOnNextConnect()
+
+                assertFalse(
+                    service.setDeviceAddress(address),
+                    "setDeviceAddress with the same connected address is a documented no-op (returns false)",
+                )
+                testDispatcher.scheduler.runCurrent()
+
+                assertTrue(
+                    service.consumeGattCacheInvalidationRequest(),
+                    "same-address rebind must preserve the pending GATT cache invalidation flag",
+                )
+            } finally {
+                service.disconnect()
+                advanceTimeBy(1_000L)
+            }
+        }
+
+    @Test
+    fun `setDeviceAddress after deselect preserves pending gatt cache invalidation flag`() = runTest(testDispatcher) {
+        val address = "xAA:BB:CC:DD:EE:FF"
+        val service = createConnectedService(address)
+        try {
+            // OTA handler deselects to free the GATT
+            assertTrue(service.setDeviceAddress("n"), "deselect must succeed")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            // Post-OTA: arm flag, then re-select the SAME device
+            service.requestGattCacheInvalidationOnNextConnect()
+            assertTrue(service.setDeviceAddress(address), "re-select must start transport")
+            testDispatcher.scheduler.runCurrent()
+            advanceTimeBy(1_000L)
+
+            assertTrue(
+                service.consumeGattCacheInvalidationRequest(),
+                "post-OTA re-select (null to address) must preserve the pending flag",
+            )
+        } finally {
+            service.disconnect()
+            advanceTimeBy(1_000L)
+        }
+    }
 }

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
             implementation(projects.core.database)
             implementation(projects.core.ble)
             implementation(projects.core.datastore)
+            implementation(libs.kotlinx.atomicfu)
             implementation(libs.androidx.room.runtime)
             api(libs.kermit)
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeBle.kt
@@ -114,6 +114,15 @@ class FakeBleConnection :
     /** Negotiated write length exposed to callers; `null` means unknown / not negotiated. */
     var maxWriteValueLength: Int? = null
 
+    /** Result returned by [invalidateServiceCache]; defaults to `false` to match the [BleConnection] default. */
+    var invalidateServiceCacheResult: Boolean = false
+
+    /** Number of times [invalidateServiceCache] has been invoked. */
+    var invalidateServiceCacheCalls: Int = 0
+
+    /** Optional callback invoked at the end of [disconnect] (e.g. seed freshly-discovered services on reconnect). */
+    var onDisconnect: (() -> Unit)? = null
+
     /** Number of times [disconnect] has been invoked. */
     var disconnectCalls: Int = 0
 
@@ -164,6 +173,7 @@ class FakeBleConnection :
             currentDevice.setState(BleConnectionState.Disconnected())
         }
         _device.value = null
+        onDisconnect?.invoke()
     }
 
     override suspend fun <T> profile(
@@ -182,6 +192,11 @@ class FakeBleConnection :
     }
 
     override fun maximumWriteValueLength(writeType: BleWriteType): Int? = maxWriteValueLength
+
+    override fun invalidateServiceCache(): Boolean {
+        invalidateServiceCacheCalls++
+        return invalidateServiceCacheResult
+    }
 }
 
 class FakeBleWrite(val characteristic: BleCharacteristic, val data: ByteArray, val writeType: BleWriteType) {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -62,6 +62,8 @@ class FakeRadioController :
     var editSettingsCalled = false
     var startProvideLocationCalled = false
     var stopProvideLocationCalled = false
+    var gattCacheInvalidationRequested = false
+        private set
 
     init {
         registerResetAction {
@@ -76,6 +78,7 @@ class FakeRadioController :
             editSettingsCalled = false
             startProvideLocationCalled = false
             stopProvideLocationCalled = false
+            gattCacheInvalidationRequested = false
         }
     }
 
@@ -205,6 +208,10 @@ class FakeRadioController :
 
     override suspend fun setDeviceAddress(address: String) {
         lastSetDeviceAddress = address
+    }
+
+    override fun requestGattCacheInvalidationOnNextConnect() {
+        gattCacheInvalidationRequested = true
     }
 
     // --- Helper methods for testing ---

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.testing
 
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.channels.Channel
@@ -121,4 +122,12 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
     fun setConnectionState(state: ConnectionState) {
         _connectionState.value = state
     }
+
+    private val gattCacheInvalidationRequested = atomic(false)
+
+    override fun requestGattCacheInvalidationOnNextConnect() {
+        gattCacheInvalidationRequested.value = true
+    }
+
+    override fun consumeGattCacheInvalidationRequest(): Boolean = gattCacheInvalidationRequested.getAndSet(false)
 }

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -98,6 +98,10 @@ class NoopRadioInterfaceService : RadioInterfaceService {
 
     override fun setDeviceAddress(deviceAddr: String?): Boolean = false
 
+    override fun requestGattCacheInvalidationOnNextConnect() {}
+
+    override fun consumeGattCacheInvalidationRequest(): Boolean = false
+
     override fun toInterfaceAddress(interfaceId: InterfaceId, rest: String): String = ""
 
     override fun onConnect() {}

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -48,6 +48,7 @@ import org.meshtastic.core.datastore.FirmwareRecoveryDataSource
 import org.meshtastic.core.datastore.model.PendingFirmwareRecovery
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceHardware
+import org.meshtastic.core.model.InterfaceId
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.repository.DeviceHardwareRepository
@@ -808,6 +809,14 @@ class FirmwareUpdateViewModel(
                 Logger.i { "Post-update: leaving USB reconnect to USB auto-recovery for ${fullAddr.anonymize}" }
             } else {
                 Logger.i { "Post-update: Requesting MeshService to reconnect to ${fullAddr.anonymize}" }
+                // GATT cache invalidation is only needed for BLE reconnects — the device
+                // reboots into a different GATT profile on the same MAC address. TCP/USB
+                // don't have this problem, and leaving a stale BLE-only request around
+                // could trigger an unnecessary refresh on a later BLE connection.
+                if (isBluetoothInterfaceAddress(fullAddr)) {
+                    Logger.d { "Post-update: Requesting GATT cache invalidation before BLE reconnect" }
+                    radioController.requestGattCacheInvalidationOnNextConnect()
+                }
                 radioController.setDeviceAddress(fullAddr)
             }
         }
@@ -906,6 +915,9 @@ private suspend fun cleanupTemporaryFiles(
 
 private fun isValidBluetoothAddress(address: String?): Boolean =
     address != null && BLUETOOTH_ADDRESS_REGEX.matches(address)
+
+private fun isBluetoothInterfaceAddress(address: String): Boolean =
+    address.startsWith(InterfaceId.BLUETOOTH.id) || address.startsWith("!")
 
 private fun FirmwareReleaseRepository.getReleaseFlow(type: FirmwareReleaseType): Flow<FirmwareRelease?> = when (type) {
     FirmwareReleaseType.STABLE -> stableRelease

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
@@ -142,16 +142,38 @@ class BleOtaTransport(
         Logger.i { "BLE OTA: Connected to OTA device, discovering services..." }
 
         try {
+            discoverAndPrepareOtaService(device, connectResponseChannel, cacheInvalidated)
+        } catch (e: TimeoutCancellationException) {
+            otaService = null
+            currentCoroutineContext().ensureActive()
+            Logger.w { "BLE OTA: Timed out waiting for OTA service discovery. Error: ${e.message}" }
+            throw OtaProtocolException.Timeout("Timed out waiting for BLE OTA service discovery")
+        } catch (e: OtaProtocolException) {
+            otaService = null
+            throw e
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            otaService = null
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            otaService = null
+            Logger.w(e) { "BLE OTA: Failed to prepare OTA service" }
+            throw OtaProtocolException.ConnectionFailed("Failed to prepare BLE OTA service", e)
+        }
+    }
+
+    @Suppress("LongMethod")
+    private suspend fun discoverAndPrepareOtaService(
+        device: BleDevice,
+        connectResponseChannel: Channel<String>,
+        cacheInvalidated: Boolean,
+    ) {
+        suspend fun prepareProfile() {
             bleConnection.profile(OTA_SERVICE_UUID) { service ->
                 service.requireOtaCharacteristics()
 
-                // Log negotiated MTU for diagnostics
                 val maxLen = bleConnection.maximumWriteValueLength(BleWriteType.WITHOUT_RESPONSE)
                 Logger.i { "BLE OTA: Service ready. Max write value length: $maxLen bytes" }
 
-                // Collect notification responses. Kable writes the CCCD descriptor as part of flow collection
-                // startup. Prefer the onSubscription readiness callback, but bound the wait because some OTA loaders
-                // never report the CCCD write completion even though notifications still flow.
                 val notificationsReady = CompletableDeferred<Unit>()
                 notificationJob =
                     launch(start = CoroutineStart.UNDISPATCHED) {
@@ -191,21 +213,26 @@ class BleOtaTransport(
                 otaService = service
                 Logger.i { "BLE OTA: Service discovered and ready" }
             }
-        } catch (e: TimeoutCancellationException) {
+        }
+
+        try {
+            prepareProfile()
+        } catch (e: OtaProtocolException.ConnectionFailed) {
+            if (!cacheInvalidated) throw e
+            Logger.i {
+                "BLE OTA: OTA characteristics missing after cache refresh; reconnecting to force service rediscovery"
+            }
+            notificationJob?.cancel()
+            notificationJob = null
             otaService = null
-            currentCoroutineContext().ensureActive()
-            Logger.w { "BLE OTA: Timed out waiting for OTA service discovery. Error: ${e.message}" }
-            throw OtaProtocolException.Timeout("Timed out waiting for BLE OTA service discovery")
-        } catch (e: OtaProtocolException) {
-            otaService = null
-            throw e
-        } catch (e: kotlinx.coroutines.CancellationException) {
-            otaService = null
-            throw e
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            otaService = null
-            Logger.w(e) { "BLE OTA: Failed to prepare OTA service" }
-            throw OtaProtocolException.ConnectionFailed("Failed to prepare BLE OTA service", e)
+            bleConnection.disconnect()
+            delay(CACHE_REFRESH_RECONNECT_DELAY)
+            val reconnectState = bleConnection.connectAndAwait(device, CONNECTION_TIMEOUT)
+            if (reconnectState is BleConnectionState.Disconnected) {
+                throw OtaProtocolException.ConnectionFailed("Failed to reconnect to OTA device after cache refresh")
+            }
+            Logger.i { "BLE OTA: Reconnected after cache refresh for OTA service rediscovery" }
+            prepareProfile()
         }
     }
 
@@ -407,6 +434,7 @@ class BleOtaTransport(
         private val ACK_TIMEOUT = 10.seconds
         private val VERIFICATION_TIMEOUT = 10.seconds
         private val REBOOT_DELAY = 5.seconds
+        private val CACHE_REFRESH_RECONNECT_DELAY = 1.seconds
         const val RECOMMENDED_CHUNK_SIZE = 512
 
         /** Fallback write payload when the MTU has not been negotiated (23-byte ATT MTU minus the 3-byte header). */

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransport.kt
@@ -131,6 +131,14 @@ class BleOtaTransport(
             throw OtaProtocolException.Timeout("Timed out connecting to OTA device")
         }
 
+        val cacheInvalidated = bleConnection.invalidateServiceCache()
+        Logger.d { "BLE OTA: GATT cache invalidation requested: $cacheInvalidated" }
+        if (cacheInvalidated) {
+            Logger.i { "BLE OTA: Invalidated stale GATT service cache before OTA discovery" }
+        } else {
+            Logger.d { "BLE OTA: GATT cache invalidation not available; proceeding with existing service cache" }
+        }
+
         Logger.i { "BLE OTA: Connected to OTA device, discovering services..." }
 
         try {
@@ -377,9 +385,17 @@ class BleOtaTransport(
         }
 
         if (missing.isNotEmpty()) {
+            val discovered = discoveredCharacteristicUuids()
+            val diagnostic =
+                if (discovered.isNotEmpty()) {
+                    " (discovered characteristics: $discovered)"
+                } else {
+                    " (no characteristics discovered for OTA service)"
+                }
             throw OtaProtocolException.ConnectionFailed(
                 "ESP32 OTA service was missing required characteristics after BLE service discovery: " +
-                    missing.joinToString(separator = "; "),
+                    missing.joinToString(separator = "; ") +
+                    diagnostic,
             )
         }
     }

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
@@ -476,4 +476,48 @@ class FirmwareUpdateViewModelTest {
         val error = assertIs<UiText.Resource>(errorState.error)
         assertEquals(Res.string.firmware_update_unknown_hardware, error.res)
     }
+
+    @Test
+    fun `BLE post-update reconnect requests GATT cache invalidation`() = runTest {
+        advanceUntilIdle()
+
+        everySuspend { firmwareUpdateManager.startUpdate(any(), any(), any(), any()) }
+            .calls {
+                @Suppress("UNCHECKED_CAST")
+                val updateState = it.args[3] as (FirmwareUpdateState) -> Unit
+                updateState(FirmwareUpdateState.Success())
+                null
+            }
+
+        viewModel.startUpdate()
+        advanceUntilIdle()
+
+        assertTrue(
+            radioController.gattCacheInvalidationRequested,
+            "BLE post-update reconnect should request GATT cache invalidation",
+        )
+    }
+
+    @Test
+    fun `TCP post-update reconnect does not request GATT cache invalidation`() = runTest {
+        advanceUntilIdle()
+
+        every { radioPrefs.devAddr } returns MutableStateFlow("tcp:192.168.1.100")
+
+        everySuspend { firmwareUpdateManager.startUpdate(any(), any(), any(), any()) }
+            .calls {
+                @Suppress("UNCHECKED_CAST")
+                val updateState = it.args[3] as (FirmwareUpdateState) -> Unit
+                updateState(FirmwareUpdateState.Success())
+                null
+            }
+
+        viewModel.startUpdate()
+        advanceUntilIdle()
+
+        assertFalse(
+            radioController.gattCacheInvalidationRequested,
+            "TCP post-update reconnect should not request GATT cache invalidation",
+        )
+    }
 }

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
@@ -502,7 +502,7 @@ class FirmwareUpdateViewModelTest {
     fun `TCP post-update reconnect does not request GATT cache invalidation`() = runTest {
         advanceUntilIdle()
 
-        every { radioPrefs.devAddr } returns MutableStateFlow("tcp:192.168.1.100")
+        every { radioPrefs.devAddr } returns MutableStateFlow("t192.168.1.100")
 
         everySuspend { firmwareUpdateManager.startUpdate(any(), any(), any(), any()) }
             .calls {
@@ -518,6 +518,29 @@ class FirmwareUpdateViewModelTest {
         assertFalse(
             radioController.gattCacheInvalidationRequested,
             "TCP post-update reconnect should not request GATT cache invalidation",
+        )
+    }
+
+    @Test
+    fun `BLE-prefixed post-update reconnect requests GATT cache invalidation`() = runTest {
+        advanceUntilIdle()
+
+        every { radioPrefs.devAddr } returns MutableStateFlow("xAA:BB:CC:DD:EE:FF")
+
+        everySuspend { firmwareUpdateManager.startUpdate(any(), any(), any(), any()) }
+            .calls {
+                @Suppress("UNCHECKED_CAST")
+                val updateState = it.args[3] as (FirmwareUpdateState) -> Unit
+                updateState(FirmwareUpdateState.Success())
+                null
+            }
+
+        viewModel.startUpdate()
+        advanceUntilIdle()
+
+        assertTrue(
+            radioController.gattCacheInvalidationRequested,
+            "BLE-prefixed (x) post-update reconnect should request GATT cache invalidation",
         )
     }
 }

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransportTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/ota/BleOtaTransportTest.kt
@@ -163,6 +163,41 @@ class BleOtaTransportTest {
         assertEquals(failure.message, cause.message)
     }
 
+    /**
+     * Regression: after a cache refresh leaves stale services, the first [bleConnection.profile] throws
+     * [OtaProtocolException.ConnectionFailed] from `requireOtaCharacteristics`. When the cache was invalidated
+     * (`invalidateServiceCache()` returned true), the transport must disconnect, reconnect once, and retry the profile
+     * — which succeeds because the reconnect surfaces the freshly-advertised OTA characteristics.
+     */
+    @Test
+    fun `connect reconnects once when cache refresh leaves stale OTA services`() = runTest {
+        val scanner = FakeBleScanner()
+        val connection = FakeBleConnection()
+        // Seed no characteristics → first profile() rejects the service as missing OTA chars.
+        val (transport) = createTransport(scanner, connection, seedOtaCharacteristics = false)
+
+        // Cache invalidation succeeds, arming the single reconnect retry in discoverAndPrepareOtaService().
+        connection.invalidateServiceCacheResult = true
+        // The forced disconnect surfaces the OTA loader's real service table; seed it for the retry.
+        connection.onDisconnect = {
+            connection.service.addCharacteristic(OTA_NOTIFY_CHARACTERISTIC)
+            connection.service.addCharacteristic(OTA_WRITE_CHARACTERISTIC)
+        }
+
+        scanner.emitDevice(FakeBleDevice(address))
+
+        val result = transport.connect()
+
+        assertTrue(
+            result.isSuccess,
+            "connect() must succeed after one cache-refresh retry: ${result.exceptionOrNull()}",
+        )
+        assertTrue(
+            connection.connectAndAwaitCalls >= 2,
+            "expected initial connect + one reconnect, got ${connection.connectAndAwaitCalls}",
+        )
+    }
+
     // -----------------------------------------------------------------------
     // startOta()
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Overview

This PR makes ESP32 BLE OTA reliable across the full profile-switching flow on Android.

During an ESP32 BLE firmware update, the same BLE address can expose three different GATT states in sequence:

1. the normal Meshtastic radio profile,
2. the ESP32 BLE OTA loader profile,
3. the normal Meshtastic radio profile again after flashing.

Android can keep a stale GATT service cache for that address across those reboots. When that happens, the app may connect successfully but still see the wrong service table. That blocks OTA startup when the OTA loader characteristics are missing, or blocks post-update verification when Android keeps stale OTA handles after the device has rebooted back into normal radio firmware.

This change adds an Android-only, best-effort GATT cache refresh path for Kable-backed BLE connections and uses it at the ESP32 OTA handoff points so service discovery reflects the profile the device is actually running.

## Key Changes

* Added a BLE connection hook for best-effort GATT service-cache invalidation.
* Implemented guarded Android `BluetoothGatt.refresh()` support for Kable connections.
* Kept JVM and iOS behavior as safe no-ops.
* Refreshed the Android GATT cache before ESP32 BLE OTA service lookup.
* Kept the BLE OTA loader connection usable after a successful cache refresh.
* Reconnected once during BLE OTA setup when cache refresh succeeds but OTA characteristics are still missing, forcing Kable to rediscover services before failing.
* Added discovered-characteristic diagnostics for OTA service mismatch failures.
* Added a one-shot post-update BLE cache refresh request before reconnecting to normal radio firmware.
* Forced the post-update BLE radio connection to reconnect after cache refresh so Kable rediscovers the normal radio profile.
* Preserved pending post-update cache invalidation across the OTA `null -> same BLE address` reconnect path.
* Cleared stale one-shot cache-invalidation requests on explicit disconnect and genuine device-to-device switches.
* Gated post-update cache invalidation to BLE reconnects only.
* Preserved existing BLE bonds; this does not unpair or re-pair devices.
* Added fake and desktop no-op implementations for the new cache-invalidation API.
* Added focused coverage for OTA cache refresh retry and post-update invalidation behavior.

## Testing

* Added coverage proving legacy BLE-address post-update reconnect requests GATT cache invalidation.
* Added coverage proving BLE-prefixed post-update reconnect requests GATT cache invalidation.
* Added coverage proving TCP post-update reconnect does not request GATT cache invalidation.
* Added coverage proving BLE OTA reconnects once when cache refresh succeeds but required OTA characteristics are still missing.
* Added coverage proving the BLE radio transport consumes a pending post-OTA cache-invalidation request and reconnects after refresh.
* Added coverage proving GATT cache invalidation requests are consumed once.
* Added coverage proving disconnect clears a pending GATT cache invalidation request.
* Added coverage proving same-address reconnect preserves a pending GATT cache invalidation request.
* Added coverage proving device switch clears a pending GATT cache invalidation request.
* Added regression coverage proving the OTA `setDeviceAddress("n") -> request invalidation -> setDeviceAddress(original BLE address)` path preserves the pending cache-invalidation request.
* Verified `git diff --check` passes.
* Verified on T-Beam ESP32 hardware through the firmware-update flow:

  * BLE OTA entered the ESP32 OTA loader.
  * BLE OTA service discovery reached the expected OTA service.
  * Firmware streamed successfully and returned `OK`.
  * Post-update reconnect requested GATT cache invalidation.
  * `refreshGattCache()` returned `true`.
  * The app reconnected after cache refresh.
  * BLE radio session became ready.
  * Mesh handshake resumed and local metadata was received.

## Migration Notes

* No user data migration is required.
* Existing BLE bonds are preserved.
* This only changes Android BLE service-cache handling around ESP32 OTA profile transitions.
* Non-Android platforms keep the existing no-op behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a BLE cache refresh flow to help reconnects find the latest device services after updates.
  * Added support for retrying BLE connections when required OTA services aren’t found on the first attempt.

* **Bug Fixes**
  * Improved post-update reconnect behavior for Bluetooth devices.
  * Added better handling for stale BLE service data, including a reconnect retry when service discovery is outdated.

* **Tests**
  * Expanded coverage for BLE reconnect, cache invalidation, and OTA recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->