### PR TITLE
fix(discovery): restore radio home config after an interrupted scan

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -380,6 +380,7 @@ discovery_dwell_time_description
 discovery_empty_history
 discovery_export_report
 discovery_history
+discovery_interrupted_scan_restored
 discovery_keep_screen_awake
 discovery_keep_screen_awake_description
 discovery_local_mesh

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -26,6 +26,7 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -42,7 +43,12 @@ import org.meshtastic.app.di.AndroidKoinApp
 import org.meshtastic.core.common.ContextServices
 import org.meshtastic.core.database.DatabaseManager
 import org.meshtastic.core.repository.MeshPrefs
+import org.meshtastic.core.repository.ServiceRepository
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.discovery_interrupted_scan_restored
+import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.core.service.worker.MeshLogCleanupWorker
+import org.meshtastic.feature.discovery.DiscoveryScanEngine
 import org.meshtastic.feature.widget.LocalStatsWidgetReceiver
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
@@ -111,6 +117,20 @@ open class MeshUtilApplication :
             val dbManager: DatabaseManager = get()
             val meshPrefs: MeshPrefs = get()
             dbManager.init(meshPrefs.deviceAddress.value)
+        }
+
+        // Restore a radio left detuned by a discovery scan that was interrupted (crash, BLE loss, process death)
+        // before it could restore the home LoRa config itself. Never returns; watches reconnects for the app's life.
+        // The engine stays UI-free — we localize the "restored" notice here and push it through the app-wide alert.
+        applicationScope.launch {
+            val scanEngine: DiscoveryScanEngine = get()
+            val serviceRepository: ServiceRepository = get()
+            scanEngine.restoreInterruptedSessionsOnReconnect { homePreset ->
+                serviceRepository.setErrorMessage(
+                    getStringSuspend(Res.string.discovery_interrupted_scan_restored, homePreset),
+                    Severity.Warn,
+                )
+            }
         }
     }
 

