### PR TITLE
fix(node): stop metric-card trailing values crushing to one-char-per-line

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/DeviceMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/DeviceMetrics.kt
@@ -20,6 +20,7 @@ package org.meshtastic.feature.node.metrics
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -444,8 +445,15 @@ private fun DeviceMetricsCard(
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            /* Channel Utilization and Air Utilization Tx */
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            /* Channel Utilization / Air Utilization Tx, and Uptime */
+            // FlowRow(SpaceBetween) so the uptime stays pinned right when it fits and drops onto its own line when the
+            // (localized) labels don't fit, instead of being crushed and wrapped one character per line.
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                itemVerticalAlignment = Alignment.CenterVertically,
+            ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     if (deviceMetrics?.channel_utilization != null) {
                         MetricValueRow(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogComponents.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogComponents.kt
@@ -20,6 +20,7 @@ package org.meshtastic.feature.node.metrics
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -82,10 +83,13 @@ fun PositionCard(
             Spacer(modifier = Modifier.height(8.dp))
 
             /* Coordinates */
-            Row(
+            // FlowRow(SpaceBetween) so "Sats" stays pinned right when it fits and drops onto its own line when the
+            // (localized) coordinate labels don't fit, instead of being crushed and wrapped one character per line.
+            FlowRow(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                itemVerticalAlignment = Alignment.CenterVertically,
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     MetricValueRow(color = GraphColors.Blue, text = "${stringResource(Res.string.latitude)}: $latitude")
@@ -105,10 +109,13 @@ fun PositionCard(
             Spacer(modifier = Modifier.height(4.dp))
 
             /* Alt, Speed, Heading */
-            Row(
+            // FlowRow(SpaceBetween) so "Heading" stays pinned right when it fits and drops onto its own line when the
+            // (localized) labels don't fit, instead of being crushed and wrapped one character per line.
+            FlowRow(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                itemVerticalAlignment = Alignment.CenterVertically,
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     MetricValueRow(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/SignalMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/SignalMetrics.kt
@@ -482,7 +482,14 @@ private fun LocalStatsCard(telemetry: Telemetry, isSelected: Boolean, onClick: (
 
             Spacer(modifier = Modifier.height(8.dp))
 
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            // FlowRow(SpaceBetween): the relays stat wraps to its own line when the traffic label is too long,
+            // instead of being crushed and wrapped one character per line.
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                itemVerticalAlignment = Alignment.CenterVertically,
+            ) {
                 Text(
                     text =
                     stringResource(
@@ -506,7 +513,14 @@ private fun LocalStatsCard(telemetry: Telemetry, isSelected: Boolean, onClick: (
 
             Spacer(modifier = Modifier.height(4.dp))
 
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            // FlowRow(SpaceBetween): the uptime stat wraps to its own line when the nodes label is too long,
+            // instead of being crushed and wrapped one character per line.
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                itemVerticalAlignment = Alignment.CenterVertically,
+            ) {
                 Text(
                     text =
                     stringResource(


### PR DESCRIPTION
## 🐛 What & Why

A v2.7.14 prod screenshot showed the Device Metrics card's uptime text ("Laufzeit: 6h 20m 8s") wrapped one character per line into a vertical column. Root cause: `DeviceMetricsCard`, `PositionCard`, and `LocalStatsCard` all laid a trailing "label: value" `Text` next to a longer sibling group inside a plain `Row(horizontalArrangement = SpaceBetween)`. Compose measures un-weighted `Row` children in order against the *remaining* width, so the first (longer, often localized) group ate nearly the full width and left the trailing text a sliver to wrap into.

This is the same failure mode already fixed once in this module — `TracerouteCardMetrics` (#5743) — which the other three cards hadn't picked up.

## 🛠️ Changes

- `DeviceMetricsCard`, `PositionCard` (×2 rows), `LocalStatsCard` (×2 rows): swap `Row(SpaceBetween)` → `FlowRow(horizontalArrangement = SpaceBetween, verticalArrangement = spacedBy(4.dp), itemVerticalAlignment = CenterVertically)`. The trailing value stays pinned to the right edge when it fits, and wraps onto its own line when the (often-localized) sibling group doesn't leave room — instead of being crushed character-by-character.
- `itemVerticalAlignment` is passed explicitly because `FlowRow` defaults to `Top` alignment within a line, unlike the `Row`s it replaces (which centered their children) — without it the indicator dots would misalign against the text.

## Testing performed

- `./gradlew :feature:node:spotlessCheck :feature:node:detekt :feature:node:allTests` — all green.
- Reviewed against M3 guidance: wrapping over truncation matches M3's text-truncation guidance ("wrap text... use flexible containers that change size to fit their content"); 4dp/12dp gaps land on defined M3 spacing tokens (Space 50/150); `FlowRow` has been stable API since Compose Foundation 1.8, no opt-in needed on this repo's 1.11.3.
- Not verified on-device — the crush only reproduces at real card width with long localized strings, so no fixed-width Compose preview reproduces it. Un-draft gate: on-device/emulator pass, ideally with a German (or other long-label) locale.

Note: an unrelated pre-existing issue in the same view (the Device Metrics chart's right/voltage axis showing "0.0 V" on every gridline for externally-powered nodes) was investigated but intentionally **not** changed here — a powered node reporting 0V is a legitimate reading, not a bug worth fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device metrics cards so channel utilization, transmit usage, and uptime information wrap cleanly on smaller screens.
  * Updated position details to prevent cramped coordinate, altitude, speed, heading, and satellite information.
  * Improved local statistics layouts so relay and uptime values remain readable instead of wrapping awkwardly.
  * Preserved existing metric values and formatting while improving responsiveness across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->