### PR TITLE
fix(settings): keep the Debug Panel accessible while disconnected

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfig.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfig.kt
@@ -80,8 +80,6 @@ fun RadioConfigItemList(
     onNavigate: (Route) -> Unit,
 ) {
     val enabled = state.connected && !state.responseState.isWaiting() && !isManaged
-    // ponytail: Debug Log/App Logs read local device data, not the radio, so they stay usable offline.
-    val debugPanelEnabled = !state.responseState.isWaiting() && !isManaged
 
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
         RadioConfigSection(isManaged, enabled, onRouteClick)
@@ -95,7 +93,7 @@ fun RadioConfigItemList(
         AdministrationSection(enabled, onNavigate)
 
         if (state.isLocal) {
-            AdvancedSection(isManaged, isOtaCapable, enabled, debugPanelEnabled, onNavigate)
+            AdvancedSection(isManaged, isOtaCapable, enabled, onNavigate)
         }
     }
 }
@@ -192,13 +190,7 @@ private fun AdministrationSection(enabled: Boolean, onNavigate: (Route) -> Unit)
 }
 
 @Composable
-private fun AdvancedSection(
-    isManaged: Boolean,
-    isOtaCapable: Boolean,
-    enabled: Boolean,
-    debugPanelEnabled: Boolean,
-    onNavigate: (Route) -> Unit,
-) {
+private fun AdvancedSection(isManaged: Boolean, isOtaCapable: Boolean, enabled: Boolean, onNavigate: (Route) -> Unit) {
     ExpressiveSection(title = stringResource(Res.string.advanced_title)) {
         if (isManaged) {
             ManagedMessage()
@@ -227,10 +219,11 @@ private fun AdvancedSection(
             onClick = { onNavigate(SettingsRoute.TakServer) },
         )
 
+        // Always enabled: the Debug Panel reads app-local logs only — no radio connection,
+        // pending config response, or managed-mode restriction applies to it.
         ListItem(
             text = stringResource(Res.string.debug_panel),
             leadingIcon = MeshtasticIcons.BugReport,
-            enabled = debugPanelEnabled,
             onClick = { onNavigate(SettingsRoute.DebugPanel) },
         )
     }


### PR DESCRIPTION
The Debug Panel reads app-local logs only, yet it could still grey out while disconnected. #6074 removed the connection gate from the entry item, but two residual conditions remained: a config `responseState` stuck in waiting after a mid-fetch disconnect (the response never arrives once the link drops), and the managed-device flag, which exists to restrict radio configuration — not local log viewing.

### 🐛 Bug Fixes

- **Debug Panel entry is now always enabled** in Settings → Advanced. `DebugViewModel` depends only on local repositories (`MeshLogRepository`, `NodeRepository`), so no connection, pending-response, or managed-mode gate applies. The `debugPanelEnabled` computation and its `AdvancedSection` parameter are deleted rather than patched (net −7 lines).
- Everything inside the panel (log list, search/filter, export via SAF/file dialog, retention settings) was already connection-free, so un-gating the entry restores the full offline path on both Android and desktop, which share this list.

### Testing Performed

Full local baseline passed: `spotlessApply spotlessCheck detekt assembleDebug test allTests`. No test changes — the item is now a plain always-enabled navigation entry with no logic left to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Debug Panel setting is now always available in Advanced settings.
  * Added clarification that the Debug Panel displays app-local logs only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->