### PR TITLE
feat(messaging): split Conversations into collapsible Channels/DM sections

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -362,6 +362,7 @@ device_theme_language
 dew_point
 direct_message
 direct_message_key
+direct_messages
 discard_changes
 disconnect
 disconnected

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -386,6 +386,7 @@
     <string name="dew_point">Dew Point</string>
     <string name="direct_message">Direct Message</string>
     <string name="direct_message_key">Direct Message Key</string>
+    <string name="direct_messages">Direct Messages</string>
     <string name="discard_changes">Discard</string>
     <string name="disconnect">Disconnect</string>
     <string name="disconnected">Disconnected</string>

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
@@ -18,7 +18,8 @@
 
 package org.meshtastic.feature.messaging.ui.contact
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -29,11 +30,11 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -54,12 +55,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.paging.LoadState
-import androidx.paging.compose.LazyPagingItems
-import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.itemKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -74,17 +75,20 @@ import org.meshtastic.core.model.ContactKey
 import org.meshtastic.core.model.ContactSettings
 import org.meshtastic.core.model.util.TimeConstants
 import org.meshtastic.core.model.util.formatMuteRemainingTime
-import org.meshtastic.core.model.util.getChannel
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.are_you_sure
 import org.meshtastic.core.resources.cancel
 import org.meshtastic.core.resources.channel_invalid
+import org.meshtastic.core.resources.channels
 import org.meshtastic.core.resources.close_selection
+import org.meshtastic.core.resources.collapsed
 import org.meshtastic.core.resources.conversations
 import org.meshtastic.core.resources.currently
 import org.meshtastic.core.resources.delete
 import org.meshtastic.core.resources.delete_messages
 import org.meshtastic.core.resources.delete_selection
+import org.meshtastic.core.resources.direct_messages
+import org.meshtastic.core.resources.expanded
 import org.meshtastic.core.resources.mark_as_read
 import org.meshtastic.core.resources.mute_1_week
 import org.meshtastic.core.resources.mute_8_hours
@@ -107,6 +111,8 @@ import org.meshtastic.core.ui.component.ScrollToTopEvent
 import org.meshtastic.core.ui.component.smartScrollToTop
 import org.meshtastic.core.ui.icon.Close
 import org.meshtastic.core.ui.icon.Delete
