### PR TITLE
ci: merge-queue contention fixes, desktop builds on main, and 22.04-runner exit for desktop releases

### DIFF
--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -15,11 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Every commit on main arrives via the merge queue, which already ran lint, tests,
+  # screenshot validation, and rb-check on this exact merge commit. Re-running them here
+  # would be pure duplication — this workflow only needs to build the debug APKs for the
+  # snapshot release below (run_lint: false also skips screenshot-check and rb-check).
   validate-and-build:
     if: github.repository == 'meshtastic/Meshtastic-Android'
     uses: ./.github/workflows/reusable-check.yml
     with:
-      run_lint: true
+      run_lint: false
       run_unit_tests: false
       upload_artifacts: true
     secrets: inherit

--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -17,14 +17,18 @@ concurrency:
 jobs:
   # Every commit on main arrives via the merge queue, which already ran lint, tests,
   # screenshot validation, and rb-check on this exact merge commit. Re-running them here
-  # would be pure duplication — this workflow only needs to build the debug APKs for the
-  # snapshot release below (run_lint: false also skips screenshot-check and rb-check).
+  # would be pure duplication — this workflow builds the debug APKs for the snapshot
+  # release below (run_lint: false also skips screenshot-check and rb-check) plus the
+  # desktop distributables. Desktop packaging runs here post-merge rather than in the
+  # merge queue: :desktopApp:test in the queue's shard-app already covers compilation,
+  # and the 4-OS matrix (macos/windows queue times) would slow every merge.
   validate-and-build:
     if: github.repository == 'meshtastic/Meshtastic-Android'
     uses: ./.github/workflows/reusable-check.yml
     with:
       run_lint: false
       run_unit_tests: false
+      run_desktop_builds: true
       upload_artifacts: true
     secrets: inherit
 
@@ -34,7 +38,10 @@ jobs:
   # expire after 7 days).
   publish-snapshot:
     needs: validate-and-build
-    if: github.repository == 'meshtastic/Meshtastic-Android'
+    # !cancelled(): a desktop-matrix failure fails validate-and-build as a whole, but the
+    # Android APKs may still have built fine — attempt the snapshot regardless. If the
+    # APK build itself failed, the artifact download below fails and this job goes red.
+    if: github.repository == 'meshtastic/Meshtastic-Android' && !cancelled()
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -7,13 +7,74 @@ on:
 permissions:
   contents: read
 
+# Note: github.ref is unique per merge-group entry (gh-readonly-queue/main/pr-N-<sha>),
+# so this group never dedupes across re-queues of the same PR — the cancel-superseded
+# job below handles that explicitly.
 concurrency:
   group: build-mq-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  android-check:
+  # When a PR is re-queued (an entry ahead of it failed or was removed), GitHub creates a
+  # new merge group but does NOT cancel the workflow runs of the destroyed one. Those stale
+  # runs sit queued/running and starve the runner pool. Cancel any older merge-queue run
+  # for the same PR — only the newest merge group per PR is ever valid.
+  cancel-superseded:
+    name: Cancel Superseded Queue Runs
     if: github.repository == 'meshtastic/Meshtastic-Android'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel older merge-queue runs for the same PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # github.ref_name: gh-readonly-queue/main/pr-<num>-<base-sha>
