### PR TITLE
ci: restrict Develocity cache writes to trusted events

### DIFF
--- a/build-logic/settings-plugin/src/main/kotlin/MeshtasticDevelocitySettingsPlugin.kt
+++ b/build-logic/settings-plugin/src/main/kotlin/MeshtasticDevelocitySettingsPlugin.kt
@@ -61,7 +61,14 @@ class MeshtasticDevelocitySettingsPlugin : Plugin<Settings> {
             remote(develocity.buildCache) {
                 isEnabled = true
                 val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")?.trim()
-                isPush = isCI && !accessKey.isNullOrEmpty()
+                // Write only from trusted events. A same-repository pull request DOES
+                // receive repository secrets, so gating on the access key alone let PR
+                // builds write into the shared cache; excluding pull_request here keeps
+                // unmerged code out of it. Fork PRs have no key and are excluded twice
+                // over, and local builds are excluded by isCI.
+                val event = System.getenv("GITHUB_EVENT_NAME")
+                val trustedForPush = event == "push" || event == "merge_group"
+                isPush = isCI && trustedForPush && !accessKey.isNullOrEmpty()
             }
         }
     }


### PR DESCRIPTION
Pull-request builds are currently writing to the shared Develocity remote build
cache. They should not be.

## The gap

`MeshtasticDevelocitySettingsPlugin` gates cache writes on CI plus a non-empty
access key:

```kotlin
isPush = isCI && !accessKey.isNullOrEmpty()
```

**A same-repository pull request does receive repository secrets**, so
`pull-request.yml` runs satisfy both conditions and push entries into the cache
that `main` and the merge queue then read. Unmerged code can serve build outputs
to trusted builds.

This is a regression introduced in #6531. The self-hosted `HttpBuildCache` that
preceded it gated on the event and excluded pull requests:

```groovy
def trustedForPush = eventName == null || eventName == "push" || eventName == "merge_group"
push = (cacheUsername && cachePassword && trustedForPush)
```

That protection was lost when the cache moved to `remote(develocity.buildCache)`.

## The fix

Require `GITHUB_EVENT_NAME` to be `push` or `merge_group` as well.

**Cache population is unaffected.** `main-check.yml` (push to `main`) and
`merge-queue.yml` (`merge_group`) remain trusted writers — and they are the runs
whose outputs correspond to code that actually landed, which is exactly what the
cache should contain. `pull-request.yml` becomes pull-only, so PRs still get the
full read benefit.

## Verification

Run against a CI-shaped environment rather than reasoned about:

```
CI=true GITHUB_EVENT_NAME=pull_request  -> pull-only
CI=true GITHUB_EVENT_NAME=push          -> writes enabled
CI=true GITHUB_EVENT_NAME=merge_group   -> writes enabled
```

`./gradlew spotlessCheck detekt` green (185 tasks). Settings-plugin-only change,
so no app code is touched.

## Context

Found while onboarding the rest of the org's Gradle repos to the same
configuration — I copied this plugin's shape into six repos and CodeRabbit
caught the missing gate there. Fixed in all six
(meshtastic/kzstd#36, meshtastic/gradle-flatpak-sources#28,
meshtastic/MQTTastic-Client-KMP#118, meshtastic/meshtastic-sdk#91,
meshtastic/protobufs#1027, meshtastic/TAKPacket-SDK#124); this brings android
back in line with them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional LoRa regions, including EU narrow/lite and amateur radio bands.
  * Added newer channel presets, including lite, narrow, turbo, and tiny options.
  * Improved frequency and channel-slot calculations for regional spacing, padding, and overrides.
* **Bug Fixes**
  * Region and preset lists now hide options unsupported by the device’s firmware.
  * The device’s current region remains available even when it is not supported by the detected firmware version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->