### PR TITLE
fix(build): suppress Datadog compiler SourceLines annotation for google release R8

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -45,6 +45,21 @@
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
 
+# ---- Datadog compiler-plugin annotations (google flavor) --------------------
+# The Datadog SDK (dd-sdk-android, google flavor only) is itself compiled with
+# Datadog's dd-javac compiler plugin, which stamps every class/method with
+# `@datadog.compiler.annotations.SourceLines` (build-time source-line metadata).
+# Datadog does not package the annotation class in the consumer artifacts, so
+# under R8 full mode (AGP 9) the dangling references — e.g. from
+# com.datadog.android.internal.utils.FixedWindowCallback and ~1000 other SDK
+# classes — are promoted from warnings to a hard "Missing classes detected"
+# error, failing minifyGoogleReleaseWithR8. The annotation is absent at runtime
+# regardless, so suppressing it changes no behaviour; this is the same rule R8
+# auto-generates into missing_rules.txt. Surfaced by the dd-sdk-android 3.12.0
+# bump (#6277). fdroid has no Datadog on the classpath, so this is a harmless
+# no-op there.
+-dontwarn datadog.compiler.annotations.**
+
 # ---- AppSearch / AppFunctions generated document factories ------------------
 # AppSearch's DocumentClassFactoryRegistry loads the generated
 # `$$__AppSearch__*` factory classes by name and instantiates them via their


### PR DESCRIPTION
The `dd-sdk-android` → 3.12.0 bump (#6277) turned the release line red: the scheduled **Create or Promote Release** run ([29466449452](https://github.com/meshtastic/Meshtastic-Android/actions/runs/29466449452)) failed in `release-google` on `:androidApp:minifyGoogleReleaseWithR8`. This restores a green google release build.

### Root cause

Datadog compiles its own SDK with the [`dd-javac-plugin`](https://github.com/DataDog/dd-javac-plugin), which stamps `@datadog.compiler.annotations.SourceLines` (build-time source-line metadata) on every class and method. Datadog does **not** package the annotation class in the consumer artifacts, so under R8 full mode (AGP 9) the dangling references — from `com.datadog.android.internal.utils.FixedWindowCallback` and ~1000 other SDK classes — are promoted from a warning to a hard error:

```
ERROR: Missing classes detected while running R8.
ERROR: R8: Missing class datadog.compiler.annotations.SourceLines
  (referenced from ...FixedWindowCallback.<init>(...) and 1043 other contexts)
> Task :androidApp:minifyGoogleReleaseWithR8 FAILED
```

The failure surfaces on Datadog's own classes (google flavor only); it is not in our code.

### 🐛 Bug Fixes

- Add `-dontwarn datadog.compiler.annotations.**` to `androidApp/proguard-rules.pro`. This is the exact rule R8 auto-generates into `missing_rules.txt`. The annotation has no runtime presence regardless — the class isn't on the classpath at all — so suppressing it changes no behaviour. fdroid carries no Datadog dependency, so the rule is a harmless no-op there.

### Testing Performed

Ran the exact failing task locally against this branch:

```
./gradlew :androidApp:minifyGoogleReleaseWithR8 -Pci=true
```

`:androidApp:minifyGoogleReleaseWithR8` now completes successfully — the "Missing class … SourceLines" / "Missing classes detected while running R8" error is gone. No source, test, or UI code is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android release builds by preventing false failures from missing Datadog annotation references.
  * No runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->