### PR TITLE
fix(analytics): restore Datadog RUM network tracking (google) & unify service name

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FlavorModule.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FlavorModule.kt
@@ -29,4 +29,7 @@ class FlavorModule {
 
     /** No Play Services font provider on F-Droid — event fonts stay off; UI falls back to the app typeface. */
     @Single fun eventFontResolver(): EventFontResolver = EventFontResolver { null }
+
+    /** No analytics on F-Droid — the shared Ktor `HttpClient` gets no Datadog interceptor or event listener. */
+    @Single fun okHttpNetworkInstrumentation(): OkHttpNetworkInstrumentation = OkHttpNetworkInstrumentation.NONE
 }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
@@ -139,10 +139,15 @@ class GooglePlatformAnalytics(private val context: Context, private val analytic
 
     private fun initDatadog(application: Application) {
         val configuration =
+            // Pin RUM/crash/trace to the same service as the Logger and OpenTelemetry (SERVICE_NAME). The core SDK
+            // otherwise defaults `service` to the applicationId (com.geeksville.mesh), splitting the app across two
+            // Datadog services. On dd-sdk-android v2+ the service name is a Configuration.Builder constructor argument
+            // (there is no setService() on the builder). See the PR description: this renames RUM/crash going forward.
             Configuration.Builder(
                 clientToken = BuildConfig.datadogClientToken,
                 env = if (BuildConfig.DEBUG) "Local" else "Production",
                 variant = BuildConfig.FLAVOR,
+                service = SERVICE_NAME,
             )
                 .useSite(DatadogSite.US5)
                 .setCrashReportsEnabled(true)

--- a/androidApp/src/google/kotlin/org/meshtastic/app/di/FlavorModule.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/di/FlavorModule.kt
@@ -18,6 +18,8 @@
 
 package org.meshtastic.app.di
 
+import com.datadog.android.okhttp.DatadogEventListener
+import com.datadog.android.okhttp.DatadogInterceptor
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 import org.meshtastic.app.map.prefs.di.GoogleMapsKoinModule
@@ -31,4 +33,15 @@ import org.meshtastic.feature.car.di.FeatureCarModule
 class FlavorModule {
     /** Downloadable Google Fonts for event branding — Google flavor only. */
     @Single fun eventFontResolver(): EventFontResolver = GoogleFontsEventFontResolver()
+
+    /**
+     * Datadog network instrumentation for the shared Ktor `HttpClient`. The interceptor emits RUM Resource spans with
+     * full DNS/connect/SSL/download timing for first-party (`meshtastic.org`) requests, and the event listener supplies
+     * the fine-grained timing breakdown. Requires `Trace.enable(...)` (see `GooglePlatformAnalytics.initDatadog`).
+     */
+    @Single
+    fun okHttpNetworkInstrumentation(): OkHttpNetworkInstrumentation = OkHttpNetworkInstrumentation(
+        interceptors = listOf(DatadogInterceptor.Builder(tracedHosts = listOf("meshtastic.org")).build()),
+        eventListenerFactory = DatadogEventListener.Factory(),
+    )
 }

--- a/androidApp/src/main/kotlin/org/meshtastic/app/di/NetworkModule.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/di/NetworkModule.kt
@@ -106,21 +106,30 @@ class NetworkModule {
      * crashes with "Unbalanced enter/exit" (Crashlytics 97ae5ea1, 2.8.0 only). Square's OkHttp has no such bug.
      */
     @Single
-    fun provideHttpClient(json: Json, buildConfigProvider: BuildConfigProvider): HttpClient =
-        HttpClient(engineFactory = OkHttp) {
-            install(plugin = ContentNegotiation) { json(json) }
-            install(DefaultRequest) { url(HttpClientDefaults.API_BASE_URL) }
-            install(plugin = HttpTimeout) {
-                requestTimeoutMillis = HttpClientDefaults.REQUEST_TIMEOUT_MS
-                connectTimeoutMillis = HttpClientDefaults.TIMEOUT_MS
-                socketTimeoutMillis = HttpClientDefaults.TIMEOUT_MS
-            }
-            install(plugin = HttpRequestRetry) { configureDefaultRetry() }
-            if (buildConfigProvider.isDebug) {
-                install(plugin = Logging) {
-                    logger = KermitHttpLogger
-                    level = LogLevel.INFO
-                }
+    fun provideHttpClient(
+        json: Json,
+        buildConfigProvider: BuildConfigProvider,
+        networkInstrumentation: OkHttpNetworkInstrumentation,
+    ): HttpClient = HttpClient(engineFactory = OkHttp) {
+        engine {
+            // Flavor-provided analytics hooks: google supplies Datadog's interceptor + event listener so RUM
+            // captures per-request network timing; fdroid supplies OkHttpNetworkInstrumentation.NONE (no-op).
+            networkInstrumentation.interceptors.forEach { addInterceptor(it) }
+            networkInstrumentation.eventListenerFactory?.let { factory -> config { eventListenerFactory(factory) } }
+        }
+        install(plugin = ContentNegotiation) { json(json) }
+        install(DefaultRequest) { url(HttpClientDefaults.API_BASE_URL) }
+        install(plugin = HttpTimeout) {
+            requestTimeoutMillis = HttpClientDefaults.REQUEST_TIMEOUT_MS
+            connectTimeoutMillis = HttpClientDefaults.TIMEOUT_MS
+            socketTimeoutMillis = HttpClientDefaults.TIMEOUT_MS
+        }
+        install(plugin = HttpRequestRetry) { configureDefaultRetry() }
+        if (buildConfigProvider.isDebug) {
+            install(plugin = Logging) {
+                logger = KermitHttpLogger
+                level = LogLevel.INFO
             }
         }
+    }
 }

--- a/androidApp/src/main/kotlin/org/meshtastic/app/di/OkHttpNetworkInstrumentation.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/di/OkHttpNetworkInstrumentation.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app.di
+
+import okhttp3.EventListener
+import okhttp3.Interceptor
+
+/**
+ * Flavor-provided OkHttp instrumentation applied to the shared Ktor [io.ktor.client.HttpClient] built in
+ * [NetworkModule.provideHttpClient].
+ *
+ * The Android Ktor engine lives in the shared `src/main` source set, so it is compiled into both the google and fdroid
+ * flavors. This holder is the seam that keeps analytics out of fdroid: the google `FlavorModule` supplies Datadog's
+ * `DatadogInterceptor` + `DatadogEventListener.Factory` (so RUM captures per-request DNS/connect/SSL/download timing
+ * for first-party hosts), while the fdroid `FlavorModule` supplies [NONE], pulling in no Datadog artifact at all.
+ */
+class OkHttpNetworkInstrumentation(
+    val interceptors: List<Interceptor> = emptyList(),
+    val eventListenerFactory: EventListener.Factory? = null,
+) {
+    companion object {
+        /** No-op instrumentation — used by the analytics-free fdroid flavor. */
+        val NONE = OkHttpNetworkInstrumentation()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -260,6 +260,7 @@ coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.r
 coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 
 dd-sdk-android-logs = { module = "com.datadoghq:dd-sdk-android-logs", version.ref = "dd-sdk-android" }
+dd-sdk-android-okhttp = { module = "com.datadoghq:dd-sdk-android-okhttp", version.ref = "dd-sdk-android" }
 dd-sdk-android-rum = { module = "com.datadoghq:dd-sdk-android-rum", version.ref = "dd-sdk-android" }
 dd-sdk-android-session-replay = { module = "com.datadoghq:dd-sdk-android-session-replay", version.ref = "dd-sdk-android" }
 dd-sdk-android-timber = { module = "com.datadoghq:dd-sdk-android-timber", version.ref = "dd-sdk-android" }
@@ -337,6 +338,7 @@ meshtastic-protobufs = { module = "org.meshtastic:protobufs", version.ref = "mes
 # Datadog RUM/telemetry stack — always consumed together (androidApp google flavor)
 dd-sdk-android = [
     "dd-sdk-android-logs",
+    "dd-sdk-android-okhttp",
     "dd-sdk-android-rum",
     "dd-sdk-android-session-replay",
     "dd-sdk-android-timber",


### PR DESCRIPTION
Shipped builds ≤ 2.7.13 emitted Datadog RUM **Resource** spans for `api.meshtastic.org` with full DNS/connect/SSL/download timing — the data that showed the API "slowness" is often DNS/connect-dominated on cellular (e.g. a device spending ~3.5s in DNS), not just server TTFB. That visibility was silently lost in the Ktor networking migration (#4890, `b3b38acc0`), which deleted the OkHttp `DatadogInterceptor`/`DatadogEventListener` wiring along with the old `GoogleNetworkModule`. This PR restores it on the google flavor and, while in the Datadog config, pins the RUM/crash/trace service name so the app no longer splits across two Datadog services.

### 🐛 Bug Fixes
- **Restore Datadog RUM network tracking (google flavor only).** Re-adds the OkHttp `DatadogInterceptor` (`tracedHosts = ["meshtastic.org"]`) and `DatadogEventListener.Factory`, so RUM Resource spans with per-request DNS/connect/SSL/download timing come back for first-party requests. This depends on the existing `Trace.enable(...)` in `GooglePlatformAnalytics` (unchanged).

### 🛠️ Refactoring & Architecture
- **New Koin seam for flavor-specific OkHttp instrumentation.** Networking is now Ktor in `core/network` (commonMain), and the Android Ktor **OkHttp** engine is built in the shared `androidApp/src/main` `NetworkModule` — compiled into *both* google and fdroid. `DatadogInterceptor`/`DatadogEventListener` are Android-only OkHttp APIs, so a straight re-add would leak Datadog into fdroid. Instead:
  - New `OkHttpNetworkInstrumentation` holder (`src/main`) carries an optional list of `okhttp3.Interceptor` + an `EventListener.Factory`.
  - `NetworkModule.provideHttpClient` injects it via Koin and applies it in the engine block (`addInterceptor` + `config { eventListenerFactory(...) }`).
  - The **google** `FlavorModule` provides the Datadog instrumentation; the **fdroid** `FlavorModule` provides `OkHttpNetworkInstrumentation.NONE` (no-op). fdroid pulls in **zero** Datadog artifacts.

### 🧹 Chores
- Add `com.datadoghq:dd-sdk-android-okhttp` to the version catalog (lib def + `dd-sdk-android` bundle, `version.ref = "dd-sdk-android"`). It's consumed only via `googleImplementation(libs.bundles.dd.sdk.android)`, so it never enters the fdroid graph.

### ✅ Service-name unification — audited, verified safe
`initDatadog()`'s `Configuration.Builder` did **not** set a `service`, so RUM/crash/trace defaulted to the applicationId **`com.geeksville.mesh`**, while the Logger and OpenTelemetry are pinned to **`org.meshtastic`** (`SERVICE_NAME`) — splitting the app across two Datadog services. This PR passes `service = SERVICE_NAME` to the `Configuration.Builder` **constructor** (dd-sdk-android v2+ has no `.setService()` builder method) so RUM + resources + logs all land under `org.meshtastic`.

**This renames the RUM/crash service going forward** — historical RUM/crash data stays under `com.geeksville.mesh`; new data moves to `org.meshtastic`. I audited the Datadog org (US5) before landing this and confirmed nothing keys off the old service name:
- **Monitors:** only 3 exist (CPU / CI status / disk), all infra keyed off `host:` / `env:ci` — none reference RUM or any app service. No breakage.
- **Custom Android dashboard** ("RUM - Android App Deployment Tracking", `team:meshtastic-android`): identifies the app by `@application.name:"Meshtastic Android"` with `service:*` **wildcard**, so it keeps matching both old and new service data. No breakage.
- **RUM data:** `org.meshtastic` doesn't yet exist as a RUM service (Android RUM/crash is 100% `com.geeksville.mesh` today); the rename genuinely unifies RUM/crash with the existing Logs/APM `org.meshtastic` service.
- **Only visible effect:** the dashboard's "Versions by service" table gains an `org.meshtastic` row for post-rename versions alongside the historical `com.geeksville.mesh` row (cosmetic).

The two changes remain independent: dropping the single `service = SERVICE_NAME` argument would keep only the network-tracking restore.

### Verification
- Baseline: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — green.
- **fdroid stays sterile:** `datadog` does not appear in `fdroidDebugRuntimeClasspath`; `dd-sdk-android-okhttp` is present only in `googleDebugRuntimeClasspath`.

### Notes
- Independent of the Datadog SDK bump (#6277), which auto-merges separately — this PR only *adds* the already-pinned `dd-sdk-android` version to a new module + bundle entry.
