### PR TITLE
fix(firmware): don't treat unparseable version as "too old" (#3726)

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/DeviceVersion.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/DeviceVersion.kt
@@ -18,6 +18,21 @@ package org.meshtastic.core.model
 
 import kotlin.jvm.JvmInline
 
+/** Outcome of checking a device's firmware version against the app's minimum requirements. */
+enum class FirmwareCheckStatus {
+    /** Firmware meets the recommended minimum. */
+    OK,
+
+    /** Firmware is usable but below the recommended minimum; the user should be nudged to update. */
+    SHOULD_UPDATE,
+
+    /** Firmware is below the absolute minimum the app supports. */
+    TOO_OLD,
+
+    /** The version string could not be parsed (e.g. a blank/transient value during connection). Status is unknown. */
+    UNKNOWN,
+}
+
 /** Zero-overhead wrapper providing structured access to parse and compare device version strings. */
 @JvmInline
 value class DeviceVersion(val asString: String) : Comparable<DeviceVersion> {
@@ -25,6 +40,25 @@ value class DeviceVersion(val asString: String) : Comparable<DeviceVersion> {
     /** The integer representation of the version (e.g., 2.7.12 → 20712). */
     val asInt: Int
         get() = parseVersion(asString)
+
+    /** True when the version string parsed to a real version (non-zero). */
+    val isValid: Boolean
+        get() = asInt > 0
+
+    /**
+     * Classify this version against the app's firmware requirements.
+     *
+     * An unparseable version (int 0) is [FirmwareCheckStatus.UNKNOWN], NOT [FirmwareCheckStatus.TOO_OLD] — a transient
+     * or garbled version string arriving mid-handshake must never be mistaken for ancient firmware (regression #3726).
+     */
+    val checkStatus: FirmwareCheckStatus
+        get() =
+            when {
+                !isValid -> FirmwareCheckStatus.UNKNOWN
+                this < DeviceVersion(ABS_MIN_FW_VERSION) -> FirmwareCheckStatus.TOO_OLD
+                this < DeviceVersion(MIN_FW_VERSION) -> FirmwareCheckStatus.SHOULD_UPDATE
+                else -> FirmwareCheckStatus.OK
+            }
 
     override fun compareTo(other: DeviceVersion): Int = asInt.compareTo(other.asInt)
 

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/DeviceVersionTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/DeviceVersionTest.kt
@@ -46,4 +46,26 @@ class DeviceVersionTest {
         assertEquals(DeviceVersion("2.7.12"), DeviceVersion("2.7.12"))
         kotlin.test.assertFalse(DeviceVersion("2.6.9") >= DeviceVersion("2.7.0"))
     }
+
+    /**
+     * Regression for #3726: an unparseable / transient firmware string (which parses to 0) must be reported as UNKNOWN,
+     * never TOO_OLD. Treating 0 as "ancient" is what triggered the false blocking "firmware too old" popup that
+     * force-disconnected devices running perfectly valid firmware.
+     */
+    @Test
+    fun checkStatus_unparseableIsUnknownNotTooOld() {
+        assertEquals(FirmwareCheckStatus.UNKNOWN, DeviceVersion("").checkStatus)
+        assertEquals(FirmwareCheckStatus.UNKNOWN, DeviceVersion("garbage").checkStatus)
+        assertEquals(FirmwareCheckStatus.UNKNOWN, DeviceVersion("2.").checkStatus)
+        assertEquals(FirmwareCheckStatus.UNKNOWN, DeviceVersion("0.0.0").checkStatus)
+    }
+
+    @Test
+    fun checkStatus_classifiesKnownVersions() {
+        assertEquals(FirmwareCheckStatus.TOO_OLD, DeviceVersion("2.2.0").checkStatus)
+        assertEquals(FirmwareCheckStatus.SHOULD_UPDATE, DeviceVersion("2.5.0").checkStatus)
+        assertEquals(FirmwareCheckStatus.OK, DeviceVersion("2.7.0").checkStatus)
+        assertEquals(FirmwareCheckStatus.OK, DeviceVersion(DeviceVersion.MIN_FW_VERSION).checkStatus)
+        assertEquals(FirmwareCheckStatus.SHOULD_UPDATE, DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION).checkStatus)
+    }
 }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/FirmwareVersionCheck.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/FirmwareVersionCheck.kt
