### PR TITLE
ci(desktop): sign Windows installers and publish production releases to winget

### DIFF
--- a/.github/workflows/create-or-promote-release.yml
+++ b/.github/workflows/create-or-promote-release.yml
@@ -27,7 +27,6 @@ permissions:
   statuses: write
   id-token: write
   attestations: write
-  actions: write # promote.yml dispatches winget-publish.yml; a called workflow's token is capped by the caller's grants
 
 jobs:
   determine-tags:
@@ -133,6 +132,18 @@ jobs:
   call-promote-workflow:
     if: ${{ !inputs.dry_run && inputs.channel != 'internal' }}
     needs: determine-tags
+    # promote.yml's token is capped by this job's grants, and a called
+    # workflow requesting more than its caller grants fails at startup —
+    # so this must cover promote.yml's declared workflow-level set, plus
+    # actions: write for its publish-workflow dispatch. Scoped to this job
+    # so call-release-workflow doesn't carry it.
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+      id-token: write
+      attestations: write
+      actions: write
     uses: ./.github/workflows/promote.yml
     with:
       tag_name: ${{ needs.determine-tags.outputs.tag_to_process }}

--- a/.github/workflows/create-or-promote-release.yml
+++ b/.github/workflows/create-or-promote-release.yml
@@ -27,6 +27,7 @@ permissions:
   statuses: write
   id-token: write
   attestations: write
+  actions: write # promote.yml dispatches winget-publish.yml; a called workflow's token is capped by the caller's grants
 
 jobs:
   determine-tags:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -63,7 +63,6 @@ permissions:
   statuses: write
   id-token: write
   attestations: write
-  actions: write # dispatch winget-publish.yml on production promotion
 
 jobs:
   prepare-build-info:
@@ -144,6 +143,15 @@ jobs:
   update-github-release:
     runs-on: ubuntu-24.04-arm
     needs: [ prepare-build-info, promote-release ]
+    # actions: write is scoped here — only this job's publish-workflow
+    # dispatch needs it, and the other jobs must not get it. Job-level
+    # permissions replace the workflow-level block, so the full set this
+    # job uses is listed.
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+      actions: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.0

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -63,6 +63,7 @@ permissions:
   statuses: write
   id-token: write
   attestations: write
+  actions: write # dispatch winget-publish.yml on production promotion
 
 jobs:
   prepare-build-info:
@@ -166,6 +167,19 @@ jobs:
             --title "${{ inputs.release_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})" \
             --draft=false \
             --prerelease=${{ inputs.channel != 'production' }}
+
+      # The edit above is made with GITHUB_TOKEN, and GITHUB_TOKEN-caused
+      # events never start workflow runs — winget-publish.yml's `released`
+      # trigger will not fire from it. workflow_dispatch is exempt from that
+      # suppression, so dispatch it explicitly. Soft-fail: a winget hiccup
+      # must not block the changelog stamp or Discord notification.
+      - name: Dispatch winget publish
+        if: ${{ inputs.channel == 'production' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.final_tag }}
+        run: gh workflow run winget-publish.yml --ref main -f "tag=$TAG"
 
       - name: Stamp CHANGELOG.md for release
         if: ${{ inputs.channel == 'production' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,20 @@ on:
         required: false
       APPLE_TEAM_ID:
         required: false
+      # Windows Authenticode signing via Azure Trusted Signing (now "Artifact Signing").
+      # All optional: the signing step skips cleanly when absent, like macOS above.
+      AZURE_TENANT_ID:
+        required: false
+      AZURE_CLIENT_ID:
+        required: false
+      AZURE_CLIENT_SECRET:
+        required: false
+      AZURE_TRUSTED_SIGNING_ENDPOINT:
+        required: false
+      AZURE_TRUSTED_SIGNING_ACCOUNT:
+        required: false
+      AZURE_TRUSTED_SIGNING_CERT_PROFILE:
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.tag_name }}
@@ -269,6 +283,8 @@ jobs:
       GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
       GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
       GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+      # Secrets aren't readable in step `if:` expressions, so surface presence here.
+      SIGN_WINDOWS: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT != '' && 'true' || 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.0
@@ -307,6 +323,39 @@ jobs:
           ./gradlew :desktopApp:packageReleaseDistributionForCurrentOS
           ${{ contains(runner.os, 'macOS') && ':desktopApp:packageReleaseUberJarForCurrentOS' || '' }}
           '-PaboutLibraries.release=true' --no-daemon
