### PR TITLE
chore(review): cut CodeRabbit round-trips and enforce the repeat defect classes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -115,9 +115,11 @@ reviews:
           field was updated, not just the one the bug was reported against. Ambient temperature
           was fixed in NodeItem.kt while its sibling NodeItemCompact.kt kept the zero-guard.
           Name any unfixed sibling explicitly. Also flag a new field defaulting to 0 where 0 is
-          a physically reachable value on that scale (RSSI, SNR, temperature, current, voltage,
-          particulate concentration); humidity is the one exception, where 0 %RH is unreachable
-          and the guard is intentional and tested.
+          a physically reachable value on that scale (RSSI, temperature, current, voltage,
+          particulate concentration). Two exceptions, do NOT flag either: humidity, where 0 %RH
+          is unreachable and the guard is intentional and tested; and the proto `rx_snr`, which
+          has no presence upstream, so its 0f ambiguity cannot be fixed app-side. An app-level
+          SNR field that IS nullable is still in scope.
       - name: "Tests prove the path, not the end state"
         mode: "warning"
         instructions: >-

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,10 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    # Review once when the PR goes ready, then on demand via `@coderabbitai review`.
+    # Re-reviewing every push turned 6-commit PRs into 8 review rounds, because each
+    # fix commit reopened a full pass. Batch the fixes, push, then ask for one re-review.
+    auto_incremental_review: false
     ignore_usernames:
       - renovate
       - renovate[bot]
@@ -69,18 +73,20 @@ reviews:
     - path: feature/car/
       instructions: Run unit tests with `./gradlew :feature:car:testGoogleDebugUnitTest`, and keep Robolectric pinned to SDK 36 for this module.
 
-  # CI is the source of truth for detekt + spotless (Zero Lint Tolerance gate),
-  # so disable detekt here to avoid duplicate comments. Keep the security/CI/shell
-  # scanners CI doesn't run inline.
+  # Every CodeRabbit tool is enabled by default, so this block only ever needs to
+  # turn things OFF or configure them. detekt is off because CI owns it (Zero Lint
+  # Tolerance gate) and duplicate comments were the noise we removed. The scanners
+  # CI doesn't run — gitleaks, shellcheck, actionlint, zizmor, semgrep, trivy,
+  # presidio (PII), buf (protobuf) — are already on by default; don't re-list them.
   tools:
     detekt:
       enabled: false
-    gitleaks:
-      enabled: true
-    shellcheck:
-      enabled: true
-    actionlint:
-      enabled: true
+    # Custom AST rules mechanically enforce the recurring defect classes that prose
+    # can't. See .coderabbit/ast-grep-rules/ and .skills/code-review/SKILL.md.
+    # essential_rules stays on (default) — these are additive.
+    ast-grep:
+      rule_dirs:
+        - ".coderabbit/ast-grep-rules"
 
   # Auto-generated docstrings/tests/autofix are noisy for a repo with strict
   # human-authored KDoc and KMP-aware tests; leave finishing touches off.
@@ -91,12 +97,43 @@ reviews:
       enabled: false
 
   # No KDoc-coverage mandate in this repo; the default warning-at-80% check
-  # would nag every PR.
+  # would nag every PR. PR titles are already linted by CI
+  # (.github/workflows/pull-request-target.yml), so no title check here either.
   pre_merge_checks:
     docstrings:
       mode: "off"
