### PR TITLE
perf(mqtt): drop payload-less client-proxy downlinks before forwarding

### DIFF
--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -40,6 +40,7 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.MqttJsonPayload
+import org.meshtastic.core.model.util.decodeOrNull
 import org.meshtastic.core.model.util.subscribeList
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioConfigRepository
@@ -56,6 +57,7 @@ import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
 import org.meshtastic.mqtt.transport.ws.WebSocketTransportFactory
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.MqttClientProxyMessage
+import org.meshtastic.proto.ServiceEnvelope
 import kotlin.concurrent.Volatile
 import kotlin.uuid.Uuid
 
@@ -162,7 +164,13 @@ class MQTTRepositoryImpl(
                     )
                 }
             }
-            add(Subscription("$rootTopic${DEFAULT_TOPIC_LEVEL}PKI/+", maxQos = QoS.AT_LEAST_ONCE, noLocal = true))
+            add(
+                Subscription(
+                    "$rootTopic$DEFAULT_TOPIC_LEVEL$PKI_CHANNEL_ID/+",
+                    maxQos = QoS.AT_LEAST_ONCE,
+                    noLocal = true,
+                ),
+            )
         }
 
         // Collect from the SharedFlow before connecting to avoid missing retained messages
@@ -248,6 +256,20 @@ class MQTTRepositoryImpl(
                 Logger.e(e) { "Failed to parse MQTT JSON: ${e.message}" }
             }
         } else {
+            // Drop provably-undeliverable downlink packets before spending BLE bandwidth on
+            // them. In client-proxy mode the public broker floods payload-less packet-header
+            // stubs the node can only decrypt-fail and discard; stopping them here saves BLE
+            // airtime, a decrypt attempt, and a node-side warning per packet.
+            if (isUndeliverableDownlink(payload, nodeRepository.myId.value)) {
+                Logger.d {
+                    if (buildConfigProvider.isDebug) {
+                        "MQTT downlink dropped (no payload): $topic"
+                    } else {
+                        "MQTT downlink dropped (no payload)"
+                    }
+                }
+                return
+            }
             trySend(MqttClientProxyMessage(topic = topic, data_ = payload.toByteString(), retained = msg.retain))
         }
     }
@@ -390,4 +412,33 @@ internal fun extractHost(address: String): String {
         }
     // Remove path (if any), then remove port
     return afterScheme.substringBefore("/").substringBefore(":")
+}
+
+private const val PKI_CHANNEL_ID = "PKI"
+
+/**
+ * Returns true when a downlink [ServiceEnvelope] is provably un-usable by the node and should be dropped before
+ * forwarding over BLE (MQTT client-proxy mode).
+ *
+ * Fails open — returns false (forward) for anything it cannot positively prove undeliverable: unparseable bytes, PKI
+ * traffic (the node accepts PKC direct messages without decrypting), our own echoed-back packets (used as implicit
+ * ACKs), a packet-less envelope, or any packet that actually carries a payload. The only drop case is Tier 1: a
+ * [MeshPacket] with neither `decoded` nor `encrypted` set — no legitimate Meshtastic packet is payload-less.
+ *
+ * Extracted as an internal top-level function so [MQTTRepositoryImplTest] can exercise every branch without spinning up
+ * the full repository.
+ *
+ * @param payload the raw MQTT payload bytes (a serialized ServiceEnvelope on the binary topic).
+ * @param myId this device's node id in `!xxxxxxxx` hex form, or null before the local node loads.
+ */
+internal fun isUndeliverableDownlink(payload: ByteArray, myId: String?): Boolean {
+    val envelope = ServiceEnvelope.ADAPTER.decodeOrNull(payload, Logger) ?: return false // fail open on garbage
+    // Guards — never drop: PKI traffic (accepted without decryption) or our own echoed-back
+    // packets (used as implicit ACKs).
+    val isGuarded = envelope.channel_id == PKI_CHANNEL_ID || (myId != null && envelope.gateway_id == myId)
+    // Tier 1: a packet with neither `decoded` nor `encrypted` carries nothing the node can use.
+    // A packet-less envelope (packet == null) has nothing to prove, so it is treated as deliverable.
+    val packet = envelope.packet
+    val hasNoPayload = packet != null && packet.decoded == null && packet.encrypted == null
+    return hasNoPayload && !isGuarded
 }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -420,10 +420,11 @@ private const val PKI_CHANNEL_ID = "PKI"
  * Returns true when a downlink [ServiceEnvelope] is provably un-usable by the node and should be dropped before
  * forwarding over BLE (MQTT client-proxy mode).
  *
- * Fails open — returns false (forward) for anything it cannot positively prove undeliverable: unparseable bytes, PKI
- * traffic (the node accepts PKC direct messages without decrypting), our own echoed-back packets (used as implicit
- * ACKs), a packet-less envelope, or any packet that actually carries a payload. The only drop case is Tier 1: a
- * [MeshPacket] with neither `decoded` nor `encrypted` set — no legitimate Meshtastic packet is payload-less.
+ * Fails open — returns false (forward) for anything it cannot positively prove undeliverable: unparseable bytes,
+ * traffic on the `PKI` channel (public-key-encrypted direct messages the node accepts without first decrypting), our
+ * own echoed-back packets (used as implicit ACKs), a packet-less envelope, or any packet that actually carries a
+ * payload. The only drop case is Tier 1: a [MeshPacket] with neither `decoded` nor `encrypted` set — no legitimate
+ * Meshtastic packet is payload-less.
  *
  * Extracted as an internal top-level function so [MQTTRepositoryImplTest] can exercise every branch without spinning up
  * the full repository.
