### PR TITLE
fix(settings): stop dropping admin config responses (0% stall, missing remote channels)

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -252,6 +252,7 @@ config_position_broadcast_smart_minimum_interval_secs_summary
 config_position_flags_summary
 config_position_gps_update_interval_summary
 config_power_is_power_saving_summary
+config_saved_restarting
 config_security_admin_key
 config_security_debug_log_api_enabled
 config_security_is_managed
@@ -1149,6 +1150,7 @@ node_list_help_node_details
 node_list_help_title
 node_list_long_click_label
 node_number
+node_restarting
 node_sort_alpha
 node_sort_button
 node_sort_channel
@@ -1420,7 +1422,9 @@ rssi_definition
 rsyslog_server
 sample_message
 sats
+### SAVE ###
 save
+save_and_restart
 save_changes
 save_csv_in_storage_esp32_only
 save_rangetest

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -51,6 +51,7 @@ import org.meshtastic.core.repository.MeshWorkerManager
 import org.meshtastic.core.repository.MqttManager
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketHandler
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.PlatformAnalytics
@@ -94,6 +95,7 @@ class MeshConnectionManagerImpl(
     private val heartbeatSender: DataLayerHeartbeatSender,
     private val lockdownCoordinator: LockdownCoordinator,
     @Named("ServiceScope") private val scope: CoroutineScope,
+    private val nodeRestartTracker: NodeRestartTracker,
 ) : MeshConnectionManager {
     /**
      * Serializes [onConnectionChanged] to prevent TOCTOU races when multiple coroutines emit state transitions
@@ -139,6 +141,11 @@ class MeshConnectionManagerImpl(
 
         // Ensure notification title and content stay in sync with state changes
         serviceRepository.connectionState.onEach { updateStatusNotification() }.launchIn(scope)
+
+        // An expected node restart ends when the post-reboot config handshake completes.
+        serviceRepository.connectionState
+            .onEach { if (it == ConnectionState.Connected) nodeRestartTracker.onConnected() }
+            .launchIn(scope)
 
         scope.launch {
             try {
@@ -623,10 +630,16 @@ class MeshConnectionManagerImpl(
     }
 
     override fun updateStatusNotification(telemetry: Telemetry?) {
-        serviceNotifications.updateServiceStateNotification(
-            serviceRepository.connectionState.value,
-            telemetry = telemetry,
-        )
+        val state = serviceRepository.connectionState.value
+        // During an expected node restart the disconnect is transient; keep the persistent notification on the
+        // connecting presentation instead of flashing "disconnected".
+        val presented =
+            if (state == ConnectionState.Disconnected && nodeRestartTracker.restartExpected.value) {
+                ConnectionState.Connecting
+            } else {
+                state
+            }
+        serviceNotifications.updateServiceStateNotification(presented, telemetry = telemetry)
     }
 
     companion object {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -66,6 +66,15 @@ class PacketHandlerImpl(
 
     companion object {
         private val TIMEOUT = 5.seconds
+
+        /**
+         * Firmware-internal `ErrorCode` (MeshTypes.h `ERRNO_SHOULD_RELEASE`) leaked into `QueueStatus.res`: "no error,
+         * but the packet should still be released". Firmware 2.8+ returns it for self-addressed packets, which are
+         * delivered through the synchronous local loopback instead of the TX queue — a success. Note it numerically
+         * collides with `Routing.Error.PKI_UNKNOWN_PUBKEY` (35); `QueueStatus.res` carries ErrorCode semantics, not
+         * Routing.Error.
+         */
+        private const val ERRNO_SHOULD_RELEASE = 35
     }
 
     private var queueJob: Job? = null
@@ -163,7 +172,8 @@ class PacketHandlerImpl(
 
     override fun handleQueueStatus(queueStatus: QueueStatus) {
         Logger.d { "[queueStatus] ${queueStatus.toOneLineString()}" }
-        val (success, isFull, requestId) = with(queueStatus) { Triple(res == 0, free == 0, mesh_packet_id) }
+        val (success, isFull, requestId) =
+            with(queueStatus) { Triple(res == 0 || res == ERRNO_SHOULD_RELEASE, free == 0, mesh_packet_id) }
         if (success && isFull) return
 
         scope.launch {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -174,7 +174,10 @@ class PacketHandlerImpl(
         Logger.d { "[queueStatus] ${queueStatus.toOneLineString()}" }
         val (success, isFull, requestId) =
             with(queueStatus) { Triple(res == 0 || res == ERRNO_SHOULD_RELEASE, free == 0, mesh_packet_id) }
-        if (success && isFull) return
+        // Only the plain res==0 "queue accepted, now full" echo is skipped here. ERRNO_SHOULD_RELEASE denotes a
+        // synchronous local-loopback delivery that still needs its queueResponse completed, even when free==0, or it
+        // would hang until TIMEOUT.
+        if (queueStatus.res == 0 && isFull) return
 
         scope.launch {
             responseMutex.withLock {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
@@ -48,6 +48,7 @@ import org.meshtastic.core.repository.MeshNotificationManager
 import org.meshtastic.core.repository.MeshWorkerManager
 import org.meshtastic.core.repository.MqttManager
 import org.meshtastic.core.repository.NodeManager
+import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketHandler
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.PlatformAnalytics
@@ -166,6 +167,7 @@ class MeshConnectionManagerImplTest {
         DataLayerHeartbeatSender(packetHandler),
         lockdownCoordinator,
         scope,
+        NodeRestartTracker(scope),
     )
 
     private fun restartTransportCallCounter(): () -> Int {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -26,6 +26,7 @@ import dev.mokkery.verifySuspend
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -42,7 +43,9 @@ import org.meshtastic.proto.QueueStatus
 import org.meshtastic.proto.ToRadio
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class PacketHandlerImplTest {
 
@@ -114,6 +117,34 @@ class PacketHandlerImplTest {
 
         handler.handleQueueStatus(status)
         testScheduler.runCurrent()
+    }
+
+    @Test
+    fun `handleQueueStatus treats ERRNO_SHOULD_RELEASE as success`() = runTest(testDispatcher) {
+        // Firmware 2.8+ returns ErrorCode 35 (ERRNO_SHOULD_RELEASE) for self-addressed packets delivered
+        // through the synchronous local loopback — a success, not a queue failure.
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 790)) }
+        testScheduler.runCurrent()
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 790, res = 35, free = 16))
+        testScheduler.runCurrent()
+
+        assertTrue(result.await())
+    }
+
+    @Test
+    fun `handleQueueStatus treats other nonzero res as failure`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 791)) }
+        testScheduler.runCurrent()
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 791, res = 33, free = 16))
+        testScheduler.runCurrent()
+
+        assertFalse(result.await())
     }
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -135,6 +135,22 @@ class PacketHandlerImplTest {
     }
 
     @Test
+    fun `handleQueueStatus completes ERRNO_SHOULD_RELEASE even when queue is full`() = runTest(testDispatcher) {
+        // Regression: a self-addressed local-loopback delivery (res=35) can coincide with a full TX queue (free=0).
+        // The success+full early return must not swallow it, or the response hangs until TIMEOUT (the very stall
+        // this fix targets). Only the plain res=0 "accepted, now full" echo should be skipped.
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 792)) }
+        testScheduler.runCurrent()
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 792, res = 35, free = 0))
+        testScheduler.runCurrent()
+
+        assertTrue(result.await())
+    }
+
+    @Test
     fun `handleQueueStatus treats other nonzero res as failure`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
 

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/AdminActionsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/AdminActionsUseCase.kt
@@ -25,6 +25,9 @@ import org.meshtastic.core.repository.RadioController
  *
  * This component provides methods for rebooting, shutting down, or resetting nodes within the mesh. It also handles
  * local database synchronization when these actions are performed on the locally connected device.
+ *
+ * Each method's `onRequestId` callback fires with the request's packet ID *before* the send is issued; callers that
+ * correlate responses by request ID must register there (see [RadioConfigUseCase] for the ordering rationale).
  */
 @Single
 open class AdminActionsUseCase
