### PR TITLE
fix(car): drop CarAppService from production manifests to satisfy Play car-app review

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -130,10 +130,6 @@ configure<ApplicationExtension> {
         }
         ndk { abiFilters += listOf("armeabi-v7a", "arm64-v8a") }
 
-        // Activates the (google-only) CarAppService. Off by default so production builds ship
-        // notification-only car messaging; flipped on by -PenableCarTemplates=true for Closed tracks.
-        manifestPlaceholders["carTemplatesEnabled"] = enableCarTemplates.toString()
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/feature/car/build.gradle.kts
+++ b/feature/car/build.gradle.kts
@@ -32,15 +32,19 @@ android {
     defaultConfig {
         minSdk = 23
         consumerProguardFiles("proguard-rules.pro")
-        // The CarAppService is disabled unless -PenableCarTemplates=true. feature:car resolves the
-        // placeholder in its OWN manifest, so it must read the property directly (the app's value does
-        // not override a library's own placeholder). Default false → production ships it disabled.
-        manifestPlaceholders["carTemplatesEnabled"] =
-            providers.gradleProperty("enableCarTemplates").map { it.toBoolean() }.getOrElse(false).toString()
     }
 
     // Robolectric provides the Android context that androidx.car.app TestCarContext/ScreenController need.
     testOptions { unitTests { isIncludeAndroidResources = true } }
+}
+
+// Production manifests must not contain the CarAppService AT ALL (a disabled service still
+// triggers Play's static car-app category review — see the manifest comments), so the service
+// lives in an overlay manifest merged in only for -PenableCarTemplates=true builds.
+if (providers.gradleProperty("enableCarTemplates").map { it.toBoolean() }.getOrElse(false)) {
+    androidComponents {
+        onVariants { variant -> variant.sources.manifests.addStaticManifestFile("src/templates/AndroidManifest.xml") }
+    }
 }
 
 dependencies {

--- a/feature/car/src/main/AndroidManifest.xml
+++ b/feature/car/src/main/AndroidManifest.xml
@@ -1,28 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Default (production) manifest: notification-only Android Auto messaging, no CarAppService.
+  The service must be entirely absent here — not merely android:enabled="false" — because Google
+  Play statically reviews any declared androidx.car.app service intent-filter and rejects
+  MESSAGING-category car apps holding location permissions ("Category not permitted", see the
+  v2.8.0-open.2 / versionCode 29321638 rejection, 2026-07-25). The templated service lives in
+  src/templates/AndroidManifest.xml, selected by -PenableCarTemplates=true for Internal/Closed.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
-        <!-- enabled is gated by the app's `carTemplatesEnabled` manifest placeholder: off by default
-             (production ships notification-only car messaging), on for -PenableCarTemplates=true builds.
-             The decisive gate is automotive_app_desc's <uses name="template" /> (see res/xml); this is
-             defense-in-depth so the templated service can't be bound in production. -->
-        <service
-            android:name="org.meshtastic.feature.car.service.MeshtasticCarAppService"
-            android:enabled="${carTemplatesEnabled}"
-            android:exported="true"
-            android:permission="androidx.car.app.CarAppService">
-            <intent-filter>
-                <action android:name="androidx.car.app.CarAppService" />
-                <category android:name="androidx.car.app.category.MESSAGING" />
-            </intent-filter>
-        </service>
-
-        <meta-data
-            android:name="androidx.car.app.minCarApiLevel"
-            android:value="7" />
-
-        <!-- Required for Android Auto to surface MessagingStyle notifications and recognize the
-             template app. Without this the automotive_app_desc declarations never reach the host. -->
+        <!-- Required for Android Auto to surface MessagingStyle notifications. -->
         <meta-data
             android:name="com.google.android.gms.car.application"
             android:resource="@xml/automotive_app_desc" />

--- a/feature/car/src/templates/AndroidManifest.xml
+++ b/feature/car/src/templates/AndroidManifest.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Templated-build manifest, selected in build.gradle.kts ONLY when -PenableCarTemplates=true
+  (Internal/Closed tracks). Production builds use src/main/AndroidManifest.xml, which must NOT
+  declare a CarAppService: Google Play statically reviews any declared androidx.car.app service
+  intent-filter — even one with android:enabled="false" — and rejects MESSAGING-category car apps
+  that hold location permissions ("Category not permitted", see v2.8.0-open.2 / versionCode
+  29321638 rejection, 2026-07-25).
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <service
+            android:name="org.meshtastic.feature.car.service.MeshtasticCarAppService"
+            android:exported="true"
+            android:permission="androidx.car.app.CarAppService">
+            <intent-filter>
+                <action android:name="androidx.car.app.CarAppService" />
+                <category android:name="androidx.car.app.category.MESSAGING" />
+            </intent-filter>
+        </service>
+
+        <meta-data
+            android:name="androidx.car.app.minCarApiLevel"
+            android:value="7" />
+
+        <!-- Required for Android Auto to surface MessagingStyle notifications and recognize the
+             template app. Without this the automotive_app_desc declarations never reach the host. -->
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+    </application>
+</manifest>


### PR DESCRIPTION
## Why

Google Play rejected **v2.8.0-open.2 (versionCode 29321638)** — "Category not permitted / the app uses a permission that is not allowed for this app category" (Auto App Quality Guidelines). Play's static car-app review flags any declared `androidx.car.app` service intent-filter, **even one with `android:enabled="false"`**, and a MESSAGING-category car app holding location permissions (`ACCESS_FINE_LOCATION` etc.) fails the category check. Nothing changed in the car surface between open.1 (passed) and open.2 (rejected) — this is enforcement catching what was always in the merged manifest.

## 🛠️ Changes

- `feature/car/src/main/AndroidManifest.xml` is now notification-only: just the `gms.car.application` → `automotive_app_desc` metadata, **no `CarAppService` node at all**.
- The templated service (+ `minCarApiLevel`) moved to `feature/car/src/templates/AndroidManifest.xml`, merged in via `variant.sources.manifests.addStaticManifestFile` only when built with `-PenableCarTemplates=true` (Internal/Closed tracks).
- Dropped the now-unused `carTemplatesEnabled` manifest placeholder from both build files.

## Testing Performed

- Merged-manifest check, default build: `MeshtasticCarAppService` **absent**, `gms.car.application` present.
- Merged-manifest check with `-PenableCarTemplates=true`: service + `minCarApiLevel` **present**.
- `spotlessApply spotlessCheck detekt assembleDebug test allTests` all pass.

## Release note

After merge, cut **open.3** and roll it out with 29321638 under "Not Included" (the rejected release was never published; open.1 remains live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Android Auto/Car app template support for builds configured with Car templates enabled.
  * Added the required Car app service and Android Auto metadata for template-enabled builds.

* **Bug Fixes**
  * Prevented the Car app service from being included in standard builds, keeping the default Car feature notification-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->