### PR TITLE
ci(desktop): publish production releases to the Microsoft Store

### DIFF
--- a/.github/workflows/msstore-publish.yml
+++ b/.github/workflows/msstore-publish.yml
@@ -1,0 +1,119 @@
+name: Publish to Microsoft Store
+
+# The `released` type fires when a release is published as a full release OR
+# when an existing pre-release is flipped to a full release — the latter is
+# what promote.yml's production promotion does (`gh release edit
+# --prerelease=false` on the already-published release object). It never fires
+# for drafts or pre-releases, so internal/closed/open promotions are ignored.
+#
+# CAVEAT: promote.yml performs that edit with the workflow's own GITHUB_TOKEN,
+# and events caused by GITHUB_TOKEN never start workflow runs — so promote.yml
+# also dispatches this workflow explicitly (workflow_dispatch is exempt from
+# that suppression). The release trigger stays for manually-published releases;
+# workflow_dispatch doubles as the manual retry path.
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Production release tag to publish (e.g., v2.8.0)'
+        required: true
+        type: string
+
+# The submission happens entirely through the Partner Center API using the
+# MSSTORE_* secrets; this repo is only read (public release assets).
+permissions:
+  contents: read
+
+jobs:
+  msstore:
+    # Belt and braces for release events — `released` should already exclude
+    # these. workflow_dispatch has no release payload and passes through.
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+    runs-on: ubuntu-latest
+    env:
+      # Secrets aren't readable in step `if:` expressions; skip cleanly until
+      # Partner Center is configured. Presence is gated on PRODUCT_ID alone so
+      # a half-configured secret set fails loudly in the configure step rather
+      # than silently skipping.
+      HAS_MSSTORE_CREDS: ${{ secrets.MSSTORE_PRODUCT_ID != '' && 'true' || 'false' }}
+    steps:
+      # The Store requires a versioned, immutable installer URL — per-tag
+      # GitHub release asset URLs are exactly that. Fails loudly if the
+      # release carries no MSI (e.g. the Windows build leg failed) rather
+      # than submitting nothing.
+      - name: Resolve MSI release asset URL
+        id: msi
+        if: env.HAS_MSSTORE_CREDS == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          URL=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            --jq '[.assets[] | select(.name | endswith(".msi"))][0].browser_download_url // empty')
+          if [ -z "$URL" ]; then
+            echo "::error::No .msi asset found on release ${TAG}"
+            exit 1
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      # Prerequisites (all manual, one-time):
+      #   1. A Partner Center account with the app already created and its
+      #      first submission live — the submission API can only UPDATE
+      #      existing Store products. The initial submission (listing copy,
+      #      screenshots, first MSI URL) must be made by hand in Partner
+      #      Center, and only with a Trusted-Signing-signed MSI: Partner
+      #      Center rejects Win32 installers whose binaries don't chain to a
+      #      Microsoft-trusted CA, so Windows signing is a hard prerequisite.
+      #   2. An Entra app registration added under Partner Center → Account
+      #      settings → User management → Microsoft Entra applications, with
+      #      the Manager role.
+      #   3. Repository secrets:
+      #        MSSTORE_TENANT_ID     – Entra tenant ID (linked to Partner Center)
+      #        MSSTORE_SELLER_ID     – Partner Center → Account settings → Seller ID
+      #        MSSTORE_PRODUCT_ID    – Partner Center app overview → Store Product ID
+      #        MSSTORE_CLIENT_ID     – app registration client ID
+      #        MSSTORE_CLIENT_SECRET – client secret for that app registration
+      # microsoft/store-submission is a thin wrapper over the stable Store
+      # submission API v1; it declares node16 and the runner transparently
+      # executes it on a current Node with a deprecation warning.
+      - name: Configure Store credentials
+        if: env.HAS_MSSTORE_CREDS == 'true'
+        uses: microsoft/store-submission@v1
+        with:
+          command: configure
+          type: win32
+          seller-id: ${{ secrets.MSSTORE_SELLER_ID }}
+          product-id: ${{ secrets.MSSTORE_PRODUCT_ID }}
+          tenant-id: ${{ secrets.MSSTORE_TENANT_ID }}
+          client-id: ${{ secrets.MSSTORE_CLIENT_ID }}
+          client-secret: ${{ secrets.MSSTORE_CLIENT_SECRET }}
+
+      # Full replace of the draft submission's package set (PUT semantics):
+      # the listing always points at exactly the current production MSI.
+      # Field values follow Microsoft's documented MSI example — silent
+      # install via msiexec flags; genericDocUrl/errorDetails are EXE-only.
+      - name: Update draft submission with new MSI
+        if: env.HAS_MSSTORE_CREDS == 'true'
+        uses: microsoft/store-submission@v1
+        with:
+          command: update
+          product-update: >-
+            {"packages":[{
+            "packageUrl":"${{ steps.msi.outputs.url }}",
+            "languages":["en-us"],
+            "architectures":["X64"],
+            "isSilentInstall":true,
+            "installerParameters":"/quiet /norestart",
+            "packageType":"msi"
+            }]}
+
+      # Fire-and-forget: this starts Store certification, which takes 1–3
+      # business days. Track progress in Partner Center; a rejection there
+      # does not surface here.
+      - name: Publish submission
+        if: env.HAS_MSSTORE_CREDS == 'true'
+        uses: microsoft/store-submission@v1
+        with:
+          command: publish

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -191,6 +191,15 @@ jobs:
           TAG: ${{ inputs.final_tag }}
         run: gh workflow run winget-publish.yml --ref main -f "tag=$TAG"
 
