### PR TITLE
fix: adopt 2024 EPA PM2.5 AQI breakpoints for cross-platform alignment

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/AirQualityIndex.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/AirQualityIndex.kt
@@ -84,15 +84,17 @@ object AirQualityIndex {
         val aqiHigh: Int,
     )
 
-    // Standard EPA PM2.5 (µg/m³) breakpoint table.
+    // Current (2024) EPA PM2.5 24-hour breakpoint table (AQS parameter 88101), µg/m³.
+    // Kept in lockstep with iOS (meshtastic/Meshtastic-Apple#2075) for cross-platform AQI alignment
+    // (meshtastic/design#54).
     private val BREAKPOINTS =
         listOf(
-            Breakpoint(0.0, 12.0, 0, 50),
-            Breakpoint(12.1, 35.4, 51, 100),
+            Breakpoint(0.0, 9.0, 0, 50),
+            Breakpoint(9.1, 35.4, 51, 100),
             Breakpoint(35.5, 55.4, 101, 150),
-            Breakpoint(55.5, 150.4, 151, 200),
-            Breakpoint(150.5, 250.4, 201, 300),
-            Breakpoint(250.5, 500.4, 301, 500),
+            Breakpoint(55.5, 125.4, 151, 200),
+            Breakpoint(125.5, 225.4, 201, 300),
+            Breakpoint(225.5, 325.4, 301, 500),
         )
 
     /**

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/AirQualityIndexTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/AirQualityIndexTest.kt
@@ -27,21 +27,28 @@ private const val EPSILON = 0.001
 
 class AirQualityIndexTest {
 
-    // EPA PM2.5 breakpoint table reference values (concentration -> AQI).
+    // Current (2024) EPA PM2.5 24-hour breakpoint table reference values (concentration -> AQI).
     @Test
     fun pm25ToAqi_matches_epa_breakpoint_table() {
         assertEquals(0, AirQualityIndex.pm25ToAqi(0.0))
-        assertEquals(50, AirQualityIndex.pm25ToAqi(12.0))
-        assertEquals(51, AirQualityIndex.pm25ToAqi(12.1))
+        assertEquals(50, AirQualityIndex.pm25ToAqi(9.0))
+        assertEquals(51, AirQualityIndex.pm25ToAqi(9.1))
         assertEquals(100, AirQualityIndex.pm25ToAqi(35.4))
         assertEquals(101, AirQualityIndex.pm25ToAqi(35.5))
         assertEquals(150, AirQualityIndex.pm25ToAqi(55.4))
         assertEquals(151, AirQualityIndex.pm25ToAqi(55.5))
-        assertEquals(200, AirQualityIndex.pm25ToAqi(150.4))
-        assertEquals(201, AirQualityIndex.pm25ToAqi(150.5))
-        assertEquals(300, AirQualityIndex.pm25ToAqi(250.4))
-        assertEquals(301, AirQualityIndex.pm25ToAqi(250.5))
-        assertEquals(500, AirQualityIndex.pm25ToAqi(500.4))
+        assertEquals(200, AirQualityIndex.pm25ToAqi(125.4))
+        assertEquals(201, AirQualityIndex.pm25ToAqi(125.5))
+        assertEquals(300, AirQualityIndex.pm25ToAqi(225.4))
+        assertEquals(301, AirQualityIndex.pm25ToAqi(225.5))
+        assertEquals(500, AirQualityIndex.pm25ToAqi(325.4))
+    }
+
+    // Regression for meshtastic/design#54: PM2.5 = 10 µg/m³ was "42, Good" on the legacy table;
+    // on the 2024 table it must be "53, Moderate", matching iOS (meshtastic/Meshtastic-Apple#2075).
+    @Test
+    fun pm25ToAqi_uses_2024_breakpoints_for_low_concentrations() {
+        assertEquals(53, AirQualityIndex.pm25ToAqi(10.0))
     }
 
     @Test


### PR DESCRIPTION
## Why

Part of the cross-platform AQI alignment work (meshtastic/design#54). iOS is landing a computed EPA NowCast AQI (meshtastic/Meshtastic-Apple#2075) built on the **current (2024) EPA PM2.5 24-hour breakpoint table**. Android's already-merged implementation (#6102) used the **legacy (pre-2024)** table, so the *same* PM2.5 reading produced a *different* AQI per platform — exactly the divergence design#54 exists to prevent.

This lands the 2024 table on Android **before** the iOS feature ships, so the two never present diverging curves.

Fixes #6272.

## 🐛 Changes

Swapped the PM2.5 breakpoint constants in `core/model/.../util/AirQualityIndex.kt` from the legacy table to the current 2024 EPA table (AQS parameter 88101):

| PM2.5 (µg/m³) legacy | AQI | → | PM2.5 (µg/m³) 2024 | AQI |
|---|---|---|---|---|
| 0.0–12.0   | 0–50    | → | 0.0–9.0    | 0–50 |
| 12.1–35.4  | 51–100  | → | 9.1–35.4   | 51–100 |
| 35.5–55.4  | 101–150 | → | 35.5–55.4  | 101–150 |
| 55.5–150.4 | 151–200 | → | 55.5–125.4 | 151–200 |
| 150.5–250.4| 201–300 | → | 125.5–225.4| 201–300 |
| 250.5–500.4| 301–500 | → | 225.5–325.4| 301–500 |

**Constants only.** The NowCast weighting (12h rolling window, 0.5 min weight factor) and the Equation-1 linear interpolation are untouched.

## 🛠️ Testing Performed

Updated `AirQualityIndexTest` breakpoint vectors to the 2024 table and re-derived the affected expected AQI values:

- Boundary vectors: `9.0→50`, `9.1→51`, `35.4→100`, `35.5→101`, `55.4→150`, `55.5→151`, `125.4→200`, `125.5→201`, `225.4→300`, `225.5→301`, `325.4→500`.
- Added a design#54 regression vector: **PM2.5 = 10 µg/m³ → 53 ("Moderate")**, which was `42 ("Good")` on the legacy table (matches the worked example in #6272 and the iOS reference).

Verified locally: `./gradlew :core:model:allTests` (all 11 AirQualityIndex tests pass), plus `spotlessApply spotlessCheck detekt` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PM2.5 air-quality calculations to use the EPA’s 2024 breakpoint values.
  * Improved AQI accuracy for low-to-mid PM2.5 concentrations, including a PM2.5 reading of 10 µg/m³ mapping to an AQI of 53.

* **Tests**
  * Added regression coverage to verify AQI results against the updated EPA guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->