### PR TITLE
fix: make NotificationManager.dispatch await the platform send

### DIFF
--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NotificationManager.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NotificationManager.kt
@@ -24,8 +24,12 @@ package org.meshtastic.core.repository
  * [MeshNotificationManager], which composes over this dispatcher.
  */
 interface NotificationManager {
-    /** Returns true only when the platform accepted the notification for delivery. */
-    fun dispatch(notification: Notification): Boolean
+    /**
+     * Returns true only when the platform accepted the notification for delivery. Suspends until the platform resolves
+     * the send, so the result reflects the actual outcome rather than an optimistic guess (desktop native senders shell
+     * out to OS tools and complete asynchronously).
+     */
+    suspend fun dispatch(notification: Notification): Boolean
 
     fun cancel(id: Int)
 

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidNotificationManagerTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidNotificationManagerTest.kt
@@ -21,6 +21,7 @@ import android.app.NotificationManager
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -66,7 +67,7 @@ class AndroidNotificationManagerTest {
     }
 
     @Test
-    fun `dispatch removes legacy node channel and creates canonical node channel`() {
+    fun `dispatch removes legacy node channel and creates canonical node channel`() = runTest {
         createChannel("NodeEvent")
 
         val manager = AndroidNotificationManager(context)
@@ -77,7 +78,7 @@ class AndroidNotificationManagerTest {
     }
 
     @Test
-    fun `dispatch routes node event notifications to canonical new nodes channel`() {
+    fun `dispatch routes node event notifications to canonical new nodes channel`() = runTest {
         val manager = AndroidNotificationManager(context)
 
         manager.dispatch(Notification(title = "Node", message = "Seen", category = Notification.Category.NodeEvent))
@@ -87,7 +88,7 @@ class AndroidNotificationManagerTest {
     }
 
     @Test
-    fun `dispatch reports false when its notification channel is disabled`() {
+    fun `dispatch reports false when its notification channel is disabled`() = runTest {
         createChannel(NotificationChannels.NEW_NODES, NotificationManager.IMPORTANCE_NONE)
         val manager = AndroidNotificationManager(context)
 
@@ -120,7 +121,7 @@ class AndroidNotificationManagerTest {
     }
 
     @Test
-    fun `dispatch routes all categories to canonical channels`() {
+    fun `dispatch routes all categories to canonical channels`() = runTest {
         val manager = AndroidNotificationManager(context)
 
         assertDispatchesToChannel(manager, Notification.Category.Message, NotificationChannels.MESSAGES)
@@ -131,7 +132,7 @@ class AndroidNotificationManagerTest {
     }
 
     @Test
-    fun `dispatch attaches deep-link PendingIntent when deepLinkUri is set`() {
+    fun `dispatch attaches deep-link PendingIntent when deepLinkUri is set`() = runTest {
         registerStubMainActivity()
         val manager = AndroidNotificationManager(context)
         val deepLink = "meshtastic://meshtastic/nodes/1234"
@@ -157,7 +158,7 @@ class AndroidNotificationManagerTest {
     }
 
     @Test
-    fun `dispatch leaves contentIntent unset when deepLinkUri is null`() {
+    fun `dispatch leaves contentIntent unset when deepLinkUri is null`() = runTest {
         val manager = AndroidNotificationManager(context)
 
         manager.dispatch(Notification(title = "Plain", message = "No tap", category = Notification.Category.NodeEvent))
@@ -167,7 +168,7 @@ class AndroidNotificationManagerTest {
     }
 
     @Test
-    fun `dispatch uses provided notification id as system id`() {
+    fun `dispatch uses provided notification id as system id`() = runTest {
         val manager = AndroidNotificationManager(context)
         val explicitId = 4242
 
@@ -186,7 +187,7 @@ class AndroidNotificationManagerTest {
         assertEquals(0, shadowOf(systemNotificationManager).allNotifications.size)
     }
 
-    private fun assertDispatchesToChannel(
+    private suspend fun assertDispatchesToChannel(
         manager: AndroidNotificationManager,
         category: Notification.Category,
         expectedChannelId: String,

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidNotificationManager.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidNotificationManager.kt
@@ -119,7 +119,7 @@ class AndroidNotificationManager(private val context: Context) : NotificationMan
             ChannelConfig(id = NotificationChannels.SERVICE, importance = SystemNotificationManager.IMPORTANCE_MIN)
     }
 
-    override fun dispatch(notification: Notification): Boolean {
+    override suspend fun dispatch(notification: Notification): Boolean {
         ensureChannelsInitialized()
         val channelId = notification.category.channelConfig().id
         if (!canPostNotifications(channelId)) return false

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
@@ -69,7 +69,7 @@ class ConnectionsViewModelTest {
     private var notificationsCanBeScheduled = true
     private val notificationManager =
         object : NotificationManager {
-            override fun dispatch(notification: Notification): Boolean {
+            override suspend fun dispatch(notification: Notification): Boolean {
                 if (notificationsCanBeScheduled) dispatchedNotifications += notification
                 return notificationsCanBeScheduled
             }

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/DesktopNotificationManager.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/DesktopNotificationManager.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.desktop
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -58,7 +59,7 @@ class DesktopNotificationManager(
      */
     val fallbackNotifications: SharedFlow<ComposeNotification> = _fallbackNotifications.asSharedFlow()
 
-    @Suppress("InjectDispatcher")
+    @Suppress("InjectDispatcher", "TooGenericExceptionCaught")
     override suspend fun dispatch(notification: Notification): Boolean {
         val enabled =
             when (notification.category) {
@@ -74,7 +75,17 @@ class DesktopNotificationManager(
         if (!enabled) return false
 
         return withContext(Dispatchers.IO) {
-            val success = nativeSender.send(notification)
+            val success =
+                try {
+                    nativeSender.send(notification)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Native senders shell out to OS tools / JNA; guard against any unexpected throw so fire-and-forget
+                    // callers still get the tray fallback instead of silently swallowing the failure.
+                    Logger.e(e) { "Native notification send threw: ${notification.title}" }
+                    false
+                }
             if (success) {
                 true
             } else {

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/DesktopNotificationManager.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/DesktopNotificationManager.kt
@@ -17,13 +17,11 @@
 package org.meshtastic.desktop
 
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.NotificationPrefs
@@ -37,7 +35,8 @@ import androidx.compose.ui.window.Notification as ComposeNotification
  * macOS, PowerShell toast on Windows) for proper native look-and-feel. Falls back to Compose Desktop tray notifications
  * (via [fallbackNotifications]) when the native sender is unavailable or fails.
  *
- * All native sends are dispatched on a background scope to avoid blocking callers.
+ * Native sends run on [Dispatchers.IO] within the suspending [dispatch] call, so the returned Boolean reflects the
+ * resolved outcome (native success, or acceptance by the tray fallback) rather than an optimistic guess.
  *
  * Registered manually in `desktopPlatformStubsModule` -- do **not** add `@Single` to avoid double-registration with the
  * `@ComponentScan("org.meshtastic.desktop")` in [DesktopDiModule][org.meshtastic.desktop.di.DesktopDiModule].
@@ -46,9 +45,6 @@ class DesktopNotificationManager(
     private val prefs: NotificationPrefs,
     private val nativeSender: NativeNotificationSender,
 ) : NotificationManager {
-
-    @Suppress("InjectDispatcher")
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     init {
         Logger.i { "DesktopNotificationManager initialized (native sender: ${nativeSender::class.simpleName})" }
@@ -62,7 +58,8 @@ class DesktopNotificationManager(
      */
     val fallbackNotifications: SharedFlow<ComposeNotification> = _fallbackNotifications.asSharedFlow()
 
-    override fun dispatch(notification: Notification): Boolean {
+    @Suppress("InjectDispatcher")
+    override suspend fun dispatch(notification: Notification): Boolean {
         val enabled =
             when (notification.category) {
                 Notification.Category.Message -> prefs.messagesEnabled.value
@@ -76,17 +73,19 @@ class DesktopNotificationManager(
         Logger.d { "DesktopNotificationManager dispatch: category=${notification.category}, enabled=$enabled" }
         if (!enabled) return false
 
-        scope.launch {
+        return withContext(Dispatchers.IO) {
             val success = nativeSender.send(notification)
-            if (!success) {
+            if (success) {
+                true
+            } else {
                 Logger.w { "Native notification failed, falling back to tray: ${notification.title}" }
                 emitFallback(notification)
             }
         }
-        return true
     }
 
-    private fun emitFallback(notification: Notification) {
+    /** Returns true when the tray fallback accepted the notification. */
+    private fun emitFallback(notification: Notification): Boolean {
         val composeType =
             when (notification.type) {
                 Notification.Type.None -> ComposeNotification.Type.None
@@ -94,7 +93,9 @@ class DesktopNotificationManager(
                 Notification.Type.Warning -> ComposeNotification.Type.Warning
                 Notification.Type.Error -> ComposeNotification.Type.Error
             }
-        _fallbackNotifications.tryEmit(ComposeNotification(notification.title, notification.message, composeType))
+        return _fallbackNotifications.tryEmit(
+            ComposeNotification(notification.title, notification.message, composeType),
+        )
     }
 
     override fun cancel(id: Int) {

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/DesktopMeshNotificationManager.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/DesktopMeshNotificationManager.kt
@@ -46,13 +46,20 @@ import org.meshtastic.proto.Telemetry
  * `@ComponentScan("org.meshtastic.desktop")` in [DesktopDiModule][org.meshtastic.desktop.di.DesktopDiModule].
  */
 @Suppress("TooManyFunctions")
-class DesktopMeshNotificationManager(private val notificationManager: NotificationManager) : MeshNotificationManager {
+class DesktopMeshNotificationManager(
+    private val notificationManager: NotificationManager,
+    // Bridges the non-suspend MeshNotificationManager entry points to the suspending NotificationManager.dispatch.
+    // Injectable so tests can substitute a TestScope / TestDispatcher.
+    @Suppress("InjectDispatcher") private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+) : MeshNotificationManager {
 
     /**
-     * Bridges the non-suspend [MeshNotificationManager] entry points to the suspending [NotificationManager.dispatch].
+     * Launches [build] on [scope] and dispatches the resulting [Notification], bridging the non-suspend entry points to
+     * the suspending [NotificationManager.dispatch]. [build] runs inside the coroutine so it may call suspend resource
+     * getters (e.g. [getString]).
      */
-    @Suppress("InjectDispatcher")
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private fun dispatchAsync(build: suspend () -> Notification) =
+        scope.launch { notificationManager.dispatch(build()) }
 
     override fun clearNotifications() {
         notificationManager.cancelAll()
@@ -124,45 +131,39 @@ class DesktopMeshNotificationManager(private val notificationManager: Notificati
     }
 
     override fun showAlertNotification(contactKey: String, name: String, alert: String) {
-        val notification =
+        dispatchAsync {
             Notification(title = name, message = alert, category = Notification.Category.Alert, contactKey = contactKey)
-        scope.launch { notificationManager.dispatch(notification) }
+        }
     }
 
     override fun showNewNodeSeenNotification(node: Node) {
-        scope.launch {
-            notificationManager.dispatch(
-                Notification(
-                    title = getString(Res.string.new_node_seen, node.user.short_name),
-                    message = node.user.long_name,
-                    category = Notification.Category.NodeEvent,
-                ),
+        dispatchAsync {
+            Notification(
+                title = getString(Res.string.new_node_seen, node.user.short_name),
+                message = node.user.long_name,
+                category = Notification.Category.NodeEvent,
             )
         }
     }
 
     override fun showOrUpdateLowBatteryNotification(node: Node, isRemote: Boolean) {
-        scope.launch {
-            notificationManager.dispatch(
-                Notification(
-                    title = getString(Res.string.low_battery_title, node.user.short_name),
-                    message = getString(Res.string.low_battery_message, node.user.long_name, node.batteryLevel ?: 0),
-                    category = Notification.Category.Battery,
-                    id = node.num,
-                ),
+        dispatchAsync {
+            Notification(
+                title = getString(Res.string.low_battery_title, node.user.short_name),
+                message = getString(Res.string.low_battery_message, node.user.long_name, node.batteryLevel ?: 0),
+                category = Notification.Category.Battery,
+                id = node.num,
             )
         }
     }
 
     override fun showClientNotification(clientNotification: ClientNotification) {
-        scope.launch {
-            notificationManager.dispatch(
-                Notification(
-                    title = getString(Res.string.desktop_notification_title),
-                    message = clientNotification.message,
-                    category = Notification.Category.Alert,
-                    id = clientNotification.toString().hashCode(),
-                ),
+        dispatchAsync {
+            Notification(
+                title = getString(Res.string.desktop_notification_title),
+                message = clientNotification.message,
+                category = Notification.Category.Alert,
+                id = clientNotification.toString().hashCode(),
             )
         }
     }

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/DesktopMeshNotificationManager.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/DesktopMeshNotificationManager.kt
@@ -16,6 +16,10 @@
  */
 package org.meshtastic.desktop.notification
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.repository.MeshNotificationManager
@@ -43,6 +47,13 @@ import org.meshtastic.proto.Telemetry
  */
 @Suppress("TooManyFunctions")
 class DesktopMeshNotificationManager(private val notificationManager: NotificationManager) : MeshNotificationManager {
+
+    /**
+     * Bridges the non-suspend [MeshNotificationManager] entry points to the suspending [NotificationManager.dispatch].
+     */
+    @Suppress("InjectDispatcher")
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override fun clearNotifications() {
         notificationManager.cancelAll()
     }
@@ -115,39 +126,45 @@ class DesktopMeshNotificationManager(private val notificationManager: Notificati
     override fun showAlertNotification(contactKey: String, name: String, alert: String) {
         val notification =
             Notification(title = name, message = alert, category = Notification.Category.Alert, contactKey = contactKey)
-        notificationManager.dispatch(notification)
+        scope.launch { notificationManager.dispatch(notification) }
     }
 
     override fun showNewNodeSeenNotification(node: Node) {
-        notificationManager.dispatch(
-            Notification(
-                title = getString(Res.string.new_node_seen, node.user.short_name),
-                message = node.user.long_name,
-                category = Notification.Category.NodeEvent,
-            ),
-        )
+        scope.launch {
+            notificationManager.dispatch(
+                Notification(
+                    title = getString(Res.string.new_node_seen, node.user.short_name),
+                    message = node.user.long_name,
+                    category = Notification.Category.NodeEvent,
+                ),
+            )
+        }
     }
 
     override fun showOrUpdateLowBatteryNotification(node: Node, isRemote: Boolean) {
-        notificationManager.dispatch(
-            Notification(
-                title = getString(Res.string.low_battery_title, node.user.short_name),
-                message = getString(Res.string.low_battery_message, node.user.long_name, node.batteryLevel ?: 0),
-                category = Notification.Category.Battery,
-                id = node.num,
-            ),
-        )
+        scope.launch {
+            notificationManager.dispatch(
+                Notification(
+                    title = getString(Res.string.low_battery_title, node.user.short_name),
+                    message = getString(Res.string.low_battery_message, node.user.long_name, node.batteryLevel ?: 0),
+                    category = Notification.Category.Battery,
+                    id = node.num,
+                ),
+            )
+        }
     }
 
     override fun showClientNotification(clientNotification: ClientNotification) {
-        notificationManager.dispatch(
-            Notification(
-                title = getString(Res.string.desktop_notification_title),
-                message = clientNotification.message,
-                category = Notification.Category.Alert,
-                id = clientNotification.toString().hashCode(),
-            ),
-        )
+        scope.launch {
+            notificationManager.dispatch(
+                Notification(
+                    title = getString(Res.string.desktop_notification_title),
+                    message = clientNotification.message,
+                    category = Notification.Category.Alert,
+                    id = clientNotification.toString().hashCode(),
+                ),
+            )
+        }
     }
 
     override fun cancelMessageNotification(contactKey: String) {

--- a/desktopApp/src/test/kotlin/org/meshtastic/desktop/notification/DesktopMeshNotificationManagerTest.kt
+++ b/desktopApp/src/test/kotlin/org/meshtastic/desktop/notification/DesktopMeshNotificationManagerTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.desktop.notification
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.meshtastic.core.repository.Notification
+import org.meshtastic.core.repository.NotificationManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DesktopMeshNotificationManagerTest {
+
+    /** Records everything dispatched so the async bridge can be asserted deterministically. */
+    private class FakeNotificationManager : NotificationManager {
+        val dispatched = mutableListOf<Notification>()
+
+        override suspend fun dispatch(notification: Notification): Boolean {
+            dispatched.add(notification)
+            return true
+        }
+
+        override fun cancel(id: Int) {}
+
+        override fun cancelAll() {}
+    }
+
+    @Test
+    fun `showAlertNotification dispatches on the injected scope`() {
+        val notificationManager = FakeNotificationManager()
+        // UnconfinedTestDispatcher runs the launched dispatch eagerly, so the fire-and-forget bridge is observable
+        // synchronously — no virtual-time advance needed.
+        val scope = CoroutineScope(UnconfinedTestDispatcher())
+        val manager = DesktopMeshNotificationManager(notificationManager, scope = scope)
+
+        manager.showAlertNotification(contactKey = "contact-1", name = "Alert", alert = "Something happened")
+
+        val dispatched = notificationManager.dispatched.single()
+        assertEquals("Alert", dispatched.title)
+        assertEquals("Something happened", dispatched.message)
+        assertEquals(Notification.Category.Alert, dispatched.category)
+        assertEquals("contact-1", dispatched.contactKey)
+
+        scope.cancel()
+    }
+}

--- a/desktopApp/src/test/kotlin/org/meshtastic/desktop/notification/DesktopMeshNotificationManagerTest.kt
+++ b/desktopApp/src/test/kotlin/org/meshtastic/desktop/notification/DesktopMeshNotificationManagerTest.kt
@@ -16,10 +16,9 @@
  */
 package org.meshtastic.desktop.notification
 
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
 import kotlin.test.Test
@@ -43,12 +42,11 @@ class DesktopMeshNotificationManagerTest {
     }
 
     @Test
-    fun `showAlertNotification dispatches on the injected scope`() {
+    fun `showAlertNotification dispatches on the injected scope`() = runTest(UnconfinedTestDispatcher()) {
         val notificationManager = FakeNotificationManager()
-        // UnconfinedTestDispatcher runs the launched dispatch eagerly, so the fire-and-forget bridge is observable
-        // synchronously — no virtual-time advance needed.
-        val scope = CoroutineScope(UnconfinedTestDispatcher())
-        val manager = DesktopMeshNotificationManager(notificationManager, scope = scope)
+        // backgroundScope inherits the UnconfinedTestDispatcher, so the launched dispatch runs eagerly and is
+        // observable synchronously — no virtual-time advance or manual teardown needed.
+        val manager = DesktopMeshNotificationManager(notificationManager, scope = backgroundScope)
 
         manager.showAlertNotification(contactKey = "contact-1", name = "Alert", alert = "Something happened")
 
@@ -57,7 +55,5 @@ class DesktopMeshNotificationManagerTest {
         assertEquals("Something happened", dispatched.message)
         assertEquals(Notification.Category.Alert, dispatched.category)
         assertEquals("contact-1", dispatched.contactKey)
-
-        scope.cancel()
     }
 }

--- a/desktopApp/src/test/kotlin/org/meshtastic/desktop/notification/DesktopNotificationManagerTest.kt
+++ b/desktopApp/src/test/kotlin/org/meshtastic/desktop/notification/DesktopNotificationManagerTest.kt
@@ -16,18 +16,20 @@
  */
 package org.meshtastic.desktop.notification
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationPrefs
 import org.meshtastic.desktop.DesktopNotificationManager
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class DesktopNotificationManagerTest {
 
@@ -77,82 +79,72 @@ class DesktopNotificationManagerTest {
     }
 
     @Test
-    fun `dispatch sends to native sender when enabled`() {
+    fun `dispatch sends to native sender and reports success when enabled`() = runTest {
         val sender = FakeNativeSender()
         val manager = DesktopNotificationManager(FakeNotificationPrefs(), sender)
 
-        manager.dispatch(Notification(title = "Test", message = "Hello"))
+        val dispatched = manager.dispatch(Notification(title = "Test", message = "Hello"))
 
-        Thread.sleep(ASYNC_WAIT_MS)
+        assertTrue(dispatched)
         assertEquals(1, sender.sent.size)
         assertEquals("Test", sender.sent[0].title)
     }
 
     @Test
-    fun `dispatch respects disabled message preference`() {
+    fun `dispatch reports false and skips native sender when preference disabled`() = runTest {
         val sender = FakeNativeSender()
         val manager = DesktopNotificationManager(FakeNotificationPrefs(messages = false), sender)
 
-        manager.dispatch(Notification(title = "Msg", message = "Hi", category = Notification.Category.Message))
+        val dispatched =
+            manager.dispatch(Notification(title = "Msg", message = "Hi", category = Notification.Category.Message))
 
-        Thread.sleep(ASYNC_WAIT_MS)
+        assertFalse(dispatched)
         assertEquals(0, sender.sent.size, "Message notification should have been suppressed")
     }
 
     @Test
-    fun `alerts are always dispatched even when messages disabled`() {
+    fun `alerts are always dispatched even when messages disabled`() = runTest {
         val sender = FakeNativeSender()
         val manager = DesktopNotificationManager(FakeNotificationPrefs(messages = false), sender)
 
-        manager.dispatch(Notification(title = "Alert", message = "Important", category = Notification.Category.Alert))
+        val dispatched =
+            manager.dispatch(
+                Notification(title = "Alert", message = "Important", category = Notification.Category.Alert),
+            )
 
-        Thread.sleep(ASYNC_WAIT_MS)
+        assertTrue(dispatched)
         assertEquals(1, sender.sent.size)
     }
 
     @Test
-    fun `fallback emitted when native sender fails`() {
+    fun `fallback emitted and dispatch still reports accepted when native sender fails`() = runTest {
         val sender = FakeNativeSender(shouldSucceed = false)
         val manager = DesktopNotificationManager(FakeNotificationPrefs(), sender)
         var fallback: androidx.compose.ui.window.Notification? = null
 
-        // Collect on a real thread since dispatch uses Dispatchers.IO
-        val job =
-            kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Default).launch {
-                fallback = manager.fallbackNotifications.first()
-            }
+        // UNDISPATCHED guarantees the collector subscribes before dispatch runs.
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { fallback = manager.fallbackNotifications.first() }
 
-        // Give the collector coroutine time to subscribe before dispatching
-        Thread.sleep(SUBSCRIBE_WAIT_MS)
-        manager.dispatch(Notification(title = "Fallback", message = "Test"))
+        val dispatched = manager.dispatch(Notification(title = "Fallback", message = "Test"))
+        collector.join()
 
-        // Block the test thread briefly to let the IO dispatcher process
-        Thread.sleep(ASYNC_WAIT_MS)
+        assertTrue(dispatched, "Tray fallback acceptance should count as delivery-accepted")
         assertNotNull(fallback, "Expected fallback notification to be emitted")
         assertEquals("Fallback", fallback!!.title)
-        job.cancel()
     }
 
     @Test
-    fun `no fallback when native sender succeeds`() {
+    fun `no fallback when native sender succeeds`() = runTest {
         val sender = FakeNativeSender(shouldSucceed = true)
         val manager = DesktopNotificationManager(FakeNotificationPrefs(), sender)
         var fallback: androidx.compose.ui.window.Notification? = null
 
-        val job =
-            kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Default).launch {
-                fallback = manager.fallbackNotifications.first()
-            }
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { fallback = manager.fallbackNotifications.first() }
 
-        manager.dispatch(Notification(title = "Success", message = "Test"))
+        val dispatched = manager.dispatch(Notification(title = "Success", message = "Test"))
 
-        Thread.sleep(ASYNC_WAIT_MS)
+        assertTrue(dispatched)
         assertNull(fallback, "Should not emit fallback when native sender succeeds")
-        job.cancel()
-    }
-
-    companion object {
-        private const val ASYNC_WAIT_MS = 300L
-        private const val SUBSCRIBE_WAIT_MS = 100L
+        collector.cancel()
     }
 }


### PR DESCRIPTION
Follow-up flagged in the [#6309 review](https://github.com/meshtastic/Meshtastic-Android/pull/6309#pullrequestreview-4731226187): `DesktopNotificationManager.dispatch` returned before the async send resolved.

`dispatch` launched the native send on a background scope and returned `true` immediately, so the interface contract ("returns true only when the platform accepted the notification for delivery") held on Android but not on desktop. Concretely, `ConnectionsViewModel` records a firmware-update notification key — permanently suppressing re-notification — whenever `dispatch` returns `true`, so a failed native send could mark a notice as delivered that the user never saw.

### Changes

- `NotificationManager.dispatch` is now a `suspend` function. Every existing call site already runs inside a coroutine, so no caller changed.
- `DesktopNotificationManager` runs the native sender on `Dispatchers.IO` within the call and returns the resolved outcome: native success, or acceptance by the tray fallback (`tryEmit` result) when the native sender fails. The internal launch scope is gone.
- `AndroidNotificationManager` only gains the `suspend` modifier; its body was already synchronous and truthful.
- `DesktopMeshNotificationManager` bridges its non-suspend entry points (`showAlertNotification`, `showNewNodeSeenNotification`, `showOrUpdateLowBatteryNotification`, `showClientNotification`) with a scope, preserving the previous fire-and-forget behavior for callers that ignore the result.
- `DesktopNotificationManagerTest` drops the `Thread.sleep` synchronization for `runTest` and now asserts `dispatch` return values directly; `AndroidNotificationManagerTest` and `ConnectionsViewModelTest` updated for the suspend signature.

### Verification

`./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Notification delivery result now reflects the actual send outcome, with the dispatch flow updated to support waiting for completion.
  - Desktop notifications now resolve success/failure only after native sending completes (or after tray fallback accepts the notification).
  - Notifications that don’t require an immediate result remain non-blocking to keep the app responsive.
- **Bug Fixes**
  - More reliable desktop fallback behavior when native delivery fails, with more accurate success/failure reporting.
- **Tests**
  - Updated desktop and UI tests to use coroutine test utilities for deterministic assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->