### PR TITLE
Onboard to the OSS Community Develocity Instance

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -13,6 +13,9 @@ inputs:
   gradle_encryption_key:
     description: 'Encryption key for Gradle remote cache'
     required: false
+  develocity_access_key:
+    description: 'Access key for the OSS Community Develocity Instance (Build Scan publishing and remote cache writes)'
+    required: false
 runs:
   using: composite
   steps:
@@ -86,6 +89,7 @@ runs:
       with:
         cache-read-only: ${{ inputs.cache_read_only }}
         cache-encryption-key: ${{ inputs.gradle_encryption_key }}
+        develocity-access-key: ${{ inputs.develocity_access_key }}
         # Cache cleanup is broken on Windows with setup-gradle v6's "enhanced
         # caching" provider: it deletes the whole Gradle User Home instead of
         # just unused entries (1739 files "excluded from the cache" here vs 25

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -53,6 +53,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -83,6 +83,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,7 @@ on:
         required: true
       GRADLE_ENCRYPTION_KEY:
         required: true
-      GRADLE_CACHE_URL:
-        required: false
-      GRADLE_CACHE_USERNAME:
-        required: false
-      GRADLE_CACHE_PASSWORD:
+      DEVELOCITY_ACCESS_KEY:
         required: false
       APPLE_SIGNING_IDENTITY:
         required: false
@@ -94,10 +90,6 @@ jobs:
     outputs:
       APP_VERSION_NAME: ${{ steps.prep_version.outputs.APP_VERSION_NAME }}
       APP_VERSION_CODE: ${{ steps.calculate_version_code.outputs.versionCode }}
-    env:
-      GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
-      GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
-      GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
@@ -133,10 +125,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     needs: [prepare-build-info]
-    env:
-      GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
-      GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
-      GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
@@ -149,6 +137,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: 'false'
 
       - name: Load secrets
@@ -218,10 +207,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     needs: [prepare-build-info]
-    env:
-      GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
-      GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
-      GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
@@ -234,6 +219,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: 'false'
 
       - name: Load secrets
@@ -284,9 +270,6 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-24.04, ubuntu-24.04-arm]
     env:
-      GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
-      GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
-      GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
       # Secrets aren't readable in step `if:` expressions, so surface presence here.
       SIGN_WINDOWS: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT != '' && 'true' || 'false' }}
     steps:
@@ -301,6 +284,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: 'false'
           install_jetbrains_jdk: 'true'
 
@@ -443,10 +427,6 @@ jobs:
         # No .deb host-coupling here (pure-Java uber jar + URL manifest) — free to track
         # the current LTS image.
         os: [ubuntu-24.04, ubuntu-24.04-arm]
-    env:
-      GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
-      GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
-      GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
@@ -459,6 +439,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: 'true'
           install_jetbrains_jdk: 'true'
 

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -30,6 +30,8 @@ on:
     secrets:
       GRADLE_ENCRYPTION_KEY:
         required: false
+      DEVELOCITY_ACCESS_KEY:
+        required: false
       CODECOV_TOKEN:
         required: false
       DATADOG_APPLICATION_ID:
@@ -38,21 +40,12 @@ on:
         required: false
       GOOGLE_MAPS_API_KEY:
         required: false
-      GRADLE_CACHE_URL:
-        required: false
-      GRADLE_CACHE_USERNAME:
-        required: false
-      GRADLE_CACHE_PASSWORD:
-        required: false
 
 env:
   DATADOG_APPLICATION_ID: ${{ secrets.DATADOG_APPLICATION_ID }}
   DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
   MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
   GITHUB_TOKEN: ${{ github.token }}
-  GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
-  GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
-  GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
   # Merge-queue and main-branch runs write to the Gradle caches; every other
   # context (PRs, release tags) is a read-only consumer.
   GRADLE_CACHE_READ_ONLY: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'merge_group') && 'false' || 'true' }}
@@ -98,6 +91,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: ${{ env.GRADLE_CACHE_READ_ONLY }}
           install_jetbrains_jdk: 'true'
 