+          PR_PREFIX=$(echo "${{ github.ref_name }}" | grep -oE 'gh-readonly-queue/.+/pr-[0-9]+-')
+          if [ -z "$PR_PREFIX" ]; then
+            echo "Could not parse PR from ref '${{ github.ref_name }}'; skipping."
+            exit 0
+          fi
+          for status in queued in_progress; do
+            gh api "repos/${{ github.repository }}/actions/runs?event=merge_group&status=${status}&per_page=100" \
+              --jq ".workflow_runs[] | select(.head_branch | startswith(\"$PR_PREFIX\")) | select(.id < ${{ github.run_id }}) | .id"
+          done | sort -u | while read -r run_id; do
+            echo "Cancelling superseded run $run_id"
+            gh run cancel "$run_id" --repo "${{ github.repository }}" || true
+          done
+
+  # Docs-only queue entries (changelog updates, markdown fixes) cannot affect the build;
+  # skip the heavy pipeline for them. Anything outside docs/ and *.md runs full CI.
+  # Mirrors the paths-ignore list in main-check.yml.
+  check-changes:
+    name: Check Changes
+    if: github.repository == 'meshtastic/Meshtastic-Android'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 1
+      - name: Diff merge group against its base
+        id: filter
+        run: |
+          git fetch --depth=1 origin "${{ github.event.merge_group.base_sha }}"
+          changed=$(git diff --name-only "${{ github.event.merge_group.base_sha }}" "${{ github.event.merge_group.head_sha }}")
+          echo "Changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -qvE '^docs/|\.md$|^$'; then
+            echo "android=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "android=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  android-check:
+    needs: check-changes
+    if: github.repository == 'meshtastic/Meshtastic-Android' && needs.check-changes.outputs.android == 'true'
     uses: ./.github/workflows/reusable-check.yml
     with:
       run_lint: true
@@ -27,12 +88,17 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     needs:
+      - check-changes
       - android-check
     if: always()
     steps:
       - name: Check Workflow Status
         run: |
-          if [[ "${{ needs.android-check.result }}" == "failure" || "${{ needs.android-check.result }}" == "cancelled" ]]; then
+          if [[ "${{ needs.check-changes.result }}" != "success" ]]; then
+            echo "::error::Change detection failed"
+            exit 1
+          fi
+          if [[ "${{ needs.check-changes.outputs.android }}" == "true" && ("${{ needs.android-check.result }}" == "failure" || "${{ needs.android-check.result }}" == "cancelled") ]]; then
             echo "::error::Android Check failed"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [macos-latest, windows-latest, ubuntu-24.04, ubuntu-24.04-arm]
     env:
       GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
@@ -286,7 +286,7 @@ jobs:
 
       - name: Install dependencies for AppImage
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libfuse2
+        run: sudo apt-get update && sudo apt-get install -y libfuse2t64
 
       - name: Package Native Distributions
         env:
@@ -307,6 +307,29 @@ jobs:
           ./gradlew :desktopApp:packageReleaseDistributionForCurrentOS
           ${{ contains(runner.os, 'macOS') && ':desktopApp:packageReleaseUberJarForCurrentOS' || '' }}
           '-PaboutLibraries.release=true' --no-daemon