+
+      # Authenticode-signs the MSI/EXE installers via Azure Trusted Signing
+      # (rebranded "Artifact Signing"). Skips cleanly when the secrets are
+      # absent, mirroring SIGN_MACOS. Required repository secrets:
+      #   AZURE_TENANT_ID                    – Entra tenant ID
+      #   AZURE_CLIENT_ID                    – app registration (service principal) client ID
+      #   AZURE_CLIENT_SECRET                – client secret for that app registration
+      #   AZURE_TRUSTED_SIGNING_ENDPOINT     – e.g. https://eus.codesigning.azure.net
+      #   AZURE_TRUSTED_SIGNING_ACCOUNT      – Trusted Signing account name
+      #   AZURE_TRUSTED_SIGNING_CERT_PROFILE – public-trust certificate profile name
+      # The service principal needs the "Trusted Signing Certificate Profile
+      # Signer" role on the account. Presence is gated on the ENDPOINT secret;
+      # a half-configured set fails here loudly rather than shipping unsigned.
+      # Note: only the installers are signed, not the launcher .exe packaged
+      # inside them — SmartScreen reputation attaches to the downloaded file.
+      # Sign the inner .exe between createReleaseDistributable and packaging
+      # if that ever becomes necessary.
+      - name: Sign Windows installers (Azure Trusted Signing)
+        if: runner.os == 'Windows' && env.SIGN_WINDOWS == 'true'
+        uses: azure/artifact-signing-action@v2.0.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERT_PROFILE }}
+          files-folder: desktopApp/build/compose/binaries/main-release
+          files-folder-filter: msi,exe
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
 
       # jpackage computes the .deb Depends: line from the build host's package names.
       # Ubuntu 24.04 records time_t64 transition names (libasound2t64, libpng16-16t64)

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,42 @@
+name: Publish to winget
+
+# The `released` type fires when a release is published as a full release OR
+# when an existing pre-release is flipped to a full release — the latter is
+# exactly what promote.yml's production promotion does (`gh release edit
+# --prerelease=false` on the already-published release object). It never fires
+# for drafts or pre-releases, so internal/closed/open promotions are ignored.
+on:
+  release:
+    types: [released]
+
+# The WINGET_TOKEN PAT does all the work against microsoft/winget-pkgs;
+# nothing in this repo is written.
+permissions: {}
+
+jobs:
+  winget:
+    # Belt and braces — `released` should already exclude these.
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+    runs-on: ubuntu-latest
+    env:
+      # Secrets aren't readable in step `if:` expressions; skip cleanly until
+      # the token is configured.
+      HAS_WINGET_TOKEN: ${{ secrets.WINGET_TOKEN != '' && 'true' || 'false' }}
+    steps:
+      # Prerequisites (both manual, one-time):
+      #   1. Meshtastic.MeshtasticDesktop must already exist in
+      #      microsoft/winget-pkgs — winget-releaser only updates existing
+      #      packages. Submit the first version by hand with `wingetcreate new
+      #      <MSI release asset URL>`.
+      #   2. WINGET_TOKEN secret: a *classic* PAT with the public_repo scope
+      #      (fine-grained PATs are not supported), owned by an account that
+      #      has (or can create) a fork of microsoft/winget-pkgs.
+      # The version is derived from the release tag with the leading `v`
+      # stripped (v2.8.0 -> 2.8.0), matching the MSI's ProductVersion.
+      - name: Submit MSI manifest to microsoft/winget-pkgs
+        if: env.HAS_WINGET_TOKEN == 'true'
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Meshtastic.MeshtasticDesktop
+          installers-regex: '\.msi$'
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -2,12 +2,24 @@ name: Publish to winget
 
 # The `released` type fires when a release is published as a full release OR
 # when an existing pre-release is flipped to a full release — the latter is
-# exactly what promote.yml's production promotion does (`gh release edit
+# what promote.yml's production promotion does (`gh release edit
 # --prerelease=false` on the already-published release object). It never fires
 # for drafts or pre-releases, so internal/closed/open promotions are ignored.
+#
+# CAVEAT: promote.yml performs that edit with the workflow's own GITHUB_TOKEN,
+# and events caused by GITHUB_TOKEN never start workflow runs — so promote.yml
+# also dispatches this workflow explicitly (workflow_dispatch is exempt from
+# that suppression). The release trigger stays for manually-published releases;
+# workflow_dispatch doubles as the manual retry/seed path.
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Production release tag to publish (e.g., v2.8.0)'
+        required: true
+        type: string
 
 # The WINGET_TOKEN PAT does all the work against microsoft/winget-pkgs;
 # nothing in this repo is written.
@@ -15,7 +27,8 @@ permissions: {}
 
 jobs:
   winget:
-    # Belt and braces — `released` should already exclude these.
+    # Belt and braces for release events — `released` should already exclude
+    # these. workflow_dispatch has no release payload and passes through.
     if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
     runs-on: ubuntu-latest
     env:
@@ -39,4 +52,5 @@ jobs:
         with:
           identifier: Meshtastic.MeshtasticDesktop
           installers-regex: '\.msi$'
