### PR TITLE
feat(analytics): restore RUM view tracking on Nav3 (Google flavor)

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
@@ -265,6 +265,16 @@ class GooglePlatformAnalytics(private val context: Context, private val analytic
         GlobalRumMonitor.get().addAction(RumActionType.CUSTOM, "connect", attributes)
     }
 
+    override fun startScreenView(key: String, name: String) {
+        if (!Datadog.isInitialized() || !GlobalRumMonitor.isRegistered()) return
+        GlobalRumMonitor.get().startView(key = key, name = name)
+    }
+
+    override fun stopScreenView(key: String) {
+        if (!Datadog.isInitialized() || !GlobalRumMonitor.isRegistered()) return
+        GlobalRumMonitor.get().stopView(key = key)
+    }
+
     private val isGooglePlayAvailable: Boolean
         get() =
             GoogleApiAvailabilityLight.getInstance().isGooglePlayServicesAvailable(context).let {

--- a/androidApp/src/main/kotlin/org/meshtastic/app/ui/Main.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/ui/Main.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import co.touchlab.kermit.Logger
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.meshtastic.app.BuildConfig
 import org.meshtastic.core.model.ConnectionState
@@ -37,6 +38,7 @@ import org.meshtastic.core.model.service.LockdownState
 import org.meshtastic.core.navigation.NodesRoute
 import org.meshtastic.core.navigation.TopLevelDestination
 import org.meshtastic.core.navigation.rememberMultiBackstack
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.app_too_old
 import org.meshtastic.core.resources.must_update
@@ -59,8 +61,7 @@ import org.meshtastic.feature.wifiprovision.navigation.wifiProvisionGraph
 @Composable
 fun MainScreen() {
     val viewModel: UIViewModel = koinViewModel()
-    // Land on Connections for first-run / no-device-selected; otherwise on Nodes. Read synchronously
-    // from the StateFlow (seeded from persisted prefs) so the initial tab is set in one shot.
+    // Land on Connections for first-run / no-device-selected; otherwise on Nodes (seeded from prefs).
     val initialTab = remember {
         if (viewModel.currentDeviceAddressFlow.value.isNullOrSelectedNone()) {
             TopLevelDestination.Connect.route
@@ -95,7 +96,9 @@ fun MainScreen() {
             uiViewModel = viewModel,
             modifier = Modifier.fillMaxSize(),
         ) {
-            val provider =
+            MeshtasticNavDisplay(
+                multiBackstack = multiBackstack,
+                entryProvider =
                 entryProvider<NavKey> {
                     contactsGraph(backStack, scrollToTopEvents, onHandleDeepLink = viewModel::handleDeepLink)
                     nodesGraph(
@@ -114,11 +117,9 @@ fun MainScreen() {
                     docsEntries(backStack)
                     firmwareGraph(backStack)
                     wifiProvisionGraph(backStack)
-                }
-            MeshtasticNavDisplay(
-                multiBackstack = multiBackstack,
-                entryProvider = provider,
+                },
                 modifier = Modifier.fillMaxSize().recalculateWindowInsets().safeDrawingPadding(),
+                analytics = koinInject<PlatformAnalytics>(),
             )
         }
     }

--- a/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/RumViewName.kt
+++ b/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/RumViewName.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.navigation
+
+import androidx.navigation3.runtime.NavKey
+
+/**
+ * Derives the analytics view name for a navigation destination.
+ *
+ * The name is the route's fully-qualified class name (e.g. `org.meshtastic.core.navigation.NodesRoute.Nodes`), matching
+ * the convention historically recorded by Datadog RUM before the Navigation 3 migration, so new per-screen data lines
+ * up with existing dashboards. Falls back to the simple name (and finally `toString()`) on the rare platform where
+ * [kotlin.reflect.KClass.qualifiedName] is unavailable.
+ */
+fun NavKey.rumViewName(): String = this::class.qualifiedName ?: this::class.simpleName ?: toString()

--- a/core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/RumViewNameTest.kt
+++ b/core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/RumViewNameTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.navigation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Guards the RUM view-name convention consumed by the analytics layer. View names must be the route's fully-qualified
+ * class name so per-screen RUM data lines up with historical Datadog dashboards. A rename of a route interface or the
+ * package would break cross-platform data continuity, so this test pins the format.
+ */
+class RumViewNameTest {
+
+    @Test
+    fun `rumViewName is the fully qualified route name for data objects`() {
+        assertEquals("org.meshtastic.core.navigation.NodesRoute.Nodes", NodesRoute.Nodes.rumViewName())
+    }
+
+    @Test
+    fun `rumViewName is stable across argument values for data classes`() {
+        val expected = "org.meshtastic.core.navigation.NodeDetailRoute.DeviceMetrics"
+        assertEquals(expected, NodeDetailRoute.DeviceMetrics(destNum = 1).rumViewName())
+        assertEquals(expected, NodeDetailRoute.DeviceMetrics(destNum = 2).rumViewName())
+    }
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PlatformAnalytics.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PlatformAnalytics.kt
@@ -53,6 +53,29 @@ interface PlatformAnalytics {
     }
 
     /**
+     * Starts tracking a screen as a RUM view, aligned with the Meshtastic-Apple Datadog integration (which auto-tracks
+     * SwiftUI views) so per-screen RUM data lines up across platforms.
+     *
+     * Starting a view implicitly stops any previously active view. Callers should pair each call with a matching
+     * [stopScreenView] using the same [key] when the screen is left.
+     *
+     * @param key A stable identifier that pairs this start with its matching [stopScreenView].
+     * @param name The route-derived view name (e.g. `org.meshtastic.core.navigation.NodesRoute.Nodes`).
+     */
+    fun startScreenView(key: String, name: String) {
+        // Default no-op for platforms that don't support RUM (fdroid, desktop)
+    }
+
+    /**
+     * Stops the RUM view previously started with [startScreenView] for the given [key].
+     *
+     * @param key The same identifier passed to the matching [startScreenView].
+     */
+    fun stopScreenView(key: String) {
+        // Default no-op for platforms that don't support RUM (fdroid, desktop)
+    }
+
+    /**
      * Indicates whether platform-specific services (like Google Play Services or Datadog) are available and
      * initialized.
      */

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.adaptive.layout.rememberPaneExpansionState
 import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
 import androidx.compose.material3.adaptive.navigation3.rememberSupportingPaneSceneStrategy
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -42,6 +43,8 @@ import androidx.navigation3.scene.DialogSceneStrategy
 import androidx.navigation3.scene.Scene
 import androidx.navigation3.ui.NavDisplay
 import org.meshtastic.core.navigation.MultiBackstack
+import org.meshtastic.core.navigation.rumViewName
+import org.meshtastic.core.repository.PlatformAnalytics
 
 /** Duration in milliseconds for the shared crossfade transition between navigation scenes. */
 private const val TRANSITION_DURATION_MS = 350
@@ -57,6 +60,7 @@ fun MeshtasticNavDisplay(
     multiBackstack: MultiBackstack,
     entryProvider: (key: NavKey) -> NavEntry<NavKey>,
     modifier: Modifier = Modifier,
+    analytics: PlatformAnalytics? = null,
 ) {
     val backStack = multiBackstack.activeBackStack
     MeshtasticNavDisplay(
@@ -64,6 +68,7 @@ fun MeshtasticNavDisplay(
         onBack = { multiBackstack.goBack() },
         entryProvider = entryProvider,
         modifier = modifier,
+        analytics = analytics,
     )
 }
 
@@ -73,10 +78,23 @@ fun MeshtasticNavDisplay(
 @Composable
 fun MeshtasticNavDisplay(
     backStack: NavBackStack<NavKey>,
-    onBack: (() -> Unit)? = null,
     entryProvider: (key: NavKey) -> NavEntry<NavKey>,
     modifier: Modifier = Modifier,
+    onBack: (() -> Unit)? = null,
+    analytics: PlatformAnalytics? = null,
 ) {
+    // Track the top-of-backstack destination as a RUM view. Datadog's dd-sdk-android-compose
+    // NavigationViewTrackingEffect only supports Jetpack Navigation, so Nav3 is wired manually here.
+    // No-op when [analytics] is null (fdroid/desktop hosts and the intro flow pass nothing).
+    if (analytics != null) {
+        val currentKey = backStack.lastOrNull()
+        DisposableEffect(currentKey) {
+            val name = currentKey?.rumViewName()
+            if (name != null) analytics.startScreenView(key = name, name = name)
+            onDispose { if (name != null) analytics.stopScreenView(key = name) }
+        }
+    }
+
     val listDetailSceneStrategy =
         rememberListDetailSceneStrategy<NavKey>(
             paneExpansionState = rememberPaneExpansionState(),

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
@@ -88,7 +88,7 @@ fun MeshtasticNavDisplay(
     // No-op when [analytics] is null (fdroid/desktop hosts and the intro flow pass nothing).
     if (analytics != null) {
         val currentKey = backStack.lastOrNull()
-        DisposableEffect(currentKey) {
+        DisposableEffect(currentKey, analytics) {
             val name = currentKey?.rumViewName()
             if (name != null) analytics.startScreenView(key = name, name = name)
             onDispose { if (name != null) analytics.stopScreenView(key = name) }


### PR DESCRIPTION
## Why

Android RUM sessions currently contain **no screens**. `RumConfiguration.Builder` sets no view-tracking strategy and there are no `startView`/`stopView` calls anywhere in the repo, so a session is just errors, ANRs, and the single custom `connect` action. Meanwhile Meshtastic-Apple auto-tracks views (and actions) via `DefaultSwiftUIRUMViewsPredicate`, so the cross-platform RUM comparison the 100% sampling exists for is apples-to-oranges.

This is also partly a **regression**: shipped builds ≤ 2.7.13 tracked views (RUM Resource spans carried `view.name: org.meshtastic.core.navigation.<X>Route.<Screen>`). The wiring — Datadog's `NavigationViewTrackingEffect` in the old `GooglePlatformAnalytics` — was dropped during the Navigation 3 migration (view tracking last present before #4735 removed it, no longer applicable once the app moved off Jetpack Navigation).

`NavigationViewTrackingEffect` (from `dd-sdk-android-compose`) targets **Jetpack Navigation** and cannot observe our Nav3 backstack (`MeshtasticNavDisplay` / `org.jetbrains.androidx.navigation3`), so the drop-in helper can't come back. This PR hooks view tracking into the Nav3 backstack manually instead.

## What

Restores per-screen RUM views on the Google flavor, wired through the existing `PlatformAnalytics` seam:

- **`PlatformAnalytics`** (commonMain) gains `startScreenView(key, name)` / `stopScreenView(key)` with default no-op bodies — commonMain stays free of any Datadog import.
- **`MeshtasticNavDisplay`** (Nav3 host, core/ui) observes the top of the active backstack and drives start/stop via a `DisposableEffect` keyed on the current destination. It takes an optional `analytics: PlatformAnalytics?` that defaults to `null`, so the intro flow and any non-app host stay untracked.
- **`GooglePlatformAnalytics`** implements the hook via `GlobalRumMonitor.get().startView/stopView`, guarded exactly like the existing `trackConnect`.
- **F-Droid / desktop** inherit the no-op defaults and emit nothing.
- View names are the route's fully-qualified class name (`NavKey.rumViewName()`), matching the historical convention so new data lines up with existing dashboards. *(Note: the sealed route types are named `<X>Route` today, so names are e.g. `org.meshtastic.core.navigation.NodesRoute.Nodes`; pre-migration they were `<X>Routes` — same package/screen, singular vs plural is the only drift and renaming route types was out of scope.)*

### 🌟 Features
- Per-screen RUM view tracking on Android (Google flavor), restoring cross-platform parity with iOS.

### 🛠️ Improvements
- View names derived from the Nav3 route FQN, aligned with pre-migration Datadog data.

## Out of scope (deliberate)

- **Action tracking.** iOS auto-tracks actions; Android keeps `trackFrustrations(false)` and only the custom `connect` action. `dd-sdk-android-compose` has **no** automatic action instrumentation for Compose (only manual `trackClick` / `TrackInteractionsEffect`), so adding it means annotating every interactive control — a much larger, noisier change. Views are the primary gap; actions can be a follow-up.

## Testing Performed

- `spotlessCheck` + `detekt` green across all touched modules (`core:repository`, `core:navigation`, `core:ui`, `androidApp`).
- `assembleDebug` green — both `googleDebug` and `fdroidDebug` compile; F-Droid inherits the no-op defaults and emits nothing.
- `:core:navigation:allTests` green — new `RumViewNameTest` (commonTest) pins the FQN view-name format for a `data object` and an argument-bearing `data class` route.
- `kmpSmokeCompile` green — confirms the common/iOS/JVM compile paths (the nav-display change lives in `commonMain`).
- CI runs the full `test allTests` matrix across every module.
- Not yet confirmed end-to-end in the Datadog RUM UI (US5, service `com.geeksville.mesh`) — that needs the Datadog org dashboard. The wiring mirrors the pre-migration implementation and reuses the existing `connect`-action init guards; debug builds run Datadog in developer mode (`startView`/`stopView` log to logcat) for local confirmation on an emulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic screen-view tracking for navigation destinations when analytics is enabled.
  * Integrated RUM-style start/stop screen tracking via the platform analytics interface.
  * Screen view names are generated consistently from the navigation route.
* **Bug Fixes**
  * Ensured tracked screen views end properly when navigating away to avoid stale tracking.
* **Tests**
  * Added coverage validating stable analytics names across navigation routes and route parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->