### PR TITLE
fix(desktop): align tray, shortcuts, and macOS chrome with current CMP desktop guidance

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -112,6 +112,8 @@ compose.desktop {
         val desktopJvmArgs =
             listOf(
                 "-Xmx2G",
+                // Let the macOS title bar follow the system light/dark theme (ignored on other OSes).
+                "-Dapple.awt.application.appearance=system",
                 "-Dapple.awt.application.name=Meshtastic Desktop",
                 "-Dcom.apple.mrj.application.apple.menu.about.name=Meshtastic Desktop",
                 "-Dcom.apple.bundle.identifier=org.meshtastic.MeshtasticDesktop",

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
@@ -30,7 +30,9 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.key
@@ -360,13 +362,17 @@ private fun CoilImageLoaderSetup() {
 
 private val isMacOS = DesktopOS.current() == DesktopOS.MacOS
 
-/** Platform-conventional shortcut modifier: Cmd on macOS, Ctrl on Windows/Linux. */
-private val androidx.compose.ui.input.key.KeyEvent.isShortcutModifierPressed: Boolean
-    get() = if (isMacOS) isMetaPressed else isCtrlPressed
+/**
+ * Platform-conventional shortcut modifier: Cmd on macOS, Ctrl on Windows/Linux. Alt must be up on the Ctrl path because
+ * Windows reports AltGr as Ctrl+Alt — otherwise typing AltGr characters (e.g. @ on German layouts, which is AltGr+Q)
+ * would trigger shortcuts like quit.
+ */
+private val KeyEvent.isShortcutModifierPressed: Boolean
+    get() = if (isMacOS) isMetaPressed else isCtrlPressed && !isAltPressed
 
 /** Handles Cmd/Ctrl-key shortcuts. Returns `true` if the event was consumed. */
 private fun handleKeyboardShortcut(
-    event: androidx.compose.ui.input.key.KeyEvent,
+    event: KeyEvent,
     multiBackstack: MultiBackstack,
     exitApplication: () -> Unit,
 ): Boolean {

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
@@ -86,6 +87,7 @@ import org.meshtastic.core.ui.viewmodel.UIViewModel
 import org.meshtastic.desktop.data.DesktopPreferencesDataSource
 import org.meshtastic.desktop.di.desktopModule
 import org.meshtastic.desktop.di.desktopPlatformModule
+import org.meshtastic.desktop.notification.DesktopOS
 import org.meshtastic.desktop.ui.DesktopMainScreen
 import java.awt.Desktop
 import java.util.Locale
@@ -232,8 +234,10 @@ private fun ApplicationScope.MeshtasticDesktopApp(uiViewModel: UIViewModel, isDa
         },
     )
 
-    if (isWindowReady && isAppVisible) {
-        MeshtasticWindow(uiViewModel, isDarkTheme, appIcon, windowState) {
+    if (isWindowReady) {
+        // Hide via `visible` rather than dropping the Window from composition so the UI tree
+        // (navigation backstack, scroll positions) survives a hide-to-tray round trip.
+        MeshtasticWindow(uiViewModel, isDarkTheme, appIcon, windowState, visible = isAppVisible) {
             // Minimize to the tray on close — but only where a tray exists. On platforms without a
             // system tray (e.g. some Linux desktop environments) there's nowhere to minimize to, so
             // quit instead; otherwise the process would be stranded with no window and no tray icon.
@@ -293,6 +297,7 @@ private fun ApplicationScope.MeshtasticWindow(
     isDarkTheme: Boolean,
     appIcon: Painter,
     windowState: WindowState,
+    visible: Boolean,
     onCloseRequest: () -> Unit,
 ) {
     val multiBackstack =
@@ -310,6 +315,7 @@ private fun ApplicationScope.MeshtasticWindow(
         title = "Meshtastic Desktop",
         icon = appIcon,
         state = windowState,
+        visible = visible,
         onPreviewKeyEvent = { event -> handleKeyboardShortcut(event, multiBackstack, ::exitApplication) },
     ) {
         val eventEdition by uiViewModel.eventEdition.collectAsState()
@@ -352,13 +358,19 @@ private fun CoilImageLoaderSetup() {
 
 // ----- Keyboard shortcuts -----
 
-/** Handles Cmd-key shortcuts. Returns `true` if the event was consumed. */
+private val isMacOS = DesktopOS.current() == DesktopOS.MacOS
+
+/** Platform-conventional shortcut modifier: Cmd on macOS, Ctrl on Windows/Linux. */
+private val androidx.compose.ui.input.key.KeyEvent.isShortcutModifierPressed: Boolean
+    get() = if (isMacOS) isMetaPressed else isCtrlPressed
+
+/** Handles Cmd/Ctrl-key shortcuts. Returns `true` if the event was consumed. */
 private fun handleKeyboardShortcut(
     event: androidx.compose.ui.input.key.KeyEvent,
     multiBackstack: MultiBackstack,
     exitApplication: () -> Unit,
 ): Boolean {
-    if (event.type != KeyEventType.KeyDown || !event.isMetaPressed) return false
+    if (event.type != KeyEventType.KeyDown || !event.isShortcutModifierPressed) return false
     val backStack = multiBackstack.activeBackStack
     return when (event.key) {
         Key.Q -> {


### PR DESCRIPTION
Audited the desktop shell against JetBrains' official Compose Multiplatform desktop docs (`kotlin-multiplatform-dev-docs` @ HEAD; newest stable CMP = 1.11.1, which is our pin). The shell already matches current guidance almost everywhere — this PR fixes the three real gaps the audit surfaced, plus a JDK-25 gap in the offline Flatpak manifest that this PR's CI run exposed.

🐛 **Bug Fixes**
- **Hide-to-tray no longer wipes UI state** — closing to the tray dropped the `Window` from composition, destroying the navigation backstack and scroll positions; restoring from the tray restarted the UI from scratch. Now uses the documented minimize-to-tray pattern (`Window(visible = …)`) so the compose tree survives the round trip.
- **Keyboard shortcuts now work on Windows/Linux** — the handler checked only the meta key, so Cmd+1–4/Comma/Slash/Q were dead on the MSI/Deb/RPM/AppImage builds. Shortcuts now use the platform-conventional modifier: Cmd on macOS, Ctrl elsewhere. The Ctrl path requires Alt to be up, because Windows reports AltGr as Ctrl+Alt — otherwise typing AltGr characters (e.g. `@` on German layouts = AltGr+Q) would fire shortcuts, including quit.
- **macOS title bar follows dark mode** — added the documented `-Dapple.awt.application.appearance=system` jvmArg; previously the window chrome stayed light while the app content was dark.
- **Offline Flatpak build provisions the JDKs the 2.8 tree actually needs** — the JBR 25 toolchain bump (#6203) raised `desktopApp` to `languageVersion=25`, but the offline manifest still shipped only the `openjdk21` SDK extension; with toolchain auto-provisioning disabled (the build is offline by design), `compileJava` failed on both arches. The manifest now ships dual JDKs — `openjdk21` for the Gradle daemon (`gradle-daemon-jvm.properties` pins `toolchainVersion=21`) and `openjdk25` for the desktop toolchain — with the coupling documented. Also realigned the manifest's bundled Gradle dist with the 9.6.1 wrapper (it was silently passing on 9.6.0). Surfaced here rather than on #6203 because `verify-flatpak` only runs on PRs touching desktop paths.

🧹 **Chores**
- **Flatpak verification now targets the official packaging repo** — CI and `scripts/verify-flatpak/verify.sh` clone `flathub/org.meshtastic.MeshtasticDesktop` (what Flathub actually builds, seeded from vidplace7's dev repo on 2026-07-08) instead of the dev fork, including the `master`-vs-`main` default-branch fix in the script's refresh path.

🧹 **Audit notes (no change needed)**
- Classic `androidx.compose.ui.window.Tray` remains the only documented tray API through CMP 1.12 — nothing to migrate.
- Repo is already clean of CMP 1.8–1.11 desktop deprecations (`onExternalDrag`, `ClipboardManager`, desktop-specific `@Preview`, `Key.Home`, explicit hot-reload plugin pin); UI tests are already on ComposeUiTest v2 (#5112).
- The ProGuard ≥7.8 requirement for JDK 25 classfiles is already satisfied by #6203 (`version.set("7.9.1")`); branch is rebased onto that JBR 25 bump.

**Testing Performed**
Full baseline green on the JBR 25 toolchain (re-run after the AltGr guard): `spotlessApply spotlessCheck detekt assembleDebug test allTests`, 0 failures. The Flatpak manifest fix is exercised by this PR's own `verify-flatpak` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS desktop title bars now follow the system light/dark appearance.
  * Desktop windows stay mounted for smoother show/hide transitions.
* **Bug Fixes**
  * Keyboard shortcuts now use the correct modifier key across macOS, Windows, and Linux.
* **Build & Packaging**
  * Updated the offline Flatpak build to include OpenJDK 25 alongside OpenJDK 21, and bumped the bundled Gradle distribution to 9.6.1.
  * Switched offline Flatpak verification/build to the official Flathub packaging repository, with related documentation updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
