### PR TITLE
fix(mqtt): stop reporting transport failures as credential rejections

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1057,6 +1057,10 @@ mpwrd_os
 mqtt
 mqtt_config
 mqtt_enabled
+mqtt_error_connection_lost
+mqtt_error_credentials_rejected
+mqtt_error_proxy_failed
+mqtt_error_rejected
 mqtt_probe_dns_failure
 mqtt_probe_other_failure
 mqtt_probe_rejected

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
@@ -34,6 +34,8 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.model.MqttConnectionState
 import org.meshtastic.core.model.MqttProbeStatus
 import org.meshtastic.core.network.repository.MQTTRepository
+import org.meshtastic.core.network.repository.MQTT_KEEPALIVE_SECONDS
+import org.meshtastic.core.network.repository.isCredentialRejection
 import org.meshtastic.core.network.repository.mqttTlsConfig
 import org.meshtastic.core.network.repository.resolveEndpoint
 import org.meshtastic.core.repository.MqttManager
@@ -81,9 +83,15 @@ class MqttManagerImpl(
                     .catch { throwable ->
                         _proxyActive.value = false
                         val message =
-                            when (throwable) {
-                                is MqttException.ConnectionRejected -> "MQTT: connection rejected (check credentials)"
-                                is MqttException.ConnectionLost -> "MQTT: connection lost"
+                            when {
+                                throwable is MqttException.ConnectionRejected && throwable.isCredentialRejection() ->
+                                    "MQTT: connection rejected (check credentials)"
+
+                                throwable is MqttException.ConnectionRejected ->
+                                    "MQTT: connection rejected: ${throwable.message}"
+
+                                throwable is MqttException.ConnectionLost -> "MQTT: connection lost"
+
                                 else -> "MQTT proxy failed: ${throwable.message}"
                             }
                         serviceStateWriter.setErrorMessage(text = message, severity = Severity.Warn)
@@ -144,6 +152,9 @@ class MqttManagerImpl(
                 // including its scoped private-CA trust hook — otherwise a probe would fail where a connect succeeds.
                 val tls = mqttTlsConfig()
                 transportFactory = TcpTransportFactory(tls) + WebSocketTransportFactory(tls)
+                // Mirror the live client's keepalive too: the library default is 0 (no keepalive),
+                // which some brokers reject — misleadingly, as CLIENT_IDENTIFIER_NOT_VALID.
+                keepAliveSeconds = MQTT_KEEPALIVE_SECONDS
                 // Per-connection random suffix: myId identifies the node (and is null →
                 // "unknown" before the node record loads), so two probes can collide on one
                 // client-id and evict each other (SESSION_TAKEN_OVER). See MQTTRepositoryImpl.

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MqttManagerImpl.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import org.koin.core.annotation.Named
 import org.koin.core.annotation.Single
+import org.meshtastic.core.common.util.safeCatchingAll
 import org.meshtastic.core.model.MqttConnectionState
 import org.meshtastic.core.model.MqttProbeStatus
 import org.meshtastic.core.network.repository.MQTTRepository
@@ -42,6 +43,13 @@ import org.meshtastic.core.repository.MqttManager
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketHandler
 import org.meshtastic.core.repository.ServiceStateWriter
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.getStringSuspend
+import org.meshtastic.core.resources.mqtt_error_connection_lost
+import org.meshtastic.core.resources.mqtt_error_credentials_rejected
+import org.meshtastic.core.resources.mqtt_error_proxy_failed
+import org.meshtastic.core.resources.mqtt_error_rejected
+import org.meshtastic.core.resources.unknown
 import org.meshtastic.mqtt.ConnectionState
 import org.meshtastic.mqtt.MqttClient
 import org.meshtastic.mqtt.MqttException
@@ -82,18 +90,26 @@ class MqttManagerImpl(
                     .onEach { message -> packetHandler.sendToRadio(ToRadio(mqttClientProxyMessage = message)) }
                     .catch { throwable ->
                         _proxyActive.value = false
+                        // safeCatchingAll swallows the Skiko ExceptionInInitializerError that
+                        // compose-resources raises on headless JVM tests; production resolves the
+                        // localized string and the error is still surfaced either way.
                         val message =
-                            when {
-                                throwable is MqttException.ConnectionRejected && throwable.isCredentialRejection() ->
-                                    "MQTT: connection rejected (check credentials)"
+                            safeCatchingAll {
+                                when {
+                                    throwable is MqttException.ConnectionRejected &&
+                                        throwable.isCredentialRejection() ->
+                                        getStringSuspend(Res.string.mqtt_error_credentials_rejected)
 
-                                throwable is MqttException.ConnectionRejected ->
-                                    "MQTT: connection rejected: ${throwable.message}"
+                                    throwable is MqttException.ConnectionRejected ->
+                                        getStringSuspend(Res.string.mqtt_error_rejected, throwable.detail())
 
-                                throwable is MqttException.ConnectionLost -> "MQTT: connection lost"
+                                    throwable is MqttException.ConnectionLost ->
+                                        getStringSuspend(Res.string.mqtt_error_connection_lost)
 
-                                else -> "MQTT proxy failed: ${throwable.message}"
+                                    else -> getStringSuspend(Res.string.mqtt_error_proxy_failed, throwable.detail())
+                                }
                             }
+                                .getOrDefault("")
                         serviceStateWriter.setErrorMessage(text = message, severity = Severity.Warn)
                     }
                     .launchIn(scope)
@@ -199,3 +215,6 @@ class MqttManagerImpl(
         is ProbeResult.Other -> MqttProbeStatus.Other(message = cause.message)
     }
 }
+
+/** Failure detail for a user-facing message; a throwable without a message still needs a placeholder to substitute. */
+private suspend fun Throwable.detail(): String = message ?: getStringSuspend(Res.string.unknown)

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -52,6 +52,7 @@ import org.meshtastic.mqtt.MqttException
 import org.meshtastic.mqtt.MqttLogLevel
 import org.meshtastic.mqtt.MqttMessage
 import org.meshtastic.mqtt.QoS
+import org.meshtastic.mqtt.ReasonCode
 import org.meshtastic.mqtt.packet.Subscription
 import org.meshtastic.mqtt.plus
 import org.meshtastic.mqtt.transport.tcp.TcpTransportFactory
@@ -199,17 +200,17 @@ class MQTTRepositoryImpl(
                     }
                     Logger.i { "MQTT connected and subscribed" }
                 }
+                val failure = result.exceptionOrNull()
                 when {
                     result.isSuccess -> return@launch
 
-                    result.exceptionOrNull() is MqttException.ConnectionRejected -> {
-                        Logger.e(result.exceptionOrNull()) { "MQTT connection rejected (unrecoverable), stopping" }
-                        close(result.exceptionOrNull()!!)
+                    failure is MqttException.ConnectionRejected && failure.isCredentialRejection() -> {
+                        Logger.e(failure) { "MQTT connection rejected (unrecoverable), stopping" }
+                        close(failure)
                         return@launch
                     }
 
                     else -> {
-                        val failure = result.exceptionOrNull()
                         // Broker- and network-side failures are what this retry loop exists to absorb — an
                         // unreachable host, a TLS problem, a dropped connection, or a broker that violates the
                         // MQTT 5 spec (e.g. the topic-alias limit). None are defects in this app, and reporting
@@ -321,6 +322,24 @@ class MQTTRepositoryImpl(
 }
 
 /**
+ * `true` only for CONNACK reason codes where retrying can never help — the broker examined our credentials or client
+ * identity and refused them. The library also wraps transport-level connect failures (timeout, TLS, socket EOF) as
+ * [MqttException.ConnectionRejected] with [ReasonCode.UNSPECIFIED_ERROR]; those are transient and must stay in the
+ * retry loop, not permanently stop the proxy with a "check credentials" dialog. Public (not internal) so
+ * `MqttManagerImpl` in `:core:data` can phrase its user-facing error from the same classification.
+ */
+fun MqttException.ConnectionRejected.isCredentialRejection(): Boolean = when (reasonCode) {
+    ReasonCode.BAD_USER_NAME_OR_PASSWORD,
+    ReasonCode.NOT_AUTHORIZED,
+    ReasonCode.BAD_AUTHENTICATION_METHOD,
+    ReasonCode.CLIENT_IDENTIFIER_NOT_VALID,
+    ReasonCode.BANNED,
+    -> true
+
+    else -> false
+}
+
+/**
  * `true` when an MQTT connect/subscribe failure is one the retry loop is designed to absorb, rather than a defect worth
  * reporting to Crashlytics/Datadog.
  *
@@ -387,8 +406,9 @@ private fun defaultMqttClientFactory(setup: MqttClientSetup): MqttClientSession 
         transportFactory = TcpTransportFactory(tls) + WebSocketTransportFactory(tls)
         keepAliveSeconds = MQTT_KEEPALIVE_SECONDS
         autoReconnect = true
-        username = setup.mqttConfig?.username
-        setup.mqttConfig?.password?.let { password(it) }
+        val (user, pass) = effectiveCredentials(setup.mqttConfig)
+        username = user
+        pass?.let { password(it) }
         logger = KermitMqttLogger()
         // WARN for production: the library emits endpoint addresses and topic strings at
         // INFO level. WARN messages (reconnect, timeout, retry) contain no PII and are
@@ -397,7 +417,9 @@ private fun defaultMqttClientFactory(setup: MqttClientSetup): MqttClientSession 
     },
 )
 
-private const val MQTT_KEEPALIVE_SECONDS = 30
+// Public (not internal/private) so MqttManagerImpl's probe in :core:data can mirror the live client —
+// some brokers reject a keepalive-0 CONNECT (misleadingly, as CLIENT_IDENTIFIER_NOT_VALID).
+const val MQTT_KEEPALIVE_SECONDS = 30
 private const val MQTT_PORT_PLAIN = 1883
 private const val MQTT_PORT_TLS = 8883
 
@@ -425,6 +447,26 @@ fun resolveEndpoint(rawAddress: String, tlsEnabled: Boolean): MqttEndpoint = if 
 }
 
 private const val DEFAULT_PUBLIC_SERVER = "mqtt.meshtastic.org"
+
+// The public broker's well-known credentials, same values as the firmware's Default.h.
+private const val DEFAULT_MQTT_USERNAME = "meshdev"
+private const val DEFAULT_MQTT_PASSWORD = "large4cats"
+
+/**
+ * Mirrors the firmware's `PubSubConfig` rule: an empty `address` means "the public broker with its well-known
+ * credentials", substituting username and password together with the server — the stored username/password are ignored
+ * in that case, whatever they contain. Substituting only the address (as this repository does for the endpoint) while
+ * passing the stored empty credentials through makes the proxy connect anonymously, which the public broker rejects
+ * with BAD_USER_NAME_OR_PASSWORD — surfaced to the user as a bogus "check credentials" error on configs the firmware
+ * itself connects with happily. Empty-address configs occur in the wild: lockdown-enabled firmware hands
+ * unauthenticated clients a zeroed MQTTConfig.
+ */
+internal fun effectiveCredentials(config: ModuleConfig.MQTTConfig?): Pair<String?, String?> =
+    if (config?.address.isNullOrEmpty()) {
+        DEFAULT_MQTT_USERNAME to DEFAULT_MQTT_PASSWORD
+    } else {
+        config?.username to config?.password
+    }
 
 fun effectiveTlsEnabled(address: String, tlsEnabled: Boolean): Boolean =
     tlsEnabled || extractHost(address).equals(DEFAULT_PUBLIC_SERVER, ignoreCase = true)

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
@@ -184,6 +184,40 @@ class MQTTRepositoryImplTest {
 
     // endregion
 
+    // region effectiveCredentials — firmware-parity credential defaulting.
+
+    @Test
+    fun `empty address substitutes the public broker's well-known credentials`() {
+        // Mirrors firmware PubSubConfig: lockdown-redacted (zeroed) configs must not connect anonymously.
+        val creds = effectiveCredentials(ModuleConfig.MQTTConfig(address = "", username = "", password = ""))
+        assertEquals("meshdev" to "large4cats", creds)
+    }
+
+    @Test
+    fun `null config substitutes the public broker's well-known credentials`() {
+        assertEquals("meshdev" to "large4cats", effectiveCredentials(null))
+    }
+
+    @Test
+    fun `empty address ignores stored credentials entirely - firmware parity`() {
+        val creds = effectiveCredentials(ModuleConfig.MQTTConfig(address = "", username = "custom", password = "pw"))
+        assertEquals("meshdev" to "large4cats", creds)
+    }
+
+    @Test
+    fun `explicit address uses the stored credentials as-is`() {
+        val config = ModuleConfig.MQTTConfig(address = "broker.example.com", username = "user", password = "pass")
+        assertEquals("user" to "pass", effectiveCredentials(config))
+    }
+
+    @Test
+    fun `explicit default server address uses the stored credentials as-is - firmware parity`() {
+        val config = ModuleConfig.MQTTConfig(address = "mqtt.meshtastic.org", username = "user", password = "pass")
+        assertEquals("user" to "pass", effectiveCredentials(config))
+    }
+
+    // endregion
+
     // region extractHost — address canonicalization tests.
 
     @Test
@@ -335,6 +369,74 @@ class MQTTRepositoryImplTest {
 
         collector.cancelAndJoin()
         runCurrent()
+    }
+
+    @Test
+    fun `transport failure wrapped as ConnectionRejected retries instead of stopping the proxy`() = runTest {
+        // The MQTT library wraps ANY connect failure — timeout, TLS, socket EOF — as
+        // ConnectionRejected with UNSPECIFIED_ERROR. Treating those as unrecoverable stopped
+        // the proxy permanently and showed users a bogus "check credentials" dialog.
+        val harness = createHarness()
+        harness.client.failConnectWith(
+            MqttException.ConnectionRejected(ReasonCode.UNSPECIFIED_ERROR, "Connection failed: Connection timed out"),
+        )
+
+        val collector = startProxyCollection(harness.repository)
+        runCurrent()
+        assertEquals(1, harness.client.connectCalls.size)
+
+        advanceTimeBy(1_000)
+        runCurrent()
+        assertEquals(2, harness.client.connectCalls.size)
+        assertEquals(1, harness.client.subscribeCalls.size)
+
+        collector.cancelAndJoin()
+        runCurrent()
+    }
+
+    @Test
+    fun `credential rejection stops the proxy permanently`() = runTest {
+        val harness = createHarness()
+        harness.client.failConnectWith(
+            MqttException.ConnectionRejected(ReasonCode.BAD_USER_NAME_OR_PASSWORD, "Connection refused"),
+        )
+
+        val outcome = backgroundScope.async { runCatching { harness.repository.proxyMessageFlow.collect {} } }
+        runCurrent()
+        advanceTimeBy(60_000)
+        runCurrent()
+
+        assertEquals(1, harness.client.connectCalls.size)
+        assertIs<MqttException.ConnectionRejected>(outcome.await().exceptionOrNull())
+    }
+
+    @Test
+    fun `only credential and identity reason codes classify as credential rejections`() {
+        val fatal =
+            listOf(
+                ReasonCode.BAD_USER_NAME_OR_PASSWORD,
+                ReasonCode.NOT_AUTHORIZED,
+                ReasonCode.BAD_AUTHENTICATION_METHOD,
+                ReasonCode.CLIENT_IDENTIFIER_NOT_VALID,
+                ReasonCode.BANNED,
+            )
+        val transient =
+            listOf(
+                ReasonCode.UNSPECIFIED_ERROR,
+                ReasonCode.SERVER_UNAVAILABLE,
+                ReasonCode.SERVER_BUSY,
+                ReasonCode.CONNECTION_RATE_EXCEEDED,
+            )
+
+        fatal.forEach { code ->
+            assertTrue(MqttException.ConnectionRejected(code, "x").isCredentialRejection(), "expected fatal: $code")
+        }
+        transient.forEach { code ->
+            assertFalse(
+                MqttException.ConnectionRejected(code, "x").isCredentialRejection(),
+                "expected transient: $code",
+            )
+        }
     }
 
     @Test

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImplTest.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.BuildConfigProvider
+import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.MqttJsonPayload
 import org.meshtastic.core.testing.FakeNodeRepository
@@ -401,7 +402,7 @@ class MQTTRepositoryImplTest {
             MqttException.ConnectionRejected(ReasonCode.BAD_USER_NAME_OR_PASSWORD, "Connection refused"),
         )
 
-        val outcome = backgroundScope.async { runCatching { harness.repository.proxyMessageFlow.collect {} } }
+        val outcome = backgroundScope.async { safeCatching { harness.repository.proxyMessageFlow.collect {} } }
         runCurrent()
         advanceTimeBy(60_000)
         runCurrent()

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1090,6 +1090,10 @@
     <string name="mqtt">MQTT</string>
     <string name="mqtt_config">MQTT Config</string>
     <string name="mqtt_enabled">MQTT enabled</string>
+    <string name="mqtt_error_connection_lost">MQTT: connection lost</string>
+    <string name="mqtt_error_credentials_rejected">MQTT: connection rejected (check credentials)</string>
+    <string name="mqtt_error_proxy_failed">MQTT proxy failed: %1$s</string>
+    <string name="mqtt_error_rejected">MQTT: connection rejected: %1$s</string>
     <string name="mqtt_probe_dns_failure">Host not found</string>
     <string name="mqtt_probe_other_failure">Connection failed</string>
     <string name="mqtt_probe_rejected">Broker rejected: %1$s</string>


### PR DESCRIPTION
Fixes #6505

MQTT stopped working for users on self-hosted and event brokers, and the app blamed their credentials for it. The reporter in #6505 (DEF CON `mqtt.defcon.run:4433`, correct credentials, working on iOS and on the 2.7.13 Android client) saw `MQTT: connection rejected (check credentials)` and an MQTT-proxy toggle that flicked green then straight back to grey.

Nothing was wrong with their credentials. Three separate defects stack up to produce that experience, and this PR fixes the app's share of them.

## 🐛 Transport failures were reported as credential rejections

`MqttClient.connect` wraps **every** connect failure — TCP timeout, TLS error, socket EOF, a broker that accepts the socket then stalls the CONNECT — as `MqttException.ConnectionRejected` carrying `UNSPECIFIED_ERROR`. `MQTTRepositoryImpl` treated any `ConnectionRejected` as unrecoverable: it closed the flow, permanently stopped the proxy, and `MqttManagerImpl` printed the credentials dialog. The Paho-era client retried these, which is why this only appeared from 2.7.14 onward (#5165).

The fatal stop is now gated on `isCredentialRejection()` — the CONNACK reason codes where retrying genuinely cannot help (`BAD_USER_NAME_OR_PASSWORD`, `NOT_AUTHORIZED`, `BAD_AUTHENTICATION_METHOD`, `CLIENT_IDENTIFIER_NOT_VALID`, `BANNED`). Everything else goes back into the existing exponential-backoff retry loop, and the user-facing message is phrased from the same classification instead of asserting a credentials problem.

This is the dominant failure mode fleet-wide, not just at DEF CON: Datadog RUM shows ~26k of these events across ~2,500 users on the 2.7.14 production build, with underlying messages like `Connection timed out`, `Chain validation failed`, and `Not enough data available`.

## 🐛 Empty-address configs connected anonymously and were refused

Firmware's `PubSubConfig` treats an empty `address` as "the public broker **with its well-known credentials**", substituting server and credentials together. The app substituted only the address and passed the stored (empty) credentials through, so the proxy connected anonymously and the public broker refused it with a real `BAD_USER_NAME_OR_PASSWORD` — a genuine rejection triggered by a config the firmware itself connects with happily. Empty-address configs do occur in the wild: lockdown-enabled firmware hands an unauthenticated client a zeroed `MQTTConfig`.

`effectiveCredentials()` now mirrors the firmware rule exactly.

## 🐛 The connection probe didn't mirror the live client

The library's probe defaults to `keepAliveSeconds = 0`, and some brokers refuse a keepalive-0 CONNECT — reporting it, misleadingly, as `CLIENT_IDENTIFIER_NOT_VALID`. The probe now sets the same keepalive as the live client. (Same class of bug as the transport/TLS mirroring already documented in this file.)

## Upstream

The remaining cause is in the MQTT client library and is fixed by meshtastic/MQTTastic-Client-KMP#113: this broker **silently closes MQTT 5 CONNECTs** without any CONNACK, and the library's 3.1.1 fallback only fired on an explicit `UNSUPPORTED_PROTOCOL_VERSION` CONNACK — so the connection died with `EOFException` instead of retrying. iOS works because it speaks 3.1.1. That PR also stops classifying transport failures as `ConnectionRejected` at the source. Once it ships in 0.8.0 and Renovate bumps us, the reason-code gate here becomes belt-and-braces; it stays correct either way, so it should not be removed while we are on ≤0.7.0.

## Testing Performed

**Unit** — 8 new tests in `MQTTRepositoryImplTest` (transport-failure retry, credential-rejection stop, the full reason-code classification table, and the five firmware-parity credential cases). Full local gate green: `spotlessApply spotlessCheck detekt`, plus `:core:network:allTests :core:data:allTests` (1,316 tests).

**On-device, with the reporter's actual broker and real credentials from run.defcon.run** — fdroid debug build on an emulator, connected to a simulated node, MQTT config set to `mqtt.defcon.run:4433` + TLS, then "Test connection". Identical app code, only the library version differing:

| MQTT client library | Result |
| --- | --- |
| Released 0.7.0 | ❌ `Timed out after 5000 ms` |
| meshtastic/MQTTastic-Client-KMP#113 build (`0.7.1-SNAPSHOT` via mavenLocal) | ✅ `Reachable. Broker accepted credentials.` |

Also verified on the public broker (`ssl://mqtt.meshtastic.org:8883`): `meshdev` succeeds; empty credentials reproduce the genuine `BAD_USER_NAME_OR_PASSWORD` this PR's second fix prevents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT connection reliability by retrying temporary connection rejections instead of stopping permanently.
  * Credential-related failures are now identified clearly and handled without unnecessary retries.
  * Fixed MQTT probe connections that could be rejected due to incorrect keep-alive settings.
  * Connections using the public broker now automatically use the appropriate default credentials when no address is configured.
  * Explicit broker configurations continue to use their saved credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->