+      # Same GITHUB_TOKEN-suppression story as the winget dispatch above.
+      - name: Dispatch Microsoft Store publish
+        if: ${{ inputs.channel == 'production' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.final_tag }}
+        run: gh workflow run msstore-publish.yml --ref main -f "tag=$TAG"
+
       - name: Stamp CHANGELOG.md for release
         if: ${{ inputs.channel == 'production' }}
         env:


### PR DESCRIPTION
## Why

Once Windows installers are Authenticode-signed (#6217), the Microsoft Store's MSI/EXE listing path becomes nearly free distribution: the Store points at our own GitHub-hosted installer, users get GUI discoverability alongside `winget`'s CLI channel, and we host nothing new. The submission API is automatable, so every production promotion can update the Store listing with zero manual work — this PR wires that up, dormant until the Partner Center secrets exist.

## 🌟 New Features

- **`msstore-publish.yml`** (new): on production release, resolves the release's `.msi` asset URL and pushes it through the Partner Center submission API via `microsoft/store-submission@v1` (configure → full package-set replace → publish). Skips cleanly until `MSSTORE_PRODUCT_ID` exists; a half-configured secret set fails loudly in the configure step rather than silently skipping. Publish is fire-and-forget — Store certification takes 1–3 business days and is tracked in Partner Center.
- **`promote.yml` + caller wiring**: same trigger story as the winget dispatch in #6217 — the production promotion edits the release with the workflow's own `GITHUB_TOKEN`, whose events never start workflow runs, so promote.yml dispatches `msstore-publish.yml` explicitly (`continue-on-error`; a Store hiccup can't block the changelog stamp or Discord notification). The `release: [released]` trigger stays for manually-published releases, and the dispatch input doubles as the manual retry path. Both promote.yml and `create-or-promote-release.yml` gain `actions: write`.

## Manual setup required (blocking activation, not merge)

Everything below gates *activation*, not merge — with no secrets configured, every step skips and promotions behave exactly as today.

1. **Partner Center account** (one-time fee; company accounts go through identity verification — lead time). Reserve the app name.
2. **Signed MSI first**: Partner Center rejects Win32 installers whose binaries don't chain to a Microsoft-trusted CA — #6217's Azure Trusted Signing must be live before the first submission.
3. **Manual first submission**: the submission API can only *update* existing products. Create the app + initial submission (listing copy, screenshots, first signed-MSI URL) by hand in Partner Center.
4. **Entra app registration** added under Partner Center → Account settings → User management → Microsoft Entra applications, with the **Manager** role.
5. **Repository secrets (5)**: `MSSTORE_TENANT_ID`, `MSSTORE_SELLER_ID`, `MSSTORE_PRODUCT_ID`, `MSSTORE_CLIENT_ID`, `MSSTORE_CLIENT_SECRET`.

## Notes

- **Deliberate overlap with #6217**: both PRs add `actions: write` to the same two permissions blocks and insert a dispatch step at the same spot in promote.yml — whichever merges second takes a trivial rebase.
- `microsoft/store-submission@v1` last shipped in 2024 but wraps the stable Store submission API v1; it declares node16, which runners transparently execute on a current Node with a deprecation warning. The actively-maintained alternative (`msstore-cli`) needs a checked-in base package JSON and PowerShell — more moving parts for the same API call.
- Package JSON follows Microsoft's documented MSI example (`isSilentInstall: true`, `installerParameters: "/quiet /norestart"`, `X64`, `en-us`). Full package-set replace, so the listing always points at exactly the current production MSI.

## Testing Performed

- `actionlint` clean on `msstore-publish.yml` and on every added line (remaining findings are pre-existing SC2086/SC2129 info/style notes in untouched scripts).
- Verified `microsoft/store-submission@v1` input names against the action's `action.yml` (`command`, `type: win32`, `seller-id`, `product-id`, `tenant-id`, `client-id`, `client-secret`, `product-update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of production MSI releases to the Microsoft Store.
  * Microsoft Store publishing can be triggered automatically after a release or manually with a release tag.
  * The workflow identifies the release installer and starts Microsoft Store certification.
  * Microsoft Store publishing failures no longer block subsequent release promotion steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->