@@ -125,6 +119,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: ${{ env.GRADLE_CACHE_READ_ONLY }}
 
       - name: Screenshot Test Validation
@@ -160,6 +155,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: 'true'
 
       - name: Verify Reproducible Build (fdroid)
@@ -435,6 +431,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: ${{ env.GRADLE_CACHE_READ_ONLY }}
 
       - name: Run Tests & Coverage (${{ matrix.shard.name }})
@@ -496,6 +493,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: ${{ env.GRADLE_CACHE_READ_ONLY }}
 
       - name: Tag main-branch builds as -SNAPSHOT
@@ -548,6 +546,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: ${{ env.GRADLE_CACHE_READ_ONLY }}
           install_jetbrains_jdk: 'true'
 
@@ -590,6 +589,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: true
           install_jetbrains_jdk: 'true'
 

--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -33,6 +33,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           cache_read_only: 'false'
 
       - name: Update Graphs

--- a/.github/workflows/verify-flatpak.yml
+++ b/.github/workflows/verify-flatpak.yml
@@ -46,6 +46,8 @@ jobs:
           token: ${{ github.token }}
 
       - uses: gradle/actions/setup-gradle@v6
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Generate flatpak-sources.json
         run: |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![CLA assistant](https://cla-assistant.io/readme/badge/meshtastic/Meshtastic-Android)](https://cla-assistant.io/meshtastic/Meshtastic-Android)
 [![Fiscal Contributors](https://opencollective.com/meshtastic/tiers/badge.svg?label=Fiscal%20Contributors&color=deeppink)](https://opencollective.com/meshtastic/)
 [![Vercel](https://img.shields.io/static/v1?label=Powered%20by&message=Vercel&style=flat&logo=vercel&color=000000)](https://vercel.com?utm_source=meshtastic&utm_campaign=oss)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=MeshtasticAndroid)
 
 This is a tool for using Android (and Compose Desktop) with open-source mesh radios. For more information see our webpage: [meshtastic.org](https://www.meshtastic.org). If you are looking for the device side code, see [here](https://github.com/meshtastic/firmware).
 

--- a/gradle/build-cache.settings.gradle
+++ b/gradle/build-cache.settings.gradle
@@ -15,67 +15,18 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-def getMeshProperty(String key) {
-    def env = System.getenv(key)
-    if (env) return env
-
-    def currentDir = settingsDir
-    while (currentDir != null) {
-        for (name in ["local.properties", "config.properties", "secrets.properties"]) {
-            def file = new File(currentDir, name)
-            if (file.exists()) {
-                def props = new Properties()
-                file.withInputStream { props.load(it) }
-                if (props.containsKey(key)) return props.getProperty(key)
-            }
-        }
-        currentDir = currentDir.parentFile
-    }
-    return null
-}
+def develocityExtension = extensions.findByName("develocity")
 
 buildCache {
     local {
         enabled = true
     }
-    remote(HttpBuildCache) {
-        // Some servers have issues with Expect: 100-continue and return 403.
-        useExpectContinue = false
-        def cacheUrl = getMeshProperty("GRADLE_CACHE_URL")?.trim()
-        def cacheUsername = getMeshProperty("GRADLE_CACHE_USERNAME")?.trim()
-        def cachePassword = getMeshProperty("GRADLE_CACHE_PASSWORD")?.trim()
 
-        if (cacheUrl) {
-            def isLogic = settingsDir.name == "build-logic"
-            logger.lifecycle "Meshtastic ${isLogic ? 'Build Logic' : 'Build'}: Remote cache URL found."
-
-            // Ensure trailing slash for cache servers
-            url = cacheUrl.endsWith("/") ? cacheUrl : "${cacheUrl}/"
-
-            if (cacheUsername && cachePassword) {
-                if (cacheUrl.startsWith("http://")) {
-                    logger.warn "Meshtastic: GRADLE_CACHE_URL uses http:// with credentials set; " +
-                            "credentials will be sent in cleartext."
-                }
-                credentials {
-                    username = cacheUsername
-                    password = cachePassword
-                }
-            }
-
-            // A cache serves compiled task outputs, so TLS matters: validate certs by default.
-            // Plain-http (e.g. a LAN cache) is opted into by the URL scheme itself; accepting a
-            // self-signed/untrusted https cert requires GRADLE_CACHE_ALLOW_UNTRUSTED=true.
-            allowInsecureProtocol = cacheUrl.startsWith("http://")
-            allowUntrustedServer = getMeshProperty("GRADLE_CACHE_ALLOW_UNTRUSTED") == "true"
-
-            // Keep push enabled if credentials are provided.
-            // This naturally disables push for fork PRs which don't have access to secrets.
-            push = (cacheUsername && cachePassword)
-
+    if (develocityExtension != null) {
+        remote(develocityExtension.buildCache) {
             enabled = true
-        } else {
-            enabled = false
+            def accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")?.trim()
+            push = System.getenv("CI") != null && accessKey
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ pluginManagement {
 
 plugins {
     id("com.gradle.develocity") version "4.5.0"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "2.8.0"
     id("org.gradle.toolchains.foojay-resolver") version "1.0.0"
     id("org.meshtastic.flatpak.sources.settings") version "0.1.5"
 }
@@ -70,22 +71,20 @@ rootProject.name = "MeshtasticAndroid"
 // https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:type-safe-project-accessors
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-// Build Cache configuration (HTTP remote cache + local)
-apply(from = "gradle/build-cache.settings.gradle")
+val isCI = System.getenv("CI") != null
 
-// Build Scans — publish in CI only for debugging and performance profiling.
 develocity {
+    server = "https://community.develocity.cloud"
+    projectId = "meshtastic"
     buildScan {
-        capture {
-            fileFingerprints = true
-        }
-        val isCi = providers.environmentVariable("CI").isPresent
-        publishing.onlyIf { isCi }
-        uploadInBackground = !isCi
-        termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
-        termsOfUseAgree = "yes"
+        uploadInBackground = !isCI
+        publishing.onlyIf { it.isAuthenticated }
+        obfuscation { ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } } }
     }
 }
+
+// Build Cache configuration (Develocity remote cache + local)
+apply(from = "gradle/build-cache.settings.gradle")
 
 @Suppress("UnstableApiUsage")
 toolchainManagement {


### PR DESCRIPTION
# Onboard to the OSS Community Develocity Instance

This PR adds [Develocity](https://gradle.com/develocity) Build Scan® and Build Cache support
for this project, publishing to the **OSS Community Develocity Instance** at
<https://community.develocity.cloud> under project ID `meshtastic`.

## What this PR adds

- The Develocity Gradle extension/plugin and the Common Custom User Data Gradle
  extension/plugin, applied at the latest released versions.
- settings.gradle.kts pointing the build at `https://community.develocity.cloud` and
  associating builds with project `meshtastic`.
- A "Revved up by Develocity" badge in the README linking to the filtered Build Scan list
  for this project's root project name.
- A setup step in each GitHub Actions workflow that runs the build, so CI publishes Build
  Scans automatically using a short-lived access token.

## Changes to configuration that already existed

This project already applied `com.gradle.develocity` 4.5.0, so this PR adapts the existing
setup rather than adding it from scratch. Please review these three points.

1. **Build Scans move from `scans.gradle.com` to `community.develocity.cloud`.** The
   `termsOfUseUrl` and `termsOfUseAgree` settings are removed, because they apply only to
   the public `scans.gradle.com` service. Publishing now happens whenever the build is
   authenticated, instead of on CI only, so local builds also publish once a developer
   provisions a key (see Step 3). The explicit `capture { fileFingerprints = true }` is
   dropped in favor of the plugin default.
2. **The remote Build Cache moves to Develocity.** `gradle/build-cache.settings.gradle`
   keeps its role as the single place cache configuration lives, but its self-hosted
   `HttpBuildCache` is replaced by `remote(develocity.buildCache)`. The now-unused
   `GRADLE_CACHE_URL`, `GRADLE_CACHE_USERNAME`, and `GRADLE_CACHE_PASSWORD` plumbing is
   removed from the workflows; `GRADLE_CACHE_READ_ONLY` stays, because it controls the
   Actions-side Gradle home cache, not the remote cache. Pushes to the cache happen only
   from CI runs that have the access key, so pull requests from forks read without
   writing.
3. **The access key is wired through the shared composite action.**
   `.github/actions/gradle-setup` gets a new optional `develocity_access_key` input that it
   forwards to `gradle/actions/setup-gradle`. All 14 call sites pass
   `secrets.DEVELOCITY_ACCESS_KEY`, and `verify-flatpak.yml` (which calls `setup-gradle`
   directly) passes it too. Every input is optional, so builds without the secret keep
   working.

## Step 1 — Get an access key for `community.develocity.cloud`

Build Scan publishing **and** Build Cache writes from CI need a Develocity access key.

1. Visit <https://community.develocity.cloud>.
2. **Sign in as the CI service account that the Develocity Solutions team has provisioned
   for your project** — that account was shared with you out-of-band when this onboarding
   was set up. The access key inherits that account's project memberships and permissions,
   which is exactly what you want for CI.
3. From the user menu in the top-right, open **My settings** → **Access keys**.
4. Click **Generate access key**, give it a description (e.g. `GitHub Actions`), and copy
   the generated key. Keep this tab open until you complete Step 2 — the key is only
   shown once.

## Step 2 — Set the GitHub Actions secret on this repository

CI uses a repository secret named `DEVELOCITY_ACCESS_KEY` to authenticate to
`community.develocity.cloud`.

1. Open this repository on GitHub.
2. Click **Settings**.
3. In the left sidebar, click **Secrets and variables** → **Actions**.
4. Click **New repository secret**. (If a `DEVELOCITY_ACCESS_KEY` secret already exists,
   click its **Update** button instead.)
5. Set **Name** to:

   ```
   DEVELOCITY_ACCESS_KEY
   ```

6. Set **Secret** to the value below, replacing `PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE`
   with the key you copied in Step 1:

   ```
   community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE
   ```

   The `community.develocity.cloud=` prefix is **required** — without the host name, the
   access key is silently ignored. This is the most common point of failure when
   onboarding, so please double-check the format.
7. Click **Add secret** (or **Update secret**).

## Step 3 — Provision an access key for your local builds

Developers building this project locally should provision an access key for
`community.develocity.cloud` so their Build Scans publish and they get reads
from the remote Build Cache. The Develocity Gradle plugin's
`provisionDevelocityAccessKey` task does this in a single command — it opens
the browser, asks the developer to confirm, and writes the key to
`~/.gradle/develocity/keys.properties` automatically.

**Before running this command**, sign out of `community.develocity.cloud` in
your browser (or use a private/incognito window) so the access key gets
associated with **your personal account**, not the CI service account you
signed in as for Step 1.

```
./gradlew provisionDevelocityAccessKey
```

## Note on the CI run on this PR

This PR was prepared from a fork. Forks can't read your repository's secrets, so the
workflow run on this PR cannot publish to `community.develocity.cloud` even after you set
the secret in Step 2.

If you want CI verification before merging, push the branch
`dv/onboard-oss-community-develocity-instance` to a temporary branch on **this** repo (not
the fork) and re-run the workflow there — it will pick up the secret and publish a Build
Scan.

After merging, every CI run **on this repository** will publish a Build Scan to
<https://community.develocity.cloud>. CI runs from forks of this repository will not (forks
don't have access to the secret either), and that's expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved build performance and reliability through streamlined remote caching.
  * Enhanced build scan availability and privacy controls for diagnostics.
  * Updated automated documentation, release, and verification workflows for more consistent builds.

* **Documentation**
  * Added a Develocity status badge to the README, providing direct access to build scan information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->