--- a/core/database/schemas/org.meshtastic.core.database.MeshtasticDatabase/48.json
+++ b/core/database/schemas/org.meshtastic.core.database.MeshtasticDatabase/48.json
@@ -1,0 +1,1708 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 48,
+    "identityHash": "14f6407fb894f6d000260b20ba66ca1a",
+    "entities": [
+      {
+        "tableName": "my_node",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`myNodeNum` INTEGER NOT NULL, `model` TEXT, `firmwareVersion` TEXT, `couldUpdate` INTEGER NOT NULL, `shouldUpdate` INTEGER NOT NULL, `currentPacketId` INTEGER NOT NULL, `messageTimeoutMsec` INTEGER NOT NULL, `minAppVersion` INTEGER NOT NULL, `maxChannels` INTEGER NOT NULL, `hasWifi` INTEGER NOT NULL, `deviceId` TEXT, `pioEnv` TEXT, PRIMARY KEY(`myNodeNum`))",
+        "fields": [
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "firmwareVersion",
+            "columnName": "firmwareVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "couldUpdate",
+            "columnName": "couldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldUpdate",
+            "columnName": "shouldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPacketId",
+            "columnName": "currentPacketId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageTimeoutMsec",
+            "columnName": "messageTimeoutMsec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxChannels",
+            "columnName": "maxChannels",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasWifi",
+            "columnName": "hasWifi",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pioEnv",
+            "columnName": "pioEnv",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "myNodeNum"
+          ]
+        }
+      },
+      {
+        "tableName": "nodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `user` BLOB NOT NULL, `long_name` TEXT, `short_name` TEXT, `position` BLOB NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `snr` REAL NOT NULL, `rssi` INTEGER NOT NULL, `last_heard` INTEGER NOT NULL, `device_metrics` BLOB NOT NULL, `channel` INTEGER NOT NULL, `via_mqtt` INTEGER NOT NULL, `hops_away` INTEGER NOT NULL, `is_favorite` INTEGER NOT NULL, `is_ignored` INTEGER NOT NULL DEFAULT 0, `is_muted` INTEGER NOT NULL DEFAULT 0, `environment_metrics` BLOB NOT NULL, `power_metrics` BLOB NOT NULL, `air_quality_metrics` BLOB NOT NULL DEFAULT x'', `paxcounter` BLOB NOT NULL, `public_key` BLOB, `notes` TEXT NOT NULL DEFAULT '', `power_channel_labels` TEXT NOT NULL DEFAULT '[]', `manually_verified` INTEGER NOT NULL DEFAULT 0, `node_status` TEXT, `last_transport` INTEGER NOT NULL DEFAULT 0, `has_xeddsa_signed` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`num`))",
+        "fields": [
+          {
+            "fieldPath": "num",
+            "columnName": "num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user",
+            "columnName": "user",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeard",
+            "columnName": "last_heard",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceTelemetry",
+            "columnName": "device_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viaMqtt",
+            "columnName": "via_mqtt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hops_away",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIgnored",
+            "columnName": "is_ignored",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isMuted",
+            "columnName": "is_muted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "environmentTelemetry",
+            "columnName": "environment_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "powerTelemetry",
+            "columnName": "power_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "airQualityTelemetry",
+            "columnName": "air_quality_metrics",
+            "affinity": "BLOB",
+            "notNull": true,
+            "defaultValue": "x''"
+          },
+          {
+            "fieldPath": "paxcounter",
+            "columnName": "paxcounter",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "public_key",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "powerChannelLabels",
+            "columnName": "power_channel_labels",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "manuallyVerified",
+            "columnName": "manually_verified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "nodeStatus",
+            "columnName": "node_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastTransport",
+            "columnName": "last_transport",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "signsPackets",
+            "columnName": "has_xeddsa_signed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "num"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nodes_last_heard",
+            "unique": false,
+            "columnNames": [
+              "last_heard"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_last_heard` ON `${TABLE_NAME}` (`last_heard`)"
+          },
+          {
+            "name": "index_nodes_short_name",
+            "unique": false,
+            "columnNames": [
+              "short_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_short_name` ON `${TABLE_NAME}` (`short_name`)"
+          },
+          {
+            "name": "index_nodes_long_name",
+            "unique": false,
+            "columnNames": [
+              "long_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_long_name` ON `${TABLE_NAME}` (`long_name`)"
+          },
+          {
+            "name": "index_nodes_hops_away",
+            "unique": false,
+            "columnNames": [
+              "hops_away"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_hops_away` ON `${TABLE_NAME}` (`hops_away`)"
+          },
+          {
+            "name": "index_nodes_is_favorite",
+            "unique": false,
+            "columnNames": [
+              "is_favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_is_favorite` ON `${TABLE_NAME}` (`is_favorite`)"
+          },
+          {
+            "name": "index_nodes_last_heard_is_favorite",
+            "unique": false,
+            "columnNames": [
+              "last_heard",
+              "is_favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_last_heard_is_favorite` ON `${TABLE_NAME}` (`last_heard`, `is_favorite`)"
+          },
+          {
+            "name": "index_nodes_public_key",
+            "unique": false,
+            "columnNames": [
+              "public_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_public_key` ON `${TABLE_NAME}` (`public_key`)"
+          }
+        ]
+      },
+      {
+        "tableName": "packet",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `myNodeNum` INTEGER NOT NULL DEFAULT 0, `port_num` INTEGER NOT NULL, `contact_key` TEXT NOT NULL, `received_time` INTEGER NOT NULL, `read` INTEGER NOT NULL DEFAULT 1, `data` TEXT NOT NULL, `packet_id` INTEGER NOT NULL DEFAULT 0, `routing_error` INTEGER NOT NULL DEFAULT -1, `snr` REAL NOT NULL DEFAULT 0, `rssi` INTEGER NOT NULL DEFAULT 0, `hopsAway` INTEGER NOT NULL DEFAULT -1, `sfpp_hash` BLOB, `filtered` INTEGER NOT NULL DEFAULT 0, `message_text` TEXT NOT NULL DEFAULT '', `translated_text` TEXT, `show_translated` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "port_num",
+            "columnName": "port_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_time",
+            "columnName": "received_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetId",
+            "columnName": "packet_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "routingError",
+            "columnName": "routing_error",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hopsAway",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "sfpp_hash",
+            "columnName": "sfpp_hash",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "filtered",
+            "columnName": "filtered",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "messageText",
+            "columnName": "message_text",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "translatedText",
+            "columnName": "translated_text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showTranslated",
+            "columnName": "show_translated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_packet_myNodeNum",
+            "unique": false,
+            "columnNames": [
+              "myNodeNum"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_myNodeNum` ON `${TABLE_NAME}` (`myNodeNum`)"
+          },
+          {
+            "name": "index_packet_port_num",
+            "unique": false,
+            "columnNames": [
+              "port_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_port_num` ON `${TABLE_NAME}` (`port_num`)"
+          },
+          {
+            "name": "index_packet_contact_key",
+            "unique": false,
+            "columnNames": [
+              "contact_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_contact_key` ON `${TABLE_NAME}` (`contact_key`)"
+          },
+          {
+            "name": "index_packet_contact_key_port_num_received_time",
+            "unique": false,
+            "columnNames": [
+              "contact_key",
+              "port_num",
+              "received_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_contact_key_port_num_received_time` ON `${TABLE_NAME}` (`contact_key`, `port_num`, `received_time`)"
+          },
+          {
+            "name": "index_packet_packet_id",
+            "unique": false,
+            "columnNames": [
+              "packet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_packet_id` ON `${TABLE_NAME}` (`packet_id`)"
+          },
+          {
+            "name": "index_packet_received_time",
+            "unique": false,
+            "columnNames": [
+              "received_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_received_time` ON `${TABLE_NAME}` (`received_time`)"
+          },
+          {
+            "name": "index_packet_filtered",
+            "unique": false,
+            "columnNames": [
+              "filtered"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_filtered` ON `${TABLE_NAME}` (`filtered`)"
+          },
+          {
+            "name": "index_packet_read",
+            "unique": false,
+            "columnNames": [
+              "read"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_read` ON `${TABLE_NAME}` (`read`)"
+          }
+        ]
+      },
+      {
+        "tableName": "packet_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS5(`message_text`, tokenize=`unicode61`, content=`packet`)",
+        "fields": [
+          {
+            "fieldPath": "messageText",
+            "columnName": "message_text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS5",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "packet",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC",
+          "contentRowId": "",
+          "columnSize": true,
+          "detail": "FULL"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_BEFORE_UPDATE BEFORE UPDATE ON `packet` BEGIN DELETE FROM `packet_fts` WHERE `rowid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_BEFORE_DELETE BEFORE DELETE ON `packet` BEGIN DELETE FROM `packet_fts` WHERE `rowid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_AFTER_UPDATE AFTER UPDATE ON `packet` BEGIN INSERT INTO `packet_fts`(`rowid`, `message_text`) VALUES (NEW.`rowid`, NEW.`message_text`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_AFTER_INSERT AFTER INSERT ON `packet` BEGIN INSERT INTO `packet_fts`(`rowid`, `message_text`) VALUES (NEW.`rowid`, NEW.`message_text`); END"
+        ]
+      },
+      {
+        "tableName": "contact_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contact_key` TEXT NOT NULL, `muteUntil` INTEGER NOT NULL, `last_read_message_uuid` INTEGER, `last_read_message_timestamp` INTEGER, `filtering_disabled` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`contact_key`))",
+        "fields": [
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muteUntil",
+            "columnName": "muteUntil",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadMessageUuid",
+            "columnName": "last_read_message_uuid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastReadMessageTimestamp",
+            "columnName": "last_read_message_timestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "filteringDisabled",
+            "columnName": "filtering_disabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contact_key"
+          ]
+        }
+      },
+      {
+        "tableName": "log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `type` TEXT NOT NULL, `received_date` INTEGER NOT NULL, `message` TEXT NOT NULL, `from_num` INTEGER NOT NULL DEFAULT 0, `port_num` INTEGER NOT NULL DEFAULT 0, `from_radio` BLOB NOT NULL DEFAULT x'', PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message_type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_date",
+            "columnName": "received_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raw_message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromNum",
+            "columnName": "from_num",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "portNum",
+            "columnName": "port_num",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fromRadio",
+            "columnName": "from_radio",
+            "affinity": "BLOB",
+            "notNull": true,
+            "defaultValue": "x''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_log_from_num",
+            "unique": false,
+            "columnNames": [
+              "from_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_log_from_num` ON `${TABLE_NAME}` (`from_num`)"
+          },
+          {
+            "name": "index_log_port_num",
+            "unique": false,
+            "columnNames": [
+              "port_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_log_port_num` ON `${TABLE_NAME}` (`port_num`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quick_chat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `message` TEXT NOT NULL, `mode` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mode",
+            "columnName": "mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "reactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`myNodeNum` INTEGER NOT NULL DEFAULT 0, `reply_id` INTEGER NOT NULL, `user_id` TEXT NOT NULL, `emoji` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `snr` REAL NOT NULL DEFAULT 0, `rssi` INTEGER NOT NULL DEFAULT 0, `hopsAway` INTEGER NOT NULL DEFAULT -1, `packet_id` INTEGER NOT NULL DEFAULT 0, `status` INTEGER NOT NULL DEFAULT 0, `routing_error` INTEGER NOT NULL DEFAULT 0, `relays` INTEGER NOT NULL DEFAULT 0, `relay_node` INTEGER, `to` TEXT, `channel` INTEGER NOT NULL DEFAULT 0, `sfpp_hash` BLOB, PRIMARY KEY(`myNodeNum`, `reply_id`, `user_id`, `emoji`))",
+        "fields": [
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "replyId",
+            "columnName": "reply_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hopsAway",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "packetId",
+            "columnName": "packet_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "routingError",
+            "columnName": "routing_error",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "relays",
+            "columnName": "relays",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "relayNode",
+            "columnName": "relay_node",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "to",
+            "columnName": "to",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sfpp_hash",
+            "columnName": "sfpp_hash",
+            "affinity": "BLOB"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "myNodeNum",
+            "reply_id",
+            "user_id",
+            "emoji"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reactions_reply_id",
+            "unique": false,
+            "columnNames": [
+              "reply_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reactions_reply_id` ON `${TABLE_NAME}` (`reply_id`)"
+          },
+          {
+            "name": "index_reactions_packet_id",
+            "unique": false,
+            "columnNames": [
+              "packet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reactions_packet_id` ON `${TABLE_NAME}` (`packet_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `proto` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`num`))",
+        "fields": [
+          {
+            "fieldPath": "num",
+            "columnName": "num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proto",
+            "columnName": "proto",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "num"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_num",
+            "unique": false,
+            "columnNames": [
+              "num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_num` ON `${TABLE_NAME}` (`num`)"
+          }
+        ]
+      },
+      {
+        "tableName": "device_hardware",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`actively_supported` INTEGER NOT NULL, `architecture` TEXT NOT NULL, `display_name` TEXT NOT NULL, `has_ink_hud` INTEGER, `has_mui` INTEGER, `hwModel` INTEGER NOT NULL, `hw_model_slug` TEXT NOT NULL, `images` TEXT, `last_updated` INTEGER NOT NULL, `partition_scheme` TEXT, `platformio_target` TEXT NOT NULL, `requires_dfu` INTEGER, `support_level` INTEGER, `tags` TEXT, PRIMARY KEY(`platformio_target`))",
+        "fields": [
+          {
+            "fieldPath": "activelySupported",
+            "columnName": "actively_supported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "architecture",
+            "columnName": "architecture",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasInkHud",
+            "columnName": "has_ink_hud",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasMui",
+            "columnName": "has_mui",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hwModel",
+            "columnName": "hwModel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hwModelSlug",
+            "columnName": "hw_model_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "images",
+            "columnName": "images",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partitionScheme",
+            "columnName": "partition_scheme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platformioTarget",
+            "columnName": "platformio_target",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requiresDfu",
+            "columnName": "requires_dfu",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportLevel",
+            "columnName": "support_level",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platformio_target"
+          ]
+        }
+      },
+      {
+        "tableName": "device_link",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`short_code` TEXT NOT NULL, `link_description` TEXT, `is_vendor` INTEGER NOT NULL, `regions` TEXT, `targets` TEXT, PRIMARY KEY(`short_code`))",
+        "fields": [
+          {
+            "fieldPath": "shortCode",
+            "columnName": "short_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkDescription",
+            "columnName": "link_description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isVendor",
+            "columnName": "is_vendor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regions",
+            "columnName": "regions",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "targets",
+            "columnName": "targets",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "short_code"
+          ]
+        }
+      },
+      {
+        "tableName": "firmware_release",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page_url` TEXT NOT NULL, `release_notes` TEXT NOT NULL, `title` TEXT NOT NULL, `zip_url` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `release_type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageUrl",
+            "columnName": "page_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseNotes",
+            "columnName": "release_notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zipUrl",
+            "columnName": "zip_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseType",
+            "columnName": "release_type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "traceroute_node_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`log_uuid` TEXT NOT NULL, `request_id` INTEGER NOT NULL, `node_num` INTEGER NOT NULL, `position` BLOB NOT NULL, PRIMARY KEY(`log_uuid`, `node_num`), FOREIGN KEY(`log_uuid`) REFERENCES `log`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "logUuid",
+            "columnName": "log_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestId",
+            "columnName": "request_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeNum",
+            "columnName": "node_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "log_uuid",
+            "node_num"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traceroute_node_position_log_uuid",
+            "unique": false,
+            "columnNames": [
+              "log_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traceroute_node_position_log_uuid` ON `${TABLE_NAME}` (`log_uuid`)"
+          },
+          {
+            "name": "index_traceroute_node_position_request_id",
+            "unique": false,
+            "columnNames": [
+              "request_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traceroute_node_position_request_id` ON `${TABLE_NAME}` (`request_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "log",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "log_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovery_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `presets_scanned` TEXT NOT NULL, `home_preset` TEXT NOT NULL, `total_unique_nodes` INTEGER NOT NULL DEFAULT 0, `avg_channel_utilization` REAL NOT NULL DEFAULT 0.0, `total_messages` INTEGER NOT NULL DEFAULT 0, `total_sensor_packets` INTEGER NOT NULL DEFAULT 0, `furthest_node_distance` REAL NOT NULL DEFAULT 0.0, `completion_status` TEXT NOT NULL DEFAULT 'complete', `ai_summary` TEXT, `user_latitude` REAL NOT NULL DEFAULT 0.0, `user_longitude` REAL NOT NULL DEFAULT 0.0, `total_dwell_seconds` INTEGER NOT NULL DEFAULT 0, `device_address` TEXT, `home_lora_config` BLOB, `home_primary_channel` BLOB)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetsScanned",
+            "columnName": "presets_scanned",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homePreset",
+            "columnName": "home_preset",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalUniqueNodes",
+            "columnName": "total_unique_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avgChannelUtilization",
+            "columnName": "avg_channel_utilization",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "totalMessages",
+            "columnName": "total_messages",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "totalSensorPackets",
+            "columnName": "total_sensor_packets",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "furthestNodeDistance",
+            "columnName": "furthest_node_distance",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "completionStatus",
+            "columnName": "completion_status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'complete'"
+          },
+          {
+            "fieldPath": "aiSummary",
+            "columnName": "ai_summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLatitude",
+            "columnName": "user_latitude",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "userLongitude",
+            "columnName": "user_longitude",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "totalDwellSeconds",
+            "columnName": "total_dwell_seconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "deviceAddress",
+            "columnName": "device_address",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "homeLoraConfig",
+            "columnName": "home_lora_config",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "homePrimaryChannel",
+            "columnName": "home_primary_channel",
+            "affinity": "BLOB"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "discovery_preset_result",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `session_id` INTEGER NOT NULL, `preset_name` TEXT NOT NULL, `dwell_duration_seconds` INTEGER NOT NULL DEFAULT 0, `unique_nodes` INTEGER NOT NULL DEFAULT 0, `direct_neighbor_count` INTEGER NOT NULL DEFAULT 0, `mesh_neighbor_count` INTEGER NOT NULL DEFAULT 0, `infrastructure_node_count` INTEGER NOT NULL DEFAULT 0, `message_count` INTEGER NOT NULL DEFAULT 0, `sensor_packet_count` INTEGER NOT NULL DEFAULT 0, `avg_channel_utilization` REAL NOT NULL DEFAULT 0.0, `avg_airtime_rate` REAL NOT NULL DEFAULT 0.0, `packet_success_rate` REAL NOT NULL DEFAULT 0.0, `packet_failure_rate` REAL NOT NULL DEFAULT 0.0, `ai_summary` TEXT, `num_packets_tx` INTEGER NOT NULL DEFAULT 0, `num_packets_rx` INTEGER NOT NULL DEFAULT 0, `num_packets_rx_bad` INTEGER NOT NULL DEFAULT 0, `num_rx_dupe` INTEGER NOT NULL DEFAULT 0, `num_tx_relay` INTEGER NOT NULL DEFAULT 0, `num_tx_relay_canceled` INTEGER NOT NULL DEFAULT 0, `num_online_nodes` INTEGER NOT NULL DEFAULT 0, `num_total_nodes` INTEGER NOT NULL DEFAULT 0, `uptime_seconds` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`session_id`) REFERENCES `discovery_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetName",
+            "columnName": "preset_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dwellDurationSeconds",
+            "columnName": "dwell_duration_seconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "uniqueNodes",
+            "columnName": "unique_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "directNeighborCount",
+            "columnName": "direct_neighbor_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "meshNeighborCount",
+            "columnName": "mesh_neighbor_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "infrastructureNodeCount",
+            "columnName": "infrastructure_node_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "messageCount",
+            "columnName": "message_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sensorPacketCount",
+            "columnName": "sensor_packet_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avgChannelUtilization",
+            "columnName": "avg_channel_utilization",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "avgAirtimeRate",
+            "columnName": "avg_airtime_rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "packetSuccessRate",
+            "columnName": "packet_success_rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "packetFailureRate",
+            "columnName": "packet_failure_rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "aiSummary",
+            "columnName": "ai_summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numPacketsTx",
+            "columnName": "num_packets_tx",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numPacketsRx",
+            "columnName": "num_packets_rx",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numPacketsRxBad",
+            "columnName": "num_packets_rx_bad",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numRxDupe",
+            "columnName": "num_rx_dupe",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numTxRelay",
+            "columnName": "num_tx_relay",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numTxRelayCanceled",
+            "columnName": "num_tx_relay_canceled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numOnlineNodes",
+            "columnName": "num_online_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numTotalNodes",
+            "columnName": "num_total_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "uptimeSeconds",
+            "columnName": "uptime_seconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovery_preset_result_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_preset_result_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "discovery_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovered_node",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `preset_result_id` INTEGER NOT NULL, `node_num` INTEGER NOT NULL, `short_name` TEXT, `long_name` TEXT, `neighbor_type` TEXT NOT NULL DEFAULT 'direct', `latitude` REAL, `longitude` REAL, `distance_from_user` REAL, `hop_count` INTEGER NOT NULL DEFAULT 0, `snr` REAL NOT NULL DEFAULT 0, `rssi` INTEGER NOT NULL DEFAULT 0, `message_count` INTEGER NOT NULL DEFAULT 0, `sensor_packet_count` INTEGER NOT NULL DEFAULT 0, `is_infrastructure` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`preset_result_id`) REFERENCES `discovery_preset_result`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetResultId",
+            "columnName": "preset_result_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeNum",
+            "columnName": "node_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "neighborType",
+            "columnName": "neighbor_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'direct'"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceFromUser",
+            "columnName": "distance_from_user",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "hopCount",
+            "columnName": "hop_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "messageCount",
+            "columnName": "message_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sensorPacketCount",
+            "columnName": "sensor_packet_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInfrastructure",
+            "columnName": "is_infrastructure",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovered_node_preset_result_id",
+            "unique": false,
+            "columnNames": [
+              "preset_result_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovered_node_preset_result_id` ON `${TABLE_NAME}` (`preset_result_id`)"
+          },
+          {
+            "name": "index_discovered_node_node_num",
+            "unique": false,
+            "columnNames": [
+              "node_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovered_node_node_num` ON `${TABLE_NAME}` (`node_num`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "discovery_preset_result",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "preset_result_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "event_firmware_edition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`edition` TEXT NOT NULL, `display_name` TEXT NOT NULL, `welcome_message` TEXT NOT NULL, `event_start` TEXT, `event_end` TEXT, `time_zone` TEXT, `location` TEXT, `icon_url` TEXT, `accent_color` TEXT, `tag` TEXT, `domain` TEXT, `theme_json` TEXT, `firmware_json` TEXT, `links_json` TEXT NOT NULL, PRIMARY KEY(`edition`))",
+        "fields": [
+          {
+            "fieldPath": "edition",
+            "columnName": "edition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "welcomeMessage",
+            "columnName": "welcome_message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventStart",
+            "columnName": "event_start",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventEnd",
+            "columnName": "event_end",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timeZone",
+            "columnName": "time_zone",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "icon_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accentColor",
+            "columnName": "accent_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeJson",
+            "columnName": "theme_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "firmwareJson",
+            "columnName": "firmware_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "linksJson",
+            "columnName": "links_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "edition"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '14f6407fb894f6d000260b20ba66ca1a')"
+    ]
+  }
+}

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/Converters.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/Converters.kt
@@ -25,6 +25,8 @@ import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.util.decodeOrNull
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
 import org.meshtastic.proto.DeviceMetadata
 import org.meshtastic.proto.FromRadio
 import org.meshtastic.proto.Paxcount
@@ -97,6 +99,22 @@ class Converters {
     @ColumnTypeConverter fun bytesToByteString(bytes: ByteArray?): ByteString? = bytes?.toByteString()
 
     @ColumnTypeConverter fun byteStringToBytes(value: ByteString?): ByteArray? = value?.toByteArray()
+
+    /** Discovery scans capture the radio's pre-scan LoRa config so an interrupted scan can restore it later. */
+    @ColumnTypeConverter
+    fun bytesToLoRaConfig(bytes: ByteArray?): Config.LoRaConfig? =
+        bytes?.let { Config.LoRaConfig.ADAPTER.decodeOrNull(it, Logger) }
+
+    @ColumnTypeConverter
+    fun loRaConfigToBytes(value: Config.LoRaConfig?): ByteArray? = value?.let { Config.LoRaConfig.ADAPTER.encode(it) }
+
+    /** Discovery scans capture the radio's pre-scan primary channel to restore after a custom-channel target. */
+    @ColumnTypeConverter
+    fun bytesToChannelSettings(bytes: ByteArray?): ChannelSettings? =
+        bytes?.let { ChannelSettings.ADAPTER.decodeOrNull(it, Logger) }
+
+    @ColumnTypeConverter
+    fun channelSettingsToBytes(value: ChannelSettings?): ByteArray? = value?.let { ChannelSettings.ADAPTER.encode(it) }
 
     @ColumnTypeConverter
     fun messageStatusToInt(value: MessageStatus?): Int = value?.ordinal ?: MessageStatus.UNKNOWN.ordinal

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -120,8 +120,9 @@ import org.meshtastic.core.database.entity.TracerouteNodePositionEntity
         AutoMigration(from = 44, to = 45),
         AutoMigration(from = 45, to = 46),
         AutoMigration(from = 46, to = 47),
+        AutoMigration(from = 47, to = 48),
     ],
-    version = 47,
+    version = 48,
     exportSchema = true,
 )
 @androidx.room3.ConstructedBy(MeshtasticDatabaseConstructor::class)

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/DiscoveryDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/DiscoveryDao.kt
@@ -55,6 +55,19 @@ interface DiscoveryDao {
     @Query("UPDATE discovery_session SET completion_status = 'interrupted' WHERE completion_status = 'in_progress'")
     suspend fun markInterruptedSessions()
 
+    /**
+     * The most recent session left mid-scan by a prior process (crash, BLE loss, or force-quit) for [deviceAddress] —
+     * "in_progress" if the process died before [markInterruptedSessions] ever ran, "interrupted" otherwise.
+     */
+    @Query(
+        """
+        SELECT * FROM discovery_session
+        WHERE device_address = :deviceAddress AND completion_status IN ('in_progress', 'interrupted')
+        ORDER BY timestamp DESC LIMIT 1
+        """,
+    )
+    suspend fun getInterruptedSession(deviceAddress: String): DiscoverySessionEntity?
+
     // endregion
 
     // region Preset result operations

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/DiscoverySessionEntity.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/DiscoverySessionEntity.kt
@@ -19,6 +19,8 @@ package org.meshtastic.core.database.entity
 import androidx.room3.ColumnInfo
 import androidx.room3.Entity
 import androidx.room3.PrimaryKey
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
 
 @Entity(tableName = "discovery_session")
 data class DiscoverySessionEntity(
@@ -36,4 +38,10 @@ data class DiscoverySessionEntity(
     @ColumnInfo(name = "user_latitude", defaultValue = "0.0") val userLatitude: Double = 0.0,
     @ColumnInfo(name = "user_longitude", defaultValue = "0.0") val userLongitude: Double = 0.0,
     @ColumnInfo(name = "total_dwell_seconds", defaultValue = "0") val totalDwellSeconds: Long = 0,
+    /** The radio address this session ran against — lets a later reconnect confirm it's the same device. */
+    @ColumnInfo(name = "device_address") val deviceAddress: String? = null,
+    /** The radio's full pre-scan LoRa config, so an interrupted scan can restore it exactly. */
+    @ColumnInfo(name = "home_lora_config") val homeLoraConfig: Config.LoRaConfig? = null,
+    /** The radio's pre-scan primary channel, only non-null when a custom-channel target retuned it. */
+    @ColumnInfo(name = "home_primary_channel") val homePrimaryChannel: ChannelSettings? = null,
 )

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonDiscoveryDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonDiscoveryDaoTest.kt
@@ -86,6 +86,51 @@ abstract class CommonDiscoveryDaoTest {
 
     // endregion
 
+    // region Interrupted-session lookup (crash / BLE-loss recovery)
+
+    @Test
+    fun getInterruptedSession_returnsInProgressSessionForDevice() = runTest {
+        dao.insertSession(testSession().copy(deviceAddress = "x:AA:BB:CC:DD:EE:FF", completionStatus = "in_progress"))
+        val found = dao.getInterruptedSession("x:AA:BB:CC:DD:EE:FF")
+        assertNotNull(found)
+        assertEquals("in_progress", found.completionStatus)
+    }
+
+    @Test
+    fun getInterruptedSession_returnsInterruptedSessionToo() = runTest {
+        dao.insertSession(testSession().copy(deviceAddress = "x:AA:BB:CC:DD:EE:FF", completionStatus = "interrupted"))
+        val found = dao.getInterruptedSession("x:AA:BB:CC:DD:EE:FF")
+        assertNotNull(found)
+        assertEquals("interrupted", found.completionStatus)
+    }
+
+    @Test
+    fun getInterruptedSession_returnsNullForDifferentDevice() = runTest {
+        dao.insertSession(testSession().copy(deviceAddress = "x:OTHER-DEVICE", completionStatus = "in_progress"))
+        assertNull(dao.getInterruptedSession("x:AA:BB:CC:DD:EE:FF"))
+    }
+
+    @Test
+    fun getInterruptedSession_returnsNullForCompletedSession() = runTest {
+        dao.insertSession(testSession().copy(deviceAddress = "x:AA:BB:CC:DD:EE:FF", completionStatus = "complete"))
+        assertNull(dao.getInterruptedSession("x:AA:BB:CC:DD:EE:FF"))
+    }
+
+    @Test
+    fun getInterruptedSession_returnsMostRecentWhenMultipleMatch() = runTest {
+        dao.insertSession(
+            testSession(timestamp = 1L).copy(deviceAddress = "x:AA:BB:CC:DD:EE:FF", completionStatus = "interrupted"),
+        )
+        dao.insertSession(
+            testSession(timestamp = 2L).copy(deviceAddress = "x:AA:BB:CC:DD:EE:FF", completionStatus = "in_progress"),
+        )
+        val found = dao.getInterruptedSession("x:AA:BB:CC:DD:EE:FF")
+        assertNotNull(found)
+        assertEquals(2L, found.timestamp)
+    }
+
+    // endregion
+
     // region Session sort order (getAllSessions returns newest-first)
 
     @Test

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -404,6 +404,7 @@
     <string name="discovery_empty_history">No discovery sessions yet</string>
     <string name="discovery_export_report">Export report</string>
     <string name="discovery_history">Discovery History</string>
+    <string name="discovery_interrupted_scan_restored">Restored radio to home config (%1$s) after an interrupted discovery scan</string>
     <string name="discovery_keep_screen_awake">Keep screen awake</string>
     <string name="discovery_keep_screen_awake_description">Prevents Android Doze mode from dropping radio packets during long scans. Recommended.</string>
     <string name="discovery_local_mesh">Local Mesh Discovery</string>

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -58,6 +58,9 @@ class FakeRadioController :
 
     var throwOnSend: Boolean = false
 
+    /** When true, [setLocalConfig] throws — simulates the radio link dropping mid config write. */
+    var throwOnSetLocalConfig: Boolean = false
+
     /**
      * When set, a channel write throws once [localChannels] has reached this many entries — simulates a mid-write
      * failure.
@@ -79,6 +82,7 @@ class FakeRadioController :
             localConfigs.clear()
             localChannels.clear()
             throwOnSend = false
+            throwOnSetLocalConfig = false
             failChannelWriteAfter = null
             lastSetDeviceAddress = null
             lastSetOwnerUser = null
@@ -118,6 +122,7 @@ class FakeRadioController :
     override suspend fun refreshMetadata(destNum: Int) {}
 
     override suspend fun setLocalConfig(config: Config) {
+        if (throwOnSetLocalConfig) error("Fake local config write failure")
         localConfigs.add(config)
     }
 

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngine.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngine.kt
@@ -19,6 +19,7 @@
 package org.meshtastic.feature.discovery
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -47,6 +48,7 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.util.decodeOrNull
 import org.meshtastic.core.repository.DiscoveryPacketCollector
 import org.meshtastic.core.repository.DiscoveryPacketCollectorRegistry
+import org.meshtastic.core.repository.MeshPrefs
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioController
@@ -79,6 +81,7 @@ class DiscoveryScanEngine(
     private val aiProvider: DiscoverySummaryAiProvider,
     private val applicationScope: ApplicationCoroutineScope,
     private val dispatchers: CoroutineDispatchers,
+    private val meshPrefs: MeshPrefs,
 ) : DiscoveryPacketCollector {
 
     // region Public state
@@ -195,7 +198,8 @@ class DiscoveryScanEngine(
             val latDouble = (myPosition?.latitude_i ?: 0).toDouble() / POSITION_DIVISOR
             val lonDouble = (myPosition?.longitude_i ?: 0).toDouble() / POSITION_DIVISOR
 
-            // Create the DB session
+            // Create the DB session. homeLoraConfig/homePrimaryChannel/deviceAddress let a later reconnect detect and
+            // restore this exact config if the process dies mid-scan before restoreHomePreset() ever runs.
             val session =
                 DiscoverySessionEntity(
                     timestamp = nowMillis,
@@ -204,6 +208,11 @@ class DiscoveryScanEngine(
                     completionStatus = "in_progress",
                     userLatitude = latDouble,
                     userLongitude = lonDouble,
+                    deviceAddress = meshPrefs.deviceAddress.value,
+                    homeLoraConfig = initialLoraConfig,
+                    // Only custom-channel targets ever overwrite the primary channel, so only they need it restored —
+                    // mirrors the tunedPrimaryChannel gating in restoreHomePreset().
+                    homePrimaryChannel = originalPrimaryChannel.takeIf { targets.any { t -> t.channel != null } },
                 )
             sessionId = discoveryDao.insertSession(session)
             _currentSession.value = session.copy(id = sessionId)
@@ -703,6 +712,57 @@ class DiscoveryScanEngine(
         delay(3000)
         // Wait briefly for reconnection after restoring
         waitForConnection()
+    }
+
+    // endregion
+
+    // region Interrupted-session restoration
+
+    /**
+     * Watches for the radio reconnecting and restores any home LoRa config a *previous process's* scan left mid-flight
+     * — process death, a crash, or BLE loss mid-scan skips [restoreHomePreset] entirely, leaving the session row
+     * "in_progress" forever and the radio detuned off the user's home mesh until this catches it.
+     *
+     * Meant to be `launch`ed once for the app's process lifetime (from app startup) — it never returns normally. Safe
+     * to call even while this engine is running a legitimate scan of its own: the [isActive] check (taken under
+     * [mutex], the same lock [startScanTargets] uses) skips every reconnect that belongs to this process's own
+     * in-progress scan.
+     *
+     * @param onRestored invoked with the restored session's home-preset label after a successful restore. The engine
+     *   stays UI-free: localizing that into a user notification is the caller's job (see MeshUtilApplication), which
+     *   also keeps this function unit-testable off a live Compose-resources runtime.
+     */
+    suspend fun restoreInterruptedSessionsOnReconnect(onRestored: suspend (homePreset: String) -> Unit = {}) {
+        serviceRepository.connectionState.collect { state ->
+            if (state !is ConnectionState.Connected) return@collect
+            try {
+                restoreInterruptedSessionIfAny()?.let { onRestored(it) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                // A radio write can fail if the link drops right after Connected — the session stays
+                // "interrupted" (it's only marked "restored" after the writes succeed), so the next
+                // reconnect retries. Swallowing keeps this process-lifetime watcher alive.
+                Logger.e(e) { "DiscoveryScanEngine: interrupted-session restore failed; will retry on reconnect" }
+            }
+        }
+    }
+
+    /** Restores an interrupted session's home config if one matches the current device; returns its home preset. */
+    private suspend fun restoreInterruptedSessionIfAny(): String? {
+        val address = meshPrefs.deviceAddress.value ?: return null
+        return mutex.withLock {
+            if (isActive) return@withLock null
+            val session = discoveryDao.getInterruptedSession(address) ?: return@withLock null
+            val loraConfig = session.homeLoraConfig ?: return@withLock null
+            Logger.w { "DiscoveryScanEngine: restoring home config after interrupted session ${session.id}" }
+            session.homePrimaryChannel?.let {
+                radioController.setLocalChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = it))
+            }
+            radioController.setLocalConfig(Config(lora = loraConfig))
+            discoveryDao.updateSession(session.copy(completionStatus = "restored"))
+            session.homePreset
+        }
     }
 
     // endregion

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngine.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngine.kt
@@ -664,11 +664,14 @@ class DiscoveryScanEngine(
         return avgChannel to avgAirRate
     }
 
-    private suspend fun finalizeSession(status: String) {
-        if (sessionId == 0L) return
+    // Guarded by [mutex] so the session-row read-modify-write can't interleave with restoreInterruptedSessionIfAny().
+    // pauseAndAbort() flips isActive to false before finalizing, so without this a reconnect-triggered restore could
+    // race this write on the same row. No caller (runScanLoop, pauseAndAbort, stopScan) holds the mutex here.
+    private suspend fun finalizeSession(status: String) = mutex.withLock {
+        if (sessionId == 0L) return@withLock
         val uniqueCount = discoveryDao.getUniqueNodeCount(sessionId)
         val presetResults = discoveryDao.getPresetResults(sessionId)
-        val session = discoveryDao.getSession(sessionId) ?: return
+        val session = discoveryDao.getSession(sessionId) ?: return@withLock
         val totalDwell = presetResults.sumOf { it.dwellDurationSeconds }
         val totalMsgs = presetResults.sumOf { it.messageCount }
         val totalSensor = presetResults.sumOf { it.sensorPacketCount }
@@ -754,7 +757,14 @@ class DiscoveryScanEngine(
         return mutex.withLock {
             if (isActive) return@withLock null
             val session = discoveryDao.getInterruptedSession(address) ?: return@withLock null
-            val loraConfig = session.homeLoraConfig ?: return@withLock null
+            // A session with no captured config can never be restored (the radio config was null at scan start).
+            // Terminalize it so it stops re-matching getInterruptedSession on every future reconnect.
+            val loraConfig =
+                session.homeLoraConfig
+                    ?: run {
+                        discoveryDao.updateSession(session.copy(completionStatus = "unrestorable"))
+                        return@withLock null
+                    }
             Logger.w { "DiscoveryScanEngine: restoring home config after interrupted session ${session.id}" }
             session.homePrimaryChannel?.let {
                 radioController.setLocalChannel(Channel(index = 0, role = Channel.Role.PRIMARY, settings = it))

--- a/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryHistoryBehaviorTest.kt
+++ b/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryHistoryBehaviorTest.kt
@@ -260,6 +260,10 @@ private class HistoryTestDao : DiscoveryDao {
             }
         }
     }
+
+    override suspend fun getInterruptedSession(deviceAddress: String): DiscoverySessionEntity? = sessions.values
+        .filter { it.deviceAddress == deviceAddress && it.completionStatus in setOf("in_progress", "interrupted") }
+        .maxByOrNull { it.timestamp }
 }
 
 // endregion

--- a/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryMapFilterTest.kt
+++ b/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryMapFilterTest.kt
@@ -245,6 +245,10 @@ private class MapTestDao : DiscoveryDao {
             }
         }
     }
+
+    override suspend fun getInterruptedSession(deviceAddress: String): DiscoverySessionEntity? = sessions.values
+        .filter { it.deviceAddress == deviceAddress && it.completionStatus in setOf("in_progress", "interrupted") }
+        .maxByOrNull { it.timestamp }
 }
 
 // endregion

--- a/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryPacketCollectionTest.kt
+++ b/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryPacketCollectionTest.kt
@@ -41,6 +41,7 @@ import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.repository.DiscoveryPacketCollector
 import org.meshtastic.core.repository.DiscoveryPacketCollectorRegistry
+import org.meshtastic.core.testing.FakeMeshPrefs
 import org.meshtastic.core.testing.FakeNodeRepository
 import org.meshtastic.core.testing.FakeRadioConfigRepository
 import org.meshtastic.core.testing.FakeRadioController
@@ -79,6 +80,7 @@ class DiscoveryPacketCollectionTest {
     private val collectorRegistry = PacketTestCollectorRegistry()
     private val discoveryDao = InMemoryDiscoveryDao()
     private val aiProvider = PacketTestAiProvider()
+    private val meshPrefs = FakeMeshPrefs()
 
     private fun createEngine(testScope: TestScope): DiscoveryScanEngine {
         val testDispatcher = UnconfinedTestDispatcher(testScope.testScheduler)
@@ -97,6 +99,7 @@ class DiscoveryPacketCollectionTest {
             aiProvider = aiProvider,
             applicationScope = appScope,
             dispatchers = dispatchers,
+            meshPrefs = meshPrefs,
         )
     }
 
@@ -426,4 +429,8 @@ private class InMemoryDiscoveryDao : DiscoveryDao {
             }
         }
     }
+
+    override suspend fun getInterruptedSession(deviceAddress: String): DiscoverySessionEntity? = sessions.values
+        .filter { it.deviceAddress == deviceAddress && it.completionStatus in setOf("in_progress", "interrupted") }
+        .maxByOrNull { it.timestamp }
 }

--- a/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngineTest.kt
+++ b/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngineTest.kt
@@ -755,5 +755,34 @@ class DiscoveryScanEngineTest {
         watcherJob.cancel()
     }
 
+    @Test
+    fun restoreInterruptedSessionsOnReconnectTerminalizesUnrestorableSession() = runTest {
+        val address = "x:AA:BB:CC:DD:EE:FF"
+        meshPrefs.setDeviceAddress(address)
+        // Config was null at scan start (nothing to restore), so this session can never be recovered.
+        discoveryDao.sessions[1] =
+            DiscoverySessionEntity(
+                id = 1,
+                timestamp = 1L,
+                presetsScanned = "SHORT_FAST",
+                homePreset = "CUSTOM",
+                completionStatus = "in_progress",
+                deviceAddress = address,
+                homeLoraConfig = null,
+            )
+
+        val restored = mutableListOf<String>()
+        val engine = createEngine(this)
+        val watcherJob = launch { engine.restoreInterruptedSessionsOnReconnect { restored += it } }
+        advanceUntilIdle()
+
+        // Marked terminal so it stops re-matching getInterruptedSession forever; radio untouched, no notification.
+        assertEquals("unrestorable", discoveryDao.sessions.getValue(1).completionStatus)
+        assertNull(radioController.lastLocalConfig, "Nothing to write to the radio without a captured config")
+        assertTrue(restored.isEmpty(), "No notification for an unrestorable session")
+
+        watcherJob.cancel()
+    }
+
     // endregion
 }

--- a/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngineTest.kt
+++ b/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngineTest.kt
@@ -603,6 +603,27 @@ class DiscoveryScanEngineTest {
 
     // region Interrupted-session detection and restore (crash / BLE-loss recovery)
 
+    /** Seeds a prior-process interrupted session directly into the fake DAO (keyed by its own id). */
+    private fun seedInterruptedSession(
+        id: Long = 1L,
+        deviceAddress: String,
+        homePreset: String = "LONG_FAST",
+        completionStatus: String = "in_progress",
+        homeLoraConfig: Config.LoRaConfig? =
+            Config.LoRaConfig(use_preset = true, modem_preset = ChannelOption.LONG_FAST.modemPreset),
+    ) {
+        discoveryDao.sessions[id] =
+            DiscoverySessionEntity(
+                id = id,
+                timestamp = 1L,
+                presetsScanned = "SHORT_FAST",
+                homePreset = homePreset,
+                completionStatus = completionStatus,
+                deviceAddress = deviceAddress,
+                homeLoraConfig = homeLoraConfig,
+            )
+    }
+
     @Test
     fun startScanCapturesDeviceAddressAndHomeConfigForLaterRestore() = runTest {
         meshPrefs.setDeviceAddress("x:AA:BB:CC:DD:EE:FF")
@@ -621,17 +642,7 @@ class DiscoveryScanEngineTest {
         val address = "x:AA:BB:CC:DD:EE:FF"
         meshPrefs.setDeviceAddress(address)
         // A previous process's scan died mid-flight and never reached restoreHomePreset/finalizeSession.
-        discoveryDao.sessions[1] =
-            DiscoverySessionEntity(
-                id = 1,
-                timestamp = 1L,
-                presetsScanned = "SHORT_FAST",
-                homePreset = "LONG_FAST",
-                completionStatus = "in_progress",
-                deviceAddress = address,
-                homeLoraConfig =
-                Config.LoRaConfig(use_preset = true, modem_preset = ChannelOption.LONG_FAST.modemPreset),
-            )
+        seedInterruptedSession(deviceAddress = address)
 
         val restored = mutableListOf<String>()
         val engine = createEngine(this)
@@ -648,17 +659,7 @@ class DiscoveryScanEngineTest {
     @Test
     fun restoreInterruptedSessionsOnReconnectIgnoresDifferentDevice() = runTest {
         meshPrefs.setDeviceAddress("x:CURRENT")
-        discoveryDao.sessions[1] =
-            DiscoverySessionEntity(
-                id = 1,
-                timestamp = 1L,
-                presetsScanned = "SHORT_FAST",
-                homePreset = "LONG_FAST",
-                completionStatus = "in_progress",
-                deviceAddress = "x:OTHER-DEVICE",
-                homeLoraConfig =
-                Config.LoRaConfig(use_preset = true, modem_preset = ChannelOption.LONG_FAST.modemPreset),
-            )
+        seedInterruptedSession(deviceAddress = "x:OTHER-DEVICE")
 
         val restored = mutableListOf<String>()
         val engine = createEngine(this)
@@ -683,17 +684,7 @@ class DiscoveryScanEngineTest {
 
         // A stale session from a *different*, already-dead process — seeded at a key the active scan's own
         // insertSession call (id=1) won't collide with, so this row's fate isolates what the watcher itself does.
-        discoveryDao.sessions[999] =
-            DiscoverySessionEntity(
-                id = 999,
-                timestamp = 1L,
-                presetsScanned = "SHORT_FAST",
-                homePreset = "LONG_FAST",
-                completionStatus = "in_progress",
-                deviceAddress = address,
-                homeLoraConfig =
-                Config.LoRaConfig(use_preset = true, modem_preset = ChannelOption.LONG_FAST.modemPreset),
-            )
+        seedInterruptedSession(id = 999, deviceAddress = address)
 
         // The connection is already Connected, so the watcher fires on its very first emission — while this engine's
         // own scan is still active. runCurrent (not advanceUntilIdle) drains that emission WITHOUT advancing virtual
@@ -717,17 +708,7 @@ class DiscoveryScanEngineTest {
     fun restoreWatcherSurvivesWriteFailureAndRetriesOnNextReconnect() = runTest {
         val address = "x:AA:BB:CC:DD:EE:FF"
         meshPrefs.setDeviceAddress(address)
-        discoveryDao.sessions[1] =
-            DiscoverySessionEntity(
-                id = 1,
-                timestamp = 1L,
-                presetsScanned = "SHORT_FAST",
-                homePreset = "LONG_FAST",
-                completionStatus = "in_progress",
-                deviceAddress = address,
-                homeLoraConfig =
-                Config.LoRaConfig(use_preset = true, modem_preset = ChannelOption.LONG_FAST.modemPreset),
-            )
+        seedInterruptedSession(deviceAddress = address)
 
         // The link drops right after Connected, so the restore's config write fails.
         radioController.throwOnSetLocalConfig = true
@@ -760,16 +741,7 @@ class DiscoveryScanEngineTest {
         val address = "x:AA:BB:CC:DD:EE:FF"
         meshPrefs.setDeviceAddress(address)
         // Config was null at scan start (nothing to restore), so this session can never be recovered.
-        discoveryDao.sessions[1] =
-            DiscoverySessionEntity(
-                id = 1,
-                timestamp = 1L,
-                presetsScanned = "SHORT_FAST",
-                homePreset = "CUSTOM",
-                completionStatus = "in_progress",
-                deviceAddress = address,
-                homeLoraConfig = null,
-            )
+        seedInterruptedSession(deviceAddress = address, homePreset = "CUSTOM", homeLoraConfig = null)
 
         val restored = mutableListOf<String>()
         val engine = createEngine(this)

--- a/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngineTest.kt
+++ b/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryScanEngineTest.kt
@@ -23,9 +23,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
@@ -43,6 +45,7 @@ import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.repository.DiscoveryPacketCollector
 import org.meshtastic.core.repository.DiscoveryPacketCollectorRegistry
+import org.meshtastic.core.testing.FakeMeshPrefs
 import org.meshtastic.core.testing.FakeNodeRepository
 import org.meshtastic.core.testing.FakeRadioConfigRepository
 import org.meshtastic.core.testing.FakeRadioController
@@ -167,6 +170,10 @@ private class FakeDiscoveryDao : DiscoveryDao {
             }
         }
     }
+
+    override suspend fun getInterruptedSession(deviceAddress: String): DiscoverySessionEntity? = sessions.values
+        .filter { it.deviceAddress == deviceAddress && it.completionStatus in setOf("in_progress", "interrupted") }
+        .maxByOrNull { it.timestamp }
 }
 
 /** Simple fake collector registry that tracks registration. */
@@ -204,6 +211,7 @@ class DiscoveryScanEngineTest {
     private val collectorRegistry = FakeCollectorRegistry()
     private val discoveryDao = FakeDiscoveryDao()
     private val aiProvider = FakeAiProvider()
+    private val meshPrefs = FakeMeshPrefs()
 
     /** Creates a [DiscoveryScanEngine] wired to test dispatchers sharing the given [testScope]'s scheduler. */
     private fun createEngine(testScope: TestScope): DiscoveryScanEngine {
@@ -223,6 +231,7 @@ class DiscoveryScanEngineTest {
             aiProvider = aiProvider,
             applicationScope = appScope,
             dispatchers = dispatchers,
+            meshPrefs = meshPrefs,
         )
     }
 
@@ -588,6 +597,162 @@ class DiscoveryScanEngineTest {
         assertEquals(DiscoveryScanState.CompletionOutcome.Success, (state as DiscoveryScanState.Complete).outcome)
         assertEquals("complete", discoveryDao.sessions.values.first().completionStatus)
         assertEquals(ChannelOption.LONG_FAST.modemPreset, radioController.lastLocalConfig?.lora?.modem_preset)
+    }
+
+    // endregion
+
+    // region Interrupted-session detection and restore (crash / BLE-loss recovery)
+
+    @Test
+    fun startScanCapturesDeviceAddressAndHomeConfigForLaterRestore() = runTest {
+        meshPrefs.setDeviceAddress("x:AA:BB:CC:DD:EE:FF")
+        val engine = createEngine(this)
+        engine.startScan(testPresets, dwellDurationSeconds = 10)
+
+        val session = discoveryDao.sessions.values.first()
+        assertEquals("x:AA:BB:CC:DD:EE:FF", session.deviceAddress)
+        assertEquals(ChannelOption.LONG_FAST.modemPreset, session.homeLoraConfig?.modem_preset)
+
+        engine.stopScan()
+    }
+
+    @Test
+    fun restoreInterruptedSessionsOnReconnectRestoresMatchingDevice() = runTest {
+        val address = "x:AA:BB:CC:DD:EE:FF"
+        meshPrefs.setDeviceAddress(address)
+        // A previous process's scan died mid-flight and never reached restoreHomePreset/finalizeSession.
+        discoveryDao.sessions[1] =
+            DiscoverySessionEntity(
+                id = 1,
+                timestamp = 1L,
+                presetsScanned = "SHORT_FAST",
+                homePreset = "LONG_FAST",
+                completionStatus = "in_progress",
+                deviceAddress = address,
+                homeLoraConfig =
+                Config.LoRaConfig(use_preset = true, modem_preset = ChannelOption.LONG_FAST.modemPreset),
+            )
+
+        val restored = mutableListOf<String>()
+        val engine = createEngine(this)
+        val watcherJob = launch { engine.restoreInterruptedSessionsOnReconnect { restored += it } }
+        advanceUntilIdle() // serviceRepository is already Connected, so the watcher's first collection fires now
+
+        assertEquals(ChannelOption.LONG_FAST.modemPreset, radioController.lastLocalConfig?.lora?.modem_preset)
+        assertEquals("restored", discoveryDao.sessions.getValue(1).completionStatus)
+        assertEquals(listOf("LONG_FAST"), restored, "Caller should be notified with the restored home preset")
+
+        watcherJob.cancel()
+    }
+
+    @Test
+    fun restoreInterruptedSessionsOnReconnectIgnoresDifferentDevice() = runTest {
+        meshPrefs.setDeviceAddress("x:CURRENT")
+        discoveryDao.sessions[1] =
+            DiscoverySessionEntity(
+                id = 1,
+                timestamp = 1L,
+                presetsScanned = "SHORT_FAST",
+                homePreset = "LONG_FAST",
+                completionStatus = "in_progress",
+                deviceAddress = "x:OTHER-DEVICE",
+                homeLoraConfig =
+                Config.LoRaConfig(use_preset = true, modem_preset = ChannelOption.LONG_FAST.modemPreset),
+            )
+
+        val restored = mutableListOf<String>()
+        val engine = createEngine(this)
+        val watcherJob = launch { engine.restoreInterruptedSessionsOnReconnect { restored += it } }
+        advanceUntilIdle()
+
+        assertNull(radioController.lastLocalConfig, "Should not touch the radio for a session from another device")
+        assertEquals("in_progress", discoveryDao.sessions.getValue(1).completionStatus)
+        assertTrue(restored.isEmpty(), "No notification for a session from another device")
+
+        watcherJob.cancel()
+    }
+
+    @Test
+    fun restoreInterruptedSessionsOnReconnectSkipsWhileScanActive() = runTest {
+        val address = "x:AA:BB:CC:DD:EE:FF"
+        meshPrefs.setDeviceAddress(address)
+
+        val engine = createEngine(this)
+        engine.startScan(testPresets, dwellDurationSeconds = 60)
+        assertScanActive(engine)
+
+        // A stale session from a *different*, already-dead process — seeded at a key the active scan's own
+        // insertSession call (id=1) won't collide with, so this row's fate isolates what the watcher itself does.
+        discoveryDao.sessions[999] =
+            DiscoverySessionEntity(
+                id = 999,
+                timestamp = 1L,
+                presetsScanned = "SHORT_FAST",
+                homePreset = "LONG_FAST",
+                completionStatus = "in_progress",
+                deviceAddress = address,
+                homeLoraConfig =
+                Config.LoRaConfig(use_preset = true, modem_preset = ChannelOption.LONG_FAST.modemPreset),
+            )
+
+        // The connection is already Connected, so the watcher fires on its very first emission — while this engine's
+        // own scan is still active. runCurrent (not advanceUntilIdle) drains that emission WITHOUT advancing virtual
+        // time, so the scan's dwell delays never elapse and it stays active for the duration of the check.
+        val restored = mutableListOf<String>()
+        val watcherJob = launch { engine.restoreInterruptedSessionsOnReconnect { restored += it } }
+        runCurrent()
+
+        assertEquals(
+            "in_progress",
+            discoveryDao.sessions.getValue(999).completionStatus,
+            "Stale row must not be touched while this engine's own scan is active",
+        )
+        assertTrue(restored.isEmpty(), "No restore notification while this engine's own scan is active")
+
+        watcherJob.cancel()
+        engine.stopScan()
+    }
+
+    @Test
+    fun restoreWatcherSurvivesWriteFailureAndRetriesOnNextReconnect() = runTest {
+        val address = "x:AA:BB:CC:DD:EE:FF"
+        meshPrefs.setDeviceAddress(address)
+        discoveryDao.sessions[1] =
+            DiscoverySessionEntity(
+                id = 1,
+                timestamp = 1L,
+                presetsScanned = "SHORT_FAST",
+                homePreset = "LONG_FAST",
+                completionStatus = "in_progress",
+                deviceAddress = address,
+                homeLoraConfig =
+                Config.LoRaConfig(use_preset = true, modem_preset = ChannelOption.LONG_FAST.modemPreset),
+            )
+
+        // The link drops right after Connected, so the restore's config write fails.
+        radioController.throwOnSetLocalConfig = true
+        val restored = mutableListOf<String>()
+        val engine = createEngine(this)
+        val watcherJob = launch { engine.restoreInterruptedSessionsOnReconnect { restored += it } }
+        advanceUntilIdle()
+
+        assertEquals("in_progress", discoveryDao.sessions.getValue(1).completionStatus, "Failed restore must not mark")
+        assertTrue(restored.isEmpty(), "No notification when the restore write failed")
+
+        // Next reconnect succeeds — the watcher must still be alive to retry. A real reconnect always passes through
+        // Disconnected first; the intermediate advanceUntilIdle lets the watcher observe the drop, so the return to
+        // Connected is a genuine transition rather than a conflated no-op the StateFlow would dedupe away.
+        radioController.throwOnSetLocalConfig = false
+        serviceRepository.setConnectionState(ConnectionState.Disconnected)
+        advanceUntilIdle()
+        serviceRepository.setConnectionState(ConnectionState.Connected)
+        advanceUntilIdle()
+
+        assertEquals("restored", discoveryDao.sessions.getValue(1).completionStatus)
+        assertEquals(ChannelOption.LONG_FAST.modemPreset, radioController.lastLocalConfig?.lora?.modem_preset)
+        assertEquals(listOf("LONG_FAST"), restored, "Caller notified once the retry succeeded")
+
+        watcherJob.cancel()
     }
 
     // endregion


### PR DESCRIPTION
A discovery scan retunes the connected radio — it rewrites the modem preset, and for beacon targets the region + primary-channel PSK — keeping the original config only in memory and restoring it when the scan finishes. If the app process dies, crashes, or loses BLE **mid-scan**, that in-memory restore never runs, so the radio is left silently detuned off the user's home mesh. For an off-grid comms app that's real user harm, and nothing recovered from it: on next launch the session row was only relabelled `interrupted` while the radio stayed on the scan preset.

This makes the restore durable. The discovery session now persists the device address and the full pre-scan LoRa config, so a later reconnect can detect the orphaned session and put the radio back on the user's home mesh automatically.

### 🌟 New Features
- On every reconnect (for the app's process lifetime), detect an `in_progress`/`interrupted` discovery session belonging to the **same device** and automatically restore its saved home LoRa config (and primary channel, when a custom-channel target had retuned it), notifying the user via the app-wide alert.

### 🛠️ Refactoring & Architecture
- `DiscoveryScanEngine` persists `deviceAddress` / `homeLoraConfig` / `homePrimaryChannel` at scan start and exposes `restoreInterruptedSessionsOnReconnect(onRestored)`. The restore runs under the **same mutex + `isActive` guard** the scan uses, so it never fights a live scan of this process; it retries on the next reconnect if a radio write fails mid-restore.
- The engine stays **UI-free**: it reports the restored preset name via a callback, and `MeshUtilApplication` (Android) localizes the notice and pushes it through `ServiceRepository.setErrorMessage`. This keeps the engine unit-testable without a Compose-resources/skiko runtime.
- `DiscoveryDao.getInterruptedSession(deviceAddress)` returns the most recent recoverable session for a device.

### 🧹 Chores
- New nullable proto `TypeConverter`s for `Config.LoRaConfig` / `ChannelSettings`; Room schema **v47 → v48** auto-migration (three new nullable columns, generated `48.json` committed).
- New string resource `discovery_interrupted_scan_restored`.

### Testing Performed
- `DiscoveryScanEngineTest` (commonTest): captures device/config at scan start; restores on device match; ignores a session from a different device; skips while this engine's own scan is active; survives a radio-write failure and retries on the next reconnect.
- `CommonDiscoveryDaoTest`: `getInterruptedSession` query correctness (status filter, device filter, most-recent selection).
- Baseline green locally: `spotlessCheck`, `detekt`, `assembleDebug`, `test`, `allTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interrupted discovery scans now recover automatically after reconnect.
  * The app restores the prior “home” radio configuration and notifies you when recovery succeeds.
  * Recovery retries after temporary radio/config write failures.
* **Bug Fixes**
  * Recovery won’t disturb discovery sessions for other devices.
  * Recovery is safely skipped while a scan is actively running, avoiding race issues.
* **Documentation**
  * Added localized warning messaging for “interrupted scan restored.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->