### PR TITLE
fix(notifications): guard blank conversation-shortcut labels

### DIFF
--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/ConversationShortcutPublisherTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/ConversationShortcutPublisherTest.kt
@@ -43,6 +43,7 @@ import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.User
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.meshtastic.core.model.Channel as MeshChannel
@@ -153,6 +154,18 @@ class ConversationShortcutPublisherTest {
             shortcutManager.dynamicShortcuts.any { it.id == "0!000000ff" },
             "pending on-demand shortcut must not be pruned before the snapshot catches up",
         )
+    }
+
+    @Test
+    fun `on-demand shortcut with a blank display name falls back instead of throwing`() = runTest {
+        // Regression: a reaction from a node the NodeDB does not know yet supplied an empty name, and
+        // ShortcutInfoCompat.Builder.build() threw "Shortcut must have a non-empty label" out of the caller's
+        // coroutine, dropping the notification (2.8.0 build 29321664).
+        publisher.ensureConversationShortcut("0!000000fe", "")
+
+        val published = shortcutManager.dynamicShortcuts.find { it.id == "0!000000fe" }
+        assertNotNull(published, "a blank display name must still publish a shortcut")
+        assertTrue(published.shortLabel?.isNotBlank() == true, "short label must be non-blank")
     }
 
     private fun pushRawShortcut(id: String, label: String) {

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/ConversationShortcutPublisher.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/ConversationShortcutPublisher.kt
@@ -251,6 +251,10 @@ class ConversationShortcutPublisher(
         pendingOnDemandIds += contactKey
         val alreadyPublished = ShortcutManagerCompat.getDynamicShortcuts(context).any { it.id == contactKey }
         if (alreadyPublished) return
+        // ShortcutInfoCompat.Builder.build() rejects a blank short label. On-demand callers derive the name from packet
+        // metadata that can be empty (an unnamed node, or a reaction that arrives before the NodeDB knows the sender),
+        // so fall back to the same localized placeholder the observer uses rather than letting build() throw.
+        val label = displayName.takeIf { it.isNotBlank() } ?: getString(Res.string.unknown_username)
         // Match the styling the observer will republish so there is no generic-head flash: rounded channel badge with
         // its number, or a circular initial for a DM. Color is derived from the key (the node object may not be known
         // yet at on-demand time).
@@ -260,21 +264,23 @@ class ConversationShortcutPublisher(
                 channelIcon(contactKey.substringBefore(NodeAddress.ID_BROADCAST).toIntOrNull() ?: 0)
             } else {
                 val (foregroundColor, backgroundColor) = nodeColorsFromNum(contactKey.hashCode())
-                PersonIconFactory.create(displayName, backgroundColor, foregroundColor)
+                PersonIconFactory.create(label, backgroundColor, foregroundColor)
             }
-        val person = Person.Builder().setName(displayName).setKey(contactKey).setIcon(icon).build()
-        val shortcut =
-            ShortcutInfoCompat.Builder(context, contactKey)
-                .setShortLabel(displayName)
-                .setLongLabel(displayName)
-                .setLocusId(LocusIdCompat(contactKey))
-                .setPerson(person)
-                .setLongLived(true)
-                .setCategories(setOf(ShortcutInfo.SHORTCUT_CATEGORY_CONVERSATION))
-                .setIntent(conversationIntent(contactKey))
-                .setIcon(icon)
-                .build()
+        val person = Person.Builder().setName(label).setKey(contactKey).setIcon(icon).build()
+        // build() as well as pushDynamicShortcut() enforces the builder's invariants, so both stay inside the guard: an
+        // escaping throw here cancels the caller's coroutine and drops the notification it was about to post.
         try {
+            val shortcut =
+                ShortcutInfoCompat.Builder(context, contactKey)
+                    .setShortLabel(label)
+                    .setLongLabel(label)
+                    .setLocusId(LocusIdCompat(contactKey))
+                    .setPerson(person)
+                    .setLongLived(true)
+                    .setCategories(setOf(ShortcutInfo.SHORTCUT_CATEGORY_CONVERSATION))
+                    .setIntent(conversationIntent(contactKey))
+                    .setIcon(icon)
+                    .build()
             ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
         } catch (e: IllegalArgumentException) {
             // Don't log the contactKey: node/channel identifiers are user-traceable (privacy-first convention).

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
@@ -508,7 +508,11 @@ class MeshNotificationManagerImpl(
         // Publish (or refresh) a long-lived conversation shortcut before the notification references it, so Android can
         // rank the notification in the shade's Conversations section and expose it to Android Auto/Wear. A channel name
         // labels a broadcast conversation; a direct message is labelled by the other participant's name.
-        conversationShortcutPublisher.value.ensureConversationShortcut(contactKey, channelName ?: conversationName)
+        // Both names come from packet metadata and can be empty, so prefer the first non-blank one.
+        conversationShortcutPublisher.value.ensureConversationShortcut(
+            contactKey,
+            channelName?.takeIf { it.isNotBlank() } ?: conversationName,
+        )
 
         val ourNode = nodeRepository.value.ourNodeInfo.value
         val history =


### PR DESCRIPTION
## 🐛 Why

A reaction arriving from a node the NodeDB does not know yet supplies an **empty** display name. `ShortcutInfoCompat.Builder.build()` rejects a blank short label, so `ensureConversationShortcut` threw `IllegalArgumentException: Shortcut must have a non-empty label` — out of the coroutine, cancelling it and **silently dropping the notification** it was about to post.

Seen in the field on **2.8.0 build 29321664** (internal track): 8 events across 6 sessions, first and last seen on that build.

```
IllegalArgumentException: Shortcut must have a non-empty label
  at ConversationShortcutPublisher.ensureConversationShortcut
  at MeshNotificationManagerImpl.showConversationNotification
  at MeshNotificationManagerImpl.updateReactionNotification
  at MeshDataHandlerImpl$rememberReaction
```

Two things went wrong together, and both are fixed here:

1. The call site used `channelName ?: conversationName`. The elvis operator only guards `null`, so an **empty** channel or node name passed straight through.
2. `build()` sat **outside** the `try/catch` that was written to contain exactly this failure. It enforces the same builder invariants `pushDynamicShortcut()` does, so the guard could never fire.

## 🛠️ What changed

- **`ConversationShortcutPublisher.ensureConversationShortcut`** — a blank label now falls back to the localized `unknown_username` placeholder, matching the fallback `buildDmShortcut` already uses on the observer path. No new string resource needed.
- **Same method** — `build()` moved inside the existing `try`, so a builder-invariant failure is logged rather than escaping into the caller's coroutine.
- **`MeshNotificationManagerImpl.showConversationNotification`** — prefers the first *non-blank* of `channelName`/`conversationName`, so a nameless channel still falls through to the participant name instead of jumping straight to the placeholder.

The on-demand shortcut path takes its inputs from packet metadata rather than NodeDB-resolved names, so blank is a normal state there, not an anomaly.

## 🧪 Testing Performed

- New regression test `on-demand shortcut with a blank display name falls back instead of throwing` in `ConversationShortcutPublisherTest` — asserts a blank name still publishes a shortcut and that its short label is non-blank. Confirmed it executed (5 tests in that class, 0 failures) rather than trusting the summary line.
- Full baseline green: `spotlessApply spotlessCheck detekt assembleDebug test allTests`.

Not reproduced on a physical device — the trigger needs a reaction from a node whose name has not resolved yet, which is awkward to stage. The fix is verified by unit test and by reading the failing path.
