### PR TITLE
Remove Ukraine 868MHz region code

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ChannelOption.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ChannelOption.kt
@@ -209,13 +209,6 @@ enum class RegionInfo(
     UA_433(RegionCode.UA_433, "Ukraine 433MHz", 433.0f, 434.7f),
 
     /**
-     * Ukraine 868MHz 868,0-868,6 Mhz 25 mW
-     *
-     * @see [NKZRZI](https://nkrzi.gov.ua/images/upload/256/5810/PDF_UUZ_19_01_2016.pdf)
-     */
-    UA_868(RegionCode.UA_868, "Ukraine 868MHz", 868.0f, 868.6f),
-
-    /**
      * Malaysia 433MHz 433 - 435 MHz at 100mW, no restrictions.
      *
      * @see [MCMC](https://www.mcmc.gov.my/skmmgovmy/media/General/pdf/Short-Range-Devices-Specification.pdf)


### PR DESCRIPTION
Ukrainian legislation[1] was harmonised with the EU's, and UA_868 is now obsolete as it is identical to the EU_868, so it was removed from the firmware.[2]

[1] http://zakon.rada.gov.ua/laws/show/262-2026-%D0%BF
[2] https://github.com/meshtastic/firmware/pull/10994

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unavailable Ukraine 868 MHz regional channel option.
  * Updated the regional channel list to prevent selection of the unsupported frequency range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->