### PR TITLE
test(database): exercise the Room migration chain in CI

### DIFF
--- a/core/database/src/androidDeviceTest/assets
+++ b/core/database/src/androidDeviceTest/assets
@@ -1,1 +1,1 @@
-../../../schemas
+../../schemas

--- a/core/database/src/androidDeviceTest/kotlin/org/meshtastic/core/database/MeshtasticDatabaseTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/org/meshtastic/core/database/MeshtasticDatabaseTest.kt
@@ -16,53 +16,66 @@
  */
 package org.meshtastic.core.database
 
-import androidx.room3.Room
 import androidx.room3.testing.MigrationTestHelper
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.runBlocking
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.meshtastic.core.database.MeshtasticDatabase.Companion.configureCommon
-import java.io.File
 import java.io.IOException
 
+/**
+ * Instrumented (on-device) equivalent of [MeshtasticDatabaseMigrationTest] (the JVM test that actually runs in CI).
+ * This walks every exported schema from v3 to the current version on a real device's SQLite.
+ *
+ * The exported schema JSONs are made available to this test via the `androidDeviceTest/assets` symlink into the
+ * module's `schemas/` directory; the android [MigrationTestHelper] loads them from the test APK assets.
+ *
+ * NOTE: `androidDeviceTest` (instrumented) tasks are not run by the PR pipeline — only `allTests` (JVM + Robolectric)
+ * is — so migration coverage in CI comes from [MeshtasticDatabaseMigrationTest]; this test adds real-device coverage
+ * when run locally via `connectedAndroidTest`.
+ */
 @RunWith(AndroidJUnit4::class)
 class MeshtasticDatabaseTest {
 
-    companion object {
-        private const val TEST_DB = "migration-test"
-    }
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val dbFile = instrumentation.targetContext.getDatabasePath(TEST_DB)
 
     @get:Rule
     val helper: MigrationTestHelper =
         MigrationTestHelper(
-            instrumentation = InstrumentationRegistry.getInstrumentation(),
-            file = File("schemas"),
+            instrumentation = instrumentation,
+            file = dbFile,
             driver = BundledSQLiteDriver(),
             databaseClass = MeshtasticDatabase::class,
+            databaseFactory = { MeshtasticDatabaseConstructor.initialize() },
         )
 
-    @org.junit.Ignore("KMP Android Library does not package Room schemas into test assets currently")
+    @Before
+    fun deleteStaleDb() {
+        instrumentation.targetContext.deleteDatabase(TEST_DB)
+    }
+
     @Test
     @Throws(IOException::class)
     fun migrateAll(): Unit = runBlocking {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        helper.createDatabase(EARLIEST_SCHEMA_VERSION).close()
+        // No manual migrations: every version bump is an @AutoMigration, so Room derives the full path itself.
+        helper.runMigrationsAndValidate(latestSchemaVersion(), emptyList()).close()
+    }
 
-        // Create earliest version of the database.
-        helper.createDatabase(version = 3).close()
+    private fun latestSchemaVersion(): Int {
+        val dbFqn = checkNotNull(MeshtasticDatabase::class.qualifiedName)
+        return checkNotNull(instrumentation.context.assets.list(dbFqn))
+            .mapNotNull { it.removeSuffix(".json").toIntOrNull() }
+            .maxOrNull() ?: error("No exported Room schemas found in test assets folder $dbFqn")
+    }
 
-        // Open latest version of the database. Room validates the schema
-        // once all migrations execute.
-        Room.databaseBuilder<MeshtasticDatabase>(
-            context = context,
-            name = context.getDatabasePath(TEST_DB).absolutePath,
-            factory = { MeshtasticDatabaseConstructor.initialize() },
-        )
-            .configureCommon()
-            .build()
-            .close()
+    companion object {
+        private const val TEST_DB = "migration-test"
+        private const val EARLIEST_SCHEMA_VERSION = 3
     }
 }

