### PR TITLE
fix(mqtt): log throwable-less client errors at warn

### DIFF
--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/KermitMqttLogger.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/KermitMqttLogger.kt
@@ -49,12 +49,11 @@ class KermitMqttLogger(
 
             MqttLogLevel.WARN -> logger.w(throwable) { message }
 
-            // The library reports a broker that closed the socket, an unreachable host, or Wi-Fi dropping mid-read at
-            // ERROR ("Read loop error: Not enough data available"), and the client then reconnects on its own. Those
-            // are expected for a mobile client and dominated our error tracking, so log them at WARN — diagnosable in
-            // a support session, but not counted as application errors.
+            // The library logs its connection lifecycle at ERROR — broker socket close, unreachable host, Wi-Fi drop —
+            // and reconnects itself; broker rejections arrive without a throwable and are user config, surfaced via
+            // MqttProbeStatus. Neither is an app defect, so both log at WARN. Real faults carry a throwable.
             MqttLogLevel.ERROR ->
-                if (throwable?.isExpectedConnectionFailure() == true) {
+                if (throwable == null || throwable.isExpectedConnectionFailure()) {
                     logger.w(throwable) { message }
                 } else {
                     logger.e(throwable) { message }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/KermitMqttLoggerTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/KermitMqttLoggerTest.kt
@@ -67,10 +67,36 @@ class KermitMqttLoggerTest {
     }
 
     @Test
-    fun `an error with no throwable stays an error`() {
+    fun `an error with no throwable is downgraded to WARN`() {
+        // A bare message carries no stack or type to triage, so it must not count as an application error.
         mqttLogger.log(level = MqttLogLevel.ERROR, tag = "MqttClient", message = "boom", throwable = null)
 
-        assertEquals(Severity.Error, writer.entries.single().first)
+        assertEquals(Severity.Warn, writer.entries.single().first)
+    }
+
+    @Test
+    fun `a connection teardown log is not reported as an application error`() {
+        mqttLogger.log(
+            level = MqttLogLevel.ERROR,
+            tag = "MqttConnection",
+            message = "Fatal error — tearing down connection",
+            throwable = null,
+        )
+
+        assertEquals(Severity.Warn, writer.entries.single().first)
+    }
+
+    @Test
+    fun `a broker rejection is a user configuration problem rather than an application error`() {
+        // Surfaced to the user through MqttProbeStatus, so it is not an app defect.
+        mqttLogger.log(
+            level = MqttLogLevel.ERROR,
+            tag = "MqttConnection",
+            message = "Connection refused: BAD_USER_NAME_OR_PASSWORD",
+            throwable = null,
+        )
+
+        assertEquals(Severity.Warn, writer.entries.single().first)
     }
 
     @Test


### PR DESCRIPTION
The MQTT client's ordinary connection lifecycle is being reported as application errors, burying real regressions in release triage. `KermitMqttLogger` gated its WARN downgrade on `throwable?.isExpectedConnectionFailure() == true`; when MQTTastic logs at ERROR with **no throwable** the safe call yields `null`, which is not `true`, so the entry fell through to `Logger.e` — and `isExpectedConnectionFailure()` could never help, because there was no exception to classify.

This is the residual gap left by #6470, which fixed the same class of noise but only where a throwable exists.

### 🐛 Bug Fixes

- `KermitMqttLogger` now treats a throwable-less ERROR as not reportable: `throwable == null || throwable.isExpectedConnectionFailure()` logs at WARN. Genuine library faults still arrive with a throwable and are still reported at error level.

**What this silences,** all of which arrive without a throwable:

- `Fatal error — tearing down connection` — the largest non-network error signature in the app by a wide margin
- `Connection timed out waiting for CONNACK`
- `Connection refused: BAD_USER_NAME_OR_PASSWORD` / `NOT_AUTHORIZED` / `BANNED` / `UNSUPPORTED_PROTOCOL_VERSION` — user configuration problems, already surfaced to the user through `MqttProbeStatus`, which is the actionable path

**Reviewer note — this reverses a deliberate choice.** The previous test asserted `an error with no throwable stays an error`; that was intentional, not an oversight. Field data reversed it: a bare message carries no stack and no type, so there is nothing for anyone to triage, which is exactly what `Logger.e` is reserved for per `.skills/code-review/SKILL.md` §8. If you would rather scope this to specific message patterns instead of all throwable-less ERRORs, that is a reasonable alternative — happy to tighten it.

**Blast radius is the MQTT bridge only.** Throwable-less `Logger.e` calls in our own code (handshake stalls, BLE errors, TCP reader, serial-device-not-found) are untouched.

### Testing Performed

`core/network/src/commonTest/.../KermitMqttLoggerTest.kt`:

- `an error with no throwable is downgraded to WARN` — **inverted** from the previous assertion
- `a connection teardown log is not reported as an application error` — new
- `a broker rejection is a user configuration problem rather than an application error` — new
- existing coverage for the throwable-bearing expected/genuine split unchanged and still passing

Full local baseline green: `spotlessApply spotlessCheck detekt assembleDebug test allTests`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT error classification to prevent expected connection events and broker rejections without exception details from appearing as application errors.
  * These events are now recorded as warnings, reducing misleading error reporting while preserving visibility into network issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->