@@ -57,52 +57,48 @@ fun FirmwareVersionCheck(viewModel: UIViewModel) {
     LaunchedEffect(connectionState, myNodeInfo) {
         if (connectionState == ConnectionState.Connected) {
             myNodeInfo?.let { info ->
-                myFirmwareVersion
-                    ?.takeIf { it.isNotBlank() }
-                    ?.let { fwVersion ->
-                        val curVer = DeviceVersion(fwVersion)
-                        Logger.i {
-                            "[FW_CHECK] Firmware version comparison - " +
-                                "device: $curVer (raw: $fwVersion), status: ${curVer.checkStatus}, " +
-                                "absoluteMin: ${DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION)}, " +
-                                "min: ${DeviceVersion(DeviceVersion.MIN_FW_VERSION)}"
-                        }
-
-                        when (curVer.checkStatus) {
-                            FirmwareCheckStatus.TOO_OLD -> {
-                                Logger.w {
-                                    "[FW_CHECK] Firmware too old - device: $curVer < " +
-                                        "absoluteMin: ${DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION)}"
-                                }
-                                val title = getString(Res.string.firmware_too_old)
-                                val message = getString(Res.string.firmware_old)
-                                viewModel.showAlert(
-                                    title = title,
-                                    html = message,
-                                    onConfirm = { viewModel.setDeviceAddress("n") },
-                                )
-                            }
-
-                            FirmwareCheckStatus.SHOULD_UPDATE -> {
-                                Logger.w {
-                                    "[FW_CHECK] Firmware should update - " +
-                                        "device: $curVer < min: ${DeviceVersion(DeviceVersion.MIN_FW_VERSION)}"
-                                }
-                                val title = getString(Res.string.should_update_firmware)
-                                val message = getString(Res.string.should_update, latestStableFirmwareRelease.asString)
-                                viewModel.showAlert(title = title, message = message, onConfirm = {})
-                            }
-
-                            // An unparseable/transient version must not disconnect the device (#3726); just log it.
-                            FirmwareCheckStatus.UNKNOWN ->
-                                Logger.w {
-                                    "[FW_CHECK] Firmware version unparseable - device raw: $fwVersion, skipping"
-                                }
-
-                            FirmwareCheckStatus.OK ->
-                                Logger.i { "[FW_CHECK] Firmware version OK - device: $curVer meets requirements" }
-                        }
+                myFirmwareVersion?.let { fwVersion ->
+                    val curVer = DeviceVersion(fwVersion)
+                    Logger.i {
+                        "[FW_CHECK] Firmware version comparison - " +
+                            "device: $curVer (raw: $fwVersion), status: ${curVer.checkStatus}, " +
+                            "absoluteMin: ${DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION)}, " +
+                            "min: ${DeviceVersion(DeviceVersion.MIN_FW_VERSION)}"
                     }
+
+                    when (curVer.checkStatus) {
+                        FirmwareCheckStatus.TOO_OLD -> {
+                            Logger.w {
+                                "[FW_CHECK] Firmware too old - device: $curVer < " +
+                                    "absoluteMin: ${DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION)}"
+                            }
+                            val title = getString(Res.string.firmware_too_old)
+                            val message = getString(Res.string.firmware_old)
+                            viewModel.showAlert(
+                                title = title,
+                                html = message,
+                                onConfirm = { viewModel.setDeviceAddress("n") },
+                            )
+                        }
+
+                        FirmwareCheckStatus.SHOULD_UPDATE -> {
+                            Logger.w {
+                                "[FW_CHECK] Firmware should update - " +
+                                    "device: $curVer < min: ${DeviceVersion(DeviceVersion.MIN_FW_VERSION)}"
+                            }
+                            val title = getString(Res.string.should_update_firmware)
+                            val message = getString(Res.string.should_update, latestStableFirmwareRelease.asString)
+                            viewModel.showAlert(title = title, message = message, onConfirm = {})
+                        }
+
+                        // An unparseable/transient version must not disconnect the device (#3726); just log it.
+                        FirmwareCheckStatus.UNKNOWN ->
+                            Logger.w { "[FW_CHECK] Firmware version unparseable - device raw: $fwVersion, skipping" }
+
+                        FirmwareCheckStatus.OK ->
+                            Logger.i { "[FW_CHECK] Firmware version OK - device: $curVer meets requirements" }
+                    }
+                }
             }
         }
     }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/FirmwareVersionCheck.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/FirmwareVersionCheck.kt
@@ -24,6 +24,7 @@ import co.touchlab.kermit.Logger
 import org.jetbrains.compose.resources.getString
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceVersion
+import org.meshtastic.core.model.FirmwareCheckStatus
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.firmware_old
 import org.meshtastic.core.resources.firmware_too_old
@@ -62,33 +63,44 @@ fun FirmwareVersionCheck(viewModel: UIViewModel) {
                         val curVer = DeviceVersion(fwVersion)
                         Logger.i {
                             "[FW_CHECK] Firmware version comparison - " +
-                                "device: $curVer (raw: $fwVersion), " +
+                                "device: $curVer (raw: $fwVersion), status: ${curVer.checkStatus}, " +
                                 "absoluteMin: ${DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION)}, " +
                                 "min: ${DeviceVersion(DeviceVersion.MIN_FW_VERSION)}"
                         }
 
-                        if (curVer < DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION)) {
-                            Logger.w {
-                                "[FW_CHECK] Firmware too old - " +
-                                    "device: $curVer < absoluteMin: ${DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION)}"
+                        when (curVer.checkStatus) {
+                            FirmwareCheckStatus.TOO_OLD -> {
+                                Logger.w {
+                                    "[FW_CHECK] Firmware too old - device: $curVer < " +
+                                        "absoluteMin: ${DeviceVersion(DeviceVersion.ABS_MIN_FW_VERSION)}"
+                                }
+                                val title = getString(Res.string.firmware_too_old)
+                                val message = getString(Res.string.firmware_old)
+                                viewModel.showAlert(
+                                    title = title,
+                                    html = message,
+                                    onConfirm = { viewModel.setDeviceAddress("n") },
+                                )
                             }
-                            val title = getString(Res.string.firmware_too_old)
-                            val message = getString(Res.string.firmware_old)
-                            viewModel.showAlert(
-                                title = title,
-                                html = message,
-                                onConfirm = { viewModel.setDeviceAddress("n") },
-                            )
-                        } else if (curVer < DeviceVersion(DeviceVersion.MIN_FW_VERSION)) {
-                            Logger.w {
-                                "[FW_CHECK] Firmware should update - " +
-                                    "device: $curVer < min: ${DeviceVersion(DeviceVersion.MIN_FW_VERSION)}"
+
+                            FirmwareCheckStatus.SHOULD_UPDATE -> {
+                                Logger.w {
+                                    "[FW_CHECK] Firmware should update - " +
+                                        "device: $curVer < min: ${DeviceVersion(DeviceVersion.MIN_FW_VERSION)}"
+                                }
+                                val title = getString(Res.string.should_update_firmware)
+                                val message = getString(Res.string.should_update, latestStableFirmwareRelease.asString)
+                                viewModel.showAlert(title = title, message = message, onConfirm = {})
                             }
-                            val title = getString(Res.string.should_update_firmware)
-                            val message = getString(Res.string.should_update, latestStableFirmwareRelease.asString)
-                            viewModel.showAlert(title = title, message = message, onConfirm = {})
-                        } else {
-                            Logger.i { "[FW_CHECK] Firmware version OK - device: $curVer meets requirements" }
+
+                            // An unparseable/transient version must not disconnect the device (#3726); just log it.
+                            FirmwareCheckStatus.UNKNOWN ->
+                                Logger.w {
+                                    "[FW_CHECK] Firmware version unparseable - device raw: $fwVersion, skipping"
+                                }
+
+                            FirmwareCheckStatus.OK ->
+                                Logger.i { "[FW_CHECK] Firmware version OK - device: $curVer meets requirements" }
                         }
                     }
             }


### PR DESCRIPTION
## Summary
Fixes #3726 — the false "firmware too old" popup that force-disconnects devices running perfectly valid firmware.

`DeviceVersion.parseVersion()` returns `0` as a sentinel for an **unparseable** string, but `FirmwareVersionCheck` compared that `0` directly against the absolute-minimum version. A transient or garbled firmware string arriving mid-handshake therefore parsed to `0`, satisfied `0 < ABS_MIN`, and fired the **blocking** alert whose `onConfirm` disconnects the device — matching reports on hardware running e.g. 2.6.11.

## Change
- Extract the decision into a pure, unit-testable `DeviceVersion.checkStatus` returning `OK / SHOULD_UPDATE / TOO_OLD / UNKNOWN`.
- An unparseable version (int `0`) is now `UNKNOWN` — logged and skipped, never a forced disconnect.
- `FirmwareVersionCheck` consumes the status instead of raw comparisons.

## Testing
- New regression tests in `DeviceVersionTest` (unparseable → `UNKNOWN`, not `TOO_OLD`; known-version classification).
- `:core:model:allTests` (161 tests) green; `:core:ui` compiles; detekt + spotless clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added firmware version check status classification (OK, SHOULD_UPDATE, TOO_OLD, UNKNOWN) and exposed it for consistent use across the app.
* **Bug Fixes**
  * Prevented unparseable or transient firmware versions from being treated as “too old.”
  * Updated firmware alerts so blocking or update-required messages show only for actionable statuses; unknown statuses now log only.
* **Tests**
  * Added regression coverage for known and unparseable firmware version inputs, including boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->