### PR TITLE
fix(strings): correct English subnet label

### DIFF
--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1611,7 +1611,7 @@
     <string name="store_forward">Store &amp; Forward</string>
     <string name="store_forward_config">Store &amp; Forward Config</string>
     <string name="store_forward_enabled">Store &amp; Forward enabled</string>
-    <string name="subnet">Subred</string>
+    <string name="subnet">Subnet</string>
     <string name="success">Success</string>
     <string name="super_deep_sleep_duration_seconds">Super deep sleep duration</string>
     <string name="supported">Supported</string>


### PR DESCRIPTION
## Why

The base English `subnet` string read **"Subred"** — Spanish. Because `core/resources/.../values/strings.xml` is the *source* that Crowdin translates from, nothing upstream was ever going to fix it, and translators worked from the wrong word: `values-fr` and `values-ro` both say "Subred" too. It has been wrong since #4628 and is user-visible as the subnet field title in the network config screen (`NetworkConfigItemList.kt:332`).

Fixing the source string invalidates the fr/ro translations in Crowdin, so they get retranslated on the next scheduled sync — which is why this PR touches **only** the base resources. Hand-editing the locale files (as #6424 did) would be clobbered by that same sync.

## 🐛 Bug Fixes

- `subnet`: "Subred" → "Subnet" in the base English resources.

Credit to @Jonher937 for spotting this in #6424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the displayed “Subnet” label to fix a spelling error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->