### PR TITLE
fix: stabilize traceroute map node identity & fix log metric alignment

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -1262,8 +1262,14 @@ private fun TracerouteMapContent(
         )
     }
     displayNodes.forEach { node ->
-        val markerState = rememberUpdatedMarkerState(position = node.position.toLatLng())
-        MarkerComposable(state = markerState, zIndex = 4f) { NodeChip(node = node) }
+        // Key by the stable node num so each marker's composition state (and MarkerComposable's cached
+        // icon bitmap) stays bound to its node. Without this, reordering displayNodes between reloads
+        // reuses marker slots positionally and swaps node labels/positions (#6197). node.user.short_name
+        // is included as a bitmap key so the rendered chip refreshes when node metadata arrives.
+        key(node.num) {
+            val markerState = rememberUpdatedMarkerState(position = node.position.toLatLng())
+            MarkerComposable(node.num, node.user.short_name, state = markerState, zIndex = 4f) { NodeChip(node = node) }
+        }
     }
 }
 

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -1264,11 +1264,21 @@ private fun TracerouteMapContent(
     displayNodes.forEach { node ->
         // Key by the stable node num so each marker's composition state (and MarkerComposable's cached
         // icon bitmap) stays bound to its node. Without this, reordering displayNodes between reloads
-        // reuses marker slots positionally and swaps node labels/positions (#6197). node.user.short_name
-        // is included as a bitmap key so the rendered chip refreshes when node metadata arrives.
+        // reuses marker slots positionally and swaps node labels/positions (#6197). The remaining keys
+        // are every NodeChip input (short name, colors, ignored strike-through) so the rendered chip
+        // bitmap refreshes when node metadata changes.
         key(node.num) {
             val markerState = rememberUpdatedMarkerState(position = node.position.toLatLng())
-            MarkerComposable(node.num, node.user.short_name, state = markerState, zIndex = 4f) { NodeChip(node = node) }
+            MarkerComposable(
+                node.num,
+                node.user.short_name,
+                node.colors,
+                node.isIgnored,
+                state = markerState,
+                zIndex = 4f,
+            ) {
+                NodeChip(node = node)
+            }
         }
     }
 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TracerouteLog.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TracerouteLog.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -267,10 +268,12 @@ private fun TracerouteCardContent(time: String, summaryText: String, icon: Image
 private fun TracerouteCardMetrics(point: TraceroutePoint) {
     if (point.forwardHops == null && point.returnHops == null && point.roundTripSeconds == null) return
     Spacer(modifier = Modifier.height(4.dp))
-    Row(
+    // FlowRow so the three metric labels wrap onto additional lines when they don't fit the card width
+    // (e.g. long translated strings), rather than the last item being crushed and wrapped per character (#5743).
+    FlowRow(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         point.forwardHops?.let { hops ->
             Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
## Why

Two related bugs in the traceroute UI/rendering path, grouped because they live in the same view and are cheap to fix together.

### 🐛 #6197 — Traceroute map node IDs change on every reload
On the traceroute map, node markers show the wrong IDs, and re-opening the same traceroute shuffles them. The google-flavor marker loop in `TracerouteMapContent` emitted `MarkerComposable`s **positionally with no composition key** and **no `MarkerComposable` keys**:

```kotlin
displayNodes.forEach { node ->
    val markerState = rememberUpdatedMarkerState(position = node.position.toLatLng())
    MarkerComposable(state = markerState, zIndex = 4f) { NodeChip(node = node) }
}
```

`displayNodes` is derived from a live, time-sorted node flow, so its order is **not stable between reloads**. `MarkerComposable` caches its rendered icon bitmap keyed by its `keys` vararg (empty here), and Compose reuses marker slots positionally — so when the list reorders, a marker keeps a stale cached chip while getting a different node's position, making node IDs look wrong and unstable. This is the same unstable-key class of bug seen elsewhere in the app (lists keyed on index/timestamp instead of `node.num`).

**Fix:** wrap each marker in `key(node.num)` and pass `node.num` + `short_name` as `MarkerComposable` keys, so each marker's composition state and cached bitmap stay bound to its stable node identity. This mirrors the existing `NodeTrackMap` marker pattern, which already wraps markers in `key(position.time)`.

### 🐛 #5743 — Traceroute log metric alignment
In the Traceroute Logs list, the third metric label (round-trip time) was crushed and wrapped **one character per line** vertically. The metrics sat in a plain `Row` with three items that can't fit the narrow card — worse with longer translated strings (reported in Russian, also reproduces on desktop and in English).

**Fix:** use `FlowRow` so the metrics wrap onto a new line cleanly instead of the last item being squeezed to zero width.

## Testing Performed
- `./gradlew spotlessApply spotlessCheck detekt` — clean, no violations
- `./gradlew assembleDebug` — passes (all flavors)
- `./gradlew :feature:node:allTests` — passes (~130 tests)

Marker keying is a Compose-recomposition fix that isn't covered by the existing headless tests; the node-selection resolution (`tracerouteNodeSelection`, already num-keyed) remains covered by `TracerouteNodeSelectionTest`.

Closes #6197
Closes #5743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved traceroute map marker stability so hop markers keep the correct node details when the list updates or reorders.
* **UI Improvements**
  * Enhanced traceroute metrics layout to wrap onto multiple lines on smaller screens, improving readability when labels don’t fit horizontally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->