### PR TITLE
feat(docs): publish open- and closed-testing docs channels

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -1,17 +1,33 @@
 name: Docs Release
 
-# Publishes release docs to the persistent gh-pages branch: the site root
-# (latest release) and a permanent /vX.Y.Z/ copy, plus refreshed Dokka at
-# /api/. The /main/ snapshot is owned by docs-deploy.yml and left untouched.
+# Publishes release docs to the persistent gh-pages branch.
 #
-# workflow_dispatch exists for backfill: run it against a vX.Y.Z tag ref to
-# (re)publish that version without cutting a new tag.
+# Production tags (vX.Y.Z) own the site root and get a permanent /vX.Y.Z/ copy,
+# plus a refreshed Dokka reference at /api/.
+#
+# Open- and closed-testing tags (vX.Y.Z-open.N / vX.Y.Z-closed.N) publish a
+# per-tag snapshot at /vX.Y.Z-open.N/ only. They deliberately do NOT touch the
+# root or /api/: the root belongs to production releases, and /api/ is an
+# unversioned channel already kept current by docs-deploy.yml on every push to
+# main — rebuilding Dokka (~14 min) for each of the many prerelease tags in a
+# cycle would cost far more than it refreshes.
+#
+# These per-tag prerelease directories accumulate during a version cycle and are
+# reaped by post-release-cleanup.yml once the production vX.Y.Z tag ships.
+#
+# The /main/ snapshot is owned by docs-deploy.yml and is left untouched here.
+#
+# workflow_dispatch exists for backfill: run it against a tag ref to (re)publish
+# that version without cutting a new tag.
 
 on:
   push:
     tags:
+      # Production plus the open/closed testing tracks. Internal builds are
+      # excluded: they are tagged many times per cycle and are not a channel we
+      # publish documentation for.
       - 'v*.*.*'
-      - '!v*-*'
+      - '!v*-internal.*'
 
   workflow_dispatch:
 
@@ -34,17 +50,34 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Extract Version
+      # Resolves the tag into: the docs version label (which becomes the
+      # published directory name) and whether this is a production release.
+      - name: Resolve Release Channel
         id: version
         run: |
