### PR TITLE
build: apply Gradle/Kotlin best-practices audit fixes

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -34,13 +34,11 @@ org.gradle.isolated-projects=true
 # incremental state that will never be reused.
 kotlin.incremental=false
 kotlin.code.style=official
-kotlin.parallel.tasks.in.project=true
 
 # ── KSP ──────────────────────────────────────────────────────────────
 # In CI, KSP incremental processing adds overhead without benefit (fresh
 # checkouts). Keep intermodule incremental off (no prior state).
 ksp.incremental=false
-ksp.run.in.process=true
 
 # ── Android ──────────────────────────────────────────────────────────
 android.experimental.lint.analysisPerComponent=true

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -27,15 +27,18 @@ plugins {
     alias(libs.plugins.meshtastic.android.application.flavors)
     alias(libs.plugins.meshtastic.android.application.compose)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
     alias(libs.plugins.secrets)
     alias(libs.plugins.androidx.baselineprofile)
-    id("meshtastic.aboutlibraries")
+    alias(libs.plugins.meshtastic.aboutlibraries)
+    // Version-less on purpose: mokkery is embedded in the convention-plugin jar (build-logic
+    // `implementation`), so a versioned alias(libs.plugins.mokkery) request is rejected by Gradle.
     id("dev.mokkery")
     alias(libs.plugins.devtools.ksp)
 }
 