+import org.meshtastic.core.ui.icon.ExpandLess
+import org.meshtastic.core.ui.icon.ExpandMore
 import org.meshtastic.core.ui.icon.MarkChatRead
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.SelectAll
@@ -140,28 +146,9 @@ fun ContactsScreen(
     val selectedContactKeys = remember { mutableStateListOf<String>() }
     val isSelectionModeActive by remember { derivedStateOf { selectedContactKeys.isNotEmpty() } }
 
-    // State for contacts list
-    val pagedContacts = viewModel.contactListPaged.collectAsLazyPagingItems()
-
-    // Create channel placeholders (always show broadcast contacts, even when empty)
+    // State for contacts list. Channel placeholders (empty broadcast channels) are already merged in by the VM.
+    val contacts by viewModel.contactList.collectAsStateWithLifecycle()
     val channels by viewModel.channels.collectAsStateWithLifecycle()
-    val channelPlaceholders =
-        remember(channels) {
-            channels.settings.mapIndexed { ch, _ ->
-                Contact(
-                    contactKey = "$ch^all",
-                    shortName = "$ch",
-                    longName = channels.getChannel(ch)?.name ?: "Channel $ch",
-                    lastMessageTime = null,
-                    lastMessageText = "",
-                    unreadCount = 0,
-                    messageCount = 0,
-                    isMuted = false,
-                    isUnmessageable = false,
-                    nodeColors = null,
-                )
-            }
-        }
 
     val contactsListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
@@ -176,11 +163,7 @@ fun ContactsScreen(
 
     // Derived state for selected contacts and count
     val selectedContacts =
-        remember(pagedContacts.itemCount, selectedContactKeys) {
-            (0 until pagedContacts.itemCount)
-                .mapNotNull { pagedContacts[it] }
-                .filter { it.contactKey in selectedContactKeys }
-        }
+        remember(contacts, selectedContactKeys) { contacts.filter { it.contactKey in selectedContactKeys } }
     // Get message count directly from repository for selected contacts
     var selectedCount by remember { mutableIntStateOf(0) }
     LaunchedEffect(selectedContactKeys.size, selectedContactKeys.joinToString(",")) {
@@ -273,17 +256,16 @@ fun ContactsScreen(
                     onDeleteSelected = { showDeleteDialog = true },
                     onSelectAll = {
                         selectedContactKeys.clear()
-                        selectedContactKeys.addAll(
-                            (0 until pagedContacts.itemCount).mapNotNull { pagedContacts[it]?.contactKey },
-                        )
+                        selectedContactKeys.addAll(contacts.map { it.contactKey })
                     },
                     isAllMuted = isAllMuted, // Pass the derived state
                 )
             }
 
-            ContactListViewPaged(
-                contacts = pagedContacts,
-                channelPlaceholders = channelPlaceholders,
+            val collapsedSections by viewModel.collapsedSections.collectAsStateWithLifecycle()
+
+            ContactListView(
+                contacts = contacts,
                 selectedList = selectedContactKeys,
                 activeContactKey = activeContactKey,
                 onClick = onContactClick,
@@ -291,6 +273,8 @@ fun ContactsScreen(
                 onNodeChipClick = onNodeChipClick,
                 listState = contactsListState,
                 channels = channels,
+                collapsedSections = collapsedSections,
+                onToggleSectionCollapse = viewModel::toggleSectionCollapse,
             )
         }
     }
@@ -480,58 +464,36 @@ private fun SelectionToolbar(
 }
 
 @Composable
-private fun ContactListViewPaged(
-    contacts: LazyPagingItems<Contact>,
-    channelPlaceholders: List<Contact>,
+private fun ContactListView(
+    contacts: List<Contact>,
     selectedList: List<String>,
     activeContactKey: String?,
     onClick: (Contact) -> Unit,
     onLongClick: (Contact) -> Unit,
     onNodeChipClick: (Contact) -> Unit,
     listState: LazyListState,
+    collapsedSections: Set<String>,
+    onToggleSectionCollapse: (String) -> Unit,
     modifier: Modifier = Modifier,
     channels: ChannelSet? = null,
 ) {
     val haptic = LocalHapticFeedback.current
-    Box(modifier = modifier.fillMaxSize()) {
-        if (contacts.loadState.refresh is LoadState.Loading && contacts.itemCount == 0) {
-            CircularWavyProgressIndicator(modifier = Modifier.align(Alignment.Center))
-        } else {
-            ContactListContentInternal(
-                contacts = contacts,
-                channelPlaceholders = channelPlaceholders,
-                selectedList = selectedList,
-                activeContactKey = activeContactKey,
-                onClick = onClick,
-                onLongClick = onLongClick,
-                onNodeChipClick = onNodeChipClick,
-                listState = listState,
-                channels = channels,
-                haptic = haptic,
-            )
+    val (channelContacts, dmContacts) =
+        remember(contacts) {
+            val (channelPart, dmPart) = contacts.partition { it.section() == ContactSection.CHANNELS }
+            // Channels keep a fixed slot order (channel index); DMs stay in the query's recency order.
+            channelPart.sortedBy { ContactKey(it.contactKey).channel } to dmPart
         }
-    }
-}
-
-@Composable
-private fun ContactListContentInternal(
-    contacts: LazyPagingItems<Contact>,
-    channelPlaceholders: List<Contact>,
-    selectedList: List<String>,
-    activeContactKey: String?,
-    onClick: (Contact) -> Unit,
-    onLongClick: (Contact) -> Unit,
-    onNodeChipClick: (Contact) -> Unit,
-    listState: LazyListState,
-    channels: ChannelSet?,
-    haptic: HapticFeedback,
-    modifier: Modifier = Modifier,
-) {
-    val visiblePlaceholders = rememberVisiblePlaceholders(contacts, channelPlaceholders)
+    val channelsTitle = stringResource(Res.string.channels)
+    val dmTitle = stringResource(Res.string.direct_messages)
 
     LazyColumn(state = listState, modifier = modifier.fillMaxSize()) {
-        contactListPagedItems(
-            contacts = contacts,
+        contactSection(
+            section = ContactSection.CHANNELS,
+            title = channelsTitle,
+            sectionContacts = channelContacts,
+            collapsed = ContactSection.CHANNELS.key in collapsedSections,
+            onToggleCollapse = onToggleSectionCollapse,
             selectedList = selectedList,
             activeContactKey = activeContactKey,
             onClick = onClick,
@@ -541,8 +503,12 @@ private fun ContactListContentInternal(
             haptic = haptic,
         )
 
-        contactListPlaceholdersItems(
-            placeholders = visiblePlaceholders,
+        contactSection(
+            section = ContactSection.DIRECT_MESSAGES,
+            title = dmTitle,
+            sectionContacts = dmContacts,
+            collapsed = ContactSection.DIRECT_MESSAGES.key in collapsedSections,
+            onToggleCollapse = onToggleSectionCollapse,
             selectedList = selectedList,
             activeContactKey = activeContactKey,
             onClick = onClick,
@@ -551,13 +517,15 @@ private fun ContactListContentInternal(
             channels = channels,
             haptic = haptic,
         )
-
-        contactListAppendLoadingItem(contacts)
     }
 }
 
-private fun LazyListScope.contactListPlaceholdersItems(
-    placeholders: List<Contact>,
+private fun LazyListScope.contactSection(
+    section: ContactSection,
+    title: String,
+    sectionContacts: List<Contact>,
+    collapsed: Boolean,
+    onToggleCollapse: (String) -> Unit,
     selectedList: List<String>,
     activeContactKey: String?,
     onClick: (Contact) -> Unit,
@@ -566,35 +534,20 @@ private fun LazyListScope.contactListPlaceholdersItems(
     channels: ChannelSet?,
     haptic: HapticFeedback,
 ) {
-    items(count = placeholders.size, key = { index -> "${placeholders[index].contactKey}_placeholder" }) { index ->
-        val contact = placeholders[index]
-        ContactItem(
-            contact = contact,
-            selected = selectedList.contains(contact.contactKey),
-            isActive = contact.contactKey == activeContactKey,
-            onClick = { onClick(contact) },
-            onLongClick = {
-                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                onLongClick(contact)
-            },
-            onNodeChipClick = { onNodeChipClick(contact) },
-            channels = channels,
+    if (sectionContacts.isEmpty()) return
+
+    stickyHeader(key = "${section.key}_header") {
+        ContactSectionHeader(
+            title = title,
+            count = sectionContacts.size,
+            collapsed = collapsed,
+            onClick = { onToggleCollapse(section.key) },
         )
     }
-}
 
-private fun LazyListScope.contactListPagedItems(
-    contacts: LazyPagingItems<Contact>,
-    selectedList: List<String>,
-    activeContactKey: String?,
-    onClick: (Contact) -> Unit,
-    onLongClick: (Contact) -> Unit,
-    onNodeChipClick: (Contact) -> Unit,
-    channels: ChannelSet?,
-    haptic: HapticFeedback,
-) {
-    items(count = contacts.itemCount, key = contacts.itemKey { it.contactKey }) { index ->
-        contacts[index]?.let { contact ->
+    if (!collapsed) {
+        items(count = sectionContacts.size, key = { index -> sectionContacts[index].contactKey }) { index ->
+            val contact = sectionContacts[index]
             ContactItem(
                 contact = contact,
                 selected = selectedList.contains(contact.contactKey),
@@ -611,21 +564,28 @@ private fun LazyListScope.contactListPagedItems(
     }
 }
 
-private fun LazyListScope.contactListAppendLoadingItem(contacts: LazyPagingItems<Contact>) {
-    if (contacts.loadState.append is LoadState.Loading) {
-        item {
-            Box(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-                CircularWavyProgressIndicator(modifier = Modifier.align(Alignment.Center))
-            }
-        }
-    }
-}
-
 @Composable
-private fun rememberVisiblePlaceholders(
-    contacts: LazyPagingItems<Contact>,
-    channelPlaceholders: List<Contact>,
-): List<Contact> = remember(contacts.itemCount, channelPlaceholders) {
-    val pagedKeys = (0 until contacts.itemCount).mapNotNull { contacts[it]?.contactKey }.toSet()
-    channelPlaceholders.filter { it.contactKey !in pagedKeys }
+private fun ContactSectionHeader(title: String, count: Int, collapsed: Boolean, onClick: () -> Unit) {
+    val expandStateDescription = stringResource(if (collapsed) Res.string.collapsed else Res.string.expanded)
+    Row(
+        modifier =
+        Modifier.fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .clickable(role = Role.Button, onClick = onClick)
+            .semantics { stateDescription = expandStateDescription }
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "$title ($count)",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.weight(1f).semantics { heading() },
+        )
+        Icon(
+            imageVector = if (collapsed) MeshtasticIcons.ExpandMore else MeshtasticIcons.ExpandLess,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
+    }
 }

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModel.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModel.kt
@@ -16,20 +16,16 @@
  */
 package org.meshtastic.feature.messaging.ui.contact
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
-import androidx.paging.map
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import org.koin.core.annotation.KoinViewModel
 import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.core.model.Contact
 import org.meshtastic.core.model.ContactKey
-import org.meshtastic.core.model.ContactSettings
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.NodeAddress
@@ -47,12 +43,28 @@ import kotlin.collections.map as collectionsMap
 
 @KoinViewModel
 class ContactsViewModel(
+    private val savedStateHandle: SavedStateHandle,
     private val nodeRepository: NodeRepository,
     private val packetRepository: PacketRepository,
     radioConfigRepository: RadioConfigRepository,
     connectionStateProvider: ConnectionStateProvider,
 ) : ViewModel() {
     val ourNodeInfo = nodeRepository.ourNodeInfo
+
+    // ponytail: stored as a comma-joined String (not a Set) — savedstate on all KMP targets only
+    // guarantees primitive types, and there are only ever two section keys.
+    private val collapsedSectionsCsv = savedStateHandle.getStateFlow(KEY_COLLAPSED_SECTIONS, "")
+
+    /** Collapsed conversation-list section keys (see [ContactSection]), persisted across process death. */
+    val collapsedSections: StateFlow<Set<String>> =
+        collapsedSectionsCsv.map { it.toSectionSet() }.stateInWhileSubscribed(initialValue = emptySet())
+
+    fun toggleSectionCollapse(sectionKey: String) {
+        // Read the authoritative saved value, not collapsedSections.value (which is emptySet when unsubscribed).
+        val current = collapsedSectionsCsv.value.toSectionSet()
+        val updated = if (sectionKey in current) current - sectionKey else current + sectionKey
+        savedStateHandle[KEY_COLLAPSED_SECTIONS] = updated.joinToString(",")
+    }
 
     val connectionState = connectionStateProvider.connectionState
 
@@ -65,12 +77,13 @@ class ContactsViewModel(
         combine(nodeRepository.myNodeInfo, nodeRepository.myId) { info, id -> Pair(info, id) }
 
     /**
-     * Non-paginated contact list.
+     * Flat contact list (channels + DMs) with empty-channel placeholders merged in, consumed by both ContactsScreen and
+     * ShareScreen. ContactsScreen groups it into collapsible Channels/DirectMessages sections at render time.
      *
-     * NOTE: This is kept for ShareScreen which needs a simple, non-paginated list of contacts. The main ContactsScreen
-     * uses [contactListPaged] instead for better performance with large contact lists.
-     *
-     * @see contactListPaged for the paginated version used in ContactsScreen
+     * ponytail: not paged. Contact counts on a mesh are bounded (channels ≤ 8, DMs = nodes you've messaged), and a
+     * LazyColumn only composes visible rows regardless. If a mesh ever grows large enough that recomputing per-row
+     * unread/message counts on every emission hurts, restore paging via [PacketRepository.getContactsPaged] and inject
+     * the two section headers with PagingData.insertSeparators over a query ordered channels-first.
      */
     val contactList =
         combine(identityFlow, packetRepository.getContacts(), channels, packetRepository.getContactSettings()) {
@@ -130,60 +143,6 @@ class ContactsViewModel(
         }
             .stateInWhileSubscribed(initialValue = emptyList())
 
-    val contactListPaged: Flow<PagingData<Contact>> =
-        combine(identityFlow, channels, packetRepository.getContactSettings()) { identity, channelSet, settings ->
-            val (myNodeInfo, myId) = identity
-            ContactsPagedParams(myNodeInfo?.myNodeNum, channelSet, settings, myId)
-        }
-            .flatMapLatest { params ->
-                val channelSet = params.channelSet
-                val settings = params.settings
-                val myId = params.myId
-                val myNodeNum = params.myNodeNum
-
-                packetRepository.getContactsPaged().map { pagingData ->
-                    pagingData.map { (contactKey, packetData) ->
-                        // Use the stored contact_key as the identity. Recomputing it here from a
-                        // possibly-null myNodeNum collapses distinct conversations onto one key and
-                        // crashes the LazyColumn with a duplicate-key error (#6131).
-                        val fromLocal = packetData.isFromLocal(myNodeNum)
-                        val toBroadcast = packetData.isBroadcast
-
-                        // grab usernames from NodeInfo
-                        val userId = if (fromLocal) packetData.to else packetData.from
-                        val user = nodeRepository.getUser(userId ?: NodeAddress.ID_BROADCAST)
-                        val node = nodeRepository.getNode(userId ?: NodeAddress.ID_BROADCAST)
-
-                        val shortName = user.short_name
-                        val longName =
-                            if (toBroadcast) {
-                                channelSet.getChannel(packetData.channel)?.name ?: "Channel ${packetData.channel}"
-                            } else {
-                                user.long_name
-                            }
-
-                        Contact(
-                            contactKey = contactKey,
-                            shortName = if (toBroadcast) packetData.channel.toString() else shortName,
-                            longName = longName,
-                            lastMessageTime = if (packetData.time != 0L) packetData.time else null,
-                            lastMessageText = if (fromLocal) packetData.text else "$shortName: ${packetData.text}",
-                            unreadCount = packetRepository.getUnreadCount(contactKey),
-                            messageCount = packetRepository.getMessageCount(contactKey),
-                            isMuted = settings[contactKey]?.isMuted == true,
-                            isUnmessageable = user.is_unmessagable ?: false,
-                            nodeColors =
-                            if (!toBroadcast) {
-                                node.colors
-                            } else {
-                                null
-                            },
-                        )
-                    }
-                }
-            }
-            .cachedIn(viewModelScope)
-
     fun getNode(userId: String?) = nodeRepository.getNode(userId ?: NodeAddress.ID_BROADCAST)
 
     fun deleteContacts(contacts: List<String>) =
@@ -205,7 +164,7 @@ class ContactsViewModel(
 
     /**
      * Get the total message count for a list of contact keys. This queries the repository directly, so it works even if
-     * contacts aren't loaded in the paged list.
+     * a contact isn't currently loaded in the list.
      */
     suspend fun getTotalMessageCount(contactKeys: List<String>): Int = if (contactKeys.isEmpty()) {
         0
@@ -213,10 +172,23 @@ class ContactsViewModel(
         contactKeys.sumOf { contactKey -> packetRepository.getMessageCount(contactKey) }
     }
 
-    private data class ContactsPagedParams(
-        val myNodeNum: Int?,
-        val channelSet: ChannelSet,
-        val settings: Map<String, ContactSettings>,
-        val myId: String?,
-    )
+    companion object {
+        private const val KEY_COLLAPSED_SECTIONS = "collapsed_contact_sections"
+    }
 }
+
+private fun String.toSectionSet(): Set<String> = split(",").filter { it.isNotEmpty() }.toSet()
+
+/** The two conversation-list sections a [Contact] is grouped into. */
+enum class ContactSection(val key: String) {
+    CHANNELS("channels"),
+    DIRECT_MESSAGES("direct_messages"),
+}
+
+/** Channel/broadcast contact keys carry a leading channel-digit prefix (e.g. `"0^all"`); DM keys don't. */
+fun Contact.section(): ContactSection =
+    if (contactKey.getOrNull(1) == '^' || contactKey.endsWith("^all") || contactKey.endsWith("^broadcast")) {
+        ContactSection.CHANNELS
+    } else {
+        ContactSection.DIRECT_MESSAGES
+    }

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModelTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModelTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.feature.messaging.ui.contact
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
@@ -60,6 +61,7 @@ class ContactsViewModelTest {
 
         viewModel =
             ContactsViewModel(
+                savedStateHandle = SavedStateHandle(),
                 nodeRepository = nodeRepository,
                 packetRepository = packetRepository,
                 radioConfigRepository = radioConfigRepository,
@@ -84,7 +86,13 @@ class ContactsViewModelTest {
 
         // Re-init VM
         viewModel =
-            ContactsViewModel(nodeRepository, packetRepository, radioConfigRepository, connectionStateProvider)
+            ContactsViewModel(
+                SavedStateHandle(),
+                nodeRepository,
+                packetRepository,
+                radioConfigRepository,
+                connectionStateProvider,
+            )
 
         viewModel.unreadCountTotal.test {
             assertEquals(0, awaitItem())

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModelTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModelTest.kt
@@ -39,7 +39,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ContactsViewModelTest {
@@ -98,6 +100,38 @@ class ContactsViewModelTest {
             assertEquals(0, awaitItem())
             countFlow.value = 5
             assertEquals(5, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggleSectionCollapse flips section membership`() = runTest(testDispatcher) {
+        viewModel.collapsedSections.test {
+            assertEquals(emptySet(), awaitItem())
+
+            viewModel.toggleSectionCollapse(ContactSection.CHANNELS.key)
+            assertTrue(ContactSection.CHANNELS.key in awaitItem())
+
+            viewModel.toggleSectionCollapse(ContactSection.CHANNELS.key)
+            assertFalse(ContactSection.CHANNELS.key in awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `collapsedSections restores persisted state from SavedStateHandle`() = runTest(testDispatcher) {
+        viewModel =
+            ContactsViewModel(
+                SavedStateHandle(mapOf("collapsed_contact_sections" to ContactSection.DIRECT_MESSAGES.key)),
+                nodeRepository,
+                packetRepository,
+                radioConfigRepository,
+                connectionStateProvider,
+            )
+
+        viewModel.collapsedSections.test {
+            assertEquals(setOf(ContactSection.DIRECT_MESSAGES.key), awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Resolves #3789.

Heavy multi-channel / many-DM users find the mixed Conversations list hard to scan. This groups the single list into two collapsible sticky-header sections — **Channels** and **Direct Messages** — so you can collapse the noise you don't want, without adding a new navigation destination. This is the lean, cheapest-to-implement option from a design pass on the issue (segmented tabs and a new bottom-nav destination were the heavier alternatives); the thread also explicitly asked for fixed channel ordering, which falls out naturally once the two lists are separate.

## 🌟 New Features
- Conversations list now renders two collapsible sections via `stickyHeader`, each with a tap-to-collapse chevron and an `(n)` count.
- **Channels** section is sorted by channel index (fixed slot order, as requested in the issue — no more channels jumping to the top on new activity); **Direct Messages** stays in the query's recency order.
- Collapse state persists across process death via `SavedStateHandle`.

## 🛠️ Refactoring & Architecture
- Dropped the paged contact flow (`contactListPaged`, `ContactsPagedParams`) for this screen and switched to the existing non-paged `contactList`, which already merges empty-channel placeholders with real unread counts. Sectioning a paged stream is a poor fit: snapshotting `LazyPagingItems` into a list to partition it forced eager full-load (defeating paging's memory guard) and left rows stale when content changed without the item count changing. A `ponytail:` comment on `contactList` names the scale ceiling (channels ≤ 8, DMs = nodes you've messaged; `LazyColumn` stays lazy in composition regardless) and the upgrade path if a mesh ever grows large enough to need it: restore `PacketRepository.getContactsPaged` and inject the two section headers with `PagingData.insertSeparators` over a channels-first query.
- Section membership derives from the existing `isBroadcast` distinction already computed per contact — no repository/query changes.

## 🧹 Chores
- Added `direct_messages` string resource (+ regenerated strings index).

## Open question for review
The paging this replaces is my own earlier work (added in #4685 / hardened in #6142), so there's no other contributor's intent to reconcile — but it's still a real tradeoff. For a bounded mesh contact list the non-paged path is simpler and correct, and it fixes the eager-load + stale-row bugs that sectioning-over-paging introduced. If we'd rather keep paging for large-mesh headroom, the clean way is `PagingData.insertSeparators` over a channels-first query (noted in the `ponytail:` comment) rather than snapshotting the paged stream. Happy to go that route instead if preferred.

## Testing Performed
- Updated `ContactsViewModelTest` for the new `SavedStateHandle` constructor arg (both call sites).
- `./gradlew spotlessCheck detekt :feature:messaging:assemble :feature:messaging:allTests` — all green (31 tests).

Note: on-device visual confirmation of the collapsing/sticky-header behavior is still pending — the app was driven to a live BLE connection on a Pixel 6a, but the available test node's config handshake kept dropping before the list populated. The change is code-complete and test-verified.

<!--
If you have screenshots or recordings to display your change, please include them!

<img src="" width="300"/>
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messaging contacts are now displayed in distinct sections for channels and direct messages.
  * Contact sections can be collapsed or expanded, and the choice is preserved across app restarts.
  * Added the “Direct Messages” label to the app.
* **Bug Fixes**
  * Improved contacts and share lists to show conversations more consistently, with selection behavior updated to match the new sectioned layout.
* **Tests**
  * Added/updated coverage for section collapse persistence and toggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