+    # The two defect classes that survive review-by-prose because they are about
+    # what's ABSENT from a diff — a sibling call site left unfixed, or a test that
+    # would still pass with the fix reverted. Warning, not error: these are
+    # judgment calls and a false positive must not block a merge.
+    custom_checks:
+      - name: "Sibling call sites and presence semantics"
+        mode: "warning"
+        instructions: >-
+          When a diff changes how an absent value is represented — making a field nullable,
+          removing a zero-guard, or adding a presence check — verify EVERY call site of that
+          field was updated, not just the one the bug was reported against. Ambient temperature
+          was fixed in NodeItem.kt while its sibling NodeItemCompact.kt kept the zero-guard.
+          Name any unfixed sibling explicitly. Also flag a new field defaulting to 0 where 0 is
+          a physically reachable value on that scale (RSSI, SNR, temperature, current, voltage,
+          particulate concentration); humidity is the one exception, where 0 %RH is unreachable
+          and the guard is intentional and tested.
+      - name: "Tests prove the path, not the end state"
+        mode: "warning"
+        instructions: >-
+          For each added or changed test, decide whether it would still pass if the production
+          code it covers were reverted. Flag tests that seed a fake's backing store and then
+          assert the value comes back, tests that assert only a collection's size rather than
+          which items survived, and tests asserting emission ORDER under Dispatchers.Unconfined
+          (not a stable contract). A test must assert the side effect only the intended path
+          produces — a call counter, a request issued, a cache written.
 
 knowledge_base:
+  # Learnings are how a confirmed finding stops recurring on the next PR. Pin the
+  # scope to this repo: the default `auto` already resolves to `local` for public
+  # repos, but being explicit keeps it from shifting if visibility ever changes.
+  learnings:
+    scope: local
   # Feed CodeRabbit the same guidance human/AI contributors follow, including
   # the repo-specific .skills/ modules and Copilot path instructions it
   # wouldn't pick up by default.

--- a/.coderabbit/ast-grep-rules/presence-vs-sentinel-zero-float.yml
+++ b/.coderabbit/ast-grep-rules/presence-vs-sentinel-zero-float.yml
@@ -1,0 +1,19 @@
+# Class A of "Recurring Defect Classes" in .skills/code-review/SKILL.md, enforced mechanically.
+# 0 is a real reading on these scales, so a zero-guard silently drops a genuine measurement.
+# Humidity is deliberately excluded: 0 %RH is not physically reachable, and
+# EnvironmentMetricsForGraphingTest.humidity_zeroFilteredOut asserts that guard on purpose.
+id: presence-vs-sentinel-zero-float
+language: kotlin
+severity: warning
+message: >-
+  Zero-guard on a zero-inclusive scale drops real readings. 0 is valid for temperature,
+  current, voltage and soil moisture, so `(x ?: 0f) != 0f` hides a genuine measurement and
+  conflates it with "not reported". Use a null check — `x?.let { }` — as NodeItem.kt does for
+  ambient temperature. Humidity is the one legitimate exception and is excluded from this rule.
+note: >-
+  See .skills/code-review/SKILL.md, "Recurring Defect Classes", class A.
+rule:
+  pattern: "($FIELD ?: 0f) != 0f"
+constraints:
+  FIELD:
+    regex: "\\.(temperature|soil_temperature|co2_temperature|current|voltage|soil_moisture)$"

--- a/.coderabbit/ast-grep-rules/presence-vs-sentinel-zero-signal.yml
+++ b/.coderabbit/ast-grep-rules/presence-vs-sentinel-zero-signal.yml
@@ -1,0 +1,28 @@
+# Class A of "Recurring Defect Classes" in .skills/code-review/SKILL.md, enforced mechanically.
+# Presence in this repo is nullability: the models are Wire-generated, so there is no hasX()
+# accessor — an optional proto field is simply `Int?`/`Float?`. The proto `rx_rssi` only becomes
+# `Int?` in protobufs 2.7.26.138 (PR #6498, still open at time of writing); on the pinned
+# 2.7.26.130 it is `Int = 0`. So this rule currently guards APP-level nullable rssi (parameters,
+# state, BLE advertisement values) and becomes a proto regression guard once #6498 lands.
+# RSSI only, deliberately NOT snr: rx_snr still has no proto presence upstream, so a 0f guard there
+# is genuinely ambiguous and unfixable app-side — flagging it would be pure noise on code nobody can
+# correct. Also excludes `replyId ?: 0` and `packet.from.takeIf { it != 0 }`, which are legitimate
+# because 0 there means "unset", not "a measurement of zero".
+id: presence-vs-sentinel-zero-signal
+language: kotlin
+severity: warning
+message: >-
+  Zero-default on a signal metric conflates "not reported" with a real reading. 0 dBm is a
+  valid RSSI (SX126x reports exactly 0, SX127x can go positive) and on a signal-strength scale
+  it renders as the STRONGEST value — so an unknown signal displays as excellent. Keep the type
+  nullable and branch on null; MetricFormatter.rssi(null) already renders "—".
+note: >-
+  See .skills/code-review/SKILL.md, "Recurring Defect Classes", class A. rx_snr still has no
+  proto presence upstream, so its 0f ambiguity cannot be fixed app-side — do not re-raise that.
+rule:
+  any:
+    - pattern: "$RECV.takeIf { it != 0 }"
+    - pattern: "$RECV ?: 0"
+constraints:
+  RECV:
+    regex: "(?i)rssi$"

