### PR TITLE
fix(database): recover firmware metadata reads after DB pool churn

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceHardwareLocalDataSource.kt
@@ -16,38 +16,33 @@
  */
 package org.meshtastic.core.data.datasource
 
-import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.DeviceHardwareEntity
 import org.meshtastic.core.database.entity.asEntity
-import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.NetworkDeviceHardware
 
 @Single
-class DeviceHardwareLocalDataSource(
-    private val dbManager: DatabaseProvider,
-    private val dispatchers: CoroutineDispatchers,
-) {
-    private val deviceHardwareDao
-        get() = dbManager.currentDb.value.deviceHardwareDao()
+class DeviceHardwareLocalDataSource(private val dbManager: DatabaseProvider) {
+    suspend fun insertAllDeviceHardware(deviceHardware: List<NetworkDeviceHardware>) {
+        dbManager.withDb { it.deviceHardwareDao().insertAll(deviceHardware.map { hw -> hw.asEntity() }) }
+    }
 
-    suspend fun insertAllDeviceHardware(deviceHardware: List<NetworkDeviceHardware>) =
-        withContext(dispatchers.io) { deviceHardwareDao.insertAll(deviceHardware.map { it.asEntity() }) }
-
-    suspend fun deleteAllDeviceHardware() = withContext(dispatchers.io) { deviceHardwareDao.deleteAll() }
+    suspend fun deleteAllDeviceHardware() {
+        dbManager.withDb { it.deviceHardwareDao().deleteAll() }
+    }
 
     suspend fun getByHwModel(hwModel: Int): List<DeviceHardwareEntity> =
-        withContext(dispatchers.io) { deviceHardwareDao.getByHwModel(hwModel) }
+        dbManager.withDb { it.deviceHardwareDao().getByHwModel(hwModel) }.orEmpty()
 
     suspend fun getByTarget(target: String): DeviceHardwareEntity? =
-        withContext(dispatchers.io) { deviceHardwareDao.getByTarget(target) }
+        dbManager.withDb { it.deviceHardwareDao().getByTarget(target) }
 
     suspend fun getByModelAndTarget(hwModel: Int, target: String): DeviceHardwareEntity? =
-        withContext(dispatchers.io) { deviceHardwareDao.getByModelAndTarget(hwModel, target) }
+        dbManager.withDb { it.deviceHardwareDao().getByModelAndTarget(hwModel, target) }
 
-    suspend fun hasAnyEntries(): Boolean = withContext(dispatchers.io) { deviceHardwareDao.count() > 0 }
+    suspend fun hasAnyEntries(): Boolean = dbManager.withDb { it.deviceHardwareDao().count() > 0 } ?: false
 
     /** All known `platformioTarget` values — used to determine which msh.to links are vendor links. */
-    suspend fun getAllTargets(): List<String> = withContext(dispatchers.io) { deviceHardwareDao.getAllTargets() }
+    suspend fun getAllTargets(): List<String> = dbManager.withDb { it.deviceHardwareDao().getAllTargets() }.orEmpty()
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
@@ -16,31 +16,32 @@
  */
 package org.meshtastic.core.data.datasource
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.flatMapLatest
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.DeviceLinkEntity
-import org.meshtastic.core.di.CoroutineDispatchers
 
 @Single
-class DeviceLinkLocalDataSource(
-    private val dbManager: DatabaseProvider,
-    private val dispatchers: CoroutineDispatchers,
-) {
-    private val deviceLinkDao
-        get() = dbManager.currentDb.value.deviceLinkDao()
+class DeviceLinkLocalDataSource(private val dbManager: DatabaseProvider) {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observeAll(): Flow<List<DeviceLinkEntity>> =
+        dbManager.currentDb.flatMapLatest { db -> db.deviceLinkDao().observeAll() }
 
-    fun observeAll(): Flow<List<DeviceLinkEntity>> = deviceLinkDao.observeAll()
+    suspend fun getAll(): List<DeviceLinkEntity> = dbManager.withDb { it.deviceLinkDao().getAll() }.orEmpty()
 
-    suspend fun getAll(): List<DeviceLinkEntity> = withContext(dispatchers.io) { deviceLinkDao.getAll() }
+    suspend fun upsertAll(links: List<DeviceLinkEntity>) {
+        dbManager.withDb { it.deviceLinkDao().upsertAll(links) }
+    }
 
-    suspend fun upsertAll(links: List<DeviceLinkEntity>) =
-        withContext(dispatchers.io) { deviceLinkDao.upsertAll(links) }
+    suspend fun deleteNotIn(keep: List<String>) {
+        dbManager.withDb { it.deviceLinkDao().deleteNotIn(keep) }
+    }
 
-    suspend fun deleteNotIn(keep: List<String>) = withContext(dispatchers.io) { deviceLinkDao.deleteNotIn(keep) }
+    suspend fun deleteAll() {
+        dbManager.withDb { it.deviceLinkDao().deleteAll() }
+    }
 
-    suspend fun deleteAll() = withContext(dispatchers.io) { deviceLinkDao.deleteAll() }
-
-    suspend fun count(): Int = withContext(dispatchers.io) { deviceLinkDao.count() }
+    suspend fun count(): Int = dbManager.withDb { it.deviceLinkDao().count() } ?: 0
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
@@ -42,7 +42,6 @@ class FirmwareReleaseLocalDataSource(private val dbManager: DatabaseProvider) {
     }
 
     suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? = dbManager.withDb {
-        val releases = it.firmwareReleaseDao().getReleasesByType(releaseType)
-        if (releases.isEmpty()) null else releases.maxBy { entity -> entity.asDeviceVersion() }
+        it.firmwareReleaseDao().getReleasesByType(releaseType).maxByOrNull { entity -> entity.asDeviceVersion() }
     }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/FirmwareReleaseLocalDataSource.kt
@@ -16,43 +16,33 @@
  */
 package org.meshtastic.core.data.datasource
 
-import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.FirmwareReleaseEntity
 import org.meshtastic.core.database.entity.FirmwareReleaseType
 import org.meshtastic.core.database.entity.asDeviceVersion
 import org.meshtastic.core.database.entity.asEntity
-import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.NetworkFirmwareRelease
 
 @Single
-class FirmwareReleaseLocalDataSource(
-    private val dbManager: DatabaseProvider,
-    private val dispatchers: CoroutineDispatchers,
-) {
-    private val firmwareReleaseDao
-        get() = dbManager.currentDb.value.firmwareReleaseDao()
-
-    suspend fun deleteAllFirmwareReleases() = withContext(dispatchers.io) { firmwareReleaseDao.deleteAll() }
+class FirmwareReleaseLocalDataSource(private val dbManager: DatabaseProvider) {
+    suspend fun deleteAllFirmwareReleases() {
+        dbManager.withDb { it.firmwareReleaseDao().deleteAll() }
+    }
 
     /** Transactionally replaces all rows of each given type with its API list; other types are untouched. */
-    suspend fun replaceFirmwareReleases(releasesByType: Map<FirmwareReleaseType, List<NetworkFirmwareRelease>>) =
-        withContext(dispatchers.io) {
-            firmwareReleaseDao.replaceByTypes(
-                types = releasesByType.keys.toList(),
-                releases = releasesByType.flatMap { (type, releases) -> releases.map { it.asEntity(type) } },
-            )
+    suspend fun replaceFirmwareReleases(releasesByType: Map<FirmwareReleaseType, List<NetworkFirmwareRelease>>) {
+        dbManager.withDb {
+            it.firmwareReleaseDao()
+                .replaceByTypes(
+                    types = releasesByType.keys.toList(),
+                    releases = releasesByType.flatMap { (type, releases) -> releases.map { r -> r.asEntity(type) } },
+                )
         }
+    }
 
-    suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? =
-        withContext(dispatchers.io) {
-            val releases = firmwareReleaseDao.getReleasesByType(releaseType)
-            if (releases.isEmpty()) {
-                return@withContext null
-            } else {
-                val latestRelease = releases.maxBy { it.asDeviceVersion() }
-                return@withContext latestRelease
-            }
-        }
+    suspend fun getLatestRelease(releaseType: FirmwareReleaseType): FirmwareReleaseEntity? = dbManager.withDb {
+        val releases = it.firmwareReleaseDao().getReleasesByType(releaseType)
+        if (releases.isEmpty()) null else releases.maxBy { entity -> entity.asDeviceVersion() }
+    }
 }

--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/DeviceLinkRepositoryImplTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/DeviceLinkRepositoryImplTest.kt
@@ -94,7 +94,7 @@ class DeviceLinkRepositoryImplTest {
     @BeforeTest
     fun setup() {
         dbProvider = FakeDatabaseProvider()
-        local = DeviceLinkLocalDataSource(dbProvider, dispatchers)
+        local = DeviceLinkLocalDataSource(dbProvider)
         api = FakeApiService(NetworkDeviceLinksResponse())
         seed = FakeBundledAssetReader(emptyList(), json)
         repository =

--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImplTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImplTest.kt
@@ -97,7 +97,7 @@ class FirmwareReleaseRepositoryImplTest {
         repository =
             FirmwareReleaseRepositoryImpl(
                 remoteDataSource = FirmwareReleaseRemoteDataSource(api, dispatchers),
-                localDataSource = FirmwareReleaseLocalDataSource(dbProvider, dispatchers),
+                localDataSource = FirmwareReleaseLocalDataSource(dbProvider),
                 assetReader = seed,
                 json = Json { ignoreUnknownKeys = true },
                 dispatchers = dispatchers,

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -352,15 +352,24 @@ open class DatabaseManager(
     private fun isDbClosedException(e: Exception): Boolean = generateSequence<Throwable>(e) { it.cause }
         .any { throwable ->
             val msg = throwable.message?.lowercase() ?: return@any false
+            val hasDbContext = DB_TERMS.any { it in msg }
             // Room can surface switched/pool-churn failures as SQLite BUSY/acquire timeout, not only "closed".
-            ("closed" in msg && DB_TERMS.any { it in msg }) || TRANSIENT_DB_POOL_TERMS.any { it in msg }
+            ("closed" in msg && hasDbContext) || (TRANSIENT_DB_POOL_TERMS.any { it in msg } && hasDbContext)
         }
 
     private companion object {
         private const val BACKFILL_COLD_START_DELAY_MS = 2_000L
         private const val WITH_DB_SLOW_OPERATION_MS = 1_000L
         val DB_TERMS = listOf("pool", "database", "connection", "sqlite")
-        val TRANSIENT_DB_POOL_TERMS = listOf("timed out attempting to acquire", "error code: 5", "database is locked")
+        val TRANSIENT_DB_POOL_TERMS =
+            listOf(
+                "timed out attempting to acquire",
+                "error code: 5",
+                "database is locked",
+                "sqlite_busy",
+                "busy",
+                "locked",
+            )
     }
 
     /**

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -281,6 +281,23 @@ open class DatabaseManager(
         Logger.d { "Closed inactive database ${anonymizeDbName(dbName)} to free connections" }
     }
 
+    /**
+     * Closes and reopens the active database under [mutex], but only if it hasn't switched since the caller snapshotted
+     * it. Returns the reopened DB, or null if another coroutine already switched to a different device.
+     */
+    private suspend fun reopenActiveDatabaseIfStillCurrent(
+        expectedDb: MeshtasticDatabase,
+        expectedDbName: String,
+    ): MeshtasticDatabase? = mutex.withLock {
+        if (_currentDb.value !== expectedDb || currentDbName != expectedDbName) return null
+
+        closeCachedDatabase(expectedDbName)
+        val reopened = withContext(dispatchers.io) { getOrOpenDatabase(expectedDbName) }
+        _currentDb.value = reopened
+        currentDbName = expectedDbName
+        reopened
+    }
+
     // Short-term runtime containment: route withDb entry through a single-lane dispatcher to narrow the Room/SQLite
     // connection-pool churn window seen during device/firmware update flows. Room suspend DAOs may continue on Room's
     // own executor after suspension, so this is not a strict global DB-I/O serialization guarantee. Preserve bounded
@@ -327,17 +344,33 @@ open class DatabaseManager(
             // If the active database switched while we held a reference to the old one,
             // and the exception indicates a closed pool/connection, retry with the new DB.
             val retryDb = _currentDb.value
-            if (retryDb == null || retryDb === db || !isDbClosedException(e)) throw e
-
-            Logger.w { "withDb: database closed during switch (${e.message}), retrying with current DB" }
-            return try {
-                runCancellableDbBlock(retryDb, block)
-            } catch (retryCancel: CancellationException) {
-                throw retryCancel
-            } catch (retryEx: Exception) {
-                retryEx.addSuppressed(e)
-                throw retryEx
+            if (retryDb != null && retryDb !== db && isDbClosedException(e)) {
+                Logger.w { "withDb: database closed during switch (${e.message}), retrying with current DB" }
+                return try {
+                    runCancellableDbBlock(retryDb, block)
+                } catch (retryCancel: CancellationException) {
+                    throw retryCancel
+                } catch (retryEx: Exception) {
+                    retryEx.addSuppressed(e)
+                    throw retryEx
+                }
             }
+
+            // Same active DB but Room's connection pool is wedged — close and reopen once.
+            if (retryDb === db && isDbPoolAcquireTimeoutException(e)) {
+                val reopened = reopenActiveDatabaseIfStillCurrent(db, active) ?: throw e
+                Logger.w { "withDb: reopened active DB after transient Room connection-pool timeout" }
+                return try {
+                    runCancellableDbBlock(reopened, block)
+                } catch (retryCancel: CancellationException) {
+                    throw retryCancel
+                } catch (retryEx: Exception) {
+                    retryEx.addSuppressed(e)
+                    throw retryEx
+                }
+            }
+
+            throw e
         }
     }
 
@@ -357,19 +390,20 @@ open class DatabaseManager(
             ("closed" in msg && hasDbContext) || (TRANSIENT_DB_POOL_TERMS.any { it in msg } && hasDbContext)
         }
 
-    private companion object {
+    internal companion object {
         private const val BACKFILL_COLD_START_DELAY_MS = 2_000L
         private const val WITH_DB_SLOW_OPERATION_MS = 1_000L
         val DB_TERMS = listOf("pool", "database", "connection", "sqlite")
         val TRANSIENT_DB_POOL_TERMS =
-            listOf(
-                "timed out attempting to acquire",
-                "error code: 5",
-                "database is locked",
-                "sqlite_busy",
-                "busy",
-                "locked",
-            )
+            listOf("timed out attempting to acquire", "error code: 5", "database is locked", "sqlite_busy")
+
+        fun isDbPoolAcquireTimeoutException(e: Exception): Boolean = generateSequence<Throwable>(e) { it.cause }
+            .any { throwable ->
+                val msg = throwable.message?.lowercase() ?: return@any false
+                "timed out attempting to acquire" in msg &&
+                    ("reader connection" in msg || "writer connection" in msg) &&
+                    DB_TERMS.any { it in msg }
+            }
     }
 
     /**

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -282,8 +282,11 @@ open class DatabaseManager(
     }
 
     /**
-     * Closes and reopens the active database under [mutex], but only if it hasn't switched since the caller snapshotted
-     * it. Returns the reopened DB, or null if another coroutine already switched to a different device.
+     * Reopens the active database under [mutex], but only if it hasn't switched since the caller snapshotted it. Emits
+     * the replacement DB BEFORE closing the old pool so [currentDb] Flow collectors can move to the new instance
+     * without seeing a closed-pool error.
+     *
+     * Returns the reopened DB, or null if another coroutine already switched to a different device.
      */
     private suspend fun reopenActiveDatabaseIfStillCurrent(
         expectedDb: MeshtasticDatabase,
@@ -291,10 +294,31 @@ open class DatabaseManager(
     ): MeshtasticDatabase? = mutex.withLock {
         if (_currentDb.value !== expectedDb || currentDbName != expectedDbName) return null
 
-        closeCachedDatabase(expectedDbName)
-        val reopened = withContext(dispatchers.io) { getOrOpenDatabase(expectedDbName) }
+        val cached = dbCache[expectedDbName]
+        if (cached !== expectedDb) {
+            Logger.w { "withDb: active DB cache entry changed before reopen; skipping active DB reopen" }
+            return null
+        }
+
+        // Remove from cache without closing so getDatabaseBuilder builds a fresh instance.
+        dbCache.remove(expectedDbName)
+
+        val reopened = withContext(dispatchers.io) { getDatabaseBuilder(expectedDbName).build() }
+        dbCache[expectedDbName] = reopened
         _currentDb.value = reopened
-        currentDbName = expectedDbName
+
+        // Close the replaced instance AFTER emitting the replacement so flatMapLatest collectors
+        // have already moved to the new DB before the old pool closes.
+        managerScope.launch(dispatchers.io) {
+            runCatching { expectedDb.close() }
+                .onFailure {
+                    Logger.w(it) { "Failed to close replaced active database ${anonymizeDbName(expectedDbName)}" }
+                }
+                .onSuccess {
+                    Logger.d { "Closed replaced active database ${anonymizeDbName(expectedDbName)} after reopen" }
+                }
+        }
+
         reopened
     }
 
@@ -397,12 +421,23 @@ open class DatabaseManager(
         val TRANSIENT_DB_POOL_TERMS =
             listOf("timed out attempting to acquire", "error code: 5", "database is locked", "sqlite_busy")
 
+        private const val ROOM_POOL_ACQUIRE_TIMEOUT_PHRASE = "timed out attempting to acquire"
+        private const val ROOM_READER_CONNECTION_PHRASE = "reader connection"
+        private const val ROOM_WRITER_CONNECTION_PHRASE = "writer connection"
+
+        /**
+         * Room KMP currently exposes pool-acquire timeouts as exception message text instead of a stable common typed
+         * signal. Keep this fallback narrow so BLE/GATT/transport connection errors do not trigger DB reopen recovery.
+         */
+        private fun isRoomPoolAcquireTimeoutMessage(message: String): Boolean =
+            ROOM_POOL_ACQUIRE_TIMEOUT_PHRASE in message &&
+                (ROOM_READER_CONNECTION_PHRASE in message || ROOM_WRITER_CONNECTION_PHRASE in message) &&
+                DB_TERMS.any { it in message }
+
         fun isDbPoolAcquireTimeoutException(e: Exception): Boolean = generateSequence<Throwable>(e) { it.cause }
             .any { throwable ->
                 val msg = throwable.message?.lowercase() ?: return@any false
-                "timed out attempting to acquire" in msg &&
-                    ("reader connection" in msg || "writer connection" in msg) &&
-                    DB_TERMS.any { it in msg }
+                isRoomPoolAcquireTimeoutMessage(msg)
             }
     }
 

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -352,13 +352,15 @@ open class DatabaseManager(
     private fun isDbClosedException(e: Exception): Boolean = generateSequence<Throwable>(e) { it.cause }
         .any { throwable ->
             val msg = throwable.message?.lowercase() ?: return@any false
-            "closed" in msg && DB_TERMS.any { it in msg }
+            // Room can surface switched/pool-churn failures as SQLite BUSY/acquire timeout, not only "closed".
+            ("closed" in msg && DB_TERMS.any { it in msg }) || TRANSIENT_DB_POOL_TERMS.any { it in msg }
         }
 
     private companion object {
         private const val BACKFILL_COLD_START_DELAY_MS = 2_000L
         private const val WITH_DB_SLOW_OPERATION_MS = 1_000L
         val DB_TERMS = listOf("pool", "database", "connection", "sqlite")
+        val TRANSIENT_DB_POOL_TERMS = listOf("timed out attempting to acquire", "error code: 5", "database is locked")
     }
 
     /**

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -282,9 +282,11 @@ open class DatabaseManager(
     }
 
     /**
-     * Reopens the active database under [mutex], but only if it hasn't switched since the caller snapshotted it. Emits
-     * the replacement DB BEFORE closing the old pool so [currentDb] Flow collectors can move to the new instance
-     * without seeing a closed-pool error.
+     * Reopens the active database under [mutex], but only if it hasn't switched since the caller snapshotted it.
+     *
+     * The replaced Room instance is intentionally left open for the rest of the process. [currentDb] is a derived
+     * StateFlow, so there is no deterministic handoff point where every app-wide collector has stopped using the old
+     * instance.
      *
      * Returns the reopened DB, or null if another coroutine already switched to a different device.
      */
@@ -300,24 +302,19 @@ open class DatabaseManager(
             return null
         }
 
-        // Remove from cache without closing so getDatabaseBuilder builds a fresh instance.
-        dbCache.remove(expectedDbName)
-
+        // Build a fresh instance directly (not through getOrPut) before touching the cache,
+        // so a failed or cancelled build leaves the existing cache entry and _currentDb consistent.
         val reopened = withContext(dispatchers.io) { getDatabaseBuilder(expectedDbName).build() }
         dbCache[expectedDbName] = reopened
         _currentDb.value = reopened
 
-        // Close the replaced instance AFTER emitting the replacement so flatMapLatest collectors
-        // have already moved to the new DB before the old pool closes.
-        managerScope.launch(dispatchers.io) {
-            runCatching { expectedDb.close() }
-                .onFailure {
-                    Logger.w(it) { "Failed to close replaced active database ${anonymizeDbName(expectedDbName)}" }
-                }
-                .onSuccess {
-                    Logger.d { "Closed replaced active database ${anonymizeDbName(expectedDbName)} after reopen" }
-                }
-        }
+        // Intentionally do not close expectedDb here. The public currentDb Flow is derived from
+        // _currentDb through stateIn, so downstream flatMapLatest collectors may still be using the
+        // replaced Room instance after this function emits the reopened DB. Closing the old pool here
+        // can surface "Connection pool is closed" to app-wide DB observers that do not have closed-pool
+        // recovery. This mirrors switchActiveDatabase's no-sync-close discipline; the leaked pool is
+        // bounded by rare active-DB reopen recovery events and is reclaimed on process death. Revisit
+        // once switching DB observers have explicit closed-pool resubscribe/retry handling.
 
         reopened
     }
@@ -355,7 +352,7 @@ open class DatabaseManager(
         }
     }
 
-    @Suppress("ReturnCount", "ThrowsCount", "TooGenericExceptionCaught")
+    @Suppress("ReturnCount", "ThrowsCount", "TooGenericExceptionCaught", "CyclomaticComplexMethod")
     private suspend fun <T> withCurrentDb(block: suspend (MeshtasticDatabase) -> T): T? {
         val db = _currentDb.value ?: return null
         val active = currentDbName
@@ -380,12 +377,19 @@ open class DatabaseManager(
                 }
             }
 
-            // Same active DB but Room's connection pool is wedged — close and reopen once.
+            // Same active DB but Room's connection pool is wedged — reopen onto a fresh active instance once.
             if (retryDb === db && isDbPoolAcquireTimeoutException(e)) {
-                val reopened = reopenActiveDatabaseIfStillCurrent(db, active) ?: throw e
-                Logger.w { "withDb: reopened active DB after transient Room connection-pool timeout" }
+                val reopened = reopenActiveDatabaseIfStillCurrent(db, active)
+                val recoveredDb = reopened ?: _currentDb.value?.takeIf { it !== db } ?: throw e
+                Logger.w {
+                    if (reopened != null) {
+                        "withDb: reopened active DB after transient Room connection-pool timeout"
+                    } else {
+                        "withDb: active DB switched during timeout recovery; retrying with current DB"
+                    }
+                }
                 return try {
-                    runCancellableDbBlock(reopened, block)
+                    runCancellableDbBlock(recoveredDb, block)
                 } catch (retryCancel: CancellationException) {
                     throw retryCancel
                 } catch (retryEx: Exception) {
@@ -406,20 +410,18 @@ open class DatabaseManager(
         return result
     }
 
-    private fun isDbClosedException(e: Exception): Boolean = generateSequence<Throwable>(e) { it.cause }
-        .any { throwable ->
-            val msg = throwable.message?.lowercase() ?: return@any false
-            val hasDbContext = DB_TERMS.any { it in msg }
-            // Room can surface switched/pool-churn failures as SQLite BUSY/acquire timeout, not only "closed".
-            ("closed" in msg && hasDbContext) || (TRANSIENT_DB_POOL_TERMS.any { it in msg } && hasDbContext)
-        }
+    private fun isDbClosedException(e: Exception): Boolean = isDbPoolAcquireTimeoutException(e) ||
+        generateSequence<Throwable>(e) { it.cause }
+            .any { throwable ->
+                val msg = throwable.message?.lowercase() ?: return@any false
+                val hasDbContext = DB_TERMS.any { it in msg }
+                ("closed" in msg && hasDbContext) || "database is locked" in msg || "sqlite_busy" in msg
+            }
 
     internal companion object {
         private const val BACKFILL_COLD_START_DELAY_MS = 2_000L
         private const val WITH_DB_SLOW_OPERATION_MS = 1_000L
         val DB_TERMS = listOf("pool", "database", "connection", "sqlite")
-        val TRANSIENT_DB_POOL_TERMS =
-            listOf("timed out attempting to acquire", "error code: 5", "database is locked", "sqlite_busy")
 
         private const val ROOM_POOL_ACQUIRE_TIMEOUT_PHRASE = "timed out attempting to acquire"
         private const val ROOM_READER_CONNECTION_PHRASE = "reader connection"
@@ -431,8 +433,7 @@ open class DatabaseManager(
          */
         private fun isRoomPoolAcquireTimeoutMessage(message: String): Boolean =
             ROOM_POOL_ACQUIRE_TIMEOUT_PHRASE in message &&
-                (ROOM_READER_CONNECTION_PHRASE in message || ROOM_WRITER_CONNECTION_PHRASE in message) &&
-                DB_TERMS.any { it in message }
+                (ROOM_READER_CONNECTION_PHRASE in message || ROOM_WRITER_CONNECTION_PHRASE in message)
 
         fun isDbPoolAcquireTimeoutException(e: Exception): Boolean = generateSequence<Throwable>(e) { it.cause }
             .any { throwable ->

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerPoolTimeoutClassifierTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerPoolTimeoutClassifierTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DatabaseManagerPoolTimeoutClassifierTest {
+
+    @Test
+    fun `matches Room reader connection acquire timeout`() {
+        val e = Exception("Error code: 5, message: Timed out attempting to acquire a reader connection.")
+        assertTrue(DatabaseManager.isDbPoolAcquireTimeoutException(e))
+    }
+
+    @Test
+    fun `matches Room writer connection acquire timeout`() {
+        val e = Exception("Error code: 5, message: Timed out attempting to acquire a writer connection.")
+        assertTrue(DatabaseManager.isDbPoolAcquireTimeoutException(e))
+    }
+
+    @Test
+    fun `matches when wrapped in a causal chain`() {
+        val root = Exception("Error code: 5, message: Timed out attempting to acquire a reader connection.")
+        val wrapper = RuntimeException("DAO query failed", root)
+        assertTrue(DatabaseManager.isDbPoolAcquireTimeoutException(wrapper))
+    }
+
+    @Test
+    fun `rejects generic connection locked`() {
+        val e = RuntimeException("connection locked by transport layer")
+        assertFalse(DatabaseManager.isDbPoolAcquireTimeoutException(e))
+    }
+
+    @Test
+    fun `rejects non-DB timeout`() {
+        val e = RuntimeException("Timed out attempting to acquire a BLE GATT connection")
+        assertFalse(DatabaseManager.isDbPoolAcquireTimeoutException(e))
+    }
+
+    @Test
+    fun `rejects plain database locked without acquire timeout`() {
+        val e = Exception("database is locked")
+        assertFalse(DatabaseManager.isDbPoolAcquireTimeoutException(e))
+    }
+}


### PR DESCRIPTION
## Overview

This PR hardens firmware metadata database access during device switches and new-node connection flows.

The app can switch active per-device databases while firmware/device capability lookups are still in flight. Room KMP can surface that churn as transient connection-pool failures such as closed-pool errors or reader/writer connection acquisition timeouts.

This change routes the affected bounded firmware/device metadata reads through `DatabaseManager.withDb` and adds one-shot recovery paths for transient Room connection-pool churn.

## Key Changes

* Routed firmware release lookups through `DatabaseManager.withDb`.
* Routed device hardware capability lookups through `DatabaseManager.withDb`.
* Routed device-link writes and point-in-time reads through `DatabaseManager.withDb`.
* Kept device-link observation as a switching `flatMapLatest` flow so it resubscribes when the active database changes.
* Added transient DB-pool error detection for Room/KMP connection-pool churn.
* Retried once against the current DB when a stale DB is closed during a device switch.
* Reopened the active DB once when Room reports a reader/writer connection acquisition timeout on the current active DB.
* Left the replaced active Room instance open for the process lifetime after active-DB reopen to avoid closed-pool races with app-wide `currentDb` collectors.
* Isolated Room pool-acquire timeout message matching behind a narrow compatibility helper so non-DB connection errors do not trigger DB reopen recovery.
* Preserved safe defaults when the active database is unavailable:
  * empty lists for list reads,
  * `false` for boolean capability checks,
  * `0` for counts,
  * nullable passthrough for single-entity lookups.
* Removed redundant datasource-level dispatcher hops now that `withDb` owns the bounded DB access lane.

## Testing

* Added coverage for Room reader connection acquisition timeout detection.
* Added coverage for Room writer connection acquisition timeout detection.
* Added coverage for wrapped Room connection-pool timeout exceptions.
* Added coverage proving generic non-DB connection errors are not treated as DB pool acquisition timeouts.
* Added coverage proving BLE/GATT connection timeout messages are not treated as DB pool acquisition timeouts.
* Added coverage proving bare `database is locked` messages are not treated as active-pool acquisition timeouts.
* Updated repository tests for the simplified datasource constructors.
* Verified `git diff --check` passes.
* Verified on device through repeated device switch / merge / unify / retire cycles without recurring Room pool acquisition timeouts.

## Migration Notes

* No user data migration is required.
* Existing per-device databases are preserved.
* This only changes runtime DB access/retry behavior during active database churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of local database access by recovering from closed connections, pool acquire timeouts, and transient locked/busy states.
  * Safer local reads and counts now fall back to empty/default values when no database result is available.
* **Reliability**
  * Improved local data observation so it always follows the currently active database.
* **Tests**
  * Added coverage for correctly detecting pool-acquire timeout errors and avoiding false positives for similar messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->