### PR TITLE
fix(strings): unescape quotes in base resources & guard against \" regressions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -114,6 +114,12 @@ jobs:
       - uses: actions/checkout@v7
       - name: Validate store listing metadata lengths
         run: python3 scripts/check-metadata-length.py
+      # Compose Multiplatform does not strip Android-style \" / \' escapes, so a
+      # backslash written before a quote renders literally in the UI (PR #6357).
+      # Guards the English source strings; locale mirrors are cleaned upstream by
+      # the Crowdin post-export processor.
+      - name: Check for escaped quotes in base string resources
+        run: python3 scripts/check-string-escapes.py
       # Flathub/AppStream needs a <release> entry for the version being shipped; a stale
       # <releases> block degrades (or fails) the Flathub listing. Fails the PR that bumps
       # VERSION_NAME_BASE until the matching entry is added.

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -629,7 +629,7 @@
     <string name="firmware_too_old">Firmware update required.</string>
     <string name="firmware_update_almost_there">Almost there...</string>
     <string name="firmware_update_alpha">Alpha</string>
-    <string name="firmware_update_archive_missing_target">No firmware for %2$s (%3$s) was found in \"%1$s\".</string>
+    <string name="firmware_update_archive_missing_target">No firmware for %2$s (%3$s) was found in "%1$s".</string>
     <string name="firmware_update_available">Firmware update available</string>
     <string name="firmware_update_battery_low">Battery too low (%1$d%). Please charge your device before updating.</string>
     <string name="firmware_update_checking">Checking for updates...</string>
@@ -657,7 +657,7 @@
     <string name="firmware_update_flashing">Flashing device, please wait...</string>
     <string name="firmware_update_hang_tight">Hang tight, we are working on it...</string>
     <string name="firmware_update_hash_rejected">Firmware hash rejected. Device may require hash provisioning or bootloader update.</string>
-    <string name="firmware_update_invalid_local_file_detail">The selected file \"%1$s\" does not match %2$s (%3$s). Choose the firmware file for this target.</string>
+    <string name="firmware_update_invalid_local_file_detail">The selected file "%1$s" does not match %2$s (%3$s). Choose the firmware file for this target.</string>
     <string name="firmware_update_keep_device_close">Keep your device close to your phone.</string>
     <string name="firmware_update_latest">Update To: %1$s</string>
     <string name="firmware_update_local_file">Local File</string>
@@ -1849,3 +1849,4 @@
     <string name="zh_CN" translatable="false">简体中文</string>
     <string name="zh_TW" translatable="false">繁體中文</string>
 </resources>
+