--- a/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/MeshtasticDatabaseMigrationTest.kt
+++ b/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/MeshtasticDatabaseMigrationTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database
+
+import androidx.room3.testing.MigrationTestHelper
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import kotlin.io.path.Path
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+/**
+ * Creates the earliest exported schema (v3) and walks every auto-migration up to the current version, validating the
+ * resulting schema against the exported JSON at each step. This is the guard that a broken migration would trip
+ * *before* users hit [MeshtasticDatabase]'s `fallbackToDestructiveMigration(dropAllTables = false)`, which would
+ * otherwise silently wipe their data.
+ *
+ * Runs on the JVM target — so it is part of `:core:database:allTests` and executes in PR CI. The JVM
+ * [MigrationTestHelper] reads the exported schemas straight from the module's `schemas/` directory, so no APK/asset
+ * packaging is needed (unlike the instrumented `androidDeviceTest` variant, which does not run in the PR pipeline).
+ */
+class MeshtasticDatabaseMigrationTest {
+
+    // The JVM MigrationTestHelper resolves schemas relative to the Gradle test working directory (the module dir).
+    private val schemaDir = Path("schemas")
+
+    private val dbFile = File.createTempFile("meshtastic-migration", ".db").apply { delete() }
+
+    // Not wired as a @Rule: jvmTest runs on the JUnit Platform, where JUnit4 @Rule does not apply. Connections are
+    // closed inline instead.
+    private val helper =
+        MigrationTestHelper(
+            schemaDirectoryPath = schemaDir,
+            databasePath = dbFile.toPath(),
+            driver = BundledSQLiteDriver(),
+            databaseClass = MeshtasticDatabase::class,
+            databaseFactory = { MeshtasticDatabaseConstructor.initialize() },
+        )
+
+    @AfterTest
+    fun cleanUp() {
+        dbFile.delete()
+    }
+
+    @Test
+    fun migrateAll() = runTest {
+        helper.createDatabase(EARLIEST_SCHEMA_VERSION).close()
+        // No manual migrations: every version bump is an @AutoMigration, so Room derives the full path itself.
+        helper.runMigrationsAndValidate(latestSchemaVersion(), emptyList()).close()
+    }
+
+    private fun latestSchemaVersion(): Int {
+        val dbSchemas = schemaDir.resolve(checkNotNull(MeshtasticDatabase::class.qualifiedName)).toFile()
+        return dbSchemas
+            .listFiles { f -> f.extension == "json" }
+            ?.mapNotNull { it.nameWithoutExtension.toIntOrNull() }
+            ?.maxOrNull() ?: error("No exported Room schemas found in $dbSchemas")
+    }
+
+    private companion object {
+        const val EARLIEST_SCHEMA_VERSION = 3
+    }
+}


### PR DESCRIPTION
## Why

The database migration chain has had **no CI coverage**. The one end-to-end test, `migrateAll`, was `@Ignore`d ("KMP Android Library does not package Room schemas into test assets currently") and lived in `androidDeviceTest` — which the PR pipeline never runs: CI runs `:core:database:allTests` (JVM + Robolectric only), and no workflow starts an emulator.

That matters because `MeshtasticDatabase` builds with `fallbackToDestructiveMigration(dropAllTables = false)`. If an auto-migration (v3 → v47 today) ever broke, Room would fall back to **destructively recreating the tables — silently wiping user data** — instead of failing loudly. Nothing tested that the migrations actually apply.

## What changed

🛠️ **Add `MeshtasticDatabaseMigrationTest` in `jvmTest`** — the real CI guard. The JVM `MigrationTestHelper` reads the exported schemas straight from the module's `schemas/` directory (no APK/asset packaging needed), creates the earliest schema (v3), and walks every `@AutoMigration` up to the current version, validating the resulting schema against the exported JSON at each step. The target version is derived from the schema files, so no edit is needed on future schema bumps. `jvmTest` is part of `:core:database:allTests`, so **this runs on every PR**.

🐛 **Fix the `androidDeviceTest/assets` symlink** — it pointed at `../../../schemas` (resolving to a nonexistent `core/schemas`, off by one). Corrected to `../../schemas`. It had been committed broken since the KMP migration (#4750), which is why the instrumented test never worked.

🐛 **Un-ignore and fix the instrumented `MeshtasticDatabaseTest`** — the `file` constructor param is the **database file**, not the schema directory (it was passing `File("schemas")`). Switched to `runMigrationsAndValidate` so a failed migration surfaces instead of being masked by the production destructive-fallback path, and added a `@Before` DB cleanup. This provides real-device coverage when run locally via `connectedAndroidTest`.

## Reviewer notes

- **CI coverage comes from the JVM test, not the device test.** Instrumented (`androidDeviceTest`) tasks are not executed by any workflow — the migration guard had to live in a target that `allTests` actually runs. The device test is supplementary (local/real-device).
- The JVM test relies on the Gradle test working directory being the module dir (`Path("schemas")`) — confirmed by the passing run.
- All migrations are `@AutoMigration`s with no-arg `AutoMigrationSpec`s, so `runMigrationsAndValidate(..., emptyList())` lets Room derive the full path itself.

## Testing Performed

- `./gradlew :core:database:jvmTest --tests "*MeshtasticDatabaseMigrationTest*"` → **PASS** (walks v3 → v47, validates each schema)
- `./gradlew spotlessCheck detekt` → clean
- `./gradlew :core:database:compileAndroidDeviceTest` → compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the database schema asset path to ensure migration resources are located reliably.

- **Tests**
  - Added automated validation for database upgrades across all exported schema versions.
  - Improved on-device migration checks to verify that existing databases can update successfully to the latest version.
  - Added JVM-based migration coverage to catch schema compatibility issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->