-val keystorePropertiesFile = rootProject.file("keystore.properties")
+// Isolated-Projects-safe root access — never reach through `rootProject`.
+val keystorePropertiesFile = isolated.rootProject.projectDirectory.file("keystore.properties").asFile
 val keystoreProperties = Properties()
 
 if (keystorePropertiesFile.exists()) {
@@ -49,7 +52,7 @@ if (keystorePropertiesFile.exists()) {
 // Build a Closed-track templated AAB with: -PenableCarTemplates=true
 // ponytail: gated by a gradle property + res override, not a full build flavor — templated is
 // parked until it leaves Google's beta. Promote to a flavor dimension only if CI must ship both.
-val enableCarTemplates = (findProperty("enableCarTemplates") as String?)?.toBoolean() ?: false
+val enableCarTemplates = providers.gradleProperty("enableCarTemplates").map { it.toBoolean() }.getOrElse(false)
 
 configure<ApplicationExtension> {
     namespace = "org.meshtastic.app"
@@ -282,7 +285,6 @@ dependencies {
     implementation(libs.koin.android)
     implementation(libs.koin.compose.viewmodel)
     implementation(libs.koin.androidx.workmanager)
-    implementation(libs.koin.annotations)
     implementation(libs.kermit)
     implementation(libs.kotlinx.datetime)
 
@@ -306,12 +308,7 @@ dependencies {
     googleImplementation(libs.androidx.compose.material)
     // Downloadable Google Fonts for event-firmware branding (Play Services font provider — Google flavor only).
     googleImplementation(libs.androidx.compose.ui.text.google.fonts)
-    googleImplementation(libs.dd.sdk.android.logs)
-    googleImplementation(libs.dd.sdk.android.rum)
-    googleImplementation(libs.dd.sdk.android.session.replay)
-    googleImplementation(libs.dd.sdk.android.timber)
-    googleImplementation(libs.dd.sdk.android.trace)
-    googleImplementation(libs.dd.sdk.android.trace.otel)
+    googleImplementation(libs.bundles.dd.sdk.android)
     googleImplementation(platform(libs.firebase.bom))
     googleImplementation(libs.firebase.analytics)
     googleImplementation(libs.firebase.crashlytics)
@@ -339,7 +336,7 @@ dependencies {
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.androidx.glance.appwidget)
     // JVM variant provides the host-platform native library for BundledSQLiteDriver under Robolectric
-    testRuntimeOnly("androidx.sqlite:sqlite-bundled-jvm:2.7.0")
+    testRuntimeOnly(libs.androidx.sqlite.bundled.jvm)
 
     // Producer of the baseline profile consumed by the release build. The androidx.baselineprofile
     // plugin merges the generated rules into src/<variant>/generated/baselineProfiles at build time.

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -129,6 +129,10 @@ gradlePlugin {
             id = "meshtastic.android.library.compose"
             implementationClass = "AndroidLibraryComposeConventionPlugin"
         }
+        register("androidScreenshot") {
+            id = "meshtastic.android.screenshot"
+            implementationClass = "AndroidScreenshotConventionPlugin"
+        }
         register("androidApplicationCompose") {
             id = "meshtastic.android.application.compose"
             implementationClass = "AndroidApplicationComposeConventionPlugin"

--- a/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AnalyticsConventionPlugin.kt
@@ -45,6 +45,9 @@ class AnalyticsConventionPlugin : Plugin<Project> {
 
 private fun Project.applyAnalyticsPlugins() {
     extensions.configure<ApplicationExtension> {
+        // Deliberately eager `all {}` (not `configureEach`): this block APPLIES plugins as a side
+        // effect of the google flavor being registered. `configureEach` defers until AGP realizes
+        // the flavor objects, which can be too late for google-services/crashlytics to hook variants.
         productFlavors.all {
             if (name == "google") {
                 apply(plugin = libs.plugin("google-services").get().pluginId)

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -46,7 +46,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                         isShrinkResources = true
                         proguardFiles(
                             getDefaultProguardFile("proguard-android-optimize.txt"),
-                            rootProject.file("config/proguard/shared-rules.pro"),
+                            isolated.rootProject.projectDirectory.file("config/proguard/shared-rules.pro").asFile,
                             "proguard-rules.pro",
                         )
                     }

--- a/build-logic/convention/src/main/kotlin/AndroidScreenshotConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidScreenshotConventionPlugin.kt
@@ -27,8 +27,8 @@ import org.meshtastic.buildlogic.libs
 /**
  * Convention for Compose Screenshot Testing modules (`:screenshot-tests`, `:docs-screenshots`).
  *
- * Owns the shared CST configuration: the `enableScreenshotTest` experimental flag, the test-retry opt-out (CST's
- * custom runner is incompatible with test-retry), and the Compose Multiplatform + screenshot-validation dependencies.
+ * Owns the shared CST configuration: the `enableScreenshotTest` experimental flag, the test-retry opt-out (CST's custom
+ * runner is incompatible with test-retry), and the Compose Multiplatform + screenshot-validation dependencies.
  * Configuration-only: apply it ALONGSIDE `meshtastic.android.library[.compose]` and `com.android.compose.screenshot`,
  * which the module declares itself. The `screenshotTests { imageDifferenceThreshold }` block stays in the module
  * scripts — it is a DSL extension of the screenshot plugin, reachable there via generated accessors only.
@@ -42,9 +42,11 @@ class AndroidScreenshotConventionPlugin : Plugin<Project> {
                 }
 
                 // CST screenshot tests use a custom runner incompatible with test-retry
-                tasks.withType<Test>().configureEach {
-                    if (name.contains("ScreenshotTest", ignoreCase = true)) {
-                        extensions.configure<TestRetryTaskExtension> { maxRetries.set(0) }
+                pluginManager.withPlugin("org.gradle.test-retry") {
+                    tasks.withType<Test>().configureEach {
+                        if (name.contains("ScreenshotTest", ignoreCase = true)) {
+                            extensions.configure<TestRetryTaskExtension> { maxRetries.set(0) }
+                        }
                     }
                 }
 

--- a/build-logic/convention/src/main/kotlin/AndroidScreenshotConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidScreenshotConventionPlugin.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.gradle.testretry.TestRetryTaskExtension
+import org.meshtastic.buildlogic.library
+import org.meshtastic.buildlogic.libs
+
+/**
+ * Convention for Compose Screenshot Testing modules (`:screenshot-tests`, `:docs-screenshots`).
+ *
+ * Owns the shared CST configuration: the `enableScreenshotTest` experimental flag, the test-retry opt-out (CST's
+ * custom runner is incompatible with test-retry), and the Compose Multiplatform + screenshot-validation dependencies.
+ * Configuration-only: apply it ALONGSIDE `meshtastic.android.library[.compose]` and `com.android.compose.screenshot`,
+ * which the module declares itself. The `screenshotTests { imageDifferenceThreshold }` block stays in the module
+ * scripts — it is a DSL extension of the screenshot plugin, reachable there via generated accessors only.
+ */
+class AndroidScreenshotConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.withPlugin("com.android.compose.screenshot") {
+                extensions.configure<LibraryExtension> {
+                    experimentalProperties["android.experimental.enableScreenshotTest"] = true
+                }
+
+                // CST screenshot tests use a custom runner incompatible with test-retry
+                tasks.withType<Test>().configureEach {
+                    if (name.contains("ScreenshotTest", ignoreCase = true)) {
+                        extensions.configure<TestRetryTaskExtension> { maxRetries.set(0) }
+                    }
+                }
+
+                dependencies.add("implementation", libs.library("compose-multiplatform-foundation"))
+                dependencies.add("implementation", libs.library("compose-multiplatform-material3"))
+                dependencies.add("implementation", libs.library("compose-multiplatform-runtime"))
+                dependencies.add("implementation", libs.library("compose-multiplatform-ui"))
+
+                // Added lazily: AGP creates the screenshotTest configurations after plugin apply.
+                configurations
+                    .matching { it.name == "screenshotTestImplementation" }
+                    .configureEach { project.dependencies.add(name, libs.library("screenshot-validation-api")) }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/DocsTasks.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/DocsTasks.kt
@@ -49,7 +49,7 @@ private val LOCALE_PATTERN = Regex("^[a-z]{2,3}(-r[A-Z]{2})?$")
  */
 class DocsTasks : Plugin<Project> {
     override fun apply(project: Project) {
-        val docsDir = project.rootProject.layout.projectDirectory.dir("docs")
+        val docsDir = project.isolated.rootProject.projectDirectory.dir("docs")
         val outputDir = project.layout.buildDirectory.dir("generated/docs")
 
         project.tasks.register<GenerateDocsBundleTask>("generateDocsBundle") {
@@ -67,7 +67,7 @@ class DocsTasks : Plugin<Project> {
             dependsOn("generateDocsBundle")
             bundleDir.set(outputDir.map { it.dir("common") })
             schemaFile.set(
-                project.rootProject.layout.projectDirectory.file(
+                project.isolated.rootProject.projectDirectory.file(
                     "specs/20260507-161858-app-docs-markdown/contracts/keyword-index-schema.json",
                 ),
             )

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
@@ -51,7 +51,8 @@ fun Project.configureDokka() {
 
                 // Standardized repo-root based source links
                 localDirectory.set(project.projectDir)
-                val relativePath = project.projectDir.relativeTo(rootProject.projectDir).path.replace("\\", "/")
+                val rootDir = project.isolated.rootProject.projectDirectory.asFile
+                val relativePath = project.projectDir.relativeTo(rootDir).path.replace("\\", "/")
                 remoteUrl.set(URI("https://github.com/meshtastic/Meshtastic-Android/blob/main/$relativePath"))
                 remoteLineSuffix.set("#L")
             }

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
@@ -185,6 +185,7 @@ internal fun Project.configureKmpTestDependencies() {
                 implementation(libs.library("kotest-assertions"))
                 implementation(libs.library("kotest-property"))
                 implementation(libs.library("turbine"))
+                implementation(libs.library("kotlinx-coroutines-test"))
             }
 
             // Configure androidHostTest lazily — the source set is created when the
@@ -203,6 +204,7 @@ internal fun Project.configureKmpTestDependencies() {
                         implementation(libs.library("turbine"))
                         implementation(libs.library("robolectric"))
                         implementation(libs.library("androidx-test-core"))
+                        implementation(libs.library("androidx-test-ext-junit"))
                     }
                 }
 

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Spotless.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Spotless.kt
@@ -24,21 +24,23 @@ private const val MAX_LINE_LENGTH = 120
 internal fun Project.configureSpotless(extension: SpotlessExtension) {
     val ktlintVersion = libs.version("ktlint")
     val maxLineWidth = MAX_LINE_LENGTH
+    // Isolated-Projects-safe root access — never reach through `rootProject`.
+    val spotlessConfigDir = isolated.rootProject.projectDirectory.dir("config/spotless")
     extension.apply {
         ratchetFrom("origin/main")
         kotlin {
             target("src/*/kotlin/**/*.kt", "src/*/java/**/*.kt")
             targetExclude("**/build/**/*.kt")
             ktfmt(libs.version("ktfmt")).kotlinlangStyle().configure { it.setMaxWidth(maxLineWidth) }
-            ktlint(ktlintVersion).setEditorConfigPath(rootProject.file("config/spotless/.editorconfig").path)
-            licenseHeaderFile(rootProject.file("config/spotless/copyright.kt"))
+            ktlint(ktlintVersion).setEditorConfigPath(spotlessConfigDir.file(".editorconfig").asFile.path)
+            licenseHeaderFile(spotlessConfigDir.file("copyright.kt").asFile)
         }
         kotlinGradle {
             target("**/*.gradle.kts")
             targetExclude("**/build/**", "**/dependencies/**")
             ktfmt(libs.version("ktfmt")).kotlinlangStyle().configure { it.setMaxWidth(maxLineWidth) }
-            ktlint(ktlintVersion).setEditorConfigPath(rootProject.file("config/spotless/.editorconfig").path)
-            licenseHeaderFile(rootProject.file("config/spotless/copyright.kts"), "(^(?![\\/ ]\\*).*$)")
+            ktlint(ktlintVersion).setEditorConfigPath(spotlessConfigDir.file(".editorconfig").asFile.path)
+            licenseHeaderFile(spotlessConfigDir.file("copyright.kts").asFile, "(^(?![\\/ ]\\*).*$)")
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/VersionInfo.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/VersionInfo.kt
@@ -40,15 +40,16 @@ fun Project.resolveVersionInfo(): VersionInfo {
     val gitVersionProvider = providers.of(GitVersionValueSource::class.java) {}
     val vcOffset = configProperties.getProperty("VERSION_CODE_OFFSET")?.toInt() ?: 0
 
+    // Providers (not findProperty/System.getenv) so the config cache tracks these as build inputs.
     val versionCode =
-        findProperty("android.injected.version.code")?.toString()?.toInt()
-            ?: System.getenv("VERSION_CODE")?.toInt()
+        providers.gradleProperty("android.injected.version.code").orNull?.toInt()
+            ?: providers.environmentVariable("VERSION_CODE").orNull?.toInt()
             ?: (gitVersionProvider.get().toInt() + vcOffset)
 
     val versionName =
-        findProperty("android.injected.version.name")?.toString()
-            ?: findProperty("appVersionName")?.toString()
-            ?: System.getenv("VERSION_NAME")
+        providers.gradleProperty("android.injected.version.name").orNull
+            ?: providers.gradleProperty("appVersionName").orNull
+            ?: providers.environmentVariable("VERSION_NAME").orNull
             ?: configProperties.getProperty("VERSION_NAME_BASE")
             ?: "1.0.0"
 

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -26,11 +26,9 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.isolated-projects=true
-org.gradle.vfs.watch=true
 org.gradle.configureondemand=false
 
-# Kotlin Optimization
-kotlin.parallel.tasks.in.project=true
+# Kotlin
 kotlin.code.style=official
 
 # Housekeeping

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.test.retry) apply false
     alias(libs.plugins.meshtastic.root)
-    id("meshtastic.docs")
+    alias(libs.plugins.meshtastic.docs)
 }
 
 plugins.withId("org.meshtastic.flatpak.sources") {

--- a/core/barcode/build.gradle.kts
+++ b/core/barcode/build.gradle.kts
@@ -29,7 +29,7 @@ configure<LibraryExtension> {
 }
 
 dependencies {
-    implementation(project(":core:resources"))
+    implementation(projects.core.resources)
     implementation(projects.core.ui)
 
     implementation(libs.androidx.activity.compose)

--- a/core/ble/build.gradle.kts
+++ b/core/ble/build.gradle.kts
@@ -17,7 +17,7 @@
 
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -39,17 +39,6 @@ kotlin {
             implementation(libs.jetbrains.lifecycle.runtime)
         }
 
-        commonTest.dependencies {
-            implementation(libs.kotlinx.coroutines.test)
-            implementation(projects.core.testing)
-        }
-
-        getByName("androidHostTest") {
-            dependencies {
-                implementation(projects.core.testing)
-                implementation(libs.kotlinx.coroutines.test)
-                implementation(libs.androidx.test.ext.junit)
-            }
-        }
+        commonTest.dependencies { implementation(projects.core.testing) }
     }
 }

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -17,8 +17,8 @@
 
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
-    id("meshtastic.kmp.jvm.android")
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.kmp.jvm.android)
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -34,7 +34,5 @@ kotlin {
             implementation(libs.kermit)
         }
         androidMain.dependencies { api(libs.androidx.core.ktx) }
-
-        commonTest.dependencies { implementation(libs.kotlinx.coroutines.test) }
     }
 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -18,8 +18,8 @@
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.kmp.jvm.android")
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.kmp.jvm.android)
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -62,16 +62,8 @@ kotlin {
             implementation(libs.androidx.core.location.altitude)
         }
 
-        commonTest.dependencies {
-            implementation(projects.core.testing)
-            implementation(libs.kotlinx.coroutines.test)
-        }
+        commonTest.dependencies { implementation(projects.core.testing) }
 
-        getByName("androidHostTest") {
-            dependencies {
-                // JVM variant provides the host-platform native for BundledSQLiteDriver (same as core:database)
-                runtimeOnly("androidx.sqlite:sqlite-bundled-jvm:2.7.0")
-            }
-        }
+        getByName("androidHostTest") { dependencies { runtimeOnly(libs.androidx.sqlite.bundled.jvm) } }
     }
 }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     alias(libs.plugins.meshtastic.kmp.library)
     alias(libs.plugins.meshtastic.android.room)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -45,17 +45,14 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(projects.core.testing)
-            implementation(libs.kotlinx.coroutines.test)
             implementation(libs.androidx.room.testing)
         }
 
         getByName("androidHostTest") {
             dependencies {
                 implementation(libs.androidx.sqlite.bundled)
-                // JVM variant provides the host-platform native for BundledSQLiteDriver
-                runtimeOnly("androidx.sqlite:sqlite-bundled-jvm:2.7.0")
+                runtimeOnly(libs.androidx.sqlite.bundled.jvm)
                 implementation(libs.androidx.room.testing)
-                implementation(libs.androidx.test.ext.junit)
                 implementation(libs.junit)
             }
         }
@@ -74,7 +71,7 @@ dependencies {
     "kspJvmTest"(libs.androidx.room.compiler)
     // KSP resolves this via a detached configuration at task execution time,
     // so we declare it explicitly to ensure offline/Flatpak builds can resolve it.
-    "kspJvm"("com.google.devtools.ksp:symbol-processing-aa-embeddable:${libs.versions.devtools.ksp.get()}")
+    "kspJvm"(libs.ksp.symbol.processing.aa.embeddable)
     "kspAndroidHostTest"(libs.androidx.room.compiler)
     "kspAndroidDeviceTest"(libs.androidx.room.compiler)
 }

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -34,10 +34,6 @@ kotlin {
             implementation(libs.kermit)
         }
 
-        commonTest.dependencies {
-            implementation(kotlin("test"))
-            implementation(libs.kotlinx.coroutines.test)
-            implementation(libs.okio)
-        }
+        commonTest.dependencies { implementation(libs.okio) }
     }
 }

--- a/core/di/build.gradle.kts
+++ b/core/di/build.gradle.kts
@@ -17,7 +17,7 @@
 
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -17,7 +17,7 @@
 
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {

--- a/core/konsist/build.gradle.kts
+++ b/core/konsist/build.gradle.kts
@@ -21,7 +21,7 @@
 // Runs under the existing `allTests` baseline gate via :core:konsist:allTests.
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
-    id("meshtastic.kmp.jvm.android")
+    alias(libs.plugins.meshtastic.kmp.jvm.android)
 }
 
 kotlin {

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -18,7 +18,7 @@
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.kmp.jvm.android")
+    alias(libs.plugins.meshtastic.kmp.jvm.android)
 }
 
 kotlin {
@@ -50,6 +50,8 @@ kotlin {
             // the app's single protobufs version (api above) is authoritative. Otherwise the older
             // transitive pin out-ranks our snapshot on the host-test classpath and breaks proto ABI
             // (NoSuchMethodError on post-2.7.25 messages). Drop once takpacket stops exporting protobufs.
+            // .toString() is load-bearing: catalog deps are immutable ("Minimal dependencies are
+            // immutable"), so the exclude{} below only works on the string-notation copy.
             api(libs.takpacket.sdk.kmp.get().toString()) {
                 exclude(group = "org.meshtastic", module = "protobufs")
                 exclude(group = "org.meshtastic", module = "protobufs-jvm")

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -18,8 +18,8 @@
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.kmp.jvm.android")
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.kmp.jvm.android)
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -67,7 +67,6 @@ kotlin {
 
         commonTest.dependencies {
             implementation(projects.core.testing)
-            implementation(libs.kotlinx.coroutines.test)
             implementation(libs.kable.core) // Kable exception types for BLE failure-injection tests
         }
     }

--- a/core/prefs/build.gradle.kts
+++ b/core/prefs/build.gradle.kts
@@ -17,7 +17,7 @@
 
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -34,7 +34,5 @@ kotlin {
             implementation(libs.kotlinx.collections.immutable)
             implementation(libs.kotlinx.coroutines.core)
         }
-
-        commonTest.dependencies { implementation(libs.kotlinx.coroutines.test) }
     }
 }

--- a/core/repository/build.gradle.kts
+++ b/core/repository/build.gradle.kts
@@ -17,7 +17,7 @@
 
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -34,9 +34,6 @@ kotlin {
             implementation(libs.kermit)
             implementation(libs.androidx.paging.common)
         }
-        commonTest.dependencies {
-            implementation(projects.core.testing)
-            implementation(libs.kotlinx.coroutines.test)
-        }
+        commonTest.dependencies { implementation(projects.core.testing) }
     }
 }

--- a/core/resources/build.gradle.kts
+++ b/core/resources/build.gradle.kts
@@ -17,7 +17,7 @@
 
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
-    id("meshtastic.kmp.library.compose")
+    alias(libs.plugins.meshtastic.kmp.library.compose)
 }
 
 kotlin {

--- a/core/service/build.gradle.kts
+++ b/core/service/build.gradle.kts
@@ -17,7 +17,7 @@
 
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -52,17 +52,8 @@ kotlin {
             implementation(libs.koin.androidx.workmanager)
         }
 
-        getByName("androidHostTest") {
-            dependencies {
-                implementation(projects.core.testing)
-                implementation(libs.androidx.test.ext.junit)
-                implementation(libs.androidx.work.testing)
-            }
-        }
+        getByName("androidHostTest") { dependencies { implementation(libs.androidx.work.testing) } }
 
-        commonTest.dependencies {
-            implementation(projects.core.testing)
-            implementation(libs.kotlinx.coroutines.test)
-        }
+        commonTest.dependencies { implementation(projects.core.testing) }
     }
 }

--- a/core/takserver/build.gradle.kts
+++ b/core/takserver/build.gradle.kts
@@ -18,8 +18,8 @@
 plugins {
     alias(libs.plugins.meshtastic.kmp.library)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.kmp.jvm.android")
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.kmp.jvm.android)
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -55,12 +55,6 @@ kotlin {
             implementation(libs.kermit)
         }
 
-        commonTest.dependencies {
-            implementation(projects.core.testing)
-            implementation(libs.kotlinx.coroutines.test)
-            implementation(libs.turbine)
-            implementation(libs.kotest.assertions)
-            implementation(libs.kotest.property)
-        }
+        commonTest.dependencies { implementation(projects.core.testing) }
     }
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -19,8 +19,8 @@ plugins {
     alias(libs.plugins.meshtastic.kmp.library)
     alias(libs.plugins.meshtastic.kmp.library.compose)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.kmp.jvm.android")
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.kmp.jvm.android)
+    alias(libs.plugins.meshtastic.koin)
 }
 
 kotlin {
@@ -71,7 +71,6 @@ kotlin {
         commonTest.dependencies {
             implementation(projects.core.testing)
             implementation(libs.junit)
-            implementation(libs.kotlinx.coroutines.test)
             implementation(libs.compose.multiplatform.ui.test)
         }
 

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -28,8 +28,8 @@ plugins {
     alias(libs.plugins.meshtastic.detekt)
     alias(libs.plugins.meshtastic.spotless)
     alias(libs.plugins.meshtastic.koin)
-    id("meshtastic.kover")
-    id("meshtastic.aboutlibraries")
+    alias(libs.plugins.meshtastic.kover)
+    alias(libs.plugins.meshtastic.aboutlibraries)
 }
 
 configureGraphTasks()
@@ -314,7 +314,6 @@ dependencies {
     implementation(libs.androidx.datastore)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.sqlite.bundled)
-    implementation(libs.koin.annotations)
     implementation(libs.kotlinx.collections.immutable)
 
     implementation(libs.jna)

--- a/docs-screenshots/build.gradle.kts
+++ b/docs-screenshots/build.gradle.kts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import com.android.build.api.dsl.LibraryExtension
-import org.gradle.testretry.TestRetryTaskExtension
 
 // Documentation screenshots — GENERATE-ONLY, intentionally NOT gated in CI.
 //
@@ -28,35 +27,20 @@ plugins {
     alias(libs.plugins.meshtastic.android.library)
     alias(libs.plugins.meshtastic.android.library.compose)
     alias(libs.plugins.compose.screenshot)
+    alias(libs.plugins.meshtastic.android.screenshot)
 }
 
 configure<LibraryExtension> {
     namespace = "org.meshtastic.screenshot.docs"
 
-    experimentalProperties["android.experimental.enableScreenshotTest"] = true
-
     testOptions { screenshotTests { imageDifferenceThreshold = 0.0005f } }
 }
 
-// CST screenshot tests use a custom runner incompatible with test-retry
-tasks.withType<Test>().configureEach {
-    if (name.contains("ScreenshotTest", ignoreCase = true)) {
-        extensions.configure<TestRetryTaskExtension> { maxRetries.set(0) }
-    }
-}
-
 dependencies {
-    implementation(project(":core:ui"))
-    implementation(project(":core:resources"))
-    implementation(project(":core:model"))
-    implementation(project(":core:common"))
-    implementation(project(":feature:connections"))
-    implementation(project(":feature:firmware"))
-
-    implementation(libs.compose.multiplatform.foundation)
-    implementation(libs.compose.multiplatform.material3)
-    implementation(libs.compose.multiplatform.runtime)
-    implementation(libs.compose.multiplatform.ui)
-
-    screenshotTestImplementation(libs.screenshot.validation.api)
+    implementation(projects.core.ui)
+    implementation(projects.core.resources)
+    implementation(projects.core.model)
+    implementation(projects.core.common)
+    implementation(projects.feature.connections)
+    implementation(projects.feature.firmware)
 }

--- a/feature/car/build.gradle.kts
+++ b/feature/car/build.gradle.kts
@@ -18,7 +18,9 @@
 plugins {
     alias(libs.plugins.meshtastic.android.library)
     alias(libs.plugins.meshtastic.android.library.flavors)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
+    // Version-less on purpose: mokkery is embedded in the convention-plugin jar (build-logic
+    // `implementation`), so a versioned alias(libs.plugins.mokkery) request is rejected by Gradle.
     id("dev.mokkery")
 }
 
@@ -34,7 +36,7 @@ android {
         // placeholder in its OWN manifest, so it must read the property directly (the app's value does
         // not override a library's own placeholder). Default false → production ships it disabled.
         manifestPlaceholders["carTemplatesEnabled"] =
-            ((findProperty("enableCarTemplates") as String?)?.toBoolean() ?: false).toString()
+            providers.gradleProperty("enableCarTemplates").map { it.toBoolean() }.getOrElse(false).toString()
     }
 
     // Robolectric provides the Android context that androidx.car.app TestCarContext/ScreenController need.
@@ -53,7 +55,6 @@ dependencies {
     implementation(libs.androidx.car.app.projected)
 
     implementation(libs.koin.android)
-    implementation(libs.koin.annotations)
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)

--- a/feature/connections/build.gradle.kts
+++ b/feature/connections/build.gradle.kts
@@ -41,13 +41,5 @@ kotlin {
         }
 
         androidMain.dependencies { implementation(libs.usb.serial.android) }
-
-        getByName("androidHostTest") {
-            dependencies {
-                implementation(projects.core.testing)
-                implementation(libs.kotlinx.coroutines.test)
-                implementation(libs.androidx.test.ext.junit)
-            }
-        }
     }
 }

--- a/feature/discovery/build.gradle.kts
+++ b/feature/discovery/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.jetbrains.navigation3.ui)
             implementation(projects.core.common)
             implementation(projects.core.data)
             implementation(projects.core.database)
@@ -49,7 +48,5 @@ kotlin {
             implementation(libs.kotlinx.collections.immutable)
             implementation(libs.meshtastic.protobufs)
         }
-
-        commonTest.dependencies { implementation(projects.core.testing) }
     }
 }

