### PR TITLE
fix(database): force Room single-connection pool on all platforms

### DIFF
--- a/core/database/src/androidMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
+++ b/core/database/src/androidMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
@@ -32,13 +32,8 @@ import org.meshtastic.core.common.ContextServices
 import org.meshtastic.core.database.MeshtasticDatabase.Companion.configureCommon
 
 /**
- * Returns a [RoomDatabase.Builder] configured for Android with the given [dbName].
- *
- * Android production deliberately opts out of Room KMP's multi-reader connection pool (`multiConnection = false`).
- * Under coroutine cancellation churn (e.g. DB switches via `flatMapLatest`), the reader-pool permit semaphore can
- * wedge: all reader connections report `Free` but `permits=0`, so every new read acquisition times out indefinitely.
- * Single-connection mode serializes reads and writes through one connection, eliminating the separate reader permit
- * pool entirely. JVM/iOS may still use the pool; see [MeshtasticDatabase.configureCommon].
+ * Returns a [RoomDatabase.Builder] configured for Android with the given [dbName]. All platforms use Room KMP's
+ * single-connection pool to avoid the reader-pool permit wedge; see [MeshtasticDatabase.configureCommon].
  */
 actual fun getDatabaseBuilder(dbName: String): RoomDatabase.Builder<MeshtasticDatabase> {
     val dbFile = ContextServices.app.getDatabasePath(dbName)
@@ -46,14 +41,14 @@ actual fun getDatabaseBuilder(dbName: String): RoomDatabase.Builder<MeshtasticDa
         name = dbFile.absolutePath,
         factory = { MeshtasticDatabaseConstructor.initialize() },
     )
-        .configureCommon(multiConnection = false)
+        .configureCommon()
         .setDriver(BundledSQLiteDriver())
 }
 
 /** Returns a [RoomDatabase.Builder] configured for an in-memory Android database. */
 actual fun getInMemoryDatabaseBuilder(): RoomDatabase.Builder<MeshtasticDatabase> =
     Room.inMemoryDatabaseBuilder<MeshtasticDatabase>(factory = { MeshtasticDatabaseConstructor.initialize() })
-        .configureCommon(multiConnection = false)
+        .configureCommon()
         .setDriver(BundledSQLiteDriver())
 
 /** Returns the Android directory where database files are stored. */

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -153,41 +153,25 @@ abstract class MeshtasticDatabase : RoomDatabase() {
         /**
          * Configures a [RoomDatabase.Builder] with standard settings for this project.
          *
-         * @param multiConnection when `true` (default), opens a multi-reader connection pool (`maxNumOfReaders = 4`,
-         *   `maxNumOfWriters = 1`) so reads can run concurrently. Pass `false` to explicitly force
-         *   [setSingleConnectionPool], serializing all reads and writes through one connection.
+         * All platforms force [setSingleConnectionPool]. Without it, Room defaults to a 4-reader pool for named
+         * databases, and under coroutine cancellation churn (e.g. DB switches via `flatMapLatest`) the reader-pool
+         * permit semaphore can wedge: all reader connections report `Free` but `permits=0`, so every read acquisition
+         * times out indefinitely ("Error code: 5, Timed out attempting to acquire a reader connection"). Android hit
+         * this first; desktop (Flathub, 2026-07-10) reproduced the identical wedge in field logs, so JVM/iOS were moved
+         * off the multi-reader pool too. Single-connection eliminates the separate reader permit pool entirely.
          *
-         * **Android production passes `false`.** Without the explicit `setSingleConnectionPool()` call, Room defaults
-         * to a 4-reader pool for named databases regardless of whether `setMultipleConnectionPool` was called. Under
-         * coroutine cancellation churn (e.g. DB switches via `flatMapLatest`), the reader-pool permit semaphore can
-         * wedge: all reader connections report `Free` but `permits=0`, so every read acquisition times out
-         * indefinitely. Forcing single-connection eliminates the separate reader permit pool entirely.
-         *
-         * **In-memory databases (tests) pass `false`.** Room already serves an in-memory database (`name == null`) from
-         * a single connection regardless of the pool configuration, so this only makes the single-connection intent
-         * explicit and serializes the query dispatcher; it is not load-bearing for read-after-write.
-         * (`DeviceLinkRepositoryImplTest` is deterministic because it runs on the wall clock, not because of this flag;
-         * see that test's comments.)
-         *
-         * **JVM/iOS production uses `true`** (the default). Revisit if desktop/iOS field logs show similar
-         * pool-exhaustion patterns under cancellation churn.
+         * For in-memory databases (tests) this is a no-op for pooling — Room already serves `name == null` databases
+         * from a single connection — it just serializes the query dispatcher.
          */
         @OptIn(ExperimentalCoroutinesApi::class)
-        fun <T : RoomDatabase> RoomDatabase.Builder<T>.configureCommon(
-            multiConnection: Boolean = true,
-        ): RoomDatabase.Builder<T> = this.fallbackToDestructiveMigration(dropAllTables = false)
-            .apply {
-                if (multiConnection) {
-                    setMultipleConnectionPool(maxNumOfReaders = 4, maxNumOfWriters = 1)
-                } else {
-                    setSingleConnectionPool()
-                }
-            }
-            .setQueryCoroutineContext(
-                // limitedParallelism(1) has the same throughput ceiling as the single-connection pool
-                // (already serialized), so this only blocks the cancellation pileup — not real I/O concurrency.
-                if (multiConnection) ioDispatcher else ioDispatcher.limitedParallelism(1),
-            )
+        fun <T : RoomDatabase> RoomDatabase.Builder<T>.configureCommon(): RoomDatabase.Builder<T> =
+            this.fallbackToDestructiveMigration(dropAllTables = false)
+                .setSingleConnectionPool()
+                .setQueryCoroutineContext(
+                    // limitedParallelism(1) has the same throughput ceiling as the single-connection pool
+                    // (already serialized), so this only blocks the cancellation pileup — not real I/O concurrency.
+                    ioDispatcher.limitedParallelism(1),
+                )
     }
 }
 

