### PR TITLE
fix(map): retain camera across tab navigation

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -188,6 +188,13 @@ import org.meshtastic.proto.BoundingBox as ProtoBoundingBox
  */
 private class GeofenceOverlayPolygon : Polygon()
 
+private const val INITIAL_MAP_ZOOM = 1.5
+
+private fun MapView.saveCameraPosition(viewModel: MapViewModel) {
+    val center = mapCenter
+    viewModel.saveCameraPosition(center.latitude, center.longitude, zoomLevelDouble)
+}
+
 private fun MapView.updateMarkers(
     nodeMarkers: List<MarkerWithLabel>,
     waypointMarkers: List<MarkerWithLabel>,
@@ -299,18 +306,34 @@ fun MapView(
         }
     }
 
-    val initialCameraView = remember {
-        val nodes = mapViewModel.nodes.value
-        val nodesWithPosition = nodes.filter { it.validPosition != null }
-        val geoPoints = nodesWithPosition.map { GeoPoint(it.latitude, it.longitude) }
-        BoundingBox.fromGeoPoints(geoPoints)
-    }
+    val nodes by mapViewModel.nodes.collectAsStateWithLifecycle()
+    val initialCameraState by mapViewModel.initialCameraState.collectAsStateWithLifecycle()
+    if (initialCameraState is InitialCameraState.Loading) return
+    val initialCameraPosition = (initialCameraState as InitialCameraState.Ready).position
     val map =
         rememberMapViewWithLifecycle(
             applicationId = mapViewModel.applicationId,
-            box = initialCameraView,
+            zoomLevel = initialCameraPosition?.zoom ?: INITIAL_MAP_ZOOM,
+            mapCenter = initialCameraPosition?.let { GeoPoint(it.latitude, it.longitude) } ?: GeoPoint(0.0, 0.0),
             tileSource = loadOnlineTileSourceBase(),
         )
+    var hasAppliedInitialNodeBounds by remember { mutableStateOf(initialCameraPosition != null) }
+
+    LaunchedEffect(nodes, hasAppliedInitialNodeBounds) {
+        val nodePoints = nodes.filter { it.validPosition != null }.map { GeoPoint(it.latitude, it.longitude) }
+        if (!hasAppliedInitialNodeBounds && nodePoints.isNotEmpty()) {
+            map.post {
+                if (nodePoints.size == 1) {
+                    map.controller.setCenter(nodePoints.first())
+                    map.controller.setZoom(WAYPOINT_ZOOM)
+                } else {
+                    map.zoomToBoundingBox(BoundingBox.fromGeoPoints(nodePoints), false)
+                }
+                map.saveCameraPosition(mapViewModel)
+            }
+            hasAppliedInitialNodeBounds = true
+        }
+    }
 
     val nodeClusterer = remember { RadiusMarkerClusterer(context) }
 
@@ -403,7 +426,6 @@ fun MapView(
         }
     }
 
-    val nodes by mapViewModel.nodes.collectAsStateWithLifecycle()
     val waypoints by mapViewModel.waypoints.collectAsStateWithLifecycle(emptyMap())
     val selectedWaypointId by mapViewModel.selectedWaypointId.collectAsStateWithLifecycle()
     val myId by mapViewModel.myId.collectAsStateWithLifecycle()
