### PR TITLE
fix(map): stop reporting cancelled layer loads as errors

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -702,6 +702,19 @@ fun MapView(
             }
         }
 
+    // osmdroid runs the tile download on its own task for minutes and then calls back from there, not from a
+    // composable. Publishing the outcome as state keeps the toast on an effect that lives and dies with this screen: a
+    // callback that lands after the user left the map can no longer launch into a forgotten composition scope.
+    var tileDownloadOutcome by remember { mutableStateOf<TileDownloadOutcome?>(null) }
+    LaunchedEffect(tileDownloadOutcome) {
+        when (val outcome = tileDownloadOutcome) {
+            null -> return@LaunchedEffect
+            is TileDownloadOutcome.Complete -> context.showToast(Res.string.map_download_complete)
+            is TileDownloadOutcome.Failed -> context.showToast(Res.string.map_download_errors, outcome.errors)
+        }
+        tileDownloadOutcome = null
+    }
+
     fun startDownload() {
         val boundingBox = downloadRegionBoundingBox ?: return
         try {
@@ -719,11 +732,11 @@ fun MapView(
                 zoomLevelMax.toInt(),
                 cacheManagerCallback(
                     onTaskComplete = {
-                        scope.launch { context.showToast(Res.string.map_download_complete) }
+                        tileDownloadOutcome = TileDownloadOutcome.Complete
                         writer.onDetach()
                     },
                     onTaskFailed = { errors ->
-                        scope.launch { context.showToast(Res.string.map_download_errors, errors) }
+                        tileDownloadOutcome = TileDownloadOutcome.Failed(errors)
                         writer.onDetach()
                     },
                 ),
@@ -934,7 +947,25 @@ fun MapView(
     }
 
     if (showPurgeTileSourceDialog) {
-        PurgeTileSourceDialog(onDismiss = { showPurgeTileSourceDialog = false })
+        PurgeTileSourceDialog(
+            onDismiss = { showPurgeTileSourceDialog = false },
+            // Purging runs on the map screen's scope, not the dialog's: the dialog dismisses itself in the same click
+            // that starts the purge, so its own rememberCoroutineScope() is already forgotten by the time the work
+            // would run — which silently skipped the purge and its toast.
+            onPurge = { sources ->
+                scope.launch {
+                    sources.forEach { source ->
+                        context.showToast(
+                            if (SqlTileWriterExt().purgeCache(source)) {
+                                getString(Res.string.map_purge_success, source)
+                            } else {
+                                getString(Res.string.map_purge_fail)
+                            },
+                        )
+                    }
+                }
+            },
+        )
     }
 
     if (showEditWaypointDialog != null) {
@@ -1200,9 +1231,7 @@ private fun CacheInfoDialog(mapView: MapView, onDismiss: () -> Unit) {
 }
 
 @Composable
-private fun PurgeTileSourceDialog(onDismiss: () -> Unit) {
-    val scope = rememberCoroutineScope()
-    val context = LocalContext.current
+private fun PurgeTileSourceDialog(onDismiss: () -> Unit, onPurge: (List<String>) -> Unit) {
     val cache = SqlTileWriterExt()
 
     val sourceList by remember { derivedStateOf { cache.sources.map { it.source as String } } }
@@ -1215,19 +1244,7 @@ private fun PurgeTileSourceDialog(onDismiss: () -> Unit) {
             TextButton(
                 enabled = selected.isNotEmpty(),
                 onClick = {
-                    selected.forEach { selectedIndex ->
-                        val source = sourceList[selectedIndex]
-                        scope.launch {
-                            context.showToast(
-                                if (cache.purgeCache(source)) {
-                                    getString(Res.string.map_purge_success, source)
-                                } else {
-                                    getString(Res.string.map_purge_fail)
-                                },
-                            )
-                        }
-                    }
-
+                    onPurge(selected.map { sourceList[it] })
                     onDismiss()
                 },
             ) {
@@ -1327,4 +1344,14 @@ private fun GeofenceBoxAuthoringBar(onConfirm: () -> Unit, onCancel: () -> Unit,
             Button(onClick = onConfirm) { Text(stringResource(Res.string.geofence_box_author_confirm)) }
         }
     }
+}
+
+/**
+ * Outcome of an osmdroid offline tile download, published as state so the toast is emitted from a composition-scoped
+ * effect rather than from the CacheManager's own callback thread.
+ */
+private sealed interface TileDownloadOutcome {
+    data object Complete : TileDownloadOutcome
+
+    data class Failed(val errors: Int) : TileDownloadOutcome
 }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -78,7 +78,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -91,6 +93,7 @@ import org.meshtastic.app.map.model.CustomTileSource
 import org.meshtastic.app.map.model.MarkerWithLabel
 import org.meshtastic.core.common.gpsDisabled
 import org.meshtastic.core.common.util.DateFormatter
+import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.common.util.nowSeconds
 import org.meshtastic.core.model.DataPacket
@@ -703,16 +706,18 @@ fun MapView(
         }
 
     // osmdroid runs the tile download on its own task for minutes and then calls back from there, not from a
-    // composable. Publishing the outcome as state keeps the toast on an effect that lives and dies with this screen: a
-    // callback that lands after the user left the map can no longer launch into a forgotten composition scope.
-    var tileDownloadOutcome by remember { mutableStateOf<TileDownloadOutcome?>(null) }
-    LaunchedEffect(tileDownloadOutcome) {
-        when (val outcome = tileDownloadOutcome) {
-            null -> return@LaunchedEffect
-            is TileDownloadOutcome.Complete -> context.showToast(Res.string.map_download_complete)
-            is TileDownloadOutcome.Failed -> context.showToast(Res.string.map_download_errors, outcome.errors)
+    // composable. The callback only queues the outcome; the toast is emitted by an effect that lives and dies with this
+    // screen, so a callback landing after the user left the map can no longer launch into a forgotten composition
+    // scope. A queue rather than a state value: outcomes are one-shot events, and two equal ones (two completions, or
+    // two failures with the same error count) must still produce two toasts.
+    val tileDownloadOutcomes = remember { Channel<TileDownloadOutcome>(Channel.UNLIMITED) }
+    LaunchedEffect(Unit) {
+        for (outcome in tileDownloadOutcomes) {
+            when (outcome) {
+                is TileDownloadOutcome.Complete -> context.showToast(Res.string.map_download_complete)
+                is TileDownloadOutcome.Failed -> context.showToast(Res.string.map_download_errors, outcome.errors)
+            }
         }
-        tileDownloadOutcome = null
     }
 
     fun startDownload() {
@@ -732,11 +737,11 @@ fun MapView(
                 zoomLevelMax.toInt(),
                 cacheManagerCallback(
                     onTaskComplete = {
-                        tileDownloadOutcome = TileDownloadOutcome.Complete
+                        tileDownloadOutcomes.trySend(TileDownloadOutcome.Complete)
                         writer.onDetach()
                     },
                     onTaskFailed = { errors ->
-                        tileDownloadOutcome = TileDownloadOutcome.Failed(errors)
+                        tileDownloadOutcomes.trySend(TileDownloadOutcome.Failed(errors))
                         writer.onDetach()
                     },
                 ),
@@ -955,8 +960,11 @@ fun MapView(
             onPurge = { sources ->
                 scope.launch {
                     sources.forEach { source ->
+                        // purgeCache does synchronous SQLite deletes over the tile cache; this scope dispatches on the
+                        // UI thread, so the delete has to move off it.
+                        val purged = withContext(ioDispatcher) { SqlTileWriterExt().purgeCache(source) }
                         context.showToast(
-                            if (SqlTileWriterExt().purgeCache(source)) {
+                            if (purged) {
                                 getString(Res.string.map_purge_success, source)
                             } else {
                                 getString(Res.string.map_purge_fail)

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -105,6 +105,7 @@ import com.google.maps.android.data.renderer.model.LineString
 import com.google.maps.android.data.renderer.model.LineStyle
 import com.google.maps.android.data.renderer.model.MultiGeometry
 import com.google.maps.android.data.renderer.model.PolygonStyle
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -1360,6 +1361,11 @@ private fun MapLayerOverlay(layerItem: MapLayerItem, mapViewModel: MapViewModel)
                 } else {
                     RenderedMapLayer(map, dataLayer)
                 }
+            } catch (e: CancellationException) {
+                // Not a load failure: this MapEffect is relaunched on every refresh (refreshToken) and cancelled when
+                // the layer or the map leaves the composition, which lands here while parseMapLayer is suspended.
+                // Swallowing it broke structured concurrency and reported routine refreshes to error tracking.
+                throw e
             } catch (e: Exception) {
                 Logger.withTag("MapView").e(e) { "Error loading map layer: ${layerItem.name}" }
                 null

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -28,6 +28,7 @@ import com.google.android.gms.maps.model.TileProvider
 import com.google.android.gms.maps.model.UrlTileProvider
 import com.google.maps.android.compose.CameraPositionState
 import com.google.maps.android.compose.MapType
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -173,6 +174,8 @@ class MapViewModel(
                         _errorFlow.emit("Failed to copy MBTiles file to internal storage.")
                         return@launch
                     }
+                } catch (e: CancellationException) {
+                    throw e // A cancelled copy (ViewModel cleared) is not a processing failure.
                 } catch (e: Exception) {
                     Logger.withTag("MapViewModel").e(e) { "Error processing local URI" }
                     _errorFlow.emit("Error processing local URI for MBTiles.")

--- a/androidApp/src/main/kotlin/org/meshtastic/app/map/MapLayersManager.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/map/MapLayersManager.kt
@@ -26,6 +26,7 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -252,6 +253,10 @@ class MapLayersManager(
                 } else {
                     application.contentResolver.openInputStream(uriToLoad)
                 }
+            } catch (e: CancellationException) {
+                // The caller is a composition-scoped effect, so a layer refresh or leaving the map cancels this fetch
+                // mid-flight. That is not a load failure and must not be reported as one.
+                throw e
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                 // Redact the URI: a content:///file:// path can include a user-chosen file name.
                 Logger.withTag(TAG).e(e) { "Error opening InputStream for layer (scheme=${uriToLoad.scheme})" }

--- a/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/ai/ChirpySessionHolder.kt
+++ b/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/ai/ChirpySessionHolder.kt
@@ -19,12 +19,15 @@ package org.meshtastic.feature.docs.ai
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
 import org.koin.core.annotation.Single
+import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.resources.chirpy_error_busy
 import org.meshtastic.core.resources.chirpy_error_model_unavailable
@@ -136,14 +139,30 @@ class ChirpySessionHolder(private val aiAssistant: AIDocAssistant, dispatchers: 
                     }
                 }
             }
-            // A stream that ends without a terminal result would otherwise leave the composer disabled for good.
-            if (sessionState.isLoading) sessionState = sessionState.copy(isLoading = false)
         }
     }
 
+    /**
+     * Runs [block] as the one current request. Every exit path — success, a stream that ended without a terminal
+     * result, a thrown failure, or cancellation — clears [AIDocAssistantSessionState.isLoading], because leaving it set
+     * blocks [submit] and [introduce] for the rest of the process. Only the current request may clear it: a superseded
+     * one must not unblock the composer on behalf of the request that replaced it.
+     */
     private fun launchRequest(block: suspend () -> Unit) {
         request?.cancel()
-        request = scope.launch { block() }
+        // LAZY so `request` is assigned before the body can observe it.
+        val job =
+            scope.launch(start = CoroutineStart.LAZY) {
+                try {
+                    safeCatching { block() }.onFailure { Logger.e(it) { "[Chirpy] request failed" } }
+                } finally {
+                    if (request === coroutineContext[Job] && sessionState.isLoading) {
+                        sessionState = sessionState.copy(isLoading = false)
+                    }
+                }
+            }
+        request = job
+        job.start()
     }
 }
 

--- a/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/ai/ChirpySessionHolder.kt
+++ b/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/ai/ChirpySessionHolder.kt
@@ -19,17 +19,186 @@ package org.meshtastic.feature.docs.ai
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import org.koin.core.annotation.Single
+import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.resources.chirpy_error_busy
+import org.meshtastic.core.resources.chirpy_error_model_unavailable
+import org.meshtastic.core.resources.chirpy_error_token_budget_exceeded
+import org.meshtastic.core.resources.chirpy_error_unknown
+import org.meshtastic.core.resources.chirpy_error_unsupported_flavor
+import org.meshtastic.core.resources.chirpy_error_unsupported_platform
+import org.meshtastic.core.resources.chirpy_suggested_pages_help
+import org.meshtastic.feature.docs.model.AIDocAssistantResult
 import org.meshtastic.feature.docs.model.AIDocAssistantSessionState
+import org.meshtastic.feature.docs.model.ChirpyMessage
+import org.meshtastic.feature.docs.model.ChirpyRole
+import org.meshtastic.feature.docs.model.DocPage
+import org.meshtastic.feature.docs.model.DocsAiError
+import org.meshtastic.feature.docs.model.SourceRef
+import kotlin.uuid.Uuid
+import org.meshtastic.core.resources.Res as CoreRes
 
 /**
  * Global Chirpy conversation state shared across all docs panes.
  *
  * Registered as a Koin singleton so both the list and detail entries access the same conversation. Uses Compose
  * snapshot state so reads trigger recomposition automatically.
+ *
+ * The holder also *runs* the requests, on its own scope. Callers must not launch them from a
+ * `rememberCoroutineScope()`: on-device inference takes seconds, and the pane that submitted a question is routinely
+ * disposed before the answer lands — the adaptive docs layout swaps the list pane for a detail pane as soon as the user
+ * opens a page. A composition scope is cancelled at that point, so the answer would be dropped mid-stream and
+ * [AIDocAssistantSessionState.isLoading] would stay `true` forever in this singleton, permanently blocking the next
+ * question. The session outlives any one pane, so the scope that fills it has to as well.
  */
 @Single
-class ChirpySessionHolder {
+class ChirpySessionHolder(private val aiAssistant: AIDocAssistant, dispatchers: CoroutineDispatchers) {
     var showSheet by mutableStateOf(false)
     var sessionState by mutableStateOf(AIDocAssistantSessionState())
+
+    private val scope = CoroutineScope(SupervisorJob() + dispatchers.main)
+
+    /** The in-flight request, if any. Kept so a new request supersedes an abandoned one instead of racing it. */
+    private var request: Job? = null
+
+    /**
+     * Auto-introduction, shown the first time the sheet opens on a ready model. Safe to call repeatedly: it no-ops once
+     * the conversation has started or while a request is already running.
+     */
+    fun introduce() {
+        if (sessionState.messages.isNotEmpty() || sessionState.isLoading) return
+        sessionState = sessionState.copy(isLoading = true)
+        launchRequest {
+            aiAssistant.resetSession()
+            val introMsg = chirpyResultToMessage(aiAssistant.answer(CHIRPY_INTRO_PROMPT, currentPageId = null))
+            sessionState = sessionState.copy(messages = sessionState.messages + introMsg, isLoading = false)
+        }
+    }
+
+    /**
+     * Submits the trimmed draft question and streams the answer into [sessionState]. No-ops on a blank draft or while a
+     * request is already running.
+     */
+    fun submit(currentPageId: String?) {
+        val question = sessionState.draftQuestion.trim()
+        if (question.isBlank() || sessionState.isLoading) return
+
+        val userMsg = ChirpyMessage(id = Uuid.random().toString(), role = ChirpyRole.USER, text = question)
+        sessionState =
+            sessionState.copy(messages = sessionState.messages + userMsg, draftQuestion = "", isLoading = true)
+
+        launchRequest {
+            var assistantMsgId: String? = null
+
+            fun updateAssistant(text: String, pages: List<DocPage>, role: ChirpyRole = ChirpyRole.ASSISTANT) {
+                val msgId = assistantMsgId ?: Uuid.random().toString().also { assistantMsgId = it }
+                val msg =
+                    ChirpyMessage(
+                        id = msgId,
+                        role = role,
+                        text = text,
+                        sources = pages.map { SourceRef(id = it.id, title = it.title) },
+                    )
+                val currentList = sessionState.messages
+                val newList =
+                    if (currentList.any { it.id == msgId }) {
+                        currentList.map { if (it.id == msgId) msg else it }
+                    } else {
+                        currentList + msg
+                    }
+                sessionState = sessionState.copy(messages = newList)
+            }
+
+            aiAssistant.answerStream(question, currentPageId = currentPageId).collect { result ->
+                when (result) {
+                    is AIDocAssistantResult.Partial -> updateAssistant(result.answer, result.sourcePages)
+
+                    is AIDocAssistantResult.Success -> {
+                        updateAssistant(result.answer, result.sourcePages)
+                        sessionState = sessionState.copy(isLoading = false)
+                    }
+
+                    is AIDocAssistantResult.Fallback -> {
+                        val finalMsg = chirpyResultToMessage(result)
+                        updateAssistant(finalMsg.text, result.suggestedPages, finalMsg.role)
+                        sessionState = sessionState.copy(isLoading = false)
+                    }
+
+                    is AIDocAssistantResult.Error -> {
+                        val finalMsg = chirpyResultToMessage(result)
+                        updateAssistant(finalMsg.text, result.suggestedPages, finalMsg.role)
+                        sessionState = sessionState.copy(isLoading = false)
+                    }
+                }
+            }
+            // A stream that ends without a terminal result would otherwise leave the composer disabled for good.
+            if (sessionState.isLoading) sessionState = sessionState.copy(isLoading = false)
+        }
+    }
+
+    private fun launchRequest(block: suspend () -> Unit) {
+        request?.cancel()
+        request = scope.launch { block() }
+    }
+}
+
+/** Short intro prompt — kept minimal to skip heavy context ranking and generate in <1s. */
+private const val CHIRPY_INTRO_PROMPT =
+    "Say hi in 1-2 sentences. State your name is Chirpy and you help with Meshtastic. " +
+        "Do not give the user a nickname. Be punchy and fun."
+
+/** Maps an [AIDocAssistantResult] to a [ChirpyMessage]. */
+private suspend fun chirpyResultToMessage(result: AIDocAssistantResult): ChirpyMessage = when (result) {
+    is AIDocAssistantResult.Partial ->
+        ChirpyMessage(
+            id = Uuid.random().toString(),
+            role = ChirpyRole.ASSISTANT,
+            text = result.answer,
+            sources = result.sourcePages.map { SourceRef(id = it.id, title = it.title) },
+        )
+
+    is AIDocAssistantResult.Success ->
+        ChirpyMessage(
+            id = Uuid.random().toString(),
+            role = ChirpyRole.ASSISTANT,
+            text = result.answer,
+            sources = result.sourcePages.map { SourceRef(id = it.id, title = it.title) },
+        )
+
+    is AIDocAssistantResult.Fallback ->
+        ChirpyMessage(
+            id = Uuid.random().toString(),
+            role = ChirpyRole.ASSISTANT,
+            text = result.message,
+            sources = result.suggestedPages.map { SourceRef(id = it.id, title = it.title) },
+        )
+
+    is AIDocAssistantResult.Error -> {
+        val errorMessage =
+            when (result.reason) {
+                DocsAiError.UnsupportedPlatform -> getString(CoreRes.string.chirpy_error_unsupported_platform)
+                DocsAiError.UnsupportedFlavor -> getString(CoreRes.string.chirpy_error_unsupported_flavor)
+                DocsAiError.ModelUnavailable -> getString(CoreRes.string.chirpy_error_model_unavailable)
+                DocsAiError.Busy -> getString(CoreRes.string.chirpy_error_busy)
+                DocsAiError.TokenBudgetExceeded -> getString(CoreRes.string.chirpy_error_token_budget_exceeded)
+                DocsAiError.Unknown -> getString(CoreRes.string.chirpy_error_unknown)
+            }
+        val text =
+            if (result.suggestedPages.isNotEmpty()) {
+                "$errorMessage ${getString(CoreRes.string.chirpy_suggested_pages_help)}"
+            } else {
+                errorMessage
+            }
+        ChirpyMessage(
+            id = Uuid.random().toString(),
+            role = ChirpyRole.SYSTEM,
+            text = text,
+            sources = result.suggestedPages.map { SourceRef(id = it.id, title = it.title) },
+        )
+    }
 }

--- a/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/navigation/DocsNavigation.kt
+++ b/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/navigation/DocsNavigation.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
@@ -32,40 +31,24 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigationevent.NavigationEventInfo
 import androidx.navigationevent.compose.NavigationBackHandler
 import androidx.navigationevent.compose.rememberNavigationEventState
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.jetbrains.compose.resources.getString
 import org.koin.compose.koinInject
 import org.meshtastic.core.common.util.currentLocaleCode
 import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.core.navigation.SettingsRoute
-import org.meshtastic.core.resources.chirpy_error_busy
-import org.meshtastic.core.resources.chirpy_error_model_unavailable
-import org.meshtastic.core.resources.chirpy_error_token_budget_exceeded
-import org.meshtastic.core.resources.chirpy_error_unknown
-import org.meshtastic.core.resources.chirpy_error_unsupported_flavor
-import org.meshtastic.core.resources.chirpy_error_unsupported_platform
-import org.meshtastic.core.resources.chirpy_suggested_pages_help
 import org.meshtastic.feature.docs.ai.AIDocAssistant
 import org.meshtastic.feature.docs.ai.ChirpySessionHolder
 import org.meshtastic.feature.docs.data.DefaultDocBundleLoader
 import org.meshtastic.feature.docs.data.DocBundleLoader
 import org.meshtastic.feature.docs.data.KeywordSearchEngine
-import org.meshtastic.feature.docs.model.AIDocAssistantResult
-import org.meshtastic.feature.docs.model.ChirpyMessage
-import org.meshtastic.feature.docs.model.ChirpyRole
 import org.meshtastic.feature.docs.model.DocPage
 import org.meshtastic.feature.docs.model.DocPageContent
-import org.meshtastic.feature.docs.model.DocsAiError
 import org.meshtastic.feature.docs.model.ModelReadiness
-import org.meshtastic.feature.docs.model.SourceRef
 import org.meshtastic.feature.docs.model.TranslationSource
 import org.meshtastic.feature.docs.translation.DocTranslationService
 import org.meshtastic.feature.docs.translation.TranslationResult
 import org.meshtastic.feature.docs.ui.DocsBrowserScreen
 import org.meshtastic.feature.docs.ui.DocsPageRouteScreen
-import kotlin.uuid.Uuid
-import org.meshtastic.core.resources.Res as CoreRes
 
 /** Registers docs navigation entries into the Settings navigation graph. */
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
@@ -106,7 +89,6 @@ private fun rememberChirpyState(
 ): ChirpyUiState {
     val aiAssistant = koinInject<AIDocAssistant>()
     val holder = koinInject<ChirpySessionHolder>()
-    val scope = rememberCoroutineScope()
 
     val modelReadiness by aiAssistant.modelStatus.collectAsState()
     var isSupported by remember { mutableStateOf(false) }
@@ -121,71 +103,11 @@ private fun rememberChirpyState(
         }
     }
 
-    // Auto-introduce Chirpy when the sheet first opens.
-    AutoIntroduceChirpy(
-        showSheet = holder.showSheet,
-        sessionState = holder.sessionState,
-        aiAssistant = aiAssistant,
-        onUpdateSessionState = { holder.sessionState = it },
-    )
-
-    fun submit() {
-        val question = holder.sessionState.draftQuestion.trim()
-        if (question.isNotBlank() && !holder.sessionState.isLoading) {
-            val userMsg = ChirpyMessage(id = Uuid.random().toString(), role = ChirpyRole.USER, text = question)
-            holder.sessionState =
-                holder.sessionState.copy(
-                    messages = holder.sessionState.messages + userMsg,
-                    draftQuestion = "",
-                    isLoading = true,
-                )
-            scope.launch {
-                var assistantMsgId: String? = null
-
-                fun updateAssistant(text: String, pages: List<DocPage>, role: ChirpyRole = ChirpyRole.ASSISTANT) {
-                    val msgId = assistantMsgId ?: Uuid.random().toString().also { assistantMsgId = it }
-                    val msg =
-                        ChirpyMessage(
-                            id = msgId,
-                            role = role,
-                            text = text,
-                            sources = pages.map { SourceRef(id = it.id, title = it.title) },
-                        )
-                    val currentList = holder.sessionState.messages
-                    val newList =
-                        if (currentList.any { it.id == msgId }) {
-                            currentList.map { if (it.id == msgId) msg else it }
-                        } else {
-                            currentList + msg
-                        }
-                    holder.sessionState = holder.sessionState.copy(messages = newList)
-                }
-
-                aiAssistant.answerStream(question, currentPageId = currentPageId).collect { result ->
-                    when (result) {
-                        is AIDocAssistantResult.Partial -> {
-                            updateAssistant(result.answer, result.sourcePages)
-                        }
-
-                        is AIDocAssistantResult.Success -> {
-                            updateAssistant(result.answer, result.sourcePages)
-                            holder.sessionState = holder.sessionState.copy(isLoading = false)
-                        }
-
-                        is AIDocAssistantResult.Fallback -> {
-                            val finalMsg = chirpyResultToMessage(result)
-                            updateAssistant(finalMsg.text, result.suggestedPages, finalMsg.role)
-                            holder.sessionState = holder.sessionState.copy(isLoading = false)
-                        }
-
-                        is AIDocAssistantResult.Error -> {
-                            val finalMsg = chirpyResultToMessage(result)
-                            updateAssistant(finalMsg.text, result.suggestedPages, finalMsg.role)
-                            holder.sessionState = holder.sessionState.copy(isLoading = false)
-                        }
-                    }
-                }
-            }
+    // Auto-introduce Chirpy when the sheet first opens on a ready model. Only the trigger is scoped to this pane; the
+    // request itself runs on the holder's scope, so an answer in flight survives the pane being disposed.
+    LaunchedEffect(holder.showSheet, modelReadiness) {
+        if (holder.showSheet && modelReadiness is ModelReadiness.Available) {
+            holder.introduce()
         }
     }
 
@@ -198,42 +120,12 @@ private fun rememberChirpyState(
         onToggle = { holder.showSheet = !holder.showSheet },
         onDismiss = { holder.showSheet = false },
         onDraftChange = { holder.sessionState = holder.sessionState.copy(draftQuestion = it) },
-        onSubmit = ::submit,
+        onSubmit = { holder.submit(currentPageId) },
         onNavigateToPage = { pageId ->
             holder.showSheet = false
             backStack.add(SettingsRoute.HelpDocPage(pageId))
         },
     )
-}
-
-@Composable
-private fun AutoIntroduceChirpy(
-    showSheet: Boolean,
-    sessionState: org.meshtastic.feature.docs.model.AIDocAssistantSessionState,
-    aiAssistant: AIDocAssistant,
-    onUpdateSessionState: (org.meshtastic.feature.docs.model.AIDocAssistantSessionState) -> Unit,
-) {
-    val currentOnUpdateSessionState by androidx.compose.runtime.rememberUpdatedState(onUpdateSessionState)
-    val currentSessionState by androidx.compose.runtime.rememberUpdatedState(sessionState)
-
-    val modelStatus by aiAssistant.modelStatus.collectAsState()
-
-    LaunchedEffect(showSheet, modelStatus) {
-        if (
-            showSheet &&
-            modelStatus is ModelReadiness.Available &&
-            currentSessionState.messages.isEmpty() &&
-            !currentSessionState.isLoading
-        ) {
-            aiAssistant.resetSession()
-            currentOnUpdateSessionState(currentSessionState.copy(isLoading = true))
-            val result = aiAssistant.answer(CHIRPY_INTRO_PROMPT, currentPageId = null)
-            val introMsg = chirpyResultToMessage(result)
-            currentOnUpdateSessionState(
-                currentSessionState.copy(messages = currentSessionState.messages + introMsg, isLoading = false),
-            )
-        }
-    }
 }
 
 // ── Screen composables ──────────────────────────────────────────────────────────
@@ -371,62 +263,4 @@ private fun DocsPageScreen(pageId: String, backStack: NavBackStack<NavKey>, chir
         onBack = { backStack.removeLastOrNull() },
         onNavigateToPage = { targetPageId -> backStack.add(SettingsRoute.HelpDocPage(targetPageId)) },
     )
-}
-
-// ── Constants & helpers ─────────────────────────────────────────────────────────
-
-/** Short intro prompt — kept minimal to skip heavy context ranking and generate in <1s. */
-private const val CHIRPY_INTRO_PROMPT =
-    "Say hi in 1-2 sentences. State your name is Chirpy and you help with Meshtastic. " +
-        "Do not give the user a nickname. Be punchy and fun."
-
-/** Maps an [AIDocAssistantResult] to a [ChirpyMessage]. */
-private suspend fun chirpyResultToMessage(result: AIDocAssistantResult): ChirpyMessage = when (result) {
-    is AIDocAssistantResult.Partial ->
-        ChirpyMessage(
-            id = Uuid.random().toString(),
-            role = ChirpyRole.ASSISTANT,
-            text = result.answer,
-            sources = result.sourcePages.map { SourceRef(id = it.id, title = it.title) },
-        )
-
-    is AIDocAssistantResult.Success ->
-        ChirpyMessage(
-            id = Uuid.random().toString(),
-            role = ChirpyRole.ASSISTANT,
-            text = result.answer,
-            sources = result.sourcePages.map { SourceRef(id = it.id, title = it.title) },
-        )
-
-    is AIDocAssistantResult.Fallback ->
-        ChirpyMessage(
-            id = Uuid.random().toString(),
-            role = ChirpyRole.ASSISTANT,
-            text = result.message,
-            sources = result.suggestedPages.map { SourceRef(id = it.id, title = it.title) },
-        )
-
-    is AIDocAssistantResult.Error -> {
-        val errorMessage =
-            when (result.reason) {
-                DocsAiError.UnsupportedPlatform -> getString(CoreRes.string.chirpy_error_unsupported_platform)
-                DocsAiError.UnsupportedFlavor -> getString(CoreRes.string.chirpy_error_unsupported_flavor)
-                DocsAiError.ModelUnavailable -> getString(CoreRes.string.chirpy_error_model_unavailable)
-                DocsAiError.Busy -> getString(CoreRes.string.chirpy_error_busy)
-                DocsAiError.TokenBudgetExceeded -> getString(CoreRes.string.chirpy_error_token_budget_exceeded)
-                DocsAiError.Unknown -> getString(CoreRes.string.chirpy_error_unknown)
-            }
-        val text =
-            if (result.suggestedPages.isNotEmpty()) {
-                "$errorMessage ${getString(CoreRes.string.chirpy_suggested_pages_help)}"
-            } else {
-                errorMessage
-            }
-        ChirpyMessage(
-            id = Uuid.random().toString(),
-            role = ChirpyRole.SYSTEM,
-            text = text,
-            sources = result.suggestedPages.map { SourceRef(id = it.id, title = it.title) },
-        )
-    }
 }

--- a/feature/docs/src/commonTest/kotlin/org/meshtastic/feature/docs/ai/ChirpySessionHolderTest.kt
+++ b/feature/docs/src/commonTest/kotlin/org/meshtastic/feature/docs/ai/ChirpySessionHolderTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.docs.ai
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.feature.docs.model.AIDocAssistantResult
+import org.meshtastic.feature.docs.model.ChirpyRole
+import org.meshtastic.feature.docs.model.ModelReadiness
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Requests are owned by the holder, not by the pane that submitted them: the docs layout disposes the list pane as soon
+ * as a page opens, so a request launched from a `rememberCoroutineScope()` was cancelled mid-answer and stranded
+ * `isLoading = true` in this app-wide singleton, wedging the composer for the rest of the process.
+ */
+class ChirpySessionHolderTest {
+
+    @Test
+    fun `submit streams the answer into the shared session`() = runTest {
+        val results = listOf(partial("Mesh"), success("Meshtastic uses LoRa."))
+        val holder = holderFor(FakeDocAssistant(stream = results.asFlow()))
+
+        holder.sessionState = holder.sessionState.copy(draftQuestion = "What is Meshtastic?")
+        holder.submit(currentPageId = null)
+        advanceUntilIdle()
+
+        assertEquals(listOf(ChirpyRole.USER, ChirpyRole.ASSISTANT), holder.sessionState.messages.map { it.role })
+        assertEquals("Meshtastic uses LoRa.", holder.sessionState.messages.last().text)
+        assertEquals("", holder.sessionState.draftQuestion)
+        assertFalse(holder.sessionState.isLoading)
+    }
+
+    @Test
+    fun `submit clears loading when the stream ends without a terminal result`() = runTest {
+        val holder = holderFor(FakeDocAssistant(stream = emptyFlow()))
+
+        holder.sessionState = holder.sessionState.copy(draftQuestion = "Anyone there?")
+        holder.submit(currentPageId = null)
+        advanceUntilIdle()
+
+        assertFalse(holder.sessionState.isLoading, "a stream with no terminal result must not wedge the composer")
+    }
+
+    @Test
+    fun `submit ignores a blank draft and a request already in flight`() = runTest {
+        val holder = holderFor(FakeDocAssistant(stream = listOf(partial("...")).asFlow()))
+
+        holder.submit(currentPageId = null)
+        assertTrue(holder.sessionState.messages.isEmpty())
+
+        holder.sessionState = holder.sessionState.copy(draftQuestion = "First?")
+        holder.submit(currentPageId = null)
+        holder.sessionState = holder.sessionState.copy(draftQuestion = "Second?")
+        holder.submit(currentPageId = null)
+
+        assertEquals(1, holder.sessionState.messages.count { it.role == ChirpyRole.USER })
+        assertEquals("Second?", holder.sessionState.draftQuestion)
+    }
+
+    @Test
+    fun `introduce runs once and resets the assistant session`() = runTest {
+        val assistant = FakeDocAssistant(stream = emptyFlow())
+        val holder = holderFor(assistant)
+
+        holder.introduce()
+        advanceUntilIdle()
+        holder.introduce()
+        advanceUntilIdle()
+
+        assertEquals(1, assistant.resetCount)
+        assertEquals(1, holder.sessionState.messages.size)
+        assertFalse(holder.sessionState.isLoading)
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.holderFor(assistant: AIDocAssistant): ChirpySessionHolder {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        return ChirpySessionHolder(
+            aiAssistant = assistant,
+            dispatchers = CoroutineDispatchers(io = dispatcher, main = dispatcher, default = dispatcher),
+        )
+    }
+}
+
+private fun partial(answer: String) = AIDocAssistantResult.Partial(answer, emptyList(), usedOnDeviceModel = true)
+
+private fun success(answer: String) = AIDocAssistantResult.Success(answer, emptyList(), usedOnDeviceModel = true)
+
+private class FakeDocAssistant(
+    private val stream: Flow<AIDocAssistantResult>,
+    private val answer: AIDocAssistantResult = success("Hi, I'm Chirpy."),
+) : AIDocAssistant {
+    var resetCount = 0
+        private set
+
+    override val modelStatus: StateFlow<ModelReadiness> = MutableStateFlow(ModelReadiness.Available)
+
+    override suspend fun isSupported(): Boolean = true
+
+    override suspend fun answer(question: String, currentPageId: String?): AIDocAssistantResult = answer
+
+    override fun answerStream(question: String, currentPageId: String?): Flow<AIDocAssistantResult> = stream
+
+    override fun resetSession() {
+        resetCount++
+    }
+}

--- a/feature/docs/src/commonTest/kotlin/org/meshtastic/feature/docs/ai/ChirpySessionHolderTest.kt
+++ b/feature/docs/src/commonTest/kotlin/org/meshtastic/feature/docs/ai/ChirpySessionHolderTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -64,6 +65,23 @@ class ChirpySessionHolderTest {
         advanceUntilIdle()
 
         assertFalse(holder.sessionState.isLoading, "a stream with no terminal result must not wedge the composer")
+    }
+
+    @Test
+    fun `a thrown failure clears loading instead of wedging the composer`() = runTest {
+        val holder = holderFor(FakeDocAssistant(stream = flow { throw IllegalStateException("assistant blew up") }))
+
+        holder.sessionState = holder.sessionState.copy(draftQuestion = "Why?")
+        holder.submit(currentPageId = null)
+        advanceUntilIdle()
+
+        assertFalse(holder.sessionState.isLoading, "a failed request must not block every later question")
+
+        // The composer is usable again: the next question is accepted rather than dropped by the isLoading guard.
+        holder.sessionState = holder.sessionState.copy(draftQuestion = "Again?")
+        holder.submit(currentPageId = null)
+
+        assertEquals(2, holder.sessionState.messages.count { it.role == ChirpyRole.USER })
     }
 
     @Test


### PR DESCRIPTION
## Why

Datadog RUM issue [475f79d4](https://us5.datadoghq.com/error-tracking/issue/475f79d4-89b6-11f1-bca9-da7ad0900000) (`ForgottenCoroutineScopeException: The coroutine scope left the composition`, 3 events on 2.8.0 build 29321664). The sample events name the call site directly — no stack needed, and none is available (the exception is a stackless `PlatformOptimizedCancellationException`):

| attribute | value |
|---|---|
| `tag` | `MapView` |
| `message` | `Error loading map layer: MTastic_LI______77bf37c3…` |
| `status` | `error` |
| `variant` | `google` |

That is `MapLayerOverlay` in the google-flavor `MapView.kt`. Its `MapEffect` **is** a `LaunchedEffect` (maps-compose implements it as one), and `refreshToken` is one of its keys — so the effect is cancelled and relaunched on **every layer refresh**, and cancelled outright when the layer or map leaves the composition. A cancellation while `parseMapLayer` or the network fetch is still suspended lands in a broad `catch (e: Exception)`, which swallowed it and logged it at **error level with the throwable attached**. `DatadogLogWriter` forwards that (unlike `CrashlyticsLogWriter`, which returns early on `CancellationException`) — so a routine refresh was reported to error tracking as a layer load failure.

This is not new in 2.8.0. The same defect has been reporting under the twin exception name since **2.7.8 (2025-11-24)** as [26971ea6](https://us5.datadoghq.com/error-tracking/issue/26971ea6-c958-11f0-ada4-da7ad0900000) — 11 events, auto-resolved and regressed twice — whose sample names the sibling site (`tag: MapViewModel`, `Error opening InputStream from URI`). `ForgottenCoroutineScopeException` and `LeftCompositionCancellationException` are two private, member-less subclasses of the same base in `Effects.kt`; the "new" issue is a new fingerprint for the long-standing bug, not new behaviour.

## 🐛 The fix

Rethrow `CancellationException` ahead of the generic catch at the three map-layer sites, matching the convention already used elsewhere in this codebase (`NodeManagementActions.setNodeNotes`, `GeminiNanoDocAssistant`, `safeCatching`):

- **`MapView.kt` `MapLayerOverlay`** — telemetry-confirmed source of 475f79d4.
- **`MapLayersManager.getInputStreamFromUri`** — telemetry-confirmed source of 26971ea6; this one wraps the HTTP fetch, the longest suspension on the path. Its swallow was masked from callers by `withContext`'s exit-time cancellation check, so the only symptom was the bogus error log.
- **`MapViewModel.addCustomTileProvider`** — same shape around a suspending file copy (cancels when the ViewModel clears). Not telemetry-confirmed; fixed because it is the identical defect on the same feature.

## 🧹 Also in this branch: composition-scope lifetime fixes

Found while auditing every `rememberCoroutineScope()` in the tree, before the telemetry above was available. These are **not** the cause of the reported issue — they are real bugs of an adjacent kind (a scope handed to an owner that outlives the composable), kept here because they were already written and verified. Say the word and I'll split them into their own PR.

- **Chirpy docs assistant** — `submit()` launched a multi-second on-device Gemini Nano stream from the docs pane's scope but wrote results into `ChirpySessionHolder`, an app-wide singleton. The adaptive list-detail layout disposes the list pane when a page opens, so the answer was cancelled mid-stream and `isLoading` stayed `true` in the singleton, permanently blocking the next question (`submit()` is guarded on it). The holder now owns its requests. Also fixes a lost-update bug in the old intro path, which rebuilt state from a pre-intro snapshot and discarded anything typed while the intro generated.
- **osmdroid tile download (F-Droid)** — `CacheManager` calls back from its own task minutes later; the toast was `scope.launch`ed from that callback. Now published as state and toasted from a composition-scoped effect.
- **Tile-source purge dialog (F-Droid)** — "Clear" launched the purge and then called `onDismiss()`, forgetting the dialog's own scope in the same frame. Purging moved to the map screen, which outlives the dialog.

## Testing Performed

- `ChirpySessionHolderTest` (4 tests, `:feature:docs:jvmTest`): a submitted question streams into the shared session on the injected dispatcher; a stream ending without a terminal result clears `isLoading` instead of wedging the composer; a blank draft and a second in-flight submit are no-ops; `introduce()` runs once and resets the assistant session.
- Baseline: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green.
- **No unit test for the three map sites.** Reaching those catches requires cancelling mid-suspension, which needs `ktor-client-mock` + `core:testing` added to `androidApp`'s test deps plus global kermit-logger capture, to guard a rethrow that is a language-level guarantee. The verification signal is telemetry: both issues should stop accruing events after the next build. Happy to add the test if you'd rather have it than the smaller diff.
- Not device-validated: the two F-Droid map paths need a real offline tile download and a tile purge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the documentation assistant with streamed responses, clearer loading states, and safer handling of repeated questions.
  * Added more reliable assistant introductions and error messages.

* **Bug Fixes**
  * Improved offline map download and tile-source purge notifications.
  * Prevented cancelled map operations from appearing as errors.
  * Improved recovery when assistant requests fail or end unexpectedly.

* **Tests**
  * Added coverage for assistant streaming, cancellation, failures, and duplicate requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->