### PR TITLE
fix(connections): dedupe recent-TCP and reaction list keys

### DIFF
--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/Packet.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/Packet.kt
@@ -55,7 +55,15 @@ data class PacketEntity(
             status = data.status,
             routingError = routingError,
             packetId = packetId,
-            emojis = reactions.filter { it.myNodeNum == myNodeNum || it.myNodeNum == 0 }.toReaction(getNode),
+            emojis =
+            reactions
+                .filter { it.myNodeNum == myNodeNum || it.myNodeNum == 0 }
+                // myNodeNum is part of the reactions primary key, so the legacy 0 bucket can hold the same
+                // (user, emoji) as this node's. The UI keys reaction rows on that pair, so keep one — the
+                // current node's, which carries the live delivery status.
+                .sortedBy { it.myNodeNum == 0 }
+                .distinctBy { it.userId to it.emoji }
+                .toReaction(getNode),
             replyId = data.replyId,
             viaMqtt = data.viaMqtt,
             relayNode = data.relayNode,

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/entity/ReactionKeyTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/entity/ReactionKeyTest.kt
@@ -86,6 +86,7 @@ class ReactionKeyTest {
 
         val keys = entity.toMessage(getNode).emojis.map { it.user.id to it.emoji }
 
+        assertEquals(3, keys.size, "keys: $keys")
         assertEquals(3, keys.toSet().size, "keys: $keys")
     }
 

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/entity/ReactionKeyTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/entity/ReactionKeyTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database.entity
+
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.model.DataPacket
+import org.meshtastic.core.model.MessageStatus
+import org.meshtastic.core.model.Node
+import org.meshtastic.proto.User
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The reaction dialog keys its rows on `user.id` + `emoji`. `myNodeNum` is part of the `reactions` primary key, so the
+ * legacy `myNodeNum = 0` bucket and this node's rows can carry the same pair — a duplicate key there is fatal.
+ */
+class ReactionKeyTest {
+
+    @Test
+    fun `a legacy reaction and its current-node twin collapse to one entry`() = runTest {
+        val entity =
+            packetEntity(
+                reactions =
+                listOf(
+                    reaction(myNodeNum = 0, userId = "!abcd1234", emoji = "👍"),
+                    reaction(myNodeNum = MY_NODE_NUM, userId = "!abcd1234", emoji = "👍"),
+                ),
+            )
+
+        val emojis = entity.toMessage(getNode).emojis
+
+        assertEquals(1, emojis.size, "duplicate user+emoji keys crash the reaction list: $emojis")
+    }
+
+    @Test
+    fun `the current-node row wins so its delivery status survives`() = runTest {
+        val entity =
+            packetEntity(
+                reactions =
+                listOf(
+                    reaction(myNodeNum = 0, userId = "!abcd1234", emoji = "👍"),
+                    reaction(
+                        myNodeNum = MY_NODE_NUM,
+                        userId = "!abcd1234",
+                        emoji = "👍",
+                        status = MessageStatus.DELIVERED,
+                    ),
+                ),
+            )
+
+        assertEquals(MessageStatus.DELIVERED, entity.toMessage(getNode).emojis.single().status)
+    }
+
+    @Test
+    fun `a lone legacy reaction is still shown`() = runTest {
+        val entity = packetEntity(reactions = listOf(reaction(myNodeNum = 0, userId = "!abcd1234", emoji = "🎉")))
+
+        assertEquals(1, entity.toMessage(getNode).emojis.size)
+    }
+
+    @Test
+    fun `distinct users and distinct emoji stay distinct`() = runTest {
+        val entity =
+            packetEntity(
+                reactions =
+                listOf(
+                    reaction(myNodeNum = MY_NODE_NUM, userId = "!abcd1234", emoji = "👍"),
+                    reaction(myNodeNum = MY_NODE_NUM, userId = "!abcd1234", emoji = "🎉"),
+                    reaction(myNodeNum = MY_NODE_NUM, userId = "!beef5678", emoji = "👍"),
+                ),
+            )
+
+        val keys = entity.toMessage(getNode).emojis.map { it.user.id to it.emoji }
+
+        assertEquals(3, keys.toSet().size, "keys: $keys")
+    }
+
+    @Test
+    fun `another node's reactions are excluded entirely`() = runTest {
+        val entity =
+            packetEntity(reactions = listOf(reaction(myNodeNum = OTHER_NODE_NUM, userId = "!abcd1234", emoji = "👍")))
+
+        assertEquals(emptyList(), entity.toMessage(getNode).emojis)
+    }
+
+    private fun packetEntity(reactions: List<ReactionEntity>) = PacketEntity(
+        packet =
+        Packet(
+            uuid = 1L,
+            myNodeNum = MY_NODE_NUM,
+            port_num = 1,
+            contact_key = "0^all",
+            received_time = 1_000L,
+            read = true,
+            data = DataPacket(bytes = null, dataType = 1, from = "!abcd1234", time = 1_000L),
+            packetId = PACKET_ID,
+        ),
+        reactions = reactions,
+    )
+
+    private fun reaction(myNodeNum: Int, userId: String, emoji: String, status: MessageStatus = MessageStatus.UNKNOWN) =
+        ReactionEntity(
+            myNodeNum = myNodeNum,
+            replyId = PACKET_ID,
+            userId = userId,
+            emoji = emoji,
+            timestamp = 1_000L,
+            packetId = PACKET_ID,
+            status = status,
+        )
+
+    private val getNode: suspend (String?) -> Node = { userId -> Node(num = 1, user = User(id = userId.orEmpty())) }
+
+    private companion object {
+        const val MY_NODE_NUM = 42
+        const val OTHER_NODE_NUM = 99
+        const val PACKET_ID = 7
+    }
+}

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/TcpDiscoveryHelpers.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/TcpDiscoveryHelpers.kt
@@ -90,6 +90,9 @@ internal fun buildRecentTcpEntries(
 ): List<DeviceListEntry.Tcp> = recentAddresses
     .filterNot { discoveredAddresses.contains(it.address) }
     .map { DeviceListEntry.Tcp(it.name, it.address) }
+    // The persisted list is not guaranteed unique: only add() dedupes, and legacy blobs bypass it. The device list
+    // keys on fullAddress, and duplicate LazyColumn keys are a hard crash.
+    .distinctBy { it.fullAddress }
     .map { entry ->
         entry.copy(node = findNodeByNameSuffix(entry.name, entry.fullAddress, nodeDb, databaseManager))
     }

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/domain/usecase/TcpDiscoveryHelpersTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/domain/usecase/TcpDiscoveryHelpersTest.kt
@@ -192,6 +192,23 @@ class TcpDiscoveryHelpersTest {
     }
 
     @Test
+    fun `buildRecentTcpEntries dedupes repeated addresses`() {
+        // A legacy recent-addresses blob is read back verbatim, so it can repeat an address that add() would have
+        // collapsed. Two rows with one fullAddress is a duplicate LazyColumn key, which is fatal.
+        val recentAddresses =
+            listOf(
+                RecentAddress("t192.168.1.50", "NodeA"),
+                RecentAddress("t192.168.1.50", "NodeA"),
+                RecentAddress("t192.168.1.51", "NodeB"),
+            )
+        val databaseManager = mock<DatabaseManager> { every { hasDatabaseFor(any()) } returns false }
+
+        val result = buildRecentTcpEntries(recentAddresses, emptySet(), emptyMap(), databaseManager)
+
+        result.map { it.fullAddress } shouldBe listOf("t192.168.1.50", "t192.168.1.51")
+    }
+
+    @Test
     fun `buildRecentTcpEntries matches node by suffix`() {
         val node = TestDataFactory.createTestNode(num = 1, userId = "!test1234")
         val recentAddresses = listOf(RecentAddress("tMeshtastic_1234", "Meshtastic_1234"))


### PR DESCRIPTION
Crashlytics `159e25351be7042db517f3af684684db` is the whole `IllegalArgumentException: Key "…" was already used` class — Compose surfaces it from `SubcomposeLayout.subcompose` with no app frames, so the only site identifier is the key string. Triage pointed at two sites; **both turn out to be already fixed on `main`**, and the events are all from builds that predate those fixes. This PR closes the two sites in the same class that are still open.

### Why the two reported sites need no change

`versionCode = git commit count + 29314197`, so build → commit is invertible:

| Reported site | Sample key | Fixed by | First build with the fix |
|---|---|---|---|
| `Contacts.kt` conversation list | `2^all` | #6169 replaced the **paged** contact list with the Map-derived `contactList` + a disjoint `partition` | 29321415 |
| `DeviceList.kt` discovered network list | `tcp-discovered:t…` | #6189 added `distinctBy { it.fullAddress }` to `processTcpServices` | 29321430 |

At the crashing revision (`cf68c86a`, 2.7.14 = **29321034**, the current Play release) `Contacts.kt` keyed a `LazyPagingItems` list off `contacts.itemKey { it.contactKey }` — paging repeats a row across a page boundary when the backing query changes mid-load, which is where `2^all` came from. `contactList` is now built from a `Map<String, DataPacket>` merged with `placeholder - contacts.keys`, so a duplicate `contactKey` is structurally impossible, and the Channels/DM sections come from one `partition` and cannot overlap.

The two largest variants (272 of ~554 events over 90 days, and both events from today) are `tcp-discovered:` on 29321034. Every remaining event sits on a build below 29321430. Nothing to change at either site; the fixes just haven't shipped to the release track yet.

### 🐛 Bug Fixes

- **`buildRecentTcpEntries` now dedupes by `fullAddress`.** It trusted the persisted recent-addresses list to be unique, but only `add()` dedupes — a legacy JSON blob is parsed and returned verbatim, and `setRecentAddresses` accepts any list. `tcp-recent:<addr>` is the same key namespace, in the same `LazyColumn`, one section below the discovered list its sibling `processTcpServices` already guards.
- **`PacketEntity.toMessage` now keeps one reaction per `(user, emoji)`.** It admitted both the legacy `myNodeNum = 0` bucket and this node's rows; `myNodeNum` is part of the `reactions` primary key, so the same `(reply_id, user_id, emoji)` triple legitimately exists in both, while `ReactionDialog` keys its rows on `"${user.id}:${emoji}"` alone. A stable `sortedBy { it.myNodeNum == 0 }` puts legacy rows last so the current node's row — the one carrying live delivery status — survives. This also stops the reaction count badge from double-counting the same tapback.

Both are `distinctBy` rather than an index suffix: a repeated address and a legacy/current reaction pair are *redundant representations of one row*, not two rows, so an index suffix would render a visible duplicate instead of a crash. It also keeps the recent list symmetric with the discovered list beside it.

### Testing Performed

`feature/connections/src/commonTest/.../TcpDiscoveryHelpersTest.kt`:
- `buildRecentTcpEntries dedupes repeated addresses` — the legacy-blob shape, asserting one entry per address

New `core/database/src/commonTest/.../ReactionKeyTest.kt`:
- `a legacy reaction and its current-node twin collapse to one entry` — the shape that crashes
- `the current-node row wins so its delivery status survives` — pins which row the dedupe keeps
- `a lone legacy reaction is still shown` — guards against dropping pre-migration reactions
- `distinct users and distinct emoji stay distinct` — the dedupe key isn't too coarse
- `another node's reactions are excluded entirely` — the pre-existing `myNodeNum` filter still holds

Full local baseline green: `spotlessApply spotlessCheck detekt assembleDebug test allTests`.

No appearance change — both edits affect item identity and a de-duplicated count only, so there is nothing visual to capture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate emoji reactions from appearing on messages while preserving the most relevant reaction status.
  * Legacy and current reaction records are now combined consistently, while reactions from unrelated nodes remain excluded.
  * Removed duplicate recent TCP device entries to prevent repeated devices and connection list display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->