-          if ! [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "This workflow must run against a vX.Y.Z tag ref (got $GITHUB_REF)." >&2
-            echo "For workflow_dispatch, select the release tag under 'Use workflow from'." >&2
+          set -euo pipefail
+          case "$GITHUB_REF" in
+            refs/tags/*) TAG="${GITHUB_REF#refs/tags/}" ;;
+            *)
+              echo "This workflow must run against a release tag ref (got $GITHUB_REF)." >&2
+              echo "For workflow_dispatch, select the tag under 'Use workflow from'." >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "docs_version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "is_production=true" >> "$GITHUB_OUTPUT"
+            echo "Production release: ${BASH_REMATCH[1]} -> / and /v${BASH_REMATCH[1]}/"
+          elif [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+-(open|closed)\.[0-9]+)$ ]]; then
+            echo "docs_version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "is_production=false" >> "$GITHUB_OUTPUT"
+            echo "${BASH_REMATCH[2]}-testing prerelease -> /v${BASH_REMATCH[1]}/ only"
+          else
+            echo "Tag '$TAG' is not a publishable docs channel." >&2
+            echo "Expected vX.Y.Z, vX.Y.Z-open.N or vX.Y.Z-closed.N." >&2
             exit 1
           fi
-          TAG=${GITHUB_REF#refs/tags/v}
-          echo "version=$TAG" >> $GITHUB_OUTPUT
-          echo "Deploying docs for version: $TAG"
 
       - name: Gradle Setup
         uses: ./.github/actions/gradle-setup
@@ -58,41 +91,59 @@ jobs:
           bundler-cache: true
           working-directory: docs
 
-      # Build root docs site (/ on Pages)
+      # Versioned docs (/vX.Y.Z/ or /vX.Y.Z-open.N/) — built for every channel.
+      - name: Build Versioned Docs
+        run: ./gradlew generateDocsBundle validateDocsBundle publishDocsSite -Pdocs.channel=release -Pdocs.version=${{ steps.version.outputs.docs_version }} -Pci=true
+
+      # Root site (/) — production releases only.
       - name: Build Root Docs Site
+        if: steps.version.outputs.is_production == 'true'
         run: ./gradlew generateDocsBundle publishDocsSite -Pdocs.channel=root -Pci=true
 
-      # Build versioned docs (/vX.Y.Z/ on Pages)
-      - name: Build Versioned Docs
-        run: ./gradlew generateDocsBundle publishDocsSite -Pdocs.channel=release -Pdocs.version=${{ steps.version.outputs.version }} -Pci=true
-
-      # Build Dokka API reference (/api/ on Pages)
+      # Dokka API reference (/api/) — production releases only.
       - name: Build Dokka HTML documentation
+        if: steps.version.outputs.is_production == 'true'
         run: ./gradlew dokkaGeneratePublicationHtml --no-configuration-cache
 
       - name: Compile Jekyll Sites
+        env:
+          DOCS_VERSION: ${{ steps.version.outputs.docs_version }}
+          IS_PRODUCTION: ${{ steps.version.outputs.is_production }}
         run: |
-          # Build versioned Jekyll site
+          set -euo pipefail
+          # Versioned site
           BUNDLE_GEMFILE=docs/Gemfile bundle exec jekyll build \
-            --source build/_site/v${{ steps.version.outputs.version }} \
+            --source "build/_site/v${DOCS_VERSION}" \
             --destination build/jekyll_release \
-            --baseurl /${{ github.event.repository.name }}/v${{ steps.version.outputs.version }}
+            --baseurl "/${{ github.event.repository.name }}/v${DOCS_VERSION}"
 
-          # Move versioned source folder out of root source folder to avoid nested build issues
-          mv build/_site/v${{ steps.version.outputs.version }} build/v_temp
+          # Move the versioned source out of the root source tree so the root
+          # build below doesn't try to nest it.
+          mv "build/_site/v${DOCS_VERSION}" build/v_temp
 
-          # Build root Jekyll site
-          BUNDLE_GEMFILE=docs/Gemfile bundle exec jekyll build \
-            --source build/_site \
-            --destination build/jekyll_root \
-            --baseurl /${{ github.event.repository.name }}
+          if [ "$IS_PRODUCTION" = "true" ]; then
+            BUNDLE_GEMFILE=docs/Gemfile bundle exec jekyll build \
+              --source build/_site \
+              --destination build/jekyll_root \
+              --baseurl "/${{ github.event.repository.name }}"
+          fi
 
       - name: Stage channels
+        id: stage
+        env:
+          DOCS_VERSION: ${{ steps.version.outputs.docs_version }}
+          IS_PRODUCTION: ${{ steps.version.outputs.is_production }}
         run: |
+          set -euo pipefail
           mkdir -p build/pages_staging
-          cp -r build/jekyll_root build/pages_staging/root
-          cp -r build/jekyll_release build/pages_staging/v${{ steps.version.outputs.version }}
-          cp -r build/dokka/html build/pages_staging/api
+          cp -r build/jekyll_release "build/pages_staging/v${DOCS_VERSION}"
+          channels="v${DOCS_VERSION}"
+          if [ "$IS_PRODUCTION" = "true" ]; then
+            cp -r build/jekyll_root build/pages_staging/root
+            cp -r build/dokka/html build/pages_staging/api
+            channels="root $channels api"
+          fi
+          echo "channels=$channels" >> "$GITHUB_OUTPUT"
 
       - name: Publish to gh-pages
-        run: scripts/docs/publish-to-gh-pages.sh build/pages_staging root v${{ steps.version.outputs.version }} api
+        run: scripts/docs/publish-to-gh-pages.sh build/pages_staging ${{ steps.stage.outputs.channels }}

--- a/.github/workflows/post-release-cleanup.yml
+++ b/.github/workflows/post-release-cleanup.yml
@@ -26,18 +26,35 @@ jobs:
   cleanup_prereleases:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
+    # Dispatch inputs reach the shell as environment variables rather than being
+    # interpolated into the script text: base_version is free-form and feeds a
+    # regex that drives `rm -rf` and tag deletion, so a value containing quotes,
+    # $(...) or a newline must not be able to break out of the assignment.
+    env:
+      BASE_VERSION: ${{ github.event.inputs.base_version }}
+      CONFIRM_DELETION: ${{ github.event.inputs.confirm_deletion }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
+      # Shared by every step below: reject anything that is not a bare X.Y.Z
+      # before it reaches a regex, a tag deletion or an rm -rf.
+      - name: Validate base_version
+        run: |
+          set -euo pipefail
+          if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "base_version must be a bare X.Y.Z version (got '$BASE_VERSION')." >&2
+            exit 1
+          fi
+          echo "Cleaning up pre-releases for $BASE_VERSION."
+
       - name: Cleanup pre-releases and their tags
         id: cleanup_releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BASE_VERSION="${{ github.event.inputs.base_version }}"
           TAG_PREFIX="v${BASE_VERSION}-"
           echo "Searching for pre-releases with tag prefix '$TAG_PREFIX'."
           RELEASES_TO_DELETE=$(gh release list --json tagName,isPrerelease --limit 100 | jq -r --arg prefix "$TAG_PREFIX" '.[] | select(.isPrerelease == true and .tagName != null and (.tagName | startswith($prefix))) | .tagName')
@@ -45,7 +62,7 @@ jobs:
           if [ -z "$RELEASES_TO_DELETE" ]; then
             echo "No pre-releases found for base version $BASE_VERSION."
           else
-            if [[ "${{ github.event.inputs.confirm_deletion }}" == "true" ]]; then
+            if [[ "$CONFIRM_DELETION" == "true" ]]; then
               echo "!!! DELETING RELEASES AND TAGS !!!"
               echo "The following pre-releases and their tags will be deleted:"
               echo "$RELEASES_TO_DELETE"
@@ -62,9 +79,8 @@ jobs:
       - name: Cleanup pre-release docs snapshots on gh-pages
         run: |
           set -euo pipefail
-          BASE_VERSION="${{ github.event.inputs.base_version }}"
           DRY_RUN=true
-          [[ "${{ github.event.inputs.confirm_deletion }}" == "true" ]] && DRY_RUN=false
+          [[ "$CONFIRM_DELETION" == "true" ]] && DRY_RUN=false
 
           if ! git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
             echo "No gh-pages branch; nothing to clean."
@@ -77,10 +93,24 @@ jobs:
           git worktree add --quiet -B gh-pages "$work" FETCH_HEAD
           trap 'git worktree remove --force "$work" 2>/dev/null || true' EXIT
 
+          # Reaping is only sound because /vX.Y.Z/ supersedes these snapshots.
+          # If it is missing, the production docs never published (or this was
+          # dispatched for the wrong version) and deleting the snapshots would
+          # destroy the only docs for this version — and whatever the site root
+          # currently falls back to. Fail closed instead.
+          if [ ! -d "$work/v${BASE_VERSION}" ]; then
+            echo "Refusing to reap docs snapshots: /v${BASE_VERSION}/ is not published on gh-pages." >&2
+            echo "Run Docs Release against the v${BASE_VERSION} tag first." >&2
+            exit 1
+          fi
+
+          # Dots are wildcards in an ERE, so escape them: an unescaped
+          # v1.2.3-open.1 pattern would also match a v1x2y3-open.1 directory.
+          version_re="${BASE_VERSION//./\\.}"
           mapfile -t stale < <(
             find "$work" -maxdepth 1 -mindepth 1 -type d \
               -regextype posix-extended \
-              -regex ".*/v${BASE_VERSION}-(open|closed)\.[0-9]+" -printf '%f\n' | sort
+              -regex ".*/v${version_re}-(open|closed)\.[0-9]+" -printf '%f\n' | sort
           )
 
           if [ ${#stale[@]} -eq 0 ]; then
@@ -120,7 +150,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BASE_VERSION="${{ github.event.inputs.base_version }}"
           TAG_PREFIX="v${BASE_VERSION}-"
           echo "Searching for any remaining remote pre-release tags with prefix '$TAG_PREFIX'."
 
@@ -130,7 +159,7 @@ jobs:
           if [ -z "$TAGS_TO_DELETE" ]; then
             echo "No dangling pre-release tags found."
           else
-            if [[ "${{ github.event.inputs.confirm_deletion }}" == "true" ]]; then
+            if [[ "$CONFIRM_DELETION" == "true" ]]; then
               echo "!!! DELETING DANGLING TAGS !!!"
               echo "The following pre-release tags will be deleted:"
               # We pipe to xargs which will run the command for each tag.

--- a/.github/workflows/post-release-cleanup.yml
+++ b/.github/workflows/post-release-cleanup.yml
@@ -56,6 +56,66 @@ jobs:
             fi
           fi
 
+      # The docs site keeps a per-tag snapshot for every open/closed testing tag
+      # in a version cycle (see docs-release.yml). Once vX.Y.Z ships, /vX.Y.Z/
+      # supersedes them all, so reap them to stop gh-pages growing without bound.
+      - name: Cleanup pre-release docs snapshots on gh-pages
+        run: |
+          set -euo pipefail
+          BASE_VERSION="${{ github.event.inputs.base_version }}"
+          DRY_RUN=true
+          [[ "${{ github.event.inputs.confirm_deletion }}" == "true" ]] && DRY_RUN=false
+
+          if ! git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            echo "No gh-pages branch; nothing to clean."
+            exit 0
+          fi
+
+          work="$(mktemp -d)"
+          rmdir "$work"
+          git fetch --quiet origin gh-pages
+          git worktree add --quiet -B gh-pages "$work" FETCH_HEAD
+          trap 'git worktree remove --force "$work" 2>/dev/null || true' EXIT
+
+          mapfile -t stale < <(
+            find "$work" -maxdepth 1 -mindepth 1 -type d \
+              -regextype posix-extended \
+              -regex ".*/v${BASE_VERSION}-(open|closed)\.[0-9]+" -printf '%f\n' | sort
+          )
+
+          if [ ${#stale[@]} -eq 0 ]; then
+            echo "No pre-release docs snapshots found for $BASE_VERSION."
+            exit 0
+          fi
+
+          printf 'Pre-release docs snapshots for %s:\n' "$BASE_VERSION"
+          printf '  %s\n' "${stale[@]}"
+
+          if [ "$DRY_RUN" = true ]; then
+            echo "DRY RUN: the directories above would be removed from gh-pages."
+            exit 0
+          fi
+
+          for d in "${stale[@]}"; do
+            rm -rf "$work/$d"
+          done
+
+          # Rebuild versions.json (and the root placeholder) from what remains,
+          # using the same generator the publisher runs.
+          python3 scripts/docs/regenerate-versions.py "$work"
+
+          cd "$work"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "gh-pages already clean."
+            exit 0
+          fi
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -q -m "docs: reap pre-release snapshots for ${BASE_VERSION}"
+          git push --quiet origin HEAD:gh-pages
+          echo "Removed ${#stale[@]} pre-release docs snapshot(s) from gh-pages."
+
       - name: Cleanup dangling pre-release tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -192,7 +192,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: Validate store listing metadata lengths
         run: python3 scripts/check-metadata-length.py
       # Compose Multiplatform does not strip Android-style \" / \' escapes, so a

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ build-scan-*.scan
 
 # Local agent memory (remember plugin) — must never be committed
 .remember/
+
+# Python bytecode from scripts/
+__pycache__/
+*.pyc

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,11 +50,30 @@ channels (GitHub Pages must be configured to serve from that branch):
 
 | Path | Content | Published by |
 |------|---------|--------------|
-| `/` | Latest published release (default landing) | `docs-release.yml` on `vX.Y.Z` tags |
+| `/` | Latest production release (default landing) | `docs-release.yml` on `vX.Y.Z` tags |
 | `/vX.Y.Z/` | Permanent per-release copy | `docs-release.yml` on `vX.Y.Z` tags |
+| `/vX.Y.Z-open.N/` | Per-tag open-testing snapshot | `docs-release.yml` on `vX.Y.Z-open.N` tags |
+| `/vX.Y.Z-closed.N/` | Per-tag closed-testing snapshot | `docs-release.yml` on `vX.Y.Z-closed.N` tags |
 | `/main/` | Snapshot of the `main` branch | `docs-deploy.yml` on pushes to `main` |
-| `/api/` | Dokka API reference | both workflows |
+| `/api/` | Dokka API reference | `docs-deploy.yml`, plus production releases |
 | `/versions.json` | Version manifest for the site's version switcher | regenerated on every deploy |
+
+`-internal.N` tags are deliberately not published — they are cut many times per
+cycle and are not a documented channel.
+
+Prerelease snapshots accumulate during a version cycle so testers can read the
+docs for the exact build they are running. Once the production `vX.Y.Z` tag
+ships, `/vX.Y.Z/` supersedes them and **Post-Release Cleanup** (run with
+`base_version=X.Y.Z`) reaps the `vX.Y.Z-open.*` / `vX.Y.Z-closed.*` directories
+along with the prerelease tags. That workflow defaults to a dry run.
+
+Only production releases own `/` and rebuild `/api/`. Prerelease tags publish
+their own directory only: `/api/` is unversioned and already refreshed by every
+push to `main`, so rebuilding Dokka (~14 min) per prerelease tag would cost far
+more than it refreshes. Until a production release exists, `/` redirects to the
+best available channel — newest open, then newest closed, then `/main/` — and
+upgrades automatically as better channels appear. Real release content at the
+root is never overwritten by that fallback.
 
 Each deploy overlays only its own channels via `scripts/docs/publish-to-gh-pages.sh`,
 so release history accumulates instead of being wiped by the next deploy. The header

--- a/docs/_includes/version_switcher.html
+++ b/docs/_includes/version_switcher.html
@@ -26,7 +26,8 @@
   var baseurl = '{{ site.baseurl }}';
   var root = baseurl;
   var channel = 'latest';
-  var match = baseurl.match(/^(.*)\/(main|v\d+\.\d+\.\d+)$/);
+  // /main/, /vX.Y.Z/ or a prerelease snapshot like /v2.8.0-open.1/.
+  var match = baseurl.match(/^(.*)\/(main|v\d+\.\d+\.\d+(?:-(?:open|closed)\.\d+)?)$/);
   if (match) {
     root = match[1];
     channel = match[2];
@@ -48,8 +49,18 @@
       if (data.latest) {
         entries.push({ id: 'latest', label: 'latest (v' + data.latest + ')', base: root });
       }
+      // Prereleases are documented ahead of general availability, so the track
+      // is always spelled out — a reader must not mistake a closed-testing
+      // snapshot for a shipped release.
+      (data.prereleases || []).forEach(function(p) {
+        entries.push({
+          id: p.dir,
+          label: p.dir.replace(/^v/, 'v') + ' — ' + p.track + ' testing',
+          base: root + '/' + p.dir
+        });
+      });
       if (data.hasMain) {
-        entries.push({ id: 'main', label: 'main (snapshot)', base: root + '/main' });
+        entries.push({ id: 'main', label: 'main (unreleased snapshot)', base: root + '/main' });
       }
       (data.versions || []).forEach(function(v) {
         entries.push({ id: 'v' + v, label: 'v' + v, base: root + '/v' + v });

--- a/scripts/docs/publish-to-gh-pages.sh
+++ b/scripts/docs/publish-to-gh-pages.sh
@@ -69,44 +69,10 @@ for channel in "${CHANNELS[@]}"; do
     echo "Published channel: $channel"
 done
 
-# Until the first release deploy lands, the site root has no content of its
-# own — point it at the main snapshot so the Pages URL isn't a 404.
-if [ ! -f "$SITE_DIR/index.html" ] && [ -d "$SITE_DIR/main" ]; then
-    cat > "$SITE_DIR/index.html" << 'EOF'
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=./main/">
-  <title>Meshtastic Android Docs</title>
-</head>
-<body><a href="./main/">Redirecting to the main-branch docs…</a></body>
-</html>
-EOF
-    echo "Wrote placeholder root index.html -> main/ (no release published yet)"
-fi
-
-# Regenerate the version manifest consumed by the docs site's version
-# switcher. Latest = highest semver among published vX.Y.Z folders.
-python3 - "$SITE_DIR" << 'EOF'
-import json, os, re, sys
-
-site = sys.argv[1]
-pattern = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
-versions = sorted(
-    (m.groups() for d in os.listdir(site) if (m := pattern.match(d)) and os.path.isdir(os.path.join(site, d))),
-    key=lambda g: tuple(map(int, g)),
-    reverse=True,
-)
-manifest = {
-    "latest": ".".join(versions[0]) if versions else None,
-    "versions": [".".join(v) for v in versions],
-    "hasMain": os.path.isdir(os.path.join(site, "main")),
-}
-with open(os.path.join(site, "versions.json"), "w") as f:
-    json.dump(manifest, f, indent=2)
-print(f"versions.json: {manifest}")
-EOF
+# Regenerate the version manifest consumed by the site's version switcher, and
+# (re)write the root placeholder when no production release owns the root yet.
+# Shared with post-release-cleanup.yml so the two can never derive it differently.
+python3 "$(dirname "$0")/regenerate-versions.py" "$SITE_DIR"
 
 # Pages must serve this branch as-is; the site is already built.
 touch "$SITE_DIR/.nojekyll"

--- a/scripts/docs/regenerate-versions.py
+++ b/scripts/docs/regenerate-versions.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regenerate versions.json (and the root placeholder) for the docs site.
+
+Scans a built gh-pages tree and derives the manifest consumed by the site's
+version switcher from the directories actually present, so the manifest can
+never disagree with what is published.
+
+Channel layout on gh-pages:
+    /                     production release docs (owns the root)
+    /vX.Y.Z/              permanent per-release snapshot
+    /vX.Y.Z-open.N/       per-tag open-testing snapshot
+    /vX.Y.Z-closed.N/     per-tag closed-testing snapshot
+    /main/                snapshot of the main branch
+    /api/                 Dokka reference (unversioned)
+
+Prerelease snapshots accumulate during a version cycle and are reaped by
+post-release-cleanup.yml once the production vX.Y.Z tag ships.
+
+Usage: regenerate-versions.py <site-dir>
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+RELEASE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+PRERELEASE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-(open|closed)\.(\d+)$")
+
+# Marks a root index.html this script generated. Production release content
+# never carries it, which is how we tell "root is unowned, retarget it freely"
+# apart from "a real release owns the root, leave it alone".
+PLACEHOLDER_MARKER = "<!-- meshtastic-docs-root-placeholder -->"
+
+PLACEHOLDER = (
+    PLACEHOLDER_MARKER
+    + """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=./{target}/">
+  <title>Meshtastic Android Docs</title>
+</head>
+<body><a href="./{target}/">Redirecting to the {target} docs…</a></body>
+</html>
+"""
+)
+
+# Track ranking for the switcher and the root fallback. Open testing is publicly
+# available, so it outranks closed testing. Sequence numbers are per-track
+# counters and are never compared across tracks.
+TRACK_RANK = {"open": 1, "closed": 0}
+
+
+def scan(site: str) -> tuple[list[dict], list[dict]]:
+    releases: list[dict] = []
+    prereleases: list[dict] = []
+    for name in sorted(os.listdir(site)):
+        if not os.path.isdir(os.path.join(site, name)):
+            continue
+        if m := RELEASE.match(name):
+            releases.append(
+                {"dir": name, "version": ".".join(m.groups()), "sort": tuple(int(x) for x in m.groups())}
+            )
+        elif m := PRERELEASE.match(name):
+            major, minor, patch, track, seq = m.groups()
+            prereleases.append(
+                {
+                    "dir": name,
+                    "version": f"{major}.{minor}.{patch}",
+                    "track": track,
+                    "seq": int(seq),
+                    "sort": (int(major), int(minor), int(patch), int(seq)),
+                }
+            )
+    releases.sort(key=lambda r: r["sort"], reverse=True)
+    # Group by track (open before closed), newest version/sequence first within
+    # each. Track must dominate: 'seq' counts up independently per track, so
+    # comparing open.1 against closed.10 numerically would be meaningless.
+    prereleases.sort(key=lambda p: (TRACK_RANK[p["track"]], p["sort"]), reverse=True)
+    return releases, prereleases
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {os.path.basename(sys.argv[0])} <site-dir>", file=sys.stderr)
+        return 2
+    site = sys.argv[1]
+    if not os.path.isdir(site):
+        print(f"not a directory: {site}", file=sys.stderr)
+        return 2
+
+    releases, prereleases = scan(site)
+    manifest = {
+        "latest": releases[0]["version"] if releases else None,
+        "versions": [r["version"] for r in releases],
+        "prereleases": [{k: p[k] for k in ("dir", "version", "track", "seq")} for p in prereleases],
+        "hasMain": os.path.isdir(os.path.join(site, "main")),
+    }
+    with open(os.path.join(site, "versions.json"), "w") as handle:
+        json.dump(manifest, handle, indent=2)
+
+    # The root belongs to production releases. Until one exists, redirect it to
+    # the best available channel so the Pages URL is never a 404:
+    # newest open prerelease -> newest closed prerelease -> main snapshot.
+    #
+    # Re-evaluated on every run so the root upgrades as better channels appear
+    # (main -> closed -> open), but only when the current root is our own
+    # placeholder — real release content is never overwritten.
+    root_index = os.path.join(site, "index.html")
+    owned_by_release = False
+    if os.path.exists(root_index):
+        with open(root_index, encoding="utf-8", errors="replace") as handle:
+            owned_by_release = PLACEHOLDER_MARKER not in handle.read(len(PLACEHOLDER_MARKER) + 64)
+
+    if not owned_by_release:
+        target = next((p["dir"] for p in prereleases if p["track"] == "open"), None) or next(
+            (p["dir"] for p in prereleases if p["track"] == "closed"), None
+        )
+        if target is None and manifest["hasMain"]:
+            target = "main"
+        if target:
+            with open(root_index, "w") as handle:
+                handle.write(PLACEHOLDER.format(target=target))
+            print(f"Root placeholder -> {target}/ (no production release published yet)")
+    else:
+        print("Root is owned by a production release; left untouched.")
+
+    print(f"versions.json: {json.dumps(manifest)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Production tags ship every few weeks, so the docs site currently has no release channel worth pointing at. `v2.7.14` is from **2026-06-03** and carries **29** pages against `main`'s **34**. Meanwhile the testing tags are cut continuously (33 `-internal`, 10 `-closed`, 1 `-open` in the current cycle) and already track current docs content.

So instead of waiting weeks for v2.8.0 production, publish the open/closed testing tracks too — the site gets a real release channel within days.

## What

- **`docs-release.yml`** accepts `vX.Y.Z-open.N` and `vX.Y.Z-closed.N` alongside `vX.Y.Z`. `-internal.N` stays excluded — cut many times per cycle and not a documented channel.
- **Prerelease tags publish a per-tag snapshot at `/vX.Y.Z-open.N/` and nothing else.** They deliberately don't touch `/` or `/api/`: the root belongs to production releases, and `/api/` is unversioned and already refreshed by every push to `main`, so rebuilding Dokka (~14 min) per prerelease tag would cost far more than it refreshes.
- **`post-release-cleanup.yml`** reaps the `vX.Y.Z-open.*` / `vX.Y.Z-closed.*` docs directories once `vX.Y.Z` ships, so per-tag history stays bounded to one cycle. Honours the workflow's existing dry-run default.
- **Root fallback chain**: until a production release exists, `/` redirects through newest open → newest closed → `/main/`, re-evaluated on every publish so it upgrades as better channels appear. A placeholder marker distinguishes a generated root from real release content, which is never overwritten.
- **Switcher spells out the track** on every prerelease entry, so a closed-testing snapshot can't be mistaken for a shipped release. `main` is labelled an unreleased snapshot.

Manifest generation moves to `scripts/docs/regenerate-versions.py`, shared by the publisher and the cleanup workflow so the two can't derive `versions.json` differently.

## Notes

Track rank dominates prerelease ordering: `seq` counts up independently per track, so comparing `open.1` against `closed.10` numerically is meaningless. My first attempt sorted by `seq` first and ranked `closed.10` above `open.1` — caught in testing.

Also carries a one-line drive-by from the workflow audit: `pull-request.yml` had a bare `actions/checkout@v7` while all 30 other usages pin `@v7.0.1`.

## Test plan

Exercised end to end against a scratch bare remote through a full version cycle, re-run after `spotlessApply` reformatted the shell/YAML to confirm behavior was unchanged:

- [x] Root upgrade chain: `main` → `v2.8.0-closed.10` → `v2.8.0-open.1` → stays on open when `closed.11` lands → moves to `open.2`
- [x] Production takeover: `v2.8.0` publishes real root content, prerelease dirs preserved alongside
- [x] A later `main` deploy does **not** reclaim the root from a production release (marker check)
- [x] Cleanup reap: removes all four `v2.8.0-*` snapshots, leaving `latest=2.8.0`, `prereleases=[]`, root untouched
- [x] Prerelease ordering in `versions.json`: open before closed, newest first within each
- [x] Switcher entry/label building verified against the new manifest in three states (mid-cycle on `/main/`, on a closed snapshot, post-production on root)
- [x] `spotlessApply spotlessCheck detekt` pass; YAML/bash/python syntax validated
- [ ] Post-merge: confirm the next `-closed`/`-open` tag publishes its snapshot and the dropdown appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated GitHub Pages docs publishing to support production and prerelease channels, including `/api/`.
  * Expanded the version switcher to recognize open/closed testing snapshot channels.
  * Added automatic `versions.json` regeneration and smarter root fallback redirects.
* **Bug Fixes**
  * Prevented internal tags from being published and tightened channel selection for publishing.
  * Added safe cleanup logic for stale prerelease docs snapshots and dangling prerelease tags (with dry-run default).
* **Documentation**
  * Refined documentation on channel layout, lifecycles, and prerelease accumulation/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->