### PR TITLE
fix(desktop): stop SIGSEGV on every Linux notification

### DIFF
--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/LinuxNotificationSender.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/LinuxNotificationSender.kt
@@ -29,6 +29,17 @@ import org.meshtastic.core.repository.Notification
  *
  * Only the minimal API surface needed for fire-and-forget desktop notifications is exposed. See:
  * https://developer-old.gnome.org/libnotify/stable/
+ *
+ * **The GLib entry points below MUST stay on this interface.** They are deliberately resolved through the *libnotify*
+ * handle rather than a separate `Native.load("gobject-2.0", ...)`. `dlsym()` on a library handle searches that library
+ * *and its dependency chain*, and libnotify has a `DT_NEEDED` on `libgobject-2.0.so.0`/`libglib-2.0.so.0` — so this
+ * guarantees we get the exact same GLib instance that libnotify itself is bound to.
+ *
+ * Loading `gobject-2.0` separately is NOT safe: a JVM process can easily have two distinct GLib copies mapped at once
+ * (e.g. the JDK/Compose Desktop AWT stack drags in a bundled GTK3 + GLib, while libnotify binds to the system GLib).
+ * Each copy owns a private `GType` registry, so freeing a `NotifyNotification` created by one copy with the other
+ * copy's `g_object_unref()` walks the wrong registry and jumps through a null vtable slot — an immediate SIGSEGV at
+ * `pc=0x0` inside `g_object_unref`, not a catchable exception.
  */
 @Suppress("FunctionNaming", "FunctionParameterNaming", "ktlint:standard:function-naming")
 private interface LibNotify : Library {
@@ -45,11 +56,9 @@ private interface LibNotify : Library {
     fun notify_notification_show(notification: Pointer, error: PointerByReference?): Boolean
 
     fun notify_uninit()
-}
 
-/** Minimal GLib bindings for GVariant creation and GObject ref-counting. */
-@Suppress("FunctionNaming", "FunctionParameterNaming", "ktlint:standard:function-naming")
-private interface GLib : Library {
+    // --- GLib, resolved via libnotify's own dependency chain. See the KDoc above before touching these. ---
+
     fun g_object_unref(obj: Pointer)
 
     fun g_variant_new_boolean(value: Boolean): Pointer
@@ -97,28 +106,22 @@ class LinuxNotificationSender(
 ) : NativeNotificationSender {
 
     private val lib: LibNotify?
-    private val glib: GLib?
 
     init {
         var loadedLib: LibNotify? = null
-        var loadedGLib: GLib? = null
         try {
             loadedLib = Native.load("notify", LibNotify::class.java) as LibNotify
-            loadedGLib = Native.load("gobject-2.0", GLib::class.java) as GLib
             if (loadedLib.notify_init(appName)) {
                 Logger.i { "libnotify initialized for '$appName'" }
             } else {
                 Logger.w { "notify_init('$appName') returned false" }
                 loadedLib = null
-                loadedGLib = null
             }
         } catch (e: UnsatisfiedLinkError) {
             Logger.w(e) { "libnotify not available — native Linux notifications disabled" }
             loadedLib = null
-            loadedGLib = null
         }
         lib = loadedLib
-        glib = loadedGLib
     }
 
     /** Whether libnotify was successfully loaded and initialized. */
@@ -151,7 +154,7 @@ class LinuxNotificationSender(
             }
             shown
         } finally {
-            glib?.g_object_unref(ptr)
+            libnotify.g_object_unref(ptr)
         }
     }
 
@@ -177,14 +180,11 @@ class LinuxNotificationSender(
 
         // desktop-entry hint associates notifications with the app's .desktop file,
         // enabling proper icon resolution and notification grouping by the daemon.
-        glib?.let { g ->
-            libnotify.notify_notification_set_hint(ptr, "desktop-entry", g.g_variant_new_string(desktopEntry))
-        }
+        // The GVariants below are floating refs; notify_notification_set_hint() sinks them, so we must not unref.
+        libnotify.notify_notification_set_hint(ptr, "desktop-entry", libnotify.g_variant_new_string(desktopEntry))
 
         if (notification.isSilent) {
-            glib?.let { g ->
-                libnotify.notify_notification_set_hint(ptr, "suppress-sound", g.g_variant_new_boolean(true))
-            }
+            libnotify.notify_notification_set_hint(ptr, "suppress-sound", libnotify.g_variant_new_boolean(true))
         }
     }
 }


### PR DESCRIPTION
`LinuxNotificationSender` loaded GLib twice and then used one copy to free objects the other copy had created, which hard-crashes the JVM with a `SIGSEGV` on every notification send on a Linux desktop. CI never caught it because headless runners have no notification daemon, so `notify_init()` returns false and `send()` short-circuits before reaching the faulty free.

## 🐛 Bug Fixes

