### PR TITLE
chore(desktop): bump Compose Desktop runtime from JBR 21 to JBR 25

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'JDK distribution (temurin or jetbrains)'
     default: 'temurin'
   install_jetbrains_jdk:
-    description: 'Also install JetBrains JDK 21 for Compose Desktop toolchain resolution'
+    description: 'Also install JetBrains JDK 25 for Compose Desktop toolchain resolution'
     default: 'false'
   gradle_encryption_key:
     description: 'Encryption key for Gradle remote cache'
@@ -30,21 +30,21 @@ runs:
         distribution: ${{ inputs.jdk_distribution }}
         token: ${{ github.token }}
 
-    - name: Restore cached JetBrains JDK 21
+    - name: Restore cached JetBrains JDK 25
       if: inputs.install_jetbrains_jdk == 'true'
       id: cache-jbr
       uses: actions/cache@v6
       with:
         path: ${{ runner.tool_cache }}/Java_JetBrains_jdk
-        key: jbr-21-${{ runner.os }}-${{ runner.arch }}
+        key: jbr-25-${{ runner.os }}-${{ runner.arch }}
 
-    - name: Set up JetBrains JDK 21 (for Compose Desktop)
+    - name: Set up JetBrains JDK 25 (for Compose Desktop)
       if: inputs.install_jetbrains_jdk == 'true' && steps.cache-jbr.outputs.cache-hit != 'true'
       id: setup-jbr
       continue-on-error: true
       uses: actions/setup-java@v5
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'jetbrains'
         check-latest: false
         token: ${{ github.token }}

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -86,18 +86,18 @@ val generateBuildConfig =
 sourceSets.main { kotlin.srcDir(generateBuildConfig.map { buildConfigOutputDir }) }
 
 // ── ProGuard configuration ───────────────────────────────────────────────────
-// compose-jb's standalone ProGuard 7.7 task does NOT auto-include
+// compose-jb's standalone ProGuard task does NOT auto-include
 // `META-INF/proguard/*.pro` consumer rules from dependency jars (only R8 on
 // Android does). We therefore inline every keep rule we need into the two
 // static .pro files referenced below.
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
         vendor.set(JvmVendorSpec.JETBRAINS)
     }
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_21)
+        jvmTarget.set(JvmTarget.JVM_25)
         freeCompilerArgs.add("-jvm-default=no-compatibility")
     }
 }
@@ -119,6 +119,8 @@ compose.desktop {
         jvmArgs(*desktopJvmArgs.toTypedArray())
 
         buildTypes.release.proguard {
+            // CMP's default ProGuard (7.7.0) can't parse Java 25 class files in the JBR 25 jmods
+            version.set("7.9.1")
             isEnabled.set(true)
             obfuscate.set(false) // Open-source project — obfuscation adds no value
             optimize.set(true)

--- a/scripts/verify-flatpak/desktop-offline.yaml
+++ b/scripts/verify-flatpak/desktop-offline.yaml
@@ -35,13 +35,13 @@ modules:
       - tar xzf jbr-*.tar.gz -C /app/jre --strip-components=1
     sources:
       - type: file
-        url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr-21.0.11-linux-x64-b1163.116.tar.gz
-        sha256: 72bf2d1830587a3cd31b718d4af9fc7a88fc6c3740642d842b3b378d4acbe476
+        url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25.0.3-linux-x64-b508.16.tar.gz
+        sha512: f936d2a4048485d3cb552c26f69b41f13eba0f75de1178c9ff6185547755c336d0ef5af9641f004e916d0d0414e34d1e9f9d12c08d262038cbca517dcad0dc96
         only-arches:
           - x86_64
       - type: file
-        url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr-21.0.11-linux-aarch64-b1163.116.tar.gz
-        sha256: 02124d01591c173f9a51ef84d99ce248900d4d1e1aa52a38c65f4708f66b6e98
+        url: https://cache-redirector.jetbrains.com/intellij-jbr/jbr-25.0.3-linux-aarch64-b508.16.tar.gz
+        sha512: 038cce6e7e2d68a28c1b269aff199c2e8a4bca58e24d27f9345fbb6031d6b6dc82d79d524586f3e96952d0272d2ca02fa84817df69b4f6052e9f2c5d34c02bad
         only-arches:
           - aarch64
 


### PR DESCRIPTION
The desktop app ships the JetBrains Runtime it is packaged with, so this bumps the bundled runtime from JBR 21 to JBR 25 (25.0.3 b508.16, the current release) to pick up JetBrains' latest AWT/Wayland fixes. The Gradle-daemon JDK and the Android/KMP module toolchain intentionally stay on 21.

## Changes

🧹 **Chores**
- `desktopApp/build.gradle.kts`: `jvmToolchain` 21 → 25 (vendor stays `JETBRAINS`); Kotlin `jvmTarget` aligned to `JVM_25` — Gradle fails the build on a `compileJava=25` / `compileKotlin=21` split, and desktopApp is a leaf application module so raising the bytecode target is safe.
- `desktopApp/build.gradle.kts`: Compose Desktop ProGuard pinned to **7.9.1** — the plugin default (7.7.0) cannot parse the Java 25 class files (v69) in the JBR 25 jmods it consumes as library jars.
- `.github/actions/gradle-setup/action.yml`: the optional JBR install step now provisions JBR 25 under a fresh `jbr-25` cache key, so stale JBR 21 tool caches are never restored.
- `scripts/verify-flatpak/desktop-offline.yaml`: bundled JRE tarballs bumped to jbr-25.0.3 (x64 + aarch64). JetBrains publishes SHA-512 checksums for these artifacts, so the source entries switch from `sha256` to `sha512` (supported by flatpak-builder).

## Reviewer notes

- Foojay's disco API serves JBR 25 for all relevant platforms (verified for linux-x64 and macos-aarch64), so both the CI fallback path and local-dev toolchain auto-provisioning work without a locally installed JBR.
- Flatpak tarball checksums were taken from JetBrains' published `.checksum` files for the `jbr-release-25.0.3b508.16` release.

## Testing Performed

- `./gradlew :desktopApp:proguardReleaseJars` — JBR 25 auto-provisioned via Foojay and ProGuard 7.9.1 processed the full app against the JDK 25 jmods (this fails with "unsupported class version" on the default 7.7.0).
- Full baseline green: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded the desktop runtime and build toolchain from Java 21 to Java 25.
  * Updated offline desktop packaging to use JetBrains Runtime 25.0.3 for supported architectures.
  * Improved release-build compatibility with Java 25 class files.
  * Updated build automation to install and cache JetBrains JDK 25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->