### PR TITLE
fix: silence false-positive Instantiatable lint on ExtensionAppFunctionService

### DIFF
--- a/androidApp/src/google/AndroidManifest.xml
+++ b/androidApp/src/google/AndroidManifest.xml
@@ -83,11 +83,22 @@
                 <action android:name="android.app.appfunctions.AppFunctionService" />
             </intent-filter>
         </service>
+        <!--
+          tools:ignore="Instantiatable": lint can't resolve this library-provided service's superclass chain
+          up to android.app.Service. ExtensionAppFunctionService extends the abstract
+          ExtensionsAppFunctionService, whose base is com.android.extensions.appfunctions.AppFunctionService —
+          a class supplied at runtime by the optional "com.android.extensions.appfunctions" <uses-library>
+          (declared android:required="false" in the appfunctions AAR), not by any compile/lint-classpath
+          artifact. Lint therefore can't prove it's a Service and false-positives. The sibling
+          PlatformAppFunctionService is fine because its chain ends in the compile-SDK
+          android.app.appfunctions.AppFunctionService, so the check stays active there and on our own services.
+        -->
         <service
             android:name="androidx.appfunctions.ExtensionAppFunctionService"
             android:enabled="@bool/enableExtensionAppFunctionService"
             android:exported="true"
-            android:permission="android.permission.BIND_APP_FUNCTION_SERVICE">
+            android:permission="android.permission.BIND_APP_FUNCTION_SERVICE"
+            tools:ignore="Instantiatable">
             <property
                 android:name="android.app.appfunctions"
                 android:value="app_functions.xml" />


### PR DESCRIPTION
## Why

The `googleRelease` lint vital report (visible in **Create or Promote Release → release-google**) emits an error that clutters release CI:

```
androidApp/src/google/AndroidManifest.xml:87: Error: ExtensionAppFunctionService must extend android.app.Service [Instantiatable]
```

It is **non-fatal** today only because our lint convention sets `abortOnError = false` — it does not fail the build, but it pollutes every release lint report with a false positive.

### Root cause

The two AppFunctions delegate services we hand-declare (since alpha10 dropped the `appfunctions-service` manifest) have different superclass chains:

| Service | Chain | Lint resolves? |
|---------|-------|----------------|
| `PlatformAppFunctionService` | → `androidx.appfunctions.AppFunctionService` → `android.app.appfunctions.AppFunctionService` (**compile SDK, API 36**) | ✅ resolves to `android.app.Service` — no warning |
| `ExtensionAppFunctionService` | → `ExtensionsAppFunctionService` (abstract) → `com.android.extensions.appfunctions.AppFunctionService` (**device `<uses-library>` sidecar**) | ❌ unresolvable |

`com.android.extensions.appfunctions.AppFunctionService` is supplied at runtime by the optional `com.android.extensions.appfunctions` shared library — declared `<uses-library android:required="false" />` in the appfunctions AAR manifest — and follows the AndroidX convention for OEM on-device sidecars (`com.android.extensions.<feature>`, kept off the boot classpath). It is not shipped in any compile/lint-classpath artifact, so lint cannot follow the superclass chain up to `android.app.Service` and false-positives. Only `ExtensionAppFunctionService` is affected (confirmed by reproduction).

Making the dependency "visible to lint" is therefore a dead end — there is no artifact to add; the class only exists on-device via `<uses-library>`.

## Changes

### 🐛 Bug Fixes
- Add a narrow `tools:ignore="Instantiatable"` to **only** the `ExtensionAppFunctionService` `<service>` element in `androidApp/src/google/AndroidManifest.xml`, with a comment explaining the `<uses-library>` sidecar chain. The check stays active on `PlatformAppFunctionService` and on all our own components, so this is the most surgical option (preferred over a scoped `lint { disable }` or a baseline).

## Testing Performed

Local verification on the `googleRelease` variant (JDK 25):
- `./gradlew :androidApp:lintVitalGoogleRelease -Pci=true` → **0 errors, 0 warnings** (was `1 error` — the `[Instantiatable]` error is gone)
- `./gradlew spotlessCheck` → pass
- `./gradlew detekt` → pass

Independent from the R8 proguard fix in #6292 — no overlap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an Android manifest tooling warning related to the app functions service.
  * No changes were made to service behavior, permissions, availability, or exported status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->