### PR TITLE
perf(r8): enable optimization for release builds (keep unobfuscated)

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -17,18 +17,23 @@
 # Open-source — no need to obfuscate
 -dontobfuscate
 
-# Disable R8 optimization passes. Tree-shaking (unused code removal) still
-# runs — only method-body rewrites and call-site transformations are suppressed.
+# R8 optimization is ENABLED. Obfuscation stays off (-dontobfuscate above), so
+# stack traces remain readable; tree-shaking plus the full optimization pass
+# (method inlining, class merging, Composer/ComposerImpl devirtualization,
+# unused-argument removal) all run.
 #
-# Why: CMP 1.11 ships consumer rules with -assumenosideeffects on
-# Composer.<clinit>() and ComposerImpl.<clinit>(), plus -assumevalues on
-# ComposeRuntimeFlags and ComposeStackTraceMode. These optimization directives
-# let R8 rewrite *call sites* (class-init triggers, flag reads) even when the
-# target classes are preserved by -keep rules. The result is that the Compose
-# recomposer/frame-clock/animation state machines silently freeze on their
-# first frame in release builds. -dontoptimize is the only directive that
-# disables processing of -assumenosideeffects/-assumevalues. See #5146.
--dontoptimize
+# History: optimization used to be disabled here via -dontoptimize (#5146).
+# androidx.compose's consumer rules ship -assumenosideeffects on
+# Composer/ComposerImpl/ComposerKt.sourceInformation* and -assumevalues on
+# ComposeRuntimeFlags/ComposeStackTraceMode; -dontoptimize is the only directive
+# that stops R8 from acting on those, and on an older R8×CMP combination acting
+# on them froze the Compose recomposer/frame-clock on the first release frame.
+# Re-verified on AGP 9.3 / CMP 1.11.1 (2026-07) by driving a minified release
+# APK on-device: first-frame render, Navigation-3 transitions, animated tab
+# switching and recomposition all work, so -dontoptimize was removed. The R8
+# config analyzer confirms OPTIMIZATION coverage jumps from 0% to ~96%.
+# If Compose animations/recomposition ever freeze in a release build after a
+# CMP/AGP/R8 bump, re-add `-dontoptimize` and re-open #5146.
 
 # Dump the full merged R8 configuration (app rules + all library consumer rules)
 # for auditing. Inspect this file after a release build to see what libraries inject.

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,8 +1,8 @@
 # ============================================================================
 # Meshtastic Android — ProGuard / R8 rules for release minification
 # ============================================================================
-# Open-source project: obfuscation and optimization are disabled. We rely on
-# tree-shaking (unused code removal) for APK size reduction.
+# Open-source project: obfuscation is disabled (readable stack traces). We rely
+# on R8 optimization + tree-shaking (unused code removal) for APK size reduction.
 #
 # Cross-platform library rules (Koin, kotlinx-serialization, Wire, Room,
 # Ktor, Coil, Kable, Kermit, Okio, DataStore, Paging, Lifecycle, Navigation 3,


### PR DESCRIPTION
## 🌟 Why

Release builds have shipped with `-dontoptimize` since #5146, disabling R8's entire optimization pass. That was the right call at the time — androidx.compose's consumer rules ship `-assumenosideeffects`/`-assumevalues` on `Composer`, `ComposerImpl`, `ComposeRuntimeFlags` and `ComposeStackTraceMode`, and on the R8×CMP combination back then, R8 acting on those froze the Compose recomposer/frame-clock on the first release frame. `-dontoptimize` is the only directive that stops R8 from processing those assume rules.

We've moved to **AGP 9.3 / CMP 1.11.1** since. These assume rules are Google's *own* intended release optimizations, so it was worth re-testing whether the freeze still reproduces. **It doesn't** — so we can reclaim the optimization pass while keeping the build fully **unobfuscated** (open-source; readable stack traces).

## 🛠️ What

- Remove `-dontoptimize` from `androidApp/proguard-rules.pro`; rewrite the surrounding comment to document the history + a re-verify tripwire.
- `-dontobfuscate` stays — this is an **optimize-only** change (inlining, class merging, `Composer`↔`ComposerImpl` devirtualization, unused-arg removal). No symbol renaming.

## 🧪 Testing performed

Built with the new **AGP 9.3 R8 config analyzer** (`:androidApp:analyzeFdroidReleaseR8Config`) and by driving a real minified APK:

| Metric (fdroidRelease) | Before | After |
|---|---|---|
| SHRINKING | 96.4% | 96.3% |
| **OPTIMIZATION** | **0.0%** | **96.1%** (classes 98.5% / methods 95.6%) |
| OBFUSCATION | 0.0% | 0.0% (unchanged — intentional) |

- `:androidApp:assembleFdroidRelease` builds clean with optimization on (1m26s); only the pre-existing non-fatal xmlutil SPI warnings.
- Installed the minified release APK on an emulator and exercised it: first-frame render, 4+ Navigation-3 animated screen transitions, animated bottom-nav tab switching, and recomposition across the Connection and Nodes screens — **all work, no first-frame freeze, no crashes/ANRs**. This is the #5146 symptom and it does not reproduce.

## ⚠️ Notes for reviewers

- PR CI already runs `assembleFdroidRelease`, so the R8 optimization pass is built in CI — but CI can't detect a *runtime* Compose freeze, which is why the on-device drive above matters.
- Only the **fdroid** release was driven on-device. `google` uses the same Compose deps so the assume-rule behavior is flavor-independent; a `google` release smoke before merge wouldn't hurt.
- **Regression tripwire:** if Compose animations/recomposition ever freeze in a release build after a future CMP/AGP/R8 bump, re-add `-dontoptimize` and re-open #5146.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android code shrinking settings to enable R8 optimizations while keeping obfuscation disabled.
  * Adjusted ProGuard/R8 rule documentation to reflect current behavior and guidance for potential future reintroductions of previous settings.
  * Verified compatibility with the existing Compose-based interface.
  * No user-facing features or app behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->