### PR TITLE
fix(ci): add Robolectric cache, skip cleanup on Windows

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -66,14 +66,34 @@ runs:
         path: ~/.konan
         key: konan-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('gradle/libs.versions.toml') }}
 
+    # Robolectric downloads its android-all-instrumented jars to the local Maven
+    # repo, which lives outside the Gradle User Home and so isn't covered by
+    # setup-gradle's caching. (This was previously attempted via
+    # gradle-home-cache-includes, but those entries resolve relative to the
+    # Gradle User Home — the `~/.m2/...` line expanded to the literal path
+    # `<gradle-home>/~/.m2/...` and never matched anything.) Keyed on the
+    # version catalog, which pins the Robolectric version.
+    - name: Cache Robolectric android-all jars
+      uses: actions/cache@v6
+      with:
+        path: ~/.m2/repository/org/robolectric
+        key: robolectric-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('gradle/libs.versions.toml') }}
+        restore-keys: |
+          robolectric-${{ runner.os }}-${{ runner.arch }}-
+
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
       with:
         cache-read-only: ${{ inputs.cache_read_only }}
         cache-encryption-key: ${{ inputs.gradle_encryption_key }}
-        cache-cleanup: on-success
+        # Cache cleanup is broken on Windows with setup-gradle v6's "enhanced
+        # caching" provider: it deletes the whole Gradle User Home instead of
+        # just unused entries (1739 files "excluded from the cache" here vs 25
+        # on Linux), so every subsequent save fails path validation and the
+        # Windows cache is never written. Upstream: gradle/actions#1013.
+        # Skip cleanup there — a slightly larger cache beats no cache at all.
+        cache-cleanup: ${{ runner.os == 'Windows' && 'never' || 'on-success' }}
         add-job-summary: always
         gradle-home-cache-includes: |
           caches
           notifications
-          ~/.m2/repository/org/robolectric


### PR DESCRIPTION
## Summary

Fix two CI caching issues:

1. **Robolectric cache** — Robolectric downloads android-all-instrumented jars to `~/.m2/repository/org/robolectric`, which lives outside the Gradle User Home and isn't covered by setup-gradle's caching. Add an explicit cache action keyed on the version catalog (which pins Robolectric). Previous attempt via `gradle-home-cache-includes` failed because those paths resolve relative to Gradle User Home.

2. **Windows cache-cleanup bug** — setup-gradle v6's enhanced caching deletes the entire Gradle User Home on Windows instead of just unused entries, causing subsequent cache saves to fail path validation. Skip cleanup on Windows (upstream: gradle/actions#1013). A slightly larger cache beats no cache.

## Testing Performed

CI verification on Windows and Linux runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build setup performance by caching locally downloaded Robolectric artifacts.
  * Updated Gradle cache cleanup behavior to avoid issues on Windows.
  * Simplified Gradle cache configuration for more reliable build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->