### PR TITLE
perf(analytics): match iOS Datadog RUM monitoring, drop dead timber dep

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
@@ -35,6 +35,7 @@ import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.sessionreplay.SessionReplay
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
@@ -157,8 +158,11 @@ class GooglePlatformAnalytics(private val context: Context, private val analytic
                 .trackAnonymousUser(true)
                 .trackBackgroundEvents(true) // Match Apple: track background events for cross-platform parity
                 .trackFrustrations(false) // Disable click-tracking based frustration detection
-                .trackLongTasks()
-                .trackNonFatalAnrs(true)
+                // Match Apple: disable long-task detection and continuous vitals monitoring to cut idle
+                // CPU/battery drain (~15% savings). This app runs a 24/7 foreground service, so the same
+                // concern applies. iOS sets longTaskThreshold = nil and vitalsUpdateFrequency = nil.
+                .setVitalsUpdateFrequency(VitalsUpdateFrequency.NEVER)
+                .trackNonFatalAnrs(true) // Android-specific; no iOS equivalent
                 .setSessionSampleRate(sampleRate)
                 .build()
         Rum.enable(rumConfiguration)
@@ -169,8 +173,8 @@ class GooglePlatformAnalytics(private val context: Context, private val analytic
         val traceConfig = TraceConfiguration.Builder().setNetworkInfoEnabled(true).build()
         Trace.enable(traceConfig)
 
-        // Session Replay for debug builds only, matching Apple's TestFlight-only gating.
-        // Masks all text inputs to protect message content.
+        // Session Replay is Android-only debug tooling — iOS ships no Session Replay at all. Enabled for
+        // debug builds only, and masks all text inputs to protect message content.
         if (BuildConfig.DEBUG) {
             val sessionReplayConfig =
                 SessionReplayConfiguration.Builder(sampleRate)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -262,7 +262,6 @@ coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 dd-sdk-android-logs = { module = "com.datadoghq:dd-sdk-android-logs", version.ref = "dd-sdk-android" }
 dd-sdk-android-rum = { module = "com.datadoghq:dd-sdk-android-rum", version.ref = "dd-sdk-android" }
 dd-sdk-android-session-replay = { module = "com.datadoghq:dd-sdk-android-session-replay", version.ref = "dd-sdk-android" }
-dd-sdk-android-timber = { module = "com.datadoghq:dd-sdk-android-timber", version.ref = "dd-sdk-android" }
 dd-sdk-android-trace = { module = "com.datadoghq:dd-sdk-android-trace", version.ref = "dd-sdk-android" }
 dd-sdk-android-trace-otel = { module = "com.datadoghq:dd-sdk-android-trace-otel", version.ref = "dd-sdk-android" }
 dokka-android-documentation-plugin = { module = "org.jetbrains.dokka:android-documentation-plugin", version.ref = "dokka" }
@@ -339,7 +338,6 @@ dd-sdk-android = [
     "dd-sdk-android-logs",
     "dd-sdk-android-rum",
     "dd-sdk-android-session-replay",
-    "dd-sdk-android-timber",
     "dd-sdk-android-trace",
     "dd-sdk-android-trace-otel",
 ]


### PR DESCRIPTION
Datadog config hygiene + iOS-parity cleanup for the google-flavor analytics. This app runs a 24/7 foreground service, so continuous RUM monitoring that iOS deliberately disables was costing idle CPU/battery here too; this aligns the two platforms and removes a dependency with no usage. No user-facing behavior change beyond reduced idle overhead.

### 🛠️ Refactoring & Architecture
- **Match iOS RUM monitoring (battery):** Disable Datadog long-task detection and continuous vitals monitoring — replace `.trackLongTasks()` with `.setVitalsUpdateFrequency(VitalsUpdateFrequency.NEVER)`. This mirrors meshtastic-apple (`MeshtasticApp.swift`), which sets `longTaskThreshold = nil` and `vitalsUpdateFrequency = nil` for ~15% idle-CPU savings. `trackNonFatalAnrs(true)` is kept — it is Android-only with no iOS equivalent.

### 🐛 Bug Fixes
- **Fix inaccurate "Match Apple" comment:** The Session Replay block claimed parity with "Apple's TestFlight-only gating," but meshtastic-apple ships **no** Session Replay at all. Reworded to describe it accurately as Android-only debug tooling (debug builds only, all text inputs masked). The two genuinely-accurate "Match Apple" comments (100% sampling, `trackBackgroundEvents`) are left intact.

### 🧹 Chores
- **Remove dead `dd-sdk-android-timber` dependency:** Logging is bridged through a custom Kermit `LogWriter` → Datadog `Logger` (`DatadogLogWriter`), not Timber. There is zero Timber usage in the repo, so the artifact was dead weight in the google APK. Removed the catalog lib def and its entry in the `dd-sdk-android` bundle.

`dd-sdk-android-trace` / `dd-sdk-android-trace-otel` are intentionally left in place — their fate depends on a separate decision about restoring network tracking.

### Testing Performed
Full local baseline is green (JDK 26):
`./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all pass (google + fdroid compile; spotless/detekt clean; ~1800+ KMP/unit tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android app stability monitoring by disabling potentially noisy vitals and long-task tracking while retaining non-fatal ANR reporting.
  * Clarified Session Replay behavior: it remains Android-only, debug-only, and masks text input.

* **Chores**
  * Removed an unused telemetry logging component from the Android build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->