### PR TITLE
fix(debug): restore node ID hex annotations broken by the Wire migration

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
@@ -92,7 +92,9 @@ import org.meshtastic.core.ui.icon.Settings
 import org.meshtastic.core.ui.theme.AnnotationColor
 import org.meshtastic.feature.settings.debugging.DebugViewModel.UiMeshLog
 
-private val REGEX_ANNOTATED_NODE_ID = Regex("\\(![0-9a-fA-F]{8}\\)$", RegexOption.MULTILINE)
+// No end-of-line anchor: Wire's toString is single-line, so annotations land mid-line
+// (`from=-1897181963 (!8ee6c775), to=…`), not at line ends as protobuf-java's format did.
+private val REGEX_ANNOTATED_NODE_ID = Regex("\\(![0-9a-fA-F]{8}\\)")
 
 // Suppressions match this screen's pre-existing detekt baseline entries; editing the body reset the baseline hashes.
 @Suppress("LongMethod", "ViewModelForwarding", "ModifierMissing")

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModel.kt
@@ -373,9 +373,11 @@ class DebugViewModel(
             Packet.getRelayNode(relayNode, nodeList, myNodeNum)?.let { node ->
                 val relayId = node.user.id
                 val relayName = node.user.long_name
-                val regex = Regex("""\brelay_node: ${relayNode.toUInt()}\b""")
+                // Wire's toString prints `relay_node=245`; rows stored before the Wire
+                // migration carry protobuf-java's `relay_node: 245`. Match both.
+                val regex = Regex("""\brelay_node[=:] ?${relayNode.toUInt()}\b""")
                 if (regex.containsMatchIn(result)) {
-                    relayNodeAnnotation = "relay_node: $relayName ($relayId)"
+                    relayNodeAnnotation = "relay_node=$relayName ($relayId)"
                     result = regex.replace(result, placeholder)
                 }
             }
@@ -407,9 +409,13 @@ class DebugViewModel(
 
     /** Look for a single node ID integer in the string and annotate it with the hex equivalent if found. */
     private fun StringBuilder.annotateNodeId(nodeId: Int): Boolean {
-        val nodeIdStr = nodeId.toUInt().toString()
-        // Only match if whitespace before and after
-        val regex = Regex("""(?<=\s|^)${Regex.escape(nodeIdStr)}(?=\s|$)""")
+        // Wire's toString prints int fields SIGNED and `=`-delimited (`from=-1897181963,`),
+        // which is what users see since the Wire migration (#6520). Rows stored before it
+        // carry protobuf-java's text format: unsigned, colon-separated, whitespace-bounded
+        // (`from: 2397785333`). Match either representation at a value position.
+        val signed = Regex.escape(nodeId.toString())
+        val unsigned = Regex.escape(nodeId.toUInt().toString())
+        val regex = Regex("""(?<=[=\s]|^)($signed|$unsigned)(?=[,}\s]|$)""")
         if (!regex.containsMatchIn(this)) return false
         regex.findAll(this).toList().asReversed().forEach {
             val idx = it.range.last + 1

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModelTest.kt
@@ -21,6 +21,7 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -196,5 +197,94 @@ class DebugViewModelTest {
     fun `requestDeleteAllLogs shows alert`() {
         viewModel.requestDeleteAllLogs()
         verify { alertManager.showAlert(titleRes = any(), messageRes = any(), onConfirm = any()) }
+    }
+
+    // Regression tests for #6520: Wire's toString prints int fields SIGNED and `=`-delimited
+    // (`from=-559038737,`), which the annotation regexes — written for protobuf-java's
+    // unsigned, whitespace-bounded text format — silently stopped matching. These go through
+    // the real generated toString, so they hold whichever wire format is in use.
+
+    @Test
+    fun `packet log annotates signed Wire-format from and to with hex`() = runTest {
+        val packet = org.meshtastic.core.testing.TestDataFactory.createTestPacket(from = 0xDEADBEEF.toInt(), to = -1)
+        meshLogRepository.insert(
+            org.meshtastic.core.model.MeshLog(
+                uuid = "1",
+                message_type = "Packet",
+                received_date = 1L,
+                raw_message = "",
+                fromRadio = org.meshtastic.proto.FromRadio(packet = packet),
+            ),
+        )
+
+        val logs = viewModel.loadLogsForExport()
+
+        logs.size shouldBe 1
+        logs[0].logMessage shouldContain "(!deadbeef)"
+        logs[0].logMessage shouldContain "(!ffffffff)"
+    }
+
+    @Test
+    fun `packet log annotates relay_node with the known node's name`() = runTest {
+        nodeRepository.setNodes(
+            listOf(
+                org.meshtastic.core.testing.TestDataFactory.createTestNode(
+                    num = 0x000001AA,
+                    userId = "!000001aa",
+                    longName = "Relay Node",
+                    lastHeard = 100,
+                ),
+            ),
+        )
+        val packet = org.meshtastic.core.testing.TestDataFactory.createTestPacket(from = 5, to = -1, relayNode = 0xAA)
+        meshLogRepository.insert(
+            org.meshtastic.core.model.MeshLog(
+                uuid = "1",
+                message_type = "Packet",
+                received_date = 1L,
+                raw_message = "",
+                fromRadio = org.meshtastic.proto.FromRadio(packet = packet),
+            ),
+        )
+
+        val logs = viewModel.loadLogsForExport()
+
+        logs[0].logMessage shouldContain "relay_node=Relay Node (!000001aa)"
+    }
+
+    @Test
+    fun `packet log annotates unknown relay_node with hex`() = runTest {
+        val packet = org.meshtastic.core.testing.TestDataFactory.createTestPacket(from = 5, to = -1, relayNode = 0xF5)
+        meshLogRepository.insert(
+            org.meshtastic.core.model.MeshLog(
+                uuid = "1",
+                message_type = "Packet",
+                received_date = 1L,
+                raw_message = "",
+                fromRadio = org.meshtastic.proto.FromRadio(packet = packet),
+            ),
+        )
+
+        val logs = viewModel.loadLogsForExport()
+
+        logs[0].logMessage shouldContain "(!000000f5)"
+    }
+
+    @Test
+    fun `node info log still annotates legacy protobuf-java text format`() = runTest {
+        meshLogRepository.insert(
+            org.meshtastic.core.model.MeshLog(
+                uuid = "1",
+                message_type = "NodeInfo",
+                received_date = 1L,
+                raw_message = "node_info {\n  num: 3735928559\n}",
+                fromRadio =
+                org.meshtastic.proto.FromRadio(node_info = org.meshtastic.proto.NodeInfo(num = 0xDEADBEEF.toInt())),
+            ),
+        )
+
+        val logs = viewModel.loadLogsForExport()
+
+        logs[0].logMessage shouldContain "num: 3735928559 (!deadbeef)"
     }
 }


### PR DESCRIPTION
The debug panel's node-ID annotations — the ` (!deadbeef)` hex and relay-name inserts — have been silently dead since the protobuf-java → Wire migration, which is what #6520 is reporting: users see `from=-1897181963` with no unsigned/hex form anywhere. Wire's `toString()` prints int fields **signed** and `=`-delimited (`from=-1897181963,`), while all three annotation regexes were written for protobuf-java's text format: unsigned decimals, colon separators, whitespace boundaries. Nothing matched, so nothing was annotated — and the styling regex that italicises annotations was anchored to end-of-line, which Wire's single-line output also never satisfies. Fixes #6520.

## 🐛 Bug Fixes

- `annotateNodeId` now matches the node number at a value position in **either** wire format — Wire's signed, `=`/`,`-delimited form and protobuf-java's unsigned, whitespace-bounded form (rows stored before the migration still render annotated). `from`, `to`, NodeInfo `num` and MyNodeInfo `my_node_num` get their ` (!xxxxxxxx)` hex back, including `to=-1 (!ffffffff)` for broadcast — which also makes the `!ffffffff` preset filter land again.
- The `relay_node` name annotation matches both `relay_node=245` and legacy `relay_node: 245`, and writes its replacement in the surrounding `=` style.
- `REGEX_ANNOTATED_NODE_ID` in `Debug.kt` drops its end-of-line anchor so mid-line annotations are styled.

## Testing Performed

`./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — every task green and **0 test failures / 0 errors across the repo's test-results XML**; `:feature:settings` ran 18 suites, 160 tests, 0 failures (counts read from the JUnit XML, not a cached task tick). One caveat, environmental and pre-existing: `:desktopApp:test` dies on this host in a **JVM native SIGSEGV** (pc=0x0 in GLib `g_object_unref`, JBR 25, during libnotify teardown right after `LinuxNotificationSenderTest` — all 15 recorded desktop tests pass first). Reproduced identically on **unmodified `main`**, so it is the host environment, not this branch; relying on CI for that task.

**Added** — `DebugViewModelTest` (4 tests), driven through `loadLogsForExport` so they exercise the *real* generated `toString()` rather than a fixture string — they hold whichever wire format the protobuf artifact uses:

- `packet log annotates signed Wire-format from and to with hex` — `from=0xDEADBEEF.toInt()` gains `(!deadbeef)`, broadcast `to=-1` gains `(!ffffffff)`.
- `packet log annotates relay_node with the known node's name` — a node DB match renders `relay_node=Relay Node (!000001aa)`.
- `packet log annotates unknown relay_node with hex` — falls back to `(!000000f5)`.
- `node info log still annotates legacy protobuf-java text format` — the backward-compat guard for pre-migration stored rows.

Verified as regression tests, not just green tests: with the two source files stashed, the three Wire-format tests fail and the legacy guard passes — exactly the broken/working split the bug describes.

## What it looks like

Before:

```
MeshPacket{from=-1897181963, to=-1, channel=1, id=850334385, … relay_node=245, …}
```

After (annotations italicised in the panel; relay name shown when the node is known):

```
MeshPacket{from=-1897181963 (!8ee6c775), to=-1 (!ffffffff), channel=1, id=850334385, … relay_node=245 (!000000f5), …}
```

## Notes for reviewers

- Docs evaluated per Constitution VI: `docs/en/user/debug-logs.md` documents the panel's tabs and export, not packet text formatting, so no page contradicts this change and none needed updating.
- Constitution check: KMP (all changes in `commonMain`/`commonTest` of `:feature:settings`) · zero-lint (spotless + detekt green) · CMP (no new UI) · privacy (no new logging) · design standards (text-only change inside an existing screen) · docs (above) · verify-before-push (baseline green locally, CI checked after push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mesh log parsing for Wire-formatted and legacy log formats.
  * Correctly annotates signed node IDs as hexadecimal values.
  * Displays known relay node names and IDs, while preserving IDs for unknown relays.
  * Continues to annotate legacy node information logs consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->