### PR TITLE
chore(ci): close the gaps left by the Develocity onboarding

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -101,3 +101,13 @@ runs:
         gradle-home-cache-includes: |
           caches
           notifications
+        # `caches` sweeps in caches/build-cache-1, the LOCAL build cache — which since the
+        # Develocity onboarding (#6531) duplicates the remote cache at
+        # community.develocity.cloud. Shipping both means paying tarball upload/download
+        # for entries the remote already serves, on every one of the ~14 jobs that call
+        # this action, against a 10 GB repo-wide Actions cache quota that evicts under
+        # pressure. Dependency and transform caches (the expensive part) still ship.
+        # Effect is measurable in the Build Scan cache-performance view; revert if remote
+        # cache latency turns out to cost more than the restore it replaced.
+        gradle-home-cache-excludes: |
+          caches/build-cache-1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -112,6 +112,38 @@ jobs:
 
           print('check-changes filter is aligned with settings.gradle module roots.')
           PY
+      # Drift guard: the Develocity settings plugin is applied in TWO settings
+      # files — the root build and the build-logic included build — because a
+      # settings `plugins {}` block cannot be sourced from an `apply(from = ...)`
+      # script, so the version literal is unavoidably duplicated. Two copies of a
+      # version string drift silently; this makes that a build failure instead.
+      - name: Verify Develocity plugin version matches across settings files
+        run: |
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          PATTERN = r'id\("com\.gradle\.develocity"\)\s+version\s+"([^"]+)"'
+          FILES = ('settings.gradle.kts', 'build-logic/settings.gradle.kts')
+
+          found = {}
+          for name in FILES:
+              matches = re.findall(PATTERN, Path(name).read_text())
+              if len(matches) != 1:
+                  print(f'{name}: expected exactly one com.gradle.develocity version '
+                        f'declaration, found {len(matches)}')
+                  raise SystemExit(1)
+              found[name] = matches[0]
+
+          if len(set(found.values())) != 1:
+              print('Develocity plugin version drift detected:')
+              for name, version in found.items():
+                  print(f'  {name}: {version}')
+              print('Both settings files must apply the same version.')
+              raise SystemExit(1)
+
+          print(f'Develocity plugin version is consistent: {next(iter(found.values()))}')
+          PY
       # Second drift guard: the shard task lists in reusable-check.yml are
       # hand-maintained and have silently dropped modules before (discovery,
       # docs, wifi-provision, car, datastore, konsist had tests that never ran

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,11 @@ firebase-debug.log
 # Firebase Studio / Antigravity auto-provisioned skills — not used by this project
 .agents/
 
+# JVM crash dumps (desktopApp test runs) — regenerable, and untracked paths leak into public Build Scans
+hs_err_pid*.log
+replay_pid*.log
+.attach_pid*
+
 # Local library development clones
 /coil/
 /kable/

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -62,10 +62,24 @@ dependencyResolutionManagement {
 // `./gradlew help --info` then reports "Using local directory build cache for build
 // ':build-logic'" with no matching remote line, while the root build gets both. Mirror the
 // root's server/project so the convention plugins share one remote cache with everything else.
+val isCI = System.getenv("CI") != null
+
 develocity {
     server = "https://community.develocity.cloud"
     projectId = "meshtastic"
-    buildScan { publishing.onlyIf { it.isAuthenticated } }
+    buildScan {
+        publishing.onlyIf { it.isAuthenticated }
+        // Mirrors the root settings. Only reachable via a standalone `-p build-logic` run —
+        // when included, the root build publishes the scan — but the leak would be identical,
+        // so don't leave the gap open.
+        obfuscation {
+            ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
+            if (!isCI) {
+                username { "local-dev" }
+                hostname { "local-machine" }
+            }
+        }
+    }
 }
 
 // Build Cache configuration (Develocity remote cache + local)

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -30,6 +30,12 @@ pluginManagement {
     }
 }
 
+plugins {
+    // Version duplicated from the root settings.gradle.kts: a settings `plugins {}`
+    // block is evaluated before the version catalog exists, so it cannot use `libs`.
+    id("com.gradle.develocity") version "4.5.0"
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
@@ -50,7 +56,19 @@ dependencyResolutionManagement {
     }
 }
 
