### PR TITLE
refactor(map): migrate custom overlays to the maps-utils 5.0 data layer

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -21,6 +21,7 @@ package org.meshtastic.app.map
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
+import android.graphics.Bitmap
 import android.location.Location
 import android.view.WindowManager
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -91,17 +92,23 @@ import com.google.maps.android.compose.TileOverlay
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberUpdatedMarkerState
 import com.google.maps.android.compose.widgets.ScaleBar
-import com.google.maps.android.data.Layer
-import com.google.maps.android.data.geojson.GeoJsonFeature
-import com.google.maps.android.data.geojson.GeoJsonLayer
-import com.google.maps.android.data.geojson.GeoJsonLineStringStyle
-import com.google.maps.android.data.geojson.GeoJsonPolygonStyle
-import com.google.maps.android.data.kml.KmlLayer
+import com.google.maps.android.data.parser.geojson.GeoJsonParser
+import com.google.maps.android.data.parser.kml.KmlParser
+import com.google.maps.android.data.parser.kml.KmzParser
+import com.google.maps.android.data.renderer.UrlIconProvider
+import com.google.maps.android.data.renderer.mapper.toLayer
+import com.google.maps.android.data.renderer.mapview.MapViewRenderer
+import com.google.maps.android.data.renderer.model.DataLayer
+import com.google.maps.android.data.renderer.model.Feature
+import com.google.maps.android.data.renderer.model.Geometry
+import com.google.maps.android.data.renderer.model.LineString
+import com.google.maps.android.data.renderer.model.LineStyle
+import com.google.maps.android.data.renderer.model.MultiGeometry
+import com.google.maps.android.data.renderer.model.PolygonStyle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.jetbrains.compose.resources.stringResource
-import org.json.JSONObject
 import org.koin.compose.viewmodel.koinViewModel
 import org.meshtastic.app.map.component.ClusterItemsListDialog
 import org.meshtastic.app.map.component.CustomMapLayersSheet
@@ -159,11 +166,15 @@ import org.meshtastic.proto.BoundingBox
 import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
 import org.meshtastic.proto.Position
 import org.meshtastic.proto.Waypoint
+import java.io.BufferedInputStream
+import java.io.InputStream
 import kotlin.coroutines.resume
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.roundToInt
 import android.graphics.Color as AndroidColor
+import com.google.android.gms.maps.GoogleMap as GmsGoogleMap
+import com.google.maps.android.data.renderer.model.Polygon as ModelPolygon
 
 // region --- Map Mode ---
 