+
+      # jpackage computes the .deb Depends: line from the build host's package names.
+      # Ubuntu 24.04 records time_t64 transition names (libasound2t64, libpng16-16t64)
+      # that don't exist on Debian 12 Bookworm / Raspberry Pi OS, making the .deb
+      # uninstallable there (#5233 pinned ubuntu-22.04 for this; those runners retire
+      # 2027-04, brownouts from 2026-09). Strip the t64 suffix instead: Bookworm ships
+      # the plain names, and on Trixie / Ubuntu 24.04+ the t64 packages Provide them.
+      # Rewriting the control file is the only host-independent fix — jpackage's
+      # --linux-package-deps is additive-only, and the Compose plugin clears its
+      # --resource-dir during the task, so a custom control template can't be injected.
+      - name: Rewrite t64 dependency names in .deb (Debian Bookworm / Pi OS compatibility)
+        if: runner.os == 'Linux'
+        run: |
+          shopt -s nullglob
+          for deb in desktopApp/build/compose/binaries/main-release/deb/*.deb; do
+            work=$(mktemp -d)
+            dpkg-deb -R "$deb" "$work"
+            echo "$(basename "$deb") before: $(grep '^Depends:' "$work/DEBIAN/control")"
+            sed -i -E '/^Depends:/ s/(lib[a-z0-9.+-]*)t64([, (]|$)/\1\2/g' "$work/DEBIAN/control"
+            echo "$(basename "$deb") after:  $(grep '^Depends:' "$work/DEBIAN/control")"
+            dpkg-deb -b --root-owner-group "$work" "$deb"
+            rm -rf "$work"
+          done
 
       - name: List Desktop Binaries
         if: runner.os == 'Linux' || runner.os == 'macOS'
@@ -348,7 +371,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm]
+        # No .deb host-coupling here (pure-Java uber jar + URL manifest) — free to track
+        # the current LTS image.
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     env:
       GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,8 +325,12 @@ jobs:
             work=$(mktemp -d)
             dpkg-deb -R "$deb" "$work"
             echo "$(basename "$deb") before: $(grep '^Depends:' "$work/DEBIAN/control")"
-            sed -i -E '/^Depends:/ s/(lib[a-z0-9.+-]*)t64([, (]|$)/\1\2/g' "$work/DEBIAN/control"
+            sed -i -E '/^(Depends|Pre-Depends|Recommends):/ s/(lib[a-z0-9.+-]*)t64([, (]|$)/\1\2/g' "$work/DEBIAN/control"
             echo "$(basename "$deb") after:  $(grep '^Depends:' "$work/DEBIAN/control")"
+            if grep -nE '^[A-Za-z-]+:.*\blib[a-z0-9.+-]*t64\b' "$work/DEBIAN/control"; then
+              echo "::error::t64 dependency name survived rewrite in $(basename "$deb") — extend the sed above"
+              exit 1
+            fi
             dpkg-deb -b --root-owner-group "$work" "$deb"
             rm -rf "$work"
           done

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -93,6 +93,7 @@ jobs:
       contents: read
     timeout-minutes: 30
     needs: setup
+    if: inputs.run_lint == true
     env:
       VERSION_CODE: ${{ needs.setup.outputs.version_code }}
 
@@ -112,12 +113,7 @@ jobs:
           install_jetbrains_jdk: 'true'
 
       - name: Lint, Analysis & KMP Smoke Compile
-        if: inputs.run_lint == true
         run: ./gradlew spotlessCheck detekt androidApp:lintFdroidDebug androidApp:lintGoogleDebug core:barcode:lintFdroidDebug core:barcode:lintGoogleDebug kmpSmokeCompile -Pci=true --continue
-
-      - name: KMP Smoke Compile (lint skipped)
-        if: inputs.run_lint == false
-        run: ./gradlew kmpSmokeCompile -Pci=true --continue
 
   # ── Screenshot Test Validation ──────────────────────────────────────
   screenshot-check:
@@ -156,13 +152,14 @@ jobs:
           if-no-files-found: warn
 
   # ── Reproducible Build Verification ─────────────────────────────────
-  # Only runs on main push and merge-queue (not PRs) to keep PR feedback fast.
+  # Only runs in the merge queue (not PRs, to keep PR feedback fast; not main pushes,
+  # which are the same merge commit the queue just verified).
   rb-check:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 30
-    if: inputs.run_lint == true && (github.event_name == 'push' || github.event_name == 'merge_group')
+    if: inputs.run_lint == true && github.event_name == 'merge_group'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -12,6 +12,9 @@ on:
       run_coverage:
         type: boolean
         default: true
+      run_desktop_builds:
+        type: boolean
+        default: false
       run_desktop_flatpak_src:
         type: boolean
         default: false

--- a/.github/workflows/verify-flatpak.yml
+++ b/.github/workflows/verify-flatpak.yml
@@ -8,6 +8,11 @@ on:
       - 'build.gradle.kts'
       - 'settings.gradle.kts'
       - '.github/workflows/verify-flatpak.yml'
+      # The desktop module's build config shapes the uber jar the flatpak wraps.
+      - 'desktopApp/**'
+      # The offline manifest pins the Gradle distribution independently of the wrapper —
+      # a wrapper bump without a manifest update breaks the offline build silently.
+      - 'gradle/wrapper/**'
   workflow_dispatch:
 
 permissions:

--- a/.skills/testing-ci/SKILL.md
+++ b/.skills/testing-ci/SKILL.md
@@ -131,6 +131,7 @@ CI is defined in `.github/workflows/reusable-check.yml` and structured as parall
 - **`fail-fast: false`:** Test sharding does not cancel other shards on failure.
 - **Explicit Gradle task paths:** Prefer `app:lintFdroidDebug` over shorthand `lintDebug` in CI.
 - **Pull request CI:** Main-only (`.github/workflows/pull-request.yml` targets `main`).
+- **Merge queue hygiene:** `merge-queue.yml` cancels superseded runs for the same PR (GitHub does not auto-cancel destroyed merge-group runs) and skips the heavy pipeline for docs-only entries (`docs/**`, `*.md`). `rb-check` runs ONLY in the merge queue. `main-check.yml` passes `run_lint: false` — every main commit is a merge-queue-verified merge commit, so main pushes only rebuild the debug APKs for the snapshot release.
 - **Cache writes:** Trusted on `main` and merge queue runs; other refs use read-only cache.
 - **Path filtering:** `check-changes` in `pull-request.yml` must include module dirs plus build/workflow entrypoints (`build-logic/**`, `gradle/**`, `.github/workflows/**`, `gradlew`, `settings.gradle.kts`, etc.).
 - **AboutLibraries:** Runs in `offlineMode` by default (no GitHub/SPDX API calls). Release builds pass `-PaboutLibraries.release=true` via Fastlane/Gradle CLI to enable remote license fetching. Do NOT re-gate on `CI` or `GITHUB_TOKEN` alone.


### PR DESCRIPTION
## Why

Three CI workstreams landed together while auditing the pipeline ahead of the Flathub submission and 2.8.0:

1. **Merge-queue runs were taking 48–96 min at peak for a pipeline that completes in 6–17 min off-peak** — pure runner-pool contention, not build time (measured from `gh run view` timing across the last 40 merge-queue runs; e.g. run 29030419053 sat 21 minutes between `setup` finishing and `lint-check` starting).
2. **Desktop distributable builds were dead code** — the `build-desktop` job was gated on a `run_desktop_builds` input that was never declared, so no caller could enable it. With Flathub in flight and 2.8.0 approaching, desktop packaging regressions need to surface before release time.
3. **The desktop release matrix was pinned to ubuntu-22.04 runners that begin brownouts 2026-09-17** (fully retired 2027-04-17), so the pin had a deadline.

## 🌟 New

- **Desktop distributable builds on every main push.** `run_desktop_builds` is now a declared input, enabled by `main-check.yml`: every merge produces `createDistributable` app images for macOS, Windows, and Linux (x64 + arm) as run artifacts. Post-merge rather than in the merge queue — `:desktopApp:test` in shard-app already covers desktop compilation there, and a 4-OS matrix (macOS/Windows queue times) would slow every merge.
- **`verify-flatpak.yml` now also triggers on `desktopApp/**` and `gradle/wrapper/**`.** The offline manifest pins the Gradle distribution independently of the wrapper, so wrapper bumps previously broke the offline Flatpak build silently; desktop build-config changes shape the uber jar the flatpak wraps.

## 🛠️ Improvements (merge-queue contention)

- **`merge-queue.yml`**: new `cancel-superseded` job. GitHub does not cancel workflow runs when a merge group is destroyed, and the old `concurrency` group keyed on `github.ref` (unique per queue entry) never matched anything — observed 3 simultaneous queued runs for PR #6166, all but one for already-destroyed merge groups, each holding ~7 heavy job slots. The new job cancels older `merge_group` runs for the same PR (matched by the `gh-readonly-queue/main/pr-N-` branch prefix, compared by run id).
- **`merge-queue.yml`**: new `check-changes` gate diffs the merge group against its base and skips the heavy pipeline when only `docs/**` / `*.md` changed (mirrors `main-check.yml`'s `paths-ignore`). `check-workflow-status` still reports success so the required check is satisfied.
- **`main-check.yml`**: passes `run_lint: false`. Every main commit is the exact merge commit the queue just verified, so re-running lint, screenshot-check, and rb-check on it was pure duplication — main pushes now build only the snapshot APKs and desktop distributables. `lint-check` is gated on `run_lint` at the job level, and `rb-check` runs solely in the merge queue.
- **`main-check.yml`**: `publish-snapshot` is guarded with `!cancelled()` so a desktop-matrix failure can't block the Android snapshot release (if the APK build itself failed, the artifact download fails and the job still goes red).

Net: ~4 fewer heavy jobs per merged PR in the gating path, stale runs no longer hold queue slots, and no gating coverage is lost — everything removed was a duplicate of a check the merge queue already ran on the same commit.

## 🐛 Fixes (desktop release off ubuntu-22.04)

- **Desktop release matrix: `ubuntu-22.04` → `ubuntu-24.04`** (x64 + arm). The pin existed because jpackage computes the `.deb` `Depends:` line from the build host, and Ubuntu 24.04 records time_t64 transition names (`libasound2t64`, `libpng16-16t64`) that don't exist on Debian 12 Bookworm / Raspberry Pi OS, making the `.deb` uninstallable there (#5233). It was never about glibc — the bundled JBR, jpackage launcher, and skiko are all vendor-prebuilt.
- **New `.deb` post-processing step** (before upload/attestation): unpack with `dpkg-deb -R`, strip the `t64` suffix from `lib*` names on the `Depends:` line, repack with `--root-owner-group`. Bookworm ships the plain names and the t64 packages `Provide` them on Trixie / Ubuntu 24.04+, so one artifact installs everywhere — strictly better than the 22.04-built one. This is the only host-independent fix: jpackage's `--linux-package-deps` is additive-only (JDK 21 `LinuxPackageBundler` appends custom deps to the host-computed list), the Compose plugin exposes no dep override, and it clears its `--resource-dir` mid-task so a custom control template can't be injected. The step logs before/after `Depends:` lines for verification on the first real release run.
- **`libfuse2` → `libfuse2t64`** for the AppImage tooling install (the old name has no install candidate on 24.04), and **`create-flatpak-src` moves to 24.04** (pure-Java uber jar + URL manifest, no host coupling).

## 🧹 Chores

- Documented the merge-queue hygiene rules in `.skills/testing-ci/SKILL.md`.

## Testing Performed

- `actionlint` on all touched workflows: the pre-existing `run_desktop_builds is not defined` error is resolved; the remaining findings are identical before/after (pre-existing shellcheck style notes).
- Docs-only merge-queue filter verified against POSIX grep for docs-only / mixed / code-only / empty-diff / `.mdx` cases; PR-prefix extraction verified against a real queue ref.
- t64 `sed` rewrite verified against a realistic `Depends:` line (versioned deps, multi-dash names, line-end), including idempotency on an already-clean line. The full unpack→rewrite→repack path can only run on a Linux release build — the step echoes before/after `Depends:` for the first release to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI checks now cancel superseded merge-queue runs and skip heavy processing for docs-only changes.
  * Desktop-related packaging can be enabled or deferred as part of CI workflows, depending on the run type.

* **Bug Fixes**
  * Improved Linux desktop release packaging by adjusting dependency handling and correcting Debian package dependency names.
  * Flatpak verification now triggers when desktop app or build-wrapper files change, reducing missed failures.

* **Documentation**
  * Updated CI guidance to reflect the new merge-queue hygiene, change-based skipping, and adjusted build-check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->