@@ -38,8 +41,9 @@ constructor(
      * @param destNum The node number to reboot.
      * @return The packet ID of the request.
      */
-    open suspend fun reboot(destNum: Int): Int {
+    open suspend fun reboot(destNum: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.reboot(destNum, packetId)
         return packetId
     }
@@ -50,8 +54,9 @@ constructor(
      * @param destNum The node number to shut down.
      * @return The packet ID of the request.
      */
-    open suspend fun shutdown(destNum: Int): Int {
+    open suspend fun shutdown(destNum: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.shutdown(destNum, packetId)
         return packetId
     }
@@ -63,8 +68,9 @@ constructor(
      * @param isLocal Whether the reset is being performed on the locally connected node.
      * @return The packet ID of the request.
      */
-    open suspend fun factoryReset(destNum: Int, isLocal: Boolean): Int {
+    open suspend fun factoryReset(destNum: Int, isLocal: Boolean, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.factoryReset(destNum, packetId)
 
         if (isLocal) {
@@ -83,8 +89,9 @@ constructor(
      * @param destNum The node number to update.
      * @return The packet ID of the request.
      */
-    open suspend fun setTime(destNum: Int): Int {
+    open suspend fun setTime(destNum: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.setTime(destNum, packetId)
         return packetId
     }
@@ -97,8 +104,14 @@ constructor(
      * @param isLocal Whether the reset is being performed on the locally connected node.
      * @return The packet ID of the request.
      */
-    open suspend fun nodedbReset(destNum: Int, preserveFavorites: Boolean, isLocal: Boolean): Int {
+    open suspend fun nodedbReset(
+        destNum: Int,
+        preserveFavorites: Boolean,
+        isLocal: Boolean,
+        onRequestId: (Int) -> Unit = {},
+    ): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.nodedbReset(destNum, packetId, preserveFavorites)
 
         if (isLocal) {

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/RadioConfigUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/RadioConfigUseCase.kt
@@ -24,7 +24,15 @@ import org.meshtastic.proto.HamParameters
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.User
 
-/** Use case for interacting with radio configuration components. */
+/**
+ * Use case for interacting with radio configuration components.
+ *
+ * Every request method takes an [onRequestId] callback invoked with the request's packet ID *before* the send is
+ * issued. Callers that correlate responses by request ID (e.g. `RadioConfigViewModel.requestIds`) MUST register the ID
+ * in this callback rather than after the method returns: the send suspends until the radio acks the packet via
+ * `QueueStatus`, and for the locally connected node the firmware (2.8+) delivers the admin response through its
+ * synchronous loopback *before* that ack — so a post-return registration loses the race and the response is dropped.
+ */
 @Suppress("TooManyFunctions")
 @Single
 open class RadioConfigUseCase constructor(private val radioController: RadioController) {
@@ -33,10 +41,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      *
      * @param destNum The node number to update.
      * @param user The new user configuration.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun setOwner(destNum: Int, user: User): Int {
+    open suspend fun setOwner(destNum: Int, user: User, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.setOwner(destNum, user, packetId)
         return packetId
     }
@@ -47,10 +57,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      *
      * @param destNum The node number to update (must be the local node).
      * @param hamParameters The ham onboarding parameters.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun setHamMode(destNum: Int, hamParameters: HamParameters): Int {
+    open suspend fun setHamMode(destNum: Int, hamParameters: HamParameters, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.setHamMode(destNum, hamParameters, packetId)
         return packetId
     }
@@ -59,10 +71,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      * Requests the owner information from the radio.
      *
      * @param destNum The node number to query.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun getOwner(destNum: Int): Int {
+    open suspend fun getOwner(destNum: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.getOwner(destNum, packetId)
         return packetId
     }
@@ -72,10 +86,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      *
      * @param destNum The node number to update.
      * @param config The new configuration.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun setConfig(destNum: Int, config: Config): Int {
+    open suspend fun setConfig(destNum: Int, config: Config, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.setConfig(destNum, config, packetId)
         return packetId
     }
@@ -85,10 +101,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      *
      * @param destNum The node number to query.
      * @param configType The type of configuration to request (from [org.meshtastic.proto.AdminMessage.ConfigType]).
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun getConfig(destNum: Int, configType: Int): Int {
+    open suspend fun getConfig(destNum: Int, configType: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.getConfig(destNum, configType, packetId)
         return packetId
     }
@@ -98,10 +116,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      *
      * @param destNum The node number to update.
      * @param config The new module configuration.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun setModuleConfig(destNum: Int, config: ModuleConfig): Int {
+    open suspend fun setModuleConfig(destNum: Int, config: ModuleConfig, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.setModuleConfig(destNum, config, packetId)
         return packetId
     }
@@ -111,10 +131,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      *
      * @param destNum The node number to query.
      * @param moduleConfigType The type of module configuration to request.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun getModuleConfig(destNum: Int, moduleConfigType: Int): Int {
+    open suspend fun getModuleConfig(destNum: Int, moduleConfigType: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.getModuleConfig(destNum, moduleConfigType, packetId)
         return packetId
     }
@@ -124,10 +146,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      *
      * @param destNum The node number to query.
      * @param index The index of the channel to request.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun getChannel(destNum: Int, index: Int): Int {
+    open suspend fun getChannel(destNum: Int, index: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.getChannel(destNum, index, packetId)
         return packetId
     }
@@ -137,10 +161,16 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      *
      * @param destNum The node number to update.
      * @param channel The new channel configuration.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun setRemoteChannel(destNum: Int, channel: org.meshtastic.proto.Channel): Int {
+    open suspend fun setRemoteChannel(
+        destNum: Int,
+        channel: org.meshtastic.proto.Channel,
+        onRequestId: (Int) -> Unit = {},
+    ): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.setRemoteChannel(destNum, channel, packetId)
         return packetId
     }
@@ -164,10 +194,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      * Requests the ringtone from the radio.
      *
      * @param destNum The node number to query.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun getRingtone(destNum: Int): Int {
+    open suspend fun getRingtone(destNum: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.getRingtone(destNum, packetId)
         return packetId
     }
@@ -181,10 +213,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      * Requests the canned messages from the radio.
      *
      * @param destNum The node number to query.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun getCannedMessages(destNum: Int): Int {
+    open suspend fun getCannedMessages(destNum: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.getCannedMessages(destNum, packetId)
         return packetId
     }
@@ -193,10 +227,12 @@ open class RadioConfigUseCase constructor(private val radioController: RadioCont
      * Requests the device connection status from the radio.
      *
      * @param destNum The node number to query.
+     * @param onRequestId Invoked with the request's packet ID before the send is issued.
      * @return The packet ID of the request.
      */
-    open suspend fun getDeviceConnectionStatus(destNum: Int): Int {
+    open suspend fun getDeviceConnectionStatus(destNum: Int, onRequestId: (Int) -> Unit = {}): Int {
         val packetId = radioController.generatePacketId()
+        onRequestId(packetId)
         radioController.getDeviceConnectionStatus(destNum, packetId)
         return packetId
     }

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/RadioConfigUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/RadioConfigUseCaseTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.domain.usecase.settings
 
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.model.Position
+import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.testing.FakeRadioController
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.HamParameters
@@ -36,6 +37,25 @@ class RadioConfigUseCaseTest {
     fun setUp() {
         radioController = FakeRadioController()
         useCase = RadioConfigUseCase(radioController)
+    }
+
+    @Test
+    fun `getConfig invokes onRequestId with the packet id before issuing the send`() = runTest {
+        // Guards against the response/registration race: for the locally connected node the firmware
+        // (2.8+) delivers the admin response before the QueueStatus ack that completes the send, so a
+        // caller registering the request id only after the send returns would drop the response.
+        val events = mutableListOf<String>()
+        val recordingController =
+            object : RadioController by radioController {
+                override suspend fun getConfig(destNum: Int, configType: Int, packetId: Int) {
+                    events.add("send:$packetId")
+                }
+            }
+        val orderedUseCase = RadioConfigUseCase(recordingController)
+
+        val packetId = orderedUseCase.getConfig(1234, 5) { events.add("registered:$it") }
+
+        assertEquals(listOf("registered:$packetId", "send:$packetId"), events)
     }
 
     @Test

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRestartTracker.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeRestartTracker.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tracks a window in which the locally connected node is expected to restart (a config save the firmware applies with a
+ * reboot, or an explicit reboot command). While the window is open, an observed transport disconnect is the expected
+ * consequence of the restart — the UI presents "restarting" instead of the alarming disconnected state, and the
+ * foreground-service notification stays on a connecting presentation.
+ *
+ * The window closes when the node completes its post-reboot config handshake ([onConnected]) or after [DEFAULT_WINDOW]
+ * if the node never comes back — after that, a persisting disconnect is a real problem and is shown as one.
+ */
+class NodeRestartTracker(private val scope: CoroutineScope) {
+
+    private val _restartExpected = MutableStateFlow(false)
+
+    /** True while a node restart (and its transport disconnect) is expected. */
+    val restartExpected: StateFlow<Boolean> = _restartExpected.asStateFlow()
+
+    private var expiryJob: Job? = null
+
+    /** Opens (or extends) the expected-restart window. Call at the moment the restart-causing action is sent. */
+    fun expectRestart(window: Duration = DEFAULT_WINDOW) {
+        expiryJob?.cancel()
+        _restartExpected.value = true
+        expiryJob =
+            scope.launch {
+                delay(window)
+                _restartExpected.value = false
+            }
+    }
+
+    /** Closes the window; call when the node is fully back online (config handshake complete). */
+    fun onConnected() {
+        expiryJob?.cancel()
+        expiryJob = null
+        _restartExpected.value = false
+    }
+
+    companion object {
+        /** Covers reboot delay (~5s), boot (~10-25s), reconnect and config sync (~10-30s) with headroom. */
+        val DEFAULT_WINDOW = 90.seconds
+    }
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/di/CoreRepositoryModule.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/di/CoreRepositoryModule.kt
@@ -26,6 +26,7 @@ import org.meshtastic.core.repository.MeshBeaconPrefs
 import org.meshtastic.core.repository.MeshBeaconRepository
 import org.meshtastic.core.repository.MessageQueue
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.repository.usecase.SendMessageUseCase
@@ -41,6 +42,10 @@ class CoreRepositoryModule {
 
     @Single
     fun provideFirmwareUpdateStatusRepository(): FirmwareUpdateStatusRepository = FirmwareUpdateStatusRepository()
+
+    @Single
+    fun provideNodeRestartTracker(@Provided applicationScope: ApplicationCoroutineScope): NodeRestartTracker =
+        NodeRestartTracker(applicationScope)
 
     @Single
     fun provideSendMessageUseCase(

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/NodeRestartTrackerTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/NodeRestartTrackerTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class NodeRestartTrackerTest {
+
+    @Test
+    fun `expectRestart opens the window`() = runTest {
+        val tracker = NodeRestartTracker(backgroundScope)
+
+        tracker.expectRestart()
+
+        assertTrue(tracker.restartExpected.value)
+    }
+
+    @Test
+    fun `onConnected closes the window`() = runTest {
+        val tracker = NodeRestartTracker(backgroundScope)
+        tracker.expectRestart()
+
+        tracker.onConnected()
+
+        assertFalse(tracker.restartExpected.value)
+    }
+
+    @Test
+    fun `window expires if the node never comes back`() = runTest {
+        val tracker = NodeRestartTracker(backgroundScope)
+        tracker.expectRestart(window = 10.seconds)
+
+        advanceTimeBy(9.seconds)
+        runCurrent()
+        assertTrue(tracker.restartExpected.value)
+
+        advanceTimeBy(2.seconds)
+        runCurrent()
+        assertFalse(tracker.restartExpected.value)
+    }
+
+    @Test
+    fun `a later expectRestart extends an open window`() = runTest {
+        val tracker = NodeRestartTracker(backgroundScope)
+        tracker.expectRestart(window = 10.seconds)
+
+        advanceTimeBy(8.seconds)
+        runCurrent()
+        tracker.expectRestart(window = 10.seconds)
+
+        advanceTimeBy(8.seconds)
+        runCurrent()
+        assertTrue(tracker.restartExpected.value)
+    }
+}

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -273,6 +273,7 @@
     <string name="config_position_flags_summary">Optional fields to include when assembling position messages. the more fields are included, the larger the message will be - leading to longer airtime and a higher risk of packet loss.</string>
     <string name="config_position_gps_update_interval_summary">How often should we try to get a GPS position (&lt;10sec keeps GPS on).</string>
     <string name="config_power_is_power_saving_summary">Will sleep everything as much as possible, for the tracker and sensor role this will also include the lora radio. Don't use this setting if you want to use your device with the phone apps or are using a device without a user button.</string>
+    <string name="config_saved_restarting">The node is restarting and will be briefly unreachable.</string>
     <string name="config_security_admin_key">The public key authorized to send admin messages to this node.</string>
     <string name="config_security_debug_log_api_enabled">Output live debug logging over serial, view and export position-redacted device logs over Bluetooth.</string>
     <string name="config_security_is_managed">Device is managed by a mesh administrator, the user is unable to access any of the device settings.</string>
@@ -1182,6 +1183,7 @@
     <string name="node_list_help_title">Node List Help</string>
     <string name="node_list_long_click_label">Node options</string>
     <string name="node_number">Node Number</string>
+    <string name="node_restarting">Restarting…</string>
     <string name="node_sort_alpha">A-Z</string>
     <string name="node_sort_button">Node sorting options</string>
     <string name="node_sort_channel">Channel</string>
@@ -1465,7 +1467,9 @@
     <string name="rsyslog_server">rsyslog server</string>
     <string name="sample_message" translatable="false">hey I found the cache, it is over here next to the big tiger. I'm kinda scared.</string>
     <string name="sats">Sats</string>
+    <!-- SAVE -->
     <string name="save">Save</string>
+    <string name="save_and_restart">Save &amp; restart</string>
     <string name="save_changes">Save</string>
     <string name="save_csv_in_storage_esp32_only">Save .CSV in storage (ESP32 only)</string>
     <string name="save_rangetest">Export rangetest packets</string>

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavigationSuite.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavigationSuite.kt
@@ -47,10 +47,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.Flow
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
+import org.meshtastic.core.model.MeshActivity
 import org.meshtastic.core.navigation.ContactsRoute
 import org.meshtastic.core.navigation.MultiBackstack
 import org.meshtastic.core.navigation.NodesRoute
@@ -60,6 +62,7 @@ import org.meshtastic.core.resources.connected
 import org.meshtastic.core.resources.connecting
 import org.meshtastic.core.resources.device_sleeping
 import org.meshtastic.core.resources.disconnected
+import org.meshtastic.core.resources.node_restarting
 import org.meshtastic.core.ui.navigation.icon
 import org.meshtastic.core.ui.viewmodel.UIViewModel
 
@@ -78,6 +81,7 @@ fun MeshtasticNavigationSuite(
     content: @Composable () -> Unit,
 ) {
     val connectionState by uiViewModel.connectionState.collectAsStateWithLifecycle()
+    val nodeRestartExpected by uiViewModel.nodeRestartExpected.collectAsStateWithLifecycle()
     val unreadMessageCount by uiViewModel.unreadMessageCount.collectAsStateWithLifecycle()
     val selectedDevice by uiViewModel.currentDeviceAddressFlow.collectAsStateWithLifecycle()
 
@@ -103,9 +107,10 @@ fun MeshtasticNavigationSuite(
                             destination = destination,
                             isSelected = isSelected,
                             connectionState = connectionState,
+                            nodeRestartExpected = nodeRestartExpected,
                             unreadMessageCount = unreadMessageCount,
                             selectedDevice = selectedDevice,
-                            uiViewModel = uiViewModel,
+                            meshActivityFlow = uiViewModel.meshActivity,
                         )
                     },
                     label =
@@ -178,9 +183,19 @@ private fun NavigationIconContent(
     connectionState: ConnectionState,
     unreadMessageCount: Int,
     selectedDevice: String?,
-    uiViewModel: UIViewModel,
+    meshActivityFlow: Flow<MeshActivity>,
+    nodeRestartExpected: Boolean = false,
 ) {
     val isConnectionsRoute = destination == TopLevelDestination.Connect
+    // An expected node restart (reboot-applying config save) presents as an in-progress state, not a scary
+    // red disconnect: the icon borrows the Connecting treatment and the tooltip says "Restarting".
+    val restarting = nodeRestartExpected && connectionState != ConnectionState.Connected
+    val presentedState =
+        if (restarting && connectionState == ConnectionState.Disconnected) {
+            ConnectionState.Connecting
+        } else {
+            connectionState
+        }
 
     TooltipBox(
         positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
@@ -188,12 +203,7 @@ private fun NavigationIconContent(
             PlainTooltip {
                 Text(
                     if (isConnectionsRoute) {
-                        when (connectionState) {
-                            ConnectionState.Connected -> stringResource(Res.string.connected)
-                            ConnectionState.Connecting -> stringResource(Res.string.connecting)
-                            ConnectionState.DeviceSleep -> stringResource(Res.string.device_sleeping)
-                            ConnectionState.Disconnected -> stringResource(Res.string.disconnected)
-                        }
+                        connectionTooltipLabel(restarting, connectionState)
                     } else {
                         stringResource(destination.label)
                     },
@@ -204,9 +214,9 @@ private fun NavigationIconContent(
     ) {
         if (isConnectionsRoute) {
             AnimatedConnectionsNavIcon(
-                connectionState = connectionState,
+                connectionState = presentedState,
                 deviceType = DeviceType.fromAddress(selectedDevice ?: "NoDevice"),
-                meshActivityFlow = uiViewModel.meshActivity,
+                meshActivityFlow = meshActivityFlow,
             )
         } else {
             BadgedBox(
@@ -236,4 +246,13 @@ private fun NavigationIconContent(
             }
         }
     }
+}
+
+@Composable
+private fun connectionTooltipLabel(restarting: Boolean, connectionState: ConnectionState): String = when {
+    restarting -> stringResource(Res.string.node_restarting)
+    connectionState == ConnectionState.Connected -> stringResource(Res.string.connected)
+    connectionState == ConnectionState.Connecting -> stringResource(Res.string.connecting)
+    connectionState == ConnectionState.DeviceSleep -> stringResource(Res.string.device_sleeping)
+    else -> stringResource(Res.string.disconnected)
 }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModel.kt
@@ -45,6 +45,7 @@ import org.meshtastic.core.model.util.TimeConstants
 import org.meshtastic.core.repository.DeviceHardwareRepository
 import org.meshtastic.core.repository.FirmwareReleaseRepository
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.RadioConfigRepository
@@ -77,6 +78,13 @@ enum class ConnectionStatus {
      */
     RECONNECTING,
 
+    /**
+     * The node is applying a change that reboots it (config save or reboot command) and the transport drop is expected.
+     * Distinct from [NOT_CONNECTED] so the UI presents an in-progress restart instead of a failure. Ends when the node
+     * finishes its post-reboot handshake or the [NodeRestartTracker] window expires.
+     */
+    RESTARTING,
+
     /** Connected with node info available. */
     CONNECTED,
 
@@ -92,6 +100,7 @@ class ConnectionsViewModel(
     radioConfigRepository: RadioConfigRepository,
     serviceRepository: ServiceRepository,
     nodeRepository: NodeRepository,
+    nodeRestartTracker: NodeRestartTracker,
     private val uiPrefs: UiPrefs,
     private val deviceHardwareRepository: DeviceHardwareRepository,
     private val firmwareReleaseRepository: FirmwareReleaseRepository,
@@ -145,18 +154,27 @@ class ConnectionsViewModel(
      * [ServiceRepository.RECONNECTING_PROGRESS_TEXT] for the cross-track contract.
      */
     val connectionStatus: StateFlow<ConnectionStatus> =
-        combine(connectionState, regionUnset, serviceRepository.connectionProgress) { state, unset, progress ->
+        combine(
+            connectionState,
+            regionUnset,
+            serviceRepository.connectionProgress,
+            nodeRestartTracker.restartExpected,
+        ) { state, unset, progress, restartExpected ->
             when (state) {
                 is ConnectionState.Connected ->
                     if (unset) ConnectionStatus.MUST_SET_REGION else ConnectionStatus.CONNECTED
 
-                ConnectionState.Connecting -> ConnectionStatus.CONNECTING
+                // While an expected node restart is in flight, the drop and the reconnect attempts are the restart
+                // —
+                // present them as such instead of as a failure.
+                ConnectionState.Connecting ->
+                    if (restartExpected) ConnectionStatus.RESTARTING else ConnectionStatus.CONNECTING
 
                 ConnectionState.Disconnected ->
-                    if (progress == ServiceRepository.RECONNECTING_PROGRESS_TEXT) {
-                        ConnectionStatus.RECONNECTING
-                    } else {
-                        ConnectionStatus.NOT_CONNECTED
+                    when {
+                        restartExpected -> ConnectionStatus.RESTARTING
+                        progress == ServiceRepository.RECONNECTING_PROGRESS_TEXT -> ConnectionStatus.RECONNECTING
+                        else -> ConnectionStatus.NOT_CONNECTED
                     }
 
                 ConnectionState.DeviceSleep -> ConnectionStatus.CONNECTED_SLEEPING

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
@@ -56,6 +56,7 @@ import org.meshtastic.core.repository.LockdownCoordinator
 import org.meshtastic.core.repository.LockdownPassphraseStore
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioController
@@ -96,7 +97,11 @@ class UIViewModel(
     packetRepository: PacketRepository,
     val alertManager: AlertManager,
     val snackbarManager: SnackbarManager,
+    nodeRestartTracker: NodeRestartTracker,
 ) : ViewModel() {
+
+    /** True while the connected node is expected to be mid-restart (reboot-applying config save or reboot command). */
+    val nodeRestartExpected: StateFlow<Boolean> = nodeRestartTracker.restartExpected
 
     private val _navigationDeepLink = MutableSharedFlow<List<NavKey>>(replay = 1)
     val navigationDeepLink = _navigationDeepLink.asSharedFlow()

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
@@ -21,8 +21,10 @@ import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -33,6 +35,7 @@ import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.model.FirmwareUpdateDestination
+import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.RadioConfigRepository
@@ -60,6 +63,7 @@ class ConnectionsViewModelTest {
     private lateinit var viewModel: ConnectionsViewModel
     private val radioConfigRepository: RadioConfigRepository = mock(MockMode.autofill)
     private val serviceRepository = FakeServiceRepository()
+    private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
     private val nodeRepository = FakeNodeRepository()
     private val uiPrefs = FakeUiPrefs()
     private val deviceHardwareRepository = FakeDeviceHardwareRepository()
@@ -94,6 +98,7 @@ class ConnectionsViewModelTest {
                 radioConfigRepository = radioConfigRepository,
                 serviceRepository = serviceRepository,
                 nodeRepository = nodeRepository,
+                nodeRestartTracker = nodeRestartTracker,
                 uiPrefs = uiPrefs,
                 deviceHardwareRepository = deviceHardwareRepository,
                 firmwareReleaseRepository = firmwareReleaseRepository,

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/ConnectingDeviceInfo.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/ConnectingDeviceInfo.kt
@@ -39,6 +39,7 @@ import org.meshtastic.core.resources.connected_sleeping
 import org.meshtastic.core.resources.connecting
 import org.meshtastic.core.resources.disconnect
 import org.meshtastic.core.resources.must_set_region
+import org.meshtastic.core.resources.node_restarting
 import org.meshtastic.core.resources.not_connected
 import org.meshtastic.core.resources.reconnecting
 import org.meshtastic.core.resources.stop_connecting
@@ -63,6 +64,7 @@ fun ConnectingDeviceInfo(
             ConnectionStatus.MUST_SET_REGION -> stringResource(Res.string.must_set_region)
             ConnectionStatus.CONNECTING -> connectionProgress ?: stringResource(Res.string.connecting)
             ConnectionStatus.RECONNECTING -> stringResource(Res.string.reconnecting)
+            ConnectionStatus.RESTARTING -> stringResource(Res.string.node_restarting)
             ConnectionStatus.CONNECTED_SLEEPING -> stringResource(Res.string.connected_sleeping)
             ConnectionStatus.NOT_CONNECTED -> stringResource(Res.string.not_connected)
         }
@@ -78,6 +80,7 @@ fun ConnectingDeviceInfo(
 
             ConnectionStatus.CONNECTING,
             ConnectionStatus.RECONNECTING,
+            ConnectionStatus.RESTARTING,
             ConnectionStatus.NOT_CONNECTED,
             -> stringResource(Res.string.stop_connecting)
         }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -68,6 +68,7 @@ import org.meshtastic.core.repository.LockdownPassphraseStore
 import org.meshtastic.core.repository.MapConsentPrefs
 import org.meshtastic.core.repository.MqttManager
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.SecurityKeyBackupStore
@@ -159,6 +160,7 @@ open class RadioConfigViewModel(
     private val lockdownCoordinator: LockdownCoordinator,
     private val securityKeyBackupStore: SecurityKeyBackupStore,
     private val snackbarManager: SnackbarManager,
+    private val nodeRestartTracker: NodeRestartTracker,
 ) : ViewModel() {
 
     val lockdownTokenInfo = serviceRepository.lockdownTokenInfo
@@ -346,6 +348,17 @@ open class RadioConfigViewModel(
         }
             .launchIn(viewModelScope)
 
+        // A reboot-applying save can't survive the reboot it triggers: the node drops the transport before the
+        // routing ACK arrives, so the save dialog would otherwise sit at 0% until the 30s request timeout and then
+        // surface a spurious "Timeout" error. The disconnect during an expected-restart window IS the confirmation
+        // the save was persisted (firmware only reboots after saveChanges writes to disk), so resolve the pending
+        // save to the restarting-success the moment the transport drops.
+        serviceRepository.connectionState
+            .map { it == ConnectionState.Connected }
+            .distinctUntilChanged()
+            .onEach { connected -> if (!connected) completeRestartingSaveIfPending() }
+            .launchIn(viewModelScope)
+
         Logger.d { "RadioConfigViewModel created" }
     }
 
@@ -354,6 +367,18 @@ open class RadioConfigViewModel(
 
     val myNodeNum
         get() = myNodeInfo.value?.myNodeNum
+
+    /**
+     * Opens the expected-restart window when a save/action is about to make the LOCALLY CONNECTED node reboot (firmware
+     * applies most config sections with a reboot a few seconds after the ack). A remote node's reboot doesn't drop our
+     * transport, so remote destinations never open the window. Called at send time because module saves disable
+     * Bluetooth on the device immediately — before the save is even acked.
+     */
+    private fun expectRestartIfLocal(behavior: RebootBehavior) {
+        if (behavior == RebootBehavior.NEVER) return
+        val dest = destNum ?: destNode.value?.num ?: return
+        if (dest == myNodeNum) nodeRestartTracker.expectRestart()
+    }
 
     val maxChannels
         get() = myNodeInfo.value?.maxChannels ?: 8
@@ -392,6 +417,7 @@ open class RadioConfigViewModel(
             _radioConfigState.update { it.copy(userConfig = user) }
             // The form's long-name field carries the callsign while licensed (iOS parity).
             // When meshtastic/protobufs#941 ships, add long_name here.
+            expectRestartIfLocal(RebootBehavior.ALWAYS)
             radioConfigUseCase.setHamMode(
                 destNum,
                 HamParameters(call_sign = user.long_name, short_name = user.short_name),
@@ -513,6 +539,7 @@ open class RadioConfigViewModel(
                     ),
                 )
             }
+            expectRestartIfLocal(config.saveRebootBehavior())
             radioConfigUseCase.setConfig(destNum, config, onRequestId = ::registerRequestId)
         }
     }
@@ -544,6 +571,7 @@ open class RadioConfigViewModel(
                     ),
                 )
             }
+            expectRestartIfLocal(config.saveRebootBehavior())
             radioConfigUseCase.setModuleConfig(destNum, config, onRequestId = ::registerRequestId)
         }
     }
@@ -571,7 +599,10 @@ open class RadioConfigViewModel(
                 safeLaunch(tag = "setTime") { adminActionsUseCase.setTime(destNum, onRequestId = ::registerRequestId) }
 
             AdminRoute.REBOOT.name ->
-                safeLaunch(tag = "reboot") { adminActionsUseCase.reboot(destNum, onRequestId = ::registerRequestId) }
+                safeLaunch(tag = "reboot") {
+                    expectRestartIfLocal(RebootBehavior.ALWAYS)
+                    adminActionsUseCase.reboot(destNum, onRequestId = ::registerRequestId)
+                }
 
             AdminRoute.SHUTDOWN.name ->
                 with(radioConfigState.value) {
@@ -587,6 +618,7 @@ open class RadioConfigViewModel(
             AdminRoute.FACTORY_RESET.name ->
                 safeLaunch(tag = "factoryReset") {
                     val isLocal = (destNum == myNodeNum)
+                    if (isLocal) nodeRestartTracker.expectRestart()
                     adminActionsUseCase.factoryReset(destNum, isLocal, onRequestId = ::registerRequestId)
                 }
 
@@ -830,6 +862,21 @@ open class RadioConfigViewModel(
         }
     }
 
+    /**
+     * Resolves a pending SAVE response to success ("node is restarting") when a restart is expected. Called on the
+     * transport-drop edge (the reboot) and as the request-timeout backstop. Scoped to saves (route is empty; gets keep
+     * their route set) and gated on [NodeRestartTracker.restartExpected] so a genuine unexpected disconnect still
+     * surfaces normally. Clears request ids first so the pending 30s timeout can't later flip success back to error.
+     */
+    private fun completeRestartingSaveIfPending() {
+        if (!nodeRestartTracker.restartExpected.value) return
+        val state = radioConfigState.value
+        if (state.responseState is ResponseState.Loading && state.route.isEmpty()) {
+            clearRequestIds()
+            setResponseStateSuccess()
+        }
+    }
+
     protected fun setResponseStateSuccess() {
         _radioConfigState.update { state ->
             if (state.responseState is ResponseState.Loading) {
@@ -883,7 +930,13 @@ open class RadioConfigViewModel(
                 if (requestIds.value.contains(packetId)) {
                     removeRequestId(packetId)
                     if (requestIds.value.isEmpty()) {
-                        sendError(Res.string.timeout)
+                        // A save that reboots the node races the reboot against its ACK; a timeout here during an
+                        // expected restart means the reboot won — treat it as the restarting-success, not an error.
+                        if (nodeRestartTracker.restartExpected.value && radioConfigState.value.route.isEmpty()) {
+                            setResponseStateSuccess()
+                        } else {
+                            sendError(Res.string.timeout)
+                        }
                     }
                 }
             }
@@ -1145,3 +1198,16 @@ private fun HashSet<Int>.withoutPacketId(packetId: Int): HashSet<Int> = HashSet(
 
 private fun HashSet<Int>.withoutPacketIds(packetIds: Set<Int>): HashSet<Int> =
     HashSet(this).apply { removeAll(packetIds) }
+
+/**
+ * Coarse mirror of firmware `AdminModule::handleSetConfig`'s reboot decision for the section being saved. Sections with
+ * field-level carve-outs map to [RebootBehavior.MAY_RESTART]; see [RebootBehavior] for why this stays coarse.
+ */
+internal fun Config.saveRebootBehavior(): RebootBehavior = when {
+    position != null || network != null || bluetooth != null || security != null -> RebootBehavior.ALWAYS
+    else -> RebootBehavior.MAY_RESTART
+}
+
+/** Firmware `AdminModule::handleSetModuleConfig` reboots for every module section except status message. */
+internal fun ModuleConfig.saveRebootBehavior(): RebootBehavior =
+    if (statusmessage != null) RebootBehavior.NEVER else RebootBehavior.ALWAYS

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -625,6 +625,9 @@ open class RadioConfigViewModel(
             AdminRoute.NODEDB_RESET.name ->
                 safeLaunch(tag = "nodedbReset") {
                     val isLocal = (destNum == myNodeNum)
+                    // Firmware reboots after a nodedb reset, so a local reset drops the transport just like a
+                    // factory reset — mark it expected so the UI shows "restarting" instead of a surprise disconnect.
+                    if (isLocal) nodeRestartTracker.expectRestart()
                     adminActionsUseCase.nodedbReset(destNum, preserveFavorites, isLocal, ::registerRequestId)
                 }
         }
@@ -854,6 +857,15 @@ open class RadioConfigViewModel(
         removeRequestIds(batchRequestIds)
     }
 
+    /**
+     * True while a manual channel batch is in flight — from enqueue through the ack-wait that outlives
+     * [finishManualChannelBatch]. [manualChannelBatchEnqueueing] alone only covers the enqueue phase, so pending batch
+     * request ids are the authoritative signal that a batch (not a reboot-applying save) owns the current Loading
+     * state.
+     */
+    private fun manualChannelBatchInFlight(): Boolean =
+        manualChannelBatchEnqueueing || manualChannelBatchRequestIds.isNotEmpty()
+
     private fun completeSetRequestOrProgressBatch() {
         if (manualChannelBatchEnqueueing) {
             incrementCompleted()
@@ -870,6 +882,10 @@ open class RadioConfigViewModel(
      */
     private fun completeRestartingSaveIfPending() {
         if (!nodeRestartTracker.restartExpected.value) return
+        // A manual channel batch shares the save shape (empty route + Loading) but never reboots the node; a stale
+        // restart window must not flip an in-flight batch to success. The batch stays in flight through its ack-wait,
+        // past finishManualChannelBatch, so key off its pending request ids — not just the enqueue flag.
+        if (manualChannelBatchInFlight()) return
         val state = radioConfigState.value
         if (state.responseState is ResponseState.Loading && state.route.isEmpty()) {
             clearRequestIds()
@@ -928,11 +944,19 @@ open class RadioConfigViewModel(
             safeLaunch(tag = "requestTimeout") {
                 delay(requestTimeout)
                 if (requestIds.value.contains(packetId)) {
+                    // Capture batch membership before removeRequestId drops the last id and empties the batch set.
+                    val timedOutBatchRequest = packetId in manualChannelBatchRequestIds
                     removeRequestId(packetId)
                     if (requestIds.value.isEmpty()) {
                         // A save that reboots the node races the reboot against its ACK; a timeout here during an
                         // expected restart means the reboot won — treat it as the restarting-success, not an error.
-                        if (nodeRestartTracker.restartExpected.value && radioConfigState.value.route.isEmpty()) {
+                        // A manual channel batch never reboots, so exclude it even inside a stale restart window.
+                        if (
+                            nodeRestartTracker.restartExpected.value &&
+                            !timedOutBatchRequest &&
+                            !manualChannelBatchInFlight() &&
+                            radioConfigState.value.route.isEmpty()
+                        ) {
                             setResponseStateSuccess()
                         } else {
                             sendError(Res.string.timeout)

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -392,12 +392,11 @@ open class RadioConfigViewModel(
             _radioConfigState.update { it.copy(userConfig = user) }
             // The form's long-name field carries the callsign while licensed (iOS parity).
             // When meshtastic/protobufs#941 ships, add long_name here.
-            val packetId =
-                radioConfigUseCase.setHamMode(
-                    destNum,
-                    HamParameters(call_sign = user.long_name, short_name = user.short_name),
-                )
-            registerRequestId(packetId)
+            radioConfigUseCase.setHamMode(
+                destNum,
+                HamParameters(call_sign = user.long_name, short_name = user.short_name),
+                onRequestId = ::registerRequestId,
+            )
         }
     }
 
@@ -409,8 +408,7 @@ open class RadioConfigViewModel(
         val destNum = destNum ?: destNode.value?.num ?: return
         safeLaunch(tag = "setOwner") {
             _radioConfigState.update { it.copy(userConfig = user) }
-            val packetId = radioConfigUseCase.setOwner(destNum, user)
-            registerRequestId(packetId)
+            radioConfigUseCase.setOwner(destNum, user, onRequestId = ::registerRequestId)
         }
     }
 
@@ -434,7 +432,9 @@ open class RadioConfigViewModel(
                         updatePlan = updatePlan,
                         currentSettings = current,
                         finalSettings = new,
-                        writeChannel = { channel -> radioConfigUseCase.setRemoteChannel(destNum, channel) },
+                        writeChannel = { channel, onRequestId ->
+                            radioConfigUseCase.setRemoteChannel(destNum, channel, onRequestId)
+                        },
                         registerRequestId = { packetId ->
                             batchRequestIds.add(packetId)
                             registerManualChannelBatchRequestId(packetId)
@@ -513,8 +513,7 @@ open class RadioConfigViewModel(
                     ),
                 )
             }
-            val packetId = radioConfigUseCase.setConfig(destNum, config)
-            registerRequestId(packetId)
+            radioConfigUseCase.setConfig(destNum, config, onRequestId = ::registerRequestId)
         }
     }
 
@@ -545,8 +544,7 @@ open class RadioConfigViewModel(
                     ),
                 )
             }
-            val packetId = radioConfigUseCase.setModuleConfig(destNum, config)
-            registerRequestId(packetId)
+            radioConfigUseCase.setModuleConfig(destNum, config, onRequestId = ::registerRequestId)
         }
     }
 
@@ -570,16 +568,10 @@ open class RadioConfigViewModel(
 
         when (route) {
             AdminRoute.SET_TIME.name ->
-                safeLaunch(tag = "setTime") {
-                    val packetId = adminActionsUseCase.setTime(destNum)
-                    registerRequestId(packetId)
-                }
+                safeLaunch(tag = "setTime") { adminActionsUseCase.setTime(destNum, onRequestId = ::registerRequestId) }
 
             AdminRoute.REBOOT.name ->
-                safeLaunch(tag = "reboot") {
-                    val packetId = adminActionsUseCase.reboot(destNum)
-                    registerRequestId(packetId)
-                }
+                safeLaunch(tag = "reboot") { adminActionsUseCase.reboot(destNum, onRequestId = ::registerRequestId) }
 
             AdminRoute.SHUTDOWN.name ->
                 with(radioConfigState.value) {
@@ -587,8 +579,7 @@ open class RadioConfigViewModel(
                         sendError(Res.string.cant_shutdown)
                     } else {
                         safeLaunch(tag = "shutdown") {
-                            val packetId = adminActionsUseCase.shutdown(destNum)
-                            registerRequestId(packetId)
+                            adminActionsUseCase.shutdown(destNum, onRequestId = ::registerRequestId)
                         }
                     }
                 }
@@ -596,15 +587,13 @@ open class RadioConfigViewModel(
             AdminRoute.FACTORY_RESET.name ->
                 safeLaunch(tag = "factoryReset") {
                     val isLocal = (destNum == myNodeNum)
-                    val packetId = adminActionsUseCase.factoryReset(destNum, isLocal)
-                    registerRequestId(packetId)
+                    adminActionsUseCase.factoryReset(destNum, isLocal, onRequestId = ::registerRequestId)
                 }
 
             AdminRoute.NODEDB_RESET.name ->
                 safeLaunch(tag = "nodedbReset") {
                     val isLocal = (destNum == myNodeNum)
-                    val packetId = adminActionsUseCase.nodedbReset(destNum, preserveFavorites, isLocal)
-                    registerRequestId(packetId)
+                    adminActionsUseCase.nodedbReset(destNum, preserveFavorites, isLocal, ::registerRequestId)
                 }
         }
     }
@@ -731,19 +720,18 @@ open class RadioConfigViewModel(
 
         when (route) {
             ConfigRoute.USER ->
-                safeLaunch(tag = "getOwner") {
-                    val packetId = radioConfigUseCase.getOwner(destNum)
-                    registerRequestId(packetId)
-                }
+                safeLaunch(tag = "getOwner") { radioConfigUseCase.getOwner(destNum, onRequestId = ::registerRequestId) }
 
             ConfigRoute.CHANNELS -> {
                 safeLaunch(tag = "getChannel0") {
-                    val packetId = radioConfigUseCase.getChannel(destNum, 0)
-                    registerRequestId(packetId)
+                    radioConfigUseCase.getChannel(destNum, 0, onRequestId = ::registerRequestId)
                 }
                 safeLaunch(tag = "getLoraConfig") {
-                    val packetId = radioConfigUseCase.getConfig(destNum, AdminMessage.ConfigType.LORA_CONFIG.value)
-                    registerRequestId(packetId)
+                    radioConfigUseCase.getConfig(
+                        destNum,
+                        AdminMessage.ConfigType.LORA_CONFIG.value,
+                        onRequestId = ::registerRequestId,
+                    )
                 }
                 // channel editor is synchronous, so we don't use requestIds as total
                 setResponseStateTotal(maxChannels + 1)
@@ -751,9 +739,11 @@ open class RadioConfigViewModel(
 
             is AdminRoute -> {
                 safeLaunch(tag = "getSessionKeyConfig") {
-                    val packetId =
-                        radioConfigUseCase.getConfig(destNum, AdminMessage.ConfigType.SESSIONKEY_CONFIG.value)
-                    registerRequestId(packetId)
+                    radioConfigUseCase.getConfig(
+                        destNum,
+                        AdminMessage.ConfigType.SESSIONKEY_CONFIG.value,
+                        onRequestId = ::registerRequestId,
+                    )
                 }
                 setResponseStateTotal(2)
             }
@@ -761,38 +751,32 @@ open class RadioConfigViewModel(
             is ConfigRoute -> {
                 if (route == ConfigRoute.LORA) {
                     safeLaunch(tag = "getChannel0ForLora") {
-                        val packetId = radioConfigUseCase.getChannel(destNum, 0)
-                        registerRequestId(packetId)
+                        radioConfigUseCase.getChannel(destNum, 0, onRequestId = ::registerRequestId)
                     }
                 }
                 if (route == ConfigRoute.NETWORK) {
                     safeLaunch(tag = "getConnectionStatus") {
-                        val packetId = radioConfigUseCase.getDeviceConnectionStatus(destNum)
-                        registerRequestId(packetId)
+                        radioConfigUseCase.getDeviceConnectionStatus(destNum, onRequestId = ::registerRequestId)
                     }
                 }
                 safeLaunch(tag = "getConfig") {
-                    val packetId = radioConfigUseCase.getConfig(destNum, route.type)
-                    registerRequestId(packetId)
+                    radioConfigUseCase.getConfig(destNum, route.type, onRequestId = ::registerRequestId)
                 }
             }
 
             is ModuleRoute -> {
                 if (route == ModuleRoute.CANNED_MESSAGE) {
                     safeLaunch(tag = "getCannedMessages") {
-                        val packetId = radioConfigUseCase.getCannedMessages(destNum)
-                        registerRequestId(packetId)
+                        radioConfigUseCase.getCannedMessages(destNum, onRequestId = ::registerRequestId)
                     }
                 }
                 if (route == ModuleRoute.EXT_NOTIFICATION) {
                     safeLaunch(tag = "getRingtone") {
-                        val packetId = radioConfigUseCase.getRingtone(destNum)
-                        registerRequestId(packetId)
+                        radioConfigUseCase.getRingtone(destNum, onRequestId = ::registerRequestId)
                     }
                 }
                 safeLaunch(tag = "getModuleConfig") {
-                    val packetId = radioConfigUseCase.getModuleConfig(destNum, route.type)
-                    registerRequestId(packetId)
+                    radioConfigUseCase.getModuleConfig(destNum, route.type, onRequestId = ::registerRequestId)
                 }
             }
         }
@@ -986,8 +970,7 @@ open class RadioConfigViewModel(
                     if (index + 1 < maxChannels && route == ConfigRoute.CHANNELS.name) {
                         // Not done yet, request next channel
                         safeLaunch(tag = "getNextChannel") {
-                            val packetId = radioConfigUseCase.getChannel(destNum, index + 1)
-                            registerRequestId(packetId)
+                            radioConfigUseCase.getChannel(destNum, index + 1, onRequestId = ::registerRequestId)
                         }
                     }
                 } else {
@@ -1076,13 +1059,20 @@ open class RadioConfigViewModel(
         }
 
         val requestId = packet.decoded?.request_id ?: return
-        removeRequestId(requestId)
+        // Defer the removal so a chain continuation launched above (e.g. the next getChannel of a
+        // sequential channel fetch) registers its request id first — launches run FIFO on the main
+        // dispatcher, and registration is the continuation's first act before its send. Removing inline
+        // would observe a momentarily-empty request set in the gap between chained requests and tear the
+        // whole flow down (clearPacketResponse), stranding the rest of the chain.
+        safeLaunch(tag = "completePacketResponse") {
+            removeRequestId(requestId)
 
-        if (requestIds.value.isEmpty()) {
-            if (route.isNotEmpty() && !AdminRoute.entries.any { it.name == route }) {
-                clearPacketResponse()
-            } else if (route.isEmpty()) {
-                completeSetRequestOrProgressBatch()
+            if (requestIds.value.isEmpty()) {
+                if (route.isNotEmpty() && !AdminRoute.entries.any { it.name == route }) {
+                    clearPacketResponse()
+                } else if (route.isEmpty()) {
+                    completeSetRequestOrProgressBatch()
+                }
             }
         }
     }
@@ -1099,7 +1089,7 @@ internal suspend fun applyManualChannelUpdatePlan(
     updatePlan: List<Channel>,
     currentSettings: List<ChannelSettings>,
     finalSettings: List<ChannelSettings>,
-    writeChannel: suspend (Channel) -> Int,
+    writeChannel: suspend (Channel, onRequestId: (Int) -> Unit) -> Int,
     registerRequestId: (Int) -> Unit,
     onInterrupted: suspend (InterruptedManualChannelUpdate) -> Unit = {},
     writeDelay: Duration = MANUAL_CHANNEL_WRITE_DELAY,
@@ -1111,9 +1101,12 @@ internal suspend fun applyManualChannelUpdatePlan(
     var updateComplete = false
     try {
         for ((index, channel) in updatePlan.withIndex()) {
-            val packetId = writeChannel(channel)
-            packetIds.add(packetId)
-            registerRequestId(packetId)
+            // Register before the write is issued: the local loopback response/ACK can arrive
+            // before the suspending send returns, so post-hoc registration would drop it.
+            writeChannel(channel) { packetId ->
+                packetIds.add(packetId)
+                registerRequestId(packetId)
+            }
             appliedSettings.applyManualChannelWrite(channel)
             appliedWriteCount++
             if (index < updatePlan.lastIndex) {

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RebootBehavior.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RebootBehavior.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio
+
+/**
+ * How the firmware applies a saved config section (firmware `AdminModule::handleSetConfig` / `handleSetModuleConfig`):
+ * most sections are applied with a node reboot a few seconds after the save is acked.
+ *
+ * This map is deliberately COARSE — the firmware's reboot decision is field-level for some sections and changes between
+ * releases, so the app only distinguishes "will restart", "may restart", and "never restarts". Bias toward
+ * [MAY_RESTART] when unsure; claim [ALWAYS] only for sections that have rebooted across firmware generations.
+ */
+enum class RebootBehavior {
+    /** The firmware applies this section with a reboot; the save UI says "Save & restart". */
+    ALWAYS,
+
+    /** The firmware reboots only when specific fields change; the save UI keeps the softer "may reboot" copy. */
+    MAY_RESTART,
+
+    /** Applied live — no reboot, no warning. */
+    NEVER,
+}

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
@@ -67,6 +67,7 @@ import org.meshtastic.core.ui.component.rememberDragDropState
 import org.meshtastic.core.ui.icon.Add
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.radio.ResponseState
 import org.meshtastic.feature.settings.radio.channel.component.ChannelCard
 import org.meshtastic.feature.settings.radio.channel.component.ChannelConfigHeader
@@ -99,7 +100,11 @@ fun ChannelConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
         LoadingOverlay(state = state.responseState)
 
         if (state.responseState is ResponseState.Success || state.responseState is ResponseState.Error) {
-            PacketResponseStateDialog(state = state.responseState, onDismiss = viewModel::clearPacketResponse)
+            PacketResponseStateDialog(
+                state = state.responseState,
+                onDismiss = viewModel::clearPacketResponse,
+                rebootBehavior = RebootBehavior.NEVER,
+            )
         }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelConfigScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -91,6 +92,7 @@ fun ChannelConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
             maxChannels = viewModel.maxChannels,
             firmwareVersion = state.metadata?.firmware_version ?: "0.0.0",
             enabled = state.connected,
+            isFetching = state.responseState is ResponseState.Loading,
             onPositiveClicked = { channelListInput -> viewModel.updateChannels(channelListInput, state.channelList) },
         )
 
@@ -112,6 +114,7 @@ private fun ChannelConfigScreen(
     maxChannels: Int = 8,
     firmwareVersion: String,
     enabled: Boolean,
+    isFetching: Boolean = false,
     onPositiveClicked: (List<ChannelSettings>) -> Unit,
 ) {
     val primarySettings = settingsList.getOrNull(0) ?: return
@@ -128,6 +131,18 @@ private fun ChannelConfigScreen(
         rememberSaveable(saver = channelPskEditStatesSaver) {
             List(settingsListInput.size) { ChannelPskEditState() }.toMutableStateList()
         }
+
+    // A remote channel fetch streams channels in one response at a time AFTER the editor first composes
+    // (composition starts as soon as channel 0 lands), so the one-shot seed above goes stale and the list
+    // would only show the channels present at seed time (#6317 — the footer Cancel's replaceWith was the
+    // accidental workaround). Adopt the authoritative list while the fetch is in flight: the loading
+    // overlay blocks input during the fetch, so there are no user edits to clobber.
+    LaunchedEffect(settingsList, isFetching) {
+        if (isFetching) {
+            settingsListInput.replaceWith(settingsList)
+            pskEditStatesInput.replaceAll(settingsList.size, ChannelPskEditState())
+        }
+    }
 
     val listState = rememberLazyListState()
     val dragDropState =

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
@@ -94,6 +94,7 @@ import org.meshtastic.feature.settings.channel.ChannelViewModel
 import org.meshtastic.feature.settings.navigation.ConfigRoute
 import org.meshtastic.feature.settings.navigation.getNavRouteFrom
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.radio.component.PacketResponseStateDialog
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
@@ -134,6 +135,7 @@ fun ChannelScreen(
     if (isWaiting) {
         PacketResponseStateDialog(
             state = radioConfigState.responseState,
+            rebootBehavior = RebootBehavior.NEVER,
             onDismiss = {
                 isWaiting = false
                 radioConfigViewModel.clearPacketResponse()

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/AmbientLightingConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/AmbientLightingConfigItemList.kt
@@ -37,6 +37,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.ModuleConfig
 
 private const val MAX_LED_CURRENT = 31
@@ -50,6 +51,7 @@ fun AmbientLightingConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> U
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.ambient_lighting),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/AudioConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/AudioConfigItemList.kt
@@ -39,6 +39,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.ModuleConfig
 
 @Composable
@@ -49,6 +50,7 @@ fun AudioConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.audio),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/BluetoothConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/BluetoothConfigItemList.kt
@@ -41,6 +41,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.Config
 
 private const val PIN_LENGTH = 6
@@ -53,6 +54,7 @@ fun BluetoothConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.bluetooth),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/CannedMessageConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/CannedMessageConfigItemList.kt
@@ -50,6 +50,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.ModuleConfig
 
 @Suppress("DEPRECATION", "LongMethod")
@@ -63,6 +64,7 @@ fun CannedMessageConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Uni
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.canned_message),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/DetectionSensorConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/DetectionSensorConfigItemList.kt
@@ -44,6 +44,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.util.IntervalConfiguration
 import org.meshtastic.feature.settings.util.gpioPins
 import org.meshtastic.feature.settings.util.toDisplayString
@@ -57,6 +58,7 @@ fun DetectionSensorConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> U
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.detection_sensor),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MQTTConfigItemList.kt
@@ -87,6 +87,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.ModuleConfig
 
 // json_enabled is deprecated in the protobuf schema but remains the only toggle for MQTT JSON
@@ -120,6 +121,7 @@ fun MQTTConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.mqtt),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/NeighborInfoConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/NeighborInfoConfigItemList.kt
@@ -35,6 +35,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.ModuleConfig
 
 @Composable
@@ -45,6 +46,7 @@ fun NeighborInfoConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.neighbor_info),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/NetworkConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/NetworkConfigItemList.kt
@@ -82,6 +82,7 @@ import org.meshtastic.core.ui.util.LocalBarcodeScannerProvider
 import org.meshtastic.core.ui.util.LocalNfcScannerProvider
 import org.meshtastic.core.ui.util.LocalNfcScannerSupported
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.Config
 
 @Composable
@@ -149,6 +150,7 @@ fun NetworkConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit, onO
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.network),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/PacketResponseStateDialog.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/PacketResponseStateDialog.kt
@@ -39,6 +39,7 @@ import org.meshtastic.core.common.util.MetricFormatter
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.cancel
 import org.meshtastic.core.resources.close
+import org.meshtastic.core.resources.config_saved_restarting
 import org.meshtastic.core.resources.delivery_confirmed
 import org.meshtastic.core.resources.delivery_confirmed_reboot_warning
 import org.meshtastic.core.resources.error
@@ -46,6 +47,7 @@ import org.meshtastic.core.ui.component.MeshtasticDialog
 import org.meshtastic.core.ui.icon.Error
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Success
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.radio.ResponseState
 
 private const val AUTO_DISMISS_DELAY_MS = 1500L
@@ -56,6 +58,7 @@ fun <T> PacketResponseStateDialog(
     onDismiss: () -> Unit = {},
     onComplete: () -> Unit = {},
     onBack: () -> Unit = {},
+    rebootBehavior: RebootBehavior = RebootBehavior.MAY_RESTART,
 ) {
     LaunchedEffect(state) {
         if (state is ResponseState.Success) {
@@ -81,7 +84,7 @@ fun <T> PacketResponseStateDialog(
                     }
 
                     is ResponseState.Success -> {
-                        SuccessContent()
+                        SuccessContent(rebootBehavior)
                     }
 
                     is ResponseState.Error -> {
@@ -136,7 +139,7 @@ private fun LoadingContent(state: ResponseState.Loading, onComplete: () -> Unit)
 }
 
 @Composable
-private fun SuccessContent() {
+private fun SuccessContent(rebootBehavior: RebootBehavior) {
     Icon(
         imageVector = MeshtasticIcons.Success,
         contentDescription = null,
@@ -149,12 +152,22 @@ private fun SuccessContent() {
             style = MaterialTheme.typography.headlineSmall,
             textAlign = TextAlign.Center,
         )
-        Text(
-            text = stringResource(Res.string.delivery_confirmed_reboot_warning),
-            style = MaterialTheme.typography.bodyMedium,
-            textAlign = TextAlign.Center,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        // The firmware applies most config sections with a node reboot; say what is actually happening for the
+        // section that was saved instead of a one-size-fits-all warning (and say nothing when nothing will happen).
+        val rebootNotice =
+            when (rebootBehavior) {
+                RebootBehavior.ALWAYS -> stringResource(Res.string.config_saved_restarting)
+                RebootBehavior.MAY_RESTART -> stringResource(Res.string.delivery_confirmed_reboot_warning)
+                RebootBehavior.NEVER -> null
+            }
+        rebootNotice?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/PaxcounterConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/PaxcounterConfigItemList.kt
@@ -37,6 +37,7 @@ import org.meshtastic.core.ui.component.SignedIntegerEditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.util.IntervalConfiguration
 import org.meshtastic.feature.settings.util.toDisplayString
 import org.meshtastic.proto.ModuleConfig
@@ -49,6 +50,7 @@ fun PaxcounterConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) 
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.paxcounter),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/PositionConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/PositionConfigScreen.kt
@@ -60,6 +60,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.util.FixedUpdateIntervals
 import org.meshtastic.feature.settings.util.IntervalConfiguration
 import org.meshtastic.feature.settings.util.toDisplayString
@@ -137,6 +138,7 @@ fun PositionConfigScreenCommon(viewModel: RadioConfigViewModel, onBack: () -> Un
 
     val focusManager = LocalFocusManager.current
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.position),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RadioConfigScreenList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RadioConfigScreenList.kt
@@ -38,9 +38,11 @@ import com.squareup.wire.Message
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.discard_changes
+import org.meshtastic.core.resources.save_and_restart
 import org.meshtastic.core.resources.save_changes
 import org.meshtastic.core.ui.component.MainAppBar
 import org.meshtastic.core.ui.component.PreferenceFooter
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.radio.ResponseState
 
 @Suppress("LongMethod")
@@ -54,6 +56,7 @@ fun <T : Message<T, *>> RadioConfigScreenList(
     enabled: Boolean,
     onSave: (T) -> Unit,
     modifier: Modifier = Modifier,
+    rebootBehavior: RebootBehavior = RebootBehavior.MAY_RESTART,
     actions: @Composable () -> Unit = {},
     additionalDirtyCheck: () -> Boolean = { false },
     onDiscard: () -> Unit = {},
@@ -99,7 +102,12 @@ fun <T : Message<T, *>> RadioConfigScreenList(
                                 configState.reset()
                                 onDiscard()
                             },
-                            positiveText = stringResource(Res.string.save_changes),
+                            positiveText =
+                            if (rebootBehavior == RebootBehavior.ALWAYS) {
+                                stringResource(Res.string.save_and_restart)
+                            } else {
+                                stringResource(Res.string.save_changes)
+                            },
                             onPositiveClicked = {
                                 focusManager.clearFocus()
                                 onSave(configState.value)
@@ -113,7 +121,11 @@ fun <T : Message<T, *>> RadioConfigScreenList(
         LoadingOverlay(state = responseState)
 
         if (responseState is ResponseState.Success || responseState is ResponseState.Error) {
-            PacketResponseStateDialog(state = responseState, onDismiss = onDismissPacketResponse)
+            PacketResponseStateDialog(
+                state = responseState,
+                onDismiss = onDismissPacketResponse,
+                rebootBehavior = rebootBehavior,
+            )
         }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RangeTestConfigItemList.kt
@@ -33,6 +33,7 @@ import org.meshtastic.core.ui.component.DropDownPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.util.IntervalConfiguration
 import org.meshtastic.feature.settings.util.toDisplayString
 import org.meshtastic.proto.ModuleConfig
@@ -47,6 +48,7 @@ fun RangeTestConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val canConfigure = state.connected && !isPublicPrimaryChannel
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.range_test),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RemoteHardwareConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/RemoteHardwareConfigItemList.kt
@@ -34,6 +34,7 @@ import org.meshtastic.core.ui.component.EditListPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.ModuleConfig
 
 @Composable
@@ -44,6 +45,7 @@ fun RemoteHardwareConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Un
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.remote_hardware),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/SecurityConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/SecurityConfigScreen.kt
@@ -66,6 +66,7 @@ import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Warning
 import org.meshtastic.feature.settings.lockdown.LockdownModeSetting
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.Config
 import kotlin.random.Random
 
@@ -108,6 +109,7 @@ fun SecurityConfigScreenCommon(viewModel: RadioConfigViewModel, onBack: () -> Un
 
     val focusManager = LocalFocusManager.current
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.security),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/SerialConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/SerialConfigItemList.kt
@@ -40,6 +40,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.ModuleConfig
 
 @Composable
@@ -50,6 +51,7 @@ fun SerialConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.serial),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/StatusMessageConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/StatusMessageConfigItemList.kt
@@ -39,6 +39,7 @@ import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.core.ui.icon.Close
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 
 @Composable
 fun StatusMessageConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
@@ -63,6 +64,7 @@ fun StatusMessageConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Uni
     LaunchedEffect(statusMessageConfig) { formState.value = statusMessageConfig }
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.NEVER,
         title = stringResource(Res.string.status_message),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/StoreForwardConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/StoreForwardConfigItemList.kt
@@ -37,6 +37,7 @@ import org.meshtastic.core.ui.component.EditTextPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.proto.ModuleConfig
 
 @Composable
@@ -47,6 +48,7 @@ fun StoreForwardConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit
     val focusManager = LocalFocusManager.current
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.store_forward),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TAKConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TAKConfigItemList.kt
@@ -82,6 +82,7 @@ import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.PlayArrow
 import org.meshtastic.core.ui.icon.Share
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.radio.ResponseState
 import org.meshtastic.feature.settings.tak.TakPermissionHandler
 import org.meshtastic.feature.settings.tak.rememberDataPackageExporter
@@ -107,6 +108,7 @@ fun TAKConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
         }
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.tak),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TelemetryConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TelemetryConfigItemList.kt
@@ -43,6 +43,7 @@ import org.meshtastic.core.ui.component.DropDownPreference
 import org.meshtastic.core.ui.component.SwitchPreference
 import org.meshtastic.core.ui.component.TitledCard
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
+import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.util.IntervalConfiguration
 import org.meshtastic.feature.settings.util.toDisplayString
 import org.meshtastic.proto.ModuleConfig
@@ -57,6 +58,7 @@ fun TelemetryConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val capabilities = remember(firmwareVersion) { Capabilities(firmwareVersion) }
 
     RadioConfigScreenList(
+        rebootBehavior = RebootBehavior.ALWAYS,
         title = stringResource(Res.string.telemetry),
         onBack = onBack,
         configState = formState,

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
@@ -20,8 +20,10 @@ import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
@@ -49,6 +51,7 @@ import org.meshtastic.core.repository.LocationRepository
 import org.meshtastic.core.repository.LocationService
 import org.meshtastic.core.repository.MapConsentPrefs
 import org.meshtastic.core.repository.MqttManager
+import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.SecurityKeyBackupStore
@@ -86,6 +89,7 @@ class ProfileRoundTripTest {
     private val importSecurityConfigUseCase: ImportSecurityConfigUseCase = mock(MockMode.autofill)
     private val securityKeyBackupStore: SecurityKeyBackupStore = mock(MockMode.autofill)
     private val snackbarManager: SnackbarManager = mock(MockMode.autofill)
+    private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
     private val installProfileUseCase: InstallProfileUseCase = mock(MockMode.autofill)
     private val radioConfigUseCase: RadioConfigUseCase = mock(MockMode.autofill)
     private val adminActionsUseCase: AdminActionsUseCase = mock(MockMode.autofill)
@@ -140,6 +144,7 @@ class ProfileRoundTripTest {
                 lockdownCoordinator = FakeLockdownCoordinator(),
                 securityKeyBackupStore = securityKeyBackupStore,
                 snackbarManager = snackbarManager,
+                nodeRestartTracker = nodeRestartTracker,
             )
     }
 

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -746,6 +746,68 @@ class RadioConfigViewModelTest {
     }
 
     @Test
+    fun `NODEDB_RESET marks an expected local restart`() = runTest {
+        // Firmware reboots after a nodedb reset, so a local reset must open the restart window (like FACTORY_RESET)
+        // or the ensuing transport drop surfaces as a surprise disconnect instead of "restarting".
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 123))
+
+        val packetFlow = MutableSharedFlow<MeshPacket>()
+        every { serviceRepository.meshPacketFlow } returns packetFlow
+        every { processRadioResponseUseCase(any(), any(), any()) } returns RadioResponseResult.ConfigResponse(Config())
+
+        viewModel = createViewModel()
+        runCurrent()
+
+        everySuspend { adminActionsUseCase.nodedbReset(any(), any(), any(), any()) } returns 42
+
+        viewModel.setResponseStateLoading(AdminRoute.NODEDB_RESET)
+        packetFlow.emit(MeshPacket())
+        advanceUntilIdle()
+
+        verifySuspend { adminActionsUseCase.nodedbReset(123, any(), any(), any()) }
+        assertTrue(nodeRestartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `manual channel batch is not completed as success by a stale restart window`() = runTest {
+        // A prior local MAY_RESTART save opened the 90s restart window, but the node never actually rebooted (stayed
+        // Connected, so onConnected never re-fired to close it early). A manual channel batch shares the save shape
+        // (empty route + Loading); a transient drop inside the stale window must not flip the incomplete batch to
+        // success and silently misreport a partial channel write.
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 123))
+
+        val connectionFlow = MutableStateFlow<ConnectionState>(ConnectionState.Connected)
+        every { serviceRepository.connectionState } returns connectionFlow
+        viewModel = createViewModel()
+        runCurrent()
+
+        nodeRestartTracker.expectRestart()
+
+        // Enqueue a manual channel batch and leave its first write awaiting an ack (no packet emitted).
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any(), any()) } calls
+            {
+                it.args.onRequestIdArg()(77)
+                77
+            }
+        viewModel.updateChannels(listOf(ChannelSettings(name = "New")), listOf(ChannelSettings(name = "Old")))
+        runCurrent()
+
+        assertTrue(nodeRestartTracker.restartExpected.value)
+        assertTrue(viewModel.radioConfigState.value.responseState is ResponseState.Loading)
+
+        // Transient transport drop inside the stale restart window.
+        connectionFlow.value = ConnectionState.Disconnected
+        runCurrent()
+
+        assertFalse(viewModel.radioConfigState.value.responseState is ResponseState.Success)
+        assertTrue(viewModel.radioConfigState.value.responseState is ResponseState.Loading)
+    }
+
+    @Test
     fun `setPreserveFavorites updates state`() = runTest {
         viewModel.radioConfigState.test {
             assertEquals(false, awaitItem().nodeDbResetPreserveFavorites)

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -187,7 +187,7 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         val config = Config(device = Config.DeviceConfig(role = Config.DeviceConfig.Role.ROUTER))
-        everySuspend { radioConfigUseCase.setConfig(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setConfig(any(), any(), any()) } returns 42
 
         viewModel.setConfig(config)
 
@@ -197,7 +197,7 @@ class RadioConfigViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
 
-        verifySuspend { radioConfigUseCase.setConfig(123, config) }
+        verifySuspend { radioConfigUseCase.setConfig(123, config, any()) }
     }
 
     @Test
@@ -293,7 +293,7 @@ class RadioConfigViewModelTest {
 
         verify { mqttManager.stop() }
         // Phone-local cut must not issue any device config read/write.
-        verifySuspend(exactly(0)) { radioConfigUseCase.setModuleConfig(any(), any()) }
+        verifySuspend(exactly(0)) { radioConfigUseCase.setModuleConfig(any(), any(), any()) }
     }
 
     @Test
@@ -311,7 +311,7 @@ class RadioConfigViewModelTest {
         viewModel.setMqttProxyActive(true)
 
         verify { mqttManager.startProxy(true, true) }
-        verifySuspend(exactly(0)) { radioConfigUseCase.setModuleConfig(any(), any()) }
+        verifySuspend(exactly(0)) { radioConfigUseCase.setModuleConfig(any(), any(), any()) }
     }
 
     @Test
@@ -356,11 +356,11 @@ class RadioConfigViewModelTest {
         val old = listOf(ChannelSettings(name = "Old"))
         val new = listOf(ChannelSettings(name = "New"))
 
-        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any(), any()) } returns 42
 
         viewModel.updateChannels(new, old)
 
-        verifySuspend { radioConfigUseCase.setRemoteChannel(123, any()) }
+        verifySuspend { radioConfigUseCase.setRemoteChannel(123, any(), any()) }
         assertEquals(new, viewModel.radioConfigState.value.channelList)
     }
 
@@ -379,7 +379,7 @@ class RadioConfigViewModelTest {
         var activeWrites = 0
         var maxConcurrentWrites = 0
 
-        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any(), any()) } calls
             {
                 val channel = it.args[1] as Channel
                 activeWrites++
@@ -396,7 +396,7 @@ class RadioConfigViewModelTest {
         assertEquals(listOf(1, 2), writtenIndexes)
         assertEquals(1, maxConcurrentWrites)
         assertEquals(new, viewModel.radioConfigState.value.channelList)
-        verifySuspend(exactly(2)) { radioConfigUseCase.setRemoteChannel(123, any()) }
+        verifySuspend(exactly(2)) { radioConfigUseCase.setRemoteChannel(123, any(), any()) }
     }
 
     @Test
@@ -415,7 +415,12 @@ class RadioConfigViewModelTest {
         val new = listOf(channelA, channelC, channelB)
         var nextPacketId = 40
 
-        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls { ++nextPacketId }
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any(), any()) } calls
+            {
+                val id = ++nextPacketId
+                it.args.onRequestIdArg()(id)
+                id
+            }
 
         viewModel.updateChannels(new, old)
         runCurrent()
@@ -452,7 +457,7 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
         runCurrent()
 
-        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any(), any()) } calls
             {
                 val channel = it.args[1] as Channel
                 writtenIndexes.add(channel.index)
@@ -487,7 +492,7 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
         runCurrent()
 
-        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any(), any()) } calls
             {
                 val channel = it.args[1] as Channel
                 writtenChannels.add("${channel.index}:${channel.role}:${channel.settings?.name.orEmpty()}")
@@ -516,12 +521,13 @@ class RadioConfigViewModelTest {
         val old = listOf(ChannelSettings(name = "Old"))
         val new = listOf(ChannelSettings(name = "New"))
 
-        everySuspend { radioConfigUseCase.getOwner(any()) } calls
+        everySuspend { radioConfigUseCase.getOwner(any(), any()) } calls
             {
+                it.args.onRequestIdArg()(42)
                 delay(10_000)
                 42
             }
-        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } returns 100
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any(), any()) } returns 100
 
         viewModel.setResponseStateLoading(ConfigRoute.USER)
         runCurrent()
@@ -531,7 +537,7 @@ class RadioConfigViewModelTest {
 
         assertEquals(ConfigRoute.USER.name, viewModel.radioConfigState.value.route)
         assertTrue(viewModel.radioConfigState.value.responseState is ResponseState.Loading)
-        verifySuspend(exactly(0)) { radioConfigUseCase.setRemoteChannel(any(), any()) }
+        verifySuspend(exactly(0)) { radioConfigUseCase.setRemoteChannel(any(), any(), any()) }
 
         advanceUntilIdle()
     }
@@ -550,14 +556,19 @@ class RadioConfigViewModelTest {
         nodeRepository.setNodes(listOf(node))
         viewModel = createViewModel()
 
-        everySuspend { radioConfigUseCase.getOwner(any()) } returns 42
-        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+        everySuspend { radioConfigUseCase.getOwner(any(), any()) } calls
+            {
+                it.args.onRequestIdArg()(42)
+                42
+            }
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any(), any()) } calls
             {
                 writeCount++
                 if (writeCount == 2) {
                     viewModel.setResponseStateLoading(ConfigRoute.USER)
                     throw IllegalStateException("boom")
                 }
+                it.args.onRequestIdArg()(100)
                 100
             }
         every { processRadioResponseUseCase(any(), 123, any()) } calls
@@ -588,13 +599,18 @@ class RadioConfigViewModelTest {
         nodeRepository.setNodes(listOf(node))
         viewModel = createViewModel()
 
-        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any()) } calls
+        everySuspend { radioConfigUseCase.setRemoteChannel(any(), any(), any()) } calls
             {
                 writeCount++
                 if (writeCount == 2) throw IllegalStateException("boom")
+                it.args.onRequestIdArg()(100)
                 100
             }
-        everySuspend { radioConfigUseCase.getOwner(any()) } returns 100
+        everySuspend { radioConfigUseCase.getOwner(any(), any()) } calls
+            {
+                it.args.onRequestIdArg()(100)
+                100
+            }
 
         viewModel.updateChannels(new, old)
         runCurrent()
@@ -624,9 +640,11 @@ class RadioConfigViewModelTest {
                 updatePlan = listOf(channelA, channelB, channelC),
                 currentSettings = listOf(ChannelSettings(name = "old")),
                 finalSettings = listOf(ChannelSettings(name = "new")),
-                writeChannel = { channel ->
+                writeChannel = { channel, onRequestId ->
                     writtenIndexes.add(channel.index)
-                    channel.index + 100
+                    val id = channel.index + 100
+                    onRequestId(id)
+                    id
                 },
                 registerRequestId = { registeredRequestIds.add(it) },
                 delayFn = { delays.add(it) },
@@ -654,10 +672,12 @@ class RadioConfigViewModelTest {
                     updatePlan = listOf(channelA, channelB, channelC),
                     currentSettings = listOf(ChannelSettings(name = "old")),
                     finalSettings = listOf(ChannelSettings(name = "new")),
-                    writeChannel = { channel ->
+                    writeChannel = { channel, onRequestId ->
                         writtenIndexes.add(channel.index)
                         if (channel.index == 2) throw IllegalStateException("boom")
-                        channel.index + 100
+                        val id = channel.index + 100
+                        onRequestId(id)
+                        id
                     },
                     registerRequestId = {},
                     onInterrupted = { interrupted = it },
@@ -686,14 +706,14 @@ class RadioConfigViewModelTest {
 
         viewModel = createViewModel()
 
-        everySuspend { adminActionsUseCase.reboot(any()) } returns 42
+        everySuspend { adminActionsUseCase.reboot(any(), any()) } returns 42
 
         viewModel.setResponseStateLoading(AdminRoute.REBOOT)
 
         // Emit a config response packet to trigger processPacketResponse -> sendAdminRequest
         packetFlow.emit(MeshPacket())
 
-        verifySuspend { adminActionsUseCase.reboot(123) }
+        verifySuspend { adminActionsUseCase.reboot(123, any()) }
     }
 
     @Test
@@ -709,14 +729,14 @@ class RadioConfigViewModelTest {
 
         viewModel = createViewModel()
 
-        everySuspend { adminActionsUseCase.factoryReset(any(), any()) } returns 42
+        everySuspend { adminActionsUseCase.factoryReset(any(), any(), any()) } returns 42
 
         viewModel.setResponseStateLoading(AdminRoute.FACTORY_RESET)
 
         // Emit a config response packet to trigger processPacketResponse -> sendAdminRequest
         packetFlow.emit(MeshPacket())
 
-        verifySuspend { adminActionsUseCase.factoryReset(123, any()) }
+        verifySuspend { adminActionsUseCase.factoryReset(123, any(), any()) }
     }
 
     @Test
@@ -736,11 +756,11 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         val user = User(long_name = "Test User")
-        everySuspend { radioConfigUseCase.setOwner(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setOwner(any(), any(), any()) } returns 42
 
         viewModel.setOwner(user)
 
-        verifySuspend { radioConfigUseCase.setOwner(123, user) }
+        verifySuspend { radioConfigUseCase.setOwner(123, user, any()) }
     }
 
     @Test
@@ -751,12 +771,14 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         val user = User(long_name = "KK7ABC", short_name = "KK7A", is_licensed = true)
-        everySuspend { radioConfigUseCase.setHamMode(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setHamMode(any(), any(), any()) } returns 42
 
         viewModel.saveUserConfig(user)
 
-        verifySuspend { radioConfigUseCase.setHamMode(123, HamParameters(call_sign = "KK7ABC", short_name = "KK7A")) }
-        verifySuspend(exactly(0)) { radioConfigUseCase.setOwner(any(), any()) }
+        verifySuspend {
+            radioConfigUseCase.setHamMode(123, HamParameters(call_sign = "KK7ABC", short_name = "KK7A"), any())
+        }
+        verifySuspend(exactly(0)) { radioConfigUseCase.setOwner(any(), any(), any()) }
     }
 
     @Test
@@ -767,12 +789,12 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         val user = User(long_name = "Test User", short_name = "TU")
-        everySuspend { radioConfigUseCase.setOwner(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setOwner(any(), any(), any()) } returns 42
 
         viewModel.saveUserConfig(user)
 
-        verifySuspend { radioConfigUseCase.setOwner(123, user) }
-        verifySuspend(exactly(0)) { radioConfigUseCase.setHamMode(any(), any()) }
+        verifySuspend { radioConfigUseCase.setOwner(123, user, any()) }
+        verifySuspend(exactly(0)) { radioConfigUseCase.setHamMode(any(), any(), any()) }
     }
 
     @Test
@@ -784,12 +806,12 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel(destNum = 456)
 
         val user = User(long_name = "KK7ABC", short_name = "KK7A", is_licensed = true)
-        everySuspend { radioConfigUseCase.setOwner(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setOwner(any(), any(), any()) } returns 42
 
         viewModel.saveUserConfig(user)
 
-        verifySuspend { radioConfigUseCase.setOwner(456, user) }
-        verifySuspend(exactly(0)) { radioConfigUseCase.setHamMode(any(), any()) }
+        verifySuspend { radioConfigUseCase.setOwner(456, user, any()) }
+        verifySuspend(exactly(0)) { radioConfigUseCase.setHamMode(any(), any(), any()) }
     }
 
     @Test
@@ -800,8 +822,8 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         val user = User(long_name = "KK7ABC", short_name = "KK7A", is_licensed = true)
-        everySuspend { radioConfigUseCase.setHamMode(any(), any()) } returns 42
-        everySuspend { radioConfigUseCase.setOwner(any(), any()) } returns 43
+        everySuspend { radioConfigUseCase.setHamMode(any(), any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setOwner(any(), any(), any()) } returns 43
 
         // First save transitions OFF→ON and onboards via set_ham_mode.
         viewModel.saveUserConfig(user)
@@ -809,8 +831,8 @@ class RadioConfigViewModelTest {
         val edited = user.copy(short_name = "KK7B")
         viewModel.saveUserConfig(edited)
 
-        verifySuspend(exactly(1)) { radioConfigUseCase.setHamMode(any(), any()) }
-        verifySuspend { radioConfigUseCase.setOwner(123, edited) }
+        verifySuspend(exactly(1)) { radioConfigUseCase.setHamMode(any(), any(), any()) }
+        verifySuspend { radioConfigUseCase.setOwner(123, edited, any()) }
     }
 
     @Test
@@ -820,12 +842,12 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         val user = User(long_name = "KK7ABC", short_name = "KK7A", is_licensed = true)
-        everySuspend { radioConfigUseCase.setOwner(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setOwner(any(), any(), any()) } returns 42
 
         viewModel.saveUserConfig(user)
 
-        verifySuspend { radioConfigUseCase.setOwner(123, user) }
-        verifySuspend(exactly(0)) { radioConfigUseCase.setHamMode(any(), any()) }
+        verifySuspend { radioConfigUseCase.setOwner(123, user, any()) }
+        verifySuspend(exactly(0)) { radioConfigUseCase.setHamMode(any(), any(), any()) }
     }
 
     @Test
@@ -896,11 +918,11 @@ class RadioConfigViewModelTest {
 
         val config =
             org.meshtastic.proto.ModuleConfig(mqtt = org.meshtastic.proto.ModuleConfig.MQTTConfig(enabled = true))
-        everySuspend { radioConfigUseCase.setModuleConfig(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setModuleConfig(any(), any(), any()) } returns 42
 
         viewModel.setModuleConfig(config)
 
-        verifySuspend { radioConfigUseCase.setModuleConfig(123, config) }
+        verifySuspend { radioConfigUseCase.setModuleConfig(123, config, any()) }
         assertEquals(true, viewModel.radioConfigState.value.moduleConfig.mqtt?.enabled)
     }
 
@@ -999,7 +1021,7 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         // SHUTDOWN
-        everySuspend { adminActionsUseCase.shutdown(any()) } returns 42
+        everySuspend { adminActionsUseCase.shutdown(any(), any()) } returns 42
         // Set metadata to allow shutdown
         every { processRadioResponseUseCase(any(), 123, any()) } returns
             RadioResponseResult.Metadata(DeviceMetadata(canShutdown = true))
@@ -1010,14 +1032,14 @@ class RadioConfigViewModelTest {
         // not after a routing ACK (Success).
         every { processRadioResponseUseCase(any(), 123, any()) } returns RadioResponseResult.ConfigResponse(Config())
         packetFlow.emit(MeshPacket())
-        verifySuspend { adminActionsUseCase.shutdown(123) }
+        verifySuspend { adminActionsUseCase.shutdown(123, any()) }
 
         // NODEDB_RESET
-        everySuspend { adminActionsUseCase.nodedbReset(any(), any(), any()) } returns 42
+        everySuspend { adminActionsUseCase.nodedbReset(any(), any(), any(), any()) } returns 42
         viewModel.setResponseStateLoading(AdminRoute.NODEDB_RESET)
         every { processRadioResponseUseCase(any(), 123, any()) } returns RadioResponseResult.ConfigResponse(Config())
         packetFlow.emit(MeshPacket())
-        verifySuspend { adminActionsUseCase.nodedbReset(123, any(), any()) }
+        verifySuspend { adminActionsUseCase.nodedbReset(123, any(), any(), any()) }
     }
 
     @Test
@@ -1027,22 +1049,26 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel()
 
         // USER
-        everySuspend { radioConfigUseCase.getOwner(any()) } returns 42
+        everySuspend { radioConfigUseCase.getOwner(any(), any()) } calls
+            {
+                it.args.onRequestIdArg()(42)
+                42
+            }
         viewModel.setResponseStateLoading(ConfigRoute.USER)
-        verifySuspend { radioConfigUseCase.getOwner(123) }
+        verifySuspend { radioConfigUseCase.getOwner(123, any()) }
 
         // CHANNELS
-        everySuspend { radioConfigUseCase.getChannel(any(), any()) } returns 42
-        everySuspend { radioConfigUseCase.getConfig(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.getChannel(any(), any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.getConfig(any(), any(), any()) } returns 42
         viewModel.setResponseStateLoading(ConfigRoute.CHANNELS)
-        verifySuspend { radioConfigUseCase.getChannel(123, 0) }
+        verifySuspend { radioConfigUseCase.getChannel(123, 0, any()) }
         verifySuspend {
-            radioConfigUseCase.getConfig(123, org.meshtastic.proto.AdminMessage.ConfigType.LORA_CONFIG.value)
+            radioConfigUseCase.getConfig(123, org.meshtastic.proto.AdminMessage.ConfigType.LORA_CONFIG.value, any())
         }
 
         // LORA
         viewModel.setResponseStateLoading(ConfigRoute.LORA)
-        verifySuspend { radioConfigUseCase.getConfig(123, ConfigRoute.LORA.type) }
+        verifySuspend { radioConfigUseCase.getConfig(123, ConfigRoute.LORA.type, any()) }
     }
 
     @Test
@@ -1051,7 +1077,11 @@ class RadioConfigViewModelTest {
         nodeRepository.setNodes(listOf(node))
         viewModel = createViewModel()
 
-        everySuspend { radioConfigUseCase.getOwner(any()) } returns 42
+        everySuspend { radioConfigUseCase.getOwner(any(), any()) } calls
+            {
+                it.args.onRequestIdArg()(42)
+                42
+            }
 
         viewModel.setResponseStateLoading(ConfigRoute.USER)
 
@@ -1163,7 +1193,7 @@ class RadioConfigViewModelTest {
         viewModel = createViewModel(destNum = 123)
         runCurrent()
 
-        everySuspend { radioConfigUseCase.setConfig(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setConfig(any(), any(), any()) } returns 42
 
         viewModel.setConfig(Config(lora = Config.LoRaConfig(region = Config.LoRaConfig.RegionCode.US)))
         runCurrent()
@@ -1175,7 +1205,7 @@ class RadioConfigViewModelTest {
         packetFlow.emit(MeshPacket(decoded = Data(request_id = 42)))
         runCurrent()
 
-        verifySuspend(exactly(0)) { radioConfigUseCase.getConfig(any(), any()) }
+        verifySuspend(exactly(0)) { radioConfigUseCase.getConfig(any(), any(), any()) }
     }
 
     @Test
@@ -1213,7 +1243,7 @@ class RadioConfigViewModelTest {
 
         viewModel.restoreSecurityKeys()
 
-        verifySuspend(exactly(0)) { radioConfigUseCase.setConfig(any(), any()) }
+        verifySuspend(exactly(0)) { radioConfigUseCase.setConfig(any(), any(), any()) }
     }
 
     @Test
@@ -1226,11 +1256,11 @@ class RadioConfigViewModelTest {
         val decoded = Config.SecurityConfig(public_key = "pub".encodeUtf8(), private_key = "priv".encodeUtf8())
         every { securityKeyBackupStore.get(123) } returns stored
         every { importSecurityConfigUseCase(stored) } returns Result.success(decoded)
-        everySuspend { radioConfigUseCase.setConfig(any(), any()) } returns 42
+        everySuspend { radioConfigUseCase.setConfig(any(), any(), any()) } returns 42
 
         viewModel.restoreSecurityKeys()
 
-        verifySuspend { radioConfigUseCase.setConfig(123, Config(security = decoded)) }
+        verifySuspend { radioConfigUseCase.setConfig(123, Config(security = decoded), any()) }
     }
 
     private fun fourChannelFixture() = listOf(
@@ -1257,3 +1287,7 @@ class RadioConfigViewModelTest {
         deviceId = null,
     )
 }
+
+/** Extracts the trailing `onRequestId` callback from a mocked request method's args. */
+@Suppress("UNCHECKED_CAST")
+private fun List<Any?>.onRequestIdArg(): (Int) -> Unit = last() as (Int) -> Unit

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -27,8 +27,10 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -48,6 +50,7 @@ import org.meshtastic.core.domain.usecase.settings.InstallProfileUseCase
 import org.meshtastic.core.domain.usecase.settings.ProcessRadioResponseUseCase
 import org.meshtastic.core.domain.usecase.settings.RadioConfigUseCase
 import org.meshtastic.core.domain.usecase.settings.RadioResponseResult
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.MqttProbeStatus
 import org.meshtastic.core.model.MyNodeInfo
 import org.meshtastic.core.model.Node
@@ -58,6 +61,7 @@ import org.meshtastic.core.repository.LocationRepository
 import org.meshtastic.core.repository.LocationService
 import org.meshtastic.core.repository.MapConsentPrefs
 import org.meshtastic.core.repository.MqttManager
+import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.SecurityKeyBackupStore
@@ -119,6 +123,7 @@ class RadioConfigViewModelTest {
     private val uiPrefs: UiPrefs = mock(MockMode.autofill)
     private val securityKeyBackupStore: SecurityKeyBackupStore = mock(MockMode.autofill)
     private val snackbarManager: SnackbarManager = mock(MockMode.autofill)
+    private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
 
     private lateinit var viewModel: RadioConfigViewModel
 
@@ -170,6 +175,7 @@ class RadioConfigViewModelTest {
         importSecurityConfigUseCase = importSecurityConfigUseCase,
         securityKeyBackupStore = securityKeyBackupStore,
         snackbarManager = snackbarManager,
+        nodeRestartTracker = nodeRestartTracker,
         installProfileUseCase = installProfileUseCase,
         radioConfigUseCase = radioConfigUseCase,
         adminActionsUseCase = adminActionsUseCase,
@@ -898,6 +904,7 @@ class RadioConfigViewModelTest {
                 importSecurityConfigUseCase = importSecurityConfigUseCase,
                 securityKeyBackupStore = securityKeyBackupStore,
                 snackbarManager = snackbarManager,
+                nodeRestartTracker = nodeRestartTracker,
                 installProfileUseCase = installProfileUseCase,
                 radioConfigUseCase = radioConfigUseCase,
                 adminActionsUseCase = adminActionsUseCase,
@@ -1286,6 +1293,68 @@ class RadioConfigViewModelTest {
         airUtilTx = 0f,
         deviceId = null,
     )
+
+    @Test
+    fun `local reboot-applying config save opens the restart window`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 123))
+        viewModel = createViewModel()
+        runCurrent()
+        everySuspend { radioConfigUseCase.setConfig(any(), any(), any()) } returns 42
+
+        nodeRestartTracker.onConnected()
+        viewModel.setConfig(Config(network = Config.NetworkConfig(wifi_enabled = true)))
+        runCurrent()
+
+        assertTrue(nodeRestartTracker.restartExpected.value)
+    }
+
+    @Test
+    fun `reboot-applying save resolves to restarting-success when the node drops`() = runTest {
+        // The reboot the save triggers eats the routing ACK; the transport-drop during the restart window is the
+        // real confirmation, so the save dialog must show success ("restarting") rather than a 30s timeout error.
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 123))
+        val connFlow = MutableStateFlow<ConnectionState>(ConnectionState.Connected)
+        every { serviceRepository.connectionState } returns connFlow
+        viewModel = createViewModel()
+        runCurrent()
+        everySuspend { radioConfigUseCase.setConfig(any(), any(), any()) } calls
+            {
+                it.args.onRequestIdArg()(77)
+                77
+            }
+
+        nodeRestartTracker.onConnected()
+        viewModel.setConfig(Config(network = Config.NetworkConfig(wifi_enabled = true)))
+        runCurrent()
+        assertTrue(viewModel.radioConfigState.value.responseState is ResponseState.Loading)
+
+        // The node reboots and the transport drops.
+        connFlow.value = ConnectionState.Disconnected
+        runCurrent()
+
+        assertTrue(viewModel.radioConfigState.value.responseState is ResponseState.Success)
+    }
+
+    @Test
+    fun `remote config save does not open the restart window`() = runTest {
+        val localNode = Node(num = 100, user = User(id = "!100"))
+        val remoteNode = Node(num = 456, user = User(id = "!456"))
+        nodeRepository.setNodes(listOf(localNode, remoteNode))
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 100))
+        viewModel = createViewModel(destNum = 456)
+        runCurrent()
+        everySuspend { radioConfigUseCase.setConfig(any(), any(), any()) } returns 42
+
+        nodeRestartTracker.onConnected()
+        viewModel.setConfig(Config(network = Config.NetworkConfig(wifi_enabled = true)))
+        runCurrent()
+
+        assertFalse(nodeRestartTracker.restartExpected.value)
+    }
 }
 
 /** Extracts the trailing `onRequestId` callback from a mocked request method's args. */


### PR DESCRIPTION
Firmware 2.8 (meshtastic/firmware#10967) delivers a locally connected node's admin responses through a synchronous loopback, so the response now reaches the phone **before** the `QueueStatus` ack for the request that produced it. The app registered each request's id for response correlation only **after** the ack-awaiting send returned — the response sailed through `meshPacketFlow` while the id set was still empty, was silently dropped by the correlation guard, and **every radio-config sub-screen stalled at a 0% loading overlay for 30s before a timeout dialog** against 2.8 firmware. Root-caused with a dual-ended capture (app logcat + firmware serial): the device handled `Get config: LoRa` and enqueued its reply to the phone in milliseconds; the app dropped it.

The same audit closed two adjacent holes behind #6317 (remote channel list shows only the first channel; the community workaround was "press Cancel"):

Likely also resolves #5592 (settings screens hang at 0% indefinitely) — same symptom, though that report is on 2.7.x firmware while the root cause fixed here is the 2.8 loopback-ordering race; worth confirming the reporter's stall clears before closing.

## 🐛 Fixes

- **Register request ids before the send is issued.** `RadioConfigUseCase` / `AdminActionsUseCase` request methods take an `onRequestId` callback invoked with the packet id ahead of the send; `RadioConfigViewModel` registers there instead of after the suspending call returns. Response ordering can no longer race registration, local or remote.
- **`QueueStatus.res = 35` is not a failure.** Firmware 2.8 returns its internal `ERRNO_SHOULD_RELEASE` ("delivered locally, packet consumed") for self-addressed packets; the handler treated any non-zero `res` as a failed send. Note: 35 numerically collides with `Routing.Error.PKI_UNKNOWN_PUBKEY` — `QueueStatus.res` carries `ErrorCode` semantics, not `Routing.Error` (diagnosis trap). The `handleQueueStatus` early return is scoped to the plain `res = 0` "accepted, now full" echo, so a `res = 35` delivery still completes its response even when the TX queue is full (`free = 0`) — otherwise it would re-introduce the same 5s-timeout stall under queue pressure.
- **Channel editor now shows channels as they stream in (#6317).** The editable list was seeded once, at first composition — i.e. the instant channel 0 arrived — and never re-synced while a remote fetch streamed the rest in; the footer *Cancel*'s `replaceWith()` was the accidental workaround. The editor adopts the authoritative list while the fetch is in flight (the loading overlay blocks edits during that window, so nothing can be clobbered).
- **Closed the request-chain gap.** `processPacketResponse` removed the completed request id inline, and could observe a momentarily-empty id set in the gap between chained `getChannel` requests — tearing the flow down (`clearPacketResponse`) and stranding the rest of the chain with a partial list. The removal now runs behind any chain continuation launched by the same response (FIFO on the main dispatcher; registration is the continuation's first act).
- **`NODEDB_RESET` marks an expected local restart.** Firmware reboots after a nodedb reset, but only `FACTORY_RESET` opened the restart window — a local nodedb reset surfaced the ensuing transport drop as a surprise disconnect instead of "restarting". `NODEDB_RESET` now calls `expectRestart()` for local resets, mirroring `FACTORY_RESET`.
- **A stale restart window can no longer mark an interrupted manual channel batch as "success".** A manual channel batch shares the save shape (empty route + `Loading`) that the restart-success paths key on. A local `MAY_RESTART` save that opened the 90s window but never actually rebooted left that window open; a transient disconnect or request timeout during a subsequent batch would then flip the *incomplete* batch to `Success`, silently misreporting a partial channel write. Both `completeRestartingSaveIfPending` and the request-timeout backstop now gate on `manualChannelBatchInFlight()`, which tracks the batch from enqueue through its ack-wait (past `finishManualChannelBatch`) via the pending batch request ids — the enqueue flag alone left the ack-wait window exposed.

## 🧹 Follow-up (firmware, not this PR)

`QueueStatus.res` leaking internal `ERRNO_*` values to clients is worth an upstream firmware issue — mapping `ERRNO_SHOULD_RELEASE` → 0 would spare every client the same trap.

## Testing Performed

- New unit tests: `getConfig invokes onRequestId with the packet id before issuing the send` (ordering regression guard); `handleQueueStatus treats ERRNO_SHOULD_RELEASE as success` / `other nonzero res as failure`; `handleQueueStatus completes ERRNO_SHOULD_RELEASE even when queue is full` (the `res = 35` + `free = 0` queue-full path — covered by test, since on-device runs didn't exercise a full TX queue); `NODEDB_RESET marks an expected local restart`; `manual channel batch is not completed as success by a stale restart window` (this one caught an insufficient first fix that guarded only the enqueue phase, not the ack-wait — both restart-window edge cases are test-covered rather than device-exercised).
- Full baseline `spotlessApply spotlessCheck detekt assembleDebug test allTests` green.
- On-hardware before/after (Pixel 6a ↔ Heltec DUT + M5Stack Cardputer, both on 2.8.0 develop firmware): before — LoRa/Security/Channels all stall at 0% → 30s timeout; after — LoRa loads in ~3s fully enabled, Channels runs the complete sequential fetch (4 chained requests) and renders every channel with the editor kept in sync throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue-status handling so a “should release” condition is treated as success.
  * Improved reliability completing radio/admin packet workflows and reducing request correlation timing issues.
* **New Features**
  * Added expected-restart tracking to smooth local reboot/reconnect behavior.
  * Added reboot-behavior support for configuration saves (including save-and-restart messaging).
* **User Experience**
  * Updated UI to clearly show “restarting” across connection/navigation and to prevent stale loading edits in channel config.
* **Tests**
  * Added/updated coverage for restart tracking, request-id ordering, and queue-status success/failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

