### PR TITLE
fix(mqtt): scope user-CA trust to the MQTT connection

### DIFF
--- a/androidApp/src/main/res/xml/network_security_config.xml
+++ b/androidApp/src/main/res/xml/network_security_config.xml
@@ -2,8 +2,12 @@
 <network-security-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
+            <!--
+              System anchors only. User-installed CAs used to be trusted here for self-hosted MQTT brokers
+              (#5365), but base-config applies to every TLS connection the app makes. mqtt-client 0.7.0 lets
+              that trust be scoped to the MQTT transports instead — see mqttTlsConfig() in :core:network.
+            -->
             <certificates src="system"/>
-            <certificates src="user"/>
         </trust-anchors>
     </base-config>
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
@@ -34,6 +34,7 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.model.MqttConnectionState
 import org.meshtastic.core.model.MqttProbeStatus
 import org.meshtastic.core.network.repository.MQTTRepository
+import org.meshtastic.core.network.repository.mqttTlsConfig
 import org.meshtastic.core.network.repository.resolveEndpoint
 import org.meshtastic.core.repository.MqttManager
 import org.meshtastic.core.repository.NodeRepository
@@ -139,8 +140,10 @@ class MqttManagerImpl(
         val endpoint = resolveEndpoint(address, tlsEnabled)
         val result =
             MqttClient.probe(endpoint = endpoint) {
-                // probe() requires a transportFactory in 0.4.0 (errors otherwise); mirror the live client.
-                transportFactory = TcpTransportFactory() + WebSocketTransportFactory()
+                // probe() requires a transportFactory in 0.4.0 (errors otherwise); mirror the live client,
+                // including its scoped private-CA trust hook — otherwise a probe would fail where a connect succeeds.
+                val tls = mqttTlsConfig()
+                transportFactory = TcpTransportFactory(tls) + WebSocketTransportFactory(tls)
                 // Per-connection random suffix: myId identifies the node (and is null →
                 // "unknown" before the node record loads), so two probes can collide on one
                 // client-id and evict each other (SESSION_TAKEN_OVER). See MQTTRepositoryImpl.

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/MqttTlsTrust.android.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/repository/MqttTlsTrust.android.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.repository
+
+import co.touchlab.kermit.Logger
+import io.ktor.network.tls.TLSConfigBuilder
+import java.security.KeyStore
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+/**
+ * `AndroidCAStore` exposes the system CAs *and* the CAs the user has installed from Settings. Anchoring MQTT on it
+ * reproduces what `<certificates src="system"/>` + `<certificates src="user"/>` used to give the whole app, but only
+ * for the MQTT socket.
+ */
+private const val ANDROID_CA_STORE = "AndroidCAStore"
+
+actual fun mqttTlsConfig(): (TLSConfigBuilder.() -> Unit)? {
+    val manager = userCaTrustManager() ?: return null
+    return { trustManager = manager }
+}
+
+/**
+ * Built through a [TrustManagerFactory] so the result is one `X509TrustManagerExtensions` can wrap — the transport
+ * needs that to reach the hostname-aware `checkServerTrusted(chain, authType, host)` overload the platform requires
+ * whenever `network_security_config.xml` carries any domain-specific config (ours does, for the localhost cleartext
+ * exemptions).
+ *
+ * Returning `null` on failure falls back to the platform default, which is the safe direction: a private-CA broker
+ * stops connecting, rather than trust silently widening.
+ */
+private fun userCaTrustManager(): X509TrustManager? = runCatching {
+    val keyStore = KeyStore.getInstance(ANDROID_CA_STORE).apply { load(null) }
+    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        .apply { init(keyStore) }
+        .trustManagers
+        .filterIsInstance<X509TrustManager>()
+        .firstOrNull()
+}
+    .onFailure {
+        Logger.w(throwable = it) { "Could not build the MQTT user-CA trust manager; using platform trust" }
+    }
+    .getOrNull()

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -351,7 +351,9 @@ private fun defaultMqttClientFactory(setup: MqttClientSetup): MqttClientSession 
     MqttClient(setup.ownerId) {
         // mqtt-client 0.4.0 makes transport a required SPI: the client throws at connect if unset.
         // Register TCP/TLS (the default) + WebSocket (for user-entered ws://-/wss:// brokers).
-        transportFactory = TcpTransportFactory() + WebSocketTransportFactory()
+        // Both get the same private-CA trust hook so the grant stays scoped to this socket — see [mqttTlsConfig].
+        val tls = mqttTlsConfig()
+        transportFactory = TcpTransportFactory(tls) + WebSocketTransportFactory(tls)
         keepAliveSeconds = MQTT_KEEPALIVE_SECONDS
         autoReconnect = true
         username = setup.mqttConfig?.username

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MqttTlsTrust.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MqttTlsTrust.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.repository
+
+import io.ktor.network.tls.TLSConfigBuilder
+
+/**
+ * TLS customisation applied to the MQTT transports, or `null` to keep the platform default trust decision.
+ *
+ * Self-hosted brokers are commonly fronted by a private or self-signed CA that the user installs into the device
+ * credential store. Android used to grant that trust app-wide via `<certificates src="user"/>` in `base-config` of
+ * `network_security_config.xml`, which widened every TLS connection the app makes — map tiles, API calls, everything.
+ * mqtt-client 0.6.0/0.7.0 added a per-transport hook (`TcpTransportFactory`/`WebSocketTransportFactory`), so the grant
+ * now applies to the MQTT socket alone.
+ *
+ * Supplying a trust manager *replaces* the platform trust decision for these connections: network-security-config
+ * anchors, pinning, and Certificate Transparency policy no longer apply to them. That is a deliberately narrower blast
+ * radius than the app-wide anchor it replaces.
+ */
+expect fun mqttTlsConfig(): (TLSConfigBuilder.() -> Unit)?

--- a/core/network/src/iosMain/kotlin/org/meshtastic/core/network/repository/MqttTlsTrust.ios.kt
+++ b/core/network/src/iosMain/kotlin/org/meshtastic/core/network/repository/MqttTlsTrust.ios.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.repository
+
+import io.ktor.network.tls.TLSConfigBuilder
+
+/**
+ * Apple's `TLSConfigBuilder` actual has no `trustManager`, so there is nothing to configure here. On iOS a private CA
+ * is trusted by installing and enabling the profile system-wide instead.
+ */
+actual fun mqttTlsConfig(): (TLSConfigBuilder.() -> Unit)? = null

--- a/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/MqttTlsTrust.jvm.kt
+++ b/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/MqttTlsTrust.jvm.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.network.repository
+
+import io.ktor.network.tls.TLSConfigBuilder
+
+/**
+ * Desktop has no equivalent of Android's user credential store: the JVM already trusts whatever the running JDK's
+ * `cacerts` holds, and a self-hosted CA is added there (or via `-Djavax.net.ssl.trustStore`) rather than by the app.
+ * Use the platform trust decision unchanged.
+ */
+actual fun mqttTlsConfig(): (TLSConfigBuilder.() -> Unit)? = null


### PR DESCRIPTION
Closes #6454

## 🌟 Why

`androidApp/src/main/res/xml/network_security_config.xml` opted the **whole app** into user-installed CAs:

```xml
<base-config cleartextTrafficPermitted="false">
    <trust-anchors>
        <certificates src="system"/>
        <certificates src="user"/>
    </trust-anchors>
</base-config>
```

That line was added for MQTT in #5365 so self-hosted brokers behind a private or self-signed CA could be reached — but because it sits in `base-config` it applies to every HTTPS connection the app makes: map tiles, API calls, everything. Anyone who can get a certificate into the user store (or who already controls a provisioned device) could intercept traffic that has nothing to do with MQTT.

`mqtt-client` 0.7.0 (already on `main` via #6453) closes the gap that kept this open: 0.6.0 added a TLS trust hook to `TcpTransportFactory` (upstream [#103](https://github.com/meshtastic/MQTTastic-Client-KMP/pull/103)) and 0.7.0 added the matching one to `WebSocketTransportFactory` (upstream [#108](https://github.com/meshtastic/MQTTastic-Client-KMP/pull/108), closing [#107](https://github.com/meshtastic/MQTTastic-Client-KMP/issues/107)). Both transports are registered here so users can enter `ssl://` **and** `wss://` brokers, so both hooks had to exist before the anchor could come out.

## 🛠️ What

- New `mqttTlsConfig()` seam in `:core:network` (`repository/MqttTlsTrust.kt` + android/jvm/ios actuals). On Android it builds an `X509TrustManager` over the `AndroidCAStore` KeyStore — which holds system **and** user-installed CAs — through a `TrustManagerFactory`, so the result is one `X509TrustManagerExtensions` can wrap. That wrapping is what reaches the hostname-aware `checkServerTrusted(chain, authType, host)` overload the platform requires whenever the security config carries any domain-specific block (ours does, for the localhost cleartext exemptions). JVM and iOS return `null` and keep the platform trust decision.
- Passed to **both** factories in `MQTTRepositoryImpl` and in `MqttManagerImpl.probe()` — the probe path needs the same trust or a probe would fail against a broker that connects fine.
- `<certificates src="user"/>` removed from `base-config`. The `localhost`/`127.0.0.1` cleartext exemptions are unrelated and stay.

## ⚠️ Behaviour change

**Custom map-tile servers behind a private CA stop working.** The google flavor fetches custom tiles through Google Maps' `UrlTileProvider` and the F-Droid flavor through osmdroid; neither exposes an SSL hook, so preserving that case would mean hand-rolling a `TileProvider` over `HttpsURLConnection`. Deliberately out of scope — a private-CA tile server now needs a publicly-trusted certificate.

Also worth stating plainly: supplying a trust manager **replaces** the platform trust decision for that socket. Network-security-config anchors, certificate pinning, and Certificate Transparency policy no longer apply to the MQTT connection. That is a much narrower blast radius than the app-wide anchor it replaces, but it is not free.

TAK is unaffected — `core/takserver/TakCertLoader.kt` builds its own `SSLContext` from bundled certs with its own `TrustManagerFactory`, independent of the app-wide anchor.

## 🧪 Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt` — clean
- `./gradlew :core:network:allTests :core:data:allTests` — 229 test tasks, all pass
- `./gradlew assembleDebug` — pass

**Still to do before this leaves draft:** on-device verification against a private-CA broker over both `ssl://` and `wss://`, with the CA installed in the user credential store and no app-wide anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted Android network connections to system-trusted certificates by default.
  * Added support for Android user-installed certificates in MQTT connections where configured.

* **Bug Fixes**
  * Applied consistent TLS trust settings to MQTT TCP, WebSocket, and connection-probe operations.
  * Preserved platform-default certificate handling on iOS and desktop environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->