### PR TITLE
perf(docs): skip Dokka when no API sources changed, drop test modules from aggregation

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,9 +16,11 @@ on:
       # Docs site sources
       - 'docs/**'
       - 'feature/docs/**'
-      # Build infrastructure
+      # Build infrastructure. Module scripts are included because they can add or
+      # drop exported `api` dependencies and reshape source sets, changing the
+      # generated reference without any edit under src/.
       - 'build-logic/**'
-      - 'build.gradle.kts'
+      - '**/build.gradle.kts'
       - 'settings.gradle.kts'
       - '.github/workflows/docs-deploy.yml'
       - 'scripts/docs/**'
@@ -82,9 +84,11 @@ jobs:
               - 'core/**/src/**'
               - 'feature/**/src/**'
               - 'desktopApp/src/**'
-              # Dokka config, module list and the plugin classpath.
+              # Dokka config, module list and the plugin classpath. '**/build.gradle.kts'
+              # covers the root script as well as every module's, since a module script
+              # can change exported `api` deps or source sets with no src/ edit.
               - 'build-logic/**'
-              - 'build.gradle.kts'
+              - '**/build.gradle.kts'
               - 'settings.gradle.kts'
               - 'gradle/libs.versions.toml'
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -59,13 +59,44 @@ jobs:
           bundler-cache: true
           working-directory: docs
 
+      # Dokka is the slowest part of this workflow (~14 min) but KDoc changes far
+      # less often than the prose docs. Rebuild /api/ only when something that can
+      # actually change the generated reference was touched; otherwise the existing
+      # /api/ on gh-pages is left in place (the publisher overlays per channel).
+      # Manual runs always rebuild everything, so the diff is only needed on push.
+      - name: Detect Dokka-relevant changes
+        if: github.event_name != 'workflow_dispatch'
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          token: ''
+          filters: |
+            # Positive patterns only. paths-filter evaluates each pattern as an
+            # independent predicate and ORs them together, so a '!excluded/**'
+            # entry would match every path outside that dir and make the filter
+            # always true. The modules in DOKKA_EXCLUDED_MODULES that live under
+            # these prefixes (:core:konsist) therefore still trigger a rebuild;
+            # they change rarely enough that the odd wasted run is fine.
+            dokka:
+              - 'androidApp/src/**'
+              - 'core/**/src/**'
+              - 'feature/**/src/**'
+              - 'desktopApp/src/**'
+              # Dokka config, module list and the plugin classpath.
+              - 'build-logic/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle/libs.versions.toml'
+
       - name: Generate Docs Site (main channel)
         run: ./gradlew generateDocsBundle validateDocsBundle publishDocsSite -Pdocs.channel=main -Pci=true
 
       # Dokka (Gradle) and Jekyll (Ruby) are independent — Dokka's output is only
       # copied in afterwards — so run them concurrently to overlap the two slowest
-      # steps (~10 min Dokka vs ~5 min Jekyll) instead of summing them (~16 -> ~11 min).
+      # steps (~14 min Dokka vs ~5 min Jekyll) instead of summing them.
       - name: Build Dokka + Jekyll concurrently
+        env:
+          BUILD_DOKKA: ${{ steps.filter.outputs.dokka == 'true' || github.event_name == 'workflow_dispatch' }}
         run: |
           set -euo pipefail
           BUNDLE_GEMFILE=docs/Gemfile bundle exec jekyll build \
@@ -73,14 +104,27 @@ jobs:
             --destination build/jekyll_site \
             --baseurl /${{ github.event.repository.name }}/main &
           jekyll_pid=$!
-          ./gradlew dokkaGeneratePublicationHtml --no-configuration-cache
+          if [ "$BUILD_DOKKA" = "true" ]; then
+            ./gradlew dokkaGeneratePublicationHtml --no-configuration-cache
+          else
+            echo "No Dokka-relevant changes — skipping API reference rebuild."
+          fi
           wait "$jekyll_pid"
 
       - name: Stage channels
+        id: stage
+        env:
+          BUILD_DOKKA: ${{ steps.filter.outputs.dokka == 'true' || github.event_name == 'workflow_dispatch' }}
         run: |
+          set -euo pipefail
           mkdir -p build/pages_staging
           cp -r build/jekyll_site build/pages_staging/main
-          cp -r build/dokka/html build/pages_staging/api
+          channels="main"
+          if [ "$BUILD_DOKKA" = "true" ]; then
+            cp -r build/dokka/html build/pages_staging/api
+            channels="$channels api"
+          fi
+          echo "channels=$channels" >> "$GITHUB_OUTPUT"
 
       - name: Publish to gh-pages
-        run: scripts/docs/publish-to-gh-pages.sh build/pages_staging main api
+        run: scripts/docs/publish-to-gh-pages.sh build/pages_staging ${{ steps.stage.outputs.channels }}

--- a/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
@@ -116,10 +116,22 @@ private val ALL_MODULES_FULL =
 private val ANDROID_ONLY_MODULES = setOf(":androidApp", ":core:barcode", ":feature:widget")
 
 /**
- * Modules excluded from Dokka aggregation. Empty now that :core:proto has been replaced by
- * the external org.meshtastic:protobufs SDK.
+ * Modules excluded from Dokka aggregation.
+ *
+ * These are test harnesses and build-time generators with no API surface a reader would look up: they exist to run
+ * checks or emit artifacts, not to be called from other modules. Aggregating them only added generation time and
+ * empty pages to the published `/api/` reference.
+ *
+ * `:core:testing` is deliberately NOT excluded — it is a shared fixture library that other modules' tests consume,
+ * so its API docs are useful to contributors writing tests.
  */