--- a/core/database/src/iosMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
+++ b/core/database/src/iosMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
@@ -51,7 +51,7 @@ actual fun getDatabaseBuilder(dbName: String): RoomDatabase.Builder<MeshtasticDa
 /** Returns a [RoomDatabase.Builder] configured for an in-memory iOS database. */
 actual fun getInMemoryDatabaseBuilder(): RoomDatabase.Builder<MeshtasticDatabase> =
     Room.inMemoryDatabaseBuilder<MeshtasticDatabase>(factory = { MeshtasticDatabaseConstructor.initialize() })
-        .configureCommon(multiConnection = false)
+        .configureCommon()
         .setDriver(BundledSQLiteDriver())
 
 /** Returns the iOS directory where database files are stored. */

--- a/core/database/src/jvmMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
+++ b/core/database/src/jvmMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
@@ -57,7 +57,7 @@ actual fun getDatabaseBuilder(dbName: String): RoomDatabase.Builder<MeshtasticDa
 /** Returns a [RoomDatabase.Builder] configured for an in-memory JVM database. */
 actual fun getInMemoryDatabaseBuilder(): RoomDatabase.Builder<MeshtasticDatabase> =
     Room.inMemoryDatabaseBuilder<MeshtasticDatabase>(factory = { MeshtasticDatabaseConstructor.initialize() })
-        .configureCommon(multiConnection = false)
+        .configureCommon()
         .setDriver(BundledSQLiteDriver())
 
 /** Returns the JVM/Desktop directory where database files are stored. */


### PR DESCRIPTION
Fixes the exception flood a Flathub tester hit immediately after the desktop app's Flathub publication: with a large node DB (~2205 nodes), the log fills with `androidx.sqlite.SQLiteException: Error code: 5, Timed out attempting to acquire a reader connection`, and the app can no longer read from the database until restart.

The root cause is a known Room KMP failure mode this repo already documented and worked around **on Android only**: under coroutine cancellation churn, the 4-reader connection pool's permit semaphore wedges — the pool dump shows every reader connection as `Free` but `permits=0` with an empty queue, so every acquisition times out. The `configureCommon` doc comment explicitly said JVM/iOS would stay on the multi-reader pool until desktop or iOS field logs showed the same pattern. That field evidence arrived with the first round of Flathub testing.

### 🐛 Bug Fixes
- Desktop (JVM) and iOS on-disk databases now use `setSingleConnectionPool()`, matching Android production. This eliminates the separate reader permit pool that wedges, ending the reader-timeout exception flood on desktop.

### 🛠️ Refactoring & Architecture
- With every call site now wanting single-connection, the `multiConnection` parameter on `MeshtasticDatabase.configureCommon()` is deleted; the builder unconditionally applies `setSingleConnectionPool()` + `ioDispatcher.limitedParallelism(1)`. Net −21 lines.
- Doc comments updated to record the desktop field evidence so the multi-reader pool isn't reintroduced without knowing the history.

### Reviewer notes
- Reads on desktop/iOS now serialize through one connection. This is the exact configuration Android ships in production, where it handles comparable node counts without issue.
- The wedge is a churn-dependent race, so the fix is verified by mechanism (removing the reader permit pool entirely, proven on Android) rather than by local reproduction of the timeout.

### Testing Performed
- Full baseline: `spotlessApply spotlessCheck detekt kmpSmokeCompile assembleDebug test allTests` — all green (411 tests executed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling across Android, iOS, and desktop platforms.
  * Standardized database access behavior for disk-backed and in-memory databases.
  * Reduced the risk of database operations becoming stalled during heavy concurrent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->