### PR TITLE
fix: preserve add mode in legacy channel URLs

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
@@ -57,12 +57,15 @@ fun CommonUri.toChannelSet(): ChannelSet {
     val fragmentBytes =
         fragmentBase64.decodeBase64() ?: throw MalformedMeshtasticUrlException("Invalid Base64 in URL fragment")
     val url = ChannelSet.ADAPTER.decode(fragmentBytes)
-    val shouldAdd =
-        fragment?.substringAfter('?', "")?.takeUnless { it.isBlank() }?.equals("add=true")
-            ?: getBooleanQueryParameter("add", false)
+    val shouldAdd = fragment?.substringAfter('?', "")?.addParameter() ?: getBooleanQueryParameter("add", false)
 
     return if (shouldAdd) url.copy(lora_config = null) else url
 }
+
+private fun String.addParameter(): Boolean? = split('&')
+    .firstOrNull { it.substringBefore('=').equals("add", ignoreCase = true) }
+    ?.substringAfter('=', missingDelimiterValue = "true")
+    ?.equals("true", ignoreCase = true)
 
 /** @return A list of globally unique channel IDs usable with MQTT subscribe() */
 val ChannelSet.subscribeList: List<String>

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/ChannelSetUrlTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/ChannelSetUrlTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model.util
+
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.common.util.CommonUri
+import org.meshtastic.proto.ChannelSet
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config.LoRaConfig
+import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
+import org.meshtastic.proto.Config.LoRaConfig.RegionCode
+import org.meshtastic.proto.ModuleSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class ChannelSetUrlTest {
+
+    @Test
+    fun `legacy fragment add parameter remains add mode alongside other parameters`() {
+        val channelSet = CommonUri.parse("$REPLACE_CHANNEL_URL?source=ios&add=true").toChannelSet()
+
+        assertEquals("Custom", channelSet.primaryChannel?.name)
+        assertFalse(channelSet.hasLoraConfig())
+    }
+
+    @Test
+    fun `all supported channel counts preserve settings for replace and add`() {
+        for (channelCount in 1..8) {
+            val original = channelSet(channelCount)
+            val replace = original.getChannelUrl().toChannelSet()
+            val add = original.getChannelUrl(shouldAdd = true).toChannelSet()
+
+            assertEquals(original.settings, replace.settings, "$channelCount-channel replace settings")
+            assertEquals(original.lora_config, replace.lora_config, "$channelCount-channel replace LoRa config")
+            assertEquals(original.settings, add.settings, "$channelCount-channel add settings")
+            assertNull(add.lora_config, "$channelCount-channel add must not retune")
+        }
+    }
+
+    private fun channelSet(channelCount: Int): ChannelSet = ChannelSet(
+        settings =
+        (0 until channelCount).map { index ->
+            ChannelSettings(
+                name = "Conference-$index",
+                psk = byteArrayOf(index.toByte(), (index + 16).toByte()).toByteString(),
+                module_settings = ModuleSettings(position_precision = index),
+            )
+        },
+        lora_config =
+        LoRaConfig(
+            use_preset = true,
+            modem_preset = ModemPreset.LONG_FAST,
+            region = RegionCode.US,
+            hop_limit = 5,
+            channel_num = 13,
+            tx_enabled = true,
+        ),
+    )
+
+    private companion object {
+        const val REPLACE_CHANNEL_URL = "https://meshtastic.org/e/#CgMSAQESBggBQANIAQ"
+    }
+}


### PR DESCRIPTION
## Summary
- parse legacy fragment query parameters by key, so `?source=ios&add=true` remains add mode
- preserve channel settings while stripping LoRa configuration for add imports
- cover all one-to-eight channel import sizes and legacy fragment URLs

Split from #6319 at maintainer request; this contains only the channel URL parser fix.

## Testing
- `:core:model:jvmTest`
- `:core:model:spotlessCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel-set URL parsing to support multiple fragment parameters.
  * Recognized `add` flags with omitted values and case-insensitive values.
  * Preserved add-mode behavior without changing LoRa configuration.

* **Tests**
  * Added coverage for legacy URLs with additional parameters.
  * Verified channel settings and configuration are preserved across supported channel counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->