### PR TITLE
feat(settings): add 2.8 amateur and EU Lite/Narrow LoRa regions

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
@@ -78,8 +78,8 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
     val supportsEsp32Ota = atLeast(V2_7_18)
 
     /**
-     * Support for the LoRa region→preset compatibility map and TINY presets. Supported since firmware v2.8.0. Older
-     * firmware never sends the map, so the UI keeps the preset list unconstrained and hides the new presets.
+     * Support for the LoRa region→preset compatibility map. Supported since firmware v2.8.0. Older firmware never sends
+     * the map, so the UI keeps the preset list unconstrained (preset *availability* is [supportsPreset]).
      */
     val supportsLoraRegionPresetMap = atLeast(V2_8_0)
 
@@ -102,6 +102,12 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
      * [RegionInfo.minFirmware]; older firmware would treat an unknown region code as UNSET, so the picker hides it.
      */
     fun supportsRegion(region: RegionInfo): Boolean = region.minFirmware?.let { atLeast(it) } ?: true
+
+    /**
+     * Whether this firmware's preset table contains [preset] ([ChannelOption.minFirmware]); older firmware silently
+     * falls back to LONG_FAST when sent an unknown preset, so the picker hides it.
+     */
+    fun supportsPreset(preset: ChannelOption): Boolean = preset.minFirmware?.let { atLeast(it) } ?: true
 
     companion object {
         private val V2_6_8 = DeviceVersion("2.6.8")

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Capabilities.kt
@@ -97,6 +97,12 @@ data class Capabilities(val firmwareVersion: String?, internal val forceEnableAl
      */
     val supportsMeshBeacon = atLeast(V2_8_0)
 
+    /**
+     * Whether this firmware's region table contains [region]. Regions declare the release that introduced them via
+     * [RegionInfo.minFirmware]; older firmware would treat an unknown region code as UNSET, so the picker hides it.
+     */
+    fun supportsRegion(region: RegionInfo): Boolean = region.minFirmware?.let { atLeast(it) } ?: true
+
     companion object {
         private val V2_6_8 = DeviceVersion("2.6.8")
         private val V2_6_9 = DeviceVersion("2.6.9")

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ChannelOption.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ChannelOption.kt
@@ -108,7 +108,11 @@ internal fun LoRaConfig.radioFreq(channelNum: Int): Float {
     }
 }
 
-/** The firmware release that introduced the EU Lite/Narrow and amateur-band ITU regions. */
+/**
+ * The firmware release that introduced the EU Lite/Narrow and amateur-band ITU regions and the LITE/NARROW/TINY/
+ * MEDIUM_TURBO presets. NB: the LITE/NARROW *enum values* were vendored into v2.7.23's protobufs, but the radio support
+ * (`modemPresetToParams` cases, preset tables, EU regions — firmware#10120) is untagged and ships in 2.8.
+ */
 private val FIRMWARE_2_8 = DeviceVersion("2.8.0")
 
 /**
@@ -453,9 +457,16 @@ enum class RegionInfo(
     }
 }
 
-enum class ChannelOption(val modemPreset: ModemPreset, val bandwidth: Float, val snrLimit: Float) {
+enum class ChannelOption(
+    val modemPreset: ModemPreset,
+    val bandwidth: Float,
+    val snrLimit: Float,
+    val minFirmware: DeviceVersion? = null,
+) {
     // Grouped by range and speed for better readability.
     // snrLimit = demodulation floor for the preset's spreading factor (see [ModemPreset.snrLimit]).
+    // minFirmware = first firmware release whose preset table has the entry ([Capabilities.supportsPreset]);
+    // older firmware silently falls back to LONG_FAST when sent an unknown preset.
     VERY_LONG_SLOW(ModemPreset.VERY_LONG_SLOW, 0.0625f, snrLimit = -20f), // SF12
     LONG_TURBO(ModemPreset.LONG_TURBO, 0.500f, snrLimit = -12.5f), // SF9
     LONG_FAST(ModemPreset.LONG_FAST, 0.250f, snrLimit = -17.5f), // SF11
@@ -466,19 +477,19 @@ enum class ChannelOption(val modemPreset: ModemPreset, val bandwidth: Float, val
     LONG_SLOW(ModemPreset.LONG_SLOW, 0.125f, snrLimit = -20f), // SF12
     MEDIUM_FAST(ModemPreset.MEDIUM_FAST, 0.250f, snrLimit = -12.5f), // SF9
     MEDIUM_SLOW(ModemPreset.MEDIUM_SLOW, 0.250f, snrLimit = -15f), // SF10
-    MEDIUM_TURBO(ModemPreset.MEDIUM_TURBO, 0.500f, snrLimit = -12.5f), // SF9
+    MEDIUM_TURBO(ModemPreset.MEDIUM_TURBO, 0.500f, snrLimit = -12.5f, minFirmware = FIRMWARE_2_8), // SF9
     SHORT_FAST(ModemPreset.SHORT_FAST, 0.250f, snrLimit = -7.5f), // SF7
     SHORT_SLOW(ModemPreset.SHORT_SLOW, 0.250f, snrLimit = -10f), // SF8
     SHORT_TURBO(ModemPreset.SHORT_TURBO, 0.500f, snrLimit = -7.5f), // SF7
-    LITE_FAST(ModemPreset.LITE_FAST, 0.125f, snrLimit = -12.5f),
-    LITE_SLOW(ModemPreset.LITE_SLOW, 0.125f, snrLimit = -15f),
-    NARROW_FAST(ModemPreset.NARROW_FAST, 0.0625f, snrLimit = -10f),
-    NARROW_SLOW(ModemPreset.NARROW_SLOW, 0.0625f, snrLimit = -12.5f),
+    LITE_FAST(ModemPreset.LITE_FAST, 0.125f, snrLimit = -12.5f, minFirmware = FIRMWARE_2_8),
+    LITE_SLOW(ModemPreset.LITE_SLOW, 0.125f, snrLimit = -15f, minFirmware = FIRMWARE_2_8),
+    NARROW_FAST(ModemPreset.NARROW_FAST, 0.0625f, snrLimit = -10f, minFirmware = FIRMWARE_2_8),
+    NARROW_SLOW(ModemPreset.NARROW_SLOW, 0.0625f, snrLimit = -12.5f, minFirmware = FIRMWARE_2_8),
 
     // 15.625 kHz LoRa bandwidth (firmware modemPresetToParams; the proto's "20kHz" is the
     // padded channel spacing, not the modem bandwidth used for numChannels/radioFreq math).
-    TINY_FAST(ModemPreset.TINY_FAST, 0.015625f, snrLimit = -7.5f), // SF7
-    TINY_SLOW(ModemPreset.TINY_SLOW, 0.015625f, snrLimit = -10f), // SF8
+    TINY_FAST(ModemPreset.TINY_FAST, 0.015625f, snrLimit = -7.5f, minFirmware = FIRMWARE_2_8), // SF7
+    TINY_SLOW(ModemPreset.TINY_SLOW, 0.015625f, snrLimit = -10f, minFirmware = FIRMWARE_2_8), // SF8
     ;
 
     companion object {

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ChannelOption.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ChannelOption.kt
@@ -21,7 +21,7 @@ package org.meshtastic.core.model
 import org.meshtastic.proto.Config.LoRaConfig
 import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
 import org.meshtastic.proto.Config.LoRaConfig.RegionCode
-import kotlin.math.floor
+import kotlin.math.round
 
 /** hash a string into an integer using the djb2 algorithm by Dan Bernstein http://www.cse.yorku.ca/~oz/hash.html */
 private fun hash(name: String): UInt { // using UInt instead of Long to match RadioInterface.cpp results
@@ -66,6 +66,13 @@ private fun LoRaConfig.bandwidth(regionInfo: RegionInfo?) = if (use_preset) {
     }
 }
 
+/**
+ * Width of one frequency slot: modem bandwidth plus the region's per-side padding and inter-slot spacing (firmware
+ * `RadioInterface::applyModemConfig`).
+ */
+private fun LoRaConfig.freqSlotWidth(regionInfo: RegionInfo): Float =
+    regionInfo.spacing + regionInfo.padding * 2 + bandwidth(regionInfo)
+
 val LoRaConfig.numChannels: Int
     get() {
         val regionInfo = RegionInfo.fromRegionCode(region)
@@ -74,27 +81,35 @@ val LoRaConfig.numChannels: Int
         val bw = bandwidth(regionInfo)
         if (bw <= 0f) return 1 // Return 1 if bandwidth is zero or negative
 
-        val num = floor((regionInfo.freqEnd - regionInfo.freqStart) / bw)
-        // If the regional frequency range is smaller than the bandwidth, the firmware would
+        val num = round((regionInfo.freqEnd - regionInfo.freqStart + regionInfo.spacing) / freqSlotWidth(regionInfo))
+        // If the regional frequency range is smaller than the slot width, the firmware would
         // fall back to a default preset. In the app, we return 1 to avoid a crash.
         return if (num > 0) num.toInt() else 1
     }
 
-internal fun LoRaConfig.channelNum(primaryName: String): Int = when {
-    channel_num != 0 -> channel_num
-    numChannels == 0 -> 0
-    else -> (hash(primaryName) % numChannels.toUInt()).toInt() + 1
+internal fun LoRaConfig.channelNum(primaryName: String): Int {
+    val overrideSlot = RegionInfo.fromRegionCode(region)?.overrideSlot ?: 0
+    return when {
+        channel_num != 0 -> channel_num
+        numChannels == 0 -> 0
+        overrideSlot > 0 -> overrideSlot
+        else -> (hash(primaryName) % numChannels.toUInt()).toInt() + 1
+    }
 }
 
 internal fun LoRaConfig.radioFreq(channelNum: Int): Float {
     if (override_frequency != 0f) return override_frequency + frequency_offset
     val regionInfo = RegionInfo.fromRegionCode(region)
     return if (regionInfo != null) {
-        (regionInfo.freqStart + bandwidth(regionInfo) / 2) + (channelNum - 1) * bandwidth(regionInfo)
+        (regionInfo.freqStart + bandwidth(regionInfo) / 2 + regionInfo.padding) +
+            (channelNum - 1) * freqSlotWidth(regionInfo)
     } else {
         0f
     }
 }
+
+/** The firmware release that introduced the EU Lite/Narrow and amateur-band ITU regions. */
+private val FIRMWARE_2_8 = DeviceVersion("2.8.0")
 
 /**
  * Regulatory regions for radio usage
@@ -104,6 +119,14 @@ internal fun LoRaConfig.radioFreq(channelNum: Int): Float {
  * @property freqStart The starting frequency in MHz
  * @property freqEnd The ending frequency in MHz
  * @property wideLora Whether the region uses wide Lora
+ * @property spacing Gap between frequency slots (and at the start of the band) in MHz, from the firmware's region
+ *   profile
+ * @property padding Gap at each side of a frequency slot in MHz, from the firmware's region profile (coerces the modem
+ *   bandwidth up to the region's slot width, e.g. ham 15.625 kHz -> 20 kHz)
+ * @property overrideSlot The region's fixed default frequency slot (1-based), or 0 to derive the slot from the primary
+ *   channel-name hash as usual
+ * @property minFirmware The first firmware release whose region table contains this region, or null for regions all
+ *   supported firmware knows; [Capabilities.supportsRegion] gates the picker with it
  * @see
  *   [LoRaWAN Regional Parameters](https://lora-alliance.org/wp-content/uploads/2020/11/lorawan_regional_parameters_v1.0.3reva_0.pdf)
  */
@@ -114,6 +137,10 @@ enum class RegionInfo(
     val freqStart: Float,
     val freqEnd: Float,
     val wideLora: Boolean = false,
+    val spacing: Float = 0f,
+    val padding: Float = 0f,
+    val overrideSlot: Int = 0,
+    val minFirmware: DeviceVersion? = null,
 ) {
     /**
      * United States
@@ -290,6 +317,132 @@ enum class RegionInfo(
      * @see [Firmware Issue #7399](https://github.com/meshtastic/firmware/pull/7399)
      */
     BR_902(RegionCode.BR_902, "Brazil 902MHz", 902.0f, 907.5f, wideLora = false),
+
+    /**
+     * European Union 865-868MHz (Lite): four 600 kHz slots at 865.7/866.3/866.9/867.5 MHz, 2.5% duty cycle.
+     *
+     * @see
+     *   [ETSI EN 300 220-2 V3.1.1](https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.01.01_60/en_30022002v030101p.pdf)
+     */
+    EU_866(
+        RegionCode.EU_866,
+        "European Union 866MHz",
+        865.6f,
+        867.6f,
+        spacing = 0.4f,
+        padding = 0.0375f,
+        minFirmware = FIRMWARE_2_8,
+    ),
+
+    /** European Union 868MHz using the narrow presets; same band as [EU_868]. */
+    EU_N_868(
+        RegionCode.EU_N_868,
+        "European Union 868MHz (Narrow)",
+        869.4f,
+        869.65f,
+        padding = 0.0104f,
+        overrideSlot = 1,
+        minFirmware = FIRMWARE_2_8,
+    ),
+
+    /**
+     * ITU Region 1 (Europe, Africa, Middle East, former USSR) amateur 2m allocation. Licensed operators only.
+     *
+     * @see [IARU Region 1 Band Plan](https://www.iaru-r1.org/on-the-air/band-plans/)
+     */
+    ITU1_2M(
+        RegionCode.ITU1_2M,
+        "ITU Region 1 / Amateur 2m",
+        144.0f,
+        146.0f,
+        padding = 0.0022f,
+        overrideSlot = 26,
+        minFirmware = FIRMWARE_2_8,
+    ),
+
+    /**
+     * ITU Region 2 (Americas) amateur 2m allocation. Licensed operators only.
+     *
+     * @see [ARRL Band Plan](https://www.arrl.org/band-plan)
+     */
+    ITU2_2M(
+        RegionCode.ITU2_2M,
+        "ITU Region 2 / Amateur 2m",
+        144.0f,
+        148.0f,
+        padding = 0.0022f,
+        overrideSlot = 51,
+        minFirmware = FIRMWARE_2_8,
+    ),
+
+    /**
+     * ITU Region 3 (Asia/Pacific) amateur 2m allocation. Licensed operators only.
+     *
+     * @see
+     *   [IARU Region 3 Band Plan](https://www.iaru.org/wp-content/uploads/2020/01/R3-004-IARU-Region-3-Bandplan-rev.2.pdf)
+     */
+    ITU3_2M(
+        RegionCode.ITU3_2M,
+        "ITU Region 3 / Amateur 2m",
+        144.0f,
+        148.0f,
+        padding = 0.0022f,
+        overrideSlot = 33,
+        minFirmware = FIRMWARE_2_8,
+    ),
+
+    /**
+     * ITU Region 2 (Americas) amateur 1.25m '125cm' allocation. Licensed operators only. Some countries do not allocate
+     * 220-222 MHz (e.g. USA, Canada) — check local law.
+     */
+    ITU2_125CM(
+        RegionCode.ITU2_125CM,
+        "ITU Region 2 / Amateur 1.25m",
+        220.0f,
+        225.0f,
+        padding = 0.01875f,
+        overrideSlot = 37,
+        minFirmware = FIRMWARE_2_8,
+    ),
+
+    /** ITU Region 1 (Europe, Africa, Middle East, former USSR) amateur 70cm allocation. Licensed operators only. */
+    ITU1_70CM(
+        RegionCode.ITU1_70CM,
+        "ITU Region 1 / Amateur 70cm",
+        430.0f,
+        440.0f,
+        padding = 0.01875f,
+        overrideSlot = 37,
+        minFirmware = FIRMWARE_2_8,
+    ),
+
+    /**
+     * ITU Region 2 (Americas) amateur 70cm allocation. Licensed operators only. Some countries do not allocate 420-430
+     * MHz or 440-450 MHz — check local law.
+     */
+    ITU2_70CM(
+        RegionCode.ITU2_70CM,
+        "ITU Region 2 / Amateur 70cm",
+        420.0f,
+        450.0f,
+        padding = 0.01875f,
+        overrideSlot = 137,
+        minFirmware = FIRMWARE_2_8,
+    ),
+
+    /**
+     * ITU Region 3 (Asia/Pacific) amateur 70cm allocation. Licensed operators only. Some countries do not allocate
+     * 440-450 MHz — check local law.
+     */
+    ITU3_70CM(
+        RegionCode.ITU3_70CM,
+        "ITU Region 3 / Amateur 70cm",
+        430.0f,
+        450.0f,
+        padding = 0.01875f,
+        overrideSlot = 37,
+        minFirmware = FIRMWARE_2_8,
+    ),
 
     /** This needs to be last. Same as US. */
     UNSET(RegionCode.UNSET, "Please set a region", 902.0f, 928.0f),

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.core.model
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -90,6 +91,37 @@ class CapabilitiesTest {
     fun supportsEsp32Ota_requires_V2_7_18() {
         assertFalse(caps("2.7.17").supportsEsp32Ota)
         assertTrue(caps("2.7.18").supportsEsp32Ota)
+    }
+
+    @Test
+    fun supportsRegion_gates_2_8_regions_but_not_established_ones() {
+        val old = caps("2.7.21")
+        val new = caps("2.8.0")
+        val gated = RegionInfo.entries.filter { it.minFirmware != null }
+        assertEquals(
+            setOf(
+                RegionInfo.EU_866,
+                RegionInfo.EU_N_868,
+                RegionInfo.ITU1_2M,
+                RegionInfo.ITU2_2M,
+                RegionInfo.ITU3_2M,
+                RegionInfo.ITU2_125CM,
+                RegionInfo.ITU1_70CM,
+                RegionInfo.ITU2_70CM,
+                RegionInfo.ITU3_70CM,
+            ),
+            gated.toSet(),
+        )
+        gated.forEach { region ->
+            assertFalse(old.supportsRegion(region), "${region.name} should be hidden on 2.7 firmware")
+            assertTrue(new.supportsRegion(region), "${region.name} should be shown on 2.8 firmware")
+        }
+        // Established regions are never gated, even with unknown firmware.
+        assertTrue(caps(null).supportsRegion(RegionInfo.US))
+        assertTrue(old.supportsRegion(RegionInfo.UNSET))
+        // Unknown firmware hides gated regions; debug forceEnableAll shows them.
+        assertFalse(caps(null).supportsRegion(RegionInfo.ITU1_2M))
+        assertTrue(Capabilities(firmwareVersion = null, forceEnableAll = true).supportsRegion(RegionInfo.ITU1_2M))
     }
 
     @Test

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/CapabilitiesTest.kt
@@ -125,6 +125,37 @@ class CapabilitiesTest {
     }
 
     @Test
+    fun supportsPreset_gates_2_8_presets_but_not_established_ones() {
+        // LITE/NARROW enum values were vendored into v2.7.23 protobufs, but their radio support
+        // (modemPresetToParams cases — firmware#10120) ships in 2.8 like TINY and MEDIUM_TURBO.
+        val gated =
+            setOf(
+                ChannelOption.TINY_FAST,
+                ChannelOption.TINY_SLOW,
+                ChannelOption.MEDIUM_TURBO,
+                ChannelOption.LITE_FAST,
+                ChannelOption.LITE_SLOW,
+                ChannelOption.NARROW_FAST,
+                ChannelOption.NARROW_SLOW,
+            )
+        assertEquals(gated, ChannelOption.entries.filter { it.minFirmware != null }.toSet())
+
+        val old = caps("2.7.26")
+        val new = caps("2.8.0")
+        gated.forEach { preset ->
+            assertFalse(old.supportsPreset(preset), "${preset.name} should be hidden on 2.7 firmware")
+            assertTrue(new.supportsPreset(preset), "${preset.name} should be shown on 2.8 firmware")
+        }
+        // Established presets are never gated, even with unknown firmware.
+        assertTrue(caps(null).supportsPreset(ChannelOption.LONG_FAST))
+        // Unknown firmware hides gated presets; debug forceEnableAll shows them.
+        assertFalse(caps(null).supportsPreset(ChannelOption.MEDIUM_TURBO))
+        assertTrue(
+            Capabilities(firmwareVersion = null, forceEnableAll = true).supportsPreset(ChannelOption.MEDIUM_TURBO),
+        )
+    }
+
+    @Test
     fun nullFirmware_returns_all_false() {
         val c = caps(null)
         assertFalse(c.canMuteNode)

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/RegionInfoTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/RegionInfoTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model
+
+import org.meshtastic.proto.Config.LoRaConfig
+import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
+import org.meshtastic.proto.Config.LoRaConfig.RegionCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Frequency-slot expectations mirror the firmware's region table and slot math in
+ * `RadioInterface.cpp::applyModemConfig` (slot width = spacing + 2*padding + bandwidth; default slots from each
+ * region's RDEF entry).
+ */
+class RegionInfoTest {
+
+    private fun lora(region: RegionCode, preset: ModemPreset, channelNum: Int = 0) =
+        LoRaConfig(use_preset = true, modem_preset = preset, region = region, channel_num = channelNum)
+
+    /**
+     * Every region the firmware's region table defines must be selectable in the app. The proto enum is a superset
+     * (e.g. EU_874, EU_917, UA_868 have no firmware entry), so parity is asserted against this explicit list.
+     */
+    @Test
+    fun ensure_firmware_regions_are_mapped_in_RegionInfo() {
+        val firmwareRegions =
+            listOf(
+                RegionCode.US,
+                RegionCode.EU_433,
+                RegionCode.EU_868,
+                RegionCode.EU_866,
+                RegionCode.EU_N_868,
+                RegionCode.CN,
+                RegionCode.JP,
+                RegionCode.ANZ,
+                RegionCode.ANZ_433,
+                RegionCode.RU,
+                RegionCode.KR,
+                RegionCode.TW,
+                RegionCode.IN,
+                RegionCode.NZ_865,
+                RegionCode.TH,
+                RegionCode.UA_433,
+                RegionCode.MY_433,
+                RegionCode.MY_919,
+                RegionCode.SG_923,
+                RegionCode.PH_433,
+                RegionCode.PH_868,
+                RegionCode.PH_915,
+                RegionCode.KZ_433,
+                RegionCode.KZ_863,
+                RegionCode.NP_865,
+                RegionCode.BR_902,
+                RegionCode.ITU1_2M,
+                RegionCode.ITU2_2M,
+                RegionCode.ITU3_2M,
+                RegionCode.ITU2_125CM,
+                RegionCode.ITU1_70CM,
+                RegionCode.ITU2_70CM,
+                RegionCode.ITU3_70CM,
+                RegionCode.LORA_24,
+                RegionCode.UNSET,
+            )
+        firmwareRegions.forEach { region ->
+            assertNotNull(
+                RegionInfo.fromRegionCode(region),
+                "Missing RegionInfo entry for firmware region '${region.name}'.",
+            )
+        }
+    }
+
+    @Test
+    fun ham_2m_regions_use_20kHz_slots() {
+        // ITU1_2M: 144-146 MHz, TINY_FAST (15.625 kHz) padded to 20.025 kHz slots -> 100 slots, default slot 26.
+        val itu1 = lora(RegionCode.ITU1_2M, ModemPreset.TINY_FAST)
+        assertEquals(100, itu1.numChannels)
+        assertEquals(26, itu1.channelNum("TinyFast"))
+        assertEquals(144.5106f, itu1.radioFreq(26), 0.001f)
+
+        // ITU2_2M: 144-148 MHz -> 200 slots, default slot 51 (145.010 MHz).
+        val itu2 = lora(RegionCode.ITU2_2M, ModemPreset.TINY_FAST)
+        assertEquals(200, itu2.numChannels)
+        assertEquals(145.011f, itu2.radioFreq(itu2.channelNum("TinyFast")), 0.001f)
+
+        // ITU3_2M: 144-148 MHz -> 200 slots, default slot 33 (144.650 MHz).
+        val itu3 = lora(RegionCode.ITU3_2M, ModemPreset.TINY_FAST)
+        assertEquals(144.6508f, itu3.radioFreq(itu3.channelNum("TinyFast")), 0.001f)
+    }
+
+    @Test
+    fun ham_70cm_and_125cm_regions_use_100kHz_slots() {
+        // ITU2_70CM: 420-450 MHz, NARROW_SLOW (62.5 kHz) padded to 100 kHz slots -> 300 slots,
+        // default slot 137 (433.650 MHz).
+        val itu270cm = lora(RegionCode.ITU2_70CM, ModemPreset.NARROW_SLOW)
+        assertEquals(300, itu270cm.numChannels)
+        assertEquals(137, itu270cm.channelNum("NarrowSlow"))
+        assertEquals(433.65f, itu270cm.radioFreq(137), 0.001f)
+
+        // ITU1_70CM: 430-440 MHz -> 100 slots, default slot 37 (433.650 MHz).
+        val itu170cm = lora(RegionCode.ITU1_70CM, ModemPreset.NARROW_SLOW)
+        assertEquals(100, itu170cm.numChannels)
+        assertEquals(433.65f, itu170cm.radioFreq(itu170cm.channelNum("NarrowSlow")), 0.001f)
+
+        // ITU3_70CM: 430-450 MHz -> 200 slots, default slot 37 (433.650 MHz).
+        val itu370cm = lora(RegionCode.ITU3_70CM, ModemPreset.NARROW_SLOW)
+        assertEquals(433.65f, itu370cm.radioFreq(itu370cm.channelNum("NarrowSlow")), 0.001f)
+
+        // ITU2_125CM: 220-225 MHz -> 50 slots, default slot 37 (223.650 MHz).
+        val itu2125cm = lora(RegionCode.ITU2_125CM, ModemPreset.NARROW_SLOW)
+        assertEquals(50, itu2125cm.numChannels)
+        assertEquals(223.65f, itu2125cm.radioFreq(itu2125cm.channelNum("NarrowSlow")), 0.001f)
+    }
+
+    @Test
+    fun eu_866_lite_gives_four_600kHz_slots() {
+        // EU_866: 865.6-867.6 MHz, LITE_FAST (125 kHz) with 400 kHz spacing + 37.5 kHz padding
+        // -> 4 slots at 865.7/866.3/866.9/867.5 MHz.
+        val eu866 = lora(RegionCode.EU_866, ModemPreset.LITE_FAST)
+        assertEquals(4, eu866.numChannels)
+        assertEquals(865.7f, eu866.radioFreq(1), 0.001f)
+        assertEquals(867.5f, eu866.radioFreq(4), 0.001f)
+    }
+
+    @Test
+    fun eu_n_868_narrow_defaults_to_first_slot() {
+        val euN868 = lora(RegionCode.EU_N_868, ModemPreset.NARROW_SLOW)
+        assertEquals(3, euN868.numChannels)
+        assertEquals(1, euN868.channelNum("NarrowSlow"))
+        assertEquals(869.4417f, euN868.radioFreq(1), 0.001f)
+    }
+
+    @Test
+    fun standard_regions_keep_legacy_slot_math() {
+        // US: 902-928 MHz, LONG_FAST (250 kHz), no spacing/padding/override -> 104 hash-addressed slots.
+        val us = lora(RegionCode.US, ModemPreset.LONG_FAST)
+        assertEquals(104, us.numChannels)
+        assertEquals(906.875f, us.radioFreq(20), 0.001f)
+    }
+
+    @Test
+    fun explicit_channel_num_wins_over_override_slot() {
+        val itu1 = lora(RegionCode.ITU1_2M, ModemPreset.TINY_FAST, channelNum = 5)
+        assertEquals(5, itu1.channelNum("TinyFast"))
+    }
+}

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/RegionInfoTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/RegionInfoTest.kt
@@ -100,6 +100,7 @@ class RegionInfoTest {
 
         // ITU3_2M: 144-148 MHz -> 200 slots, default slot 33 (144.650 MHz).
         val itu3 = lora(RegionCode.ITU3_2M, ModemPreset.TINY_FAST)
+        assertEquals(200, itu3.numChannels)
         assertEquals(144.6508f, itu3.radioFreq(itu3.channelNum("TinyFast")), 0.001f)
     }
 
@@ -119,6 +120,7 @@ class RegionInfoTest {
 
         // ITU3_70CM: 430-450 MHz -> 200 slots, default slot 37 (433.650 MHz).
         val itu370cm = lora(RegionCode.ITU3_70CM, ModemPreset.NARROW_SLOW)
+        assertEquals(200, itu370cm.numChannels)
         assertEquals(433.65f, itu370cm.radioFreq(itu370cm.channelNum("NarrowSlow")), 0.001f)
 
         // ITU2_125CM: 220-225 MHz -> 50 slots, default slot 37 (223.650 MHz).

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -77,9 +77,9 @@ private val SPREAD_FACTOR_RANGE = 7..12
 private val CODING_RATE_RANGE = 5..8
 
 /**
- * Builds the modem-preset dropdown items: hide the 2.8-only TINY presets on firmware without
- * [Capabilities.supportsLoraRegionPresetMap], restrict to the region's legal presets (R7), then always keep the current
- * selection present (disabled) so the field is never blank when the device's preset is illegal for the region.
+ * Builds the modem-preset dropdown items: hide presets the target firmware's preset table doesn't have yet
+ * ([Capabilities.supportsPreset]), restrict to the region's legal presets (R7), then always keep the current selection
+ * present (disabled) so the field is never blank when the device's preset is illegal for the region.
  */
 private fun buildPresetItems(
     presetConstraint: RegionPresetConstraint?,
@@ -89,10 +89,7 @@ private fun buildPresetItems(
 ): List<DropDownItem<ModemPreset>> {
     val items =
         ChannelOption.entries
-            .filter { option ->
-                capabilities.supportsLoraRegionPresetMap ||
-                    (option != ChannelOption.TINY_FAST && option != ChannelOption.TINY_SLOW)
-            }
+            .filter { option -> capabilities.supportsPreset(option) }
             .filter { option -> presetConstraint == null || option.modemPreset in presetConstraint.presets }
             .map { option ->
                 DropDownItem(value = option.modemPreset, label = option.modemPreset.name, enabled = !presetsGated)

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -104,6 +104,15 @@ private fun buildPresetItems(
     }
 }
 
+/**
+ * Builds the region dropdown items: hide regions the target firmware's region table doesn't have yet
+ * ([Capabilities.supportsRegion]), but never hide the device's current selection.
+ */
+private fun buildRegionItems(capabilities: Capabilities, selectedRegion: RegionCode): List<Pair<RegionCode, String>> =
+    RegionInfo.entries
+        .filter { capabilities.supportsRegion(it) || it.regionCode == selectedRegion }
+        .map { it.regionCode to it.description }
+
 @Composable
 fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val state by viewModel.radioConfigState.collectAsStateWithLifecycle()
@@ -158,7 +167,10 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     title = stringResource(Res.string.region_frequency_plan),
                     summary = stringResource(Res.string.config_lora_region_summary),
                     enabled = state.connected,
-                    items = RegionInfo.entries.map { it.regionCode to it.description },
+                    items =
+                    remember(capabilities, formState.value.region) {
+                        buildRegionItems(capabilities, formState.value.region)
+                    },
                     selectedItem = formState.value.region,
                     onItemSelected = { region ->
                         val freshSetup = formState.value.region == RegionCode.UNSET


### PR DESCRIPTION
Adds the 2.8 firmware regions to the region picker: ITU1/2/3 2m, ITU2 1.25m, ITU1/2/3 70cm, plus EU_866 (Lite) and EU_N_868 (Narrow).

- `RegionInfo.minFirmware` + `Capabilities.supportsRegion()` hide them from pre-2.8 targets, remote admin included; the current selection is never hidden
- slot math now mirrors firmware `applyModemConfig`: per-profile spacing/padding and fixed default slots, so e.g. ITU2_70CM shows slot 137 @ 433.650 MHz
- preset gating generalized the same way: `ChannelOption.minFirmware` + `supportsPreset()` replace the hardcoded TINY filter, and now also gate MEDIUM_TURBO and LITE/NARROW — all 2.8-only in firmware (LITE/NARROW enum values shipped in v2.7.23 protobufs, but the `modemPresetToParams` cases are 2.8; older firmware silently falls back to LongFast)
- tests pin slot counts, default frequencies, and the gated region/preset sets to the firmware table

Fixes #6547