### PR TITLE
fix(node): respect display units for position ground speed

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1550,6 +1550,7 @@ soil_moisture
 soil_temperature
 speed
 speed_kmh
+speed_mph
 spread_factor
 ssid
 state_broadcast_seconds

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/DistanceExtensions.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/DistanceExtensions.kt
@@ -18,11 +18,11 @@
 
 package org.meshtastic.core.model.util
 
-import kotlin.math.roundToInt
 import org.meshtastic.core.common.util.MeasurementSystem
 import org.meshtastic.core.common.util.formatString
 import org.meshtastic.core.common.util.getSystemMeasurementSystem
 import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
+import kotlin.math.roundToInt
 
 @Suppress("MagicNumber")
 enum class DistanceUnit(val symbol: String, val multiplier: Float, val system: Int) {
@@ -92,9 +92,9 @@ fun Float.toSpeedString(system: DisplayUnits): String = if (system == DisplayUni
 }
 
 /**
- * Converts a speed already expressed in km/h (e.g. protobuf `Position.ground_speed`) to [system]'s unit,
- * rounded to a whole number. Callers render the result through a localized string resource so the unit
- * label itself stays translatable (see `speed_kmh`/`speed_mph`).
+ * Converts a speed already expressed in km/h (e.g. protobuf `Position.ground_speed`) to [system]'s unit, rounded to a
+ * whole number. Callers render the result through a localized string resource so the unit label itself stays
+ * translatable (see `speed_kmh`/`speed_mph`).
  */
 @Suppress("MagicNumber")
 fun Int.kmhIn(system: DisplayUnits): Int =

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/DistanceExtensions.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/DistanceExtensions.kt
@@ -90,6 +90,14 @@ fun Float.toSpeedString(system: DisplayUnits): String = if (system == DisplayUni
     formatString("%.0f mph", this * 2.23694f)
 }
 
+/** Formats a speed already expressed in km/h (e.g. protobuf `Position.ground_speed`) for [system]. */
+@Suppress("MagicNumber")
+fun Int.kmhToSpeedString(system: DisplayUnits): String = if (system == DisplayUnits.IMPERIAL) {
+    formatString("%.0f mph", this * 0.621371f)
+} else {
+    formatString("%.0f km/h", this.toFloat())
+}
+
 @Suppress("MagicNumber")
 fun Float.toSmallDistanceString(system: DisplayUnits): String = if (system == DisplayUnits.IMPERIAL) {
     formatString("%.2f in", this / 25.4f)

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/DistanceExtensions.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/DistanceExtensions.kt
@@ -18,6 +18,7 @@
 
 package org.meshtastic.core.model.util
 
+import kotlin.math.roundToInt
 import org.meshtastic.core.common.util.MeasurementSystem
 import org.meshtastic.core.common.util.formatString
 import org.meshtastic.core.common.util.getSystemMeasurementSystem
@@ -90,13 +91,14 @@ fun Float.toSpeedString(system: DisplayUnits): String = if (system == DisplayUni
     formatString("%.0f mph", this * 2.23694f)
 }
 
-/** Formats a speed already expressed in km/h (e.g. protobuf `Position.ground_speed`) for [system]. */
+/**
+ * Converts a speed already expressed in km/h (e.g. protobuf `Position.ground_speed`) to [system]'s unit,
+ * rounded to a whole number. Callers render the result through a localized string resource so the unit
+ * label itself stays translatable (see `speed_kmh`/`speed_mph`).
+ */
 @Suppress("MagicNumber")
-fun Int.kmhToSpeedString(system: DisplayUnits): String = if (system == DisplayUnits.IMPERIAL) {
-    formatString("%.0f mph", this * 0.621371f)
-} else {
-    formatString("%.0f km/h", this.toFloat())
-}
+fun Int.kmhIn(system: DisplayUnits): Int =
+    if (system == DisplayUnits.IMPERIAL) (this * 0.621371f).roundToInt() else this
 
 @Suppress("MagicNumber")
 fun Float.toSmallDistanceString(system: DisplayUnits): String = if (system == DisplayUnits.IMPERIAL) {

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/DistanceExtensionsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/DistanceExtensionsTest.kt
@@ -23,18 +23,18 @@ import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
 class DistanceExtensionsTest {
 
     @Test
-    fun `kmhToSpeedString formats metric as-is`() {
-        assertEquals("50 km/h", 50.kmhToSpeedString(DisplayUnits.METRIC))
+    fun `kmhIn returns value unchanged for metric`() {
+        assertEquals(50, 50.kmhIn(DisplayUnits.METRIC))
     }
 
     @Test
-    fun `kmhToSpeedString converts to mph for imperial`() {
-        assertEquals("31 mph", 50.kmhToSpeedString(DisplayUnits.IMPERIAL))
+    fun `kmhIn converts to mph for imperial`() {
+        assertEquals(31, 50.kmhIn(DisplayUnits.IMPERIAL))
     }
 
     @Test
-    fun `kmhToSpeedString handles zero`() {
-        assertEquals("0 km/h", 0.kmhToSpeedString(DisplayUnits.METRIC))
-        assertEquals("0 mph", 0.kmhToSpeedString(DisplayUnits.IMPERIAL))
+    fun `kmhIn handles zero`() {
+        assertEquals(0, 0.kmhIn(DisplayUnits.METRIC))
+        assertEquals(0, 0.kmhIn(DisplayUnits.IMPERIAL))
     }
 }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/DistanceExtensionsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/DistanceExtensionsTest.kt
@@ -16,9 +16,9 @@
  */
 package org.meshtastic.core.model.util
 
+import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
 
 class DistanceExtensionsTest {
 

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/DistanceExtensionsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/DistanceExtensionsTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
+
+class DistanceExtensionsTest {
+
+    @Test
+    fun `kmhToSpeedString formats metric as-is`() {
+        assertEquals("50 km/h", 50.kmhToSpeedString(DisplayUnits.METRIC))
+    }
+
+    @Test
+    fun `kmhToSpeedString converts to mph for imperial`() {
+        assertEquals("31 mph", 50.kmhToSpeedString(DisplayUnits.IMPERIAL))
+    }
+
+    @Test
+    fun `kmhToSpeedString handles zero`() {
+        assertEquals("0 km/h", 0.kmhToSpeedString(DisplayUnits.METRIC))
+        assertEquals("0 mph", 0.kmhToSpeedString(DisplayUnits.IMPERIAL))
+    }
+}

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/DistanceExtensionsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/DistanceExtensionsTest.kt
@@ -30,6 +30,7 @@ class DistanceExtensionsTest {
     @Test
     fun `kmhIn converts to mph for imperial`() {
         assertEquals(31, 50.kmhIn(DisplayUnits.IMPERIAL))
+        assertEquals(50, 80.kmhIn(DisplayUnits.IMPERIAL))
     }
 
     @Test

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1592,6 +1592,7 @@
     <string name="soil_temperature">Soil Temp</string>
     <string name="speed">Speed</string>
     <string name="speed_kmh">%1$d Km/h</string>
+    <string name="speed_mph">%1$d mph</string>
     <string name="spread_factor">Spread Factor</string>
     <string name="ssid">SSID</string>
     <string name="state_broadcast_seconds">State broadcast (seconds)</string>

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogComponents.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogComponents.kt
@@ -40,7 +40,7 @@ import org.meshtastic.core.common.util.formatString
 import org.meshtastic.core.model.util.GeoConstants.DEG_D
 import org.meshtastic.core.model.util.GeoConstants.HEADING_DEG
 import org.meshtastic.core.model.util.TimeConstants.MS_PER_SEC
-import org.meshtastic.core.model.util.kmhToSpeedString
+import org.meshtastic.core.model.util.kmhIn
 import org.meshtastic.core.model.util.metersIn
 import org.meshtastic.core.model.util.toString
 import org.meshtastic.core.resources.Res
@@ -49,6 +49,8 @@ import org.meshtastic.core.resources.heading
 import org.meshtastic.core.resources.latitude
 import org.meshtastic.core.resources.longitude
 import org.meshtastic.core.resources.sats
+import org.meshtastic.core.resources.speed_kmh
+import org.meshtastic.core.resources.speed_mph
 import org.meshtastic.core.ui.theme.GraphColors
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.Position
@@ -120,9 +122,15 @@ fun PositionCard(
                     )
                     if (position.ground_speed != null && position.ground_speed != 0) {
                         Spacer(Modifier.width(12.dp))
+                        val speedRes =
+                            if (displayUnits == Config.DisplayConfig.DisplayUnits.IMPERIAL) {
+                                Res.string.speed_mph
+                            } else {
+                                Res.string.speed_kmh
+                            }
                         MetricValueRow(
                             color = GraphColors.Gold,
-                            text = (position.ground_speed ?: 0).kmhToSpeedString(displayUnits),
+                            text = stringResource(speedRes, (position.ground_speed ?: 0).kmhIn(displayUnits)),
                         )
                     }
                 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogComponents.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogComponents.kt
@@ -40,6 +40,7 @@ import org.meshtastic.core.common.util.formatString
 import org.meshtastic.core.model.util.GeoConstants.DEG_D
 import org.meshtastic.core.model.util.GeoConstants.HEADING_DEG
 import org.meshtastic.core.model.util.TimeConstants.MS_PER_SEC
+import org.meshtastic.core.model.util.kmhToSpeedString
 import org.meshtastic.core.model.util.metersIn
 import org.meshtastic.core.model.util.toString
 import org.meshtastic.core.resources.Res
@@ -48,7 +49,6 @@ import org.meshtastic.core.resources.heading
 import org.meshtastic.core.resources.latitude
 import org.meshtastic.core.resources.longitude
 import org.meshtastic.core.resources.sats
-import org.meshtastic.core.resources.speed_kmh
 import org.meshtastic.core.ui.theme.GraphColors
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.Position
@@ -122,7 +122,7 @@ fun PositionCard(
                         Spacer(Modifier.width(12.dp))
                         MetricValueRow(
                             color = GraphColors.Gold,
-                            text = stringResource(Res.string.speed_kmh, position.ground_speed ?: 0),
+                            text = (position.ground_speed ?: 0).kmhToSpeedString(displayUnits),
                         )
                     }
                 }


### PR DESCRIPTION
## Why

`PositionCard` rendered ground speed via a hardcoded `speed_kmh` string resource, always showing km/h regardless of the user's metric/imperial display-units setting — inconsistent with altitude on the same card, which already respects `displayUnits` via `.metersIn(displayUnits).toString(displayUnits)`. This also violates upstream design standards §10.2/§10.5 (no hardcoded unit labels; convert per locale/measurement-system setting).

## What changed

- 🛠️ Added `Int.kmhToSpeedString(system: DisplayUnits)` in [`DistanceExtensions.kt`](core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/DistanceExtensions.kt), alongside the existing `toSpeedString`/`toDistanceString` helpers, converting km/h → mph for imperial (passes through for metric). The existing `Float.toSpeedString` overload assumes an m/s source (used for wind speed) so a separate km/h-source function was added rather than overloading ambiguously.
- 🛠️ `PositionCard` now calls `(position.ground_speed ?: 0).kmhToSpeedString(displayUnits)` instead of `stringResource(Res.string.speed_kmh, ...)`.

## Testing Performed

- Added `DistanceExtensionsTest.kt` covering metric, imperial, and zero-speed cases.
- `./gradlew :feature:node:spotlessCheck :feature:node:detekt :feature:node:allTests :core:model:allTests` — all pass (686 tests, 0 failures).

## Notes for reviewer

- The now-unused `speed_kmh` string resource (translated across all Crowdin locales) was left in place rather than removed, since deleting translated resources is a separate cleanup concern outside this fix's scope.
- Heading (°) and coordinates (decimal degrees) on the same card are universal units per §10.4 and were left as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Speed rendering now adapts to the selected measurement system, showing km/h for metric and mph for imperial.
  * Added an mph string label/format to support consistent speed display in the UI.
* **Bug Fixes**
  * Node position cards now use the correct speed conversion when displaying ground speed.
* **Tests**
  * Added unit tests covering metric, imperial (rounded conversion), and zero speed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->