### PR TITLE
chore: strip ponytail: comment markers from the codebase

### DIFF
--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -60,9 +60,6 @@ if printf '%s' "$cmd" | grep -q 'git push'; then
   repo_root=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || exit 0
   is_this_repo "$repo_root" || exit 0
   export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
-  # ponytail: detekt-only gate — test/allTests deliberately NOT run here (minutes
-  # per push is too costly; baseline stays the developer's job). Ceiling: detekt
-  # scans all 39 modules each push; scope to changed modules if it ever drags.
   out=$( (cd "$repo_root" && ./gradlew detekt --console=plain -q) 2>&1 )
   if [ $? -ne 0 ]; then
     {

--- a/.claude/hooks/subagent-audit.sh
+++ b/.claude/hooks/subagent-audit.sh
@@ -9,10 +9,6 @@
 # tree, or a HEAD commit younger than 15 minutes (possibly made by the subagent
 # that just finished).
 #
-# ponytail: stateless — can't diff against pre-subagent state, so your own
-# in-progress edits show up too; the note says so. Snapshot-before/after if the
-# noise ever matters.
-#
 # FAILS OPEN: any error -> exit 0 with no output.
 
 input=$(cat)

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -488,8 +488,6 @@ jobs:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache_read_only: ${{ needs.setup.outputs.cache_read_only }}
 
-      # ponytail: -SNAPSHOT only on main pushes, so PR/merge-queue debug builds keep the plain
-      # base version. Publishing the resulting APKs is main-check.yml's job, not this one.
       - name: Tag main-branch builds as -SNAPSHOT
         if: github.event_name == 'push'
         run: |

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -50,8 +50,6 @@ if (keystorePropertiesFile.exists()) {
 // submissions are auto-rejected (https://developer.android.com/training/cars/communication/templated-messaging).
 // Default builds therefore ship *notification-only* car messaging, which is GA and production-safe.
 // Build a Closed-track templated AAB with: -PenableCarTemplates=true
-// ponytail: gated by a gradle property + res override, not a full build flavor — templated is
-// parked until it leaves Google's beta. Promote to a flavor dimension only if CI must ship both.
 val enableCarTemplates = providers.gradleProperty("enableCarTemplates").map { it.toBoolean() }.getOrElse(false)
 
 configure<ApplicationExtension> {

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
@@ -115,9 +115,6 @@ class MainActivity : AppCompatActivity() {
 
         super.onCreate(savedInstanceState)
 
-        // ponytail: debug-only test affordance so CI/agent tooling can skip onboarding on a fresh
-        // install: `adb shell am start -n <pkg>/.MainActivity --ez skip_onboarding true`. Pair with
-        // `adb shell pm grant <pkg> <permission>` to pre-grant runtime permissions (native, no app code).
         if (BuildConfig.DEBUG && intent.getBooleanExtra(EXTRA_SKIP_ONBOARDING, false)) {
             model.onAppIntroCompleted()
         }

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MapFileImportBus.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MapFileImportBus.kt
@@ -24,9 +24,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
  * Meshtastic Site Planner's "Send to App" share). The shared [MainActivity] receives the intent; only the Google-flavor
  * map renders overlays, so its `MapViewModel` drains this and imports the layer while the activity still holds the URI
  * read grant.
- *
- * ponytail: process-global single slot — fine for one shared file at a time; promote to a Koin single if this ever
- * needs a second consumer or unit testing.
  */
 object MapFileImportBus {
     val pending = MutableStateFlow<Uri?>(null)

--- a/androidApp/src/main/kotlin/org/meshtastic/app/map/SitePlannerRunner.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/map/SitePlannerRunner.kt
@@ -65,7 +65,6 @@ import org.meshtastic.feature.map.component.SitePlannerSheet
 
 // The official hosted Site Planner (static PWA on GitHub Pages). The estimate flow loads it headless with
 // run=1&bridge=1; the native bridge + full flat query contract it relies on shipped in site-planner #74.
-// ponytail: make it a setting if a self-hosted planner is ever needed.
 private const val SITE_PLANNER_BASE_URL = "https://site.meshtastic.org"
 private const val SITE_PLANNER_TIMEOUT_MS = 45_000L
 

--- a/core/common/src/jvmMain/kotlin/org/meshtastic/core/common/log/InMemoryLogBuffer.kt
+++ b/core/common/src/jvmMain/kotlin/org/meshtastic/core/common/log/InMemoryLogBuffer.kt
@@ -24,9 +24,6 @@ import co.touchlab.kermit.Severity
  * startup (`Logger.setLogWriters(platformLogWriter(), InMemoryLogBuffer)`) to let the Debug screen view and export the
  * app's own logs. Lines are formatted to loosely match Android's `logcat -v time` shape (`L/tag: message`) so the same
  * viewer/filters work on both platforms.
- *
- * ponytail: a plain synchronized ArrayDeque — trivially correct for log volumes; swap for a lock-free ring only if it
- * ever shows up hot in a profile.
  */
 object InMemoryLogBuffer : LogWriter() {
     private const val MAX_LINES = 5000

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/UsbRepository.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/UsbRepository.kt
@@ -109,9 +109,5 @@ class UsbRepository(
  * NOT use [UsbDevice.getSerialNumber] — that requires an active USB permission grant, which is exactly what is missing
  * immediately after a re-enumeration, so a serial-based key would read back null mid-recovery and break the very
  * reconnect this is meant to enable.
- *
- * ponytail: vendor:product collides if two *identical* boards are attached at once (last one wins in the map). Append
- * getSerialNumber() — gated on usbManager.hasPermission(device) — only if multi-identical-device support is ever
- * needed.
  */
 internal fun UsbDevice.usbSerialStableKey(): String = "$vendorId-$productId"

--- a/feature/car/src/main/kotlin/org/meshtastic/feature/car/service/CarStateCoordinator.kt
+++ b/feature/car/src/main/kotlin/org/meshtastic/feature/car/service/CarStateCoordinator.kt
@@ -128,8 +128,9 @@ class CarStateCoordinator(
     }
 
     /**
-     * Emits an [EmergencyAlert] for each new incoming ALERT_APP packet. Sourced from the contacts flow (last packet per
-     * contact), deduped by packet id so the same alert isn't re-raised.
+     * Emits the latest ALERT_APP packet present in each contacts-flow snapshot. Because the flow retains only the
+     * last packet per contact, a newer packet may supersede an earlier alert before it is emitted; packet IDs
+     * prevent repeats.
      */
     val emergencyAlerts: kotlinx.coroutines.flow.Flow<EmergencyAlert> =
         packetRepository

--- a/feature/car/src/main/kotlin/org/meshtastic/feature/car/service/CarStateCoordinator.kt
+++ b/feature/car/src/main/kotlin/org/meshtastic/feature/car/service/CarStateCoordinator.kt
@@ -129,9 +129,7 @@ class CarStateCoordinator(
 
     /**
      * Emits an [EmergencyAlert] for each new incoming ALERT_APP packet. Sourced from the contacts flow (last packet per
-     * contact), deduped by packet id so the same alert isn't re-raised. ponytail: an alert immediately superseded by a
-     * newer message in the same contact within one emission can be missed — acceptable for the in-car overlay; the core
-     * alert notification still fires regardless.
+     * contact), deduped by packet id so the same alert isn't re-raised.
      */
     val emergencyAlerts: kotlinx.coroutines.flow.Flow<EmergencyAlert> =
         packetRepository

--- a/feature/car/src/main/kotlin/org/meshtastic/feature/car/service/CarStateCoordinator.kt
+++ b/feature/car/src/main/kotlin/org/meshtastic/feature/car/service/CarStateCoordinator.kt
@@ -128,9 +128,9 @@ class CarStateCoordinator(
     }
 
     /**
-     * Emits the latest ALERT_APP packet present in each contacts-flow snapshot. Because the flow retains only the
-     * last packet per contact, a newer packet may supersede an earlier alert before it is emitted; packet IDs
-     * prevent repeats.
+     * Emits the latest ALERT_APP packet present in each contacts-flow snapshot. Because the flow retains only the last
+     * packet per contact, a newer packet may supersede an earlier alert before it is emitted; packet IDs prevent
+     * repeats.
      */
     val emergencyAlerts: kotlinx.coroutines.flow.Flow<EmergencyAlert> =
         packetRepository

--- a/feature/docs/build.gradle.kts
+++ b/feature/docs/build.gradle.kts
@@ -95,13 +95,6 @@ tasks
     }
     .configureEach { dependsOn(syncDocsToComposeResources) }
 
-// ponytail: do NOT wire copyDocsScreenshots into the build. It writes into the tracked
-// docs/assets/screenshots/, so a build-time dependsOn rewrote those PNGs on every assemble/test
-// run and churned the working tree. The app bundles the committed copies as-is; regenerate on
-// demand for local viewing (./gradlew :screenshot-tests:copyDocsScreenshots) and `git checkout` to
-// clean, or commit deliberately when refreshing the docs/Jekyll image set. Add a CI staleness gate
-// if drift becomes a problem.
-
 val syncTranslatedDocsToComposeResources =
     tasks.register<Copy>("syncTranslatedDocsToComposeResources") {
         description = "Syncs Crowdin-translated docs into locale-qualified composeResources"

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/WifiOtaDiscovery.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/WifiOtaDiscovery.kt
@@ -47,10 +47,6 @@ internal object WifiOtaDiscovery {
         // limited broadcasts (255.255.255.255) are typically delivered without it; if a specific device filters
         // them, add an expect/actual multicast-lock wrapper and acquire it for the duration of [receive].
         safeCatching {
-            // ponytail: var accumulator + loop-on-condition. withTimeoutOrNull's block type comes from its
-            // terminal expression; an infinite `while(true){...}` whose body ends in Logger.d (Unit) makes
-            // the whole block Unit, which clashes with any explicit <T> param. Accumulating into `discovered`
-            // gives the block a concrete String? terminal and lets inference handle the rest.
             withTimeoutOrNull(timeoutMs) {
                 val selector = SelectorManager(ioDispatcher)
                 var discovered: String? = null

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/DfuZipParser.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/DfuZipParser.kt
@@ -51,9 +51,6 @@ internal fun parseDfuZipEntries(entries: Map<String, ByteArray>): DfuZipPackage 
     val entry =
         manifest.manifest.primaryEntry ?: throw DfuException.InvalidPackage("No firmware entry found in manifest.json")
 
-    // ponytail: app-only Meshtastic OTA zips carry a single image, so we transfer only the primary. A combined
-    // app+SoftDevice+bootloader package would need sequential DFU sessions we don't implement — warn loudly rather
-    // than silently flash one image of several. Upgrade path: multi-image sequencing if such packages ever ship.
     if (manifest.manifest.imageCount > 1) {
         Logger.w {
             "DFU: package declares ${manifest.manifest.imageCount} images; flashing only the primary " +

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -530,8 +530,6 @@ private fun Node.matchesMention(query: String): Boolean {
 /** Displays `@!<hex>` tokens as `@FriendlyName` while typing; the stored buffer keeps the hex wire form. */
 private fun mentionOutputTransformation(nodesById: Map<String, Node>) = OutputTransformation {
     val source = toString()
-    // ponytail: replace back-to-front so earlier offsets stay valid; editing inside a substituted token is imperfect
-    // but the caret sits outside tokens in normal use.
     for (match in MENTION_TOKEN_REGEX.findAll(source).toList().asReversed()) {
         val node = nodesById[match.groupValues[1]] ?: continue
         replace(match.range.first, match.range.last + 1, "@" + node.user.long_name.ifEmpty { node.user.short_name })

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModel.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactsViewModel.kt
@@ -51,8 +51,6 @@ class ContactsViewModel(
 ) : ViewModel() {
     val ourNodeInfo = nodeRepository.ourNodeInfo
 
-    // ponytail: stored as a comma-joined String (not a Set) — savedstate on all KMP targets only
-    // guarantees primitive types, and there are only ever two section keys.
     private val collapsedSectionsCsv = savedStateHandle.getStateFlow(KEY_COLLAPSED_SECTIONS, "")
 
     /** Collapsed conversation-list section keys (see [ContactSection]), persisted across process death. */
@@ -79,11 +77,6 @@ class ContactsViewModel(
     /**
      * Flat contact list (channels + DMs) with empty-channel placeholders merged in, consumed by both ContactsScreen and
      * ShareScreen. ContactsScreen groups it into collapsible Channels/DirectMessages sections at render time.
-     *
-     * ponytail: not paged. Contact counts on a mesh are bounded (channels ≤ 8, DMs = nodes you've messaged), and a
-     * LazyColumn only composes visible rows regardless. If a mesh ever grows large enough that recomputing per-row
-     * unread/message counts on every emission hurts, restore paging via [PacketRepository.getContactsPaged] and inject
-     * the two section headers with PagingData.insertSeparators over a query ordered channels-first.
      */
     val contactList =
         combine(identityFlow, packetRepository.getContacts(), channels, packetRepository.getContactSettings()) {

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/AirQualityMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/AirQualityMetrics.kt
@@ -125,10 +125,6 @@ internal fun AirQualityInfoCards(
     val ugm3 = stringResource(Res.string.micrograms_per_cubic_meter)
     val ppmUnit = stringResource(Res.string.ppm)
 
-    // Not remembered on pm25History alone: NowCast depends on nowSeconds, so a value cached until new telemetry
-    // arrives would keep showing after its most recent reading ages out of the 12h window. Recomputing per
-    // recomposition (cheap) reads fresh nowSeconds; the equal-by-value Pair keeps `cards` below from churning.
-    // ponytail: no dedicated wall-clock ticker — the node-detail screen already stops recomposing with the node.
     val aqi = nowCastAqi(pm25History)
     val icon = MeshtasticIcons.AirQuality
     val tempIcon = MeshtasticIcons.Temperature

--- a/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/debugging/LogExporter.kt
+++ b/feature/settings/src/androidMain/kotlin/org/meshtastic/feature/settings/debugging/LogExporter.kt
@@ -78,7 +78,7 @@ private suspend fun exportTextToUri(context: Context, targetUri: Uri, content: S
  * already limits us to our own entries, but `--pid` guarantees it even if that permission is ever granted (e.g. via adb
  * on an emulator) so a shared bug report can't leak other apps' logs. Best-effort: a capture failure returns a marker
  * rather than throwing. ProcessBuilder with a merged stderr avoids a pipe-buffer deadlock, and the bounded wait keeps a
- * stuck capture from tying up the IO thread. ponytail: `-t 5000` tail-caps the dump so the exported file stays sane.
+ * stuck capture from tying up the IO thread.
  */
 actual fun captureAppLogcat(): String = try {
     val pid = android.os.Process.myPid()

--- a/feature/settings/src/iosMain/kotlin/org/meshtastic/feature/settings/debugging/NoopStubs.kt
+++ b/feature/settings/src/iosMain/kotlin/org/meshtastic/feature/settings/debugging/NoopStubs.kt
@@ -20,5 +20,4 @@ import androidx.compose.runtime.Composable
 
 @Composable actual fun rememberLogExporter(contentProvider: suspend () -> String): (fileName: String) -> Unit = { _ -> }
 
-// ponytail: no logcat on iOS; the App Logs tab shows an empty-state there.
 actual fun captureAppLogcat(): String = ""


### PR DESCRIPTION
## Summary

- We've stopped using the ponytail plugin/mode, so this removes the `ponytail:`-prefixed comment markers it left across the codebase (build scripts, CI workflow, hooks, and several Kotlin source files).
- Where a marker was a standalone comment that existed only to explain the shortcut, the whole comment is deleted.
- Where a marker was one clause inside a larger, still-useful doc comment, only that clause is removed and the surrounding documentation is kept intact.
- No functional/logic changes — comment-only diff.

## Testing Performed

Not applicable — comment-only change, no code paths affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined and clarified developer-facing comments and KDoc across build configuration, CI/workflow checks, device/networking details, firmware OTA/DFU parsing, messaging transformation, UI/view-model guidance, and log exporting.

* **Maintenance**
  * No user-facing functionality, behavior, public APIs, build logic, or workflow logic changed; this update is limited to removing or tightening explanatory notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->