### PR TITLE
fix(nodes): refresh distance when display units change

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
@@ -106,7 +106,9 @@ fun NodeItem(
             Config.DisplayConfig.DisplayUnits.fromValue(distanceUnits) ?: Config.DisplayConfig.DisplayUnits.METRIC
         }
     val distance =
-        remember(thisNode, thatNode) { thisNode?.distance(thatNode)?.takeIf { it > 0 }?.toDistanceString(system) }
+        remember(thisNode, thatNode, system) {
+            thisNode?.distance(thatNode)?.takeIf { it > 0 }?.toDistanceString(system)
+        }
     val bearingDegrees = remember(thisNode, thatNode) { thisNode?.bearing(thatNode) }
 
     val contentColor = MaterialTheme.colorScheme.onSurface
@@ -133,7 +135,7 @@ fun NodeItem(
     val a11yStrings = rememberNodeDescriptionStrings()
     val modemPreset = LocalModemPreset.current
     val nodeDescription =
-        remember(thatNode, a11yStrings, modemPreset) {
+        remember(thatNode, distance, a11yStrings, modemPreset) {
             buildNodeDescription(
                 name = originalLongName,
                 isOnline = thatNode.isOnline,

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItemCompact.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItemCompact.kt
@@ -122,7 +122,9 @@ fun NodeItemCompact(
             Config.DisplayConfig.DisplayUnits.fromValue(distanceUnits) ?: Config.DisplayConfig.DisplayUnits.METRIC
         }
     val distance =
-        remember(thisNode, thatNode) { thisNode?.distance(thatNode)?.takeIf { it > 0 }?.toDistanceString(system) }
+        remember(thisNode, thatNode, system) {
+            thisNode?.distance(thatNode)?.takeIf { it > 0 }?.toDistanceString(system)
+        }
     val bearingDegrees = remember(thisNode, thatNode) { thisNode?.bearing(thatNode) }
     val unmessageable =
         remember(thatNode) {
@@ -143,7 +145,7 @@ fun NodeItemCompact(
     val a11yStrings = rememberNodeDescriptionStrings()
     val modemPreset = LocalModemPreset.current
     val nodeDescription =
-        remember(thatNode, lastHeardIsRelative, a11yStrings, modemPreset) {
+        remember(thatNode, distance, lastHeardIsRelative, a11yStrings, modemPreset) {
             buildNodeDescription(
                 name = longName,
                 isOnline = thatNode.isOnline,

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/NodeItemDistanceUnitsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/NodeItemDistanceUnitsTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.v2.runComposeUiTest
 import org.meshtastic.core.model.ConnectionState
@@ -74,6 +75,8 @@ class NodeItemDistanceUnitsTest {
 
         onNodeWithText(metricDistance).assertDoesNotExist()
         onNodeWithText(imperialDistance).assertIsDisplayed()
+        onNodeWithContentDescription(metricDistance, substring = true).assertDoesNotExist()
+        onNodeWithContentDescription(imperialDistance, substring = true).assertIsDisplayed()
     }
 
     private fun node(num: Int, latitudeI: Int, longitudeI: Int): Node = Node(

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/NodeItemDistanceUnitsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/NodeItemDistanceUnitsTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.component
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.Node
+import org.meshtastic.core.model.util.toDistanceString
+import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
+import org.meshtastic.proto.Position
+import org.meshtastic.proto.User
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class NodeItemDistanceUnitsTest {
+
+    @Test
+    fun nodeItem_updatesDistanceWhenUnitsChange() = runComposeUiTest {
+        assertDistanceUpdates { thisNode, thatNode, distanceUnits ->
+            NodeItem(
+                thisNode = thisNode,
+                thatNode = thatNode,
+                distanceUnits = distanceUnits,
+                tempInFahrenheit = false,
+                connectionState = ConnectionState.Connected,
+            )
+        }
+    }
+
+    @Test
+    fun nodeItemCompact_updatesDistanceWhenUnitsChange() = runComposeUiTest {
+        assertDistanceUpdates { thisNode, thatNode, distanceUnits ->
+            NodeItemCompact(thisNode = thisNode, thatNode = thatNode, distanceUnits = distanceUnits)
+        }
+    }
+
+    private fun ComposeUiTest.assertDistanceUpdates(
+        content: @androidx.compose.runtime.Composable (Node, Node, Int) -> Unit,
+    ) {
+        val thisNode = node(num = 1, latitudeI = 100_000_000, longitudeI = 100_000_000)
+        val thatNode = node(num = 2, latitudeI = 100_000_000, longitudeI = 110_000_000)
+        val distanceMeters = requireNotNull(thisNode.distance(thatNode))
+        val metricDistance = distanceMeters.toDistanceString(DisplayUnits.METRIC)
+        val imperialDistance = distanceMeters.toDistanceString(DisplayUnits.IMPERIAL)
+        var distanceUnits by mutableIntStateOf(DisplayUnits.METRIC.value)
+
+        setContent { MaterialTheme { content(thisNode, thatNode, distanceUnits) } }
+
+        onNodeWithText(metricDistance).assertIsDisplayed()
+
+        runOnIdle { distanceUnits = DisplayUnits.IMPERIAL.value }
+
+        onNodeWithText(metricDistance).assertDoesNotExist()
+        onNodeWithText(imperialDistance).assertIsDisplayed()
+    }
+
+    private fun node(num: Int, latitudeI: Int, longitudeI: Int): Node = Node(
+        num = num,
+        user = User(id = "!$num", long_name = "Node $num"),
+        position = Position(latitude_i = latitudeI, longitude_i = longitudeI),
+    )
+}


### PR DESCRIPTION
## Summary

- Reformat node-list distances when the display unit state changes.
- Refresh node-row accessibility descriptions with the new distance text.
- Add Compose Multiplatform regression tests for the full and compact node layouts.

## Root cause

The formatted distance was remembered using only the two nodes as keys. When the node-list state changed from its initial metric value to the locale-derived imperial value, Compose retained the cached kilometer string until either node refreshed.

## User impact

Distances on the Nodes tab now switch to miles immediately when imperial units become active, without requiring a node refresh.

## Validation

- `./gradlew spotlessCheck detekt assembleDebug test --no-configuration-cache`
- `./gradlew :core:ui:allTests --no-configuration-cache`
- Both new metric-to-imperial Compose regression tests pass.

Repository-wide `allTests` was also attempted on Windows. The unrelated `:core:datastore:allTests` task failed because 18 existing `RecentAddressesDataSourceTest` cases could not rename DataStore temporary files; the failure reproduces in that module alone. The changed `:core:ui` module's complete `allTests` lifecycle passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node distance text now updates immediately when switching between metric and imperial units (including compact views).
  * Accessibility distance descriptions are now kept in sync with the currently displayed distance.
* **Tests**
  * Added UI coverage to verify distance text and accessibility content update correctly in both node view modes when measurement units change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->