### PR TITLE
fix(strings): remove stray "to" in share location description

### DIFF
--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1556,7 +1556,7 @@
     <string name="share_connected_node">Share Connected Node</string>
     <string name="share_contact">Share Contact</string>
     <string name="share_location">Share Location</string>
-    <string name="share_location_description">Use your phone GPS to send locations to your node to instead of using a hardware GPS on your node.</string>
+    <string name="share_location_description">Use your phone GPS to send locations to your node instead of using a hardware GPS on your node.</string>
     <string name="share_to">Share to…</string>
     <string name="share_your_location_in_real_time">Share your location in real-time and keep your group coordinated with integrated GPS features.</string>
     <string name="short_name">Short Name</string>


### PR DESCRIPTION
## 🐛 Bug Fix

The onboarding **Phone Location** screen described location sharing as:

> Use your phone GPS to send locations to your node **to instead of** using a hardware GPS on your node.

The extra "to" reads as a false start mid-sentence. Removed it so the copy parses cleanly.

Only the base `values/strings.xml` is touched — the translated copies will re-sync through Crowdin.

## Testing Performed

Copy-only change; no code paths or tests affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the location-sharing description to accurately explain that phone GPS is used to send locations to the node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->