### PR TITLE
chore: bump VERSION_NAME_BASE to 2.8.1

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -27,7 +27,7 @@ COMPILE_SDK=37
 # Base version name for local development and fallback
 # On CI, this is overridden by the Git tag
 # Before a release, update this to the new Git tag version
-VERSION_NAME_BASE=2.8.0
+VERSION_NAME_BASE=2.8.1
 
 # Minimum firmware versions supported by this app
 MIN_FW_VERSION=2.5.14

--- a/desktopApp/packaging/linux/org.meshtastic.MeshtasticDesktop.metainfo.xml
+++ b/desktopApp/packaging/linux/org.meshtastic.MeshtasticDesktop.metainfo.xml
@@ -92,7 +92,7 @@
   </screenshots>
 
   <releases>
-    <release version="2.8.0" date="2026-07-10">
+    <release version="2.8.1" date="2026-08-02">
       <description>
         <p>In-app update notifications, native OS notifications, deep-link handling, keyboard shortcuts, window-state persistence, and many stability fixes.</p>
       </description>


### PR DESCRIPTION
bump version 2.8.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->