### PR TITLE
fix(waypoint): reject non-owner modification of a stored locked waypoint

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
@@ -21,6 +21,7 @@ import co.touchlab.kermit.Severity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import okio.ByteString
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
@@ -33,6 +34,7 @@ import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.Reaction
 import org.meshtastic.core.model.destination
+import org.meshtastic.core.model.geofence.activeWaypointPackets
 import org.meshtastic.core.model.isBroadcast
 import org.meshtastic.core.model.isFromLocal
 import org.meshtastic.core.model.isModifiableBy
@@ -291,8 +293,33 @@ class MeshDataHandlerImpl(
         val u = Waypoint.ADAPTER.decode(payload)
         // A locked waypoint may only be created/updated by its owner; drop it if the sender isn't allowed to modify it.
         if (!u.isModifiableBy(packet.from)) return
-        val currentSecond = nowSeconds.toInt()
-        rememberDataPacket(dataPacket, myNodeNum, updateNotification = u.expire > currentSecond, session = session)
+        val updateNotification = u.expire > nowSeconds.toInt()
+        radioInterfaceService.launchSessionWork(scope, session) {
+            // Persisted-owner enforcement: a stored, locked waypoint may only be modified by the node it is locked to.
+            // The inbound check above only validates the incoming payload, so without this a non-owner could hijack a
+            // stored locked waypoint by replaying its id with locked_to = 0 (unlock) or their own num (takeover). The
+            // read and the write share this one lease so the check sees a committed snapshot (see [persistDataPacket]).
+            if (!storedWaypointModifiableBy(u.id, packet.from)) return@launchSessionWork
+            persistDataPacket(dataPacket, myNodeNum, updateNotification)
+        }
+    }
+
+    /**
+     * Whether an inbound waypoint update from [from] may modify the currently-stored waypoint with [waypointId]. A new
+     * waypoint (nothing stored) or an unlocked stored waypoint is always modifiable; a locked stored waypoint is
+     * modifiable only by the node it is locked to — this deliberately rejects inbound unlock (`locked_to = 0`) attempts
+     * from anyone else.
+     *
+     * [PacketRepository.getWaypoints] is a row-per-transmission firehose, so it is collapsed via
+     * [activeWaypointPackets] (newest-per-id, expired dropped) — the same normalisation the map UI and geofence engine
+     * use, so the three cannot drift. Waypoint packets are infrequent, so this one-shot read per waypoint is not hot.
+     */
+    private suspend fun storedWaypointModifiableBy(waypointId: Int, from: Int): Boolean {
+        // firstOrNull().orEmpty(): getWaypoints() is a hot repository flow that always emits (an empty list when there
+        // are none), but tolerate a flow that completes without emitting rather than throwing on the inbound path.
+        val active = packetRepository.value.getWaypoints().firstOrNull().orEmpty().activeWaypointPackets(nowSeconds)
+        val stored = active[waypointId]?.waypoint
+        return stored == null || stored.isModifiableBy(from)
     }
 
     private fun handleTextMessage(
@@ -405,6 +432,18 @@ class MeshDataHandlerImpl(
         session: RadioSessionContext?,
     ) {
         if (dataPacket.dataType !in rememberDataType) return
+        radioInterfaceService.launchSessionWork(scope, session) {
+            persistDataPacket(dataPacket, myNodeNum, updateNotification)
+        }
+    }
+
+    /**
+     * Deduplicates, filters, persists, and (when appropriate) notifies for a single [dataPacket]. Runs inside a session
+     * lease — callers must launch it via [RadioInterfaceService.launchSessionWork] and must have already confirmed the
+     * packet's [DataPacket.dataType] is one of [rememberDataType]. Split out from [rememberDataPacket] so the waypoint
+     * path can gate persistence on a repository read within the same lease (see [handleWaypoint]).
+     */
+    private suspend fun persistDataPacket(dataPacket: DataPacket, myNodeNum: Int, updateNotification: Boolean) {
         val fromLocal = dataPacket.isFromLocal(myNodeNum)
         val toBroadcast = dataPacket.isBroadcast
         val contactId = if (fromLocal || toBroadcast) dataPacket.to else dataPacket.from
@@ -412,33 +451,24 @@ class MeshDataHandlerImpl(
         // contactKey: unique contact key filter (channel)+(nodeId)
         val contactKey = "${dataPacket.channel}$contactId"
 
-        radioInterfaceService.launchSessionWork(scope, session) {
-            packetRepository.value.apply {
-                // Check for duplicates before inserting
-                val existingPackets = findPacketsWithId(dataPacket.id)
-                if (existingPackets.isNotEmpty()) {
-                    Logger.d {
-                        "Skipping duplicate packet: packetId=${dataPacket.id} from=${dataPacket.from} " +
-                            "to=${dataPacket.to} contactKey=$contactKey" +
-                            " (already have ${existingPackets.size} packet(s))"
-                    }
-                    return@launchSessionWork
+        packetRepository.value.apply {
+            // Check for duplicates before inserting
+            val existingPackets = findPacketsWithId(dataPacket.id)
+            if (existingPackets.isNotEmpty()) {
+                Logger.d {
+                    "Skipping duplicate packet: packetId=${dataPacket.id} from=${dataPacket.from} " +
+                        "to=${dataPacket.to} contactKey=$contactKey" +
+                        " (already have ${existingPackets.size} packet(s))"
                 }
+                return
+            }
 
-                // Check if message should be filtered
-                val isFiltered = shouldFilterMessage(dataPacket, contactKey)
+            // Check if message should be filtered
+            val isFiltered = shouldFilterMessage(dataPacket, contactKey)
 
-                insert(
-                    dataPacket,
-                    myNodeNum,
-                    contactKey,
-                    nowMillis,
-                    read = fromLocal || isFiltered,
-                    filtered = isFiltered,
-                )
-                if (!isFiltered) {
-                    handlePacketNotification(dataPacket, contactKey, updateNotification)
-                }
+            insert(dataPacket, myNodeNum, contactKey, nowMillis, read = fromLocal || isFiltered, filtered = isFiltered)
+            if (!isFiltered) {
+                handlePacketNotification(dataPacket, contactKey, updateNotification)
             }
         }
     }

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -74,6 +75,7 @@ import org.meshtastic.proto.Position
 import org.meshtastic.proto.Routing
 import org.meshtastic.proto.Telemetry
 import org.meshtastic.proto.User
+import org.meshtastic.proto.Waypoint
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -942,5 +944,130 @@ class MeshDataHandlerTest {
         verifySuspend {
             serviceNotifications.updateMessageNotification(any(), any(), any(), any(), any(), isSilent = false)
         }
+    }
+
+    // --- Waypoint persisted-owner enforcement ---
+    //
+    // A locked waypoint (locked_to != 0) may only be modified by the node it is locked to. The inbound-payload check
+    // alone (locked_to == from) cannot enforce this: a non-owner can still replay an existing id with locked_to = 0
+    // (unlock) or their own num (takeover). handleWaypoint additionally consults the currently-stored owner.
+
+    private fun waypointPacket(txId: Int, from: Int, waypoint: Waypoint): MeshPacket {
+        val payload = waypoint.encode().toByteString()
+        val packet =
+            MeshPacket(id = txId, from = from, decoded = Data(portnum = PortNum.WAYPOINT_APP, payload = payload))
+        val dataPacket =
+            DataPacket(
+                id = txId,
+                from = NodeAddress.numToDefaultId(from),
+                to = NodeAddress.ID_BROADCAST,
+                bytes = payload,
+                dataType = PortNum.WAYPOINT_APP.value,
+            )
+        every { dataMapper.toDataPacket(packet) } returns dataPacket
+        return packet
+    }
+
+    /** Persist a single stored waypoint (via the getWaypoints firehose) so handleWaypoint can read its owner. */
+    private fun storeWaypoint(id: Int, lockedTo: Int) {
+        val stored =
+            DataPacket(to = NodeAddress.ID_BROADCAST, channel = 0, waypoint = Waypoint(id = id, locked_to = lockedTo))
+        every { packetRepository.getWaypoints() } returns flowOf(listOf(stored))
+    }
+
+    private fun stubWaypointPersistDependencies(txId: Int) {
+        everySuspend { packetRepository.findPacketsWithId(txId) } returns emptyList()
+        everySuspend { packetRepository.getContactSettings(any()) } returns ContactSettings(contactKey = "test")
+        every { messageFilter.shouldFilter(any(), any()) } returns false
+    }
+
+    @Test
+    fun `non-owner unlock replay of a locked waypoint is dropped`() = testScope.runTest {
+        storeWaypoint(id = 42, lockedTo = 111)
+        // Mallory (999) replays waypoint 42 with locked_to = 0 (unlock). The inbound check passes, so only the
+        // stored-owner check can drop it.
+        val packet = waypointPacket(txId = 500, from = 999, waypoint = Waypoint(id = 42, locked_to = 0))
+        stubWaypointPersistDependencies(500)
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend(exactly(0)) { packetRepository.insert(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `non-owner takeover of a locked waypoint is dropped`() = testScope.runTest {
+        storeWaypoint(id = 42, lockedTo = 111)
+        // Mallory (999) locks waypoint 42 to herself. The inbound check passes (locked_to == from), so only the
+        // stored-owner check can catch this.
+        val packet = waypointPacket(txId = 501, from = 999, waypoint = Waypoint(id = 42, locked_to = 999))
+        stubWaypointPersistDependencies(501)
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend(exactly(0)) { packetRepository.insert(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `owner unlock of their own locked waypoint is accepted`() = testScope.runTest {
+        storeWaypoint(id = 42, lockedTo = 111)
+        val packet = waypointPacket(txId = 502, from = 111, waypoint = Waypoint(id = 42, locked_to = 0))
+        stubWaypointPersistDependencies(502)
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend { packetRepository.insert(any(), 123, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `owner edit of their own locked waypoint is accepted`() = testScope.runTest {
+        storeWaypoint(id = 42, lockedTo = 111)
+        val packet = waypointPacket(txId = 503, from = 111, waypoint = Waypoint(id = 42, locked_to = 111))
+        stubWaypointPersistDependencies(503)
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend { packetRepository.insert(any(), 123, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `new waypoint from a non-owner is accepted when none is stored`() = testScope.runTest {
+        // Nothing persisted yet: getWaypoints() emits an empty list (as Room does). A creation, not a hijack.
+        every { packetRepository.getWaypoints() } returns flowOf(emptyList())
+        val packet = waypointPacket(txId = 504, from = 999, waypoint = Waypoint(id = 42, locked_to = 0))
+        stubWaypointPersistDependencies(504)
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend { packetRepository.insert(any(), 123, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `non-owner update to an unlocked waypoint is accepted`() = testScope.runTest {
+        storeWaypoint(id = 42, lockedTo = 0)
+        val packet = waypointPacket(txId = 505, from = 999, waypoint = Waypoint(id = 42, locked_to = 0))
+        stubWaypointPersistDependencies(505)
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend { packetRepository.insert(any(), 123, any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `waypoint locked to someone other than the sender is dropped`() = testScope.runTest {
+        // Pre-existing inbound-payload rule: a node can only lock a waypoint to itself. Nothing stored here — the
+        // payload itself is invalid, so it is rejected before any repository read.
+        val packet = waypointPacket(txId = 506, from = 999, waypoint = Waypoint(id = 42, locked_to = 111))
+        stubWaypointPersistDependencies(506)
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend(exactly(0)) { packetRepository.insert(any(), any(), any(), any(), any(), any()) }
     }
 }


### PR DESCRIPTION
## Why

A locked waypoint (`locked_to != 0`) is meant to be editable only by the node it is
locked to. Inbound waypoint handling only validated the **incoming** packet's `locked_to`
against its sender (`locked_to == 0 || locked_to == from`) — it never consulted the
**already-stored** waypoint's owner. So a non-owner could hijack someone else's locked
waypoint by re-sending an update for the same waypoint id with:

- `locked_to = 0` — silently **unlocks** and overwrites the stored waypoint, or
- `locked_to = <their own num>` — **takes over** ownership.

Both slip past the inbound-only check. This is a pre-existing protocol-facing gap (called
out during CodeRabbit review of #6344 and deferred there as out-of-scope, since #6344 was a
straight refactor of the existing check). This PR closes it.

## What

`MeshDataHandlerImpl.handleWaypoint` now, before persisting an update, reads the
currently-stored waypoint for that id and rejects the update when the stored copy is locked
to a **different** node than the sender — including inbound `locked_to = 0` unlock attempts.

- 🛠️ Load the stored waypoint via `PacketRepository.getWaypoints()` collapsed through
  `activeWaypointPackets(now)` (newest-per-id, expired dropped) — the same normalisation the
  map UI and geofence engine already use, so the three can't drift.
- 🛠️ Reuse `Waypoint.isModifiableBy` (the shared `locked_to` helper added in #6344) for the
  stored-owner check as well, so the inbound and persisted checks share one source of truth.
- 🛠️ The stored-owner read and the persist run inside **one** `launchSessionWork` lease
  (`persistDataPacket` extracted from `rememberDataPacket`), so the check sees a committed
  snapshot rather than nesting a second lease across two coroutines.
- 🧹 `rememberDataPacket`'s body split into `persistDataPacket` (behaviour-preserving; the
  duplicate-skip `return` semantics are unchanged).

Preserved (not dropped): new-waypoint creation, owner unlock/edit, updates to unlocked
waypoints, and the inbound `isModifiableBy` rule (a node can't lock a waypoint to a third party).

## Behaviour matrix

| stored | incoming `from` | incoming `locked_to` | result |
|---|---|---|---|
| none | any | 0 or self | persisted (creation) |
| none | X | Y≠X | dropped (inbound rule) |
| unlocked | any | 0 or self | persisted |
| locked→owner | owner | 0 (unlock) / owner (edit) | persisted |
| locked→owner | attacker | 0 (unlock) | **dropped** ← fix |
| locked→owner | attacker | attacker (takeover) | **dropped** ← fix |

## Testing performed

- New regression tests in `core/data` `MeshDataHandlerTest` covering every row above (7 cases).
- Full local baseline green: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`.
- **Not yet exercised on a real mesh / replay** — see testing note below.

## Testing note

Unit-tested and baseline-green (above), but **not yet validated on a real mesh / replay**
(burningmesh-replay sandbox) to confirm no legitimate cross-client waypoint updates are
dropped — worth a maintainer's on-device check before merge. Notes:

- Enforcement is **client-side** (`locked_to` is advisory on the wire); this protects the
  local DB/view, matching how the map UI already gates edits.
- Known, accepted residuals (documented, not fixed here):
  - **Node renumber** (fw 2.8 identity migration): after a renumber the owner's `from` no
    longer matches the old `locked_to`, so their edits would be dropped — but the map UI
    already blocks the owner from editing in that state (`locked_to == myNodeNum`), so no new
    inconsistency is introduced. Waypoints also expire.
  - **Simultaneous create/attack race**: `getWaypoints()` reflects committed rows, so a
    replay landing before the owner's create commits isn't a hard transactional lock — but it
    self-heals on the owner's next re-broadcast (their locked copy becomes newest again).

Follow-up to #6344 / thread
https://github.com/meshtastic/Meshtastic-Android/pull/6344#discussion_r3625536895

Rebased onto `main` after #6344 merged, so the inbound check and this PR's stored-owner
check both go through the same `Waypoint.isModifiableBy` helper.