-private val DOKKA_EXCLUDED_MODULES = emptySet<String>()
+private val DOKKA_EXCLUDED_MODULES =
+    setOf(
+        ":core:konsist", // Konsist architecture assertions; single test class, no callable API
+        ":screenshot-tests", // Paparazzi/Roborazzi harness for the screenshot gate
+        ":docs-screenshots", // generate-only module that emits documentation screenshots
+        ":baselineprofile", // macrobenchmark module that generates baseline-prof.txt
+    )
 
 private fun allModules(): List<String> = ALL_MODULES_FULL
 

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
@@ -69,7 +69,11 @@ fun Project.configureDokka() {
             // sourceLink block and only compiled because Kotlin resolved them against the outer receiver.
             enableJdkDocumentationLink.set(true)
             enableKotlinStdLibDocumentationLink.set(true)
-            reportUndocumented.set(true)
+
+            // Off deliberately: this emitted a warning per undocumented declaration — thousands of lines that
+            // dominated the docs-deploy log without anyone acting on them. It never failed the build, so it was
+            // noise rather than a gate. Re-enable locally (or flip this) when doing a deliberate KDoc pass.
+            reportUndocumented.set(false)
 
             sourceLink {
                 // Standardized repo-root based source links

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Dokka.kt
@@ -65,11 +65,13 @@ fun Project.configureDokka() {
             val isCoreSourceSet = name in baseSourceSets
             suppress.set(!isCoreSourceSet)
 
-            sourceLink {
-                enableJdkDocumentationLink.set(true)
-                enableKotlinStdLibDocumentationLink.set(true)
-                reportUndocumented.set(true)
+            // These are source-set level settings, not sourceLink ones — they previously sat inside the
+            // sourceLink block and only compiled because Kotlin resolved them against the outer receiver.
+            enableJdkDocumentationLink.set(true)
+            enableKotlinStdLibDocumentationLink.set(true)
+            reportUndocumented.set(true)
 
+            sourceLink {
                 // Standardized repo-root based source links
                 localDirectory.set(project.projectDir)
                 val rootDir = project.isolated.rootProject.projectDirectory.asFile


### PR DESCRIPTION
## Summary

Dokka dominates the docs deploy — ~14 min of the ~16 min "Build Dokka + Jekyll" step — and currently reruns on **every** push to `main`, including prose-only edits under `docs/` that cannot possibly change the generated API reference.

Three changes:

1. **Gate the Dokka rebuild on a path filter.** When no API sources or Dokka config changed, `/api/` is left as-is on `gh-pages` and the publisher is invoked with the `main` channel only — the per-channel overlay model from #6410 makes this safe. `workflow_dispatch` always rebuilds everything. Docs-only pushes now skip the slowest step entirely.
2. **Populate `DOKKA_EXCLUDED_MODULES`** with `:core:konsist`, `:screenshot-tests`, `:docs-screenshots`, `:baselineprofile` — test harnesses and build-time generators with no callable API, so aggregating them only cost generation time and added empty pages to `/api/`. `:core:testing` deliberately stays in: it's a shared fixture library other modules' tests consume, so its docs are useful.
3. **Fix misplaced Dokka source-set settings.** `enableJdkDocumentationLink`, `enableKotlinStdLibDocumentationLink` and `reportUndocumented` were inside the `sourceLink { }` block and only compiled because Kotlin resolved them against the outer receiver. Moved to the source-set scope where they belong — behavior unchanged by the move itself.
4. **Turn off `reportUndocumented`.** It emitted one warning per undocumented declaration — thousands of lines that dominated the docs-deploy log. It never failed the build, so it was noise rather than a KDoc-coverage gate. Flip it back on locally when doing a deliberate documentation pass.

## Note on the filter patterns

The filter uses **positive patterns only**, deliberately. `dorny/paths-filter` evaluates each pattern as an independent `picomatch` predicate and ORs them (`predicateQuantifier` defaults to `some`), so a `'!core/konsist/**'` entry matches every path *outside* that directory and pins the filter permanently true. I had written exactly that first and caught it in testing — a docs-only change matched the `dokka` filter via the negation, which would have silently defeated the whole optimization. Consequence of dropping it: a `:core:konsist`-only source change still triggers a rebuild. That's one file that changes almost never, so the occasional wasted run is an acceptable trade for a filter that actually works.

## Test plan

- [x] `./gradlew :build-logic:convention:compileKotlin` — passes, confirming the moved Dokka DSL properties are valid `DokkaSourceSetSpec` members in Dokka 2.2.0 (re-run after the `reportUndocumented` flip)
- [x] `./gradlew spotlessApply spotlessCheck detekt` — pass, no new formatting diffs
- [x] `./gradlew :dependencies --configuration dokka` — verified `:core:model` / `:feature:map` still aggregate, and `konsist` / `screenshot-tests` / `docs-screenshots` / `baselineprofile` no longer appear
- [x] Filter logic verified against `picomatch` directly with the real pattern list: docs/, `docs/_includes/`, `scripts/docs/` and workflow-only changes → `dokka=false`; `core/**/src`, `feature/**/src`, `androidApp/src`, `build-logic/**` → `dokka=true`
- [x] `docs-deploy.yml` YAML validated
- [ ] Post-merge: confirm a docs-only push skips the Dokka step and leaves `/api/` intact, and that a source change still refreshes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API reference documentation by excluding irrelevant internal modules.
  * Corrected documentation links and source-set settings for more accurate generated references.

* **Chores**
  * Documentation deployments now rebuild API references only when relevant changes occur.
  * Manual documentation builds continue to regenerate all API references.
  * Publishing now includes only the documentation channels generated in each build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
