### PR TITLE
feat(desktop): Homebrew cask for macOS + tap automation on production releases

### DIFF
--- a/.github/homebrew/meshtastic-desktop.rb
+++ b/.github/homebrew/meshtastic-desktop.rb
@@ -1,8 +1,9 @@
 # Homebrew Cask template for Meshtastic Desktop.
 #
-# Source of truth for the cask published to the meshtastic/homebrew-meshtastic tap.
-# The `update-homebrew-cask` job in promote.yml substitutes {{VERSION}} and
-# {{SHA256}} and pushes the rendered file to the tap on every production release.
+# Source of truth for the cask published to the meshtastic/homebrew-tap tap
+# (alongside the meshtasticd formula). The `update-homebrew-cask` job in
+# promote.yml substitutes {{VERSION}} and {{SHA256}} and opens a PR against the
+# tap on every production release, so its brew test-bot CI validates the bump.
 # The download URL depends on the jpackage DMG being named
 # "Meshtastic Desktop-<version>.dmg" (GitHub rewrites the space to a dot).
 #

--- a/.github/homebrew/meshtastic-desktop.rb
+++ b/.github/homebrew/meshtastic-desktop.rb
@@ -1,0 +1,33 @@
+# Homebrew Cask template for Meshtastic Desktop.
+#
+# Source of truth for the cask published to the meshtastic/homebrew-meshtastic tap.
+# The `update-homebrew-cask` job in promote.yml substitutes {{VERSION}} and
+# {{SHA256}} and pushes the rendered file to the tap on every production release.
+# The download URL depends on the jpackage DMG being named
+# "Meshtastic Desktop-<version>.dmg" (GitHub rewrites the space to a dot).
+#
+# ponytail: arm64-only — CI has no Intel macOS runner, so no x86_64 DMG exists.
+# When one is added, switch to `arch arm: ..., intel: ...` with per-arch sha256.
+cask "meshtastic-desktop" do
+  version "{{VERSION}}"
+  sha256 "{{SHA256}}"
+
+  url "https://github.com/meshtastic/Meshtastic-Android/releases/download/v#{version}/Meshtastic.Desktop-#{version}.dmg",
+      verified: "github.com/meshtastic/Meshtastic-Android/"
+  name "Meshtastic Desktop"
+  desc "Companion app for Meshtastic mesh-networking radios"
+  homepage "https://meshtastic.org/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates false
+  depends_on arch: :arm64
+  depends_on macos: :monterey
+
+  app "Meshtastic Desktop.app"
+
+  zap trash: "~/.meshtastic"
+end

--- a/.github/homebrew/meshtastic-desktop.rb
+++ b/.github/homebrew/meshtastic-desktop.rb
@@ -7,7 +7,7 @@
 # The download URL depends on the jpackage DMG being named
 # "Meshtastic Desktop-<version>.dmg" (GitHub rewrites the space to a dot).
 #
-# ponytail: arm64-only — CI has no Intel macOS runner, so no x86_64 DMG exists.
+# NOTE: arm64-only — CI has no Intel macOS runner, so no x86_64 DMG exists.
 # When one is added, switch to `arch arm: ..., intel: ...` with per-arch sha256.
 cask "meshtastic-desktop" do
   version "{{VERSION}}"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -330,6 +330,11 @@ jobs:
             echo "HOMEBREW_TAP_TOKEN not set; skipping Homebrew cask update."
             exit 0
           fi
+          # Tags cut before the template landed check out without it — skip, don't fail.
+          if [[ ! -f .github/homebrew/meshtastic-desktop.rb ]]; then
+            echo "Cask template not present at this tag; skipping Homebrew cask update."
+            exit 0
+          fi
 
           VERSION=${TAG#v}
           # GitHub rewrites spaces in asset names to dots:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -310,7 +310,7 @@ jobs:
 
   # Runs in-workflow rather than on `release: published` because the undraft above
   # uses github.token, whose events never trigger other workflows. Once the cask is
-  # promoted to homebrew/cask, replace the tap push with `brew bump-cask-pr`.
+  # promoted to homebrew/cask, replace the tap PR with `brew bump-cask-pr`.
   update-homebrew-cask:
     if: ${{ inputs.channel == 'production' }}
     runs-on: ubuntu-24.04-arm
@@ -321,7 +321,7 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha || inputs.tag_name }}
 