--- a/feature/docs/build.gradle.kts
+++ b/feature/docs/build.gradle.kts
@@ -18,7 +18,7 @@
 plugins {
     alias(libs.plugins.meshtastic.kmp.feature)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.kmp.jvm.android")
+    alias(libs.plugins.meshtastic.kmp.jvm.android)
 }
 
 kotlin {

--- a/feature/firmware/build.gradle.kts
+++ b/feature/firmware/build.gradle.kts
@@ -49,7 +49,5 @@ kotlin {
         }
 
         androidMain.dependencies { implementation(libs.markdown.renderer.android) }
-
-        commonTest.dependencies { implementation(projects.core.testing) }
     }
 }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -18,7 +18,7 @@
 plugins {
     alias(libs.plugins.meshtastic.kmp.feature)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
-    id("meshtastic.kmp.jvm.android")
+    alias(libs.plugins.meshtastic.kmp.jvm.android)
 }
 
 kotlin {

--- a/feature/widget/build.gradle.kts
+++ b/feature/widget/build.gradle.kts
@@ -18,7 +18,7 @@
 plugins {
     alias(libs.plugins.meshtastic.android.library)
     alias(libs.plugins.meshtastic.android.library.compose)
-    id("meshtastic.koin")
+    alias(libs.plugins.meshtastic.koin)
 }
 
 android {
@@ -42,5 +42,4 @@ dependencies {
 
     implementation(libs.compose.multiplatform.resources)
     implementation(libs.kermit)
-    implementation(libs.koin.annotations)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,14 +12,10 @@ enableComposeCompilerReports=false
 kotlin.code.style=official
 kotlin.daemon.jvm.options=-Xmx4g -XX\:+UseG1GC -XX\:SoftRefLRUPolicyMSPerMB=1 -XX\:ReservedCodeCacheSize=320m -XX\:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallback=false
-kotlin.parallel.tasks.in.project=true
 
 # --- KSP ---
-ksp.incremental=true
-ksp.incremental.classpath=true
-ksp.incremental.intermodule=true
+# (incremental processing is default-on in KSP2; only the non-default flag is declared)
 ksp.project.isolation.enabled=true
-ksp.run.in.process=true
 
 # --- Gradle ---
 org.gradle.caching=true
@@ -27,5 +23,4 @@ org.gradle.configuration-cache=true
 org.gradle.isolated-projects=true
 org.gradle.jvmargs=-Xmx8g -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:ReservedCodeCacheSize=512m -XX:MaxMetaspaceSize=2g -Xss2m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
-org.gradle.vfs.watch=true
 org.gradle.welcome=never

--- a/gradle/build-cache.settings.gradle
+++ b/gradle/build-cache.settings.gradle
@@ -57,6 +57,10 @@ buildCache {
             url = cacheUrl.endsWith("/") ? cacheUrl : "${cacheUrl}/"
 
             if (cacheUsername && cachePassword) {
+                if (cacheUrl.startsWith("http://")) {
+                    logger.warn "Meshtastic: GRADLE_CACHE_URL uses http:// with credentials set; " +
+                            "credentials will be sent in cleartext."
+                }
                 credentials {
                     username = cacheUsername
                     password = cachePassword

--- a/gradle/build-cache.settings.gradle
+++ b/gradle/build-cache.settings.gradle
@@ -63,8 +63,11 @@ buildCache {
                 }
             }
 
-            allowInsecureProtocol = true
-            allowUntrustedServer = true
+            // A cache serves compiled task outputs, so TLS matters: validate certs by default.
+            // Plain-http (e.g. a LAN cache) is opted into by the URL scheme itself; accepting a
+            // self-signed/untrusted https cert requires GRADLE_CACHE_ALLOW_UNTRUSTED=true.
+            allowInsecureProtocol = cacheUrl.startsWith("http://")
+            allowUntrustedServer = getMeshProperty("GRADLE_CACHE_ALLOW_UNTRUSTED") == "true"
 
             // Keep push enabled if credentials are provided.
             // This naturally disables push for fork PRs which don't have access to secrets.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ car-app = "1.7.0"
 appfunctions = "1.0.0-alpha10"
 
 # androidx
+androidx-sqlite-bundled = "2.7.0"
+androidx-work = "2.11.2"
 datastore = "1.2.1"
 glance = "1.2.0-rc01"
 lifecycle = "2.11.0"
@@ -148,9 +150,11 @@ androidx-room-compiler = { module = "androidx.room3:room3-compiler", version.ref
 androidx-room-paging = { module = "androidx.room3:room3-paging", version.ref = "room" }
 androidx-room-runtime = { module = "androidx.room3:room3-runtime", version.ref = "room" }
 androidx-room-testing = { module = "androidx.room3:room3-testing", version.ref = "room" }
-androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version = "2.7.0" }
-androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version = "2.11.2" }
-androidx-work-testing = { module = "androidx.work:work-testing", version = "2.11.2" }
+androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "androidx-sqlite-bundled" }
+# JVM variant provides the host-platform native library for BundledSQLiteDriver in host/Robolectric tests
+androidx-sqlite-bundled-jvm = { module = "androidx.sqlite:sqlite-bundled-jvm", version.ref = "androidx-sqlite-bundled" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work" }
+androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "androidx-work" }
 
 # Baseline Profiles / Macrobenchmark
 androidx-profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "profileinstaller" }
@@ -309,6 +313,9 @@ koin-gradlePlugin = { module = "io.insert-koin.compiler.plugin:io.insert-koin.co
 mokkery-gradlePlugin = { module = "dev.mokkery:mokkery-gradle", version.ref = "mokkery" }
 kover-gradlePlugin = { module = "org.jetbrains.kotlinx.kover:org.jetbrains.kotlinx.kover.gradle.plugin", version.ref = "kover" }
 ksp-gradlePlugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "devtools-ksp" }
+# KSP resolves this via a detached configuration at task execution time; declared explicitly (core:database)
+# so offline/Flatpak builds can resolve it.
+ksp-symbol-processing-aa-embeddable = { module = "com.google.devtools.ksp:symbol-processing-aa-embeddable", version.ref = "devtools-ksp" }
 serialization-gradlePlugin = { module = "org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin", version.ref = "kotlin" }
 spotless-gradlePlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 test-retry-gradlePlugin = { module = "org.gradle:test-retry-gradle-plugin", version.ref = "testRetry" }
@@ -322,6 +329,18 @@ takpacket-sdk-kmp = { module = "org.meshtastic:takpacket-sdk", version.ref = "ta
 
 # Meshtastic Protobufs SDK (Wire-generated KMP models from meshtastic/protobufs)
 meshtastic-protobufs = { module = "org.meshtastic:protobufs", version.ref = "meshtastic-protobufs" }
+
+
+[bundles]
+# Datadog RUM/telemetry stack — always consumed together (androidApp google flavor)
+dd-sdk-android = [
+    "dd-sdk-android-logs",
+    "dd-sdk-android-rum",
+    "dd-sdk-android-session-replay",
+    "dd-sdk-android-timber",
+    "dd-sdk-android-trace",
+    "dd-sdk-android-trace-otel",
+]
 
 
 [plugins]
@@ -370,10 +389,14 @@ meshtastic-android-library = { id = "meshtastic.android.library" }
 meshtastic-android-library-compose = { id = "meshtastic.android.library.compose" }
 meshtastic-android-library-flavors = { id = "meshtastic.android.library.flavors" }
 meshtastic-android-room = { id = "meshtastic.android.room" }
+meshtastic-android-screenshot = { id = "meshtastic.android.screenshot" }
 meshtastic-detekt = { id = "meshtastic.detekt" }
+meshtastic-docs = { id = "meshtastic.docs" }
 meshtastic-koin = { id = "meshtastic.koin" }
+meshtastic-kover = { id = "meshtastic.kover" }
 meshtastic-kotlinx-serialization = { id = "meshtastic.kotlinx.serialization" }
 meshtastic-kmp-feature = { id = "meshtastic.kmp.feature" }
+meshtastic-kmp-jvm-android = { id = "meshtastic.kmp.jvm.android" }
 meshtastic-kmp-library = { id = "meshtastic.kmp.library" }
 meshtastic-kmp-library-compose = { id = "meshtastic.kmp.library.compose" }
 meshtastic-root = { id = "meshtastic.root" }

--- a/screenshot-tests/build.gradle.kts
+++ b/screenshot-tests/build.gradle.kts
@@ -15,50 +15,34 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import com.android.build.api.dsl.LibraryExtension
-import org.gradle.testretry.TestRetryTaskExtension
 
 plugins {
     alias(libs.plugins.meshtastic.android.library)
     alias(libs.plugins.meshtastic.android.library.compose)
     alias(libs.plugins.compose.screenshot)
+    alias(libs.plugins.meshtastic.android.screenshot)
 }
 
 configure<LibraryExtension> {
     namespace = "org.meshtastic.screenshot.tests"
 
-    experimentalProperties["android.experimental.enableScreenshotTest"] = true
-
     testOptions { screenshotTests { imageDifferenceThreshold = 0.0005f } }
 }
 
-// CST screenshot tests use a custom runner incompatible with test-retry
-tasks.withType<Test>().configureEach {
-    if (name.contains("ScreenshotTest", ignoreCase = true)) {
-        extensions.configure<TestRetryTaskExtension> { maxRetries.set(0) }
-    }
-}
-
 dependencies {
-    implementation(project(":core:ui"))
-    implementation(project(":core:resources"))
-    implementation(project(":core:model"))
-    implementation(project(":core:common"))
-    implementation(project(":feature:messaging"))
-    implementation(project(":feature:node"))
-    implementation(project(":feature:wifi-provision"))
-    implementation(project(":feature:connections"))
-    implementation(project(":feature:settings"))
-    implementation(project(":feature:intro"))
-    implementation(project(":feature:map"))
-    implementation(project(":feature:docs"))
-    implementation(project(":feature:discovery"))
-
-    implementation(libs.compose.multiplatform.foundation)
-    implementation(libs.compose.multiplatform.material3)
-    implementation(libs.compose.multiplatform.runtime)
-    implementation(libs.compose.multiplatform.ui)
-
-    screenshotTestImplementation(libs.screenshot.validation.api)
+    implementation(projects.core.ui)
+    implementation(projects.core.resources)
+    implementation(projects.core.model)
+    implementation(projects.core.common)
+    implementation(projects.feature.messaging)
+    implementation(projects.feature.node)
+    implementation(projects.feature.wifiProvision)
+    implementation(projects.feature.connections)
+    implementation(projects.feature.settings)
+    implementation(projects.feature.intro)
+    implementation(projects.feature.map)
+    implementation(projects.feature.docs)
+    implementation(projects.feature.discovery)
 }
 
 tasks.register<Copy>("copyDocsScreenshots") {
@@ -68,10 +52,11 @@ tasks.register<Copy>("copyDocsScreenshots") {
 
     val referenceDir = layout.projectDirectory.dir("src/screenshotTestDebug/reference")
     // Doc-framed compositions live in the generate-only :docs-screenshots module; aggregate its references too.
-    val docsReferenceDir = rootProject.layout.projectDirectory.dir("docs-screenshots/src/screenshotTestDebug/reference")
+    val docsReferenceDir =
+        isolated.rootProject.projectDirectory.dir("docs-screenshots/src/screenshotTestDebug/reference")
     val manifestFile = layout.projectDirectory.file("docs-screenshots-manifest.txt")
     val aliasFile = layout.projectDirectory.file("docs-screenshot-aliases.properties")
-    val outputDir = rootProject.layout.projectDirectory.dir("docs/assets/screenshots")
+    val outputDir = isolated.rootProject.projectDirectory.dir("docs/assets/screenshots")
 
     // Read manifest patterns at configuration time so Copy task can resolve includes
     val manifestPatterns =


### PR DESCRIPTION
An audit of the build logic against documented Gradle/Kotlin best practices (lazy configuration, Isolated Projects, version-catalog hygiene, convention-plugin DRY) found no high-severity issues but a batch of mechanical gaps. This PR applies them in one pass: the build gets safer under `org.gradle.isolated-projects=true` (which we already enable, so every `rootProject` reach-through was a live risk), the remote build cache stops trusting arbitrary certificates, and ~20 files of duplicated build-script boilerplate move into the conventions that should own them. Net **−66 lines** across 43 files with no behavioral change to what ships.

## 🛠️ Refactoring & Architecture

- **Isolated-Projects hygiene:** all remaining `rootProject.file(...)`/`rootProject.projectDir` accesses now use the IP-safe `isolated.rootProject.projectDirectory` API (Spotless/Dokka/AndroidApplication conventions, `DocsTasks`, the androidApp keystore read, and the `copyDocsScreenshots` task).
- **Config-cache input tracking:** `System.getenv`/`findProperty` reads replaced with `providers.environmentVariable(...)`/`providers.gradleProperty(...)` in `VersionInfo` and the `enableCarTemplates` gates (androidApp, feature:car).
- **Test-dependency hoist:** `kotlinx-coroutines-test` (commonTest) and `androidx-test-ext-junit` (androidHostTest) are now defaults in the KMP library convention — ~20 per-module re-declarations deleted, several `androidHostTest` blocks removed entirely, along with deps the koin/feature conventions already provide (`koin-annotations`, `core:testing`, `navigation3-ui`).
- **New `meshtastic.android.screenshot` convention** owns the shared CST configuration (experimental flag, test-retry opt-out, CMP + validation-API deps) for `:screenshot-tests` and `:docs-screenshots`, which were near-clones.
- **Version catalog:** new `androidx-sqlite-bundled-jvm` and `ksp-symbol-processing-aa-embeddable` aliases replace 4 hardcoded coordinates; shared `version.ref`s for androidx-work and sqlite-bundled prevent bump drift; a `dd-sdk-android` bundle collapses six androidApp lines; 20 string-form `project(":x:y")` references converted to typesafe `projects.*` accessors; plugin applications standardized on catalog `alias(...)` (new aliases for `kmp-jvm-android`, `kover`, `docs`, `android-screenshot`).

## 🐛 Security

- **Remote build cache no longer unconditionally trusts the server:** TLS certificates validate by default; plain-http is opted into by the URL scheme itself, and accepting a self-signed/untrusted https cert now requires `GRADLE_CACHE_ALLOW_UNTRUSTED=true`. A cache serves compiled task outputs, so silent `allowUntrustedServer = true` was a MITM/supply-chain exposure. *Reviewer note: if the CI cache server uses an invalid cert, the first CI run will surface it — set the new property or fix the cert.*

## 🧹 Chores

- Removed dead/no-op flags: `kotlin.parallel.tasks.in.project` (deprecated since Kotlin 1.5.20), `ksp.run.in.process` (KSP1-only no-op under KSP2), default-valued `ksp.incremental*` and `org.gradle.vfs.watch=true` (root, build-logic, and CI properties files). The meaningful non-defaults (`ksp.project.isolation.enabled`, CI's `vfs.watch=false`) stay.

## Load-bearing idioms now documented in place

Three things that look like antipatterns are deliberate, and verification runs confirmed each breaks when "fixed" — they now carry explanatory comments so future cleanups don't regress them:

- `api(libs.takpacket.sdk.kmp.get().toString())` — catalog dependencies are immutable; `exclude {}` requires the string-notation copy.
- Version-less `id("dev.mokkery")` — mokkery is embedded in the convention-plugin jar (build-logic `implementation`), so a versioned `alias()` request is rejected by Gradle.
- Eager `productFlavors.all {}` in the analytics convention — it applies plugins as a side effect of flavor registration; `configureEach` fires too late.

## Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt kmpSmokeCompile assembleDebug test allTests` — all green locally (1371 test tasks).
- No test code changed; the hoisted test dependencies resolve identically via the convention (all module test suites pass unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized Android Compose screenshot testing support across screenshot and documentation projects.

* **Bug Fixes**
  * Improved build reliability for isolated project setups and configuration-cache usage.
  * Secured remote build-cache behavior by default (TLS validation tightened; insecure/untrusted access is now opt-in).

* **Chores**
  * Streamlined Gradle plugin/dependency declarations using centralized version aliases.
  * Updated CI/build properties for better build-time performance consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->