### PR TITLE
fix(ci): pin release-notes baseline to the newest published v* release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -555,13 +555,36 @@ jobs:
       - name: Exclude flatpak-multisrc artifacts from release
         run: rm -rf ./artifacts/flatpak-multisrc-*
 
+      # Generate the notes ourselves with an explicit previous tag. GitHub's automatic
+      # previous-release selection considers any published release, including the rolling
+      # "snapshot" prerelease that main-check.yml recreates on every push to main — when
+      # snapshot's commit is an ancestor of this tag it wins and the notes come out empty
+      # (see v2.8.0-open.3). Internal releases are drafts and invisible to the API's
+      # auto-selection, so pick the newest published v* release ourselves.
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag_name }}
+          TARGET: ${{ inputs.commit_sha || github.sha }}
+        run: |
+          PREV=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq '.[] | select(.draft == false) | .tag_name' \
+            | grep -E '^v[0-9]' | grep -Fxv "$TAG" | head -1 || true)
+          echo "Previous release tag: ${PREV:-<none>}"
+          gh api "repos/${REPO}/releases/generate-notes" \
+            -f tag_name="$TAG" \
+            -f target_commitish="$TARGET" \
+            ${PREV:+-f previous_tag_name="$PREV"} \
+            --jq '.body' > release-notes.md
+
       - name: Create or Update GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag_name }}
           target_commitish: ${{ inputs.commit_sha || github.sha }}
           name: ${{ inputs.tag_name }} (${{ needs.prepare-build-info.outputs.APP_VERSION_CODE }})
-          generate_release_notes: true
+          body_path: release-notes.md
           files: ./artifacts/**/*
           draft: true
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -568,10 +568,13 @@ jobs:
           TAG: ${{ inputs.tag_name }}
           TARGET: ${{ inputs.commit_sha || github.sha }}
         run: |
-          PREV=$(gh api "repos/${REPO}/releases" --paginate \
-            --jq '.[] | select(.draft == false) | .tag_name' \
-            | grep -E '^v[0-9]' | grep -Fxv "$TAG" | head -1 || true)
-          echo "Previous release tag: ${PREV:-<none>}"
+          # Fail the step if the listing itself fails — an empty PREV must only ever
+          # mean "no published v* release exists yet", never a swallowed API error,
+          # because empty PREV re-enables the automatic selection this step avoids.
+          PUBLISHED_TAGS=$(gh api "repos/${REPO}/releases" --paginate \
+            --jq '.[] | select(.draft == false) | .tag_name')
+          PREV=$(printf '%s\n' "$PUBLISHED_TAGS" | grep -E '^v[0-9]' | grep -Fxv "$TAG" | head -1 || true)
+          echo "Previous release tag: ${PREV:-<none — falling back to automatic selection>}"
           gh api "repos/${REPO}/releases/generate-notes" \
             -f tag_name="$TAG" \
             -f target_commitish="$TARGET" \


### PR DESCRIPTION
## Why

v2.8.0-open.3 shipped with empty release notes — just a `Full Changelog: snapshot...v2.8.0-internal.38` line.

`release.yml` used `generate_release_notes: true` with no explicit previous tag, letting GitHub auto-pick the baseline. Since #6160, `main-check.yml` recreates the rolling `snapshot` prerelease on every push to main; it's a published (non-draft) release, so when its commit happens to be an ancestor of the release tag, GitHub selects it as the previous release and the diff is empty. Whether notes come out full or empty is a race on where `snapshot` points when the draft is created (open.2 got lucky and fell back to `v2.8.0-closed.9`).

## What

- Generate notes explicitly via `gh api .../releases/generate-notes`, pinning `previous_tag_name` to the newest **published** `v*` release (drafts and `snapshot` excluded), and pass them to `softprops/action-gh-release` via `body_path`.
- Falls back to GitHub auto-selection only if no published `v*` release exists.

The open.3 notes themselves were already repaired one-off via `gh release edit` against `v2.8.0-open.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notes are now generated automatically using the GitHub CLI by computing the most recent prior published version.
  * The generated release notes are written to a file and included in the corresponding GitHub release body when creating/updating releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->