--- a/.coderabbit/ast-grep-rules/presence-vs-sentinel-zero-signal.yml
+++ b/.coderabbit/ast-grep-rules/presence-vs-sentinel-zero-signal.yml
@@ -1,9 +1,14 @@
 # Class A of "Recurring Defect Classes" in .skills/code-review/SKILL.md, enforced mechanically.
 # Presence in this repo is nullability: the models are Wire-generated, so there is no hasX()
-# accessor — an optional proto field is simply `Int?`/`Float?`. The proto `rx_rssi` only becomes
-# `Int?` in protobufs 2.7.26.138 (PR #6498, still open at time of writing); on the pinned
-# 2.7.26.130 it is `Int = 0`. So this rule currently guards APP-level nullable rssi (parameters,
-# state, BLE advertisement values) and becomes a proto regression guard once #6498 lands.
+# accessor — an optional field is simply a nullable type. The proto `rx_rssi` only becomes `Int?`
+# in protobufs 2.7.26.138 (PR #6498, still open at time of writing); on the pinned 2.7.26.130 it
+# is `Int = 0`. So this rule currently guards APP-level nullable rssi (parameters, state, BLE
+# advertisement values) and becomes a proto regression guard once #6498 lands.
+#
+# INT LITERALS ONLY, deliberately. RSSI is an integer dBm value everywhere in this repo —
+# proto `rx_rssi: Int`, `Node.rssi: Int`, `MetricFormatter.rssi(value: Int)` — and there is no
+# Float-typed rssi declaration anywhere. Adding `?: 0f` / `takeIf { it != 0f }` variants here
+# would be dead patterns. Float sentinels on genuinely-Float metrics are the float rule's job.
 # RSSI only, deliberately NOT snr: rx_snr still has no proto presence upstream, so a 0f guard there
 # is genuinely ambiguous and unfixable app-side — flagging it would be pure noise on code nobody can
 # correct. Also excludes `replyId ?: 0` and `packet.from.takeIf { it != 0 }`, which are legitimate
@@ -15,7 +20,7 @@ message: >-
   Zero-default on a signal metric conflates "not reported" with a real reading. 0 dBm is a
   valid RSSI (SX126x reports exactly 0, SX127x can go positive) and on a signal-strength scale
   it renders as the STRONGEST value — so an unknown signal displays as excellent. Keep the type
-  nullable and branch on null; MetricFormatter.rssi(null) already renders "—".
+  nullable and branch on null, rendering absence explicitly rather than substituting a number.
 note: >-
   See .skills/code-review/SKILL.md, "Recurring Defect Classes", class A. rx_snr still has no
   proto presence upstream, so its 0f ambiguity cannot be fixed app-side — do not re-raise that.

--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -3,6 +3,50 @@
 ## Description
 Perform comprehensive code reviews for `Meshtastic-Android`, ensuring changes adhere to KMP architecture, Kotlin Multiplatform conventions, MAD standards, and CMP best practices.
 
