### PR TITLE
docs: drop two derivable lines from the always-loaded agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,6 @@ You are an expert Android/KMP engineer. Maintain architectural boundaries, use M
 
 <context_and_memory>
 - **Project Goal:** Decouple business logic from Android for multi-platform (Android, Desktop, iOS).
-- **Tech:** Kotlin 2.4+ (JDK 25), Ktor, Okio, Room KMP, Koin 4.2+.
 - **Agent Memory:** `.agent_memory/` is local-only scratch (git-ignored) — never stage or commit it. Skim the top (most recent) entry of `.agent_memory/session_context.md` for current state — it is capped at ~5 entries; older handovers live in `session_context.archive.md` (read only if you need historical detail).
 - **Skills Directory (CONSULT THESE FIRST):** 
   - `.skills/project-overview/` - Codebase map, namespacing, **Bootstrap Steps**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Claude-Specific Instructions
 
-- **Think First:** Outline step-by-step reasoning inside `<thinking>` tags before writing code or shell commands.
 - **Skills:** Load only the `.skills/` module relevant to the current task — don't read them all. Start with `.skills/project-overview/SKILL.md` (codebase map, bootstrap, troubleshooting).
 - **Plan Mode:** Use it for changes spanning multiple modules; write plans to `.agent_plans/` (git-ignored).
 - **Delegate to keep context lean** (this is a 20+ module KMP repo):


### PR DESCRIPTION
`AGENTS.md` and `CLAUDE.md` are loaded into context on every agent session, so every line in them is paid for on every run. Two lines earn nothing, and one of them is an active staleness risk — this removes both.

## 🧹 Chores

- **`AGENTS.md` — removed the `**Tech:**` line.** It hardcoded `Kotlin 2.4+ (JDK 25), Ktor, Okio, Room KMP, Koin 4.2+`, duplicating `gradle/libs.versions.toml`. A pinned version list in prose drifts out of date the moment Renovate lands a toolchain bump, and it has no mechanism keeping it honest — any session can read the catalog for the real answer. `JDK 25 is required` is still stated in `CLAUDE.md`'s Quick Reference, so no fact is lost.
- **`CLAUDE.md` — removed the `**Think First:**` line.** `Outline step-by-step reasoning inside <thinking> tags before writing code or shell commands` is generic reasoning guidance rather than repo knowledge, and `AGENTS.md` already carries the substantive version of the same heading: *"Read only what you need. Consult indices (like `strings-index.txt`) before reading large files."*

## Why these two and nothing else

The rest of both files was reviewed against the same test — *could a session working in this repo reconstruct this by reading the code?* — and everything else is a keep: gotchas and failure contracts, safety prohibitions (`No Framework Bleed`, `Never Touch Protos or Secrets`, `Privacy First`), repo etiquette, non-guessable build invocations (the `test` vs `allTests` distinction, the bootstrap steps), and pointers into `.skills/`.

Two deliberate non-changes worth flagging for review:

- **`AGENTS.md:31`'s baseline-verification line was kept** even though `CLAUDE.md:28-32` states the same command more fully. `AGENTS.md` is read standalone by Gemini and Copilot sessions that never load `CLAUDE.md`, so that "duplicate" is load-bearing there.
- **The `.claude/settings.json` guarded-files note in `CLAUDE.md` was kept.** The deny/ask rules do enforce it mechanically, but the useful half — *consult `.skills/compose-ui/strings-index.txt` instead of the raw file* — is a pointer no rule conveys.

## Testing Performed

None, and none applies: this is a two-line deletion from two Markdown files that no build, lint, or CI job reads. `spotless` and `detekt` do not inspect `AGENTS.md`/`CLAUDE.md`, and there is no markdown-lint or docs-sync job in `.github/workflows/`. The full Gradle baseline was deliberately not run — it exercises nothing this diff touches. Reviewers should confirm the two removals read correctly in context; `git diff` is the whole story.

Net effect is about 55 fewer resident tokens per session, which is negligible — the real motivation is removing a version list that will silently go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance by removing outdated technology-stack details.
  * Simplified development instructions by removing the requirement to provide step-by-step reasoning before actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->