-      - name: Render cask and push to meshtastic/homebrew-meshtastic
+      - name: Render cask and open PR against meshtastic/homebrew-tap
         env:
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           TAG: ${{ inputs.final_tag }}
@@ -342,14 +342,24 @@ jobs:
           sed -e "s/{{VERSION}}/${VERSION}/" -e "s/{{SHA256}}/${SHA256}/" \
             .github/homebrew/meshtastic-desktop.rb > /tmp/meshtastic-desktop.rb
 
-          git clone "https://x-access-token:${TAP_TOKEN}@github.com/meshtastic/homebrew-meshtastic.git" /tmp/tap
-          mkdir -p /tmp/tap/Casks
-          cp /tmp/meshtastic-desktop.rb /tmp/tap/Casks/meshtastic-desktop.rb
+          # PR (not a direct push to main) so the tap's brew test-bot CI validates the bump.
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/meshtastic/homebrew-tap.git" /tmp/tap
           cd /tmp/tap
+          BRANCH="meshtastic-desktop-${VERSION}"
+          git checkout -b "$BRANCH"
+          mkdir -p Casks
+          cp /tmp/meshtastic-desktop.rb Casks/meshtastic-desktop.rb
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/meshtastic-desktop.rb
-          git diff --cached --quiet || {
-            git commit -m "meshtastic-desktop ${VERSION}"
-            git push
-          }
+          if git diff --cached --quiet; then
+            echo "Cask already up to date."
+            exit 0
+          fi
+          git commit -m "meshtastic-desktop ${VERSION}"
+          git push -fu origin "$BRANCH"
+          GH_TOKEN="$TAP_TOKEN" gh pr create --repo meshtastic/homebrew-tap \
+            --head "$BRANCH" --base main \
+            --title "meshtastic-desktop ${VERSION}" \
+            --body "Automated cask bump for the ${TAG} production release of [Meshtastic-Android](https://github.com/${{ github.repository }}/releases/tag/${TAG})." \
+            || echo "PR already exists for $BRANCH; branch updated."

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -52,6 +52,8 @@ on:
         required: true
       DISCORD_WEBHOOK_ANDROID:
         required: false
+      HOMEBREW_TAP_TOKEN:
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.tag_name }}
@@ -305,3 +307,49 @@ jobs:
           )
 
           curl -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK"