+## Recurring Defect Classes (check these first)
+
+These four classes account for most of the Major findings raised on recent PRs, and they recur because the compiler, `detekt`, and `spotless` cannot see any of them. Check them while *writing* the code, not only while reviewing it.
+
+### A. Presence vs. sentinel zero
+**A numeric field whose absence matters must be nullable. Never let `0` stand in for "not reported".**
+
+`0` is a legitimate reading for RSSI (0 dBm), SNR, temperature, and air-quality concentration, so a `0` default silently merges "no data" with a real measurement. Both directions are bugs: an absent value gets persisted and displayed as a real one, and a genuine `0` gets discarded by a `takeIf { it != 0 }` guard.
+
+- [ ] **Accumulators and defaults:** a field collected over time defaults to `null`, not `0`. Absence checks read `== null` and presence checks `!= null` — never `== 0` for either.
+- [ ] **Aggregates over empty sets:** median/mean/min helpers return `T?` and propagate `null` for an empty input. A `0` fallback ranks missing data as a perfect score — it outranks every real negative RSSI.
+- [ ] **Comparators:** sort missing values explicitly last; do not let them fall through to a numeric default.
+- [ ] **No zero-guards on real scales:** `takeIf { it != 0 }` is only valid where `0` is genuinely impossible. On any signed or zero-inclusive scale it destroys data.
+- [ ] **Proto presence:** when a proto field gains explicit presence, adopt the nullable accessor everywhere rather than keeping a `0` comparison. Fields with *no* presence cannot be fixed app-side — say so rather than faking it.
+- [ ] **Tests:** a nullable numeric needs **both** a null case and a zero-value case. One without the other does not pin the distinction.
+
+### B. Read–decide–write across a suspend boundary
+**Read the current value, decide, and write inside a single `dataStore.edit { }` block.**
+
+Reading a `StateFlow` (or a prior `suspend` getter), branching on it, and then issuing separate writes leaves a window where a concurrent change interleaves — so a guard can fire against state that no longer exists and clobber a user preference. `NotificationPrefsImpl.setGeofenceAlertOptIn` (`core/prefs/…/notification/NotificationPrefsImpl.kt`) is the reference example: it parses, mutates, caps, and writes in one `edit`.
+
+- [ ] Any "if the flag is X, set Y and Z" transition happens inside one `edit`/`updateData` lambda.
+- [ ] The decision reads the block's own `prefs`/`current` snapshot, **not** a cached `StateFlow` value from outside.
+- [ ] Multi-key transitions are one `edit` call, not several `scope.launch` writes.
+- [ ] Radio-side config mutations go through a single `editSettings { }` transaction (see `AdminController.editSettings`).
+
+### C. Tests that pass for the wrong reason
+**Assert that the intended code path produced the result — not merely that the result exists.**
+
+Seeding a fake's backing store and then asserting the value comes back passes even if the production code under test is deleted. The test must fail when the path breaks.
+
+- [ ] **Prove the path ran:** assert the side effect that only the intended path produces (a call counter incremented, a request issued, a cache written) alongside the observed value.
+- [ ] **Don't pre-seed the answer:** drive the value in through the path being tested (a gated fake response) instead of injecting it directly into the cache.
+- [ ] **Isolate the variable:** a test for one field must not let a second differing field explain the assertion.
+- [ ] **Assert survivors, not just counts:** for dedup/merge logic, assert the identities that remain, not the size.
+- [ ] **No ordering assertions under `Dispatchers.Unconfined`:** emission order is not a stable contract there — assert final state.
+
+### D. Room schema bump without a migration test
+**Every schema-version increment ships a migration test that proves existing rows survive.**
+
+- [ ] A new `core/database/schemas/<n>.json` is accompanied by an `(n-1)→n` test in `core/database/src/androidHostTest/.../*MigrationTest.kt`.
+- [ ] The test inserts rows at the old version, migrates, and asserts **row count and column values** are preserved — not merely that the migration runs.
+- [ ] Columns going nullable assert that pre-existing values are retained and that the new `NULL` state is reachable (this is class A at the storage layer).
+
 ## Code Review Checklist
 
 When reviewing code, meticulously verify the following categories. Flag any deviations and propose the canonical project pattern as a fix.

