### PR TITLE
build(deps): force patched jackson-core on Dokka classpath (GHSA-r7wm-3cxj-wff9)

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
@@ -22,7 +22,28 @@ import org.gradle.kotlin.dsl.project
 import org.jetbrains.dokka.gradle.DokkaExtension
 import java.net.URI
 
+/**
+ * Patched jackson-core forced onto Dokka's classpaths.
+ *
+ * Dokka 2.x pulls jackson-core transitively (dokka-core -> jackson-dataformat-xml / -module-kotlin),
+ * and the 2.15.x line it selects is vulnerable to GHSA-r7wm-3cxj-wff9 (async-parser `maxNumberLength`
+ * bypass, CWE-770). Dokka is a build-time-only documentation tool, so this never ships in the app, but
+ * pinning the patched line keeps the resolved dependency graph clean and closes the Dependabot alert.
+ * 2.18.8 is the first patched release and the closest maintenance line to Dokka's transitive 2.15.3.
+ */
+private const val PATCHED_JACKSON_CORE = "com.fasterxml.jackson.core:jackson-core:2.18.8"
+
+/** Force [PATCHED_JACKSON_CORE] on every Dokka configuration of this project (no-op elsewhere). */
+private fun Project.pinPatchedJacksonOnDokkaClasspaths() {
+    configurations.configureEach {
+        if (name.contains("dokka", ignoreCase = true)) {
+            resolutionStrategy.force(PATCHED_JACKSON_CORE)
+        }
+    }
+}
+
 fun Project.configureDokka() {
+    pinPatchedJacksonOnDokkaClasspaths()
     extensions.configure<DokkaExtension> {
         // Use the full project path as the module name to ensure uniqueness
         moduleName.set(project.path.removePrefix(":").replace(":", "-").ifEmpty { project.name })
@@ -67,6 +88,7 @@ fun Project.configureDokka() {
  * Isolated Projects. The list should match the modules declared in `settings.gradle.kts`.
  */
 fun Project.configureDokkaAggregation(subprojectPaths: List<String>) {
+    pinPatchedJacksonOnDokkaClasspaths()
     extensions.configure<DokkaExtension> {
         moduleName.set("Meshtastic App")
         dokkaPublications.configureEach { suppressInheritedMembers.set(true) }


### PR DESCRIPTION
## Why

[Dependabot #60](https://github.com/meshtastic/Meshtastic-Android/security/dependabot/60) flags **`com.fasterxml.jackson.core:jackson-core < 2.18.8`** — [GHSA-r7wm-3cxj-wff9](https://github.com/FasterXML/jackson-core/security/advisories/GHSA-r7wm-3cxj-wff9), an async-parser `maxNumberLength` bypass causing unbounded `TextBuffer` allocation (memory exhaustion, CWE-770, **High** / CVSS 8.7).

`jackson-core` is **not** a declared dependency anywhere in the app or `gradle/libs.versions.toml`. It is a **build-time-only transitive of Dokka 2.2.0**:

```
org.jetbrains.dokka:dokka-gradle-plugin → dokka-core
   → jackson-dataformat-xml / jackson-module-kotlin 2.15.3 → jackson-core 2.15.3
```

It rides Dokka's generator classpath (`dokkaHtmlGeneratorRuntime`), never ships in the APK, and the vulnerable path (a reactive HTTP server fed attacker-controlled chunked JSON) is unreachable here. Dokka `2.2.0` is already the latest release in **every** channel (Maven Central, GitHub tags, JetBrains dev/beta) — there is no version bump that moves it off `2.15.3`, so a `resolutionStrategy.force` is the only route to a patched jackson-core.

## 🛠️ What changed

`build-logic/convention/.../Dokka.kt`: force `jackson-core` to **2.18.8** on every Dokka configuration, centralized in the existing Dokka convention plugin and applied from both `configureDokka()` (per-module) and `configureDokkaAggregation()` (root).

- **`2.18.8`** is the first patched release and the closest maintenance line to Dokka's transitive `2.15.3` (advisory patched lines: 2.18.8 / 2.21.4 / 2.22.1).
- Forcing **only** `jackson-core` while its siblings (`databind`/`dataformat-xml`/`module-kotlin`) stay at 2.15.3 is the officially-safe "core-ahead" direction within Jackson 2.x.
- No `allprojects {}` / `subprojects {}` iteration — kept compatible with Gradle Isolated Projects, matching the existing convention.

## ✅ Testing Performed

- `dependencyInsight`: resolves **`2.15.3 -> 2.18.8 (forced, By constraint)`** on both the root aggregation classpath and `:core:model`.
- `./gradlew spotlessCheck detekt` — pass.
- `./gradlew :core:model:dokkaGenerateModuleHtml` — **BUILD SUCCESSFUL**, no jackson version-mismatch (`NoSuchMethodError`/`NoClassDefFoundError`/`AbstractMethodError`) at execution time.
- App baseline (`assembleDebug`/`test`/`allTests`) intentionally not run: this touches only the Dokka docs classpath and cannot affect app compilation or runtime.

## Note for reviewers

When a future Dokka release bundles a patched jackson, this force becomes a harmless no-op (it only fires if jackson-core is still below 2.18.8 on the Dokka classpath) and can be dropped. If Dependabot's rescan uses static parsing rather than live resolution, alert #60 may not auto-close on merge — it can then be dismissed citing the build-time-only + patched-force rationale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation build reliability by ensuring Dokka uses a patched Jackson Core version consistently across standard and aggregated documentation builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->