@@ -432,8 +433,10 @@ private const val PKI_CHANNEL_ID = "PKI"
  * @param myId this device's node id in `!xxxxxxxx` hex form, or null before the local node loads.
  */
 internal fun isUndeliverableDownlink(payload: ByteArray, myId: String?): Boolean {
-    val envelope = ServiceEnvelope.ADAPTER.decodeOrNull(payload, Logger) ?: return false // fail open on garbage
-    // Guards — never drop: PKI traffic (accepted without decryption) or our own echoed-back
+    // Decode without a logger: this is fail-open and, on a public broker, may see arbitrary bytes on the binary
+    // topic. Passing Logger would emit an error log per unparseable downlink — expensive noise for an expected case.
+    val envelope = ServiceEnvelope.ADAPTER.decodeOrNull(payload) ?: return false // fail open on garbage
+    // Guards — never drop: PKI-channel traffic (accepted without decryption) or our own echoed-back
     // packets (used as implicit ACKs).
     val isGuarded = envelope.channel_id == PKI_CHANNEL_ID || (myId != null && envelope.gateway_id == myId)
     // Tier 1: a packet with neither `decoded` nor `encrypted` carries nothing the node can use.

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
@@ -51,12 +51,16 @@ import org.meshtastic.mqtt.ReasonCode
 import org.meshtastic.mqtt.packet.Subscription
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Data
 import org.meshtastic.proto.LocalModuleConfig
+import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.ModuleConfig
+import org.meshtastic.proto.ServiceEnvelope
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -423,6 +427,89 @@ class MQTTRepositoryImplTest {
         assertTrue(jsonStr.contains("\"type\":\"text\""))
         assertTrue(jsonStr.contains("\"from\":12345678"))
         assertTrue(jsonStr.contains("\"payload\":\"Hello World\""))
+    }
+
+    // endregion
+
+    // region isUndeliverableDownlink — Tier 1 drop filter for MQTT client-proxy downlink packets.
+
+    private fun envelopeBytes(
+        channelId: String = "LongFast",
+        gatewayId: String = "!aabbccdd",
+        packet: MeshPacket? = MeshPacket(),
+    ): ByteArray =
+        ServiceEnvelope.ADAPTER.encode(ServiceEnvelope(packet = packet, channel_id = channelId, gateway_id = gatewayId))
+
+    @Test
+    fun `payload-less packet is undeliverable`() {
+        // The observed LongFast flood: a packet with neither decoded nor encrypted set.
+        val bytes = envelopeBytes(packet = MeshPacket(from = 1, to = 2))
+        assertTrue(isUndeliverableDownlink(bytes, myId = "!12345678"))
+    }
+
+    @Test
+    fun `decoded packet is deliverable`() {
+        val bytes = envelopeBytes(packet = MeshPacket(decoded = Data()))
+        assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))
+    }
+
+    @Test
+    fun `encrypted packet is deliverable`() {
+        val bytes = envelopeBytes(packet = MeshPacket(encrypted = byteArrayOf(1, 2, 3).toByteString()))
+        assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))
+    }
+
+    @Test
+    fun `PKI payload-less packet is deliverable (guard)`() {
+        val bytes = envelopeBytes(channelId = "PKI", packet = MeshPacket(from = 1))
+        assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))
+    }
+
+    @Test
+    fun `own echo payload-less packet is deliverable (guard)`() {
+        val bytes = envelopeBytes(gatewayId = "!12345678", packet = MeshPacket(from = 1))
+        assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))
+    }
+
+    @Test
+    fun `a different gateway's payload-less packet is undeliverable`() {
+        val bytes = envelopeBytes(gatewayId = "!deadbeef", packet = MeshPacket(from = 1))
+        assertTrue(isUndeliverableDownlink(bytes, myId = "!12345678"))
+    }
+
+    @Test
+    fun `null myId does not suppress dropping`() {
+        val bytes = envelopeBytes(gatewayId = "!deadbeef", packet = MeshPacket(from = 1))
+        assertTrue(isUndeliverableDownlink(bytes, myId = null))
+    }
+
+    @Test
+    fun `packet-less envelope is deliverable (fail open)`() {
+        val bytes = envelopeBytes(packet = null)
+        assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))
+    }
+
+    @Test
+    fun `garbage bytes are deliverable (fail open)`() {
+        // Non-protobuf bytes must never be dropped.
+        val bytes = byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0x42)
+        assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))
+    }
+
+    @Test
+    fun `payload-less downlink stubs are dropped before forwarding`() = runTest {
+        val harness = createHarness()
+        val stub = envelopeBytes(packet = MeshPacket(from = 1, to = 2)) // no payload → dropped
+        val real = envelopeBytes(packet = MeshPacket(decoded = Data())) // has payload → forwarded
+
+        val nextMessage = backgroundScope.async { harness.repository.proxyMessageFlow.first() }
+        runCurrent()
+        harness.client.emitMessage(MqttMessage(topic = "msh/2/e/alpha/node", payload = stub, retain = false))
+        harness.client.emitMessage(MqttMessage(topic = "msh/2/e/alpha/node", payload = real, retain = false))
+
+        // first() returns the first *forwarded* message; the stub was dropped, so it must be `real`.
+        val proxyMessage = nextMessage.await()
+        assertContentEquals(real, proxyMessage.data_?.toByteArray())
     }
 
     // endregion

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
@@ -460,13 +460,13 @@ class MQTTRepositoryImplTest {
     }
 
     @Test