--- a/scripts/check-string-escapes.py
+++ b/scripts/check-string-escapes.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Guard against Android-style backslash-escaped quotes in Compose resources.
+
+These strings live under ``composeResources`` and are read by the Compose
+Multiplatform resources library, whose build-time ``handleSpecialCharacters``
+only processes ``\\n``, ``\\t``, ``\\uXXXX`` and ``\\\\`` -- it does NOT strip
+``\\"`` or ``\\'`` the way Android's AAPT does. A backslash written before a
+quote or apostrophe therefore renders *literally* in the UI (see the Italian
+``permission_missing_31`` regression, PR #6357). The correct value is a bare
+``"`` / ``'`` (or ``&#34;`` / ``&#39;`` if you want it explicit).
+
+Scope: the English **base** ``values/strings.xml`` only -- the source of truth
+authored in this repo. The per-locale ``values-*/`` files are Crowdin mirrors;
+their escaping is fixed upstream by the project's custom post-export processor
+(strips ``\\'`` and ``\\"`` on export), so editing them here would just be
+overwritten on the next sync. This guard catches developer-authored escapes in
+the source before they get propagated to every translation.
+
+Exit status is non-zero if any base string contains ``\\"`` or ``\\'``, so it
+can gate CI.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Repo root = parent of this script's directory (scripts/).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Base (source-language) resource files only: `values/`, never `values-*/`.
+BASE_STRINGS_GLOB = "**/composeResources/values/strings.xml"
+
+# A backslash directly before a quote or apostrophe, but not one that is itself
+# escaped (`\\"` = literal backslash + quote, which is intentional). `\n`, `\t`,
+# `\uXXXX` and `\\` are meaningful CMP escapes and are deliberately left alone.
+ESCAPED_QUOTE = re.compile(r"(?<!\\)\\(['\"])")
+
+# Running inside GitHub Actions enables ::error:: annotations on the PR.
+IN_GITHUB_ACTIONS = os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def main() -> int:
+    files = sorted(REPO_ROOT.glob(BASE_STRINGS_GLOB))
+    if not files:
+        print(f"error: no base strings.xml found under {REPO_ROOT}", file=sys.stderr)
+        return 2
+
+    violations: list[tuple[Path, int, str]] = []
+
+    for path in files:
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if ESCAPED_QUOTE.search(line):
+                violations.append((path, lineno, line.strip()))
+
+    if not violations:
+        print("No backslash-escaped quotes found in base string resources.")
+        return 0
+
+    print("Backslash-escaped quotes found in base string resources:\n")
+    for path, lineno, text in violations:
+        rel = path.relative_to(REPO_ROOT)
+        message = "escaped quote/apostrophe renders literally in Compose Multiplatform"
+        print(f"  - {rel}:{lineno}: {text}")
+        if IN_GITHUB_ACTIONS:
+            print(f"::error file={rel},line={lineno}::{message}")
+
+    print(
+        "\nCompose Multiplatform does not strip \\\" or \\' (unlike Android AAPT), "
+        "so the backslash shows up in the UI. Use a bare \" / ' (or &#34; / &#39;)."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Compose Multiplatform's build-time `handleSpecialCharacters` only processes `\n`, `\t`, `\uXXXX` and `\\` — it does **not** strip `\"` or `\'` the way Android's AAPT does. So a backslash written before a quote in a `composeResources` string renders **literally** in the UI. That's the bug behind the Italian `permission_missing_31` report in #6357, where users saw `\"Dispositivi nelle vicinanze\"` with visible backslashes.

The English base string uses a bare `"`, but two other base strings had slipped in with `\"`. Because those are the authored source of truth, they'd keep re-propagating `\"` into every translation on each Crowdin sync.

## 🐛 What changed

- **Unescaped two base strings** in `core/resources/.../values/strings.xml`:
  - `firmware_update_archive_missing_target`
  - `firmware_update_invalid_local_file_detail`

  `\"%1$s\"` → `"%1$s"`.

## 🛠️ Guard against regressions

- Added `scripts/check-string-escapes.py`, wired as a step into the existing lightweight `check-metadata` CI job (already gated by `check-workflow-status`).
- It fails the build on `\"` / `\'` in the **base** `values/strings.xml`, with `::error file=…,line=…::` annotations.
- Regex `(?<!\\)\\(['"])` flags escaped quotes/apostrophes while leaving meaningful escapes (`\n`, `\t`, `\\`) untouched.

## Scope note

The guard intentionally covers only the English **base** file. The 20 per-locale `values-*/` files are Crowdin mirrors (~114 remaining escapes); editing them here is overwritten on the next sync. The upstream fix is the project's Crowdin **custom post-export processor**, whose regex currently strips `\'` but not `\"` — extending it (`content.replace(/\\(['"])/g, "$1")`) plus a re-sync clears the locales. This PR fixes the source and prevents developer-authored regressions.

## Testing performed

- `python3 scripts/check-string-escapes.py` → passes on the cleaned base file (exit 0); confirmed it exits non-zero when a `\"` is present.
- Verified the regex flags `\"` and `\'` but not `\n` / `\\`.
- `pull-request.yml` validated as well-formed YAML.

Refs #6357

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected firmware-related text so quotation marks display properly without unwanted backslashes.
* **Quality Improvements**
  * Added automated validation to detect incorrectly escaped quotation marks and apostrophes in localized strings.
  * Metadata checks now provide clearer feedback when invalid string escaping is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->