### PR TITLE
fix(data): don't let coarse position reports overwrite precise coordinates

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/NodeManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/NodeManagerImpl.kt
@@ -308,6 +308,60 @@ class NodeManagerImpl(
         private const val NODE_PERSISTENCE_LANE_COUNT = 64
         private const val TIME_MS_TO_S = 1000L
         private const val GENERATED_NODE_NAME_SUFFIX_LENGTH = 4
+
+        /** `precision_bits` value used by firmware for an un-degraded (full 32-bit) coordinate. */
+        private const val FULL_POSITION_PRECISION_BITS = 32
+
+        /** Total bits in the `latitude_i` / `longitude_i` fixed-point representation. */
+        private const val POSITION_COORDINATE_BITS = 32
+
+        /**
+         * Reproduces the firmware's coarsening of a coordinate to [bits] of precision: mask off the low bits, then
+         * re-center the value inside the remaining box. Mirrors `Router::sendLocal` / `PositionModule` behaviour so we
+         * can tell whether a coarse report describes the box that already contains a coordinate we hold.
+         */
+        internal fun coarsenCoordinate(degI: Int, bits: Int): Int =
+            (degI and (-1 shl (POSITION_COORDINATE_BITS - bits))) + (1 shl (POSITION_COORDINATE_BITS - 1 - bits))
+
+        /**
+         * Returns [incoming] with the coordinates of [stored] restored when [incoming] is merely a precision-degraded
+         * restatement of what we already know (see [isRedundantCoarsePosition]); otherwise [incoming] unchanged.
+         */
+        internal fun preservingKnownPrecision(incoming: ProtoPosition, stored: ProtoPosition): ProtoPosition =
+            if (isRedundantCoarsePosition(incoming, stored)) {
+                incoming.copy(
+                    latitude_i = stored.latitude_i,
+                    longitude_i = stored.longitude_i,
+                    precision_bits = stored.precision_bits,
+                )
+            } else {
+                incoming
+            }
+
+        /**
+         * True when [incoming] is a precision-degraded report that carries no new information over [stored].
+         *
+         * Nodes on a channel with `position_precision` set broadcast their location coarsened to the box centre. When
+         * we already hold a more precise coordinate for that node (e.g. a fixed position we just wrote, or an earlier
+         * full-precision report) and that coordinate falls inside the same box, adopting the coarse value would make
+         * the position visibly "drift" away from the real one (issue #6360). Only positions from a *different* box
+         * indicate the node actually moved, and those are accepted normally.
+         */
+        internal fun isRedundantCoarsePosition(incoming: ProtoPosition, stored: ProtoPosition): Boolean {
+            val incomingBits = incoming.precision_bits
+            val storedLatI = stored.latitude_i ?: 0
+            val storedLonI = stored.longitude_i ?: 0
+            // `0` means the stored coordinate was never degraded, so treat it as full precision.
+            val storedBits = stored.precision_bits.takeIf { it > 0 } ?: FULL_POSITION_PRECISION_BITS
+
+            val isDegradedReport = incomingBits > 0 && incomingBits < FULL_POSITION_PRECISION_BITS
+            val haveMorePreciseCoordinate = (storedLatI != 0 || storedLonI != 0) && storedBits > incomingBits
+
+            return isDegradedReport &&
+                haveMorePreciseCoordinate &&
+                coarsenCoordinate(storedLatI, incomingBits) == (incoming.latitude_i ?: 0) &&
+                coarsenCoordinate(storedLonI, incomingBits) == (incoming.longitude_i ?: 0)
+        }
     }
 
     override fun loadCachedNodeDB() {
@@ -573,16 +627,17 @@ class NodeManagerImpl(
             val newLastHeard = maxOf(node.lastHeard, posTime)
 
             val newPos =
-                if (isZeroPos) {
-                    p.copy(
-                        time = posTime,
-                        latitude_i = node.position.latitude_i,
-                        longitude_i = node.position.longitude_i,
-                        altitude = p.altitude ?: node.position.altitude,
-                        sats_in_view = p.sats_in_view,
-                    )
-                } else {
-                    p.copy(time = posTime)
+                when {
+                    isZeroPos ->
+                        p.copy(
+                            time = posTime,
+                            latitude_i = node.position.latitude_i,
+                            longitude_i = node.position.longitude_i,
+                            altitude = p.altitude ?: node.position.altitude,
+                            sats_in_view = p.sats_in_view,
+                        )
+
+                    else -> preservingKnownPrecision(p.copy(time = posTime), node.position)
                 }
 
             node.copy(position = newPos, lastHeard = newLastHeard)
@@ -643,7 +698,10 @@ class NodeManagerImpl(
             next = next.copy(user = newUser, publicKey = newUser.public_key)
         }
         info.position?.let { position ->
-            next = next.copy(position = position.copy(time = clampTimestampToNow(position.time)))
+            // The NodeDB snapshot from the connected device carries the coarsened position for nodes on a
+            // precision-limited channel; do not let it clobber a more precise coordinate we already hold (#6360).
+            val timed = position.copy(time = clampTimestampToNow(position.time))
+            next = next.copy(position = preservingKnownPrecision(timed, next.position))
         }
         return next.copy(
             lastHeard = clampTimestampToNow(info.last_heard),

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
@@ -259,6 +259,101 @@ class NodeManagerImplTest {
     }
 
     @Test
+    fun `handleReceivedPosition keeps precise position when a coarse report lands in the same box`() {
+        // Regression test for #6360: a fixed position set from the app is exact, but the node then broadcasts
+        // that same position coarsened to the channel's position_precision. The coarse report must not
+        // replace the exact coordinates we already hold, otherwise the value shown in the app "drifts".
+        val nodeNum = 1234
+        val exactLatI = 524595000 // 52.4595
+        val exactLonI = 310255000 // 31.0255
+        nodeManager.handleReceivedPosition(
+            nodeNum,
+            9999,
+            ProtoPosition(latitude_i = exactLatI, longitude_i = exactLonI, altitude = 135, time = 1000),
+            1000000L,
+        )
+
+        // Firmware coarsening for precision_bits = 13: mask off the low (32 - 13) bits, then re-center the box.
+        val coarseLatI = (exactLatI and (-1 shl 19)) + (1 shl 18) // 524550144 -> 52.4550144
+        val coarseLonI = (exactLonI and (-1 shl 19)) + (1 shl 18) // 310116352 -> 31.0116352
+        nodeManager.handleReceivedPosition(
+            nodeNum,
+            9999,
+            ProtoPosition(
+                latitude_i = coarseLatI,
+                longitude_i = coarseLonI,
+                altitude = 135,
+                time = 2000,
+                precision_bits = 13,
+            ),
+            2000000L,
+        )
+
+        val result = nodeManager.nodeDBbyNodeNum[nodeNum]
+        assertNotNull(result)
+        assertEquals(exactLatI, result.position.latitude_i)
+        assertEquals(exactLonI, result.position.longitude_i)
+        // The newer report is still applied for everything else.
+        assertEquals(2000, result.position.time)
+        assertEquals(2000, result.lastHeard)
+    }
+
+    @Test
+    fun `handleReceivedPosition accepts a coarse report from a different box`() {
+        val nodeNum = 1234
+        nodeManager.handleReceivedPosition(
+            nodeNum,
+            9999,
+            ProtoPosition(latitude_i = 524595000, longitude_i = 310255000, time = 1000),
+            1000000L,
+        )
+
+        // A coarse report whose box does not contain the stored position means the node actually moved.
+        val movedLatI = ((524595000 + (1 shl 20)) and (-1 shl 19)) + (1 shl 18)
+        val movedLonI = ((310255000 + (1 shl 20)) and (-1 shl 19)) + (1 shl 18)
+        nodeManager.handleReceivedPosition(
+            nodeNum,
+            9999,
+            ProtoPosition(latitude_i = movedLatI, longitude_i = movedLonI, time = 2000, precision_bits = 13),
+            2000000L,
+        )
+
+        val result = nodeManager.nodeDBbyNodeNum[nodeNum]
+        assertNotNull(result)
+        assertEquals(movedLatI, result.position.latitude_i)
+        assertEquals(movedLonI, result.position.longitude_i)
+        assertEquals(13, result.position.precision_bits)
+    }
+
+    @Test
+    fun `handleReceivedPosition accepts a coarse report when the stored position is coarser`() {
+        val nodeNum = 1234
+        val coarseLatI = (524595000 and (-1 shl 21)) + (1 shl 20)
+        val coarseLonI = (310255000 and (-1 shl 21)) + (1 shl 20)
+        nodeManager.handleReceivedPosition(
+            nodeNum,
+            9999,
+            ProtoPosition(latitude_i = coarseLatI, longitude_i = coarseLonI, time = 1000, precision_bits = 11),
+            1000000L,
+        )
+
+        val finerLatI = (524595000 and (-1 shl 19)) + (1 shl 18)
+        val finerLonI = (310255000 and (-1 shl 19)) + (1 shl 18)
+        nodeManager.handleReceivedPosition(
+            nodeNum,
+            9999,
+            ProtoPosition(latitude_i = finerLatI, longitude_i = finerLonI, time = 2000, precision_bits = 13),
+            2000000L,
+        )
+
+        val result = nodeManager.nodeDBbyNodeNum[nodeNum]
+        assertNotNull(result)
+        assertEquals(finerLatI, result.position.latitude_i)
+        assertEquals(finerLonI, result.position.longitude_i)
+        assertEquals(13, result.position.precision_bits)
+    }
+
+    @Test
     fun `handleReceivedPosition for local node ignores purely empty packets`() {
         val myNum = 1111
         val emptyPos = ProtoPosition(latitude_i = 0, longitude_i = 0, sats_in_view = 0, time = 0)
@@ -431,6 +526,32 @@ class NodeManagerImplTest {
         assertEquals(pk, result.publicKey)
         assertEquals(pk, result.user.public_key)
         assertTrue(result.hasPKC)
+    }
+
+    @Test
+    fun `installNodeInfo keeps precise position when the snapshot only has the coarse one`() {
+        val nodeNum = 5678
+        val exactLatI = 524595000
+        val exactLonI = 310255000
+        nodeManager.handleReceivedPosition(
+            nodeNum,
+            9999,
+            ProtoPosition(latitude_i = exactLatI, longitude_i = exactLonI, time = 1000),
+            1000000L,
+        )
+
+        val coarse =
+            ProtoPosition(
+                latitude_i = (exactLatI and (-1 shl 19)) + (1 shl 18),
+                longitude_i = (exactLonI and (-1 shl 19)) + (1 shl 18),
+                time = 2000,
+                precision_bits = 13,
+            )
+        nodeManager.installNodeInfo(ProtoNodeInfo(num = nodeNum, position = coarse, last_heard = 2000, channel = 0))
+
+        val result = nodeManager.nodeDBbyNodeNum[nodeNum]!!
+        assertEquals(exactLatI, result.position.latitude_i)
+        assertEquals(exactLonI, result.position.longitude_i)
     }
 
     @Test

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
@@ -282,7 +282,8 @@ class NodeManagerImplTest {
             ProtoPosition(
                 latitude_i = coarseLatI,
                 longitude_i = coarseLonI,
-                altitude = 135,
+                altitude = 210,
+                sats_in_view = 7,
                 time = 2000,
                 precision_bits = 13,
             ),
@@ -293,7 +294,12 @@ class NodeManagerImplTest {
         assertNotNull(result)
         assertEquals(exactLatI, result.position.latitude_i)
         assertEquals(exactLonI, result.position.longitude_i)
-        // The newer report is still applied for everything else.
+        // The stored precision must be retained as well. If the incoming precision_bits were kept, the *next*
+        // coarse report would compare as equally precise and would be free to overwrite the exact coordinates.
+        assertEquals(0, result.position.precision_bits)
+        // Everything else from the newer report is still applied.
+        assertEquals(210, result.position.altitude)
+        assertEquals(7, result.position.sats_in_view)
         assertEquals(2000, result.position.time)
         assertEquals(2000, result.lastHeard)
     }
@@ -552,6 +558,11 @@ class NodeManagerImplTest {
         val result = nodeManager.nodeDBbyNodeNum[nodeNum]!!
         assertEquals(exactLatI, result.position.latitude_i)
         assertEquals(exactLonI, result.position.longitude_i)
+        // Full precision is retained, so a later coarse snapshot cannot displace the exact coordinates either.
+        assertEquals(0, result.position.precision_bits)
+        // The snapshot's newer timestamps are still adopted.
+        assertEquals(2000, result.position.time)
+        assertEquals(2000, result.lastHeard)
     }
 
     @Test


### PR DESCRIPTION
Fixes #6360

## Root cause

Not the write path, and not phone GPS. The reporter's channel has `position_precision` set, so the remote node broadcasts its fixed position **coarsened to the box centre**, and the app stored that over the exact value it had just written.

The arithmetic confirms it exactly — for `precision_bits = 13`:

- `(524595000 and (-1 shl 19)) + (1 shl 18)` = `524550144` → `52.4550144`
- `(310255000 and (-1 shl 19)) + (1 shl 18)` = `310116352` → `31.0116352`

Those are precisely the drifted values in the reporter's third screenshot. Screenshot 2, taken right after save+reconnect, still showed the exact input — only the later coarse broadcast changed it.

Two earlier hypotheses are ruled out by this:

- **"Latitude doesn't save"** (original report) — both axes are coarsened. How far each *appears* to move just depends on where the value sat inside its box, which is why it looked latitude-only.
- **"App prefers phone GPS"** (later comment) — not the cause here. `CommandSenderImpl.setFixedPosition` (`:244-259`) is correct: `latitude_i = degI(pos.latitude)`, no axis swap.

## The bug

- `NodeManagerImpl.handleReceivedPosition` (`:596-636`) replaced the stored position with any non-zero incoming one, including a precision-degraded report.
- `NodeManagerImpl.applyNodeInfo` (`:698`) did the same for the config-handshake NodeDB snapshot, so the coarse value returned after every reconnect.

Because there is no `lat/lon` in `Config.PositionConfig` and no admin "get fixed position", the node DB position is the app's only source for the fixed-position editor (`PositionConfigScreen.kt:109-115`) — so any degradation of that value shows up as the "saved" fixed position.

## Fix

New helpers on `NodeManagerImpl`: `coarsenCoordinate(degI, bits)` (mirrors the firmware mask + box re-centre), `isRedundantCoarsePosition(...)`, `preservingKnownPrecision(...)`. Both the live-position and handshake paths now keep the more precise stored coordinates when an incoming coarse report resolves to the same box, while still applying the newer report's time/altitude/sats.

A coarse report from a **different** box is still accepted, so genuine movement on precision-limited channels keeps working.

## Tests

4 new tests in `commonTest` (`NodeManagerImplTest`):

1. coarse report in the same box keeps precise lat/lon while time/lastHeard advance — **this one fails without the fix** (`AssertionFailedError` on the latitude assert)
2. coarse report from a different box is applied (real movement)
3. a finer report always wins over a coarser stored one
4. handshake snapshot path preserves precision

## Verification

- `spotlessApply spotlessCheck :core:data:detekt :core:data:allTests` → pass (two intermediate detekt violations, `ReturnCount` and a misplaced KDoc, were fixed rather than suppressed)
- `assembleDebug` → `BUILD SUCCESSFUL`
- Full-repo `test`/`allTests` **not** run locally — leaving that to CI.
- **No hardware validation.** Reproducing needs a channel with coarse `position_precision`; a `replay_inject` POSITION_APP packet with `precision_bits = 13` and lat_i/lon_i = `524550144`/`310116352` is the shortcut.

## Reviewer notes

- **Worth confirming with the reporter** that their channel has `position_precision` set. The arithmetic match is near-conclusive, but it's the precondition — without it the bug doesn't reproduce.
- **Known trade-off:** a node that genuinely moves *within* its coarse box will keep showing the older precise coordinates. That seemed clearly better than discarding a known-exact position for a box centre, but it is a behaviour change worth a second opinion.
- **Separate bug found, not fixed here:** `MeshConnectionManagerImpl.kt:158-175` → `sendPosition` (`:197-219`) — the `fixed_position` guard only skips the *local DB write*; the POSITION_APP packet is still transmitted to the connected node even when local `fixed_position` is enabled. That's essentially the phone-GPS hypothesis, real but unrelated to this remote-node report. Deserves its own issue.
- #6263 (spurious 0 SNR/RSSI/HOPS) lives in the same file but has no code overlap; untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved more precise device locations when receiving or installing coarsened position updates.
  - Prevented redundant coarse reports from overwriting accurate coordinates.
  - Continued accepting legitimate position changes from different areas.
  - Improved handling of position timestamps and precision differences.

- **Tests**
  - Added regression coverage for coarse and precise position update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->