### PR TITLE
fix(agents): datadog-rum-investigator blocked by Datadog MCP UUID mount prefix

### DIFF
--- a/.claude/agents/datadog-rum-investigator.md
+++ b/.claude/agents/datadog-rum-investigator.md
@@ -1,14 +1,18 @@
 ---
 name: datadog-rum-investigator
 description: Investigates a Datadog RUM error/crash end-to-end for Meshtastic-Android and returns a tight, distilled verdict — the RUM counterpart to crash-investigator (Firebase). The app reports crashes to BOTH backends; use this one for Datadog. Pulls the RUM error group + sample events, maps the affected versionCode(s) to git tag/commit/Play track, locates the suspect code from the stack frames, and reports root-cause hypothesis + fix area — WITHOUT dumping huge RUM stack payloads into the caller's context. Use when given a Datadog RUM issue id/URL, an error signature, or a "is build NNNN still erroring in RUM?" question.
-tools: mcp__plugin_datadog_mcp__*, mcp__datadog__*, ToolSearch, Bash, Read, Grep, Glob
+tools: mcp__9ddcb30f-f735-4568-9c09-71434cf47355__*, mcp__plugin_datadog_mcp__*, mcp__datadog__*, ToolSearch, Bash, Read, Grep, Glob
 model: sonnet
 ---
 
 You are a crash/error-triage specialist for the **Meshtastic-Android** KMP app, working the **Datadog RUM** side. The app reports to both Firebase Crashlytics (handled by the sibling `crash-investigator` agent) and Datadog RUM — you own RUM. You investigate one RUM error group and return a compact verdict. Your entire value is doing the noisy parts — querying RUM, reading stack traces, mapping build numbers — in your own context and returning only the distilled signal. You are READ-ONLY: never edit code; propose the fix area, don't apply it.
 
 ## Setup (do this first)
-The Datadog MCP (`plugin:datadog:mcp`) must be connected and the **RUM** toolset enabled (Error Tracking toolset is intentionally off in this project). If no `mcp__*datadog*` tools are available to you, say so and stop — the user runs `/datadog:ddsetup` (first time) or `/datadog:ddtoolsets` to enable RUM, then re-invokes you. Use `ToolSearch` with `datadog rum error` to discover the exact tool names if the namespace has shifted.
+The Datadog MCP must be connected and the **RUM** toolset enabled (Error Tracking toolset is intentionally off in this project). It mounts under different prefixes depending on how the session attached it — all are allowlisted in this file's frontmatter:
+- `mcp__9ddcb30f-f735-4568-9c09-71434cf47355__*` — the claude.ai Datadog **connector** (that UUID is its stable server-side registration id; verified 2026-07-12). Tool names under this prefix do NOT contain "datadog" (they're `get`, `list`, `search_rum_applications`, …), so discover by function, not brand: `ToolSearch` with `search_rum` / `rum applications` / `rum error`.
+- `mcp__plugin_datadog_mcp__*` — the `datadog` plugin's server (`plugin:datadog:mcp`) in plain CLI sessions.
+
+If ToolSearch surfaces no RUM tools under any prefix, say so and stop, distinguishing the two causes for the caller: (a) the Datadog connector/plugin simply isn't attached to this session — the user attaches the connector or runs `/datadog:ddsetup` (first time) / `/datadog:ddtoolsets` (enable RUM), then re-invokes you; (b) the connector was re-registered under a NEW uuid — then the frontmatter allowlist of `.claude/agents/datadog-rum-investigator.md` must be updated with the new `mcp__<uuid>__*` prefix (find it by grepping a working session transcript for `mcp__` + a 36-char uuid, or via ToolSearch in the main session).
 
 ## Project constants (Meshtastic-Android RUM)
 - **RUM application id**: `59af7f62-…` (confirm the full id from the connected config; this is the Android app).


### PR DESCRIPTION
The `datadog-rum-investigator` subagent (`.claude/agents/datadog-rum-investigator.md`) has been dead in current sessions: the Datadog MCP now reaches sessions as a claude.ai **connector** mounted under `mcp__9ddcb30f-f735-4568-9c09-71434cf47355__*` (the connector's stable registration id, identical across all sessions 2026-07-10 → 07-12), not the `mcp__plugin_datadog_mcp__*` / `mcp__datadog__*` prefixes the agent's `tools:` allowlist expected. With nothing matching, `ToolSearch` inside the agent surfaced zero Datadog tools and every invocation reported BLOCKED.

### 🐛 Bug Fixes
- **Pin the UUID connector prefix** first in the frontmatter `tools:` allowlist, keeping the legacy plugin/CLI prefixes for plain-CLI sessions where the `datadog` plugin mounts under its own name.

### 🧹 Chores
- **Rewrite the agent's Setup section** to document the two mount variants, and a recovery procedure if the connector is ever re-registered under a new uuid (grep a working session transcript for `mcp__` + a 36-char uuid, update the allowlist).
- **Fix discovery guidance**: tool names under the connector don't contain "datadog" (`get_rum_summary`, `search_rum_applications`, `aggregate_rum_events`, …), so the agent now discovers by function (`search_rum`) instead of brand. A `mcp__*datadog*` glob can never match these, and a fully prefix-agnostic `mcp__*` isn't a documented allow-grant for agent `tools:` — pinning the UUID is the supported approach.

### Testing Performed
- Launched the fixed agent with a trivial "list one recent RUM error for `@application.name:\"Meshtastic Android\"`" prompt: it discovered the UUID-mounted tools via ToolSearch, queried RUM (`search_rum_applications` + `aggregate_rum_events`), and returned a real error group — confirming the allowlist fix end-to-end. Agent `.md` frontmatter hot-reloads, so no session restart is needed.
- Reviewer note / gotcha found while testing: the connector attaches **minutes late** in a session; before it attaches, the agent spawns with a degraded toolset and looks identical to this bug. If it reports missing Datadog tools right at session start, retry after the connector connects.

Docs-only change to an agent definition; no app code or build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Datadog RUM investigation guidance to support connector tools with varying session-specific names.
  * Added instructions for discovering RUM tools by capability and troubleshooting unavailable tools.
  * Expanded setup guidance to distinguish missing connectors from connectors registered under a new identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->