### PR TITLE
docs: correct the baseline profile output path in the testing guide

### DIFF
--- a/docs/en/developer/testing.md
+++ b/docs/en/developer/testing.md
@@ -81,7 +81,7 @@ The Macrobenchmark generator (`BaselineProfileGenerator`) and the before/after b
 ./gradlew :androidApp:benchmarkGoogleReleaseBaselineProfile  # Quantify the cold-start win
 ```
 
-The generated profile is merged into `androidApp/src/googleRelease/generated/baselineProfiles/` and packaged into release builds via `androidx.profileinstaller`.
+The generated profile is merged into `androidApp/src/google/generated/baselineProfiles/` and packaged into release builds via `androidx.profileinstaller`.
 
 > ⚠️ **Warning:** The journey currently covers cold start only (launch → first frame), because CI has no paired radio. Post-connection screens (node list, map, message thread) are not yet AOT-compiled; extend the journey once a fake transport or connected device is wired into the harness.
 


### PR DESCRIPTION
The testing guide told contributors the generated baseline profile lands in `androidApp/src/googleRelease/generated/baselineProfiles/`. It does not. Anyone following the doc would look in a directory that never gets written, and — since nothing is committed there yet — would have no file to contradict them. Pre-existing drift, unrelated to the androidx.benchmark bump that surfaced it.

The `google` flavor source set is the real destination, and the scheduled job is the proof: [`scheduled-baseline.yml`](https://github.com/meshtastic/Meshtastic-Android/blob/main/.github/workflows/scheduled-baseline.yml) runs `git status --porcelain` against `androidApp/src/google/generated/baselineProfiles` to decide whether the profile changed, then commits `androidApp/src/google/generated/baselineProfiles/**`. If the plugin wrote to `googleRelease/`, that job would detect no change and open no PR — it would be silently dead. Three other in-repo sources already agree with the workflow:

- `.coderabbit.yaml`
- `baselineprofile/README.md`
- the KDoc on `BaselineProfileGenerator`

That made the stale doc the lone dissenter, so it was corrected rather than the other five.

### 🧹 Chores

- Point the baseline profile path in `docs/en/developer/testing.md` at `androidApp/src/google/generated/baselineProfiles/`.

### Notes for reviewers

- One line, one path string — no prose restructuring and no doc-registration changes (no new strings, no `UserPageDef` entry, no `CoreRes` accessors), which is expected for an edit to existing prose.
- There is only one copy of this page to fix. `feature/docs` ships no markdown of its own; its `build.gradle.kts` syncs `docs/en/` into `composeResources` at build time, so the in-app docs page regenerates from this single source.
- Docs-only, so no test changes. `./gradlew spotlessApply spotlessCheck detekt` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Baseline Profile and startup performance documentation with the current generated-profile output path.
  * Clarified that profiles continue to be packaged into release builds through Profile Installer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->