### PR TITLE
fix(connections): send set_time_only at MyNodeInfo instead of onNodeDbReady

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/CommandSenderImpl.kt
@@ -182,6 +182,12 @@ class CommandSenderImpl(
         packetHandler.sendToRadio(packet)
     }
 
+    override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {
+        val adminMsg = initFn().copy(session_passkey = sessionManager.getPasskey(destNum))
+        val packet = buildAdminPacket(to = destNum, adminMessage = adminMsg)
+        packetHandler.sendToRadio(ToRadio(packet = packet))
+    }
+
     override suspend fun sendAdminAwait(
         destNum: Int,
         requestId: Int,

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
@@ -343,6 +343,7 @@ class MeshConfigFlowManagerImpl(
                 // this newer session. The async clear also rechecks transport authority before touching persistence.
                 clearGeneration = handshakeGeneration.incrementAndGet()
                 connectionManager.value.onHandshakeProgress()
+                connectionManager.value.onMyNodeInfoReceived(myInfo.my_node_num)
             }
         if (!admitted) {
             Logger.d { "[DeviceAssociation] discard stale MyNodeInfo gen=${session.generation}" }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -500,20 +500,26 @@ class MeshConnectionManagerImpl(
         }
     }
 
+    override fun onMyNodeInfoReceived(myNodeNum: Int) {
+        // Set device time as early as possible: MyNodeInfo is the first Stage 1 frame, so this
+        // lands before the firmware flushes its queued packet backlog and lets it stamp those
+        // packets with a corrected clock (firmware #11274). A single small write ahead of the
+        // config/node-info bursts avoids the GATT contention that pushed the old
+        // onRadioConfigLoaded-time send out of Stage 1. Must bypass the outbound packet queue:
+        // it only drains once Connected, which would hold this until after the backlog flush.
+        commandSender.sendAdminImmediate(myNodeNum) { AdminMessage(set_time_only = nowSeconds.toInt()) }
+    }
+
     override suspend fun onNodeDbReady() {
         // Collapse cancel+clear into one atomic swap so a concurrent re-arm cannot
         // orphan a job in the gap between cancel and reassign.
         handshakeTimeout.getAndSet(null)?.cancel()
 
         val myNodeNum = nodeManager.myNodeNum.value ?: 0
-        // Set device time now that the full node picture is ready. Sending this during Stage 1
-        // (onRadioConfigLoaded) introduced GATT write contention with the Stage 2 node-info burst.
-        commandSender.sendAdmin(myNodeNum) { AdminMessage(set_time_only = nowSeconds.toInt()) }
-
         // Proactively seed the session passkey. The firmware embeds session_passkey in every
-        // admin *response* (wantResponse=true), but set_time_only has no response. A get_owner
-        // request is the lightest way to trigger a response and populate the passkey cache so
-        // that subsequent write operations don't fail with ADMIN_BAD_SESSION_KEY.
+        // admin *response* (wantResponse=true), but set_time_only (sent at MyNodeInfo) has no
+        // response. A get_owner request is the lightest way to trigger a response and populate the
+        // passkey cache so that subsequent write operations don't fail with ADMIN_BAD_SESSION_KEY.
         commandSender.sendAdmin(myNodeNum, wantResponse = true) { AdminMessage(get_owner_request = true) }
 
         // Start MQTT if enabled

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/CommandSenderImplTest.kt
@@ -21,6 +21,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verifySuspend
@@ -40,11 +41,13 @@ import org.meshtastic.core.repository.PacketHandler
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.SessionManager
 import org.meshtastic.core.repository.TracerouteHandler
+import org.meshtastic.proto.AdminMessage
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.NeighborInfo
 import org.meshtastic.proto.PortNum
+import org.meshtastic.proto.ToRadio
 import org.meshtastic.proto.User
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -200,6 +203,34 @@ class CommandSenderImplTest {
         commandSender.sendAdmin(DEST_NODE) { org.meshtastic.proto.AdminMessage(get_owner_request = true) }
 
         verifySuspend { packetHandler.sendToRadio(any<MeshPacket>()) }
+    }
+
+    // --- sendAdminImmediate ---
+
+    @Test
+    fun sendAdminImmediate_dispatchesDirectToRadioWithPasskeyAndNoResponse() {
+        val passkey = "secret".encodeUtf8()
+        every { sessionManager.getPasskey(DEST_NODE) } returns passkey
+        every { packetHandler.sendToRadio(any<ToRadio>()) } returns Unit
+
+        commandSender.sendAdminImmediate(DEST_NODE) { AdminMessage(set_time_only = 12345) }
+
+        // Direct ToRadio dispatch (not the Connected-gated MeshPacket queue), correct destination,
+        // no want_response, and the session passkey injected into the admin payload.
+        verify {
+            packetHandler.sendToRadio(
+                matches<ToRadio> { toRadio ->
+                    val packet = toRadio.packet ?: return@matches false
+                    val decoded = packet.decoded ?: return@matches false
+                    val admin = AdminMessage.ADAPTER.decode(decoded.payload)
+                    packet.to == DEST_NODE &&
+                        decoded.portnum == PortNum.ADMIN_APP &&
+                        !decoded.want_response &&
+                        admin.set_time_only == 12345 &&
+                        admin.session_passkey == passkey
+                },
+            )
+        }
     }
 
     // --- requestTraceroute ---

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/LockdownCoordinatorImplTest.kt
@@ -114,6 +114,8 @@ class LockdownCoordinatorImplTest {
             initFn: () -> AdminMessage,
         ) = Unit
 
+        override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) = Unit
+
         override suspend fun sendAdminAwait(
             destNum: Int,
             requestId: Int,
@@ -148,6 +150,8 @@ class LockdownCoordinatorImplTest {
         }
 
         override fun startNodeInfoOnly() = Unit
+
+        override fun onMyNodeInfoReceived(myNodeNum: Int) = Unit
 
         override suspend fun onNodeDbReady() = Unit
 

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
@@ -49,6 +49,13 @@ interface CommandSender {
     )
 
     /**
+     * Sends an admin message immediately, bypassing the outbound packet queue. The queue only drains while the
+     * connection state is Connected, so mid-handshake sends (e.g. set_time_only at MyNodeInfo) must use this path or
+     * they stall until the handshake finishes.
+     */
+    fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage)
+
+    /**
      * Sends an admin message and suspends until the radio acknowledges it.
      *
      * This is used when the caller needs to guarantee a packet has been accepted by the radio before proceeding, such

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshConnectionManager.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshConnectionManager.kt
@@ -29,6 +29,13 @@ interface MeshConnectionManager {
     /** Initiates the node information synchronization stage. */
     fun startNodeInfoOnly()
 
+    /**
+     * Called when the MyNodeInfo frame arrives — the first frame of the Stage 1 config stream. This is the earliest
+     * point where the local node number is authoritative, before the firmware flushes its queued packet backlog, so
+     * time-sensitive setup (e.g. set_time_only) sent here lets the firmware stamp backlog packets with real rx_time.
+     */
+    fun onMyNodeInfoReceived(myNodeNum: Int)
+
     /** Called when the node database is ready and fully populated. */
     suspend fun onNodeDbReady()
 

--- a/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
+++ b/core/takserver/src/commonTest/kotlin/org/meshtastic/core/takserver/TAKMeshIntegrationTest.kt
@@ -134,6 +134,8 @@ class TAKMeshIntegrationTest {
             initFn: () -> AdminMessage,
         ) {}
 
+        override fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage) {}
+
         override suspend fun sendAdminAwait(
             destNum: Int,
             requestId: Int,


### PR DESCRIPTION
### 🛠️ Why

The app has sent `set_time_only` on every config handshake since #4103 — but at the *end* of the handshake (`onNodeDbReady`). By then the firmware has already begun flushing its queued packet backlog to the phone, so the backlog is stamped with the device's old clock. Firmware meshtastic/firmware#11274 introduces backlog re-timing, which only helps if the phone's time arrives **before** the packets are requested.

### What changed

- `set_time_only` now goes out the moment the `MyNodeInfo` frame arrives — the first Stage 1 frame, and the earliest point the local node number is authoritative (new `MeshConnectionManager.onMyNodeInfoReceived` hook).
- The send bypasses the outbound packet queue via a new `CommandSender.sendAdminImmediate`: the queue only drains while `Connected`, which would otherwise hold the packet until after the backlog flush (verified on hardware — the queued path delayed it ~4s, landing after the flush began).
- The `get_owner_request` session-passkey seeding stays at `onNodeDbReady`, unchanged.

### 🧪 Testing Performed

- New unit test pins the `sendAdminImmediate` contract: direct `ToRadio` dispatch (not the Connected-gated queue), destination, `ADMIN_APP` portnum, `want_response=false`, and `session_passkey` injection.
- `spotlessCheck detekt :core:data:allTests :core:repository:allTests :core:service:allTests :core:takserver:allTests` all green.
- E2E on Pixel 9 Pro (fdroid debug) + RAK4631 (WisMesh Pocket) over BLE, watching the firmware serial log:
  - **Before:** `Client received set_time_only command` arrived ~100 ms *after* the first backlog `phone downloaded packet`.
  - **After:** it arrives during the Stage 1 config stream (`state=3`), ~5 s *before* `Config Send Complete` and the backlog/replay drain. Handshake completes normally — no GATT contention from the single early write.
  - (Test node has GPS, so firmware correctly ignored the NTP-quality time — the ordering is what was under test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Device time is now set earlier during connection setup, improving message timing and synchronization.
  - Local node information is processed immediately after handshake progress updates.
  - Administrative commands can be sent immediately when needed, bypassing the normal outbound packet queue.
- **Documentation**
  - Expanded guidance on when local node number information is first authoritative during the connection stream.
- **Tests**
  - Updated and added coverage for immediate admin message dispatch, including passkey injection and expected packet attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->