### PR TITLE
fix(desktop): restore eager JBR javaHome pin for ProGuard packaging

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -17,10 +17,6 @@
 
 import dev.detekt.gradle.Detekt
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.compose.desktop.application.tasks.AbstractCheckNativeDistributionRuntime
-import org.jetbrains.compose.desktop.application.tasks.AbstractJvmToolOperationTask
-import org.jetbrains.compose.desktop.application.tasks.AbstractProguardTask
-import org.jetbrains.compose.desktop.application.tasks.AbstractSuggestModulesTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.meshtastic.buildlogic.configureGraphTasks
 import org.meshtastic.buildlogic.resolveVersionInfo
@@ -109,28 +105,32 @@ kotlin {
 // Exclude generated Compose resource files from detekt analysis
 tasks.withType<Detekt>().configureEach { exclude("**/generated/**") }
 
-// Compose Desktop otherwise derives these task inputs from the JVM running Gradle. Bind only the packaging tasks to a
-// JBR 25 provider so ProGuard and jlink receive jmods without provisioning JBR while unrelated CI tasks configure.
-// Task-type configuration also covers aliases and dependency-driven execution without parsing requested task names.
-val desktopPackagingJavaHome =
-    javaToolchains
-        .launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(25))
-            vendor.set(JvmVendorSpec.JETBRAINS)
-        }
-        .map { launcher -> launcher.metadata.installationPath.asFile.absolutePath }
-
-tasks.withType<AbstractJvmToolOperationTask>().configureEach { javaHome.set(desktopPackagingJavaHome) }
-
-tasks.withType<AbstractProguardTask>().configureEach { javaHome.set(desktopPackagingJavaHome) }
-
-tasks.withType<AbstractSuggestModulesTask>().configureEach { javaHome.set(desktopPackagingJavaHome) }
-
-tasks.withType<AbstractCheckNativeDistributionRuntime>().configureEach { jdkHome.set(desktopPackagingJavaHome) }
-
 compose.desktop {
     application {
         mainClass = "org.meshtastic.desktop.MainKt"
+
+        // CMP resolves javaHome from the JVM running Gradle, not the Kotlin toolchain. On CI
+        // that's Temurin 25, which ships without jmods (JEP 493): jlink still works, but the
+        // ProGuard task derives -libraryjars from $javaHome/jmods and fails with ~857k
+        // unresolved java.* references. Pin packaging to the JBR SDK toolchain (jmods
+        // included) so ProGuard sees the platform classes and the bundled runtime is
+        // deterministically JBR 25 on every machine.
+        //
+        // This assignment must stay EAGER here on the extension. Deferring it to lazy
+        // `tasks.withType<AbstractProguardTask>().configureEach { javaHome.set(provider) }` (PR #6401)
+        // does not reach `proguardReleaseJars` — the extension value still wins, ProGuard relaunches
+        // under the Gradle JVM, and every Build Desktop leg goes red with the jmods-less signature.
+        javaHome =
+            javaToolchains
+                .launcherFor {
+                    languageVersion.set(JavaLanguageVersion.of(25))
+                    vendor.set(JvmVendorSpec.JETBRAINS)
+                }
+                .get()
+                .metadata
+                .installationPath
+                .asFile
+                .absolutePath
 
         val desktopJvmArgs =
             listOf(


### PR DESCRIPTION
Every `Build Desktop Debug` leg on `main` has been red since #6401 merged, and the release path is red with it — `:desktopApp:proguardReleaseJars` is the one task the release workflow depends on that main-check deliberately exercises early, so this blocks the next desktop release, not just CI.

#6401 replaced the eager `compose.desktop { application { javaHome = ... } }` pin with lazy per-task-type wiring:

```kotlin
tasks.withType<AbstractProguardTask>().configureEach { javaHome.set(desktopPackagingJavaHome) }
```

That `.set()` never reaches `proguardReleaseJars` — the extension-level value still wins. ProGuard relaunches under the Gradle JVM, which on CI is Temurin 25. Temurin 24+ enables JEP 493 and ships no `jmods/`, so ProGuard derives an empty `-libraryjars` and dies with thousands of `can't find superclass or interface java.lang.Object` warnings, then `java.io.IOException: Please correct the above warnings first.`

The failing run's own log names the culprit JVM:

```
* Command: [/usr/lib/jvm/temurin-25-jdk-amd64/bin/java, -cp, ".../proguard-gradle-7.9.1.jar:...", proguard.ProGuard, ...]
```

This is the exact failure mode #6213 fixed and that the comment #6401 deleted described.

## 🐛 Bug Fixes

- **Restore the eager `javaHome` pin on `compose.desktop.application`.** Reverts the `desktopApp/build.gradle.kts` portion of #6401 (`00994c0f1`): drops the four `Abstract*Task` imports and the four `configureEach { javaHome.set(...) }` blocks, restores the direct assignment to the JBR 25 toolchain launcher.

## 🧹 Housekeeping

- Added a comment at the assignment recording *why* it must stay eager, naming #6401, so the next attempt to defer it starts from the failure evidence rather than rediscovering it on a red release run.

## Trade-off this reinstates

#6401 was not pointless. The eager `.get()` resolves — and can provision — the JBR toolchain at configuration time for *any* `:desktopApp` configuration, not just packaging. This revert brings that cost back.

I did not try to preserve the optimisation here, because `compose.desktop.application.javaHome` is a plain `String?`, not a `Property<String>` — there is no lazy form CMP will honour. A genuine deferral needs a different mechanism, and that is a change to make deliberately against a *green* desktop leg, not while `main` is red.

## Testing Performed

`spotlessApply spotlessCheck detekt assembleDebug test allTests` green, plus `:desktopApp:createDistributable :desktopApp:proguardReleaseJars -Pci=true` green.

**Local verification cannot prove this fix, and I want to be explicit about that.** `gradle/gradle-daemon-jvm.properties` pins `toolchainVersion=25` with no vendor, so the local daemon resolves to a JetBrains Runtime (`jbrsdk_jcef-25.0.3`, "Detected by: Current JVM"). I ran the control: on the **unfixed** tree, `:desktopApp:proguardReleaseJars --rerun-tasks` **also passes locally**, because JBR has the jmods either way. That is precisely the local-CI drift that let the original bug reach a release run in #6213.

So the only meaningful signal is this PR's own CI. The `Build Desktop Debug` matrix must be green on all four legs — ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-latest. Note that **macOS passes even on broken `main`**, so a green macOS leg alone means nothing here; the Linux and Windows legs are the real check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop application packaging with consistent Java 25 runtime configuration.
  * Resolved potential packaging failures caused by mismatched Java runtime and class library inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->