### PR TITLE
fix: keep node-mute authoritative over @mentions

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
@@ -415,11 +415,13 @@ class MeshDataHandlerImpl(
     ) {
         val conversationMuted = packetRepository.value.getContactSettings(contactKey).isMuted
         val nodeMuted = nodeManager.getNodeById(dataPacket.from.orEmpty())?.isMuted == true
-        // A mention of our own id is a targeted ping, so it should still notify even in a muted channel/contact.
+        // A mention of our own id is a targeted ping, so it breaks through a muted channel/conversation
+        // (per meshtastic/design#21). Node mute is a stronger, per-sender signal and stays authoritative:
+        // a muted node cannot force a notification by spamming @-mentions.
         val mentionsMe =
             dataPacket.dataType == PortNum.TEXT_MESSAGE_APP.value &&
                 textMentionsNode(dataPacket.text, nodeManager.getMyId())
-        val isSilent = (conversationMuted || nodeMuted) && !mentionsMe
+        val isSilent = nodeMuted || (conversationMuted && !mentionsMe)
         if (dataPacket.dataType == PortNum.ALERT_APP.value && !isSilent) {
             scope.launch {
                 notificationManager.dispatch(

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
@@ -797,4 +797,64 @@ class MeshDataHandlerTest {
 
         verifySuspend { packetRepository.insert(any(), 123, any(), any(), any(), filtered = true) }
     }
+
+    // --- Mention / mute interaction (meshtastic/design#21) ---
+
+    private val myId = "!abcd1234"
+
+    private fun mentionPacket() = MeshPacket(
+        id = 101,
+        from = 456,
+        decoded =
+        Data(portnum = PortNum.TEXT_MESSAGE_APP, payload = "hey @$myId".encodeToByteArray().toByteString()),
+    )
+
+    private fun mentionDataPacket() = DataPacket(
+        id = 101,
+        from = "!remote",
+        to = NodeAddress.ID_BROADCAST,
+        bytes = "hey @$myId".encodeToByteArray().toByteString(),
+        dataType = PortNum.TEXT_MESSAGE_APP.value,
+    )
+
+    @Test
+    fun `mention from a muted node does not notify`() = testScope.runTest {
+        val packet = mentionPacket()
+        every { dataMapper.toDataPacket(packet) } returns mentionDataPacket()
+        everySuspend { packetRepository.findPacketsWithId(101) } returns emptyList()
+        everySuspend { packetRepository.getContactSettings(any()) } returns ContactSettings(contactKey = "test")
+        every { messageFilter.shouldFilter(any(), any()) } returns false
+        every { nodeManager.getMyId() } returns myId
+        // Node mute is authoritative: a mention must NOT break through it.
+        every { nodeManager.getNodeById("!remote") } returns
+            Node(num = 456, user = User(id = "!remote", long_name = "Remote User"), isMuted = true)
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend(mode = dev.mokkery.verify.VerifyMode.not) {
+            serviceNotifications.updateMessageNotification(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `mention from an unmuted node in a muted channel still notifies`() = testScope.runTest {
+        val packet = mentionPacket()
+        every { dataMapper.toDataPacket(packet) } returns mentionDataPacket()
+        everySuspend { packetRepository.findPacketsWithId(101) } returns emptyList()
+        // Channel/conversation muted — a mention breaks through it (design#21).
+        everySuspend { packetRepository.getContactSettings(any()) } returns
+            ContactSettings(contactKey = "test", isMuted = true)
+        every { messageFilter.shouldFilter(any(), any()) } returns false
+        every { nodeManager.getMyId() } returns myId
+        every { nodeManager.getNodeById("!remote") } returns
+            Node(num = 456, user = User(id = "!remote", long_name = "Remote User"))
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend {
+            serviceNotifications.updateMessageNotification(any(), any(), any(), any(), any(), isSilent = false)
+        }
+    }
 }


### PR DESCRIPTION
## Why

A node the user explicitly muted could still force a notification by spamming `@!<userId>` mention tokens. The `@mention` bypass added in #6108 applied to **both** conversation/channel-mute *and* node-mute.

Per meshtastic/design#21, mentions are meant to break through a **muted channel** — a busy channel shouldn't hide a targeted ping. But muting a specific *node* is a stronger, per-sender signal, and a muted node shouldn't be able to override it. This restores that: mentions bypass conversation/channel mutes only; node-mute stays authoritative.

## 🐛 What changed

- `MeshDataHandlerImpl` — `isSilent` is now `nodeMuted || (conversationMuted && !mentionsMe)` (was `(conversationMuted || nodeMuted) && !mentionsMe`). Comment updated to reference design#21 and note the deviation.

## Testing Performed

Added two `MeshDataHandlerTest` cases:
- muted node + mention → **no** notification (`updateMessageNotification` not called)
- muted channel + mention from an unmuted node → notification (`isSilent = false`)

`./gradlew :core:data:allTests` and `:core:data:detekt` pass; `:core:data:spotlessCheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated mention notification precedence: a message that mentions you can still trigger audible notifications even when the conversation/channel is muted, provided the sending node isn’t muted.
  * If the sending node is muted, notifications stay suppressed even if the message mentions you.

* **Tests**
  * Added coroutine test coverage for mention vs. mute behavior, including cases where sender-node mute blocks notifications and where conversation mute is overridden by a mention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->