### PR TITLE
fix(model): gate TAK module config on firmware 2.8.0

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
@@ -52,8 +52,17 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
     /** Support for Status Message module. Supported since firmware v2.8.0. */
     val supportsStatusMessage = atLeast(V2_8_0)
 
-    /** Support for TAK (ATAK) module configuration. Supported since firmware v2.7.19. */
-    val supportsTakConfig = atLeast(V2_7_19)
+    /**
+     * Support for TAK (ATAK) module configuration. Gated to firmware v2.8.0.
+     *
+     * The v2.7.19 gate this replaces was set on protobuf availability rather than firmware support: v2.7.x
+     * `AdminModule::handleSetModuleConfig()` has no case for the `tak` submessage, so the node ACKs the write and
+     * reboots without storing anything, and `NodeDB::saveToDisk()` never sets `has_tak`. The editor therefore appeared
+     * to save and always read back as unspecified (Meshtastic-Android#6430).
+     *
+     * The firmware write, persist and remote-admin read paths land in meshtastic/firmware#11216, labelled for 2.8.
+     */
+    val supportsTakConfig = atLeast(V2_8_0)
 
     /**
      * Support for the v2 TAK port (ATAK_PLUGIN_V2 = 78) with TAKPacketV2 + zstd dictionary compression. Supported since
@@ -94,7 +103,6 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
         private val V2_6_10 = DeviceVersion("2.6.10")
         private val V2_7_12 = DeviceVersion("2.7.12")
         private val V2_7_18 = DeviceVersion("2.7.18")
-        private val V2_7_19 = DeviceVersion("2.7.19")
         private val V2_8_0 = DeviceVersion("2.8.0")
         private val UNRELEASED = DeviceVersion("9.9.9")
     }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
@@ -80,9 +80,10 @@ class CapabilitiesTest {
     }
 
     @Test
-    fun supportsTakConfig_requires_V2_7_19() {
-        assertFalse(caps("2.7.18").supportsTakConfig)
-        assertTrue(caps("2.7.19").supportsTakConfig)
+    fun supportsTakConfig_requires_V2_8_0() {
+        assertFalse(caps("2.7.19").supportsTakConfig)
+        assertFalse(caps("2.7.26").supportsTakConfig)
+        assertTrue(caps("2.8.0").supportsTakConfig)
     }
 
     @Test


### PR DESCRIPTION
Refs #6430

## Why

`supportsTakConfig` was gated on `2.7.19`, but that floor was set on **protobuf availability**, not firmware support. No released firmware implements the TAK module config write path, so the app has been offering an editor that cannot work:

- `AdminModule::handleSetModuleConfig()` in v2.7.x has **no case** for the `tak` submessage. The message falls through the switch, and the handler still runs `saveChanges(SEGMENT_MODULECONFIG, shouldReboot); return true;` — so the node **ACKs success and reboots**, having stored nothing. The value never even takes effect in RAM.
- `NodeDB::saveToDisk()` never sets `moduleConfig.has_tak = true`, so even a populated struct would be omitted by nanopb on flash write.
- v2.7.26's `PhoneAPI` `STATE_SEND_MODULECONFIG` has no `tak` case, so the node never echoes a TAK config back — which is what the app renders as "Unspecified".

Net user-visible effect (#6430): pick a Team Color and Member Role → Save → **node reboots** (the screen is `RebootBehavior.ALWAYS`) → both fields read "Unspecified" again. The app was doing everything right — `TAKConfigItemList.kt` → `RadioConfigViewModel` (per-submessage merge preserves `tak`) → `AdminControllerImpl` sends `AdminMessage.set_module_config` with `ModuleConfig.tak` (field 16) populated — so there was no app-side fix for the persistence itself, only this bad capability floor.

## Change

Raise the floor to `2.8.0`, matching the firmware fix in **meshtastic/firmware#11216** (labelled `2.8`), which adds all three missing pieces:

| Firmware defect | Fixed in #11216 |
|---|---|
| No `tak` set case in `handleSetModuleConfig()` | `case meshtastic_ModuleConfig_tak_tag:` + `moduleConfig.has_tak = true` |
| `saveToDisk()` never sets `has_tak` | `moduleConfig.has_tak = true;` in the `SEGMENT_MODULECONFIG` block |
| No remote-admin `TAK_CONFIG` read case | `case meshtastic_AdminMessage_ModuleConfigType_TAK_CONFIG:` |

Also removes the now-unused `V2_7_19` constant, and records the reasoning in KDoc so the floor doesn't get lowered back onto protobuf availability.

## Tests

`CapabilitiesTest.supportsTakConfig_requires_V2_7_19` asserted `2.7.19` → true and would have failed. Renamed to `supportsTakConfig_requires_V2_8_0`, and `2.7.26` added as an explicit false case since that is the firmware version in the bug report.

Verified: `spotlessApply spotlessCheck :core:model:detekt :core:model:allTests` → `BUILD SUCCESSFUL`.

## Merge dependency

⚠️ **meshtastic/firmware#11216 is open, not yet merged.** This gate is only *correct* once that lands in a 2.8.0 build — until then it gates the editor off for everyone, which is still strictly better than the current behaviour (an editor that silently no-ops and costs a reboot).

If 2.8.0 ends up shipping without #11216, the floor needs revisiting. The repo's `UNRELEASED = DeviceVersion("9.9.9")` idiom (used by `canRequestNeighborInfo`) is the alternative if a hard gate is preferred over a version bet.

## Related

- meshtastic/firmware#11216 — the firmware fix this floor matches (write + persist + remote-admin read)
- meshtastic/firmware#10256 — merged earlier, added the **PhoneAPI read** case only; its PR body wrongly asserts that `AdminModule.cpp` already handles `SET_MODULE_CONFIG` for TAK
- meshtastic/firmware#9716 — closed unmerged; would have wired ATAKConfig through AdminModule get/set
- #6397 — the TAK thread this was split out of

Not related, despite surface similarity: the `Router::sendLocal` loopback regression on firmware `develop` (`d6b12ea3f`). Different failure mode — admin round-trips in #6430 succeed (the node ACKs and reboots); this is a plain missing switch case that predates that range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the firmware compatibility requirement for TAK configuration support.
  * TAK configuration is now enabled starting with firmware version 2.8.0; versions 2.7.19 and 2.7.26 no longer qualify.
* **Documentation**
  * Expanded compatibility guidance to clarify the correct firmware version paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->