-// Build Cache configuration (HTTP remote cache + local)
+// build-logic is a plugin-included build with its own settings, so it does NOT inherit the
+// root build's Develocity configuration. Without this block the shared build-cache script
+// below finds no `develocity` extension and silently falls back to local-cache-only —
+// `./gradlew help --info` then reports "Using local directory build cache for build
+// ':build-logic'" with no matching remote line, while the root build gets both. Mirror the
+// root's server/project so the convention plugins share one remote cache with everything else.
+develocity {
+    server = "https://community.develocity.cloud"
+    projectId = "meshtastic"
+    buildScan { publishing.onlyIf { it.isAuthenticated } }
+}
+
+// Build Cache configuration (Develocity remote cache + local)
 apply(from = "../gradle/build-cache.settings.gradle")
 
 rootProject.name = "build-logic"

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -33,8 +33,11 @@ pluginManagement {
 plugins {
     // Version duplicated from the root settings.gradle.kts: a settings `plugins {}`
     // block is evaluated before the version catalog exists, so it cannot use `libs`.
+    // A CI drift guard in .github/workflows/pull-request.yml keeps the two in sync.
     id("com.gradle.develocity") version "4.5.0"
 }
+
+val isCI = System.getenv("CI") != null
 
 dependencyResolutionManagement {
     repositories {
@@ -62,19 +65,21 @@ dependencyResolutionManagement {
 // `./gradlew help --info` then reports "Using local directory build cache for build
 // ':build-logic'" with no matching remote line, while the root build gets both. Mirror the
 // root's server/project so the convention plugins share one remote cache with everything else.
-val isCI = System.getenv("CI") != null
-
 develocity {
     server = "https://community.develocity.cloud"
     projectId = "meshtastic"
     buildScan {
         publishing.onlyIf { it.isAuthenticated }
-        // Mirrors the root settings. Only reachable via a standalone `-p build-logic` run —
-        // when included, the root build publishes the scan — but the leak would be identical,
-        // so don't leave the gap open.
+        // Mirrors the root settings — see the rationale there. Only reachable via a standalone
+        // `-p build-logic` run (when included, the root build publishes the scan), but the
+        // exposure would be identical, so don't leave the gap open.
+        // The `if` stays outside the lambdas — see the root settings for why.
         obfuscation {
             ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
-            if (!isCI) {
+            if (isCI) {
+                username { "ci" }
+                hostname { "ci-runner" }
+            } else {
                 username { "local-dev" }
                 hostname { "local-machine" }
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -84,12 +84,30 @@ develocity {
         // scan payload is not worth paying for on every local build.
         capture { fileFingerprints = isCI }
         // community.develocity.cloud is a public OSS instance — the README badge links its
-        // scan list. CI runners are disposable and their identity is already public in the
-        // Actions log, but a contributor's workstation is not: without this, every local
-        // build would publish their OS username and machine hostname.
+        // scan list — so no machine identity is published, from CI or a workstation.
+        //
+        // The workstation case is the live one: without this, every local build would publish
+        // a contributor's OS username and machine hostname. The CI case is a hedge. Every
+        // runner today is GitHub-hosted, so the raw hostname is an ephemeral Azure VM name
+        // that leaks nothing and correlates nothing (VMs are never reused). But a self-hosted
+        // runner's hostname WOULD be real infrastructure, and whoever adds one will not be
+        // thinking about build scans.
+        //
+        // Deliberately constants, not something descriptive: the scan already records
+        // `operatingSystem` ("Linux 7.0.0-28-generic (amd64)") and `numberOfCpuCores`, and the
+        // common-custom-user-data plugin already adds CI workflow/job/step/run values, so an
+        // "informative" hostname would only duplicate them.
+        //
+        // The `if` must stay OUTSIDE the lambdas. Referencing `isCI` inside one captures the
+        // enclosing settings script object, which the configuration cache cannot serialize
+        // ("cannot serialize Gradle script object references"). Keeping each lambda a bare
+        // constant keeps it capture-free.
         obfuscation {
             ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
-            if (!isCI) {
+            if (isCI) {
+                username { "ci" }
+                hostname { "ci-runner" }
+            } else {
                 username { "local-dev" }
                 hostname { "local-machine" }
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -83,7 +83,17 @@ develocity {
         // down to the individual changed input. That is a CI-debugging tool, and the extra
         // scan payload is not worth paying for on every local build.
         capture { fileFingerprints = isCI }
-        obfuscation { ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } } }
+        // community.develocity.cloud is a public OSS instance — the README badge links its
+        // scan list. CI runners are disposable and their identity is already public in the
+        // Actions log, but a contributor's workstation is not: without this, every local
+        // build would publish their OS username and machine hostname.
+        obfuscation {
+            ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } }
+            if (!isCI) {
+                username { "local-dev" }
+                hostname { "local-machine" }
+            }
+        }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -79,6 +79,10 @@ develocity {
     buildScan {
         uploadInBackground = !isCI
         publishing.onlyIf { it.isAuthenticated }
+        // File fingerprints are what let Develocity's build comparison explain a cache miss
+        // down to the individual changed input. That is a CI-debugging tool, and the extra
+        // scan payload is not worth paying for on every local build.
+        capture { fileFingerprints = isCI }
         obfuscation { ipAddresses { addresses -> addresses.map { _ -> "0.0.0.0" } } }
     }
 }


### PR DESCRIPTION
Follow-up to #6531. Onboarding to the OSS Community Develocity instance landed the plumbing, but three things were left on the table: the `build-logic` included build never actually got the remote cache, Build Scans lost the one capture setting that makes cache misses diagnosable, and CI now ships a local build cache that duplicates the remote one. This PR closes those gaps so the sponsorship is doing the work it can do.

## 🛠️ Improvements

- **`build-logic` now shares the remote build cache.** `build-logic` is a plugin-included build with its own `settings.gradle.kts`, so it does not inherit the root build's Develocity configuration. It applies the shared `gradle/build-cache.settings.gradle`, but that script looks up `extensions.findByName("develocity")` — which is `null` there — so the entire `remote {}` block was skipped and the convention plugins compiled against the local cache only. The pre-#6531 `HttpBuildCache` config handled this case explicitly (it had an `isLogic` branch and its own log line); the Develocity port dropped it. Applying the Develocity settings plugin in `build-logic/settings.gradle.kts` restores parity.

  Verified with `./gradlew help --info`:

  ```
  # before
  Using local directory build cache for build ':build-logic'
  Using local directory build cache for the root build
  Using remote Develocity build cache for the root build (pull-only, ...)

  # after
  Using local directory build cache for build ':build-logic'
  Using remote Develocity build cache for build ':build-logic' (pull-only, ...)   # ← new
  Using local directory build cache for the root build
  Using remote Develocity build cache for the root build (pull-only, ...)
  ```

  No additional Build Scan is published — the included build mirrors the root's `publishing.onlyIf { it.isAuthenticated }` guard.

- **Restore `capture { fileFingerprints }` on CI.** #6531 dropped the explicit setting in favour of the plugin default. File fingerprints are what let Develocity's build-comparison view explain a cache miss down to the individual changed input, which is the main reason to reach for a scan in the first place. Re-enabled on CI only (`fileFingerprints = isCI`), so local builds don't pay the scan payload for a tool that gets used when debugging CI.

- **Stop shipping the local build cache in the Actions cache.** `gradle-home-cache-includes: caches` sweeps in `caches/build-cache-1`, which since #6531 duplicates the remote cache at `community.develocity.cloud`. Every one of the ~14 jobs that call the shared `gradle-setup` action paid tarball upload/download for entries the remote already serves, against a 10 GB repo-wide Actions cache quota that evicts under pressure. Added `gradle-home-cache-excludes: caches/build-cache-1`; dependency and artifact-transform caches — the expensive part — still ship.

  This one is a trade, not a strict win: it swaps one bulk tarball restore for per-entry HTTP against Develocity. The effect is now measurable in the Build Scan cache-performance view, and the comment in the action says to revert if remote latency costs more than the restore it replaced.

- **Obfuscate username and hostname in Build Scans, from both CI and workstations.** `community.develocity.cloud` is a public OSS instance and the README badge links its scan list, but only IP addresses were being obfuscated.

  The workstation case is the live one: provisioning a local access key is what makes local builds publish at all (`publishing.onlyIf { it.isAuthenticated }`), so the moment a contributor runs `./gradlew provisionDevelocityAccessKey`, every local build would publish their OS username and machine hostname. Now `local-dev` / `local-machine`.

  The CI case is a hedge, not a fix for a live leak. Every runner today is GitHub-hosted, so the raw hostname is an ephemeral Azure VM name that leaks nothing and correlates nothing (VMs are never reused). But a self-hosted runner's hostname *would* be real infrastructure, and whoever adds one will not be thinking about build scans. Now `ci` / `ci-runner`.

  Values are deliberately constants rather than anything descriptive: the scan already records `operatingSystem` (`"Linux 7.0.0-28-generic (amd64)"` — including architecture) and `numberOfCpuCores`, and `common-custom-user-data` already adds `CI workflow` / `CI job` / `CI step` / `CI run` values, so an "informative" hostname would only duplicate them.

  **Reviewer note on structure:** the `if` must stay *outside* the obfuscation lambdas. Referencing `isCI` from inside one captures the enclosing settings script object, which the configuration cache cannot serialize (`cannot serialize Gradle script object references`) — this repo runs with `org.gradle.configuration-cache=true`. The first attempt at this collapsed the branch into `username { if (isCI) ... }` and failed the baseline; the constraint is now commented in both files so it doesn't get refactored back.

  Applied in both settings files. In `build-logic` it is only reachable via a standalone `-p build-logic` run (when included, the root build publishes the scan), but the exposure would be identical, so the gap is closed there too.

- **Gitignore JVM crash dumps so they stay out of public scans.** `common-custom-user-data` publishes the raw output of `git status --porcelain` as the `Git status` custom value, and it offers no opt-out: `CaptureGitMetadataAction` runs unconditionally, and the `obfuscation {}` block used above covers only username, hostname, IP addresses and external process names — not custom values. So on a public instance every untracked, non-ignored path in the working tree is visible.

  The `:desktopApp:test` crash described at the bottom of this PR leaves `hs_err_pid*.log` dumps behind, and three of them were riding along in every local scan. Ignoring them — plus `replay_pid*.log` and `.attach_pid*`, same family — scopes the value back to real working-tree changes; a fresh scan now reports `Git status: " M .gitignore"` alone. Paths only, never file contents, but worth keeping honest.

## Notes for reviewers

- **No test-retry changes.** Flaky-test detection was the other thing worth chasing here, but it turns out the repo already has it: `configureTestOptions()` wires `org.gradle.test-retry` with `maxRetries=2`, `maxFailures=10`, `failOnPassedAfterRetry=false` across the Android app/library and KMP library convention plugins. Develocity's within-build detection works with the standalone plugin as-is, and cross-build detection needs no client config at all — so the flaky data is already flowing to the Tests dashboard and no code change is warranted. Migrating to the built-in `develocity.testRetry` would be tidy but is not required, and would risk the screenshot-test opt-out in `AndroidScreenshotConventionPlugin`; left alone deliberately.
- **`failOnPassedAfterRetry` stays `false`.** Develocity's guide suggests `true` to keep a flake as a gate failure, but recording flakes without breaking CI is the more useful posture now that the Tests dashboard actually surfaces them.
- **Obfuscation verified against real published scans, both modes.** Queried back via `/api/builds/{id}/gradle-attributes`: a local build reports `local-dev` / `local-machine`, a `CI=true` build reports `ci` / `ci-runner`, and the configuration cache stores cleanly in each. Initial local-only verification is in [this comment](https://github.com/meshtastic/Meshtastic-Android/pull/6541#issuecomment-5152830551).
- **The `com.gradle.develocity` version literal is duplicated** across the two settings files, and is now guarded by a CI drift check (third guard in `check-changes`). It cannot be shared — a settings plugin must be applied in the settings file itself, so a `plugins {}` block cannot move into an `apply(from = …)` script. Folding the rest of the `develocity { }` body into the shared Groovy `gradle/build-cache.settings.gradle` was considered and rejected: `publishing.onlyIf { it.isAuthenticated }` does not port literally to Groovy (boolean getter → `it.authenticated`), and getting it wrong would silently disable the publish guard this PR just tightened. Not worth trading compile-time checking for ~12 lines on that particular block.
- **No PR-comment integration.** `setup-gradle`'s `add-job-summary-as-pr-comment` was considered and skipped: with ~14 jobs behind the shared action, a broad failure would post ~14 comments. The existing `add-job-summary: always` already carries the scan links.

## Testing Performed

- `./gradlew help --info` before and after, confirming which builds resolve the remote cache (output quoted above).
- Baseline: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests -x :desktopApp:test --continue` — **BUILD SUCCESSFUL**, no failing tasks, spotless produced no reformatting. Re-run after the obfuscation commit: still green.
- Build-config-only change; no production source touched, so no new tests are applicable.

**One task was excluded from the local baseline and needs CI to cover it.** `:desktopApp:test` aborts on my Linux workstation with `exit value 134` (SIGABRT) — a native SIGSEGV in `libgobject-2.0.so` / `g_object_unref` under the JetBrains JRE, almost certainly `LinuxNotificationSenderTest` touching GLib/GTK on a host with a real desktop session. I confirmed it is **pre-existing and unrelated** to this change by stashing the diff and running `:desktopApp:test --rerun-tasks` on the unmodified tree: identical crash, identical signature, and an `hs_err` log from before this work began. CI covers the task in the `shard-app` test shard, and **that shard passed on this PR** — so the gap is closed by CI, not left open. Flagging it because the full local baseline as documented in `CLAUDE.md` is currently unrunnable on a Linux desktop session, which is worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