+          release-tag: ${{ inputs.tag || github.event.release.tag_name }}
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
## Why

Windows desktop installers ship unsigned, so every download trips SmartScreen — the single biggest trust barrier for desktop adoption. And once installers are signed, winget is the cheapest store-adjacent distribution channel we can add: users get `winget install Meshtastic.MeshtasticDesktop` plus automatic upgrade detection, with zero hosting on our side.

## 🛠️ Improvements

- **Windows code signing** (`release.yml`): the Windows matrix leg now Authenticode-signs the MSI and EXE via [Azure Trusted Signing](https://azure.microsoft.com/en-us/products/trusted-signing) (`azure/artifact-signing-action@v2.0.0` — the action's post-rebrand name). Gated on secrets presence exactly like `SIGN_MACOS`: with no secrets configured the step skips and the build is byte-identical to today. Signing runs **before** upload and attestation, so release assets and build provenance cover the signed bytes.
- **winget publishing** (`winget-publish.yml`, new): submits the MSI manifest to `microsoft/winget-pkgs` via `vedantmgoyal9/winget-releaser@v2` when a release reaches production. Skips cleanly until `WINGET_TOKEN` exists.
- **winget trigger wiring** (`promote.yml` + caller): the production promotion edits the release with the workflow's own `GITHUB_TOKEN`, and GitHub never starts workflow runs for events caused by `GITHUB_TOKEN` — so a plain `release:` trigger would silently never fire from the automated path. `workflow_dispatch` is exempt from that suppression, so promote.yml's production leg dispatches `winget-publish.yml` explicitly (`continue-on-error` — a winget hiccup can't block the changelog stamp or Discord notification; needs `actions: write` on promote.yml and its caller). The workflow also keeps a `release: [released]` trigger for manually-published releases (`released` fires on the prerelease→release flip and never for pre-releases/drafts), and the dispatch input doubles as the manual retry path.

## Manual setup required (blocking activation, not merge)

Everything below is account/secret work only a human can do; the workflows are inert until it's done.

**Signing (do this first — see ordering note):**
1. Create an Azure Trusted Signing account + public-trust certificate profile (identity validation for "Meshtastic LLC" happens here). ~$9.99/mo basic tier.
2. Create an Entra app registration (service principal) with the **Trusted Signing Certificate Profile Signer** role on the account.
3. Add repo secrets (documented in the workflow comment): `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`, `AZURE_TRUSTED_SIGNING_CERT_PROFILE`. Presence is gated on the endpoint secret; a half-configured set fails loudly rather than shipping unsigned.

**winget (after signing is live):**
1. Seed the package manually once: `wingetcreate new <MSI release-asset URL>` — winget-releaser only *updates* existing packages.
2. Add `WINGET_TOKEN`: a **classic** PAT with `public_repo` scope (fine-grained PATs unsupported), on an account with a fork of `microsoft/winget-pkgs`.

**Ordering matters:** winget-pkgs moderation flags unsigned installers (and SmartScreen-flagged binaries get community reports). Land signing, cut one signed production release, then seed winget from that release.

## Notes & limitations

- Only the installers are signed, not the launcher `.exe` inside them — SmartScreen reputation attaches to the downloaded file, so this is the 90% win. Signing the inner exe would mean splitting `createReleaseDistributable` from packaging; noted in a workflow comment as the upgrade path if ever needed.
- Cannot be end-to-end tested without the real secrets/account. Both new steps are verified skip-safe by construction (`if:` on computed env), and the no-secrets path is the exact current behavior.
- Action pins follow repo convention (version tags). `winget-releaser` is a personal-account action; happy to SHA-pin both if preferred.

## Testing Performed

- `actionlint` on all four touched workflows: `winget-publish.yml` clean; `release.yml`/`promote.yml`/`create-or-promote-release.yml` have identical pre-existing shellcheck info-level findings before and after.
- Verified action input names against `Azure/artifact-signing-action` v2.0.0 `action.yml` (repo renamed from `trusted-signing-action`; `signing-account-name` supersedes the deprecated `trusted-signing-account-name`).
- Verified event semantics: `released` fires on pre-release→release transitions (our production path) and never for pre-releases.
- Verified MSI asset naming (`Meshtastic.Desktop-<version>.msi`) matches winget-releaser's default version derivation (tag minus leading `v` == MSI `ProductVersion`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows desktop installers can now be optionally Authenticode-signed via Azure Trusted Signing for added install trust.
  * Added automated Windows Package Manager (winget) publishing for production releases (MSI manifest updates).
* **Release Improvements**
  * Production promotion now triggers winget publishing automatically.
  * Package publishing failures won’t stop other release completion steps.
* **Maintenance**
  * Updated workflow permissions to support publishing and dispatch actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