-    fun `PKI payload-less packet is deliverable (guard)`() {
+    fun `PKI payload-less packet is deliverable - guard`() {
         val bytes = envelopeBytes(channelId = "PKI", packet = MeshPacket(from = 1))
         assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))
     }
 
     @Test
-    fun `own echo payload-less packet is deliverable (guard)`() {
+    fun `own echo payload-less packet is deliverable - guard`() {
         val bytes = envelopeBytes(gatewayId = "!12345678", packet = MeshPacket(from = 1))
         assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))
     }
@@ -484,13 +484,13 @@ class MQTTRepositoryImplTest {
     }
 
     @Test
-    fun `packet-less envelope is deliverable (fail open)`() {
+    fun `packet-less envelope is deliverable - fail open`() {
         val bytes = envelopeBytes(packet = null)
         assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))
     }
 
     @Test
-    fun `garbage bytes are deliverable (fail open)`() {
+    fun `garbage bytes are deliverable - fail open`() {
         // Non-protobuf bytes must never be dropped.
         val bytes = byteArrayOf(0xFF.toByte(), 0xFF.toByte(), 0xFF.toByte(), 0x42)
         assertFalse(isUndeliverableDownlink(bytes, myId = "!12345678"))


### PR DESCRIPTION
## Summary

When a node uses the app as its MQTT **client proxy** (`mqtt.proxy_to_client_enabled`), the app forwards **every** message it receives from the broker to the node over BLE. On the public broker a large, continuous fraction is stuff the node **provably cannot use** — most visibly a flood of **payload-less, channel-hash-0 packet-header stubs** on `LongFast`. Each one costs BLE bandwidth + a decrypt attempt + a warning on the node, only to be dropped.

The app already holds the bytes and knows the node can't use them, so it's the right place to stop this one hop earlier.

## What changed

In `MQTTRepositoryImpl.processMessage`'s binary/protobuf branch (the one that wraps broker bytes into a `MqttClientProxyMessage`), the inbound `ServiceEnvelope` is now parsed and undeliverable packets are dropped **before** the message enters `proxyMessageFlow` / becomes a `ToRadio`.

**Tier 1 (this PR):** drop packets whose `MeshPacket` has **no payload** (`decoded == null && encrypted == null`). No legitimate Meshtastic packet is payload-less; this alone removes 100% of the observed flood.

**Fail open + guards — never drops anything the node can use:**
- Unparseable bytes → forwarded unchanged (`decodeOrNull` returns null → forward).
- `channel_id == "PKI"` → forwarded (the node accepts PKC direct messages without decrypting).
- `gateway_id == myId` → forwarded (our echoed-back packets are implicit ACKs). These carry a payload and would pass Tier 1 anyway; the guard is explicit so a future change can't break ACKs.

The drop is logged via Kermit with `BuildConfig.isDebug`-gated topic detail, matching the existing publish-drop log's PII convention. The decision is extracted into a pure, unit-tested top-level `isUndeliverableDownlink()`; the inline `"PKI"` topic literal is now a named constant.

## Testing
Added to `MQTTRepositoryImplTest` (`kotlin.test`): direct cases for `isUndeliverableDownlink` (payload-less drop; decoded/encrypted forward; PKI + own-gateway guards; different-gateway/null-myId still drop; packet-less + garbage bytes fail open) plus a harness test asserting a payload-less stub is dropped while a real message is forwarded. All 37 tests pass; `spotlessCheck` and `detekt` are clean.

## Scope
Tier 1 + guards only, default-on. The optional Tier 2 (dropping *encrypted* packets for channels the node doesn't hold — Android already has the `xorHash`/`Channel.hash` utility for it) is intentionally left out to keep this change zero-risk. A companion PR applies the same Tier 1 filter to Meshtastic-Apple.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT downlink handling by attempting to interpret downlink payloads as service envelopes and filtering out packets that are provably undeliverable (including payload-less stubs), reducing unnecessary forwarding.
  * Added an explicit MQTT subscription for the PKI topic under the default topic root.
  * Preserved “fail open” behavior: when deliverability can’t be confirmed, traffic is not dropped.
* **Tests**
  * Expanded MQTT repository test coverage for deliverability/undeliverability and downlink forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->