### PR TITLE
fix: label channel share FAB "Import/Export" and announce Close when expanded

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -772,7 +772,9 @@ ignore_add
 ignore_incoming
 ignore_mqtt
 ignore_remove
+### IMPORT ###
 import_configuration
+import_export_label
 import_known_shared_contact_text
 import_label
 import_shared_contact

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -796,7 +796,9 @@
     <string name="ignore_incoming">Ignore incoming</string>
     <string name="ignore_mqtt">Ignore MQTT</string>
     <string name="ignore_remove">Remove '%1$s' from ignore list?</string>
+    <!-- IMPORT -->
     <string name="import_configuration">Import configuration</string>
+    <string name="import_export_label">Import/Export</string>
     <string name="import_known_shared_contact_text">Warning: This contact is known, importing will overwrite the previous contact information.</string>
     <string name="import_label">Import</string>
     <string name="import_shared_contact">Import Shared Contact?</string>

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/ImportFab.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/ImportFab.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.cancel
+import org.meshtastic.core.resources.import_export_label
 import org.meshtastic.core.resources.import_label
 import org.meshtastic.core.resources.input_channel_url
 import org.meshtastic.core.resources.input_shared_contact_url
@@ -206,12 +207,15 @@ fun MeshtasticImportFAB(
         onExpandedChange = { expanded = it },
         items = items,
         modifier = modifier.padding(bottom = 16.dp),
-        contentDescription = stringResource(Res.string.import_label),
+        contentDescription = stringResource(importFabContentDescriptionRes(onShareChannels, onShareContact)),
         testTag = testTag,
     )
 }
 
 internal fun normalizeImportContents(contents: String?): String? = contents?.trim()?.takeIf { it.isNotEmpty() }
+
+private fun importFabContentDescriptionRes(onShareChannels: (() -> Unit)?, onShareContact: (() -> Unit)?) =
+    if (onShareChannels != null || onShareContact != null) Res.string.import_export_label else Res.string.import_label
 
 @Composable
 private fun NfcScanningDialog(onDismiss: () -> Unit) {

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MenuFAB.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MenuFAB.kt
@@ -34,6 +34,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.close
 import org.meshtastic.core.ui.icon.Close
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.OfflineShare
@@ -48,13 +51,14 @@ fun MenuFAB(
     contentDescription: String? = null,
     testTag: String? = null,
 ) {
+    val stateAwareDescription = if (expanded) stringResource(Res.string.close) else contentDescription
     FloatingActionButtonMenu(
         modifier = modifier.then(if (testTag != null) Modifier.testTag(testTag) else Modifier),
         expanded = expanded,
         button = {
             TooltipBox(
                 positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
-                tooltip = { contentDescription?.let { PlainTooltip { Text(it) } } },
+                tooltip = { stateAwareDescription?.let { PlainTooltip { Text(it) } } },
                 state = rememberTooltipState(),
             ) {
                 ToggleFloatingActionButton(
@@ -62,7 +66,7 @@ fun MenuFAB(
                     onCheckedChange = onExpandedChange,
                     content = {
                         val imageVector = if (expanded) MeshtasticIcons.Close else MeshtasticIcons.OfflineShare
-                        Icon(imageVector = imageVector, contentDescription = contentDescription)
+                        Icon(imageVector = imageVector, contentDescription = stateAwareDescription)
                     },
                     containerColor = ToggleFloatingActionButtonDefaults.containerColor(),
                 )

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/ImportFabUiTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/ImportFabUiTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -107,6 +108,33 @@ class ImportFabUiTest {
 
         onNodeWithTag(testTag).performClick()
         onNodeWithTag("share_contact").assertIsDisplayed()
+    }
+
+    @Test
+    fun importFab_describesImport_whenNoShareCallbacks() = runComposeUiTest {
+        setContent { MeshtasticImportFAB(onImport = {}, isContactContext = true) }
+
+        onNodeWithContentDescription("Import").assertIsDisplayed()
+    }
+
+    @Test
+    fun importFab_describesImportExport_whenShareCallbackProvided() = runComposeUiTest {
+        setContent { MeshtasticImportFAB(onImport = {}, onShareChannels = {}, isContactContext = false) }
+
+        onNodeWithContentDescription("Import/Export").assertIsDisplayed()
+    }
+
+    @Test
+    fun importFab_describesClose_whenExpanded() = runComposeUiTest {
+        val testTag = "import_fab"
+        setContent {
+            MeshtasticImportFAB(onImport = {}, onShareChannels = {}, isContactContext = false, testTag = testTag)
+        }
+
+        onNodeWithTag(testTag).performClick()
+
+        onNodeWithContentDescription("Close").assertIsDisplayed()
+        onNodeWithContentDescription("Import/Export").assertDoesNotExist()
     }
 
     @Test


### PR DESCRIPTION
Fixes #6297

## Why

The FAB on the Channels tab is labeled "Import", but its menu also offers export actions (Share Channels QR, Share Connected Node), so the label undersells what the button does. Separately, when the menu is expanded the FAB icon changes to a Close glyph but screen readers kept announcing the import label — the announced action no longer matched what tapping would do.

## What Changed

🐛 **Bug Fixes**
- Added a new `import_export_label` ("Import/Export") string and use it as the `MeshtasticImportFAB` label whenever a share callback (`onShareChannels`/`onShareContact`) is provided — i.e., the Channels tab and node list. Import-only contexts (shared-contact dialog, config import) keep the plain "Import" label.
- `MenuFAB` accessibility: the tooltip and icon `contentDescription` now switch to the existing localized "Close" string while the menu is expanded, matching the Close glyph.

## Things a Reviewer Should Know

- The label conditional was extracted into a small helper (`importFabContentDescriptionRes`) because inlining it pushed `MeshtasticImportFAB` over detekt's cyclomatic-complexity limit.
- `.skills/compose-ui/strings-index.txt` churn is the auto-generated index from `scripts/sort-strings.py`.
- Verified locally: `spotlessApply spotlessCheck detekt` and `:core:ui` compilation all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved menu button labels and tooltips to reflect whether menus are open or closed.
  * Added clearer “Import/Export” labeling for import actions that also support sharing.

* **Localization**
  * Added a localized “Import/Export” string for use across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->