### PR TITLE
fix: keep cached data flowing when api.meshtastic.org is down

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/DeviceHardwareRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/DeviceHardwareRepositoryImpl.kt
@@ -17,15 +17,8 @@
 package org.meshtastic.core.data.repository
 
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.nowMillis
@@ -33,6 +26,7 @@ import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.data.datasource.BundledAssetReader
 import org.meshtastic.core.data.datasource.DeviceHardwareLocalDataSource
 import org.meshtastic.core.data.datasource.decode
+import org.meshtastic.core.data.util.SingleFlightRefresher
 import org.meshtastic.core.data.util.staleWhileRevalidateFlow
 import org.meshtastic.core.database.entity.DeviceHardwareEntity
 import org.meshtastic.core.database.entity.asExternalModel
@@ -56,15 +50,18 @@ class DeviceHardwareRepositoryImpl(
     private val dispatchers: CoroutineDispatchers,
 ) : DeviceHardwareRepository {
 
-    /** Guards [inFlightRefresh] so concurrent callers share one full-table refresh. */
-    private val refreshGuard = Mutex()
-
-    private var inFlightRefresh: Deferred<Unit>? = null
-
-    // This @Single lives for the entire app lifetime, so the SupervisorJob is never cancelled. Refreshes run here
-    // so a caller that stops waiting (the node-details path bounds its wait) can't abort the shared fetch — slow
-    // api.meshtastic.org responses (measured 20-60s) still land in the DB for the next lookup.
-    private val refreshScope = CoroutineScope(dispatchers.io + SupervisorJob())
+    /**
+     * Shared full-table refresh; a caller that stops waiting (the node-details path bounds its wait) can't abort it.
+     */
+    private val refresher =
+        SingleFlightRefresher(dispatchers.io, "DeviceHardwareRepository") {
+            Logger.d { "DeviceHardwareRepository: fetching from remote API" }
+            val remoteHardware = remoteDataSource.getAllDeviceHardware()
+            Logger.d { "DeviceHardwareRepository: remote returned ${remoteHardware.size} entries" }
+            localDataSource.insertAllDeviceHardware(remoteHardware)
+            // Refresh msh.to device links from the API after a hardware refresh.
+            deviceLinkRepository.reconcile()
+        }
 
     /**
      * Retrieves device hardware information by its model ID and optional target string.
@@ -93,7 +90,7 @@ class DeviceHardwareRepositoryImpl(
 
         var entities = lookupEntities(hwModel, target)
         if (forceRefresh || entities.isEmpty() || entities.any { it.isStale() }) {
-            singleFlightRefresh(maxWaitMs = NETWORK_REFRESH_TIMEOUT_MS)
+            refresher.refresh(maxWaitMs = NETWORK_REFRESH_TIMEOUT_MS)
             entities = lookupEntities(hwModel, target)
         }
 
@@ -110,7 +107,7 @@ class DeviceHardwareRepositoryImpl(
             resolveHardware(hwModel, lookupEntities(hwModel, target), target)
         },
         shouldFetch = { cached -> cached == null || lookupEntities(hwModel, target).any { it.isStale() } },
-        fetch = { singleFlightRefresh() },
+        fetch = { refresher.refresh() },
         context = dispatchers.io,
         networkTimeoutMs = null,
         tag = "DeviceHardwareRepository",
@@ -132,39 +129,6 @@ class DeviceHardwareRepositoryImpl(
                 localDataSource.insertAllDeviceHardware(jsonHardware)
             }
                 .onFailure { e -> Logger.w(e) { "DeviceHardwareRepository: failed to seed cache from bundled JSON" } }
-        }
-    }
-
-    /**
-     * Starts (or joins) a single shared refresh running in [refreshScope]. When [maxWaitMs] is set, the caller waits at
-     * most that long before falling back to cached data; the refresh itself always runs to completion, bounded only by
-     * the HttpClient's own timeout/retry policy.
-     */
-    private suspend fun singleFlightRefresh(maxWaitMs: Long? = null) {
-        val refresh =
-            refreshGuard.withLock {
-                inFlightRefresh?.takeIf { it.isActive }
-                    ?: refreshScope
-                        .async {
-                            safeCatching {
-                                Logger.d { "DeviceHardwareRepository: fetching from remote API" }
-                                val remoteHardware = remoteDataSource.getAllDeviceHardware()
-                                Logger.d {
-                                    "DeviceHardwareRepository: remote returned ${remoteHardware.size} entries"
-                                }
-                                localDataSource.insertAllDeviceHardware(remoteHardware)
-                                // Refresh msh.to device links from the API after a hardware refresh.
-                                deviceLinkRepository.reconcile()
-                            }
-                                .onFailure { e -> Logger.w(e) { "DeviceHardwareRepository: network refresh failed" } }
-                            Unit
-                        }
-                        .also { inFlightRefresh = it }
-            }
-        if (maxWaitMs == null) {
-            refresh.join()
-        } else if (withTimeoutOrNull(maxWaitMs) { refresh.join() } == null) {
-            Logger.w { "DeviceHardwareRepository: refresh still in flight after ${maxWaitMs}ms; using cached data" }
         }
     }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/DeviceLinkRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/DeviceLinkRepositoryImpl.kt
@@ -34,6 +34,7 @@ import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.data.datasource.BundledAssetReader
 import org.meshtastic.core.data.datasource.DeviceLinkLocalDataSource
 import org.meshtastic.core.data.datasource.decode
+import org.meshtastic.core.data.util.SingleFlightRefresher
 import org.meshtastic.core.database.entity.asEntity
 import org.meshtastic.core.database.entity.asExternalModel
 import org.meshtastic.core.di.CoroutineDispatchers
@@ -63,10 +64,13 @@ class DeviceLinkRepositoryImpl(
     /** Serializes seeding and network refreshes so concurrent collectors don't duplicate writes. */
     private val writeMutex = Mutex()
 
-    /** Single-flights stale-triggered refreshes so concurrent collectors don't start duplicate fetches. */
-    private val refreshMutex = Mutex()
-
     @Volatile private var lastRefreshMillis = 0L
+
+    /** Single-flights stale-triggered refreshes; the TTL is re-checked inside so late joiners don't re-fetch. */
+    private val staleRefresher =
+        SingleFlightRefresher(dispatchers.io, "DeviceLinkRepository") {
+            if (nowMillis - lastRefreshMillis > CACHE_EXPIRATION_TIME_MS) reconcile()
+        }
 
     override suspend fun ensureImported() {
         ensureSeeded()
@@ -134,10 +138,10 @@ class DeviceLinkRepositoryImpl(
         }
     }
 
-    /** Best-effort network refresh, gated by [CACHE_EXPIRATION_TIME_MS] and single-flighted via [refreshMutex]. */
+    /** Best-effort network refresh, gated by [CACHE_EXPIRATION_TIME_MS] and single-flighted via [staleRefresher]. */
     private suspend fun refreshIfStale() {
         if (nowMillis - lastRefreshMillis <= CACHE_EXPIRATION_TIME_MS) return
-        refreshMutex.withLock { if (nowMillis - lastRefreshMillis > CACHE_EXPIRATION_TIME_MS) reconcile() }
+        staleRefresher.refresh()
     }
 
     /**

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/EventFirmwareRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/EventFirmwareRepositoryImpl.kt
@@ -17,14 +17,9 @@
 package org.meshtastic.core.data.repository
 
 import co.touchlab.kermit.Logger
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.nowMillis
@@ -32,6 +27,7 @@ import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.data.datasource.BundledAssetReader
 import org.meshtastic.core.data.datasource.EventFirmwareEditionLocalDataSource
 import org.meshtastic.core.data.datasource.decode
+import org.meshtastic.core.data.util.SingleFlightRefresher
 import org.meshtastic.core.database.entity.asEntity
 import org.meshtastic.core.database.entity.asExternalModel
 import org.meshtastic.core.di.CoroutineDispatchers
@@ -69,22 +65,24 @@ class EventFirmwareRepositoryImpl(
     // longer active. The cooldown caps retries while offline without waiting the full CACHE_EXPIRATION_TIME_MS.
     @Volatile private var lastAttemptMillis = 0L
 
-    /** Guards [inFlightRefresh] so concurrent callers share one network fetch. */
-    private val refreshGuard = Mutex()
-
-    private var inFlightRefresh: Deferred<Unit>? = null
-
-    // This @Single lives for the entire app lifetime, so the SupervisorJob is never cancelled. The refresh runs
-    // here so a caller that stops waiting can't abort the shared fetch — api.meshtastic.org has been measured
-    // taking 20-60s, and the fetch should still land in the DB for the next lookup.
-    private val refreshScope = CoroutineScope(dispatchers.io + SupervisorJob())
+    /** Shared refresh; a caller that stops waiting can't abort it, and the fetch still lands in the DB. */
+    private val refresher =
+        SingleFlightRefresher(dispatchers.io, "EventFirmwareRepository") {
+            lastAttemptMillis = nowMillis
+            val editions = remoteDataSource.getEventFirmware().editions
+            if (editions.isNotEmpty()) {
+                localDataSource.upsertAll(editions.map { it.asEntity() })
+                localDataSource.deleteNotIn(editions.map { it.edition })
+                lastRefreshMillis = nowMillis
+            }
+        }
 
     override suspend fun getEdition(editionName: String): EventFirmwareEdition? = withContext(dispatchers.io) {
         ensureSeeded()
         val stale = nowMillis - lastRefreshMillis > CACHE_EXPIRATION_TIME_MS
         val retryCooldownElapsed = nowMillis - lastAttemptMillis > REFRESH_RETRY_COOLDOWN_MS
         if (stale && retryCooldownElapsed) {
-            singleFlightRefresh(maxWaitMs = NETWORK_REFRESH_TIMEOUT_MS)
+            refresher.refresh(maxWaitMs = NETWORK_REFRESH_TIMEOUT_MS)
         }
         localDataSource.getByEdition(editionName)?.asExternalModel()
     }
@@ -100,36 +98,6 @@ class EventFirmwareRepositoryImpl(
                 }
                     .onFailure { e -> Logger.w(e) { "EventFirmwareRepository: failed to seed from bundled JSON" } }
             }
-        }
-    }
-
-    /**
-     * Starts (or joins) a single shared refresh running in [refreshScope]. The caller waits at most [maxWaitMs] before
-     * falling back to cached data; the refresh itself always runs to completion, bounded only by the HttpClient's own
-     * timeout/retry policy.
-     */
-    private suspend fun singleFlightRefresh(maxWaitMs: Long) {
-        val refresh =
-            refreshGuard.withLock {
-                inFlightRefresh?.takeIf { it.isActive }
-                    ?: refreshScope
-                        .async {
-                            lastAttemptMillis = nowMillis
-                            safeCatching {
-                                val editions = remoteDataSource.getEventFirmware().editions
-                                if (editions.isNotEmpty()) {
-                                    localDataSource.upsertAll(editions.map { it.asEntity() })
-                                    localDataSource.deleteNotIn(editions.map { it.edition })
-                                    lastRefreshMillis = nowMillis
-                                }
-                            }
-                                .onFailure { e -> Logger.w(e) { "EventFirmwareRepository: network refresh failed" } }
-                            Unit
-                        }
-                        .also { inFlightRefresh = it }
-            }
-        if (withTimeoutOrNull(maxWaitMs) { refresh.join() } == null) {
-            Logger.w { "EventFirmwareRepository: refresh still in flight after ${maxWaitMs}ms; using cached data" }
         }
     }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
