### PR TITLE
fix: dedup node lists to prevent LazyColumn duplicate-key crash

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/ClusterItemsListDialog.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/ClusterItemsListDialog.kt
@@ -48,7 +48,9 @@ fun ClusterItemsListDialog(
         text = {
             // Use a LazyColumn for potentially long lists of items
             LazyColumn(contentPadding = PaddingValues(vertical = 8.dp)) {
-                items(items, key = { it.node.num }) { item ->
+                // Dedup by node.num: it's the LazyColumn key and must be unique, but filteredNodes can
+                // contain the same node from two sources (or a num=0 placeholder). See NodeListScreen.
+                items(items.distinctBy { it.node.num }, key = { it.node.num }) { item ->
                     ClusterDialogListItem(item = item, onClick = { onItemClick(item) })
                 }
             }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -106,7 +106,12 @@ fun NodeListScreen(
     val scope = rememberCoroutineScope()
     val state by viewModel.nodesUiState.collectAsStateWithLifecycle()
 
-    val nodes by viewModel.nodeList.collectAsStateWithLifecycle()
+    // Dedup by num: it's the LazyColumn key (must be unique) but the upstream flow can momentarily emit
+    // two entries with the same num (a num=0 unknown-node placeholder, or a brief double-emission during
+    // an active-DB switch). Dedup once here so the count in the app bar and the rendered rows agree.
+    // Composite "num_index" keys would also fix the crash but break animateItem() reorder animations.
+    val allNodes by viewModel.nodeList.collectAsStateWithLifecycle()
+    val nodes = remember(allNodes) { allNodes.distinctBy { it.num } }
     val ourNode by viewModel.ourNodeInfo.collectAsStateWithLifecycle()
     val onlineNodeCount by viewModel.onlineNodeCount.collectAsStateWithLifecycle(0)
     val totalNodeCount by viewModel.totalNodeCount.collectAsStateWithLifecycle(0)
@@ -235,11 +240,7 @@ fun NodeListScreen(
                     )
                 }
 
-                // Dedup by num: it's the LazyColumn key (must be unique) but the upstream flow can
-                // momentarily emit two entries with the same num (e.g. a num=0 unknown-node placeholder,
-                // or a brief double-emission during an active-DB switch). Composite "num_index" keys would
-                // fix the crash but break animateItem() reorder animations, so dedup instead.
-                items(nodes.distinctBy { it.num }, key = { it.num }) { node ->
+                items(nodes, key = { it.num }) { node ->
                     var expanded by remember { mutableStateOf(false) }
 
                     Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -235,7 +235,11 @@ fun NodeListScreen(
                     )
                 }
 
-                items(nodes, key = { it.num }) { node ->
+                // Dedup by num: it's the LazyColumn key (must be unique) but the upstream flow can
+                // momentarily emit two entries with the same num (e.g. a num=0 unknown-node placeholder,
+                // or a brief double-emission during an active-DB switch). Composite "num_index" keys would
+                // fix the crash but break animateItem() reorder animations, so dedup instead.
+                items(nodes.distinctBy { it.num }, key = { it.num }) { node ->
                     var expanded by remember { mutableStateOf(false) }
 
                     Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {


### PR DESCRIPTION
### Why

Crashlytics issue `159e25351be7042db517f3af684684db` is an umbrella for `IllegalArgumentException: Key "X" was already used` crashes in `LazyColumn`. Two variants are already fixed (contactKey via #6169, tcp-discovered via #6189). This closes out the third, untriaged variant: **bare-numeric keys** — observed `"0"` on 2.8.0-internal.4 and `"2322"` on 2.7.13.

Both come from lists keyed on a raw `Int` node num:
- `NodeListScreen` — `items(nodes, key = { it.num })`
- map `ClusterItemsListDialog` — `items(items, key = { it.node.num })`

`num = 0` is the unknown-node sentinel, and a brief double-emission during an active-DB switch (`SwitchingNodeInfoReadDataSource`'s `flatMapLatest`) can momentarily surface two entries with the same `num`, tripping Compose's unique-key requirement. The DB itself can't hold duplicate nums (`num` is the `@PrimaryKey`), so this is a transient render-boundary collision.

### 🐛 Fix

Dedup with `distinctBy { it.num }` at both render sites.

Deliberately **not** the `"${num}_$index"` composite-key pattern used elsewhere in the codebase for timestamp keys: `NodeListScreen` uses `Modifier.animateItem()` and the list reorders (sort by last-heard/distance). Index-in-key changes when an item moves, which turns move animations into remove+insert. Dedup keeps `key = { it.num }` stable **and** unique, preserving the animation.

### Testing Performed

No regression test added — the fix is a stdlib `distinctBy` one-liner at the UI boundary with no custom list logic to unit-test (the collision only manifests through Compose's `items` key path). Baseline verification passed locally: `spotlessCheck detekt assembleDebug`, `:androidApp:testGoogleDebugUnitTest`, and `:feature:node:allTests` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate entries from appearing in the map’s cluster items list by deduplicating nodes by their numeric ID.
  * Improved the node list by deduplicating temporarily repeated node IDs so the app bar count and displayed rows remain consistent.
  * Preserved smooth list reordering animations by keeping stable item keys based on the node numeric ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->