### PR TITLE
fix(ci): defer desktop packaging toolchain resolution

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -17,6 +17,10 @@
 
 import dev.detekt.gradle.Detekt
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import org.jetbrains.compose.desktop.application.tasks.AbstractCheckNativeDistributionRuntime
+import org.jetbrains.compose.desktop.application.tasks.AbstractJvmToolOperationTask
+import org.jetbrains.compose.desktop.application.tasks.AbstractProguardTask
+import org.jetbrains.compose.desktop.application.tasks.AbstractSuggestModulesTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.meshtastic.buildlogic.configureGraphTasks
 import org.meshtastic.buildlogic.resolveVersionInfo
@@ -105,27 +109,28 @@ kotlin {
 // Exclude generated Compose resource files from detekt analysis
 tasks.withType<Detekt>().configureEach { exclude("**/generated/**") }
 
+// Compose Desktop otherwise derives these task inputs from the JVM running Gradle. Bind only the packaging tasks to a
+// JBR 25 provider so ProGuard and jlink receive jmods without provisioning JBR while unrelated CI tasks configure.
+// Task-type configuration also covers aliases and dependency-driven execution without parsing requested task names.
+val desktopPackagingJavaHome =
+    javaToolchains
+        .launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(25))
+            vendor.set(JvmVendorSpec.JETBRAINS)
+        }
+        .map { launcher -> launcher.metadata.installationPath.asFile.absolutePath }
+
+tasks.withType<AbstractJvmToolOperationTask>().configureEach { javaHome.set(desktopPackagingJavaHome) }
+
+tasks.withType<AbstractProguardTask>().configureEach { javaHome.set(desktopPackagingJavaHome) }
+
+tasks.withType<AbstractSuggestModulesTask>().configureEach { javaHome.set(desktopPackagingJavaHome) }
+
+tasks.withType<AbstractCheckNativeDistributionRuntime>().configureEach { jdkHome.set(desktopPackagingJavaHome) }
+
 compose.desktop {
     application {
         mainClass = "org.meshtastic.desktop.MainKt"
-
-        // CMP resolves javaHome from the JVM running Gradle, not the Kotlin toolchain. On CI
-        // that's Temurin 25, which ships without jmods (JEP 493): jlink still works, but the
-        // ProGuard task derives -libraryjars from $javaHome/jmods and fails with ~857k
-        // unresolved java.* references. Pin packaging to the JBR SDK toolchain (jmods
-        // included) so ProGuard sees the platform classes and the bundled runtime is
-        // deterministically JBR 25 on every machine.
-        javaHome =
-            javaToolchains
-                .launcherFor {
-                    languageVersion.set(JavaLanguageVersion.of(25))
-                    vendor.set(JvmVendorSpec.JETBRAINS)
-                }
-                .get()
-                .metadata
-                .installationPath
-                .asFile
-                .absolutePath
 
         val desktopJvmArgs =
             listOf(


### PR DESCRIPTION
## Overview

This prevents unrelated Gradle tasks from provisioning the JetBrains Runtime toolchain required by Compose Desktop packaging.

Desktop packaging requires JBR 25 with `jmods`, but eagerly resolving the packaging launcher during project configuration can provision that toolchain while running Android builds, lint, unit tests, and other tasks that never package the desktop application.

In CI, this could lead to intermittent failures when those unrelated tasks attempted to resolve or download the Desktop toolchain unnecessarily, especially in environments where the required JBR was unavailable or not expected to be used.

This change keeps JBR selection lazy and attaches it only to the Desktop task types that actually require it.

## Key Changes

* Create a lazy JBR 25 launcher provider without resolving it during project configuration.
* Apply the provider to Desktop packaging, ProGuard, runtime-module, and native-runtime validation tasks.
* Cover task aliases and dependency-driven execution through task-type configuration rather than requested-task-name parsing.
* Preserve deterministic JBR 25 selection for actual Desktop packaging.
* Leave Android and application runtime behavior unchanged.

## Migration Notes

* No application behavior or user data changes.
* Desktop package contents and the required packaging JDK remain unchanged.
* This only changes when the packaging toolchain provider is realized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop application packaging reliability by consistently using the configured Java 25 runtime across build and packaging tasks.
  * Reduced inconsistencies between local and continuous integration builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->