### PR TITLE
feat(desktop): attach installable .flatpak bundles to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -510,6 +510,92 @@ jobs:
         with:
           subject-path: flatpak-sources.json
 
+  # Builds installable .flatpak bundles the same way verify-flatpak.yml does:
+  # the shared offline overlay manifest (scripts/verify-flatpak/desktop-offline.yaml)
+  # over the Flathub packaging repo, compiling the tag checkout with the
+  # combined offline sources. Sideloadable via `flatpak install ./<file>` —
+  # the runtime resolves from Flathub via --runtime-repo, and a later Flathub
+  # install of the same app id supersedes the sideload. Note: this job pulls
+  # the runtime/SDK from Flathub at build time, so Flathub availability is a
+  # release-cut dependency; a failed cut is retried as a fresh dispatch.
+  build-flatpak-bundle:
+    if: ${{ inputs.build_flatpak_src }}
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    needs: [prepare-build-info, release-flatpak-src]
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ inputs.tag_name }}
+          submodules: 'recursive'
+
+      - name: Download combined Flatpak sources
+        uses: actions/download-artifact@v8
+        with:
+          name: flatpak-sources
+
+      - name: Clone the Flathub packaging repo
+        run: |
+          git clone --depth 1 --recurse-submodules \
+            https://github.com/flathub/org.meshtastic.MeshtasticDesktop.git \
+            "$RUNNER_TEMP/org.meshtastic.MeshtasticDesktop"
+
+      - name: Wire overlay manifest + sources
+        run: |
+          cp scripts/verify-flatpak/desktop-offline.yaml \
+            "$RUNNER_TEMP/org.meshtastic.MeshtasticDesktop/org.meshtastic.MeshtasticDesktop.yaml"
+          cp flatpak-sources.json \
+            "$RUNNER_TEMP/org.meshtastic.MeshtasticDesktop/flatpak-sources.json"
+          rsync -a --delete \
+            --exclude='/build/' --exclude='/.gradle/' \
+            --exclude='*/build/' --exclude='*/.gradle/' \
+            --exclude='/.idea/' --exclude='/local.properties' \
+            ./ "$RUNNER_TEMP/org.meshtastic.MeshtasticDesktop/meshtastic-android/"
+
+      - name: Install flatpak-builder
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq flatpak flatpak-builder
+          flatpak remote-add --user --if-not-exists flathub \
+            https://dl.flathub.org/repo/flathub.flatpakrepo
+
+      - name: Build flatpak offline
+        working-directory: ${{ runner.temp }}/org.meshtastic.MeshtasticDesktop
+        run: |
+          flatpak-builder --user --repo=repo --install-deps-from=flathub \
+            --force-clean builddir org.meshtastic.MeshtasticDesktop.yaml
+
+      - name: Export versioned .flatpak bundle
+        working-directory: ${{ runner.temp }}/org.meshtastic.MeshtasticDesktop
+        env:
+          ARCH: ${{ matrix.arch }}
+          VERSION: ${{ needs.prepare-build-info.outputs.APP_VERSION_NAME }}
+        run: |
+          flatpak build-bundle repo \
+            "org.meshtastic.MeshtasticDesktop-${VERSION}-${ARCH}.flatpak" \
+            org.meshtastic.MeshtasticDesktop \
+            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Upload Flatpak bundle artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: desktop-flatpak-${{ matrix.arch }}
+          path: ${{ runner.temp }}/org.meshtastic.MeshtasticDesktop/org.meshtastic.MeshtasticDesktop-*.flatpak
+          retention-days: 1
+          if-no-files-found: ignore
+
+      - name: Attest Flatpak bundle provenance
+        if: success()
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ runner.temp }}/org.meshtastic.MeshtasticDesktop/org.meshtastic.MeshtasticDesktop-*.flatpak
+
   github-release:
     if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-24.04-arm
@@ -519,6 +605,7 @@ jobs:
       - release-fdroid
       - release-desktop
       - release-flatpak-src
+      - build-flatpak-bundle
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Why

Releases carry `flatpak-sources.json` (the offline build manifest for Flathub) but no installable Flatpak — Linux users must wait for the Flathub manifest bump to propagate, or build it themselves. Meanwhile `verify-flatpak.yml` already builds real per-arch `.flatpak` bundles on every relevant PR and then discards them as short-lived workflow artifacts. This PR runs that same proven build at release time and attaches the bundles to the GitHub release, giving sideloadable Flatpaks (`flatpak install ./….flatpak`) the moment a release exists — independent of Flathub propagation, and superseded cleanly by a later Flathub install of the same app id.

## 🌟 New Features

- **`build-flatpak-bundle` job in `release.yml`** (x86_64 + aarch64, gated on `build_flatpak_src` like the sources jobs): clones the Flathub packaging repo, overlays the shared offline manifest (`scripts/verify-flatpak/desktop-offline.yaml`) plus the **combined** `flatpak-sources.json` from `release-flatpak-src` (the two-arch union — strictly safer than verify's single-arch capture), rsyncs the **tag checkout** in as the build source, and builds fully offline. Exported as `org.meshtastic.MeshtasticDesktop-<version>-<arch>.flatpak`, provenance-attested, and picked up by the existing `github-release` artifact download (its `flatpak-multisrc-*` exclusion doesn't match).
- `github-release` now also `needs` the bundle job, keeping the strict all-or-nothing release semantics.

## Trade-offs

- **Flathub becomes a release-cut dependency**: the job pulls the freedesktop runtime/SDK + openjdk extension from Flathub at build time. A Flathub outage fails the cut; the existing retry path (failed internal release deletes its tag → fresh dispatch) covers it. Noted in a job comment.
- **Runner time**: two more jobs per internal cut (verify-flatpak's timings suggest ~20–40 min each, free-tier public runners — contention cost only).
- The build steps intentionally mirror `verify-flatpak.yml` rather than being extracted to a composite action; the substantive pins (runtime version, JBR, openjdk extension) already live in the shared overlay manifest, so drift risk is confined to mechanical steps.

## Testing Performed

- `actionlint` clean (pre-existing info-level shellcheck notes in untouched steps only).
- The build recipe is byte-for-byte the `verify-flatpak.yml` `build-flatpak` job — green on both arches as recently as #6219's PR checks — with three release-specific deltas: tag checkout instead of PR head, combined two-arch sources instead of single-host capture, and a versioned bundle filename.
- First real-artifact validation on the next internal release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating installable, versioned Flatpak bundles during releases.
  * Flatpak bundles are now included in draft GitHub Releases.
  * Generated bundles are uploaded with provenance attestations for improved distribution trust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->