- **Resolve GLib symbols through the libnotify handle instead of a second `Native.load`.** The class did:

  ```kotlin
  loadedLib  = Native.load("notify", LibNotify::class.java)      // binds libnotify → its GLib
  loadedGLib = Native.load("gobject-2.0", GLib::class.java)      // a SECOND, unrelated GLib
  ...
  finally { glib?.g_object_unref(ptr) }   // frees a libnotify object with the other copy's unref
  ```

  A JVM process routinely has two distinct GLib copies mapped at once: the JBR / Compose Desktop AWT stack drags in a bundled GTK3 + GLib, while JNA's `Native.load("gobject-2.0", …)` binds the system one. **Each copy owns a private `GType` registry**, so `g_type_free_instance()` looks up the object's type ID in a registry that never saw it and calls through a null vtable slot — `SIGSEGV` at `pc=0x0`, a native fault that no `try/catch` can contain.

  The fix folds `g_object_unref` and the two `g_variant_new_*` entry points onto the existing `LibNotify` interface and deletes the separate load. `dlsym()` on a library handle searches that library **and its dependency chain**, and libnotify carries a `DT_NEEDED` on `libgobject-2.0.so.0` / `libglib-2.0.so.0` — so symbols resolved through the libnotify handle are guaranteed to be the same GLib instance libnotify itself is bound to. KDoc on the interface records why they must not be split back out.

### Evidence

1. **Crash dump.** `SIGSEGV`, `si_code=SEGV_MAPERR`, `si_addr=0x0`, `pc=0x0`; problematic frame `g_object_unref+0xbc`, reached from `LinuxNotificationSender.send()`'s `finally` block via JNA.
2. **Two GObject copies in the dump's loaded-library list** — `…/glib-2.88.1/lib/libgobject-2.0.so.0.8800.**1**` (bundled, via the JBR's GTK3/GDK/gdk-pixbuf) and `/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.8800.**0**` (system, via JNA). The crash frame is in the system copy: the object was created under one GLib and freed under the other.
3. **The obvious explanations were ruled out, not assumed away.** A C repro replaying the exact `send()` sequence — `notify_init` → `notify_notification_new` → both `set_hint` calls → `show` → `g_object_unref` — against a *single* GLib ran 40 iterations clean. So this is not a double-unref, not a floating-ref mistake, and not a dangling JNA `String` buffer inside the GVariant (`g_variant_new_string` copies).
4. **The mechanism was then reproduced directly.** Creating a `NotifyNotification` via libnotify and unreffing it through a *different* mapped GLib copy segfaults on iteration 0; the identical sequence with the matching GLib is clean.

### Impact

`send()` is the shipping notification path, so this is not a test-only defect. Any Linux desktop user on a runtime that maps its own GTK/GLib alongside the system one — Compose Desktop's packaged JRE, Flatpak, Snap, Nix — takes a hard crash on **every** notification. Worth noting given `:desktopApp` is packaged for Flathub.

It also made the documented local baseline in `CLAUDE.md` unrunnable on any Linux host with a desktop session: `./gradlew … allTests` aborted with exit 134 (SIGABRT) unless `-x :desktopApp:test` was passed. That is no longer necessary.

## Testing Performed

No test changes — the existing tests already reproduce this; they just needed the production bug fixed. They still instantiate a real sender and fire real notifications through the session daemon, with no `DISPLAY` guard, no skip, and no weakened assertions. **This is a fix, not a mask.**

- `./gradlew :desktopApp:test --rerun-tasks` — **10 consecutive passes** (7 pre-rebase, 3 post-rebase against current `main`), zero `SIGSEGV`, zero `hs_err_pid*.log` dumps generated. Before the fix the same command crashed on every attempt. The forced re-runs matter: a use-after-free can present as intermittent, so a single green run would not have been evidence.
- Full baseline, **no exclusions**: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` → `BUILD SUCCESSFUL`. `spotlessApply` produced no reformatting.

## Notes for reviewers

- **Two adjacent defects were deliberately left out of this PR**, to keep it to one concern: `notify_uninit()` is never called, and the `GError` from a failed `notify_notification_show()` is never `g_error_free()`d. Both are small leaks; neither can crash. Happy to fold them in if preferred.
- **The `glib?.let { … }` null-guards around the two `set_hint` calls are gone**, not lost. `glib` was only ever non-null when `lib` was non-null (both were cleared together in every failure path), so the guard was already unreachable-when-null; the hint calls now sit behind the same single `lib` check as the rest of `send()`.
- **The GVariants are still not unreffed, on purpose.** They are floating refs and `notify_notification_set_hint()` sinks them — unreffing would be a second bug of the same family. That is now stated in a comment at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux notification compatibility by resolving required library functions through the notification system.
  * Ensured notification metadata and cleanup work consistently when desktop notifications are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->