### PR TITLE
fix(desktop): free the GError and release libnotify on shutdown

### DIFF
--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
@@ -101,6 +101,7 @@ import org.meshtastic.desktop.notification.DesktopOS
 import org.meshtastic.desktop.ui.DesktopMainScreen
 import java.awt.Desktop
 import java.util.Locale
+import kotlin.system.exitProcess
 import coil3.util.Logger as CoilLogger
 
 /** Meshtastic Desktop — the first non-Android target for the shared KMP module graph. */
@@ -128,7 +129,10 @@ private fun svgPainterResource(path: String, density: Density): Painter = rememb
 
 @OptIn(ExperimentalCoilApi::class)
 fun main(args: Array<String>) {
-    application {
+    // exitProcessOnExit = false is what makes the shutdown block below reachable at all: with the default (true),
+    // application() calls System.exit(0) itself as soon as the Compose loop ends, and control never returns here.
+    // Do not "simplify" this back to a bare application {} — that silently disables every teardown that follows.
+    application(exitProcessOnExit = false) {
         val koinApp = remember {
             // Keep console output and also capture into the in-memory buffer the Debug screen views/exports.
             Logger.setLogWriters(listOf(platformLogWriter(), InMemoryLogBuffer))
@@ -144,12 +148,16 @@ fun main(args: Array<String>) {
         ThemeAndLocaleProvider(uiViewModel)
     }
 
-    // `application {}` returns once the last window closes or exitApplication() is called, so this runs on the main
-    // thread with the UI already gone. Closing the container fires the `onClose` callbacks that release native
-    // handles — currently libnotify's process-wide state in LinuxNotificationSender. Guarded because a teardown
-    // failure must not turn a clean quit into a non-zero exit.
+    // Runs on the main thread with the UI already gone. Closing the container fires the `onClose` callbacks that
+    // release native handles — currently libnotify's process-wide state in LinuxNotificationSender. Guarded because
+    // a teardown failure must not turn a clean quit into a non-zero exit.
     runCatching { stopKoin() }.onFailure { Logger.w(it) { "stopKoin() failed during shutdown" } }
     Logger.i { "Meshtastic Desktop — Stopped" }
+
+    // Restores the exit application() no longer performs. Not optional: lingering non-daemon threads (coroutine
+    // dispatchers, ktor pools, AWT stragglers) would otherwise keep the JVM alive after the last window closes,
+    // turning "quit" into a hung background process.
+    exitProcess(0)
 }
 
 // ----- Deep link handling -----

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
@@ -71,6 +71,7 @@ import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import org.meshtastic.core.common.BuildConfigProvider
 import org.meshtastic.core.common.log.InMemoryLogBuffer
 import org.meshtastic.core.common.util.CommonUri
@@ -126,20 +127,29 @@ private fun svgPainterResource(path: String, density: Density): Painter = rememb
 }
 
 @OptIn(ExperimentalCoilApi::class)
-fun main(args: Array<String>) = application {
-    val koinApp = remember {
-        // Keep console output and also capture into the in-memory buffer the Debug screen views/exports.
-        Logger.setLogWriters(listOf(platformLogWriter(), InMemoryLogBuffer))
-        Logger.i { "Meshtastic Desktop — Starting" }
-        startKoin { modules(desktopPlatformModule(), desktopModule()) }
-    }
-    val systemLocale = remember { Locale.getDefault() }
-    val uiViewModel = remember { koinApp.koin.get<UIViewModel>() }
-    val httpClient = remember { koinApp.koin.get<HttpClient>() }
+fun main(args: Array<String>) {
+    application {
+        val koinApp = remember {
+            // Keep console output and also capture into the in-memory buffer the Debug screen views/exports.
+            Logger.setLogWriters(listOf(platformLogWriter(), InMemoryLogBuffer))
+            Logger.i { "Meshtastic Desktop — Starting" }
+            startKoin { modules(desktopPlatformModule(), desktopModule()) }
+        }
+        val systemLocale = remember { Locale.getDefault() }
+        val uiViewModel = remember { koinApp.koin.get<UIViewModel>() }
+        val httpClient = remember { koinApp.koin.get<HttpClient>() }
 
-    DeepLinkHandler(args, uiViewModel)
-    MeshServiceLifecycle()
-    ThemeAndLocaleProvider(uiViewModel)
+        DeepLinkHandler(args, uiViewModel)
+        MeshServiceLifecycle()
+        ThemeAndLocaleProvider(uiViewModel)
+    }
+
+    // `application {}` returns once the last window closes or exitApplication() is called, so this runs on the main
+    // thread with the UI already gone. Closing the container fires the `onClose` callbacks that release native
+    // handles — currently libnotify's process-wide state in LinuxNotificationSender. Guarded because a teardown
+    // failure must not turn a clean quit into a non-zero exit.
+    runCatching { stopKoin() }.onFailure { Logger.w(it) { "stopKoin() failed during shutdown" } }
+    Logger.i { "Meshtastic Desktop — Stopped" }
 }
 
 // ----- Deep link handling -----

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/di/DesktopKoinModule.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/di/DesktopKoinModule.kt
@@ -33,6 +33,7 @@ import io.ktor.client.request.url
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import org.koin.dsl.module
+import org.koin.dsl.onClose
 import org.meshtastic.core.common.di.ServiceScope
 import org.meshtastic.core.data.datasource.BundledAssetReader
 import org.meshtastic.core.network.HttpClientDefaults
@@ -209,6 +210,11 @@ private fun desktopPlatformStubsModule() = module {
             DesktopOS.Windows -> WindowsNotificationSender()
         }
     }
+        .onClose { sender ->
+            // Only the Linux sender holds a native handle; the others are stateless. `stopKoin()` in Main.kt is what
+            // drives this, after the Compose application loop has returned.
+            (sender as? AutoCloseable)?.close()
+        }
     single { DesktopNotificationManager(prefs = get(), nativeSender = get()) }
     single<NotificationManager> { get<DesktopNotificationManager>() }
     single<MeshNotificationManager> { DesktopMeshNotificationManager(notificationManager = get()) }

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/LinuxNotificationSender.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/LinuxNotificationSender.kt
@@ -61,6 +61,8 @@ private interface LibNotify : Library {
 
     fun g_object_unref(obj: Pointer)
 
+    fun g_error_free(error: Pointer)
+
     fun g_variant_new_boolean(value: Boolean): Pointer
 
     fun g_variant_new_string(string: String): Pointer
@@ -103,9 +105,15 @@ private object NotifyUrgency {
 class LinuxNotificationSender(
     private val appName: String = "Meshtastic",
     private val desktopEntry: String = appName.lowercase(),
-) : NativeNotificationSender {
+) : NativeNotificationSender,
+    AutoCloseable {
 
-    private val lib: LibNotify?
+    /**
+     * Cleared by [close]. Volatile so a [close] on the shutdown path is visible to any thread that is about to call
+     * [send]; a send already past its null check will still complete against the old handle, which is why [close] is
+     * documented as "once sends have stopped".
+     */
+    @Volatile private var lib: LibNotify?
 
     init {
         var loadedLib: LibNotify? = null
@@ -154,8 +162,30 @@ class LinuxNotificationSender(
             }
             shown
         } finally {
+            // On failure libnotify hands us ownership of a GError; nothing else frees it, so without this every
+            // failed send leaks the struct and its message. Freed here rather than in the `if (!shown)` branch so
+            // it is released even if `show()` reports success while still having set an error. The message is read
+            // above, before the free — GErrorStruct dereferences the pointer.
+            errorRef.value?.let { libnotify.g_error_free(it) }
             libnotify.g_object_unref(ptr)
         }
+    }
+
+    /**
+     * Releases libnotify's process-wide state — the D-Bus proxy and cached app name allocated by `notify_init()`.
+     *
+     * Idempotent: the second and later calls are no-ops. Afterwards [isAvailable] is false and [send] returns false
+     * rather than calling into a torn-down library.
+     *
+     * Call this once sends have stopped. `notify_uninit()` is resolved through the libnotify handle, so it runs against
+     * the same GLib instance that allocated the state — see the [LibNotify] KDoc for why that matters.
+     */
+    @Synchronized
+    override fun close() {
+        val libnotify = lib ?: return
+        lib = null
+        runCatching { libnotify.notify_uninit() }
+            .onFailure { Logger.w(it) { "notify_uninit() failed during shutdown" } }
     }
 
     private fun applyMetadata(libnotify: LibNotify, ptr: Pointer, notification: Notification) {

--- a/desktopApp/src/test/kotlin/org/meshtastic/desktop/di/DesktopKoinTest.kt
+++ b/desktopApp/src/test/kotlin/org/meshtastic/desktop/di/DesktopKoinTest.kt
@@ -22,11 +22,14 @@ import io.ktor.client.engine.HttpClientEngine
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.dsl.koinApplication
 import org.koin.dsl.module
+import org.koin.dsl.onClose
 import org.koin.test.verify.verify
 import org.meshtastic.core.ble.BleLogFormat
 import org.meshtastic.core.ble.BleLogLevel
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 @OptIn(KoinExperimentalAPI::class)
 class DesktopKoinTest {
@@ -55,5 +58,21 @@ class DesktopKoinTest {
                     BleLogFormat::class,
                 ),
             )
+    }
+
+    @Test
+    fun `closing a koin container fires onClose for instantiated singles`() {
+        // Pins the mechanism desktopModule() relies on: LinuxNotificationSender's native teardown
+        // (notify_uninit) runs only because Koin invokes onClose when the container closes, which
+        // Main.kt triggers via stopKoin() once the Compose application loop returns. A Koin upgrade
+        // that changed this would silently reinstate the leak, so it is asserted rather than assumed.
+        var closed = false
+        val app = koinApplication {
+            modules(module { single<AutoCloseable> { AutoCloseable { closed = true } }.onClose { it?.close() } })
+        }
+        app.koin.get<AutoCloseable>() // onClose only fires for singles that were actually instantiated
+        app.close()
+
+        assertTrue(closed, "Expected Koin to invoke onClose when the container is closed")
     }
 }

--- a/desktopApp/src/test/kotlin/org/meshtastic/desktop/notification/LinuxNotificationSenderTest.kt
+++ b/desktopApp/src/test/kotlin/org/meshtastic/desktop/notification/LinuxNotificationSenderTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.desktop.notification
 
 import org.meshtastic.core.repository.Notification
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -73,5 +74,23 @@ class LinuxNotificationSenderTest {
         if (!sender.isAvailable) return
         val result = sender.send(Notification(title = "Silent", message = "Shhh", isSilent = true))
         assertTrue(result, "Expected silent send() to succeed")
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        // Uses its own sender: close() calls notify_uninit(), which tears down libnotify for the whole process.
+        // Every other test builds its own sender and so re-runs notify_init().
+        val closeable = LinuxNotificationSender(appName = "MeshtasticTestClose")
+        closeable.close()
+        closeable.close() // second call must be a no-op, not a double notify_uninit()
+        assertFalse(closeable.isAvailable, "Expected isAvailable to be false after close()")
+    }
+
+    @Test
+    fun `send after close returns false instead of calling into a torn-down library`() {
+        val closeable = LinuxNotificationSender(appName = "MeshtasticTestClosedSend")
+        closeable.close()
+        val result = closeable.send(Notification(title = "After close", message = "Should not be delivered"))
+        assertFalse(result, "Expected send() to return false after close()")
     }
 }


### PR DESCRIPTION
Follow-up to #6543. That PR fixed the crash in `LinuxNotificationSender` and deliberately left two adjacent native-resource leaks alone to keep the diff to one concern. This closes them.

## 🐛 Bug Fixes

- **Free the `GError` on a failed send.** `notify_notification_show()` allocates a `GError` when it fails and transfers ownership to the caller. Nothing freed it, so every failed send leaked the struct and its message string. It is unbounded over a session, and it accumulates precisely when the notification daemon is already misbehaving — the case where you least want the app growing.

  Freed in the same `finally` block as the notification's `g_object_unref`, after the message has been read for the log line (`GErrorStruct` dereferences the pointer, so ordering matters). Freeing there rather than inside the `if (!shown)` branch also releases it in the pathological case where `show()` reports success but still set an error.

  `g_error_free` is declared on the `LibNotify` interface, not loaded separately — same reasoning as #6543, since a second GLib copy would free against the wrong allocator.

- **Release libnotify's process-wide state on shutdown.** `notify_init()` allocates a D-Bus proxy and caches the app name; `notify_uninit()` releases them, and nothing called it.

  `LinuxNotificationSender` is now `AutoCloseable` with an idempotent `close()`. After closing, `isAvailable` is false and `send()` returns false rather than calling into a torn-down library. The backing handle is `@Volatile` so a shutdown-path close is visible to a thread about to send.

## 🛠️ Refactoring & Architecture

- **The desktop app had no shutdown path at all.** `startKoin()` was called; `stopKoin()` never was. Without somewhere to hang teardown, `close()` would have been dead code.

  `main()` now calls `stopKoin()` after the Compose `application` loop returns — on the main thread, with the UI already gone, which is the safest possible moment to be calling into GLib given what #6543 was about. The `NativeNotificationSender` single declares an `onClose` that releases the handle; the macOS and Windows senders are stateless and are simply not `AutoCloseable`, so the cast skips them.

  The `stopKoin()` call is wrapped in `runCatching` so a teardown failure logs rather than turning a clean quit into a non-zero exit. This is the only behavioural change outside the notification path, and it only executes after the last window closes.

- **`application(exitProcessOnExit = false)` is what makes any of the above reachable** — the first cut of this PR got it wrong, and an adversarial re-review caught it. Compose Desktop's `application()` defaults to `exitProcessOnExit = true`, meaning it calls `System.exit(0)` itself the moment the Compose loop ends (confirmed in the `ui-desktop-1.11.1` bytecode: `runBlocking` return → `System.exit(0)`). With the default, control never returns to `main()` and everything after the `application {}` block is dead code — the shutdown path would have existed in source and never executed on a real quit.

  Passing `exitProcessOnExit = false` hands control back to `main()`, which runs teardown and then calls `exitProcess(0)` explicitly. The explicit exit is not optional: it restores the exit `application()` no longer performs, without which lingering non-daemon threads (coroutine dispatchers, ktor pools, AWT stragglers) would keep the JVM alive after the last window closes and turn "quit" into a hung background process. Both call sites carry comments warning against reverting them, because a bare `application {}` reads like an equivalent simplification and would silently disable every teardown that follows.

## Testing Performed

Four tests added:

- `close is idempotent` — a second `close()` must not produce a second `notify_uninit()`.
- `send after close returns false instead of calling into a torn-down library`.
- `closing a koin container fires onClose for instantiated singles` — pins the mechanism the wiring depends on. A Koin upgrade that changed `onClose` semantics would silently reinstate the leak, so it is asserted rather than assumed.
- The two `close` tests build their own sender, because `notify_uninit()` tears down libnotify for the whole process; every other test constructs its own sender and so re-runs `notify_init()`.

Verification:

- `./gradlew :desktopApp:test --rerun-tasks` — **5 consecutive passes**, zero `hs_err_pid*.log` dumps. The repeated runs specifically check that the process-wide `notify_uninit()` in the close tests does not make the rest of the suite order-dependent.
- Confirmed from the JUnit XML that all seven `LinuxNotificationSenderTest` cases and both `DesktopKoinTest` cases actually executed rather than being skipped — the suite skips itself when libnotify is unavailable, so a green run is not by itself evidence the new tests ran.
- Full baseline, no exclusions: `./gradlew spotlessCheck detekt assembleDebug test allTests` → `BUILD SUCCESSFUL`.

## Notes for reviewers

- **Neither leak can crash**, and `notify_init()`'s state is reclaimed by the OS at process exit regardless. The `GError` is the one with real runtime consequence; the `notify_uninit()` half is correctness and gives the app an explicit teardown point it did not previously have.
- **The `close()` race is documented, not eliminated.** A `send()` already past its null check completes against the old handle. Closing concurrently with active sends would need a lock on the whole send path, which is not worth it for a shutdown-time operation — the KDoc says to call `close()` once sends have stopped, and the only caller does exactly that.
- **`stopKoin()` is a new call on a previously untested path.** No existing singleton declared an `onClose`, so nothing else changes behaviour today; the risk is that a future singleton adds a blocking `onClose` and slows quit. Worth knowing, not worth pre-empting.
- **`LaunchedEffect`s can now delay quit in a way they previously could not.** Per the [`application()` KDoc](https://github.com/JetBrains/compose-multiplatform-core/blob/jb-main/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt), with `exitProcessOnExit = false` the function unblocks "when the last window is closed, **and all LaunchedEffect are complete**". The old `System.exit(0)` guillotined running effects; now a long-running one holds the quit open until it finishes. The app's current effects are event-driven collectors that cancel with composition rather than long finite jobs, so today's quit should be unaffected — but a future `LaunchedEffect` that runs a genuinely long operation would surface as "app takes ages to quit", and this is where to look first.
- **The quit path itself has no automated coverage.** No test can reasonably drive `main()` through a real window-close, so the `exitProcessOnExit` requirement is enforced by comments rather than a test — that is the honest limit of what this PR verifies. The evidence that control now returns to `main()` is the bytecode of `application()` plus this being the JetBrains-documented pattern for post-application cleanup, not an observed runtime quit. A manual quit on a Linux desktop (checking for the `Meshtastic Desktop — Stopped` log line and prompt process exit) is the remaining validation worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop app shutdown reliability and ensured resources are released cleanly when the application exits.
  - Linux notifications now shut down safely, prevent sends after closure, and release native error resources properly.
  - Shutdown failures are logged without interrupting the rest of the application teardown.

- **Tests**
  - Added coverage for application lifecycle cleanup and repeated notification shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->