### PR TITLE
fix(node): show node counts without truncation

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1112,7 +1112,10 @@ no_usb_devices_found
 no_usb_devices_hint
 no_usb_devices_seen
 ### NODE ###
+node_count_online
+node_count_shown
 node_count_template
+node_count_total
 node_filter_exclude_infrastructure
 node_filter_exclude_mqtt
 node_filter_ignored

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1145,7 +1145,10 @@
     <string name="no_usb_devices_hint">Connect a device with a USB data cable to use serial.</string>
     <string name="no_usb_devices_seen">No USB devices detected</string>
     <!-- NODE -->
+    <string name="node_count_online">%1$d online</string>
+    <string name="node_count_shown">%1$d shown</string>
     <string name="node_count_template">(%1$d online / %2$d shown / %3$d total)</string>
+    <string name="node_count_total">%1$d total</string>
     <string name="node_filter_exclude_infrastructure">Exclude infrastructure</string>
     <string name="node_filter_exclude_mqtt">Exclude MQTT</string>
     <string name="node_filter_ignored">You are viewing ignored nodes,\nPress to return to the node list.</string>

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeCountSummary.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeCountSummary.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.node_count_online
+import org.meshtastic.core.resources.node_count_shown
+import org.meshtastic.core.resources.node_count_template
+import org.meshtastic.core.resources.node_count_total
+
+/** Horizontal gap between two count labels that share a line. */
+private val LABEL_GAP = 12.dp
+
+/** Vertical gap between wrapped lines of count labels. */
+private val LINE_GAP = 2.dp
+
+/**
+ * Node totals for the Nodes list header: how many nodes are online, how many the current filter shows, and how many are
+ * known in total.
+ *
+ * This used to live in the app bar `subtitle` slot, where it was clipped by the fixed app-bar height and squeezed
+ * horizontally by the node chip plus two icon buttons — the single long string was ellipsized on most phones
+ * (issue #6268). Here it gets the full content width and, crucially, is free to grow vertically: each count is an
+ * independent label inside a [FlowRow], so at large font scales or in verbose locales the labels reflow onto extra
+ * lines instead of truncating. No `maxLines`, no ellipsis, no autosizing anywhere in this component.
+ *
+ * Screen readers get one coherent sentence via [Res.string.node_count_template] rather than three disjointed fragments.
+ */
+@Composable
+fun NodeCountSummary(onlineCount: Int, shownCount: Int, totalCount: Int, modifier: Modifier = Modifier) {
+    NodeCountSummaryContent(
+        labels =
+        listOf(
+            stringResource(Res.string.node_count_online, onlineCount),
+            stringResource(Res.string.node_count_shown, shownCount),
+            stringResource(Res.string.node_count_total, totalCount),
+        ),
+        contentDescription = stringResource(Res.string.node_count_template, onlineCount, shownCount, totalCount),
+        modifier = modifier,
+    )
+}
+
+/**
+ * Layout half of [NodeCountSummary], split out so previews can inject deliberately long strings (long locales) without
+ * needing a translated resource bundle.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun NodeCountSummaryContent(labels: List<String>, contentDescription: String, modifier: Modifier = Modifier) {
+    FlowRow(
+        modifier = modifier.clearAndSetSemantics { this.contentDescription = contentDescription },
+        horizontalArrangement = Arrangement.spacedBy(LABEL_GAP),
+        verticalArrangement = Arrangement.spacedBy(LINE_GAP),
+    ) {
+        labels.forEach { label ->
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeCountSummaryPreviews.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeCountSummaryPreviews.kt
@@ -35,7 +35,7 @@ private val ENGLISH_LABELS = listOf("76 online", "398 shown", "1247 total")
  * Deliberately verbose stand-ins for the longest Crowdin locales (German/Hungarian style compounds run roughly twice
  * the English width). Hard-coded rather than locale-switched so the preview does not depend on a translated bundle.
  */
-private val LONG_LOCALE_LABELS = listOf("76 verbunden", "398 angezeigt", "1247 insgesamt insgesamt")
+private val LONG_LOCALE_LABELS = listOf("76 Knoten verbunden", "398 Knoten angezeigt", "1247 Knoten insgesamt")
 
 private const val ENGLISH_DESCRIPTION = "(76 online / 398 shown / 1247 total)"
 
@@ -67,7 +67,7 @@ fun NodeCountSummaryNarrowPreview() {
 }
 
 /** Long/translated text: verbose locale on a narrow phone. */
