### PR TITLE
fix(database): recover wedged observer pools

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
@@ -18,7 +18,6 @@ package org.meshtastic.core.data.datasource
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapLatest
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.DeviceLinkEntity
@@ -27,7 +26,7 @@ import org.meshtastic.core.database.entity.DeviceLinkEntity
 class DeviceLinkLocalDataSource(private val dbManager: DatabaseProvider) {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observeAll(): Flow<List<DeviceLinkEntity>> =
-        dbManager.currentDb.flatMapLatest { db -> db.deviceLinkDao().observeAll() }
+        dbManager.observeCurrentDb { db -> db.deviceLinkDao().observeAll() }
 
     suspend fun getAll(): List<DeviceLinkEntity> = dbManager.withReadDb { it.deviceLinkDao().getAll() }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/EventFirmwareEditionLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/EventFirmwareEditionLocalDataSource.kt
@@ -18,7 +18,6 @@ package org.meshtastic.core.data.datasource
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
@@ -40,7 +39,7 @@ class EventFirmwareEditionLocalDataSource(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observeByEdition(edition: String): Flow<EventFirmwareEditionEntity?> =
-        dbManager.currentDb.flatMapLatest { db -> db.eventFirmwareEditionDao().observeByEdition(edition) }
+        dbManager.observeCurrentDb { db -> db.eventFirmwareEditionDao().observeByEdition(edition) }
 
     suspend fun upsertAll(editions: List<EventFirmwareEditionEntity>) {
         withContext(dispatchers.io) { dbManager.withDb { it.eventFirmwareEditionDao().upsertAll(editions) } }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSource.kt
@@ -18,7 +18,6 @@ package org.meshtastic.core.data.datasource
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -51,8 +50,8 @@ class SwitchingChannelSetDataSource(
     private val writeMutex = Mutex()
 
     val channelSetFlow: Flow<ChannelSet> =
-        dbManager.currentDb
-            .flatMapLatest { db -> db.channelSetDao().observe() }
+        dbManager
+            .observeCurrentDb { db -> db.channelSetDao().observe() }
             .map { entity -> entity?.channelSet ?: ChannelSet() }
             .distinctUntilChanged()
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoReadDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoReadDataSource.kt
@@ -17,7 +17,6 @@
 package org.meshtastic.core.data.datasource
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapLatest
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.MyNodeEntity
@@ -28,10 +27,10 @@ import org.meshtastic.core.database.entity.NodeWithRelations
 class SwitchingNodeInfoReadDataSource(private val dbManager: DatabaseProvider) : NodeInfoReadDataSource {
 
     override fun myNodeInfoFlow(): Flow<MyNodeEntity?> =
-        dbManager.currentDb.flatMapLatest { db -> db.nodeInfoDao().getMyNodeInfo() }
+        dbManager.observeCurrentDb { db -> db.nodeInfoDao().getMyNodeInfo() }
 
     override fun nodeDBbyNumFlow(): Flow<Map<Int, NodeWithRelations>> =
-        dbManager.currentDb.flatMapLatest { db -> db.nodeInfoDao().nodeDBbyNum() }
+        dbManager.observeCurrentDb { db -> db.nodeInfoDao().nodeDBbyNum() }
 
     override fun getNodesFlow(
         sort: String,
@@ -39,7 +38,7 @@ class SwitchingNodeInfoReadDataSource(private val dbManager: DatabaseProvider) :
         includeUnknown: Boolean,
         hopsAwayMax: Int,
         lastHeardMin: Int,
-    ): Flow<List<NodeWithRelations>> = dbManager.currentDb.flatMapLatest { db ->
+    ): Flow<List<NodeWithRelations>> = dbManager.observeCurrentDb { db ->
         db.nodeInfoDao()
             .getNodes(
                 sort = sort,

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/MeshLogRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/MeshLogRepositoryImpl.kt
@@ -57,14 +57,14 @@ open class MeshLogRepositoryImpl(
 ) : MeshLogRepository {
 
     /** Retrieves all [MeshLog]s in the database, up to [maxItem]. */
-    override fun getAllLogs(maxItem: Int): Flow<List<MeshLog>> = dbManager.currentDb
-        .flatMapLatest { it.meshLogDao().getAllLogs(maxItem) }
+    override fun getAllLogs(maxItem: Int): Flow<List<MeshLog>> = dbManager
+        .observeCurrentDb { it.meshLogDao().getAllLogs(maxItem) }
         .map { list -> list.map { it.asExternalModel() } }
         .flowOn(dispatchers.io)
 
     /** Retrieves all [MeshLog]s in the database in the order they were received. */
-    override fun getAllLogsInReceiveOrder(maxItem: Int): Flow<List<MeshLog>> = dbManager.currentDb
-        .flatMapLatest { it.meshLogDao().getAllLogsInReceiveOrder(maxItem) }
+    override fun getAllLogsInReceiveOrder(maxItem: Int): Flow<List<MeshLog>> = dbManager
+        .observeCurrentDb { it.meshLogDao().getAllLogsInReceiveOrder(maxItem) }
         .map { list -> list.map { it.asExternalModel() } }
         .flowOn(dispatchers.io)
 
@@ -72,8 +72,8 @@ open class MeshLogRepositoryImpl(
     override fun getAllLogsUnbounded(): Flow<List<MeshLog>> = getAllLogs(Int.MAX_VALUE)
 
     /** Retrieves all [MeshLog]s associated with a specific [nodeNum] and [portNum]. */
-    override fun getLogsFrom(nodeNum: Int, portNum: Int): Flow<List<MeshLog>> = dbManager.currentDb
-        .flatMapLatest { it.meshLogDao().getLogsFrom(nodeNum, portNum, DEFAULT_MAX_LOGS) }
+    override fun getLogsFrom(nodeNum: Int, portNum: Int): Flow<List<MeshLog>> = dbManager
+        .observeCurrentDb { it.meshLogDao().getLogsFrom(nodeNum, portNum, DEFAULT_MAX_LOGS) }
         .map { list -> list.map { it.asExternalModel() } }
         .distinctUntilChanged()
         .flowOn(dispatchers.io)
@@ -85,8 +85,10 @@ open class MeshLogRepositoryImpl(
     /** Retrieves telemetry history for a specific node, automatically handling local node redirection. */
     override fun getTelemetryFrom(nodeNum: Int): Flow<List<Telemetry>> = effectiveLogId(nodeNum)
         .flatMapLatest { logId ->
-            dbManager.currentDb
-                .flatMapLatest { it.meshLogDao().getLogsFrom(logId, PortNum.TELEMETRY_APP.value, DEFAULT_MAX_LOGS) }
+            dbManager
+                .observeCurrentDb {
+                    it.meshLogDao().getLogsFrom(logId, PortNum.TELEMETRY_APP.value, DEFAULT_MAX_LOGS)
+                }
                 .distinctUntilChanged()
                 .mapLatest { list -> list.map { it.asExternalModel() }.mapNotNull(::parseTelemetryLog) }
         }
@@ -97,8 +99,8 @@ open class MeshLogRepositoryImpl(
      *
      * A request log is defined as an outgoing packet (`fromNum = 0`) where `want_response` is true.
      */
-    override fun getRequestLogs(targetNodeNum: Int, portNum: PortNum): Flow<List<MeshLog>> = dbManager.currentDb
-        .flatMapLatest { it.meshLogDao().getLogsFrom(MeshLog.NODE_NUM_LOCAL, portNum.value, DEFAULT_MAX_LOGS) }
+    override fun getRequestLogs(targetNodeNum: Int, portNum: PortNum): Flow<List<MeshLog>> = dbManager
+        .observeCurrentDb { it.meshLogDao().getLogsFrom(MeshLog.NODE_NUM_LOCAL, portNum.value, DEFAULT_MAX_LOGS) }
         .map { list ->
             list
                 .map { it.asExternalModel() }
@@ -148,8 +150,8 @@ open class MeshLogRepositoryImpl(
         .distinctUntilChanged()
 
     /** Returns the cached [MyNodeInfo] from the system logs. */
-    override fun getMyNodeInfo(): Flow<MyNodeInfo?> = dbManager.currentDb
-        .flatMapLatest { db -> db.meshLogDao().getLogsFrom(MeshLog.NODE_NUM_LOCAL, 0, DEFAULT_MAX_LOGS) }
+    override fun getMyNodeInfo(): Flow<MyNodeInfo?> = dbManager
+        .observeCurrentDb { db -> db.meshLogDao().getLogsFrom(MeshLog.NODE_NUM_LOCAL, 0, DEFAULT_MAX_LOGS) }
         .mapLatest { list -> list.map { it.asExternalModel() }.firstOrNull { it.myNodeInfo != null }?.myNodeInfo }
         .flowOn(dispatchers.io)
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
@@ -22,7 +22,6 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
@@ -53,12 +52,11 @@ import org.meshtastic.core.repository.PacketRepository as SharedPacketRepository
 class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val dispatchers: CoroutineDispatchers) :
     SharedPacketRepository {
 
-    override fun getWaypoints(): Flow<List<DataPacket>> = dbManager.currentDb
-        .flatMapLatest { db -> db.packetDao().getAllWaypointsFlow() }
-        .map { list -> list.map { it.data } }
+    override fun getWaypoints(): Flow<List<DataPacket>> =
+        dbManager.observeCurrentDb { db -> db.packetDao().getAllWaypointsFlow() }.map { list -> list.map { it.data } }
 
-    override fun getContacts(): Flow<Map<String, DataPacket>> = dbManager.currentDb
-        .flatMapLatest { db -> db.packetDao().getContactKeys() }
+    override fun getContacts(): Flow<Map<String, DataPacket>> = dbManager
+        .observeCurrentDb { db -> db.packetDao().getContactKeys() }
         .map { map -> map.mapValues { it.value.data } }
 
     override fun getContactsPaged(): Flow<PagingData<Pair<String, DataPacket>>> = Pager(
@@ -80,16 +78,16 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         withContext(dispatchers.io) { dbManager.currentDb.value.packetDao().getUnreadCount(contact) }
 
     override fun getUnreadCountFlow(contact: String): Flow<Int> =
-        dbManager.currentDb.flatMapLatest { db -> db.packetDao().getUnreadCountFlow(contact) }
+        dbManager.observeCurrentDb { db -> db.packetDao().getUnreadCountFlow(contact) }
 
     override fun getFirstUnreadMessageUuid(contact: String): Flow<Long?> =
-        dbManager.currentDb.flatMapLatest { db -> db.packetDao().getFirstUnreadMessageUuid(contact) }
+        dbManager.observeCurrentDb { db -> db.packetDao().getFirstUnreadMessageUuid(contact) }
 
     override fun hasUnreadMessages(contact: String): Flow<Boolean> =
-        dbManager.currentDb.flatMapLatest { db -> db.packetDao().hasUnreadMessages(contact) }
+        dbManager.observeCurrentDb { db -> db.packetDao().hasUnreadMessages(contact) }
 
     override fun getUnreadCountTotal(): Flow<Int> =
-        dbManager.currentDb.flatMapLatest { db -> db.packetDao().getUnreadCountTotal() }
+        dbManager.observeCurrentDb { db -> db.packetDao().getUnreadCountTotal() }
 
     // One-shot writes go through withDb so they register with the cross-transport merge drain barrier. The callback
     // is never replayed after it starts; callers needing retries must make that policy explicit where idempotency is
@@ -361,8 +359,8 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         withContext(dispatchers.io) { dbManager.withDb { it.packetDao().update(packet) } }
     }
 
-    override fun getContactSettings(): Flow<Map<String, ContactSettings>> = dbManager.currentDb
-        .flatMapLatest { db -> db.packetDao().getContactSettings() }
+    override fun getContactSettings(): Flow<Map<String, ContactSettings>> = dbManager
+        .observeCurrentDb { db -> db.packetDao().getContactSettings() }
         .map { map -> map.mapValues { it.value.toShared() } }
 
     override suspend fun getContactSettings(contact: String): ContactSettings = withContext(dispatchers.io) {
@@ -382,7 +380,7 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
     }
 
     override fun getFilteredCountFlow(contactKey: String): Flow<Int> =
-        dbManager.currentDb.flatMapLatest { db -> db.packetDao().getFilteredCountFlow(contactKey) }
+        dbManager.observeCurrentDb { db -> db.packetDao().getFilteredCountFlow(contactKey) }
 
     override suspend fun getFilteredCount(contactKey: String): Int =
         withContext(dispatchers.io) { dbManager.currentDb.value.packetDao().getFilteredCount(contactKey) }
@@ -442,7 +440,7 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
     override fun searchMessages(query: String, contactKey: String?, getNode: (String?) -> Node): Flow<List<Message>> {
         val sanitized = sanitizeFtsQuery(query)
         if (sanitized.isBlank()) return flowOf(emptyList())
-        return dbManager.currentDb.flatMapLatest { db ->
+        return dbManager.observeCurrentDb { db ->
             kotlinx.coroutines.flow.flow {
                 val dao = db.packetDao()
                 val packets =

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/QuickChatActionRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/QuickChatActionRepositoryImpl.kt
@@ -17,7 +17,6 @@
 package org.meshtastic.core.data.repository
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
@@ -32,7 +31,7 @@ class QuickChatActionRepositoryImpl(
     private val dispatchers: CoroutineDispatchers,
 ) : QuickChatActionRepository {
     override fun getAllActions(): Flow<List<QuickChatAction>> =
-        dbManager.currentDb.flatMapLatest { it.quickChatActionDao().getAll() }.flowOn(dispatchers.io)
+        dbManager.observeCurrentDb { it.quickChatActionDao().getAll() }.flowOn(dispatchers.io)
 
     // Writes go through withDb so they register with the cross-transport merge drain barrier (see DatabaseProvider).
     override suspend fun upsert(action: QuickChatAction) {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/TracerouteSnapshotRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/TracerouteSnapshotRepositoryImpl.kt
@@ -19,7 +19,6 @@ package org.meshtastic.core.data.repository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.withContext
@@ -36,8 +35,8 @@ class TracerouteSnapshotRepositoryImpl(
     private val dispatchers: CoroutineDispatchers,
 ) : TracerouteSnapshotRepository {
 
-    override fun getSnapshotPositions(logUuid: String): Flow<Map<Int, Position>> = dbManager.currentDb
-        .flatMapLatest { it.tracerouteNodePositionDao().getByLogUuid(logUuid) }
+    override fun getSnapshotPositions(logUuid: String): Flow<Map<Int, Position>> = dbManager
+        .observeCurrentDb { it.tracerouteNodePositionDao().getByLogUuid(logUuid) }
         .distinctUntilChanged()
         .mapLatest { list -> list.associate { it.nodeNum to it.position } }
         .flowOn(dispatchers.io)

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -24,6 +24,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import co.touchlab.kermit.Logger
+import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CancellationException
@@ -39,11 +40,17 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -57,6 +64,11 @@ import org.meshtastic.core.database.di.DatabaseDataStore
 import org.meshtastic.core.di.CoroutineDispatchers
 import kotlin.concurrent.Volatile
 import org.meshtastic.core.common.database.DatabaseManager as SharedDatabaseManager
+
+internal const val MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES = 3
+
+/** Allows two recovered failure streaks while hard-bounding Flow-created detached pools for this manager lifetime. */
+internal const val MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME = MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES * 2
 
 /** Returns database names that form either side of an unfinished, crash-recoverable association route. */
 internal fun pendingRouteDbNames(preferences: Preferences): Set<String> = preferences
@@ -88,6 +100,11 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
         OPEN,
         CLOSING,
         CLOSED,
+    }
+
+    private enum class ReopenOrigin {
+        BOUNDED_OPERATION,
+        FLOW_OBSERVER,
     }
 
     @Volatile private var lifecycleState = LifecycleState.OPEN
@@ -194,6 +211,9 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
     /** Replaced pools that remain live for consumers of an earlier [currentDb] emission until orderly shutdown. */
     private val detachedDatabases = mutableListOf<NamedDatabase>()
 
+    /** Guarded by [mutex]; counts successful automatic Flow-triggered replacements for this manager's lifetime. */
+    private var flowPoolRecoveriesThisLifetime = 0
+
     /** Databases merged and logically retired but kept open — app-wide consumers may still hold references. */
     private val logicallyRetired = mutableSetOf<String>()
 
@@ -272,6 +292,60 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
 
     override val currentDb: StateFlow<MeshtasticDatabase>
         get() = _currentDb
+
+    /**
+     * Re-latches long-lived DAO flows on database switches and recovers the active Room pool after a reader/writer
+     * acquisition timeout. A failed query is never replayed on the same pool; publishing the replacement causes
+     * [flatMapLatest] to start a fresh DAO flow. Concurrent failing collectors converge on the same replacement.
+     *
+     * Each collector stops after [MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES] replacements without a successful emission,
+     * while the manager permits at most [MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME] successful Flow-triggered
+     * replacements for its lifetime. The second bound prevents intermittent wedge/recover/emission cycles from
+     * retaining an unbounded number of detached Room instances before orderly shutdown can reclaim them.
+     */
+    override fun <T> observeCurrentDb(query: (MeshtasticDatabase) -> Flow<T>): Flow<T> = flow {
+        val consecutivePoolRecoveries = atomic(0)
+        emitAll(
+            currentDb.flatMapLatest { database ->
+                flow { emitAll(query(database).onEach { consecutivePoolRecoveries.value = 0 }) }
+                    .catch { failure ->
+                        if (failure is CancellationException) throw failure
+                        val exception = failure as? Exception ?: throw failure
+                        if (!isDbPoolAcquireTimeoutException(exception)) throw failure
+                        if (
+                            consecutivePoolRecoveries.value >= MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES &&
+                            shouldRethrowFlowFailure(database)
+                        ) {
+                            throw exception
+                        }
+                        consecutivePoolRecoveries.incrementAndGet()
+
+                        val reopened =
+                            try {
+                                // Once a timeout is classified, finish or reject the manager-level ownership transfer
+                                // atomically even if this collector is cancelled. A cancellable reopen could otherwise
+                                // build a replacement and abandon the cache/publication handoff halfway through.
+                                withContext(NonCancellable) { reopenFlowDatabaseIfStillCurrent(database) }
+                            } catch (@Suppress("TooGenericExceptionCaught") recoveryFailure: Exception) {
+                                exception.addSuppressed(recoveryFailure)
+                                Logger.w(recoveryFailure) { "Failed to recover active DB after a Flow pool timeout" }
+                                throw exception
+                            }
+                        if (reopened != null) {
+                            Logger.w { "Reopened active DB after a Room Flow connection-pool timeout" }
+                        } else if (shouldRethrowFlowFailure(database)) {
+                            throw exception
+                        }
+                    }
+            },
+        )
+    }
+
+    /** Checks flow ownership without lazily rebuilding [currentDb] while shutdown is clearing its publication. */
+    private fun shouldRethrowFlowFailure(database: MeshtasticDatabase): Boolean {
+        val isStillCurrent = synchronized(initializationLock) { currentDbState?.value === database }
+        return isStillCurrent || lifecycleState != LifecycleState.OPEN
+    }
 
     private val _currentAddress = MutableStateFlow<String?>(null)
     val currentAddress: StateFlow<String?> = _currentAddress
@@ -798,14 +872,34 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
      *
      * Returns the reopened DB, or null if another coroutine switched databases or shutdown has started.
      */
+    private suspend fun reopenFlowDatabaseIfStillCurrent(expectedDb: MeshtasticDatabase): MeshtasticDatabase? {
+        val expectedDbName =
+            mutex.withLock {
+                if (lifecycleState != LifecycleState.OPEN || _currentDb.value !== expectedDb) return null
+                currentDbName
+            }
+        return reopenActiveDatabaseIfStillCurrent(expectedDb, expectedDbName, ReopenOrigin.FLOW_OBSERVER)
+    }
+
     @Suppress("ReturnCount")
     private suspend fun reopenActiveDatabaseIfStillCurrent(
         expectedDb: MeshtasticDatabase,
         expectedDbName: String,
+        origin: ReopenOrigin,
     ): MeshtasticDatabase? = withManagerOperation {
         mutex.withLock {
             if (lifecycleState != LifecycleState.OPEN) return@withManagerOperation null
             if (_currentDb.value !== expectedDb || currentDbName != expectedDbName) return@withManagerOperation null
+            if (
+                origin == ReopenOrigin.FLOW_OBSERVER &&
+                flowPoolRecoveriesThisLifetime >= MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME
+            ) {
+                Logger.w {
+                    "Flow DB recovery limit reached ($flowPoolRecoveriesThisLifetime); refusing another automatic " +
+                        "replacement"
+                }
+                return@withManagerOperation null
+            }
 
             val registered =
                 dbCache[expectedDbName]
@@ -815,7 +909,7 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
                         null
                     }
             if (registered !== expectedDb) {
-                Logger.w { "withDb: active DB registration changed before reopen; skipping active DB reopen" }
+                Logger.w { "DB recovery: active registration changed before reopen; skipping active DB reopen" }
                 return@withManagerOperation null
             }
 
@@ -835,6 +929,9 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
                 synchronized(initializationLock) { initializedDefaultDb = reopened }
             }
             _currentDb.value = reopened
+            if (origin == ReopenOrigin.FLOW_OBSERVER) {
+                flowPoolRecoveriesThisLifetime += 1
+            }
             if (detachedDatabases.none { it.database === expectedDb }) {
                 detachedDatabases.add(NamedDatabase(expectedDbName, expectedDb))
             }
@@ -1106,7 +1203,7 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
             if (currentDb === db && isDbPoolAcquireTimeoutException(e)) {
                 val reopened =
                     try {
-                        reopenActiveDatabaseIfStillCurrent(db, active)
+                        reopenActiveDatabaseIfStillCurrent(db, active, ReopenOrigin.BOUNDED_OPERATION)
                     } catch (recoveryCancel: CancellationException) {
                         throw recoveryCancel
                     } catch (recoveryFailure: Exception) {

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseProvider.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseProvider.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.database
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -30,11 +31,15 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * One-shot DAO *reads* use [withReadDb]. They stay out of writer admission and the serialized containment lane; the
  * logical-retirement guarantee in [DatabaseManager] keeps a captured published pool alive for the process lifetime.
- * [currentDb] itself remains the right latch for Flow/Paging factories, which must re-latch on database switches.
+ * Long-lived DAO Flows use [observeCurrentDb] so each implementation must make its database-switch/recovery policy
+ * explicit. [currentDb] remains the synchronous ownership source and the backing latch for existing Paging factories.
  */
 interface DatabaseProvider {
     /** Reactive stream of the currently active database instance. */
     val currentDb: StateFlow<MeshtasticDatabase>
+
+    /** Re-latches [query] whenever the active database changes. Production also recovers a wedged Room pool. */
+    fun <T> observeCurrentDb(query: (MeshtasticDatabase) -> Flow<T>): Flow<T>
 
     /**
      * Execute one bounded read against the synchronously published current database without writer admission. The read

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/SwitchingDiscoveryDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/SwitchingDiscoveryDao.kt
@@ -16,9 +16,7 @@
  */
 package org.meshtastic.core.database.dao
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapLatest
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.DiscoveredNodeEntity
 import org.meshtastic.core.database.entity.DiscoveryPresetResultEntity
@@ -28,8 +26,8 @@ import org.meshtastic.core.database.entity.DiscoverySessionEntity
  * A switch-aware [DiscoveryDao] that resolves the active database on every call instead of pinning the one that was
  * current at injection time. This is what Koin hands to `feature:discovery` consumers (ViewModels and the scan engine),
  * which hold their DAO for their whole lifetime:
- * - Flow methods re-latch via `currentDb.flatMapLatest`, so an open discovery screen follows a device/DB switch instead
- *   of watching the old database forever.
+ * - Flow methods re-latch through [DatabaseProvider.observeCurrentDb], so an open discovery screen follows a device/DB
+ *   switch and recovers from a wedged active Room pool.
  * - Suspend methods go through [DatabaseProvider.withDb], so writes register with the cross-transport merge drain
  *   barrier (a mid-scan merge can't snapshot-then-retire the DB underneath an in-flight session write). A callback is
  *   never replayed after it starts, so higher layers must make any retry policy explicit where idempotency is known.
@@ -37,7 +35,6 @@ import org.meshtastic.core.database.entity.DiscoverySessionEntity
  * `withDb` only returns null when no database is open, which [DatabaseProvider] guarantees can't happen (the default DB
  * is the floor), so the non-null coercions below are structural, not behavioral.
  */
-@OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("TooManyFunctions")
 class SwitchingDiscoveryDao(private val dbManager: DatabaseProvider) : DiscoveryDao {
 
@@ -51,7 +48,7 @@ class SwitchingDiscoveryDao(private val dbManager: DatabaseProvider) : Discovery
     }
 
     override fun getAllSessions(): Flow<List<DiscoverySessionEntity>> =
-        dbManager.currentDb.flatMapLatest { it.discoveryDao().getAllSessions() }
+        dbManager.observeCurrentDb { it.discoveryDao().getAllSessions() }
 
     override suspend fun getAllSessionsSnapshot(): List<DiscoverySessionEntity> =
         dbManager.withDb { it.discoveryDao().getAllSessionsSnapshot() }.orEmpty()
@@ -60,7 +57,7 @@ class SwitchingDiscoveryDao(private val dbManager: DatabaseProvider) : Discovery
         dbManager.withDb { it.discoveryDao().getSession(sessionId) }
 
     override fun getSessionFlow(sessionId: Long): Flow<DiscoverySessionEntity?> =
-        dbManager.currentDb.flatMapLatest { it.discoveryDao().getSessionFlow(sessionId) }
+        dbManager.observeCurrentDb { it.discoveryDao().getSessionFlow(sessionId) }
 
     override suspend fun deleteSession(sessionId: Long) {
         dbManager.withDb { it.discoveryDao().deleteSession(sessionId) }
@@ -88,7 +85,7 @@ class SwitchingDiscoveryDao(private val dbManager: DatabaseProvider) : Discovery
         dbManager.withDb { it.discoveryDao().getPresetResults(sessionId) }.orEmpty()
 
     override fun getPresetResultsFlow(sessionId: Long): Flow<List<DiscoveryPresetResultEntity>> =
-        dbManager.currentDb.flatMapLatest { it.discoveryDao().getPresetResultsFlow(sessionId) }
+        dbManager.observeCurrentDb { it.discoveryDao().getPresetResultsFlow(sessionId) }
 
     // endregion
 
@@ -109,7 +106,7 @@ class SwitchingDiscoveryDao(private val dbManager: DatabaseProvider) : Discovery
         dbManager.withDb { it.discoveryDao().getDiscoveredNodes(presetResultId) }.orEmpty()
 
     override fun getDiscoveredNodesFlow(presetResultId: Long): Flow<List<DiscoveredNodeEntity>> =
-        dbManager.currentDb.flatMapLatest { it.discoveryDao().getDiscoveredNodesFlow(presetResultId) }
+        dbManager.observeCurrentDb { it.discoveryDao().getDiscoveredNodesFlow(presetResultId) }
 
     override suspend fun getUniqueNodeNums(sessionId: Long): List<Long> =
         dbManager.withDb { it.discoveryDao().getUniqueNodeNums(sessionId) }.orEmpty()

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerShutdownTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerShutdownTest.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -334,6 +336,127 @@ class DatabaseManagerShutdownTest : DatabaseManagerTestFixture() {
         manager.close()
         assertEquals(1, manager.closedDatabases.count { it === original })
         assertEquals(1, manager.closedDatabases.count { it === reopened })
+    }
+
+    @Test
+    fun flowPoolTimeoutReopensAndRelatchesWithoutRepeatingTheFailedPool() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val original = manager.currentDb.value
+        var originalQueries = 0
+
+        val value =
+            manager
+                .observeCurrentDb { database ->
+                    if (database === original) {
+                        flow<String> {
+                            originalQueries += 1
+                            throw roomPoolTimeout()
+                        }
+                    } else {
+                        flowOf("recovered")
+                    }
+                }
+                .first()
+
+        assertEquals("recovered", value)
+        assertEquals(1, originalQueries)
+        assertTrue(manager.currentDb.value !== original)
+    }
+
+    @Test
+    fun flowPoolRecoveryStopsAfterIntermittentFailuresReachTheManagerLifetimeLimit() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val buildsBeforeRecovery = manager.builtDatabases.size
+        var successfulEmissions = 0
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                manager
+                    .observeCurrentDb {
+                        flow {
+                            successfulEmissions += 1
+                            emit(Unit)
+                            throw roomPoolTimeout()
+                        }
+                    }
+                    .first { false }
+            }
+
+        assertTrue(failure.message.orEmpty().contains("Timed out attempting to acquire"))
+        assertEquals(MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME + 1, successfulEmissions)
+        assertEquals(
+            buildsBeforeRecovery + MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME,
+            manager.builtDatabases.size,
+            "successful emissions must not reset the manager-lifetime Flow recovery budget",
+        )
+    }
+
+    @Test
+    fun flowPoolRecoveryStopsAfterConsecutiveReplacementPoolsFail() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val buildsBeforeRecovery = manager.builtDatabases.size
+        var queryAttempts = 0
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                manager
+                    .observeCurrentDb<Unit> {
+                        flow {
+                            queryAttempts += 1
+                            throw roomPoolTimeout()
+                        }
+                    }
+                    .first()
+            }
+
+        assertTrue(failure.message.orEmpty().contains("Timed out attempting to acquire"))
+        assertEquals(MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES + 1, queryAttempts)
+        assertEquals(
+            buildsBeforeRecovery + MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES,
+            manager.builtDatabases.size,
+            "automatic recovery must bound the number of detached replacement pools",
+        )
+    }
+
+    @Test
+    fun flowPoolTimeoutRetainsItsOriginalFailureAfterShutdownClearsCurrentPublication() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val buildsBeforeFailure = manager.builtDatabases.size
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                manager
+                    .observeCurrentDb<Unit> {
+                        flow {
+                            manager.close()
+                            throw roomPoolTimeout()
+                        }
+                    }
+                    .first()
+            }
+
+        assertTrue(failure.message.orEmpty().contains("Timed out attempting to acquire"))
+        assertEquals(buildsBeforeFailure, manager.builtDatabases.size, "shutdown must suppress Flow pool recovery")
+    }
+
+    @Test
+    fun flowRecoveryDoesNotSwallowUnrelatedDatabaseFailures() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val original = manager.currentDb.value
+        val buildsBeforeFailure = manager.builtDatabases.size
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                manager.observeCurrentDb<String> { flow { throw IllegalStateException("query failed") } }.first()
+            }
+
+        assertEquals("query failed", failure.message)
+        assertTrue(manager.currentDb.value === original)
+        assertEquals(
+            buildsBeforeFailure,
+            manager.builtDatabases.size,
+            "unrelated failures must not trigger recovery",
+        )
     }
 
     @Test

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/SwitchingDiscoveryDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/SwitchingDiscoveryDaoTest.kt
@@ -16,9 +16,12 @@
  */
 package org.meshtastic.core.database.dao
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.database.DatabaseProvider
@@ -87,9 +90,13 @@ class SwitchingDiscoveryDaoTest {
     }
 
     /** Minimal [DatabaseProvider] whose active DB the test can swap, mirroring a device/DB switch. */
+    @OptIn(ExperimentalCoroutinesApi::class)
     private class TestProvider(db: MeshtasticDatabase) : DatabaseProvider {
         private val _currentDb = MutableStateFlow(db)
         override val currentDb: StateFlow<MeshtasticDatabase> = _currentDb
+
+        override fun <T> observeCurrentDb(query: (MeshtasticDatabase) -> Flow<T>): Flow<T> =
+            currentDb.flatMapLatest(query)
 
         override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = block(_currentDb.value)
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDatabaseProvider.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDatabaseProvider.kt
@@ -16,18 +16,24 @@
  */
 package org.meshtastic.core.testing
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.MeshtasticDatabase
 import org.meshtastic.core.database.getInMemoryDatabaseBuilder
 import kotlin.concurrent.Volatile
 
 /** A real [DatabaseProvider] that uses an in-memory database for testing. */
+@OptIn(ExperimentalCoroutinesApi::class)
 class FakeDatabaseProvider : DatabaseProvider {
     @Volatile private var db: MeshtasticDatabase = getInMemoryDatabaseBuilder().build()
     private val _currentDb = MutableStateFlow(db)
     override val currentDb: StateFlow<MeshtasticDatabase> = _currentDb
+
+    override fun <T> observeCurrentDb(query: (MeshtasticDatabase) -> Flow<T>): Flow<T> = currentDb.flatMapLatest(query)
 
     override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = block(db)
 


### PR DESCRIPTION
## Overview

Long-lived Room `Flow` observers can remain attached to a database connection pool that has stopped granting reader or writer connections. Existing bounded database operations already recover the recognized pool-acquisition timeout, but a failing DAO `Flow` could otherwise remain latched to the failed pool indefinitely.

This change adds a shared observation path that can replace the still-current database after that specific timeout and automatically relatch long-lived DAO flows to the replacement, while bounding both repeated failures and lifetime pool retention.

## Changes

* Add `DatabaseProvider.observeCurrentDb()` as the explicit contract for long-lived DAO `Flow` observation.
* Require each `DatabaseProvider` implementation to define its relatching policy rather than silently inheriting a non-recovering default.
* On the existing recognized Room connection-pool acquisition timeout, replace only the still-current database and let `flatMapLatest` attach observers to the fresh pool.
* Never replay the failed query on the same database instance.
* Preserve coroutine cancellation and propagate unrelated database or query failures unchanged.
* Converge concurrent recovery attempts on the same replacement instead of reopening once per failing collector.
* Limit each collector to three consecutive automatic Flow pool recoveries without a successful emission.
* Independently limit successful Flow-triggered replacements to six for the lifetime of a `DatabaseManager`, preventing intermittent recover/emit/wedge cycles from accumulating detached Room instances without bound.
* Keep the manager ownership-transfer portion of an admitted reopen non-cancellable so a replacement cannot be abandoned between construction, cache replacement, and publication.
* Route existing long-lived read flows through the shared helper while leaving one-shot write/replay semantics unchanged.
* Keep non-production providers on explicit ordinary `flatMapLatest` relatching behavior.

## Testing

* Added coverage proving a Flow pool timeout reopens the database and relatches without repeating the failed pool.
* Added coverage proving three consecutive failing replacement pools exhaust the per-collector recovery budget.
* Added coverage proving successful emissions do not reset the manager-lifetime recovery budget and intermittent failures stop after six Flow-triggered replacements.
* Added coverage proving shutdown suppresses recovery and does not build another database.
* Added coverage proving unrelated database failures propagate unchanged and do not trigger a replacement.
* Existing shutdown and detached-pool ownership coverage continues to verify retained databases are reclaimed during orderly close.

## Scope

* Recovery remains limited to the existing recognized Room connection-pool timeout condition.
* Ordinary query failures are not retried.
* One-shot writes are not replayed.
* Recovery used by bounded one-shot operations remains separate from the Flow-specific lifetime budget.
* Existing PagingSource creation from `currentDb.value` is unchanged; paging relatching is a pre-existing follow-up concern rather than part of this change.
* Database schema, persisted data, DAO contracts, and migration behavior are unchanged.