@@ -1297,110 +1308,160 @@ private fun offsetPolyline(
 @OptIn(MapsComposeExperimentalApi::class)
 @Composable
 private fun MapLayerOverlay(layerItem: MapLayerItem, mapViewModel: MapViewModel) {
-    val context = LocalContext.current
-    var currentLayer by remember { mutableStateOf<Layer?>(null) }
+    var currentLayer by remember { mutableStateOf<RenderedMapLayer?>(null) }
 
     MapEffect(layerItem.id, layerItem.refreshToken) { map ->
-        currentLayer?.safeRemoveLayerFromMap()
+        currentLayer?.safeHide()
         currentLayer = null
         val inputStream = mapViewModel.getInputStreamFromUri(layerItem) ?: return@MapEffect
         val layer =
             try {
-                when (layerItem.layerType) {
-                    // KmlLayer parses the stream in its constructor but doesn't close it — close it ourselves.
-                    LayerType.KML -> inputStream.use { KmlLayer(map, it, context) }
-
-                    LayerType.GEOJSON ->
-                        GeoJsonLayer(map, JSONObject(inputStream.bufferedReader().use { it.readText() })).also {
-                            it.applySimpleStyleSpec()
-                        }
+                val dataLayer = inputStream.use { stream -> parseMapLayer(layerItem.layerType, stream) }
+                if (dataLayer == null) {
+                    Logger.withTag("MapView").e { "Error loading map layer: ${layerItem.name} (unrecognized format)" }
+                    null
+                } else {
+                    RenderedMapLayer(map, dataLayer)
                 }
             } catch (e: Exception) {
                 Logger.withTag("MapView").e(e) { "Error loading map layer: ${layerItem.name}" }
                 null
             }
         layer?.let {
-            if (layerItem.isVisible) it.safeAddLayerToMap()
+            if (layerItem.isVisible) it.safeShow()
             currentLayer = it
         }
     }
 
     DisposableEffect(layerItem.id) {
         onDispose {
-            currentLayer?.safeRemoveLayerFromMap()
+            currentLayer?.safeHide()
             currentLayer = null
         }
     }
 
     LaunchedEffect(layerItem.isVisible) {
         val layer = currentLayer ?: return@LaunchedEffect
-        if (layerItem.isVisible) layer.safeAddLayerToMap() else layer.safeRemoveLayerFromMap()
+        if (layerItem.isVisible) layer.safeShow() else layer.safeHide()
     }
 }
 
-private fun Layer.safeRemoveLayerFromMap() {
-    try {
-        removeLayerFromMap()
-    } catch (e: Exception) {
-        Logger.withTag("MapView").e(e) { "Error removing map layer" }
-    }
-}
+/** Zip magic bytes; a [LayerType.KML] source starting with these is a KMZ archive rather than bare KML. */
+private val KMZ_MAGIC = byteArrayOf('P'.code.toByte(), 'K'.code.toByte())
 
-private fun Layer.safeAddLayerToMap() {
-    try {
-        // maps-utils 5.0.0 dropped isLayerOnMap() from the Layer base class; both concrete layers still expose it.
-        val isOnMap =
-            when (this) {
-                is GeoJsonLayer -> isLayerOnMap()
-                is KmlLayer -> isLayerOnMap()
-                else -> false
+/**
+ * Parse a custom overlay into the maps-utils platform-agnostic [DataLayer] model; null if the format is unrecognized.
+ */
+private fun parseMapLayer(layerType: LayerType, stream: InputStream): DataLayer? = when (layerType) {
+    LayerType.KML -> {
+        val buffered = BufferedInputStream(stream)
+        buffered.mark(KMZ_MAGIC.size)
+        val magic = ByteArray(KMZ_MAGIC.size)
+        val read = buffered.read(magic)
+        buffered.reset()
+        val kml =
+            if (read == KMZ_MAGIC.size && magic.contentEquals(KMZ_MAGIC)) {
+                KmzParser().parse(buffered)
+            } else {
+                KmlParser().parse(buffered)
             }
-        if (!isOnMap) addLayerToMap()
+        kml.toLayer()
+    }
+
+    LayerType.GEOJSON -> GeoJsonParser().parse(stream)?.toLayer()?.applySimpleStyleSpec()
+}
+
+/**
+ * A parsed custom overlay (KML/KMZ/GeoJSON) plus the machinery to draw it on the map.
+ *
+ * Each [show] creates a fresh single-use [MapViewRenderer] and [hide] tears it down with [MapViewRenderer.clear].
+ * Renderers are deliberately not reused: clear() cancels their icon-loading scope for good, and per-feature removal
+ * ([MapViewRenderer.removeFeature]) silently no-ops for MultiGeometry features (the renderer keys rendered map objects
+ * by internal per-geometry copies), so clear() is the only teardown that reliably takes everything off the map.
+ */
+private class RenderedMapLayer(private val map: GmsGoogleMap, private val dataLayer: DataLayer) {
+    private var renderer: MapViewRenderer? = null
+
+    /** Images extracted from a KMZ archive, keyed by archive path; the KML mapper stashes them in layer properties. */
+    private val localImages: Map<String, Bitmap>
+        @Suppress("UNCHECKED_CAST")
+        get() = dataLayer.properties["images"] as? Map<String, Bitmap> ?: emptyMap()
+
+    fun show() {
+        if (renderer != null) return
+        renderer =
+            MapViewRenderer(map, UrlIconProvider()).also { r ->
+                localImages.forEach { (path, bitmap) -> r.cacheImageData(path, bitmap) }
+                r.addLayer(dataLayer)
+            }
+    }
+
+    fun hide() {
+        renderer?.clear()
+        renderer = null
+    }
+}
+
+private fun RenderedMapLayer.safeShow() {
+    try {
+        show()
     } catch (e: Exception) {
         Logger.withTag("MapView").e(e) { "Error adding map layer" }
     }
 }
 
-/**
- * Apply simplestyle-spec (https://github.com/mapbox/simplestyle-spec) properties to a GeoJSON layer.
- *
- * Google's [GeoJsonLayer] otherwise applies one default style to every feature, so exports that carry per-feature
- * colors render unstyled. In particular, Meshtastic Site Planner coverage contours set `fill`/`stroke` (plus a legacy
- * `color`) and `fill-opacity`; read those and style each polygon/line so the coverage draws in its dBm colors instead
- * of the default black outline.
- */
-private fun GeoJsonLayer.applySimpleStyleSpec() {
-    for (feature in features) {
-        val fill = feature.cssColor("fill") ?: feature.cssColor("color")
-        val stroke = feature.cssColor("stroke") ?: feature.cssColor("color")
-        val fillOpacity = feature.getProperty("fill-opacity")?.toFloatOrNull()
-        val strokeWidth = feature.getProperty("stroke-width")?.toFloatOrNull() ?: DEFAULT_GEOJSON_STROKE_WIDTH
-        when (feature.getGeometry()?.getGeometryType()) {
-            "Polygon",
-            "MultiPolygon",
-            ->
-                feature.polygonStyle =
-                    GeoJsonPolygonStyle().apply {
-                        fill?.let { fillColor = it.resolveFillAlpha(fillOpacity) }
-                        stroke?.let { setStrokeColor(it) }
-                        setStrokeWidth(strokeWidth)
-                    }
-
-            "LineString",
-            "MultiLineString",
-            ->
-                feature.lineStringStyle =
-                    GeoJsonLineStringStyle().apply {
-                        stroke?.let { color = it }
-                        setWidth(strokeWidth)
-                    }
-
-            else -> Unit // Points keep the default marker.
-        }
+private fun RenderedMapLayer.safeHide() {
+    try {
+        hide()
+    } catch (e: Exception) {
+        Logger.withTag("MapView").e(e) { "Error removing map layer" }
     }
 }
 
-private fun GeoJsonFeature.cssColor(key: String): Int? = getProperty(key)?.let { parseCssColor(it) }
+/**
+ * Apply simplestyle-spec (https://github.com/mapbox/simplestyle-spec) properties to a parsed GeoJSON layer.
+ *
+ * The maps-utils GeoJSON mapper reads `fill`/`stroke`/`stroke-width`/`fill-opacity` itself, but misses several things
+ * this app relies on for Meshtastic Site Planner coverage exports: the legacy `color` fallback, `rgb()`/`rgba()`
+ * colors, a default fill opacity so stacked contour bands read as a gradient, and polygon styling for MultiPolygon
+ * features (the mapper styles any multi-geometry as a line). Rebuild each feature's style from its properties so the
+ * coverage draws in its dBm colors instead of the default black outline.
+ */
+private fun DataLayer.applySimpleStyleSpec(): DataLayer = copy(features = features.map { it.applySimpleStyleSpec() })
+
+private fun Feature.applySimpleStyleSpec(): Feature {
+    val fill = cssColor("fill") ?: cssColor("color")
+    val stroke = cssColor("stroke") ?: cssColor("color")
+    val fillOpacity = stringProperty("fill-opacity")?.toFloatOrNull()
+    val strokeWidth = stringProperty("stroke-width")?.toFloatOrNull() ?: DEFAULT_GEOJSON_STROKE_WIDTH
+    return when {
+        geometry.isPolygonal() ->
+            copy(
+                style =
+                PolygonStyle(
+                    fillColor = fill?.resolveFillAlpha(fillOpacity) ?: AndroidColor.TRANSPARENT,
+                    strokeColor = stroke ?: AndroidColor.BLACK,
+                    strokeWidth = strokeWidth,
+                ),
+            )
+
+        geometry.isLinear() -> copy(style = LineStyle(color = stroke ?: AndroidColor.BLACK, width = strokeWidth))
+
+        else -> this // Points keep the default marker; mixed geometry collections keep the mapper's style.
+    }
+}
+
+/** Polygon or MultiPolygon (a multi-geometry whose members are all polygons). */
+private fun Geometry.isPolygonal(): Boolean =
+    this is ModelPolygon || (this is MultiGeometry && geometries.isNotEmpty() && geometries.all { it is ModelPolygon })
+
+/** LineString or MultiLineString (a multi-geometry whose members are all line strings). */
+private fun Geometry.isLinear(): Boolean =
+    this is LineString || (this is MultiGeometry && geometries.isNotEmpty() && geometries.all { it is LineString })
+
+private fun Feature.stringProperty(key: String): String? = properties[key] as? String
+
+private fun Feature.cssColor(key: String): Int? = stringProperty(key)?.let { parseCssColor(it) }
 
 /**
  * Resolve a polygon fill's alpha: `fill-opacity` wins when present; otherwise keep any alpha the color already carries

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -106,8 +106,10 @@ import com.google.maps.android.data.renderer.model.LineStyle
 import com.google.maps.android.data.renderer.model.MultiGeometry
 import com.google.maps.android.data.renderer.model.PolygonStyle
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.meshtastic.app.map.component.ClusterItemsListDialog
@@ -1316,7 +1318,10 @@ private fun MapLayerOverlay(layerItem: MapLayerItem, mapViewModel: MapViewModel)
         val inputStream = mapViewModel.getInputStreamFromUri(layerItem) ?: return@MapEffect
         val layer =
             try {
-                val dataLayer = inputStream.use { stream -> parseMapLayer(layerItem.layerType, stream) }
+                val dataLayer =
+                    withContext(Dispatchers.IO) {
+                        inputStream.use { stream -> parseMapLayer(layerItem.layerType, stream) }
+                    }
                 if (dataLayer == null) {
                     Logger.withTag("MapView").e { "Error loading map layer: ${layerItem.name} (unrecognized format)" }
                     null
@@ -1421,18 +1426,22 @@ private fun RenderedMapLayer.safeHide() {
 /**
  * Apply simplestyle-spec (https://github.com/mapbox/simplestyle-spec) properties to a parsed GeoJSON layer.
  *
- * The maps-utils GeoJSON mapper reads `fill`/`stroke`/`stroke-width`/`fill-opacity` itself, but misses several things
- * this app relies on for Meshtastic Site Planner coverage exports: the legacy `color` fallback, `rgb()`/`rgba()`
- * colors, a default fill opacity so stacked contour bands read as a gradient, and polygon styling for MultiPolygon
- * features (the mapper styles any multi-geometry as a line). Rebuild each feature's style from its properties so the
- * coverage draws in its dBm colors instead of the default black outline.
+ * The maps-utils GeoJSON mapper reads `fill`/`stroke`/`stroke-width`/`fill-opacity`/`stroke-opacity` itself, but misses
+ * several things this app relies on for Meshtastic Site Planner coverage exports: the legacy `color` fallback,
+ * `rgb()`/`rgba()` colors, a default fill opacity so stacked contour bands read as a gradient, and polygon styling for
+ * MultiPolygon features (the mapper styles any multi-geometry as a line). Rebuild each feature's style from its
+ * properties so the coverage draws in its dBm colors instead of the default black outline.
  */
 private fun DataLayer.applySimpleStyleSpec(): DataLayer = copy(features = features.map { it.applySimpleStyleSpec() })
 
 private fun Feature.applySimpleStyleSpec(): Feature {
     val fill = cssColor("fill") ?: cssColor("color")
-    val stroke = cssColor("stroke") ?: cssColor("color")
     val fillOpacity = stringProperty("fill-opacity")?.toFloatOrNull()
+    val strokeOpacity = stringProperty("stroke-opacity")?.toFloatOrNull()
+    val stroke =
+        (cssColor("stroke") ?: cssColor("color"))?.let {
+            if (strokeOpacity != null) it.withAlpha(strokeOpacity) else it
+        }
     val strokeWidth = stringProperty("stroke-width")?.toFloatOrNull() ?: DEFAULT_GEOJSON_STROKE_WIDTH
     return when {
         geometry.isPolygonal() ->


### PR DESCRIPTION
Follow-up to #6301. That bump pulled android-maps-utils 5.0.0, which deprecated the entire `com.google.maps.android.data` KML/GeoJSON stack ("Use the new platform-agnostic data layer and renderer instead"). The catch: in 5.0.0 the deprecated classes are no longer the battle-tested 4.x implementations — they are thin bridges over the new pipeline, and the bridges break this feature at runtime. This PR moves the google-flavor custom map overlays (Map Layers) directly onto the new public pipeline, which both clears the deprecation and fixes the regressions the bridges would ship.

### 🐛 Bug Fixes (regressions in the 5.0.0 legacy bridges, avoided by migrating)
- GeoJSON/KML point features rendered **invisible**: the bridges map them to `PointStyle(color = 0)`, which the renderer turns into marker alpha 0.
- Per-feature **MultiPolygon styles silently dropped** at render time — Meshtastic Site Planner coverage contours would lose their dBm colors and draw as default black outlines.
- **Layer visibility toggling leaked MultiGeometry objects**: `MapViewRenderer.removeFeature` keys rendered map objects by internal per-geometry copies in an `IdentityHashMap`, so removal no-ops and re-showing duplicates the geometry.

### 🛠️ Refactoring & Architecture
- `MapLayerOverlay` now parses via the new `GeoJsonParser` / `KmlParser` / `KmzParser` (zip magic sniffed — `LayerType.KML` covers both `.kml` and `.kmz`) and maps into the immutable `DataLayer` model via `toLayer()`.
- `applySimpleStyleSpec` is reimplemented as a pass over the model features, preserving everything the upstream mapper misses: the legacy `color` fallback, `rgb()`/`rgba()` colors, the 0.35 default fill opacity that lets stacked contour bands read as a gradient, and `PolygonStyle` for MultiPolygon (upstream styles any multi-geometry as a line).
- Rendering goes through a **single-use `MapViewRenderer` per show**, torn down with `clear()` — the only teardown that reliably removes MultiGeometry objects — re-wiring KMZ archive images via `cacheImageData` on each show.
- Zero `@Deprecated` maps-utils usages remain in the map code.

Behavior preserved: KML/KMZ/GeoJSON custom layers, per-feature simplestyle colors for Site Planner coverage exports, layer visibility toggling, refresh re-parse, points keep the default marker.

The three bridge/renderer bugs above are candidates for upstream reports against googlemaps/android-maps-utils.

### Testing Performed
- `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — green.
- `:androidApp:compileGoogleDebugKotlin` — no deprecation warnings remain in map code.
- Draft until a device pass: loading a Site Planner coverage GeoJSON (per-band colors + opacity), a KMZ with icon images, and visibility toggle/refresh of each layer type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced map-layer support for KML, KMZ, and GeoJSON, with smoother activation/deactivation of layers.
  * Updated styling for rendered map features, including improved handling of fill, stroke, transparency, and line widths.
* **Improvements**
  * More robust color parsing (hex, named colors, and rgb/rgba) to produce consistent visual results and safer fallbacks when styles can’t be interpreted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->