-@Preview(name = "NodeCountSummary - long locale", widthDp = 360)
+@Preview(name = "NodeCountSummary - long locale", widthDp = 320)
 @Composable
 fun NodeCountSummaryLongLocalePreview() {
     PreviewBody(LONG_LOCALE_LABELS, ENGLISH_DESCRIPTION)
@@ -81,7 +81,7 @@ fun NodeCountSummaryLargeFontPreview() {
 }
 
 /** Worst case: verbose locale AND largest font scale on a narrow phone. */
-@Preview(name = "NodeCountSummary - long locale font scale 2x", widthDp = 360, fontScale = 2.0f)
+@Preview(name = "NodeCountSummary - long locale font scale 2x", widthDp = 320, fontScale = 2.0f)
 @Composable
 fun NodeCountSummaryLongLocaleLargeFontPreview() {
     PreviewBody(LONG_LOCALE_LABELS, ENGLISH_DESCRIPTION)

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeCountSummaryPreviews.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeCountSummaryPreviews.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+@file:Suppress("MagicNumber", "PreviewPublic")
+
+package org.meshtastic.feature.node.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.meshtastic.core.ui.theme.AppTheme
+
+/** English labels matching the counts from issue #6268 (76 online / 398 shown / 1247 total). */
+private val EnglishLabels = listOf("76 online", "398 shown", "1247 total")
+
+/**
+ * Deliberately verbose stand-ins for the longest Crowdin locales (German/Hungarian style compounds run roughly twice
+ * the English width). Hard-coded rather than locale-switched so the preview does not depend on a translated bundle.
+ */
+private val LongLocaleLabels = listOf("76 verbunden", "398 angezeigt", "1247 insgesamt insgesamt")
+
+private const val ENGLISH_DESCRIPTION = "(76 online / 398 shown / 1247 total)"
+
+@Composable
+private fun PreviewBody(labels: List<String>, description: String) {
+    AppTheme {
+        Surface(color = MaterialTheme.colorScheme.surfaceDim) {
+            NodeCountSummaryContent(
+                labels = labels,
+                contentDescription = description,
+                modifier = Modifier.fillMaxWidth().padding(12.dp),
+            )
+        }
+    }
+}
+
+/** Default case on a narrow (compact-width) phone. */
+@Preview(name = "NodeCountSummary - default", widthDp = 360)
+@Composable
+fun NodeCountSummaryDefaultPreview() {
+    PreviewBody(EnglishLabels, ENGLISH_DESCRIPTION)
+}
+
+/** Narrowest realistic phone width — labels must reflow, never ellipsize. */
+@Preview(name = "NodeCountSummary - narrow 320dp", widthDp = 320)
+@Composable
+fun NodeCountSummaryNarrowPreview() {
+    PreviewBody(EnglishLabels, ENGLISH_DESCRIPTION)
+}
+
+/** Long/translated text: verbose locale on a narrow phone. */
+@Preview(name = "NodeCountSummary - long locale", widthDp = 360)
+@Composable
+fun NodeCountSummaryLongLocalePreview() {
+    PreviewBody(LongLocaleLabels, ENGLISH_DESCRIPTION)
+}
+
+/** Accessibility text size: largest Android font scale. */
+@Preview(name = "NodeCountSummary - font scale 2x", widthDp = 360, fontScale = 2.0f)
+@Composable
+fun NodeCountSummaryLargeFontPreview() {
+    PreviewBody(EnglishLabels, ENGLISH_DESCRIPTION)
+}
+
+/** Worst case: verbose locale AND largest font scale on a narrow phone. */
+@Preview(name = "NodeCountSummary - long locale font scale 2x", widthDp = 360, fontScale = 2.0f)
+@Composable
+fun NodeCountSummaryLongLocaleLargeFontPreview() {
+    PreviewBody(LongLocaleLabels, ENGLISH_DESCRIPTION)
+}
+
+/** Wide/tablet layout — the labels stay on one line and the block does not stretch awkwardly. */
+@Preview(name = "NodeCountSummary - wide 840dp", widthDp = 840)
+@Composable
+fun NodeCountSummaryWidePreview() {
+    PreviewBody(EnglishLabels, ENGLISH_DESCRIPTION)
+}

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeCountSummaryPreviews.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeCountSummaryPreviews.kt
@@ -29,13 +29,13 @@ import androidx.compose.ui.unit.dp
 import org.meshtastic.core.ui.theme.AppTheme
 
 /** English labels matching the counts from issue #6268 (76 online / 398 shown / 1247 total). */
-private val EnglishLabels = listOf("76 online", "398 shown", "1247 total")
+private val ENGLISH_LABELS = listOf("76 online", "398 shown", "1247 total")
 
 /**
  * Deliberately verbose stand-ins for the longest Crowdin locales (German/Hungarian style compounds run roughly twice
  * the English width). Hard-coded rather than locale-switched so the preview does not depend on a translated bundle.
  */
-private val LongLocaleLabels = listOf("76 verbunden", "398 angezeigt", "1247 insgesamt insgesamt")
+private val LONG_LOCALE_LABELS = listOf("76 verbunden", "398 angezeigt", "1247 insgesamt insgesamt")
 
 private const val ENGLISH_DESCRIPTION = "(76 online / 398 shown / 1247 total)"
 
@@ -56,40 +56,40 @@ private fun PreviewBody(labels: List<String>, description: String) {
 @Preview(name = "NodeCountSummary - default", widthDp = 360)
 @Composable
 fun NodeCountSummaryDefaultPreview() {
-    PreviewBody(EnglishLabels, ENGLISH_DESCRIPTION)
+    PreviewBody(ENGLISH_LABELS, ENGLISH_DESCRIPTION)
 }
 
 /** Narrowest realistic phone width — labels must reflow, never ellipsize. */
 @Preview(name = "NodeCountSummary - narrow 320dp", widthDp = 320)
 @Composable
 fun NodeCountSummaryNarrowPreview() {
-    PreviewBody(EnglishLabels, ENGLISH_DESCRIPTION)
+    PreviewBody(ENGLISH_LABELS, ENGLISH_DESCRIPTION)
 }
 
 /** Long/translated text: verbose locale on a narrow phone. */
 @Preview(name = "NodeCountSummary - long locale", widthDp = 360)
 @Composable
 fun NodeCountSummaryLongLocalePreview() {
-    PreviewBody(LongLocaleLabels, ENGLISH_DESCRIPTION)
+    PreviewBody(LONG_LOCALE_LABELS, ENGLISH_DESCRIPTION)
 }
 
 /** Accessibility text size: largest Android font scale. */
 @Preview(name = "NodeCountSummary - font scale 2x", widthDp = 360, fontScale = 2.0f)
 @Composable
 fun NodeCountSummaryLargeFontPreview() {
-    PreviewBody(EnglishLabels, ENGLISH_DESCRIPTION)
+    PreviewBody(ENGLISH_LABELS, ENGLISH_DESCRIPTION)
 }
 
 /** Worst case: verbose locale AND largest font scale on a narrow phone. */
 @Preview(name = "NodeCountSummary - long locale font scale 2x", widthDp = 360, fontScale = 2.0f)
 @Composable
 fun NodeCountSummaryLongLocaleLargeFontPreview() {
-    PreviewBody(LongLocaleLabels, ENGLISH_DESCRIPTION)
+    PreviewBody(LONG_LOCALE_LABELS, ENGLISH_DESCRIPTION)
 }
 
 /** Wide/tablet layout — the labels stay on one line and the block does not stretch awkwardly. */
 @Preview(name = "NodeCountSummary - wide 840dp", widthDp = 840)
 @Composable
 fun NodeCountSummaryWidePreview() {
-    PreviewBody(EnglishLabels, ENGLISH_DESCRIPTION)
+    PreviewBody(ENGLISH_LABELS, ENGLISH_DESCRIPTION)
 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -63,7 +63,6 @@ import org.meshtastic.core.model.NodeListDensity
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.channel_invalid
 import org.meshtastic.core.resources.hop_histogram_title
-import org.meshtastic.core.resources.node_count_template
 import org.meshtastic.core.resources.node_list_help_title
 import org.meshtastic.core.resources.nodes
 import org.meshtastic.core.resources.nodes_empty_disconnected_hint
@@ -85,6 +84,7 @@ import org.meshtastic.core.ui.icon.NoDevice
 import org.meshtastic.core.ui.icon.Nodes
 import org.meshtastic.core.ui.util.parseDeepLinkOrInvalid
 import org.meshtastic.feature.node.component.NodeContextMenu
+import org.meshtastic.feature.node.component.NodeCountSummary
 import org.meshtastic.feature.node.component.NodeFilterTextField
 import org.meshtastic.feature.node.component.NodeHopHistogramSheet
 import org.meshtastic.feature.node.component.NodeListHelp
@@ -168,7 +168,9 @@ fun NodeListScreen(
         topBar = {
             MainAppBar(
                 title = stringResource(Res.string.nodes),
-                subtitle = stringResource(Res.string.node_count_template, onlineNodeCount, nodes.size, totalNodeCount),
+                // Node counts deliberately live in the list header (NodeCountSummary), not here: the app bar's
+                // title/subtitle slot competes for width with the node chip + action icons and is clipped to a
+                // single line, which truncated the counts (issue #6268).
                 ourNode = ourNode,
                 showNodeChip = ourNode != null && connectionState is ConnectionState.Connected,
                 canNavigateUp = false,
@@ -212,32 +214,43 @@ fun NodeListScreen(
                 stickyHeader {
                     val animatedAlpha by
                         animateFloatAsState(targetValue = if (!isScrollInProgress) 1.0f else 0f, label = "alpha")
-                    NodeFilterTextField(
+                    Column(
                         modifier =
                         Modifier.fillMaxWidth()
                             .graphicsLayer(alpha = animatedAlpha)
                             .background(MaterialTheme.colorScheme.surfaceDim)
                             .padding(8.dp),
-                        filterText = state.filter.filterText,
-                        onTextChange = { viewModel.nodeFilterText = it },
-                        currentSortOption = state.sort,
-                        onSortSelect = viewModel::setSortOption,
-                        includeUnknown = state.filter.includeUnknown,
-                        onToggleIncludeUnknown = { viewModel.nodeFilterPreferences.toggleIncludeUnknown() },
-                        excludeInfrastructure = state.filter.excludeInfrastructure,
-                        onToggleExcludeInfrastructure = {
-                            viewModel.nodeFilterPreferences.toggleExcludeInfrastructure()
-                        },
-                        onlyOnline = state.filter.onlyOnline,
-                        onToggleOnlyOnline = { viewModel.nodeFilterPreferences.toggleOnlyOnline() },
-                        onlyDirect = state.filter.onlyDirect,
-                        onToggleOnlyDirect = { viewModel.nodeFilterPreferences.toggleOnlyDirect() },
-                        showIgnored = state.filter.showIgnored,
-                        onToggleShowIgnored = { viewModel.nodeFilterPreferences.toggleShowIgnored() },
-                        ignoredNodeCount = ignoredNodeCount,
-                        excludeMqtt = state.filter.excludeMqtt,
-                        onToggleExcludeMqtt = { viewModel.nodeFilterPreferences.toggleExcludeMqtt() },
-                    )
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        NodeCountSummary(
+                            onlineCount = onlineNodeCount,
+                            shownCount = nodes.size,
+                            totalCount = totalNodeCount,
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+                        )
+                        NodeFilterTextField(
+                            modifier = Modifier.fillMaxWidth(),
+                            filterText = state.filter.filterText,
+                            onTextChange = { viewModel.nodeFilterText = it },
+                            currentSortOption = state.sort,
+                            onSortSelect = viewModel::setSortOption,
+                            includeUnknown = state.filter.includeUnknown,
+                            onToggleIncludeUnknown = { viewModel.nodeFilterPreferences.toggleIncludeUnknown() },
+                            excludeInfrastructure = state.filter.excludeInfrastructure,
+                            onToggleExcludeInfrastructure = {
+                                viewModel.nodeFilterPreferences.toggleExcludeInfrastructure()
+                            },
+                            onlyOnline = state.filter.onlyOnline,
+                            onToggleOnlyOnline = { viewModel.nodeFilterPreferences.toggleOnlyOnline() },
+                            onlyDirect = state.filter.onlyDirect,
+                            onToggleOnlyDirect = { viewModel.nodeFilterPreferences.toggleOnlyDirect() },
+                            showIgnored = state.filter.showIgnored,
+                            onToggleShowIgnored = { viewModel.nodeFilterPreferences.toggleShowIgnored() },
+                            ignoredNodeCount = ignoredNodeCount,
+                            excludeMqtt = state.filter.excludeMqtt,
+                            onToggleExcludeMqtt = { viewModel.nodeFilterPreferences.toggleExcludeMqtt() },
+                        )
+                    }
                 }
 
                 items(nodes, key = { it.num }) { node ->


### PR DESCRIPTION
Fixes #6268

## Root cause

The count string was rendered in the app bar's **subtitle** slot, which is hard-clipped to one ellipsized line:

- `NodeListScreen.kt:171` (pre-fix) passed `subtitle = stringResource(Res.string.node_count_template, ...)`
- `MainAppBar.kt:96-106` renders that subtitle with `maxLines = 1, overflow = TextOverflow.Ellipsis` at `titleSmall`

The width left for the title column is whatever survives the branding icon (`MainAppBar.kt:119`), the our-node shortname chip (`:152-155`), and the two `IconButton`s this screen supplies (`NodeListScreen.kt:177-188`). In an M3 `TopAppBar` the actions win that space and the title column absorbs the shortfall — which is exactly the reporter's "the shortname obscures the description".

The deficit is **absolute, not a distribution problem**: `(76 online / 398 shown / 1247 total)` at `titleSmall` needs ~230dp, while chip + 2 icons + branding consume ~200dp of a 360dp phone. And because the single-row app bar has a fixed container height, simply dropping `maxLines` would clip *vertically* instead of wrapping. **The slot cannot be fixed in place.**

## Approaches considered

1. **Rebalance the Row weights / shrink the chip** — rejected; the deficit is absolute, no weighting makes it fit, and longer locales or large font scales widen the gap.
2. **Drop `maxLines`, or switch to a two-row / flexible top app bar** — rejected; fixed height clips wrapped lines, and a taller bar still competes with the actions row, so it only postpones truncation while spending vertical space on a list screen.
3. **Abbreviate (`76/398/1247`) or autosize** — rejected outright; that hides the problem and drops the labels that make the numbers meaningful.
4. **Chosen: move the counts into the list's sticky header as a wrap-capable `FlowRow` of three independent labels.**

Why 4: it gets the full content width with nothing competing, it can grow vertically, and because each count is its own child it reflows at meaningful boundaries instead of mid-phrase. `FlowRow` is layout-direction aware, so RTL mirrors for free. It sits directly above the filter field — arguably its right home, since the filter is what changes "shown".

## Changes

- **`NodeCountSummary.kt`** (new) — `FlowRow` of three labels, 12dp/2dp gaps, `labelLarge` on `onSurfaceVariant`, **no `maxLines`/overflow anywhere**. `Modifier.clearAndSetSemantics` collapses the three into one screen-reader announcement built from `node_count_template`.
- **`NodeCountSummaryPreviews.kt`** (new) — 6 previews driving an `internal` layout half with injected labels, so long-locale cases don't need a translated bundle.
- **`NodeListScreen.kt`** — drops the `subtitle` argument (with a comment on why counts must not go back there); sticky header now hosts `NodeCountSummary` above `NodeFilterTextField`.
- **`strings.xml`** — adds `node_count_online`, `node_count_shown`, `node_count_total`. `node_count_template` is **retained** (now used for the a11y label), so no existing Crowdin translation is orphaned. `sort-strings.py` run; index regenerated.

## Verification

- `spotlessApply spotlessCheck :feature:node:detekt :core:resources:detekt` → clean
- `:feature:node:allTests`, `:core:konsist:allTests` → pass
- `assembleDebug` → `BUILD SUCCESSFUL`
- No new tests: pure layout change with no logic to assert.

## Reviewer notes

- ⚠️ **This relocates visible UI.** Users who read the counts next to the "Nodes" title now look ~40dp lower. That's a deliberate UX change rather than a pure bug fix, and the call I'd most like confirmed. Worth a release-note line.
- ⚠️ **Never visually verified.** The Compose preview renderer is broken on the dev machine used here (`android` CLI has no `studio render-compose-preview`), so all 6 previews are unrendered. Please render `NodeCountSummaryLongLocaleLargeFontPreview` (long locale @ 2× font) before merging — that's the worst case. Others: `...Default`, `...Narrow` (320dp), `...LongLocale`, `...LargeFont`, `...Wide` (840dp).
- **Residual risk:** at 2× font on a 320dp phone the sticky header grows to ~130dp and eats list rows. Deliberate legibility-over-density trade; if too heavy, move `NodeCountSummary` from `stickyHeader` into a plain `item {}` so it scrolls away — one line, keeps the no-truncation guarantee.
- Labels have no separator glyph (spacing only) and sit on `surfaceDim` while the filter field paints its own background — a subtle two-tone band worth a design eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a node count summary showing online, shown, and total nodes.
  * Moved the summary to a sticky header area above the node filters.
  * Supports responsive wrapping for narrow screens, long translations, and larger font sizes.
  * Added accessibility text covering the full node count summary.
* **Documentation**
  * Added new translation strings for the node count labels and details in the Compose UI strings index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->