### PR TITLE
fix(widget): remove Glance's crash-on-launch ActionTrampolineActivity

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -317,6 +317,33 @@
         </receiver>
 
         <!--
+            glance-appwidget declares ActionTrampolineActivity, but nothing in Glance ever targets it. Its onCreate
+            calls launchTrampolineAction(intent), which require()s an "ACTION_INTENT" Intent extra, so ANY launch that
+            does not carry that extra is a guaranteed FATAL IllegalArgumentException ("List adapter activity trampoline
+            invoked without specifying target intent") before a single line of our code runs.
+
+            Nothing can supply that extra, because nothing creates the intent. Verified against the Glance sources for
+            our pinned 1.2.0-rc01 (and 1.3.0-alpha02): applyTrampolineIntent() picks ActionTrampolineActivity only for
+            ActionTrampolineType.ACTIVITY, and no call site ever passes ACTIVITY. The four call sites all live in
+            getFillInIntentForAction() - i.e. only inside a lazy collection - and pass BROADCAST / SERVICE /
+            FOREGROUND_SERVICE, which all route to InvisibleActionTrampolineActivity instead. StartActivityAction is
+            special-cased there to skip the trampoline entirely and ride the collection's pending-intent template. The
+            non-lazy path never trampolines at all: actionStartActivity() becomes a direct PendingIntent.getActivity()
+            and actionRunCallback() a direct PendingIntent.getBroadcast() to ActionCallbackBroadcastReceiver.
+
+            So this is dead-but-launchable library code: an exported=false activity that crashes the process on every
+            launch and that our widget can never legitimately reach (LocalStatsWidget has no lazy collection, and a tap
+            on it dispatches its own PendingIntent directly). Same defect class as the ATAK marker below. Removing the
+            node is the whole fix - it takes the component out of the merged manifest so it cannot be started.
+
+            If glance is ever bumped, re-verify that ActionTrampolineType.ACTIVITY still has no producer before
+            trusting this removal; GlanceTrampolineManifestTest guards the removal itself.
+        -->
+        <activity
+            android:name="androidx.glance.appwidget.action.ActionTrampolineActivity"
+            tools:node="remove" />
+
+        <!--
             ATAK plugin-discovery marker. The action is what ATAK looks for, so the filter stays exported; it now
             resolves to a real no-op activity because the name used to be com.atakmap.app.component, a class not
             present in this APK, so anything that launched it crashed the app on instantiation.

--- a/androidApp/src/test/kotlin/org/meshtastic/app/widget/GlanceTrampolineManifestTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/widget/GlanceTrampolineManifestTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app.widget
+
+import android.app.Application
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+/**
+ * Guards the `tools:node="remove"` of `androidx.glance.appwidget.action.ActionTrampolineActivity` in
+ * `androidApp/src/main/AndroidManifest.xml`.
+ *
+ * That activity's `onCreate` unconditionally `require()`s an `"ACTION_INTENT"` Intent extra, so any launch without it
+ * is a FATAL `IllegalArgumentException` ("List adapter activity trampoline invoked without specifying target intent")
+ * raised before any of our code runs. Nothing can supply the extra, because nothing in Glance ever creates the intent:
+ * `applyTrampolineIntent()` selects this component only for `ActionTrampolineType.ACTIVITY`, and no call site passes
+ * `ACTIVITY` — the lazy-collection call sites all pass `BROADCAST`/`SERVICE`/`FOREGROUND_SERVICE`, which route to
+ * [androidx.glance.appwidget.action.InvisibleActionTrampolineActivity] instead. It is dead-but-launchable library code,
+ * so we take it out of the merged manifest entirely.
+ *
+ * These assertions run against the *merged* manifest (Robolectric reads it, which is why the AAR-declared invisible
+ * trampoline resolves), so they fail if the removal is dropped or if a Glance bump reshuffles these components.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class GlanceTrampolineManifestTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `crash-on-launch activity trampoline is absent from the merged manifest`() {
+        assertFailsWith<PackageManager.NameNotFoundException>(
+            "$ACTION_TRAMPOLINE is declared in the merged manifest. Glance never targets it, and its onCreate " +
+                "require()s an ACTION_INTENT extra, so every launch is a FATAL IllegalArgumentException. Restore " +
+                "the tools:node=\"remove\" entry in androidApp/src/main/AndroidManifest.xml.",
+        ) {
+            context.packageManager.getActivityInfo(ComponentName(context, ACTION_TRAMPOLINE), 0)
+        }
+    }
+
+    @Test
+    fun `invisible trampoline Glance actually uses is still declared and not exported`() {
+        // Positive control: proves the merged manifest under test really does include glance-appwidget's own
+        // components, so the assertion above is a genuine absence rather than a manifest that was never merged.
+        val activityInfo = context.packageManager.getActivityInfo(ComponentName(context, INVISIBLE_TRAMPOLINE), 0)
+
+        assertFalse(
+            activityInfo.exported,
+            "$INVISIBLE_TRAMPOLINE must stay unexported — it launches intents handed to it verbatim.",
+        )
+    }
+
+    private companion object {
+        const val ACTION_TRAMPOLINE = "androidx.glance.appwidget.action.ActionTrampolineActivity"
+        const val INVISIBLE_TRAMPOLINE = "androidx.glance.appwidget.action.InvisibleActionTrampolineActivity"
+    }
+}


### PR DESCRIPTION
## Why

2.8.0 internal builds 29321592 and 29321664 report a FATAL crash ([Datadog RUM](https://us5.datadoghq.com/error-tracking/issue/60a5c852-86f6-11f1-b6dd-da7ad0900000)):

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{
  com.geeksville.mesh/androidx.glance.appwidget.action.ActionTrampolineActivity}
Caused by: java.lang.IllegalArgumentException: List adapter activity trampoline
  invoked without specifying target intent.
    at androidx.glance.appwidget.action.ToggleableKt.launchTrampolineAction(...)
    at androidx.glance.appwidget.action.ActionTrampolineActivity.onCreate(...)
```

`glance-appwidget` declares `ActionTrampolineActivity` in its manifest, so it is merged into our APK. Its `onCreate` calls `launchTrampolineAction(intent)`, which does:

```kotlin
requireNotNull(intent.getParcelableExtra<Intent>("ACTION_INTENT")) {
    "List adapter activity trampoline invoked without specifying target intent."
}
```

**Nothing can ever supply that extra, because nothing in Glance creates the intent.** `applyTrampolineIntent()` selects this component only for `ActionTrampolineType.ACTIVITY`, and no call site passes `ACTIVITY`:

- All four `applyTrampolineIntent()` call sites live in `getFillInIntentForAction()` — reached only when `isLazyCollectionDescendant` — and pass `BROADCAST` / `SERVICE` / `FOREGROUND_SERVICE`, all of which route to `InvisibleActionTrampolineActivity` instead.
- `StartActivityAction` is special-cased in that same function to skip the trampoline entirely and ride the collection's `setPendingIntentTemplate` (a bare `Intent()` with `FILL_IN_COMPONENT`).
- The non-lazy path never trampolines at all: `actionStartActivity()` becomes a direct `PendingIntent.getActivity()`, `actionRunCallback()` a direct `PendingIntent.getBroadcast()` to `ActionCallbackBroadcastReceiver`.

Verified against the sources for our pinned **1.2.0-rc01** and also **1.3.0-alpha02** — upstream still ships the same dead component, so there is no version to bump to (1.2.0 stable does not exist; 1.2.0-rc01 is the newest non-alpha).

So this is dead-but-launchable library code: an `exported="false"` activity that kills the process on *every* launch and that our widget can never legitimately reach. Removing the node is the whole fix — it takes the component out of the merged manifest so it cannot be started, by anything.

### Why Android 12 left this component stranded

The [Glance docs](https://developer.android.com/develop/ui/compose/glance/user-interaction) note that *"apps that target Android 12 or higher can't start activities from services or broadcast receivers that act as trampolines."* That restriction is what forced Glance to stop routing activity starts through `ActionTrampolineActivity`. The producer was dropped; the manifest declaration was not. So this is fossilised code rather than a regression — and it is why no version bump fixes it. Nothing in the [Glance release notes](https://developer.android.com/jetpack/androidx/releases/glance) mentions the trampolines at all, and I could find no upstream bug filed (Google's issue tracker gates search behind login, so that is not exhaustive).

Note the public reports carrying this same exception message are about `InvisibleActionTrampolineActivity` — the *live* trampoline, reached from real lazy-collection fill-in intents. That is a different bug. Match on the component name, not the message.

### It was never a user-facing crash

The report that prompted this PR assumed a widget tap. **A widget tap cannot reach this activity** — `LocalStatsWidget` has no lazy collection, and both its actions (refresh `actionRunCallback`, root `actionStartActivity`) dispatch their own `PendingIntent`s directly, never through a trampoline. Datadog RUM confirms it:

- **3 events, 3 sessions, 3 distinct anonymous users, total, ever** (2026-07-23 → 2026-07-27).
- **`action_count: 0` in every session** — not one UI tap. `LocalStatsWidget` / `LocalStatsWidgetReceiver` appear in *no* RUM session for this app in the entire 30-day window.
- All three sessions originate from one city and one ASN (GTS Telecom SRL, Romania) tagged `@geo.as.type: hosting` — a datacenter network, not residential or mobile-carrier.
- All three report `Nexus 5X` on Android 13, a combination impossible on real hardware (that device never shipped past 8.1) — an emulator or GSI image on a stock AOSP fingerprint, with a fresh anonymous ID each run.
- Exactly one event per newly-published build, each landing ~1.5–22h after that build went out. Two of three crash within 10–18s of cold start without leaving `ApplicationLaunch`; the third shows `MainActivity` recreated 6 times with 19 long tasks (worst 1.78s main-thread stall) — a resource-starved runner, not a phone.

So: an automated rig cold-starting each new build and launching activities, not a person. The precise launch mechanism is still inferred rather than proven — but an `exported="false"` activity with zero producers, hit with no taps in the session, is consistent only with something enumerating manifest components.

Two corrections to the original report while we are here: the affected builds are on the Play **open (beta)** track, not internal — v2.8.0-open.1 / open.2 / open.4 — and there is a **third** affected versionCode, 29321638 (open.2), alongside 29321592 and 29321664. **Production is unaffected**: it is still on v2.7.14 (29321034), and the 2.8.0 line has never shipped to production.

This does not warrant blocking 2.8.0 promotion. It is worth removing anyway: a manifest-declared component that kills the process on every launch is a liability regardless of who trips it, and it pollutes release crash metrics.

## 🐛 Bug Fixes

- Remove `androidx.glance.appwidget.action.ActionTrampolineActivity` from the merged manifest via `tools:node="remove"`, eliminating a guaranteed-fatal `IllegalArgumentException` on any launch of it.

That single manifest node is the entire change. **Scope deliberately kept to one release-hardening fix** — the Glance best-practice work this investigation also turned up (error UI, documenting the Compose-resources bridge, the module's first unit tests) is split out into #6473 so it cannot hold up 2.8.0.

## Testing Performed

`GlanceTrampolineManifestTest` asserts against the **merged** manifest, so it tests the actual merge outcome rather than the source declaration:

- `crash-on-launch activity trampoline is absent from the merged manifest` — fails if the removal is ever dropped.
- `invisible trampoline Glance actually uses is still declared and not exported` — a positive control proving the manifest under test really does include `glance-appwidget`'s own components, so the absence above is genuine rather than an unmerged manifest. It also guards that only the dead trampoline went and the live one stayed.

Full baseline green: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests`. This branch previously passed a complete CI run (all shards, lint, screenshots, Android build) before the follow-up work was split off, and has been rebased onto current `main`.

Not device-verified — but the change only removes a component that no code path reaches, and the widget's own refresh/launch actions are untouched. Confirming the widget still refreshes and still opens the app on a real device would be reasonable belt-and-braces.

**Maintenance note:** if `glance` is ever bumped, re-verify that `ActionTrampolineType.ACTIVITY` still has no producer before trusting this removal. The manifest comment and the test KDoc both say so, and the test fails loudly if the node disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