@@ -646,6 +668,7 @@ fun MapView(
     val boxOverlayListener =
         object : MapListener {
             override fun onScroll(event: ScrollEvent): Boolean {
+                event.source.saveCameraPosition(mapViewModel)
                 when {
                     downloadRegionBoundingBox != null -> event.source.generateBoxOverlay()
                     geofenceBoxDraft != null -> event.source.generateGeofenceBoxOverlay()
@@ -653,7 +676,10 @@ fun MapView(
                 return true
             }
 
-            override fun onZoom(event: ZoomEvent): Boolean = false
+            override fun onZoom(event: ZoomEvent): Boolean {
+                event.source.saveCameraPosition(mapViewModel)
+                return false
+            }
         }
 
     fun startDownload() {

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -159,6 +159,7 @@ import org.meshtastic.feature.map.component.WaypointInfoDialog
 import org.meshtastic.proto.Waypoint
 import org.osmdroid.bonuspack.utils.BonusPackHelper.getBitmapFromVectorDrawable
 import org.osmdroid.config.Configuration
+import org.osmdroid.events.DelayedMapListener
 import org.osmdroid.events.MapEventsReceiver
 import org.osmdroid.events.MapListener
 import org.osmdroid.events.ScrollEvent
@@ -665,10 +666,27 @@ fun MapView(
         invalidate()
     }
 
+    val cameraSaveListener =
+        remember(mapViewModel) {
+            DelayedMapListener(
+                object : MapListener {
+                    override fun onScroll(event: ScrollEvent): Boolean {
+                        event.source.saveCameraPosition(mapViewModel)
+                        return true
+                    }
+
+                    override fun onZoom(event: ZoomEvent): Boolean {
+                        event.source.saveCameraPosition(mapViewModel)
+                        return true
+                    }
+                },
+            )
+        }
+
     val boxOverlayListener =
         object : MapListener {
             override fun onScroll(event: ScrollEvent): Boolean {
-                event.source.saveCameraPosition(mapViewModel)
+                cameraSaveListener.onScroll(event)
                 when {
                     downloadRegionBoundingBox != null -> event.source.generateBoxOverlay()
                     geofenceBoxDraft != null -> event.source.generateGeofenceBoxOverlay()
@@ -677,7 +695,7 @@ fun MapView(
             }
 
             override fun onZoom(event: ZoomEvent): Boolean {
-                event.source.saveCameraPosition(mapViewModel)
+                cameraSaveListener.onZoom(event)
                 return false
             }
         }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -18,13 +18,16 @@ package org.meshtastic.app.map
 
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
 import org.meshtastic.core.common.BuildConfigProvider
 import org.meshtastic.core.model.Node
+import org.meshtastic.core.repository.MapCameraPosition
 import org.meshtastic.core.repository.MapPrefs
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.NotificationPrefs
@@ -55,6 +58,19 @@ class MapViewModel(
     radioConfigRepository,
     notificationPrefs,
 ) {
+
+    private val mutableInitialCameraState = MutableStateFlow<InitialCameraState>(InitialCameraState.Loading)
+    internal val initialCameraState: StateFlow<InitialCameraState> = mutableInitialCameraState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            mutableInitialCameraState.value = InitialCameraState.Ready(mapPrefs.awaitCameraPosition())
+        }
+    }
+
+    internal fun saveCameraPosition(latitude: Double, longitude: Double, zoom: Double) {
+        mapPrefs.setCameraPosition(MapCameraPosition(latitude, longitude, zoom))
+    }
 
     private val _selectedWaypointId = MutableStateFlow(savedStateHandle.get<Int>("waypointId"))
     val selectedWaypointId: StateFlow<Int?> = _selectedWaypointId.asStateFlow()
@@ -105,4 +121,10 @@ class MapViewModel(
     fun consumeSitePlannerRequest() {
         pendingSitePlannerNodeNum.value = null
     }
+}
+
+internal sealed interface InitialCameraState {
+    data object Loading : InitialCameraState
+
+    data class Ready(val position: MapCameraPosition?) : InitialCameraState
 }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewWithLifecycle.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewWithLifecycle.kt
@@ -130,7 +130,11 @@ internal fun rememberMapViewWithLifecycle(
 
         lifecycle.addObserver(observer)
 
-        onDispose { lifecycle.removeObserver(observer) }
+        onDispose {
+            savedCenter = mapView.projection.currentCenter
+            savedZoom = mapView.zoomLevelDouble
+            lifecycle.removeObserver(observer)
+        }
     }
     return mapView
 }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -290,10 +290,12 @@ fun MapView(
     // Main mode persists camera; NodeTrack/Traceroute use ephemeral state with auto-centering.
     val cameraPositionState =
         if (mode is GoogleMapMode.Main) mapViewModel.cameraPositionState else rememberCameraPositionState()
+    val cameraInitialization by mapViewModel.cameraInitialization.collectAsStateWithLifecycle()
+    var isMapLoaded by remember { mutableStateOf(false) }
 
     if (mode is GoogleMapMode.Main) {
-        LaunchedEffect(cameraPositionState.isMoving) {
-            if (!cameraPositionState.isMoving) {
+        LaunchedEffect(cameraPositionState.isMoving, cameraInitialization) {
+            if (!cameraPositionState.isMoving && cameraInitialization == CameraInitialization.Restored) {
                 mapViewModel.saveCameraPosition(cameraPositionState.position)
             }
         }
@@ -374,6 +376,27 @@ fun MapView(
                     (nowSeconds - node.lastHeard) <= mapFilterState.lastHeardFilter.seconds ||
                     node.num == ourNodeInfo?.num
             }
+
+    LaunchedEffect(mode, cameraInitialization, isMapLoaded, filteredNodes) {
+        if (
+            mode is GoogleMapMode.Main &&
+            cameraInitialization == CameraInitialization.FitNodes &&
+            isMapLoaded &&
+            filteredNodes.isNotEmpty()
+        ) {
+            val points = filteredNodes.map { it.position.toLatLng() }
+            val cameraUpdate =
+                if (points.size == 1) {
+                    CameraUpdateFactory.newLatLngZoom(points.first(), 12f)
+                } else {
+                    val bounds = LatLngBounds.builder()
+                    points.forEach(bounds::include)
+                    CameraUpdateFactory.newLatLngBounds(bounds.build(), 80)
+                }
+            cameraPositionState.move(cameraUpdate)
+            mapViewModel.onInitialNodeBoundsApplied()
+        }
+    }
 
     val myNodeNum = mapViewModel.myNodeNum
     val isConnected by mapViewModel.isConnected.collectAsStateWithLifecycle()
@@ -591,6 +614,7 @@ fun MapView(
                 mapType = effectiveGoogleMapType,
                 isMyLocationEnabled = isLocationTrackingEnabled && locationPermission.isGranted,
             ),
+            onMapLoaded = { isMapLoaded = true },
             onMapClick = { latLng ->
                 if (isMainMode && boxAuthoringDraft != null) {
                     val first = boxAuthoringFirstCorner

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -38,10 +38,10 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.Serializable
 import org.koin.core.annotation.KoinViewModel
 import org.meshtastic.app.map.model.CustomTileProviderConfig
 import org.meshtastic.app.map.prefs.map.GoogleMapsPrefs
+import org.meshtastic.app.map.prefs.map.MapCameraPosition
 import org.meshtastic.app.map.repository.CustomTileProviderRepository
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.Node
@@ -65,14 +65,11 @@ import kotlin.uuid.Uuid
 
 private const val TILE_SIZE = 256
 
-@Serializable
-data class MapCameraPosition(
-    val targetLat: Double,
-    val targetLng: Double,
-    val zoom: Float,
-    val tilt: Float,
-    val bearing: Float,
-)
+enum class CameraInitialization {
+    Loading,
+    FitNodes,
+    Restored,
+}
 
 @Suppress("TooManyFunctions", "LongParameterList")
 @KoinViewModel
@@ -129,23 +126,10 @@ class MapViewModel(
         }
     }
 
-    private val targetLatLng =
-        googleMapsPrefs.cameraTargetLat.value
-            .takeIf { it != 0.0 }
-            ?.let { lat -> googleMapsPrefs.cameraTargetLng.value.takeIf { it != 0.0 }?.let { lng -> LatLng(lat, lng) } }
-            ?: ourNodeInfo.value?.position?.toLatLng()
-            ?: LatLng(0.0, 0.0)
+    val cameraPositionState = CameraPositionState(CameraPosition.fromLatLngZoom(LatLng(0.0, 0.0), 7f))
 
-    val cameraPositionState =
-        CameraPositionState(
-            position =
-            CameraPosition(
-                targetLatLng,
-                googleMapsPrefs.cameraZoom.value,
-                googleMapsPrefs.cameraTilt.value,
-                googleMapsPrefs.cameraBearing.value,
-            ),
-        )
+    private val _cameraInitialization = MutableStateFlow(CameraInitialization.Loading)
+    val cameraInitialization: StateFlow<CameraInitialization> = _cameraInitialization.asStateFlow()
 
     val theme: StateFlow<Int> = uiPrefs.theme
 
@@ -364,6 +348,16 @@ class MapViewModel(
 
     init {
         viewModelScope.launch {
+            val savedCamera = googleMapsPrefs.cameraPosition.first()
+            if (savedCamera == null) {
+                _cameraInitialization.value = CameraInitialization.FitNodes
+            } else {
+                cameraPositionState.position = savedCamera.toCameraPosition()
+                _cameraInitialization.value = CameraInitialization.Restored
+            }
+        }
+
+        viewModelScope.launch {
             customTileProviderRepository.getCustomTileProviders().first()
             loadPersistedMapType()
         }
@@ -381,13 +375,13 @@ class MapViewModel(
     }
 
     fun saveCameraPosition(cameraPosition: CameraPosition) {
-        viewModelScope.launch {
-            googleMapsPrefs.setCameraTargetLat(cameraPosition.target.latitude)
-            googleMapsPrefs.setCameraTargetLng(cameraPosition.target.longitude)
-            googleMapsPrefs.setCameraZoom(cameraPosition.zoom)
-            googleMapsPrefs.setCameraTilt(cameraPosition.tilt)
-            googleMapsPrefs.setCameraBearing(cameraPosition.bearing)
-        }
+        if (_cameraInitialization.value != CameraInitialization.Restored) return
+        googleMapsPrefs.setCameraPosition(cameraPosition.toMapCameraPosition())
+    }
+
+    fun onInitialNodeBoundsApplied() {
+        _cameraInitialization.value = CameraInitialization.Restored
+        saveCameraPosition(cameraPositionState.position)
     }
 
     private fun loadPersistedMapType() {
@@ -478,3 +472,13 @@ class MapViewModel(
 
     override fun getUser(userId: String?) = nodeRepository.getUser(userId ?: NodeAddress.ID_BROADCAST)
 }
+
+private fun MapCameraPosition.toCameraPosition() = CameraPosition(LatLng(targetLat, targetLng), zoom, tilt, bearing)
+
+private fun CameraPosition.toMapCameraPosition() = MapCameraPosition(
+    targetLat = target.latitude,
+    targetLng = target.longitude,
+    zoom = zoom,
+    tilt = tilt,
+    bearing = bearing,
+)

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -40,8 +40,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.KoinViewModel
 import org.meshtastic.app.map.model.CustomTileProviderConfig
+import org.meshtastic.app.map.prefs.map.GoogleCameraPosition
 import org.meshtastic.app.map.prefs.map.GoogleMapsPrefs
-import org.meshtastic.app.map.prefs.map.MapCameraPosition
 import org.meshtastic.app.map.repository.CustomTileProviderRepository
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.Node
@@ -473,9 +473,9 @@ class MapViewModel(
     override fun getUser(userId: String?) = nodeRepository.getUser(userId ?: NodeAddress.ID_BROADCAST)
 }
 
-private fun MapCameraPosition.toCameraPosition() = CameraPosition(LatLng(targetLat, targetLng), zoom, tilt, bearing)
+private fun GoogleCameraPosition.toCameraPosition() = CameraPosition(LatLng(targetLat, targetLng), zoom, tilt, bearing)
 
-private fun CameraPosition.toMapCameraPosition() = MapCameraPosition(
+private fun CameraPosition.toMapCameraPosition() = GoogleCameraPosition(
     targetLat = target.latitude,
     targetLng = target.longitude,
     zoom = zoom,

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefs.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefs.kt
@@ -45,12 +45,12 @@ interface GoogleMapsPrefs {
 
     fun setSelectedCustomTileUrl(value: String?)
 
-    val cameraPosition: Flow<MapCameraPosition?>
+    val cameraPosition: Flow<GoogleCameraPosition?>
 
-    fun setCameraPosition(value: MapCameraPosition)
+    fun setCameraPosition(value: GoogleCameraPosition)
 }
 
-data class MapCameraPosition(
+data class GoogleCameraPosition(
     val targetLat: Double,
     val targetLng: Double,
     val zoom: Float,
@@ -97,11 +97,11 @@ class GoogleMapsPrefsImpl(
         }
     }
 
-    override val cameraPosition: Flow<MapCameraPosition?> =
+    override val cameraPosition: Flow<GoogleCameraPosition?> =
         dataStore.data.map { preferences ->
             val latitude = preferences.getCameraCoordinate(KEY_CAMERA_TARGET_LAT_PREF) ?: return@map null
             val longitude = preferences.getCameraCoordinate(KEY_CAMERA_TARGET_LNG_PREF) ?: return@map null
-            MapCameraPosition(
+            GoogleCameraPosition(
                 targetLat = latitude,
                 targetLng = longitude,
                 zoom = preferences[KEY_CAMERA_ZOOM_PREF] ?: 7f,
@@ -110,7 +110,7 @@ class GoogleMapsPrefsImpl(
             )
         }
 
-    override fun setCameraPosition(value: MapCameraPosition) {
+    override fun setCameraPosition(value: GoogleCameraPosition) {
         scope.launch {
             dataStore.edit { preferences ->
                 preferences[KEY_CAMERA_TARGET_LAT_PREF] = value.targetLat
@@ -122,6 +122,8 @@ class GoogleMapsPrefsImpl(
         }
     }
 
+    // Coordinates were previously written as Float values. Reading the same preference name through the legacy
+    // floatPreferencesKey after ClassCastException preserves saved cameras for existing installs during migration.
     private fun Preferences.getCameraCoordinate(key: Preferences.Key<Double>): Double? = try {
         this[key]
     } catch (_: ClassCastException) {

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefs.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefs.kt
@@ -25,6 +25,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import com.google.maps.android.compose.MapType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -44,26 +45,18 @@ interface GoogleMapsPrefs {
 
     fun setSelectedCustomTileUrl(value: String?)
 
-    val cameraTargetLat: StateFlow<Double>
+    val cameraPosition: Flow<MapCameraPosition?>
 
-    fun setCameraTargetLat(value: Double)
-
-    val cameraTargetLng: StateFlow<Double>
-
-    fun setCameraTargetLng(value: Double)
-
-    val cameraZoom: StateFlow<Float>
-
-    fun setCameraZoom(value: Float)
-
-    val cameraTilt: StateFlow<Float>
-
-    fun setCameraTilt(value: Float)
-
-    val cameraBearing: StateFlow<Float>
-
-    fun setCameraBearing(value: Float)
+    fun setCameraPosition(value: MapCameraPosition)
 }
+
+data class MapCameraPosition(
+    val targetLat: Double,
+    val targetLng: Double,
+    val zoom: Float,
+    val tilt: Float,
+    val bearing: Float,
+)
 
 @Single
 class GoogleMapsPrefsImpl(
@@ -104,55 +97,35 @@ class GoogleMapsPrefsImpl(
         }
     }
 
-    override val cameraTargetLat: StateFlow<Double> =
-        dataStore.data
-            .map {
-                try {
-                    it[KEY_CAMERA_TARGET_LAT_PREF] ?: 0.0
-                } catch (_: ClassCastException) {
-                    it[floatPreferencesKey(KEY_CAMERA_TARGET_LAT_PREF.name)]?.toDouble() ?: 0.0
-                }
+    override val cameraPosition: Flow<MapCameraPosition?> =
+        dataStore.data.map { preferences ->
+            val latitude = preferences.getCameraCoordinate(KEY_CAMERA_TARGET_LAT_PREF) ?: return@map null
+            val longitude = preferences.getCameraCoordinate(KEY_CAMERA_TARGET_LNG_PREF) ?: return@map null
+            MapCameraPosition(
+                targetLat = latitude,
+                targetLng = longitude,
+                zoom = preferences[KEY_CAMERA_ZOOM_PREF] ?: 7f,
+                tilt = preferences[KEY_CAMERA_TILT_PREF] ?: 0f,
+                bearing = preferences[KEY_CAMERA_BEARING_PREF] ?: 0f,
+            )
+        }
+
+    override fun setCameraPosition(value: MapCameraPosition) {
+        scope.launch {
+            dataStore.edit { preferences ->
+                preferences[KEY_CAMERA_TARGET_LAT_PREF] = value.targetLat
+                preferences[KEY_CAMERA_TARGET_LNG_PREF] = value.targetLng
+                preferences[KEY_CAMERA_ZOOM_PREF] = value.zoom
+                preferences[KEY_CAMERA_TILT_PREF] = value.tilt
+                preferences[KEY_CAMERA_BEARING_PREF] = value.bearing
             }
-            .stateIn(scope, SharingStarted.Eagerly, 0.0)
-
-    override fun setCameraTargetLat(value: Double) {
-        scope.launch { dataStore.edit { it[KEY_CAMERA_TARGET_LAT_PREF] = value } }
+        }
     }
 
-    override val cameraTargetLng: StateFlow<Double> =
-        dataStore.data
-            .map {
-                try {
-                    it[KEY_CAMERA_TARGET_LNG_PREF] ?: 0.0
-                } catch (_: ClassCastException) {
-                    it[floatPreferencesKey(KEY_CAMERA_TARGET_LNG_PREF.name)]?.toDouble() ?: 0.0
-                }
-            }
-            .stateIn(scope, SharingStarted.Eagerly, 0.0)
-
-    override fun setCameraTargetLng(value: Double) {
-        scope.launch { dataStore.edit { it[KEY_CAMERA_TARGET_LNG_PREF] = value } }
-    }
-
-    override val cameraZoom: StateFlow<Float> =
-        dataStore.data.map { it[KEY_CAMERA_ZOOM_PREF] ?: 7f }.stateIn(scope, SharingStarted.Eagerly, 7f)
-
-    override fun setCameraZoom(value: Float) {
-        scope.launch { dataStore.edit { it[KEY_CAMERA_ZOOM_PREF] = value } }
-    }
-
-    override val cameraTilt: StateFlow<Float> =
-        dataStore.data.map { it[KEY_CAMERA_TILT_PREF] ?: 0f }.stateIn(scope, SharingStarted.Eagerly, 0f)
-
-    override fun setCameraTilt(value: Float) {
-        scope.launch { dataStore.edit { it[KEY_CAMERA_TILT_PREF] = value } }
-    }
-
-    override val cameraBearing: StateFlow<Float> =
-        dataStore.data.map { it[KEY_CAMERA_BEARING_PREF] ?: 0f }.stateIn(scope, SharingStarted.Eagerly, 0f)
-
-    override fun setCameraBearing(value: Float) {
-        scope.launch { dataStore.edit { it[KEY_CAMERA_BEARING_PREF] = value } }
+    private fun Preferences.getCameraCoordinate(key: Preferences.Key<Double>): Double? = try {
+        this[key]
+    } catch (_: ClassCastException) {
+        this[floatPreferencesKey(key.name)]?.toDouble()
     }
 
     companion object {

--- a/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefsTest.kt
+++ b/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefsTest.kt
@@ -70,7 +70,7 @@ class GoogleMapsPrefsTest {
     @Test
     fun `camera position is saved and restored atomically`() = testScope.runTest {
         val cameraPosition =
-            MapCameraPosition(targetLat = 0.0, targetLng = -90.25, zoom = 13.5f, tilt = 20f, bearing = 125f)
+            GoogleCameraPosition(targetLat = 0.0, targetLng = -90.25, zoom = 13.5f, tilt = 20f, bearing = 125f)
 
         prefs.setCameraPosition(cameraPosition)
 

--- a/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefsTest.kt
+++ b/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/prefs/map/GoogleMapsPrefsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app.map.prefs.map
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import okio.FileSystem
+import okio.Path
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.meshtastic.core.di.CoroutineDispatchers
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+class GoogleMapsPrefsTest {
+    private lateinit var tmpDir: Path
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var prefs: GoogleMapsPrefsImpl
+    private lateinit var testDispatcher: TestDispatcher
+    private lateinit var testScope: TestScope
+
+    @Before
+    fun setup() {
+        testDispatcher = UnconfinedTestDispatcher()
+        testScope = TestScope(testDispatcher)
+        tmpDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "googleMapsPrefsTest-${Uuid.random()}"
+        FileSystem.SYSTEM.createDirectories(tmpDir)
+        dataStore =
+            PreferenceDataStoreFactory.createWithPath(
+                scope = testScope,
+                produceFile = { tmpDir / "test.preferences_pb" },
+            )
+        val dispatchers = CoroutineDispatchers(testDispatcher, testDispatcher, testDispatcher)
+        prefs = GoogleMapsPrefsImpl(dataStore, dispatchers)
+    }
+
+    @After
+    fun tearDown() {
+        testScope.cancel()
+        FileSystem.SYSTEM.deleteRecursively(tmpDir)
+    }
+
+    @Test
+    fun `camera position is absent until one has been saved`() =
+        testScope.runTest { assertNull(prefs.cameraPosition.first()) }
+
+    @Test
+    fun `camera position is saved and restored atomically`() = testScope.runTest {
+        val cameraPosition =
+            MapCameraPosition(targetLat = 0.0, targetLng = -90.25, zoom = 13.5f, tilt = 20f, bearing = 125f)
+
+        prefs.setCameraPosition(cameraPosition)
+
+        assertEquals(cameraPosition, prefs.cameraPosition.first())
+    }
+}

--- a/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/map/MapPrefsImpl.kt
+++ b/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/map/MapPrefsImpl.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.prefs.map
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
@@ -34,9 +35,11 @@ import kotlinx.coroutines.launch
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
 import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.repository.MapCameraPosition
 import org.meshtastic.core.repository.MapPrefs
 
 @Single
+@Suppress("TooManyFunctions")
 class MapPrefsImpl(
     @Named("MapDataStore") private val dataStore: DataStore<Preferences>,
     dispatchers: CoroutineDispatchers,
@@ -117,6 +120,25 @@ class MapPrefsImpl(
     override suspend fun awaitNetworkMapLayers(): Set<String> =
         dataStore.data.map { it[KEY_NETWORK_MAP_LAYERS_PREF] ?: emptySet() }.first()
 
+    override fun setCameraPosition(position: MapCameraPosition) {
+        scope.launch {
+            dataStore.edit {
+                it[KEY_CAMERA_LATITUDE] = position.latitude
+                it[KEY_CAMERA_LONGITUDE] = position.longitude
+                it[KEY_CAMERA_ZOOM] = position.zoom
+            }
+        }
+    }
+
+    override suspend fun awaitCameraPosition(): MapCameraPosition? = dataStore.data
+        .map { preferences ->
+            val latitude = preferences[KEY_CAMERA_LATITUDE] ?: return@map null
+            val longitude = preferences[KEY_CAMERA_LONGITUDE] ?: return@map null
+            val zoom = preferences[KEY_CAMERA_ZOOM] ?: return@map null
+            MapCameraPosition(latitude, longitude, zoom)
+        }
+        .first()
+
     companion object {
         val KEY_MAP_STYLE_PREF = intPreferencesKey("map_style_id")
         val KEY_SHOW_ONLY_FAVORITES_PREF = booleanPreferencesKey("show_only_favorites")
@@ -126,5 +148,8 @@ class MapPrefsImpl(
         val KEY_LAST_HEARD_TRACK_FILTER_PREF = longPreferencesKey("last_heard_track_filter")
         val KEY_HIDDEN_LAYER_URLS_PREF = stringSetPreferencesKey("hidden_layer_urls")
         val KEY_NETWORK_MAP_LAYERS_PREF = stringSetPreferencesKey("network_map_layers")
+        val KEY_CAMERA_LATITUDE = doublePreferencesKey("camera_latitude")
+        val KEY_CAMERA_LONGITUDE = doublePreferencesKey("camera_longitude")
+        val KEY_CAMERA_ZOOM = doublePreferencesKey("camera_zoom")
     }
 }

--- a/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/map/MapPrefsImplTest.kt
+++ b/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/map/MapPrefsImplTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.prefs.map
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import okio.FileSystem
+import okio.Path
+import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.repository.MapCameraPosition
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+class MapPrefsImplTest {
+    private lateinit var tmpDir: Path
+    private lateinit var dataStore: DataStore<Preferences>
+    private lateinit var prefs: MapPrefsImpl
+    private lateinit var testScope: TestScope
+
+    @BeforeTest
+    fun setup() {
+        val testDispatcher = UnconfinedTestDispatcher()
+        testScope = TestScope(testDispatcher)
+        tmpDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / "mapPrefsTest-${Uuid.random()}"
+        FileSystem.SYSTEM.createDirectories(tmpDir)
+        dataStore =
+            PreferenceDataStoreFactory.createWithPath(
+                scope = testScope,
+                produceFile = { tmpDir / "test.preferences_pb" },
+            )
+        prefs = MapPrefsImpl(dataStore, CoroutineDispatchers(testDispatcher, testDispatcher, testDispatcher))
+    }
+
+    @AfterTest
+    fun tearDown() {
+        testScope.cancel()
+        FileSystem.SYSTEM.deleteRecursively(tmpDir)
+    }
+
+    @Test
+    fun `camera is absent before the map has been positioned`() =
+        testScope.runTest { assertNull(prefs.awaitCameraPosition()) }
+
+    @Test
+    fun `camera position is persisted as a complete record`() = testScope.runTest {
+        val expected = MapCameraPosition(latitude = 38.627, longitude = -90.1994, zoom = 13.5)
+
+        prefs.setCameraPosition(expected)
+
+        assertEquals(expected, prefs.awaitCameraPosition())
+    }
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AppPreferences.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AppPreferences.kt
@@ -228,6 +228,7 @@ interface NotificationPrefs {
 }
 
 /** Reactive interface for general map preferences. */
+@Suppress("TooManyFunctions")
 interface MapPrefs {
     val mapStyle: StateFlow<Int>
 
@@ -270,7 +271,15 @@ interface MapPrefs {
 
     /** Persisted [networkMapLayers]; suspends for the first disk load to avoid a cold-start empty default. */
     suspend fun awaitNetworkMapLayers(): Set<String>
+
+    /** Persist the F-Droid map camera as one atomic preference update. */
+    fun setCameraPosition(position: MapCameraPosition)
+
+    /** Load the complete persisted camera, or null before the map has ever been positioned. */
+    suspend fun awaitCameraPosition(): MapCameraPosition?
 }
+
+data class MapCameraPosition(val latitude: Double, val longitude: Double, val zoom: Double)
 
 /** Reactive interface for map consent. */
 interface MapConsentPrefs {

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeAppPreferences.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeAppPreferences.kt
@@ -25,6 +25,7 @@ import org.meshtastic.core.repository.AppPreferences
 import org.meshtastic.core.repository.CustomEmojiPrefs
 import org.meshtastic.core.repository.FilterPrefs
 import org.meshtastic.core.repository.HomoglyphPrefs
+import org.meshtastic.core.repository.MapCameraPosition
 import org.meshtastic.core.repository.MapConsentPrefs
 import org.meshtastic.core.repository.MapPrefs
 import org.meshtastic.core.repository.MapTileProviderPrefs
@@ -251,7 +252,10 @@ class FakeUiPrefs : UiPrefs {
     }
 }
 
+@Suppress("TooManyFunctions")
 class FakeMapPrefs : MapPrefs {
+    private var cameraPosition: MapCameraPosition? = null
+
     override val mapStyle = MutableStateFlow(0)
 
     override fun setMapStyle(style: Int) {
@@ -303,6 +307,12 @@ class FakeMapPrefs : MapPrefs {
     }
 
     override suspend fun awaitNetworkMapLayers(): Set<String> = networkMapLayers.value
+
+    override fun setCameraPosition(position: MapCameraPosition) {
+        cameraPosition = position
+    }
+
+    override suspend fun awaitCameraPosition(): MapCameraPosition? = cameraPosition
 }
 
 class FakeMapConsentPrefs : MapConsentPrefs {


### PR DESCRIPTION
Switching away from the map recreated provider camera state, causing the map to reopen at a default or unrelated viewport. This retains the last camera across tab navigation while preserving the first-use behavior of fitting discovered nodes.

- Persist Google and F-Droid camera values atomically instead of treating temporary startup coordinates as saved state.
- Wait for persisted camera loading before initializing the map, preventing the default ocean-centered camera from winning startup races.
- Fit positioned nodes only when no camera has previously been saved.
- Add regression coverage for absent camera state, atomic restoration, and valid zero-valued coordinates.

## Testing Performed

- `./gradlew spotlessCheck detekt assembleDebug :core:prefs:jvmTest --tests org.meshtastic.core.prefs.map.MapPrefsImplTest :androidApp:testFdroidDebugUnitTest :androidApp:testGoogleDebugUnitTest --tests org.meshtastic.app.map.prefs.map.GoogleMapsPrefsTest`
- Verified F-Droid behavior on a physical Android device: pan/zoom, change tabs, and return to the same viewport.
- The repository-wide `spotlessApply spotlessCheck detekt assembleDebug test allTests --continue` invocation exceeded the 10-minute local command limit without reporting a map-related failure; the bounded cross-flavor matrix above completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map camera position is now restored when reopening the map (including target, zoom, tilt, and bearing where available).
  * When no saved camera exists, the map can automatically fit nodes after map data is ready.
* **Bug Fixes**
  * Improved camera initialization timing to avoid applying node bounds before nodes/maps are ready.
  * Camera saving now occurs at the right lifecycle points, including on effect disposal.
* **Tests**
  * Added/updated tests to verify camera position persistence and restore behavior, including the “absent before set” case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->