+
+  # Runs in-workflow rather than on `release: published` because the undraft above
+  # uses github.token, whose events never trigger other workflows. Once the cask is
+  # promoted to homebrew/cask, replace the tap push with `brew bump-cask-pr`.
+  update-homebrew-cask:
+    if: ${{ inputs.channel == 'production' }}
+    runs-on: ubuntu-24.04-arm
+    needs: [ update-github-release ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ inputs.commit_sha || inputs.tag_name }}
+
+      - name: Render cask and push to meshtastic/homebrew-meshtastic
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ inputs.final_tag }}
+        run: |
+          if [[ -z "$TAP_TOKEN" ]]; then
+            echo "HOMEBREW_TAP_TOKEN not set; skipping Homebrew cask update."
+            exit 0
+          fi
+
+          VERSION=${TAG#v}
+          # GitHub rewrites spaces in asset names to dots:
+          # "Meshtastic Desktop-X.dmg" is served as "Meshtastic.Desktop-X.dmg".
+          # --retry-all-errors covers the brief 404 window while the undraft propagates.
+          curl -fsSL --retry 5 --retry-delay 30 --retry-all-errors -o /tmp/app.dmg \
+            "https://github.com/${{ github.repository }}/releases/download/${TAG}/Meshtastic.Desktop-${VERSION}.dmg"
+          SHA256=$(sha256sum /tmp/app.dmg | cut -d' ' -f1)
+
+          sed -e "s/{{VERSION}}/${VERSION}/" -e "s/{{SHA256}}/${SHA256}/" \
+            .github/homebrew/meshtastic-desktop.rb > /tmp/meshtastic-desktop.rb
+
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/meshtastic/homebrew-meshtastic.git" /tmp/tap
+          mkdir -p /tmp/tap/Casks
+          cp /tmp/meshtastic-desktop.rb /tmp/tap/Casks/meshtastic-desktop.rb
+          cd /tmp/tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/meshtastic-desktop.rb
+          git diff --cached --quiet || {
+            git commit -m "meshtastic-desktop ${VERSION}"
+            git push
+          }

--- a/desktopApp/README.md
+++ b/desktopApp/README.md
@@ -26,11 +26,10 @@ A Compose Desktop application target — the first full non-Android target for t
 ## Install via Homebrew (macOS, Apple Silicon)
 
 ```bash
-brew tap meshtastic/meshtastic
-brew install --cask meshtastic-desktop
+brew install --cask meshtastic/tap/meshtastic-desktop
 ```
 
-The cask lives in the [meshtastic/homebrew-meshtastic](https://github.com/meshtastic/homebrew-meshtastic) tap and is regenerated from the template at `.github/homebrew/meshtastic-desktop.rb` by the `update-homebrew-cask` job in `promote.yml` on every production release.
+The cask lives in the [meshtastic/homebrew-tap](https://github.com/meshtastic/homebrew-tap) tap (alongside the `meshtasticd` formula) and is regenerated from the template at `.github/homebrew/meshtastic-desktop.rb` by the `update-homebrew-cask` job in `promote.yml`, which opens a PR against the tap on every production release.
 
 ## ProGuard / Minification
 

--- a/desktopApp/README.md
+++ b/desktopApp/README.md
@@ -29,7 +29,7 @@ A Compose Desktop application target — the first full non-Android target for t
 brew install --cask meshtastic/tap/meshtastic-desktop
 ```
 
-The cask lives in the [meshtastic/homebrew-tap](https://github.com/meshtastic/homebrew-tap) tap (alongside the `meshtasticd` formula) and is regenerated from the template at `.github/homebrew/meshtastic-desktop.rb` by the `update-homebrew-cask` job in `promote.yml`, which opens a PR against the tap on every production release.
+The cask lives in the [meshtastic/homebrew-tap](https://github.com/meshtastic/homebrew-tap) tap (alongside the `meshtasticd` formula) and is regenerated from the template at `.github/homebrew/meshtastic-desktop.rb` by the `update-homebrew-cask` job in `promote.yml`, which opens a PR against the tap for production releases when `HOMEBREW_TAP_TOKEN` is configured.
 
 ## ProGuard / Minification
 

--- a/desktopApp/README.md
+++ b/desktopApp/README.md
@@ -23,6 +23,15 @@ A Compose Desktop application target — the first full non-Android target for t
 ./gradlew :desktopApp:packageReleaseDistributionForCurrentOS
 ```
 
+## Install via Homebrew (macOS, Apple Silicon)
+
+```bash
+brew tap meshtastic/meshtastic
+brew install --cask meshtastic-desktop
+```
+
+The cask lives in the [meshtastic/homebrew-meshtastic](https://github.com/meshtastic/homebrew-meshtastic) tap and is regenerated from the template at `.github/homebrew/meshtastic-desktop.rb` by the `update-homebrew-cask` job in `promote.yml` on every production release.
+
 ## ProGuard / Minification
 
 Release builds use ProGuard for tree-shaking (unused code removal), significantly reducing distribution size. Obfuscation is disabled since the project is open-source. Rules are aligned with the Android R8 rules in `androidApp/proguard-rules.pro` — both targets share the same anti-class-merging philosophy.


### PR DESCRIPTION
## Why

macOS desktop users currently have to download the DMG by hand from GitHub releases and get no upgrade path. The `release-desktop` job has been building an uber-jar "for the Homebrew Cask" since it landed, but no cask ever existed. This PR makes `brew install --cask meshtastic/tap/meshtastic-desktop` / `brew upgrade` real.

## 🌟 New Features

- **`.github/homebrew/meshtastic-desktop.rb`** — Homebrew cask template (single source of truth). DMG-based, since the .app inside the DMG is what gets signed/notarized; a jar-based cask would need a bundled JRE. Includes:
  - `livecheck` with `strategy :github_latest` — correctly resolves the latest production release and ignores `-internal`/`-closed`/`-open` prereleases and drafts (verified with `brew livecheck`).
  - `auto_updates false` (the app has no self-updater), `depends_on macos: :monterey` (matches `minimumSystemVersion = "12.0"`).
  - `zap trash: "~/.meshtastic"` — the app's data dir per `desktopDataDir()` in `core/database` (DataStore + Room DB are co-located there).
  - `depends_on arch: :arm64` — see findings below.
- **`update-homebrew-cask` job in `promote.yml`** — on production promotion only (`inputs.channel == 'production'`, i.e. exactly when `prerelease=false` is set), downloads the release DMG, computes the sha256, renders the template, and **opens a PR against the existing [meshtastic/homebrew-tap](https://github.com/meshtastic/homebrew-tap)** (which already ships the `meshtasticd` formula). A PR rather than a direct push, so the tap's `brew test-bot` CI (macOS 15/26, arm64 + Intel) validates every bump. Runs in-workflow rather than on `release: published` because the undraft uses `github.token`, whose events never trigger other workflows. Skips gracefully when `HOMEBREW_TAP_TOKEN` is unset.

## Placement

The org's existing tap, `meshtastic/homebrew-tap`, is the natural home — it already ships `meshtasticd` and has proper tap CI. No name collision: nothing meshtastic-related exists in homebrew-core or homebrew/cask (`brew search meshtastic` is empty; the Python CLI is pipx-only). Later, once signed releases are routine, the cask can additionally be promoted to homebrew/cask — the repo far exceeds notability thresholds — by swapping the tap PR for `brew bump-cask-pr` (noted in a comment on the job).

## Findings / prerequisites before first publish

1. **The v2.7.14 DMG is ad-hoc signed and not notarized** (`codesign` reports `Signature=adhoc`, no TeamIdentifier; `spctl` rejects it; no stapled ticket). The signing wiring existed in the workflow at that tag, so the Apple secrets were evidently not configured. **The first cask release must wait for a production release built with `APPLE_SIGNING_IDENTITY` etc. configured** — shipping a Gatekeeper-rejected app via brew would be a terrible first impression, especially on Sequoia where the ctrl-click bypass is gone.
2. **Only an arm64 DMG exists** — `release-desktop` runs on `macos-latest` (arm64) only, and the v2.7.14 DMG contains a thin arm64 binary. The cask therefore declares `depends_on arch: :arm64`. To cover Intel Macs, add an Intel runner (e.g. `macos-15-intel`) to the matrix and disambiguate the DMG names (both arches currently produce the identical `Meshtastic Desktop-<version>.dmg`, which would collide on upload), then switch the cask to per-arch `arch`/`sha256` interpolation.
3. **One secret to add:** `HOMEBREW_TAP_TOKEN` — fine-grained PAT with contents:write + pull-requests:write on `meshtastic/homebrew-tap`. Until it exists the job no-ops.
4. The automation depends on the DMG asset staying named `Meshtastic Desktop-<version>.dmg` (GitHub serves it as `Meshtastic.Desktop-<version>.dmg`).

## Testing Performed

- `brew style --cask` — 0 offenses.
- `brew audit --cask --online` — passes (after adding `verified:` and the `macos: :monterey` form it flagged).
- `brew livecheck` — resolves 2.7.14 as latest, correctly skipping all 2.8.0 prereleases/drafts.
- Template render (`sed` with real v2.7.14 version + sha256) installed into a throwaway local tap for the above checks.
- `actionlint` on promote.yml — new job is clean (remaining SC2086 infos are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Homebrew cask for the macOS Apple Silicon desktop app.
  * Added production release automation to regenerate the cask with the latest version and checksum, and create/update a PR when the optional Homebrew tap token is available.
* **Documentation**
  * Added “Install via Homebrew (macOS, Apple Silicon)” instructions, including the `brew install --cask meshtastic/tap/meshtastic-desktop` command and where the cask is maintained and regenerated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->