--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -13,7 +13,7 @@ These four classes account for most of the Major findings raised on recent PRs, 
 `0` is a legitimate reading for RSSI (0 dBm), SNR, temperature, and air-quality concentration, so a `0` default silently merges "no data" with a real measurement. Both directions are bugs: an absent value gets persisted and displayed as a real one, and a genuine `0` gets discarded by a `takeIf { it != 0 }` guard.
 
 - [ ] **Accumulators and defaults:** a field collected over time defaults to `null`, not `0`. Absence checks read `== null` and presence checks `!= null` — never `== 0` for either.
-- [ ] **Aggregates over empty sets:** median/mean/min helpers return `T?` and propagate `null` for an empty input. A `0` fallback ranks missing data as a perfect score — it outranks every real negative RSSI.
+- [ ] **Aggregates over empty sets:** median/mean/min helpers return `T?` and propagate `null` for an empty input. A `0` fallback biases the result in whichever direction the comparator sorts — under the higher-is-better RSSI ordering used for ranking, an empty set's `0` outranks a real `-80 dBm`; under a plain `min` it would instead win as the smallest. Either way the missing value competes as if measured.
 - [ ] **Comparators:** sort missing values explicitly last; do not let them fall through to a numeric default.
 - [ ] **No zero-guards on real scales:** `takeIf { it != 0 }` is only valid where `0` is genuinely impossible. On any signed or zero-inclusive scale it destroys data.
 - [ ] **Proto presence:** when a proto field gains explicit presence, adopt the nullable accessor everywhere rather than keeping a `0` comparison. Fields with *no* presence cannot be fixed app-side — say so rather than faking it.


### PR DESCRIPTION
## Why

Review rounds were outrunning commits. PR #6499 took **8 CodeRabbit review rounds over 6 commits**; #6498 took 5 over 4, #6497 5 over 3. The cause was mechanical, not qualitative: `auto_incremental_review` defaults to `true`, so every single-commit fix push reopened a full review pass, which surfaced new findings mid-stream and multiplied the loop.

The findings themselves are worth keeping. Across the last 13 non-bot PRs CodeRabbit produced ~18 findings — **1 Critical, 9 Major, 7 Minor, zero style nitpicks** — and each one I checked was confirmed valid rather than argued down. They catch semantic bugs CI structurally cannot: presence-vs-zero, read-modify-write races across a suspend boundary, tests that pass for the wrong reason.

So this shortens the loop and stops the same classes recurring, rather than dialing the review down.

## 🛠️ Changes

**Batch the reviews.** `auto_review.auto_incremental_review: false` — one review when the PR goes ready, then on demand via `@coderabbitai review` once fixes are batched into a single push. #6499 would have been ~2 rounds instead of 8.

**Document the recurring classes.** Four classes account for most Major findings, and none were written down: presence-vs-sentinel-zero, read–decide–write across a suspend boundary, tests that assert the end state instead of the path, and Room schema bumps without a migration test. They now lead `.skills/code-review/SKILL.md`. Because `knowledge_base.code_guidelines.filePatterns` already includes `.skills/**/SKILL.md`, this single edit tightens both the authoring and the reviewing end.

**Enforce class A mechanically.** Prose alone did not hold it — an audit found **9 live sites still in the tree**, including `(env.temperature ?: 0f) != 0f` in `NodeItemCompact.kt` that the `NodeItem.kt` fix missed, so a node reporting exactly 0 °C shows no temperature in the compact row. `tools.ast-grep.rule_dirs` now loads two Kotlin rules from `.coderabbit/ast-grep-rules/`.

