### PR TITLE
chore(coderabbit): tune review config for repo specifics

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,6 +16,12 @@ reviews:
     ignore_usernames:
       - renovate
       - renovate[bot]
+      # Workflow-authored PRs (changelog updates, scheduled firmware/hardware/
+      # translation bumps) — machine-generated content, nothing to review.
+      - github-actions
+      - github-actions[bot]
+    ignore_title_keywords:
+      - "chore: Scheduled updates"
   # Stop reviewing once a PR is closed.
   abort_on_close: true
 
@@ -29,6 +35,8 @@ reviews:
     - "!**/flatpak-sources.json"
     # Crowdin-managed translations — owned upstream, not hand-edited here.
     - "!**/values-*/strings.xml"
+    # Spec Kit scaffolding — vendored tooling, not hand-maintained here.
+    - "!.specify/**"
 
   path_instructions:
     - path: "**/commonMain/**"
@@ -51,3 +59,36 @@ reviews:
   tools:
     detekt:
       enabled: false
+    gitleaks:
+      enabled: true
+    shellcheck:
+      enabled: true
+    actionlint:
+      enabled: true
+
+  # Auto-generated docstrings/tests/autofix are noisy for a repo with strict
+  # human-authored KDoc and KMP-aware tests; leave finishing touches off.
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+
+  # No KDoc-coverage mandate in this repo; the default warning-at-80% check
+  # would nag every PR.
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+
+knowledge_base:
+  # Feed CodeRabbit the same guidance human/AI contributors follow, including
+  # the repo-specific .skills/ modules and Copilot path instructions it
+  # wouldn't pick up by default.
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - ".skills/**/SKILL.md"
+      - ".github/copilot-instructions.md"
+      - ".github/instructions/*.instructions.md"


### PR DESCRIPTION
### Why
CodeRabbit was running on near-defaults; this tunes it to this repo's actual review economy — CI already gates detekt/spotless/tests, so CodeRabbit's job is substance, not lint echo.

### 🧹 Chores & Refactoring
- **Scanners CI doesn't run inline**: enable `gitleaks`, `shellcheck`, `actionlint` (real shell scripts in `scripts/` and 16 workflow files).
- **Less noise**: skip `.specify/` vendored scaffolding, `github-actions[bot]` changelog PRs, and "chore: Scheduled updates" PRs.
- **Finishing touches off**: auto-generated docstrings/unit tests disabled; also disabled the default pre-merge warning demanding 80% docstring coverage (no KDoc mandate here).
- **Knowledge base wired**: `code_guidelines.filePatterns` now feeds AGENTS.md, CLAUDE.md, `.skills/**/SKILL.md`, and the Copilot instruction files, so CodeRabbit reviews against the same rules contributors follow (no java/android imports in commonMain, string sorting, privacy).

Validated against the official schema (`schema.v2.json`) — no unknown keys; `mode: "off"` quoted to dodge the YAML 1.1 boolean trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated review settings to better focus on meaningful changes and reduce noise from scheduled maintenance updates.
  * Expanded security and workflow checks to catch more issues earlier.
  * Updated review guidance sources so automated feedback can follow the latest project instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->