@@ -27,6 +27,7 @@ import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.data.datasource.BundledAssetReader
 import org.meshtastic.core.data.datasource.FirmwareReleaseLocalDataSource
 import org.meshtastic.core.data.datasource.decode
+import org.meshtastic.core.data.util.SingleFlightRefresher
 import org.meshtastic.core.data.util.staleWhileRevalidateFlow
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.FirmwareReleaseEntity
@@ -52,8 +53,16 @@ open class FirmwareReleaseRepositoryImpl(
     private val dispatchers: CoroutineDispatchers,
 ) : FirmwareReleaseRepository {
 
-    /** Single-flight guard so concurrent collectors share one network refresh. */
-    private val refreshMutex = Mutex()
+    /** Serializes Room writes so the bundled-seed apply can't race a network refresh and regress fresher data. */
+    private val writeMutex = Mutex()
+
+    /** API release-list refresh shared by the stable and alpha flows (node detail collects both together). */
+    private val releaseRefresher =
+        SingleFlightRefresher(dispatchers.io, "FirmwareReleaseRepository") { fetchAndPersistReleases() }
+
+    /** Nightly lives on meshtastic.github.io, not in the API's release list, so it refreshes on its own flight. */
+    private val nightlyRefresher =
+        SingleFlightRefresher(dispatchers.io, "FirmwareReleaseRepository.nightly") { fetchAndPersistNightly() }
 
     /** Serializes target-manifest downloads and preserves successful results for the selected release URL. */
     private val manifestMutex = Mutex()
@@ -106,7 +115,13 @@ open class FirmwareReleaseRepositoryImpl(
         },
         // Nightly lives on meshtastic.github.io, not in the API's release list, so it refreshes on its own
         // path — regular (locked) users never hit the nightly URL because only unlocked UI collects that flow.
-        fetch = { if (releaseType == FirmwareReleaseType.NIGHTLY) refreshNightly() else singleFlightRefresh() },
+        fetch = {
+            if (releaseType == FirmwareReleaseType.NIGHTLY) {
+                nightlyRefresher.refresh()
+            } else {
+                releaseRefresher.refresh()
+            }
+        },
         context = dispatchers.default,
         // No collector blocks on the fetch (cache is emitted first), so let the HttpClient's own
         // timeout/retry policy bound it — api.meshtastic.org routinely takes 20-60s to serve this list,
@@ -143,8 +158,8 @@ open class FirmwareReleaseRepositoryImpl(
         if (bundleDecodeFailed) return // don't retry the bundled asset on every collection once it has failed
 
         // seedMutex guards only the decode + snapshot cache; the DB apply runs outside it (so concurrent
-        // collectors don't block on a Room write or on refreshMutex) and under refreshMutex (so it can't
-        // race singleFlightRefresh and overwrite fresher data that just arrived from the API).
+        // collectors don't block on a Room write or on writeMutex) and under writeMutex (so it can't
+        // race a network refresh and overwrite fresher data that just arrived from the API).
         val bundled =
             seedMutex.withLock {
                 // Decode the bundled JSON once per process; the asset never changes between launches.
@@ -165,7 +180,7 @@ open class FirmwareReleaseRepositoryImpl(
             } ?: return
 
         safeCatching {
-            refreshMutex.withLock {
+            writeMutex.withLock {
                 val toApply =
                     listOf(FirmwareReleaseType.STABLE to bundled.stable, FirmwareReleaseType.ALPHA to bundled.alpha)
                         .filter { (type, releases) -> isBundleNewerFor(type, releases) }
@@ -186,14 +201,14 @@ open class FirmwareReleaseRepositoryImpl(
         return cachedNewest == null || bundledNewest > cachedNewest
     }
 
-    private suspend fun singleFlightRefresh() {
-        refreshMutex.withLock {
-            Logger.d { "FirmwareReleaseRepository: fetching from remote API" }
-            val releases = remoteDataSource.getFirmwareReleases().releases
-            if (releases.stable.isEmpty() && releases.alpha.isEmpty()) {
-                Logger.w { "FirmwareReleaseRepository: remote returned no releases; leaving cache untouched" }
-            } else {
-                // Replace rather than upsert so releases pulled or reclassified upstream don't linger as "latest".
+    private suspend fun fetchAndPersistReleases() {
+        Logger.d { "FirmwareReleaseRepository: fetching from remote API" }
+        val releases = remoteDataSource.getFirmwareReleases().releases
+        if (releases.stable.isEmpty() && releases.alpha.isEmpty()) {
+            Logger.w { "FirmwareReleaseRepository: remote returned no releases; leaving cache untouched" }
+        } else {
+            // Replace rather than upsert so releases pulled or reclassified upstream don't linger as "latest".
+            writeMutex.withLock {
                 localDataSource.replaceFirmwareReleases(
                     mapOf(FirmwareReleaseType.STABLE to releases.stable, FirmwareReleaseType.ALPHA to releases.alpha),
                 )
@@ -201,12 +216,12 @@ open class FirmwareReleaseRepositoryImpl(
         }
     }
 
-    private suspend fun refreshNightly() {
-        refreshMutex.withLock {
-            Logger.d { "FirmwareReleaseRepository: fetching nightly index" }
-            // A 404 (nothing currently published) returns null and clears any stale nightly row; transport and
-            // server errors throw before the write and leave the cache untouched.
-            val nightly = remoteDataSource.getNightlyFirmware()?.asFirmwareRelease()
+    private suspend fun fetchAndPersistNightly() {
+        Logger.d { "FirmwareReleaseRepository: fetching nightly index" }
+        // A 404 (nothing currently published) returns null and clears any stale nightly row; transport and
+        // server errors throw before the write and leave the cache untouched.
+        val nightly = remoteDataSource.getNightlyFirmware()?.asFirmwareRelease()
+        writeMutex.withLock {
             localDataSource.replaceFirmwareReleases(mapOf(FirmwareReleaseType.NIGHTLY to listOfNotNull(nightly)))
         }
     }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/util/SingleFlightRefresher.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/util/SingleFlightRefresher.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.data.util
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import org.meshtastic.core.common.util.safeCatching
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Runs [fetchAndPersist] as a single shared flight on a detached, app-lifetime scope: concurrent callers join the
+ * in-flight refresh instead of starting their own, a caller that stops waiting (cancellation or [refresh]'s
+ * `maxWaitMs`) can't abort it, and — critically — no lock a cache-read path can see is ever held across the network
+ * call. api.meshtastic.org routinely takes 20-60s (and minutes during outages); holding a caller-visible mutex across
+ * that request has wedged cached emissions, and the UI with them, before.
+ *
+ * [fetchAndPersist] performs the network call and writes results to the local cache as a side-effect; its failures are
+ * caught and logged here, so callers observe refresh results only through the cache. The owner is expected to be an
+ * app-lifetime singleton — the internal SupervisorJob is never cancelled.
+ */
+internal class SingleFlightRefresher(
+    context: CoroutineContext,
+    private val tag: String,
+    private val fetchAndPersist: suspend () -> Unit,
+) {
+
+    /** Guards [inFlight] so concurrent callers share one refresh. */
+    private val guard = Mutex()
+
+    private var inFlight: Deferred<Unit>? = null
+
+    private val scope = CoroutineScope(context + SupervisorJob())
+
+    /**
+     * Starts (or joins) the shared refresh. When [maxWaitMs] is set, the caller waits at most that long before falling
+     * back to cached data; the refresh itself always runs to completion, bounded only by the HttpClient's own
+     * timeout/retry policy.
+     */
+    suspend fun refresh(maxWaitMs: Long? = null) {
+        val refresh =
+            guard.withLock {
+                inFlight?.takeIf { it.isActive }
+                    ?: scope
+                        .async {
+                            safeCatching { fetchAndPersist() }
+                                .onFailure { e -> Logger.w(e) { "$tag: network refresh failed" } }
+                            Unit
+                        }
+                        .also { inFlight = it }
+            }
+        if (maxWaitMs == null) {
+            refresh.join()
+        } else if (withTimeoutOrNull(maxWaitMs) { refresh.join() } == null) {
+            Logger.w { "$tag: refresh still in flight after ${maxWaitMs}ms; using cached data" }
+        }
+    }
+}

--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImplTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImplTest.kt
@@ -16,9 +16,14 @@
  */
 package org.meshtastic.core.data.repository
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import kotlinx.serialization.json.Json
 import okio.Buffer
 import okio.Source
@@ -53,12 +58,20 @@ class FirmwareReleaseRepositoryImplTest {
         var nightlyUnreachable = false
         var manifest: FirmwareReleaseManifest? = null
         var manifestCalls = 0
+        var firmwareCalls = 0
+
+        /** When set, [getFirmwareReleases] hangs until completed — simulates a slow/unreachable API. */
+        var responseGate: CompletableDeferred<Unit>? = null
 
         override suspend fun getDeviceHardware(): List<NetworkDeviceHardware> = error("unused")
 
         override suspend fun getDeviceLinks(): NetworkDeviceLinksResponse = error("unused")
 
-        override suspend fun getFirmwareReleases(): NetworkFirmwareReleases = response
+        override suspend fun getFirmwareReleases(): NetworkFirmwareReleases {
+            firmwareCalls++
+            responseGate?.await()
+            return response
+        }
 
         override suspend fun getFirmwareReleaseManifest(manifestUrl: String): FirmwareReleaseManifest {
             manifestCalls++
@@ -316,6 +329,53 @@ class FirmwareReleaseRepositoryImplTest {
         dao.insert(FirmwareReleaseEntity(id = "v2.8.0.f52e2ea", releaseType = FirmwareReleaseType.NIGHTLY))
 
         assertEquals("v2.8.0.f52e2ea", repository.nightlyRelease.toList().first()?.id)
+    }
+
+    @Test
+    fun cachedEmissionIsNotBlockedByAnotherFlowsInFlightRefresh() = runBlocking {
+        // Regression for the api.meshtastic.org outage of 2026-07: the stable flow's refresh held a lock for the
+        // full request+retry window (minutes), wedging the alpha flow's *cached* emission behind it — and with it
+        // the node detail screen, which combines both flows into its first UI state.
+        dao.insert(staleRow("v2.7.26.54e0d8d", FirmwareReleaseType.STABLE))
+        dao.insert(staleRow("v2.7.27.abc1234", FirmwareReleaseType.ALPHA))
+        val gate = CompletableDeferred<Unit>()
+        api.responseGate = gate
+        api.response = NetworkFirmwareReleases()
+
+        val stableCollector = launch { repository.stableRelease.collect {} }
+        withTimeout(2_000) { while (api.firmwareCalls == 0) yield() } // stable's refresh is now hanging on the API
+
+        val alphaCached = withTimeout(2_000) { repository.alphaRelease.first() }
+        assertEquals("v2.7.27.abc1234", alphaCached?.id, "alpha cache emits while the stable refresh is in flight")
+
+        gate.complete(Unit)
+        stableCollector.join()
+    }
+
+    @Test
+    fun concurrentCollectorsShareOneNetworkRefresh() = runBlocking {
+        dao.insert(staleRow("v2.7.26.54e0d8d", FirmwareReleaseType.STABLE))
+        dao.insert(staleRow("v2.7.27.abc1234", FirmwareReleaseType.ALPHA))
+        val gate = CompletableDeferred<Unit>()
+        api.responseGate = gate
+        // The response refreshes BOTH channels, so whichever collector reaches its fetch decision second either
+        // joins the in-flight refresh (refresh still hanging on [gate]) or finds its rows already fresh (refresh
+        // completed) — one network call in both interleavings.
+        api.response =
+            NetworkFirmwareReleases(
+                releases =
+                Releases(stable = listOf(release("v2.7.28.def5678")), alpha = listOf(release("v2.7.29.fedcba9"))),
+            )
+
+        val stableCollector = launch { repository.stableRelease.collect {} }
+        val alphaCollector = launch { repository.alphaRelease.collect {} }
+        withTimeout(2_000) { while (api.firmwareCalls == 0) yield() }
+
+        gate.complete(Unit)
+        stableCollector.join()
+        alphaCollector.join()
+
+        assertEquals(1, api.firmwareCalls, "stable and alpha collectors share one refresh")
     }
 
     @Test

--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/util/SingleFlightRefresherTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/util/SingleFlightRefresherTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.data.util
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+// Real dispatchers + runBlocking, NOT runTest — the refresher's detached scope must interleave with the
+// callers on real coroutine semantics, and Unconfined keeps the interleaving deterministic.
+class SingleFlightRefresherTest {
+
+    private class GatedWork {
+        val gate = CompletableDeferred<Unit>()
+        var starts = 0
+        var completions = 0
+
+        suspend fun run() {
+            starts++
+            gate.await()
+            completions++
+        }
+    }
+
+    @Test
+    fun concurrentCallersShareOneFlight() = runBlocking {
+        val work = GatedWork()
+        val refresher = SingleFlightRefresher(Dispatchers.Unconfined, "test") { work.run() }
+
+        val first = launch { refresher.refresh() }
+        val second = launch { refresher.refresh() }
+        withTimeout(2_000) { while (work.starts == 0) yield() }
+
+        work.gate.complete(Unit)
+        first.join()
+        second.join()
+
+        assertEquals(1, work.starts, "second caller joins the in-flight refresh instead of starting its own")
+        assertEquals(1, work.completions)
+    }
+
+    @Test
+    fun timedOutCallerFallsBackWhileRefreshRunsToCompletion() = runBlocking {
+        val work = GatedWork()
+        val refresher = SingleFlightRefresher(Dispatchers.Unconfined, "test") { work.run() }
+
+        refresher.refresh(maxWaitMs = 50)
+
+        assertEquals(1, work.starts)
+        assertFalse(work.completions > 0, "caller returned before the refresh finished")
+
+        work.gate.complete(Unit)
+        withTimeout(2_000) { while (work.completions == 0) yield() }
+        assertEquals(1, work.completions, "the refresh ran to completion after the caller stopped waiting")
+    }
+
+    @Test
+    fun callerCancellationDoesNotAbortTheSharedRefresh() = runBlocking {
+        val work = GatedWork()
+        val refresher = SingleFlightRefresher(Dispatchers.Unconfined, "test") { work.run() }
+
+        val caller = launch { refresher.refresh() }
+        withTimeout(2_000) { while (work.starts == 0) yield() }
+        caller.cancel()
+        caller.join()
+
+        work.gate.complete(Unit)
+        withTimeout(2_000) { while (work.completions == 0) yield() }
+        assertEquals(1, work.completions, "the detached refresh survives its caller's cancellation")
+    }
+
+    @Test
+    fun failureIsContainedAndTheNextRefreshStartsANewFlight() = runBlocking {
+        var attempts = 0
+        val refresher =
+            SingleFlightRefresher(Dispatchers.Unconfined, "test") {
+                attempts++
+                if (attempts == 1) error("network down")
+            }
+
+        refresher.refresh() // must not throw
+        refresher.refresh()
+
+        assertEquals(2, attempts, "a failed flight is not reused; the next caller starts a fresh one")
+    }
+}

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
@@ -145,8 +145,10 @@ constructor(
                     .map { it?.firmware_edition }
                     .distinctUntilChanged()
                     .onStart { emit(null) },
-                firmwareReleaseRepository.stableRelease,
-                firmwareReleaseRepository.alphaRelease,
+                // Placeholders keep the first UI emission from waiting on the firmware cache/refresh pipeline —
+                // real values land via re-emission once the repository produces them.
+                firmwareReleaseRepository.stableRelease.onStart { emit(null) },
+                firmwareReleaseRepository.alphaRelease.onStart { emit(null) },
                 nodeRequestActions.lastTracerouteTime,
                 nodeRequestActions.lastRequestNeighborTimes.map { it[nodeId] },
             ) { edition, stable, alpha, trTime, niTime ->


### PR DESCRIPTION
## Why

During the recent api.meshtastic.org outage, the node detail screen blocked for a minute or more on load. The REST-backed repositories are designed to be offline-friendly — emit cached/bundled data immediately, refresh in the background — but `FirmwareReleaseRepositoryImpl` held its refresh mutex across the entire network call (90s request timeout × 3 retries) *and* took that same mutex on its cache-read path. When the stable channel's refresh hung on the dead API, the alpha flow couldn't emit its **cached** value, and since node detail combines both flows into its first UI state, the whole screen waited.

Four repositories had hand-rolled, subtly divergent copies of the same seed → stale-while-revalidate → single-flight refresh pattern; this one had the fatal divergence. This PR fixes the outage behavior and extracts the pattern so the bug class can't be reintroduced per-repo.

## 🐛 Bug fixes

- **Firmware release flows no longer block behind an in-flight network refresh.** The repository's mutex now guards Room writes only — never the network request — so cached emissions are instant even mid-outage.
- **Node detail's first emission no longer waits on the firmware pipeline at all**: the two firmware flows in `CommonGetNodeDetailsUseCase` get the same `.onStart { emit(null) }` placeholders every other flow in the combine already had.
- Stable + alpha collectors now **share one release-list fetch** instead of queueing two sequential ones.

## 🧹 Cleanup

- New `SingleFlightRefresher` (core:data): runs a refresh as a single shared flight on a detached app-lifetime scope — concurrent callers join the in-flight fetch, a caller that stops waiting (or is cancelled) can't abort it, optional `maxWaitMs` bounded wait, failures contained and logged.
- `FirmwareRelease`, `DeviceHardware`, `EventFirmware`, and `DeviceLink` repositories all migrate onto it, deleting four bespoke guard/deferred/scope implementations (net −124 lines of concurrency plumbing).

## Testing Performed

- New `SingleFlightRefresherTest` (4 tests): flight sharing, timeout fallback while the refresh completes, caller-cancellation survival, failure containment + fresh-flight restart.
- New regression tests in `FirmwareReleaseRepositoryImplTest`: `cachedEmissionIsNotBlockedByAnotherFlowsInFlightRefresh` reproduces the outage scenario with a gated fake API (deadlocked before the fix), and `concurrentCollectorsShareOneNetworkRefresh` pins the shared-fetch behavior.
- Full baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — 1,587 tests passing, both flavors assembled, zero lint violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh handling to prevent duplicate network requests when multiple parts of the app request the same data.
  * Cached data remains available while a background refresh is in progress.
  * Refresh timeouts and cancellations no longer interrupt shared updates.

* **Tests**
  * Added coverage for concurrent refreshes, timeouts, cancellations, failures, and cached emissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->