**Two `pre_merge_checks`** for what an AST rule cannot see, because it is about what is *absent* from a diff: an unfixed sibling call site, and a test that would still pass if the fix were reverted. Both `mode: warning`, never `error` — these are judgment calls and a false positive must not block a merge.

## 🧹 Cleanups

- Dropped three no-op `tools` entries. **All 57 CodeRabbit tools default to `enabled: true`**, so listing `gitleaks`/`shellcheck`/`actionlint` as `enabled: true` did nothing; only `detekt: false` was load-bearing. `presidio` (PII), `zizmor`, `buf`, `semgrep` and `trivy` were already running.
- Pinned `knowledge_base.learnings.scope: local` — `auto` already resolves to local for public repos, but being explicit stops it shifting if visibility changes.
- No `pre_merge_checks.title`: CI already lints PR titles in `pull-request-target.yml`, and duplicating CI is what created the noise this config removed.

## Reviewer notes

**Scope: config and documentation only.** No Kotlin changed. The nine flagged code sites — 6 float guards plus 2 RSSI display paths and 1 BLE advertisement default — are tracked as separate work, since one is a user-facing defect that deserves its own PR with regression tests.

**The ast-grep rules are validated, not guessed.** Run against the tree with `ast-grep scan -r <rule> core/ feature/ androidApp/ desktopApp/`: 6 and 3 matches respectively, with these deliberate exclusions —

| Excluded | Why |
|---|---|
| `relative_humidity`, `co2_humidity` | 0 %RH is not physically reachable; the guard is intentional and `EnvironmentMetricsForGraphingTest.humidity_zeroFilteredOut` asserts it |
| `rx_snr` | Still `Float = 0f` upstream with no proto presence — genuinely unfixable app-side, so flagging it would be pure noise |
| `replyId`, `packet.from` | 0 there means "unset", not a measurement of zero |

Two ast-grep gotchas are captured in the rule files: patterns containing `?:` must be quoted (YAML reads `: ` as a mapping separator), and Rust's regex has no lookahead, so field names are anchored — `co2` otherwise matched `co2_humidity`.

**Presence here is nullability, not `hasX()`.** The models are Wire-generated, so there is no presence accessor; `EnvironmentMetrics.temperature/voltage/current/soil_temperature` are already `Float? = null`, which is why the zero-guards are discarding information the proto faithfully preserved. Note `packet.rx_rssi` is still `Int = 0` on the pinned `2.7.26.130` — nullability arrives with `2.7.26.138` in #6498, so the signal rule currently guards app-level nullable RSSI and becomes a proto regression guard once that lands.

## Testing Performed

No tests changed — spotless targets Kotlin and Kotlin-Gradle sources only, and no Kotlin or Gradle files are touched, so the baseline gradle run does not apply to this diff.

- `.coderabbit.yaml` validated against `schema.v2.json`: no unknown keys, no bad enums, nested array objects valid, `custom_checks` instructions within the 10,000-char limit.
- Both ast-grep rule files parse and were scanned across `core/`, `feature/`, `androidApp/`, `desktopApp/` — match counts and exclusions as tabled above.
- Reviewed locally with the CodeRabbit CLI (`coderabbit review --agent --include-untracked --base main`) before pushing, which is the loop this PR sets up. It returned 2 Major findings on this very change, both applied: the signal rule's `(rssi|snr)$` constraint contradicted its own note that `rx_snr` is unfixable, and the checklist described `== null` as a presence check when it tests absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new automated code analysis rules to detect sentinel-value misuse in Kotlin (distinguishing valid zero readings from missing data for measurements and RSSI).
  * Strengthened pre-merge guidance with additional warning-level checks for correct absence/presence behavior and ensuring added/changed tests validate intended side effects safely.

* **Chores**
  * Updated automated review settings to stop incremental re-reviews on every push, refreshed enabled tool settings, and set review learnings to be local.
  * Added custom AST-grep rule configuration for the new detection patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->