### PR TITLE
fix(channels): store channel set per-device to stop cross-device duplicates (#4623)

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSource.kt
@@ -57,7 +57,9 @@ class SwitchingChannelSetDataSource(
             .distinctUntilChanged()
 
     suspend fun clearChannelSet() {
-        withContext(dispatchers.io) { dbManager.withDb { it.channelSetDao().clear() } }
+        // Must take writeMutex like mutate() -- otherwise a concurrent mutate() can read the row before this delete,
+        // then upsert it back afterwards, silently undoing the clear.
+        withContext(dispatchers.io) { writeMutex.withLock { dbManager.withDb { it.channelSetDao().clear() } } }
     }
 
     /** Replaces all [ChannelSettings] in a single atomic operation. */

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSource.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.data.datasource
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
+import org.meshtastic.core.database.DatabaseProvider
+import org.meshtastic.core.database.entity.ChannelSetEntity
+import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSet
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+
+/**
+ * Per-device channel-set storage backed by the current device's Room database.
+ *
+ * Replaces the former single global `channel_set.pb` DataStore. The channel set now switches with
+ * [DatabaseProvider.currentDb], exactly like messages and nodes, so switching between devices can no longer render one
+ * device's conversations against another device's channels (#4623).
+ *
+ * The whole [ChannelSet] proto is stored in one row (see [ChannelSetEntity]); mutations are read-modify-write, so they
+ * are serialized through [writeMutex] to preserve the atomicity the old DataStore's `updateData {}` provided (the
+ * handshake fires overlapping [updateChannelSettings] calls as it downloads channels one by one).
+ */
+@Single
+class SwitchingChannelSetDataSource(
+    private val dbManager: DatabaseProvider,
+    private val dispatchers: CoroutineDispatchers,
+) {
+    private val writeMutex = Mutex()
+
+    val channelSetFlow: Flow<ChannelSet> =
+        dbManager.currentDb
+            .flatMapLatest { db -> db.channelSetDao().observe() }
+            .map { entity -> entity?.channelSet ?: ChannelSet() }
+            .distinctUntilChanged()
+
+    suspend fun clearChannelSet() {
+        withContext(dispatchers.io) { dbManager.withDb { it.channelSetDao().clear() } }
+    }
+
+    /** Replaces all [ChannelSettings] in a single atomic operation. */
+    suspend fun replaceAllSettings(settingsList: List<ChannelSettings>) {
+        mutate { it.copy(settings = settingsList) }
+    }
+
+    /** Places [channel]'s settings at its index, resizing with blank channels to fill any gap (parity with legacy). */
+    suspend fun updateChannelSettings(channel: Channel) {
+        if (channel.role == Channel.Role.DISABLED) return
+        mutate { current ->
+            val settings = current.settings.toMutableList()
+            while (settings.size <= channel.index) {
+                settings.add(ChannelSettings())
+            }
+            settings[channel.index] = channel.settings ?: ChannelSettings()
+            current.copy(settings = settings)
+        }
+    }
+
+    suspend fun setLoraConfig(config: Config.LoRaConfig) {
+        mutate { it.copy(lora_config = config) }
+    }
+
+    private suspend fun mutate(transform: (ChannelSet) -> ChannelSet) {
+        withContext(dispatchers.io) {
+            writeMutex.withLock {
+                dbManager.withDb { db ->
+                    val dao = db.channelSetDao()
+                    val current = dao.get()?.channelSet ?: ChannelSet()
+                    dao.upsert(ChannelSetEntity(channelSet = transform(current)))
+                }
+            }
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImpl.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import org.koin.core.annotation.Single
-import org.meshtastic.core.datastore.ChannelSetDataSource
+import org.meshtastic.core.data.datasource.SwitchingChannelSetDataSource
 import org.meshtastic.core.datastore.LocalConfigDataSource
 import org.meshtastic.core.datastore.ModuleConfigDataSource
 import org.meshtastic.core.model.util.getChannelUrl
@@ -51,7 +51,7 @@ private const val MAX_FILE_MANIFEST_ENTRIES = 4096
 @Suppress("TooManyFunctions") // All functions mandated by RadioConfigRepository interface; logically grouped by concern
 open class RadioConfigRepositoryImpl(
     private val nodeDB: NodeRepository,
-    private val channelSetDataSource: ChannelSetDataSource,
+    private val channelSetDataSource: SwitchingChannelSetDataSource,
     private val localConfigDataSource: LocalConfigDataSource,
     private val moduleConfigDataSource: ModuleConfigDataSource,
 ) : RadioConfigRepository {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSourceTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSourceTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.data.datasource
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.testing.FakeDatabaseProvider
+import org.meshtastic.proto.Channel
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SwitchingChannelSetDataSourceTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val dispatchers = CoroutineDispatchers(main = testDispatcher, io = testDispatcher, default = testDispatcher)
+    private val dbProvider = FakeDatabaseProvider()
+    private val dataSource = SwitchingChannelSetDataSource(dbProvider, dispatchers)
+
+    @AfterTest fun tearDown() = dbProvider.close()
+
+    private fun secondary(index: Int, name: String) =
+        Channel(index = index, settings = ChannelSettings(name = name), role = Channel.Role.SECONDARY)
+
+    @Test
+    fun `updateChannelSettings places channel at its index`() = runTest(testDispatcher) {
+        dataSource.updateChannelSettings(secondary(0, "primary"))
+        dataSource.updateChannelSettings(secondary(1, "second"))
+
+        val names = dataSource.channelSetFlow.first().settings.map { it.name }
+        assertEquals(listOf("primary", "second"), names)
+    }
+
+    @Test
+    fun `updateChannelSettings fills gaps with blank channels to preserve indices`() = runTest(testDispatcher) {
+        // Arrive out of order / with a gap: index 2 before 0/1 exist.
+        dataSource.updateChannelSettings(secondary(2, "third"))
+
+        val settings = dataSource.channelSetFlow.first().settings
+        assertEquals(3, settings.size)
+        assertEquals("", settings[0].name)
+        assertEquals("", settings[1].name)
+        assertEquals("third", settings[2].name)
+    }
+
+    @Test
+    fun `disabled channels are ignored`() = runTest(testDispatcher) {
+        dataSource.updateChannelSettings(Channel(index = 0, role = Channel.Role.DISABLED))
+        assertTrue(dataSource.channelSetFlow.first().settings.isEmpty())
+    }
+
+    @Test
+    fun `replaceAllSettings replaces the whole list`() = runTest(testDispatcher) {
+        dataSource.updateChannelSettings(secondary(0, "old"))
+        dataSource.replaceAllSettings(listOf(ChannelSettings(name = "a"), ChannelSettings(name = "b")))
+
+        assertEquals(listOf("a", "b"), dataSource.channelSetFlow.first().settings.map { it.name })
+    }
+
+    @Test
+    fun `setLoraConfig preserves existing channel settings`() = runTest(testDispatcher) {
+        dataSource.updateChannelSettings(secondary(0, "keep"))
+        dataSource.setLoraConfig(Config.LoRaConfig(channel_num = 7))
+
+        val set = dataSource.channelSetFlow.first()
+        assertEquals("keep", set.settings.single().name)
+        assertEquals(7, set.lora_config?.channel_num)
+    }
+
+    @Test
+    fun `clearChannelSet empties the channel set`() = runTest(testDispatcher) {
+        dataSource.updateChannelSettings(secondary(0, "gone"))
+        dataSource.clearChannelSet()
+        assertTrue(dataSource.channelSetFlow.first().settings.isEmpty())
+    }
+
+    /**
+     * Regression for #4623: channels are now stored per-device. Switching to a different device's database must NOT
+     * surface the previous device's channels — the old global DataStore was the source of the cross-device duplicate
+     * channel rows.
+     */
+    @Test
+    fun `switching device does not leak channels across databases`() = runTest(testDispatcher) {
+        dataSource.updateChannelSettings(secondary(0, "deviceA-primary"))
+        assertEquals("deviceA-primary", dataSource.channelSetFlow.first().settings.single().name)
+
+        dbProvider.switchToNewDatabase()
+
+        assertTrue(
+            dataSource.channelSetFlow.first().settings.isEmpty(),
+            "A freshly selected device must start with no channels, not device A's",
+        )
+    }
+
+    /** Handshake fires overlapping updateChannelSettings as it streams channels; the mutex must not drop any. */
+    @Test
+    fun `concurrent updateChannelSettings does not lose updates`() = runTest(testDispatcher) {
+        val n = 8
+        coroutineScope {
+            (0 until n).map { i -> async { dataSource.updateChannelSettings(secondary(i, "ch$i")) } }.awaitAll()
+        }
+
+        val settings = dataSource.channelSetFlow.first().settings
+        assertEquals(n, settings.size)
+        assertEquals((0 until n).map { "ch$it" }, settings.map { it.name })
+    }
+}

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImplTest.kt
@@ -27,11 +27,12 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
-import org.meshtastic.core.datastore.ChannelSetDataSource
+import org.meshtastic.core.data.datasource.SwitchingChannelSetDataSource
+import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.datastore.LocalConfigDataSource
 import org.meshtastic.core.datastore.ModuleConfigDataSource
+import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.repository.NodeRepository
-import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.FileInfo
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
@@ -43,10 +44,18 @@ class RadioConfigRepositoryImplTest {
 
     private val nodeDB = mock<NodeRepository>(MockMode.autofill)
 
-    // The DataSources are final classes (can't be mocked directly) that just wrap a DataStore<T> --
-    // mock the DataStore instead. None of these are touched by the addFileInfo/fileManifestFlow/
-    // clearFileManifest behavior under test here.
-    private val channelSetDataSource = ChannelSetDataSource(mock<DataStore<ChannelSet>>(MockMode.autofill))
+    // These data sources are concrete wrappers -- construct them with mocked dependencies. Channels are now stored
+    // per-device via SwitchingChannelSetDataSource (DatabaseProvider), the others still wrap a DataStore<T>. None are
+    // touched by the addFileInfo/fileManifestFlow/clearFileManifest behavior under test here.
+    private val channelSetDataSource =
+        SwitchingChannelSetDataSource(
+            mock<DatabaseProvider>(MockMode.autofill),
+            CoroutineDispatchers(
+                main = Dispatchers.Unconfined,
+                io = Dispatchers.Unconfined,
+                default = Dispatchers.Unconfined,
+            ),
+        )
     private val localConfigDataSource = LocalConfigDataSource(mock<DataStore<LocalConfig>>(MockMode.autofill))
     private val moduleConfigDataSource = ModuleConfigDataSource(mock<DataStore<LocalModuleConfig>>(MockMode.autofill))
 

--- a/core/database/schemas/org.meshtastic.core.database.MeshtasticDatabase/50.json
+++ b/core/database/schemas/org.meshtastic.core.database.MeshtasticDatabase/50.json
@@ -1,0 +1,1756 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 50,
+    "identityHash": "d931e13b7d629adb636c23c0bd7d36b6",
+    "entities": [
+      {
+        "tableName": "my_node",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`myNodeNum` INTEGER NOT NULL, `model` TEXT, `firmwareVersion` TEXT, `couldUpdate` INTEGER NOT NULL, `shouldUpdate` INTEGER NOT NULL, `currentPacketId` INTEGER NOT NULL, `messageTimeoutMsec` INTEGER NOT NULL, `minAppVersion` INTEGER NOT NULL, `maxChannels` INTEGER NOT NULL, `hasWifi` INTEGER NOT NULL, `deviceId` TEXT, `pioEnv` TEXT, PRIMARY KEY(`myNodeNum`))",
+        "fields": [
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "model",
+            "columnName": "model",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "firmwareVersion",
+            "columnName": "firmwareVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "couldUpdate",
+            "columnName": "couldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldUpdate",
+            "columnName": "shouldUpdate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPacketId",
+            "columnName": "currentPacketId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageTimeoutMsec",
+            "columnName": "messageTimeoutMsec",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minAppVersion",
+            "columnName": "minAppVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxChannels",
+            "columnName": "maxChannels",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasWifi",
+            "columnName": "hasWifi",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pioEnv",
+            "columnName": "pioEnv",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "myNodeNum"
+          ]
+        }
+      },
+      {
+        "tableName": "nodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `user` BLOB NOT NULL, `long_name` TEXT, `short_name` TEXT, `position` BLOB NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `snr` REAL NOT NULL, `rssi` INTEGER NOT NULL, `last_heard` INTEGER NOT NULL, `device_metrics` BLOB NOT NULL, `channel` INTEGER NOT NULL, `via_mqtt` INTEGER NOT NULL, `hops_away` INTEGER NOT NULL, `is_favorite` INTEGER NOT NULL, `is_ignored` INTEGER NOT NULL DEFAULT 0, `is_muted` INTEGER NOT NULL DEFAULT 0, `environment_metrics` BLOB NOT NULL, `power_metrics` BLOB NOT NULL, `air_quality_metrics` BLOB NOT NULL DEFAULT x'', `paxcounter` BLOB NOT NULL, `public_key` BLOB, `notes` TEXT NOT NULL DEFAULT '', `power_channel_labels` TEXT NOT NULL DEFAULT '[]', `manually_verified` INTEGER NOT NULL DEFAULT 0, `node_status` TEXT, `last_transport` INTEGER NOT NULL DEFAULT 0, `has_xeddsa_signed` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`num`))",
+        "fields": [
+          {
+            "fieldPath": "num",
+            "columnName": "num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "user",
+            "columnName": "user",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastHeard",
+            "columnName": "last_heard",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceTelemetry",
+            "columnName": "device_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viaMqtt",
+            "columnName": "via_mqtt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hops_away",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIgnored",
+            "columnName": "is_ignored",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isMuted",
+            "columnName": "is_muted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "environmentTelemetry",
+            "columnName": "environment_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "powerTelemetry",
+            "columnName": "power_metrics",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "airQualityTelemetry",
+            "columnName": "air_quality_metrics",
+            "affinity": "BLOB",
+            "notNull": true,
+            "defaultValue": "x''"
+          },
+          {
+            "fieldPath": "paxcounter",
+            "columnName": "paxcounter",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "public_key",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "powerChannelLabels",
+            "columnName": "power_channel_labels",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "manuallyVerified",
+            "columnName": "manually_verified",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "nodeStatus",
+            "columnName": "node_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastTransport",
+            "columnName": "last_transport",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "signsPackets",
+            "columnName": "has_xeddsa_signed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "num"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_nodes_last_heard",
+            "unique": false,
+            "columnNames": [
+              "last_heard"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_last_heard` ON `${TABLE_NAME}` (`last_heard`)"
+          },
+          {
+            "name": "index_nodes_short_name",
+            "unique": false,
+            "columnNames": [
+              "short_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_short_name` ON `${TABLE_NAME}` (`short_name`)"
+          },
+          {
+            "name": "index_nodes_long_name",
+            "unique": false,
+            "columnNames": [
+              "long_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_long_name` ON `${TABLE_NAME}` (`long_name`)"
+          },
+          {
+            "name": "index_nodes_hops_away",
+            "unique": false,
+            "columnNames": [
+              "hops_away"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_hops_away` ON `${TABLE_NAME}` (`hops_away`)"
+          },
+          {
+            "name": "index_nodes_is_favorite",
+            "unique": false,
+            "columnNames": [
+              "is_favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_is_favorite` ON `${TABLE_NAME}` (`is_favorite`)"
+          },
+          {
+            "name": "index_nodes_last_heard_is_favorite",
+            "unique": false,
+            "columnNames": [
+              "last_heard",
+              "is_favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_last_heard_is_favorite` ON `${TABLE_NAME}` (`last_heard`, `is_favorite`)"
+          },
+          {
+            "name": "index_nodes_public_key",
+            "unique": false,
+            "columnNames": [
+              "public_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_public_key` ON `${TABLE_NAME}` (`public_key`)"
+          }
+        ]
+      },
+      {
+        "tableName": "packet",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `myNodeNum` INTEGER NOT NULL DEFAULT 0, `port_num` INTEGER NOT NULL, `contact_key` TEXT NOT NULL, `received_time` INTEGER NOT NULL, `read` INTEGER NOT NULL DEFAULT 1, `data` TEXT NOT NULL, `packet_id` INTEGER NOT NULL DEFAULT 0, `routing_error` INTEGER NOT NULL DEFAULT -1, `snr` REAL NOT NULL DEFAULT 0, `rssi` INTEGER NOT NULL DEFAULT 0, `hopsAway` INTEGER NOT NULL DEFAULT -1, `sfpp_hash` BLOB, `filtered` INTEGER NOT NULL DEFAULT 0, `message_text` TEXT NOT NULL DEFAULT '', `translated_text` TEXT, `show_translated` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "port_num",
+            "columnName": "port_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_time",
+            "columnName": "received_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packetId",
+            "columnName": "packet_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "routingError",
+            "columnName": "routing_error",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hopsAway",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "sfpp_hash",
+            "columnName": "sfpp_hash",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "filtered",
+            "columnName": "filtered",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "messageText",
+            "columnName": "message_text",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "translatedText",
+            "columnName": "translated_text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showTranslated",
+            "columnName": "show_translated",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_packet_myNodeNum",
+            "unique": false,
+            "columnNames": [
+              "myNodeNum"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_myNodeNum` ON `${TABLE_NAME}` (`myNodeNum`)"
+          },
+          {
+            "name": "index_packet_port_num",
+            "unique": false,
+            "columnNames": [
+              "port_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_port_num` ON `${TABLE_NAME}` (`port_num`)"
+          },
+          {
+            "name": "index_packet_contact_key",
+            "unique": false,
+            "columnNames": [
+              "contact_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_contact_key` ON `${TABLE_NAME}` (`contact_key`)"
+          },
+          {
+            "name": "index_packet_contact_key_port_num_received_time",
+            "unique": false,
+            "columnNames": [
+              "contact_key",
+              "port_num",
+              "received_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_contact_key_port_num_received_time` ON `${TABLE_NAME}` (`contact_key`, `port_num`, `received_time`)"
+          },
+          {
+            "name": "index_packet_packet_id",
+            "unique": false,
+            "columnNames": [
+              "packet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_packet_id` ON `${TABLE_NAME}` (`packet_id`)"
+          },
+          {
+            "name": "index_packet_received_time",
+            "unique": false,
+            "columnNames": [
+              "received_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_received_time` ON `${TABLE_NAME}` (`received_time`)"
+          },
+          {
+            "name": "index_packet_filtered",
+            "unique": false,
+            "columnNames": [
+              "filtered"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_filtered` ON `${TABLE_NAME}` (`filtered`)"
+          },
+          {
+            "name": "index_packet_read",
+            "unique": false,
+            "columnNames": [
+              "read"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_packet_read` ON `${TABLE_NAME}` (`read`)"
+          }
+        ]
+      },
+      {
+        "tableName": "packet_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS5(`message_text`, tokenize=`unicode61`, content=`packet`)",
+        "fields": [
+          {
+            "fieldPath": "messageText",
+            "columnName": "message_text",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": []
+        },
+        "ftsVersion": "FTS5",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "packet",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC",
+          "contentRowId": "",
+          "columnSize": true,
+          "detail": "FULL"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_BEFORE_UPDATE BEFORE UPDATE ON `packet` BEGIN DELETE FROM `packet_fts` WHERE `rowid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_BEFORE_DELETE BEFORE DELETE ON `packet` BEGIN DELETE FROM `packet_fts` WHERE `rowid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_AFTER_UPDATE AFTER UPDATE ON `packet` BEGIN INSERT INTO `packet_fts`(`rowid`, `message_text`) VALUES (NEW.`rowid`, NEW.`message_text`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_packet_fts_AFTER_INSERT AFTER INSERT ON `packet` BEGIN INSERT INTO `packet_fts`(`rowid`, `message_text`) VALUES (NEW.`rowid`, NEW.`message_text`); END"
+        ]
+      },
+      {
+        "tableName": "contact_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`contact_key` TEXT NOT NULL, `muteUntil` INTEGER NOT NULL, `last_read_message_uuid` INTEGER, `last_read_message_timestamp` INTEGER, `filtering_disabled` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`contact_key`))",
+        "fields": [
+          {
+            "fieldPath": "contact_key",
+            "columnName": "contact_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muteUntil",
+            "columnName": "muteUntil",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadMessageUuid",
+            "columnName": "last_read_message_uuid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastReadMessageTimestamp",
+            "columnName": "last_read_message_timestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "filteringDisabled",
+            "columnName": "filtering_disabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "contact_key"
+          ]
+        }
+      },
+      {
+        "tableName": "log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `type` TEXT NOT NULL, `received_date` INTEGER NOT NULL, `message` TEXT NOT NULL, `from_num` INTEGER NOT NULL DEFAULT 0, `port_num` INTEGER NOT NULL DEFAULT 0, `from_radio` BLOB NOT NULL DEFAULT x'', PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message_type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received_date",
+            "columnName": "received_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "raw_message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromNum",
+            "columnName": "from_num",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "portNum",
+            "columnName": "port_num",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fromRadio",
+            "columnName": "from_radio",
+            "affinity": "BLOB",
+            "notNull": true,
+            "defaultValue": "x''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uuid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_log_from_num",
+            "unique": false,
+            "columnNames": [
+              "from_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_log_from_num` ON `${TABLE_NAME}` (`from_num`)"
+          },
+          {
+            "name": "index_log_port_num",
+            "unique": false,
+            "columnNames": [
+              "port_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_log_port_num` ON `${TABLE_NAME}` (`port_num`)"
+          }
+        ]
+      },
+      {
+        "tableName": "quick_chat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `message` TEXT NOT NULL, `mode` TEXT NOT NULL, `position` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mode",
+            "columnName": "mode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uuid"
+          ]
+        }
+      },
+      {
+        "tableName": "reactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`myNodeNum` INTEGER NOT NULL DEFAULT 0, `reply_id` INTEGER NOT NULL, `user_id` TEXT NOT NULL, `emoji` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `snr` REAL NOT NULL DEFAULT 0, `rssi` INTEGER NOT NULL DEFAULT 0, `hopsAway` INTEGER NOT NULL DEFAULT -1, `packet_id` INTEGER NOT NULL DEFAULT 0, `status` INTEGER NOT NULL DEFAULT 0, `routing_error` INTEGER NOT NULL DEFAULT 0, `relays` INTEGER NOT NULL DEFAULT 0, `relay_node` INTEGER, `to` TEXT, `channel` INTEGER NOT NULL DEFAULT 0, `sfpp_hash` BLOB, PRIMARY KEY(`myNodeNum`, `reply_id`, `user_id`, `emoji`))",
+        "fields": [
+          {
+            "fieldPath": "myNodeNum",
+            "columnName": "myNodeNum",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "replyId",
+            "columnName": "reply_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hopsAway",
+            "columnName": "hopsAway",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "packetId",
+            "columnName": "packet_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "routingError",
+            "columnName": "routing_error",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "relays",
+            "columnName": "relays",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "relayNode",
+            "columnName": "relay_node",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "to",
+            "columnName": "to",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channel",
+            "columnName": "channel",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sfpp_hash",
+            "columnName": "sfpp_hash",
+            "affinity": "BLOB"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "myNodeNum",
+            "reply_id",
+            "user_id",
+            "emoji"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reactions_reply_id",
+            "unique": false,
+            "columnNames": [
+              "reply_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reactions_reply_id` ON `${TABLE_NAME}` (`reply_id`)"
+          },
+          {
+            "name": "index_reactions_packet_id",
+            "unique": false,
+            "columnNames": [
+              "packet_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reactions_packet_id` ON `${TABLE_NAME}` (`packet_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`num` INTEGER NOT NULL, `proto` BLOB NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`num`))",
+        "fields": [
+          {
+            "fieldPath": "num",
+            "columnName": "num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "proto",
+            "columnName": "proto",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "num"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_metadata_num",
+            "unique": false,
+            "columnNames": [
+              "num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_metadata_num` ON `${TABLE_NAME}` (`num`)"
+          }
+        ]
+      },
+      {
+        "tableName": "device_hardware",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`actively_supported` INTEGER NOT NULL, `architecture` TEXT NOT NULL, `display_name` TEXT NOT NULL, `has_ink_hud` INTEGER, `has_mui` INTEGER, `hwModel` INTEGER NOT NULL, `hw_model_slug` TEXT NOT NULL, `images` TEXT, `last_updated` INTEGER NOT NULL, `partition_scheme` TEXT, `platformio_target` TEXT NOT NULL, `requires_dfu` INTEGER, `support_level` INTEGER, `tags` TEXT, PRIMARY KEY(`platformio_target`))",
+        "fields": [
+          {
+            "fieldPath": "activelySupported",
+            "columnName": "actively_supported",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "architecture",
+            "columnName": "architecture",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasInkHud",
+            "columnName": "has_ink_hud",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hasMui",
+            "columnName": "has_mui",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hwModel",
+            "columnName": "hwModel",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hwModelSlug",
+            "columnName": "hw_model_slug",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "images",
+            "columnName": "images",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "partitionScheme",
+            "columnName": "partition_scheme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "platformioTarget",
+            "columnName": "platformio_target",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requiresDfu",
+            "columnName": "requires_dfu",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "supportLevel",
+            "columnName": "support_level",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platformio_target"
+          ]
+        }
+      },
+      {
+        "tableName": "device_link",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`short_code` TEXT NOT NULL, `link_description` TEXT, `is_vendor` INTEGER NOT NULL, `regions` TEXT, `targets` TEXT, PRIMARY KEY(`short_code`))",
+        "fields": [
+          {
+            "fieldPath": "shortCode",
+            "columnName": "short_code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "linkDescription",
+            "columnName": "link_description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isVendor",
+            "columnName": "is_vendor",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "regions",
+            "columnName": "regions",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "targets",
+            "columnName": "targets",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "short_code"
+          ]
+        }
+      },
+      {
+        "tableName": "firmware_release",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `page_url` TEXT NOT NULL, `release_notes` TEXT NOT NULL, `title` TEXT NOT NULL, `zip_url` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `release_type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pageUrl",
+            "columnName": "page_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseNotes",
+            "columnName": "release_notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "zipUrl",
+            "columnName": "zip_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseType",
+            "columnName": "release_type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "traceroute_node_position",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`log_uuid` TEXT NOT NULL, `request_id` INTEGER NOT NULL, `node_num` INTEGER NOT NULL, `position` BLOB NOT NULL, PRIMARY KEY(`log_uuid`, `node_num`), FOREIGN KEY(`log_uuid`) REFERENCES `log`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "logUuid",
+            "columnName": "log_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestId",
+            "columnName": "request_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeNum",
+            "columnName": "node_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "log_uuid",
+            "node_num"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traceroute_node_position_log_uuid",
+            "unique": false,
+            "columnNames": [
+              "log_uuid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traceroute_node_position_log_uuid` ON `${TABLE_NAME}` (`log_uuid`)"
+          },
+          {
+            "name": "index_traceroute_node_position_request_id",
+            "unique": false,
+            "columnNames": [
+              "request_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traceroute_node_position_request_id` ON `${TABLE_NAME}` (`request_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "log",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "log_uuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovery_session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `presets_scanned` TEXT NOT NULL, `home_preset` TEXT NOT NULL, `total_unique_nodes` INTEGER NOT NULL DEFAULT 0, `avg_channel_utilization` REAL NOT NULL DEFAULT 0.0, `total_messages` INTEGER NOT NULL DEFAULT 0, `total_sensor_packets` INTEGER NOT NULL DEFAULT 0, `furthest_node_distance` REAL NOT NULL DEFAULT 0.0, `completion_status` TEXT NOT NULL DEFAULT 'complete', `ai_summary` TEXT, `user_latitude` REAL NOT NULL DEFAULT 0.0, `user_longitude` REAL NOT NULL DEFAULT 0.0, `total_dwell_seconds` INTEGER NOT NULL DEFAULT 0, `device_address` TEXT, `home_lora_config` BLOB, `home_primary_channel` BLOB)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetsScanned",
+            "columnName": "presets_scanned",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homePreset",
+            "columnName": "home_preset",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalUniqueNodes",
+            "columnName": "total_unique_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avgChannelUtilization",
+            "columnName": "avg_channel_utilization",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "totalMessages",
+            "columnName": "total_messages",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "totalSensorPackets",
+            "columnName": "total_sensor_packets",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "furthestNodeDistance",
+            "columnName": "furthest_node_distance",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "completionStatus",
+            "columnName": "completion_status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'complete'"
+          },
+          {
+            "fieldPath": "aiSummary",
+            "columnName": "ai_summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLatitude",
+            "columnName": "user_latitude",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "userLongitude",
+            "columnName": "user_longitude",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "totalDwellSeconds",
+            "columnName": "total_dwell_seconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "deviceAddress",
+            "columnName": "device_address",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "homeLoraConfig",
+            "columnName": "home_lora_config",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "homePrimaryChannel",
+            "columnName": "home_primary_channel",
+            "affinity": "BLOB"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "discovery_preset_result",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `session_id` INTEGER NOT NULL, `preset_name` TEXT NOT NULL, `dwell_duration_seconds` INTEGER NOT NULL DEFAULT 0, `unique_nodes` INTEGER NOT NULL DEFAULT 0, `direct_neighbor_count` INTEGER NOT NULL DEFAULT 0, `mesh_neighbor_count` INTEGER NOT NULL DEFAULT 0, `infrastructure_node_count` INTEGER NOT NULL DEFAULT 0, `message_count` INTEGER NOT NULL DEFAULT 0, `sensor_packet_count` INTEGER NOT NULL DEFAULT 0, `avg_channel_utilization` REAL NOT NULL DEFAULT 0.0, `avg_airtime_rate` REAL NOT NULL DEFAULT 0.0, `packet_success_rate` REAL NOT NULL DEFAULT 0.0, `packet_failure_rate` REAL NOT NULL DEFAULT 0.0, `ai_summary` TEXT, `num_packets_tx` INTEGER NOT NULL DEFAULT 0, `num_packets_rx` INTEGER NOT NULL DEFAULT 0, `num_packets_rx_bad` INTEGER NOT NULL DEFAULT 0, `num_rx_dupe` INTEGER NOT NULL DEFAULT 0, `num_tx_relay` INTEGER NOT NULL DEFAULT 0, `num_tx_relay_canceled` INTEGER NOT NULL DEFAULT 0, `num_online_nodes` INTEGER NOT NULL DEFAULT 0, `num_total_nodes` INTEGER NOT NULL DEFAULT 0, `uptime_seconds` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`session_id`) REFERENCES `discovery_session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetName",
+            "columnName": "preset_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dwellDurationSeconds",
+            "columnName": "dwell_duration_seconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "uniqueNodes",
+            "columnName": "unique_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "directNeighborCount",
+            "columnName": "direct_neighbor_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "meshNeighborCount",
+            "columnName": "mesh_neighbor_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "infrastructureNodeCount",
+            "columnName": "infrastructure_node_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "messageCount",
+            "columnName": "message_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sensorPacketCount",
+            "columnName": "sensor_packet_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "avgChannelUtilization",
+            "columnName": "avg_channel_utilization",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "avgAirtimeRate",
+            "columnName": "avg_airtime_rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "packetSuccessRate",
+            "columnName": "packet_success_rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "packetFailureRate",
+            "columnName": "packet_failure_rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "aiSummary",
+            "columnName": "ai_summary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numPacketsTx",
+            "columnName": "num_packets_tx",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numPacketsRx",
+            "columnName": "num_packets_rx",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numPacketsRxBad",
+            "columnName": "num_packets_rx_bad",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numRxDupe",
+            "columnName": "num_rx_dupe",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numTxRelay",
+            "columnName": "num_tx_relay",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numTxRelayCanceled",
+            "columnName": "num_tx_relay_canceled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numOnlineNodes",
+            "columnName": "num_online_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "numTotalNodes",
+            "columnName": "num_total_nodes",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "uptimeSeconds",
+            "columnName": "uptime_seconds",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovery_preset_result_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovery_preset_result_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "discovery_session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "discovered_node",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `preset_result_id` INTEGER NOT NULL, `node_num` INTEGER NOT NULL, `short_name` TEXT, `long_name` TEXT, `neighbor_type` TEXT NOT NULL DEFAULT 'direct', `latitude` REAL, `longitude` REAL, `distance_from_user` REAL, `hop_count` INTEGER NOT NULL DEFAULT 0, `snr` REAL NOT NULL DEFAULT 0, `rssi` INTEGER NOT NULL DEFAULT 0, `message_count` INTEGER NOT NULL DEFAULT 0, `sensor_packet_count` INTEGER NOT NULL DEFAULT 0, `is_infrastructure` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`preset_result_id`) REFERENCES `discovery_preset_result`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presetResultId",
+            "columnName": "preset_result_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeNum",
+            "columnName": "node_num",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "short_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "long_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "neighborType",
+            "columnName": "neighbor_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'direct'"
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "distanceFromUser",
+            "columnName": "distance_from_user",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "hopCount",
+            "columnName": "hop_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "snr",
+            "columnName": "snr",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "rssi",
+            "columnName": "rssi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "messageCount",
+            "columnName": "message_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sensorPacketCount",
+            "columnName": "sensor_packet_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isInfrastructure",
+            "columnName": "is_infrastructure",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_discovered_node_preset_result_id",
+            "unique": false,
+            "columnNames": [
+              "preset_result_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovered_node_preset_result_id` ON `${TABLE_NAME}` (`preset_result_id`)"
+          },
+          {
+            "name": "index_discovered_node_node_num",
+            "unique": false,
+            "columnNames": [
+              "node_num"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_discovered_node_node_num` ON `${TABLE_NAME}` (`node_num`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "discovery_preset_result",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "preset_result_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "event_firmware_edition",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`edition` TEXT NOT NULL, `display_name` TEXT NOT NULL, `welcome_message` TEXT NOT NULL, `event_start` TEXT, `event_end` TEXT, `time_zone` TEXT, `location` TEXT, `icon_url` TEXT, `accent_color` TEXT, `tag` TEXT, `domain` TEXT, `theme_json` TEXT, `firmware_json` TEXT, `links_json` TEXT NOT NULL, PRIMARY KEY(`edition`))",
+        "fields": [
+          {
+            "fieldPath": "edition",
+            "columnName": "edition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "welcomeMessage",
+            "columnName": "welcome_message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventStart",
+            "columnName": "event_start",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "eventEnd",
+            "columnName": "event_end",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timeZone",
+            "columnName": "time_zone",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconUrl",
+            "columnName": "icon_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accentColor",
+            "columnName": "accent_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeJson",
+            "columnName": "theme_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "firmwareJson",
+            "columnName": "firmware_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "linksJson",
+            "columnName": "links_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "edition"
+          ]
+        }
+      },
+      {
+        "tableName": "merge_marker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`source_db_name` TEXT NOT NULL, `merged_at` INTEGER NOT NULL, PRIMARY KEY(`source_db_name`))",
+        "fields": [
+          {
+            "fieldPath": "sourceDbName",
+            "columnName": "source_db_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mergedAt",
+            "columnName": "merged_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "source_db_name"
+          ]
+        }
+      },
+      {
+        "tableName": "channel_set",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `channel_set` BLOB NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelSet",
+            "columnName": "channel_set",
+            "affinity": "BLOB",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd931e13b7d629adb636c23c0bd7d36b6')"
+    ]
+  }
+}

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/Converters.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/Converters.kt
@@ -25,6 +25,7 @@ import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.util.decodeOrNull
+import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.Config
 import org.meshtastic.proto.DeviceMetadata
@@ -79,6 +80,11 @@ class Converters {
         DeviceMetadata.ADAPTER.decodeOrNull(bytes, Logger) ?: DeviceMetadata()
 
     @ColumnTypeConverter fun metadataToBytes(value: DeviceMetadata): ByteArray = DeviceMetadata.ADAPTER.encode(value)
+
+    @ColumnTypeConverter
+    fun bytesToChannelSet(bytes: ByteArray): ChannelSet = ChannelSet.ADAPTER.decodeOrNull(bytes, Logger) ?: ChannelSet()
+
+    @ColumnTypeConverter fun channelSetToBytes(value: ChannelSet): ByteArray = ChannelSet.ADAPTER.encode(value)
 
     @ColumnTypeConverter
     fun fromStringList(value: String?): List<String>? {

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/MeshtasticDatabase.kt
@@ -25,6 +25,7 @@ import androidx.room3.RoomDatabase
 import androidx.room3.migration.AutoMigrationSpec
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.meshtastic.core.common.util.ioDispatcher
+import org.meshtastic.core.database.dao.ChannelSetDao
 import org.meshtastic.core.database.dao.DeviceHardwareDao
 import org.meshtastic.core.database.dao.DeviceLinkDao
 import org.meshtastic.core.database.dao.DiscoveryDao
@@ -36,6 +37,7 @@ import org.meshtastic.core.database.dao.NodeInfoDao
 import org.meshtastic.core.database.dao.PacketDao
 import org.meshtastic.core.database.dao.QuickChatActionDao
 import org.meshtastic.core.database.dao.TracerouteNodePositionDao
+import org.meshtastic.core.database.entity.ChannelSetEntity
 import org.meshtastic.core.database.entity.ContactSettings
 import org.meshtastic.core.database.entity.DeviceHardwareEntity
 import org.meshtastic.core.database.entity.DeviceLinkEntity
@@ -76,6 +78,7 @@ import org.meshtastic.core.database.entity.TracerouteNodePositionEntity
         DiscoveredNodeEntity::class,
         EventFirmwareEditionEntity::class,
         MergeMarkerEntity::class,
+        ChannelSetEntity::class,
     ],
     autoMigrations =
     [
@@ -125,13 +128,15 @@ import org.meshtastic.core.database.entity.TracerouteNodePositionEntity
         AutoMigration(from = 46, to = 47),
         AutoMigration(from = 47, to = 48),
         AutoMigration(from = 48, to = 49),
+        AutoMigration(from = 49, to = 50),
     ],
-    version = 49,
+    version = 50,
     exportSchema = true,
 )
 @androidx.room3.ConstructedBy(MeshtasticDatabaseConstructor::class)
 @ColumnTypeConverters(Converters::class)
 @androidx.room3.DaoReturnTypeConverters(androidx.room3.paging.PagingSourceDaoReturnTypeConverter::class)
+@Suppress("TooManyFunctions") // One accessor per DAO; the count grows with the schema, not with class complexity.
 abstract class MeshtasticDatabase : RoomDatabase() {
     abstract fun nodeInfoDao(): NodeInfoDao
 
@@ -154,6 +159,8 @@ abstract class MeshtasticDatabase : RoomDatabase() {
     abstract fun eventFirmwareEditionDao(): EventFirmwareEditionDao
 
     abstract fun mergeMarkerDao(): MergeMarkerDao
+
+    abstract fun channelSetDao(): ChannelSetDao
 
     companion object {
         /**

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/ChannelSetDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/ChannelSetDao.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database.dao
+
+import androidx.room3.Dao
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.Query
+import kotlinx.coroutines.flow.Flow
+import org.meshtastic.core.database.entity.ChannelSetEntity
+
+/** Per-device persistence of the connected device's [ChannelSetEntity]. */
+@Dao
+interface ChannelSetDao {
+
+    /** Observes the single stored channel set, emitting null when none has been persisted for this device yet. */
+    @Query("SELECT * FROM channel_set WHERE id = 0 LIMIT 1")
+    fun observe(): Flow<ChannelSetEntity?>
+
+    /** One-shot read of the stored channel set for read-modify-write updates; null when none is persisted yet. */
+    @Query("SELECT * FROM channel_set WHERE id = 0 LIMIT 1")
+    suspend fun get(): ChannelSetEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: ChannelSetEntity)
+
+    @Query("DELETE FROM channel_set")
+    suspend fun clear()
+}

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/ChannelSetDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/ChannelSetDao.kt
@@ -35,6 +35,11 @@ interface ChannelSetDao {
     @Query("SELECT * FROM channel_set WHERE id = 0 LIMIT 1")
     suspend fun get(): ChannelSetEntity?
 
+    // Deliberately @Insert(onConflict = REPLACE), not @Upsert: on this entity, Room's generated @Upsert UPDATE path
+    // throws a bare android.database.SQLException under Robolectric's androidHostTest SQLite implementation on every
+    // write past the first (verified: 4/8 SwitchingChannelSetDataSourceTest cases failed, all and only the ones that
+    // write to an already-existing row -- pure-JVM jvmTest and on-device runs are unaffected). REPLACE is a single
+    // INSERT OR REPLACE statement with no separate UPDATE path, so it doesn't hit this incompatibility.
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: ChannelSetEntity)
 

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/ChannelSetEntity.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/ChannelSetEntity.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database.entity
+
+import androidx.room3.ColumnInfo
+import androidx.room3.Entity
+import androidx.room3.PrimaryKey
+import org.meshtastic.proto.ChannelSet
+
+/**
+ * The connected device's channel set, stored per-device (one row per Room database).
+ *
+ * The channel set was historically a single **global** DataStore (`channel_set.pb`) while messages are per-device, so
+ * switching between devices rendered one device's messages against another device's channels — the same channel then
+ * appeared multiple times in the conversation list (#4623). Storing it here, in the per-device database, keeps it in
+ * lockstep with the messages it labels. The whole [ChannelSet] proto (settings + lora_config) is persisted as one row
+ * so semantics match the old whole-proto DataStore exactly.
+ */
+@Entity(tableName = "channel_set")
+data class ChannelSetEntity(
+    @PrimaryKey @ColumnInfo(name = "id") val id: Int = SINGLETON_ID,
+    @ColumnInfo(name = "channel_set") val channelSet: ChannelSet,
+) {
+    companion object {
+        /** There is only ever one channel set per device, so every row uses this fixed primary key. */
+        const val SINGLETON_ID = 0
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #4623 — the same channel (same name/PSK) appearing as multiple rows in the conversation list, seen after switching/reconnecting between devices and "self-correcting" over time.

## Root cause (confirmed on-device)
The channel set lived in a single **global** DataStore (`channel_set.pb`) while messages/nodes are **per-device** Room DBs (`currentDb` switches per node). Switching devices rendered one device's messages against another device's channel set, so the same logical channel resolved at mismatched indices → duplicate rows, resolving only once the matching device's handshake re-synced the global set. Verified on a bench phone: one global `channel_set.pb` shared across three per-device message DBs.

## Change
- New `ChannelSetEntity` (one row, whole `ChannelSet` proto) + `ChannelSetDao` in the per-device DB.
- Room **v49→v50** additive `AutoMigration` (schema `50.json` exported) — no data transform.
- `SwitchingChannelSetDataSource` reads via `currentDb` and serializes read-modify-write mutations through a mutex (parity with the old DataStore's atomic `updateData`; the handshake streams channels via overlapping updates).
- `RadioConfigRepositoryImpl` now sources channels per-device.

Channels re-download on every connect, so per-device rows self-populate; the legacy global blob is not migrated.

## Testing
- 8 new `SwitchingChannelSetDataSourceTest` cases incl. the #4623 regression (switching DB must not leak the previous device's channels) and concurrent-update atomicity; `RadioConfigRepositoryImplTest` updated. `:core:database:allTests` + `:core:data:allTests` green; detekt + spotless + `assembleFdroidDebug` clean.
- **On-device (Pixel 6a)**: installed over the existing app → 49→50 migration ran clean (no crash); the connected device's per-device `channel_set` re-populated from the live handshake; Messages tab shows `olm3sh / IROMesh / LongFast` once each — no duplicates.

## Notes for reviewers
- Non-current device DBs migrate lazily when next opened (Room opens per-device on switch); their channel list is briefly empty until each device reconnects and re-downloads channels. Acceptable, but worth confirming the desired post-upgrade UX.
- Ultimate manual confirmation: pair a 2nd node, switch back and forth, verify no duplicate channel rows (the unit test already proves the DB-switch isolation this relies on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent, per-device storage for channel configurations and LoRa settings.
  * Channel settings now update reactively and remain isolated when switching devices.
  * Added ability to safely replace, clear, observe, and update channel configurations.
  * Introduced the required database migration for this new storage.
* **Bug Fixes**
  * Prevented channel updates from being lost during concurrent changes.
  * Disabled channels are now ignored during updates.
* **Tests**
  * Added coverage for index placement, gap filling, replacement semantics, LoRa preservation, device isolation, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->