### PR TITLE
Fix: add back navigation to Clean Node Database screen

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
@@ -126,7 +126,10 @@ fun EntryProviderScope<NavKey>.settingsGraph(backStack: NavBackStack<NavKey>) {
 
     entry<SettingsRoute.CleanNodeDb> {
         val viewModel: CleanNodeDatabaseViewModel = koinViewModel()
-        CleanNodeDatabaseScreen(viewModel = viewModel)
+        CleanNodeDatabaseScreen(
+            viewModel = viewModel,
+            onBack = dropUnlessResumed { backStack.removeLastOrNull() },
+        )
     }
 
     ConfigRoute.entries.forEach { routeInfo ->

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
@@ -126,10 +126,7 @@ fun EntryProviderScope<NavKey>.settingsGraph(backStack: NavBackStack<NavKey>) {
 
     entry<SettingsRoute.CleanNodeDb> {
         val viewModel: CleanNodeDatabaseViewModel = koinViewModel()
-        CleanNodeDatabaseScreen(
-            viewModel = viewModel,
-            onBack = dropUnlessResumed { backStack.removeLastOrNull() },
-        )
+        CleanNodeDatabaseScreen(viewModel = viewModel, onBack = dropUnlessResumed { backStack.removeLastOrNull() })
     }
 
     ConfigRoute.entries.forEach { routeInfo ->

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/CleanNodeDatabaseScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/CleanNodeDatabaseScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -46,6 +47,7 @@ import org.meshtastic.core.resources.clean_nodes_older_than
 import org.meshtastic.core.resources.clean_now
 import org.meshtastic.core.resources.clean_unknown_nodes
 import org.meshtastic.core.resources.nodes_queued_for_deletion
+import org.meshtastic.core.ui.component.MainAppBar
 import org.meshtastic.core.ui.component.NodeChip
 
 /**
@@ -53,40 +55,59 @@ import org.meshtastic.core.ui.component.NodeChip
  * nodes to be deleted updates automatically as filter criteria change.
  */
 @Composable
-fun CleanNodeDatabaseScreen(viewModel: CleanNodeDatabaseViewModel) {
+fun CleanNodeDatabaseScreen(viewModel: CleanNodeDatabaseViewModel, onBack: () -> Unit) {
     val olderThanDays by viewModel.olderThanDays.collectAsStateWithLifecycle()
     val onlyUnknownNodes by viewModel.onlyUnknownNodes.collectAsStateWithLifecycle()
     val nodesToDelete by viewModel.nodesToDelete.collectAsStateWithLifecycle()
 
     LaunchedEffect(olderThanDays, onlyUnknownNodes) { viewModel.getNodesToDelete() }
 
-    Column(modifier = Modifier.padding(16.dp).verticalScroll(rememberScrollState())) {
-        Text(stringResource(Res.string.clean_node_database_title))
-        Text(stringResource(Res.string.clean_node_database_description), style = MaterialTheme.typography.bodySmall)
-        Spacer(modifier = Modifier.height(16.dp))
+    Scaffold(
+        topBar = {
+            MainAppBar(
+                title = stringResource(Res.string.clean_node_database_title),
+                ourNode = null,
+                showNodeChip = false,
+                canNavigateUp = true,
+                onNavigateUp = onBack,
+                actions = {},
+                onClickChip = {},
+            )
+        },
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues).padding(16.dp).verticalScroll(rememberScrollState())) {
+            Text(
+                stringResource(Res.string.clean_node_database_description),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
 
-        DaysThresholdFilter(
-            olderThanDays = olderThanDays,
-            onlyUnknownNodes = onlyUnknownNodes,
-            onDaysChanged = viewModel::onOlderThanDaysChanged,
-        )
+            DaysThresholdFilter(
+                olderThanDays = olderThanDays,
+                onlyUnknownNodes = onlyUnknownNodes,
+                onDaysChanged = viewModel::onOlderThanDaysChanged,
+            )
 
-        Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
-        UnknownNodesFilter(onlyUnknownNodes = onlyUnknownNodes, onCheckedChanged = viewModel::onOnlyUnknownNodesChanged)
+            UnknownNodesFilter(
+                onlyUnknownNodes = onlyUnknownNodes,
+                onCheckedChanged = viewModel::onOnlyUnknownNodesChanged,
+            )
 
-        Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(32.dp))
 
-        NodesDeletionPreview(nodesToDelete = nodesToDelete)
+            NodesDeletionPreview(nodesToDelete = nodesToDelete)
 
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
-        Button(
-            onClick = { if (nodesToDelete.isNotEmpty()) viewModel.requestCleanNodes() },
-            modifier = Modifier.fillMaxWidth(),
-            enabled = nodesToDelete.isNotEmpty(),
-        ) {
-            Text(stringResource(Res.string.clean_now))
+            Button(
+                onClick = { if (nodesToDelete.isNotEmpty()) viewModel.requestCleanNodes() },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = nodesToDelete.isNotEmpty(),
+            ) {
+                Text(stringResource(Res.string.clean_now))
+            }
         }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/CleanNodeDatabaseScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/CleanNodeDatabaseScreen.kt
@@ -76,10 +76,7 @@ fun CleanNodeDatabaseScreen(viewModel: CleanNodeDatabaseViewModel, onBack: () ->
         },
     ) { paddingValues ->
         Column(modifier = Modifier.padding(paddingValues).padding(16.dp).verticalScroll(rememberScrollState())) {
-            Text(
-                stringResource(Res.string.clean_node_database_description),
-                style = MaterialTheme.typography.bodySmall,
-            )
+            Text(stringResource(Res.string.clean_node_database_description), style = MaterialTheme.typography.bodySmall)
             Spacer(modifier = Modifier.height(16.dp))
 
             DaysThresholdFilter(


### PR DESCRIPTION
## What changed

The **Clean Node Database** screen (Settings → gear icon → Clean Node Database) had no top app bar and no back action. The only ways out were completing the clean operation or force-closing the app — even switching tabs and returning left you on the same screen.

This adds a `Scaffold` + `MainAppBar` with `canNavigateUp = true`, matching the pattern used by other settings sub-screens (e.g. `AdministrationScreen`), and wires `onBack` through the nav graph to pop the back stack.

## Why

Fixes #6227. Reported flow:
1. Open gear icon → Clean Node Database.
2. No way to cancel/back out except cleaning or closing the app.
3. If "Clean up only unknown nodes" is on and there are none, the "Clean Now" button greys out with no escape.

With a back arrow always present in the app bar, the user can leave the screen at any time regardless of filter state or button-enabled state.

## Testing Performed

- `./gradlew :feature:settings:compileCommonMainKotlinMetadata :feature:settings:allTests` — pass, existing `CleanNodeDatabaseViewModelTest` suite unaffected (no ViewModel logic changed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added proper back navigation handling to the Clean Node Database settings screen.
  * Updated the screen to use a consistent app bar with “navigate up” support.
  * Improved layout and spacing by using scaffold padding for the scrollable content.
  * Kept the clean action behavior the same, including the enabled state based on selected nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->