### PR TITLE
ci(renovate): stop protobufs snapshot downgrade loop

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,6 +58,13 @@
       "automerge": true
     },
     {
+      "description": "Protobufs: only accept the dot-form snapshot scheme (X.Y.Z.N-g<sha>-SNAPSHOT) or plain releases. Legacy hyphen-SHA snapshots (e.g. 2.7.26-678281c-SNAPSHOT) tokenize their digit-leading SHA as a huge int that outranks the dot-form commit-count in Renovate's maven comparator, so without this constraint Renovate keeps proposing a downgrade to an old snapshot (see PR #6229). The snapshot repo has no delete API; legacy versions auto-prune after 90 days.",
+      "matchPackageNames": [
+        "org.meshtastic:protobufs"
+      ],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(\\.\\d+-g[0-9a-f]+-SNAPSHOT)?$/"
+    },
+    {
       "description": "Group CMP and the androidx.compose artifacts that track it so Renovate bumps them together (see PR #5180)",
       "groupName": "compose-multiplatform",
       "matchPackageNames": [


### PR DESCRIPTION
## 🐛 Why

Renovate keeps opening PRs to **downgrade** `org.meshtastic:protobufs` (e.g. #6229 → `2.7.26-678281c-SNAPSHOT`), even though `main` is already at the newer `2.7.26.97-g9d589c1-SNAPSHOT`. Its maven comparator ranks the **legacy hyphen-SHA snapshot form above the dot-form scheme**: a digit-leading git short-SHA (`678281c`) tokenizes into a huge integer (`678281`) sitting at the first hyphen segment, which dwarfs the dot-form's commit-count segment (`.97`). So the comparison is inverted and being on `.97` doesn't help.

## 🛠️ Fix

Add an `allowedVersions` rule pinning `org.meshtastic:protobufs` to dot-form snapshots (`X.Y.Z.N-g<sha>-SNAPSHOT`) or plain releases, excluding the legacy hyphen-SHA snapshots so Renovate never considers them again.

The Central Portal snapshot repo has **no delete API** and only auto-prunes ~90 days after last publish, so constraining Renovate is the only durable lever. #6229 will auto-retire once `678281c` drops from the candidate set.

> Note: this PR originally also bundled the protobufs `.97` bump + `MEDIUM_TURBO` preset wiring, but both already landed on `main` independently — so it's now scoped to just the Renovate config, the one piece still missing.

## ✅ Testing

`renovate.json` validated as well-formed JSON; regex confirmed to keep `2.7.26.97-g…-SNAPSHOT` / `2.7.27` and reject `2.7.26-678281c-SNAPSHOT` / `2.7.26-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling for protobuf packages.
  * Restricted updates to supported snapshot version formats.
  * Enabled automatic merging for matching updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->