### PR TITLE
fix(desktop): pin Compose packaging javaHome to the JBR toolchain

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -546,7 +546,10 @@ jobs:
           install_jetbrains_jdk: 'true'
 
       - name: Build Desktop
-        run: ./gradlew :desktopApp:createDistributable -Pci=true
+        # proguardReleaseJars is included because it is otherwise only exercised by the
+        # release workflow: jlink tolerates a jmods-less JDK (JEP 493) but ProGuard does
+        # not, so a broken packaging JDK would surface at release time instead of here.
+        run: ./gradlew :desktopApp:createDistributable :desktopApp:proguardReleaseJars -Pci=true
 
       - name: Upload Desktop artifact
         if: ${{ inputs.upload_artifacts }}

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -109,6 +109,24 @@ compose.desktop {
     application {
         mainClass = "org.meshtastic.desktop.MainKt"
 
+        // CMP resolves javaHome from the JVM running Gradle, not the Kotlin toolchain. On CI
+        // that's Temurin 25, which ships without jmods (JEP 493): jlink still works, but the
+        // ProGuard task derives -libraryjars from $javaHome/jmods and fails with ~857k
+        // unresolved java.* references. Pin packaging to the JBR SDK toolchain (jmods
+        // included) so ProGuard sees the platform classes and the bundled runtime is
+        // deterministically JBR 25 on every machine.
+        javaHome =
+            javaToolchains
+                .launcherFor {
+                    languageVersion.set(JavaLanguageVersion.of(25))
+                    vendor.set(JvmVendorSpec.JETBRAINS)
+                }
+                .get()
+                .metadata
+                .installationPath
+                .asFile
+                .absolutePath
+
         val desktopJvmArgs =
             listOf(
                 "-Xmx2G",


### PR DESCRIPTION
## Why

Release run [29132882661](https://github.com/meshtastic/Meshtastic-Android/actions/runs/29132882661) failed `:desktopApp:proguardReleaseJars` on **all four desktop platforms** with ~857k unresolved `java.*` references (`configuration refers to the unknown class 'java.lang.String'`).

Root cause chain:

1. The Compose Multiplatform plugin resolves the packaging `javaHome` from **the JVM running Gradle** (`System.getProperty("java.home")`), not from the Kotlin `jvmToolchain`.
2. On CI, Gradle runs on the runner's **Temurin 25** (the daemon JVM criteria pin version 25 but no vendor).
3. Temurin 24+ enables [JEP 493](https://adoptium.net/news/2025/08/eclipse-temurin-jdk24-JEP493-enabled) and **ships without a `jmods/` directory** (see also [actions/runner-images#13158](https://github.com/actions/runner-images/issues/13158)). jlink links from the runtime image, so `createDistributable` in main-check stayed green — but ProGuard derives its `-libraryjars` from `$javaHome/jmods` and got **zero platform classes**.
4. Locally the Gradle daemon runs on the Foojay-provisioned JBR SDK (which still ships jmods), so #6203 validated clean. Classic local/CI drift, and the failing path only ran in the release workflow.

## 🐛 Fixes

- **`desktopApp/build.gradle.kts`** — pin `compose.desktop.application.javaHome` to the JETBRAINS 25 toolchain (the same spec already used for compilation, resolvable on all four CI platforms today). The JBR SDK ships jmods, so ProGuard sees the platform classes again. Side benefit: the bundled runtime is now **deterministically JBR 25**, which was the actual intent of #6203 — before this fix, CI distributions silently bundled whatever JVM ran Gradle (Temurin).
- **`.github/workflows/reusable-check.yml`** — the main-check desktop matrix now also runs `:desktopApp:proguardReleaseJars`, so this previously release-only path is exercised post-merge instead of surfacing at release time.

## Testing Performed

- Reproduced the mechanism locally: verified `jars-config.pro` gains 72 `-libraryjars` entries resolving to the JBR SDK jmods, and `:desktopApp:proguardReleaseJars` builds successfully with the pin (`BUILD SUCCESSFUL`, ProGuard 7.9.1 parses the Java 25 class files fine — proguard-core 9.3.2 supports up to class file v70).
- Full baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green.

## Notes

- The failed release's cleanup deleted its tag, so once this merges the release needs a **fresh dispatch** of *Create or Promote Release* (not a re-run of the failed run).
- Alternatives considered and rejected: switching CI setup-java to the `jetbrains` distribution (fixes only CI, leaves the ambient-JVM trap armed for local builds, and depends on the rate-limited JetBrainsRuntime GitHub releases API) and adding `toolchainVendor=JETBRAINS` to the daemon JVM criteria (forces JBR provisioning on every job and machine, including ones that never touch desktop packaging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop release build validation to detect packaging and optimization issues earlier.
  * Standardized the Java toolchain used for desktop packaging, improving build consistency and reliability.

* **Chores**
  * Updated automated desktop build checks to cover additional release packaging steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->