### PR TITLE
fix(connections): show device long names in the connection manager (#5808)

### DIFF
--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/component/ConnectionsPreviews.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/component/ConnectionsPreviews.kt
@@ -30,6 +30,7 @@ import org.meshtastic.core.ble.BleConnectionState
 import org.meshtastic.core.ble.BleDevice
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
+import org.meshtastic.core.model.Node
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Search
 import org.meshtastic.core.ui.theme.AppTheme
@@ -43,6 +44,7 @@ import org.meshtastic.feature.connections.ui.components.DeviceSectionHeader
 import org.meshtastic.feature.connections.ui.components.DisconnectButton
 import org.meshtastic.feature.connections.ui.components.EmptyStateContent
 import org.meshtastic.feature.connections.ui.components.TransportSelector
+import org.meshtastic.proto.User
 
 private const val PREVIEW_BLE_RSSI = -60
 
@@ -50,6 +52,16 @@ private const val PREVIEW_BLE_RSSI = -60
 @Composable
 fun DeviceListItemPreview() {
     val device = DeviceListEntry.Tcp(name = "Meshtastic_abcd", fullAddress = "s192.168.1.100")
+    AppTheme { DeviceListItem(connectionState = ConnectionState.Disconnected, device = device, onSelect = {}) }
+}
+
+// Previously-connected device: shows the short-name NodeChip alongside the unique long name (#5808), which wraps to a
+// second line rather than truncating.
+@PreviewLightDark
+@Composable
+private fun DeviceListItemWithLongNamePreview() {
+    val node = Node(num = 13444, user = User(short_name = "AB12", long_name = "James' Rooftop Solar Repeater"))
+    val device = DeviceListEntry.Tcp(name = "Meshtastic_ab12", fullAddress = "s192.168.1.101", node = node)
     AppTheme { DeviceListItem(connectionState = ConnectionState.Disconnected, device = device, onSelect = {}) }
 }
 

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/DeviceListItem.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/DeviceListItem.kt
@@ -184,7 +184,7 @@ private fun DeviceHeadline(device: DeviceListEntry) {
     if (node != null) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             NodeChip(node = node)
-            DeviceName(text = node.user.long_name.ifEmpty { device.name }, modifier = Modifier.weight(1f))
+            DeviceName(text = node.user.long_name.ifBlank { device.name }, modifier = Modifier.weight(1f))
         }
     } else {
         DeviceName(text = device.name)

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/DeviceListItem.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/DeviceListItem.kt
@@ -174,20 +174,30 @@ fun DeviceListItem(
 
 /**
  * Headline for a device row. When we have a [DeviceListEntry.node] in the local DB (i.e. we've previously connected and
- * learned the device's mesh identity), render the colored [NodeChip] + the node's long name so users can visually
- * identify the device at a glance. Otherwise fall back to the raw advertised device name.
+ * learned the device's mesh identity), render the colored [NodeChip] alongside the node's **long name** so users can
+ * distinguish devices that share a similar short/advertised name (see #5808). Otherwise fall back to the raw advertised
+ * name. The name is allowed to wrap to two lines so long names are legible rather than truncated at a single line.
  */
 @Composable
 private fun DeviceHeadline(device: DeviceListEntry) {
     val node = device.node
     if (node != null) {
-        NodeChip(node = node)
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            NodeChip(node = node)
+            DeviceName(text = node.user.long_name.ifEmpty { device.name }, modifier = Modifier.weight(1f))
+        }
     } else {
-        Text(
-            text = device.name,
-            style = MaterialTheme.typography.titleLarge,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        DeviceName(text = device.name)
     }
+}
+
+@Composable
+private fun DeviceName(text: String, modifier: Modifier = Modifier) {
+    Text(
+        modifier = modifier,
+        text = text,
+        style = MaterialTheme.typography.titleLarge,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+    )
 }


### PR DESCRIPTION
## Why

Closes #5808. A user with several devices whose **short** names look alike (`Meshtastic_ab12`, `Meshtastic_ab13`, …) can't tell them apart in the Bluetooth connection manager, even though each has a distinct **long** name.

Digging in, this was two problems, not one:

1. **The long name was hidden even when we already had it.** The BLE *advertisement* only carries the short name; the long name is a mesh-identity attribute (`node.user.long_name`) learned after the first connection. For a previously-connected device (`node != null`) we hold that unique long name — but `DeviceHeadline` replaced the whole row headline with a tiny short-name-only `NodeChip` and threw the long name away.
2. **Advertised names truncated.** The headline was `maxLines = 1` + ellipsis, with the trailing RSSI/radio eating horizontal width, so long names were cut off (the literal symptom in the issue title).

## 🐛 / 🌟 Changes

- **Show the long name** (`node.user.long_name`) next to the `NodeChip` for known devices, falling back to the advertised name when the long name is empty. This is the core of #5808 — for the common "my devices" case (already paired/connected), the distinguishing field is now on screen.
- **Wrap instead of truncate:** the device name is now allowed `maxLines = 2` for both the known-node and advertised-name paths, so long names stay legible rather than being ellipsized at one line. The name column takes weighted width so it no longer competes with the RSSI/radio.
- Extracted a small `DeviceName` helper so both headline paths render identically.
- Added a `DeviceListItemWithLongNamePreview` (`@PreviewLightDark`) covering the known-node + long-name branch.

Only the row headline changed; the leading transport/connection icon, address supporting line, RSSI bars, and selection radio are untouched.

### Scope / follow-ups (intentionally not in this PR)
While reviewing the picker I noted a few things worth separate issues rather than expanding this change: surfacing `bonded`/pair state on the row, a clearer "currently connected" cue on non-selected rows, and an adaptive two-pane layout of the connections screen for tablet/foldable.

## Testing Performed

- `./gradlew spotlessCheck detekt assembleDebug test allTests` — all green locally.
- New `DeviceListItemWithLongNamePreview` for visual verification. Live PNGs weren't rendered here (the in-repo Compose→PNG path needs a running Android Studio, which wasn't available in this environment); a reviewer can render the preview, or I can attach before/after screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device list rendering for known mesh devices by showing the identifying chip alongside the full long name.
  * Long device names now wrap onto up to two lines for clearer readability.
  * Improved fallback device name display when mesh identity details aren’t available.

* **Tests**
  * Added a new UI preview to verify device list layout for long device names and wrapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->