### PR TITLE
fix(docs): publish only screenshots a synced page references

### DIFF
--- a/scripts/sync-android-docs.js
+++ b/scripts/sync-android-docs.js
@@ -15,6 +15,9 @@
 //   docs/software/android/developer/*.md
 //   docs/software/android/index.md
 //   static/img/android/docs/*.webp (or .png/.svg if not converting)
+//
+// Only screenshots a synced page actually references are published; any other
+// file already under those two directories is pruned at the end of the run.
 
 "use strict";
 
@@ -231,17 +234,42 @@ function convertCallouts(content) {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
-function processMarkdown(srcPath, destPath, section, isIndex = false) {
+/**
+ * Collect the `/img/android/docs/<name>` basenames a page references, so only
+ * screenshots some page actually shows get published. Runs on the transformed
+ * content, which has already had relative paths rewritten to the site path and
+ * convertible extensions renamed to .webp — so these are destination names.
+ */
+function collectImageReferences(content, into) {
+    const re = /\/img\/android\/docs\/([^)"'\s>]+)/g;
+    let match;
+    while ((match = re.exec(content)) !== null) {
+        into.add(path.basename(match[1]));
+    }
+}
+
+function processMarkdown(srcPath, destPath, section, isIndex = false, referencedImages = null) {
     let content = fs.readFileSync(srcPath, "utf-8");
     content = transformFrontmatter(content, section);
     content = rewriteImagePaths(content);
     content = rewriteSiblingLinks(content, section, isIndex);
     content = convertCallouts(content);
+    if (referencedImages) collectImageReferences(content, referencedImages);
     writeFile(destPath, content);
 }
 
-/** Sync screenshots, returning the set of destination basenames written. */
-function processImages() {
+/**
+ * Sync screenshots, returning the set of destination basenames written.
+ *
+ * Only images `referenced` by a synced page are published. The source
+ * screenshots directory accumulates captures faster than pages cite them (and
+ * the Compose screenshot tests regenerate the whole set), so copying it
+ * wholesale ships assets no page shows. Anything skipped here is absent from
+ * the returned set, which is what pruneStale() deletes against — so a
+ * screenshot that loses its last reference is removed from the site on the
+ * next sync rather than lingering forever.
+ */
+function processImages(referenced) {
     const written = new Set();
     if (!fs.existsSync(SRC_SCREENSHOTS_DIR)) {
         console.log("No screenshots directory found, skipping image sync.");
@@ -251,12 +279,20 @@ function processImages() {
     const images = fs.readdirSync(SRC_SCREENSHOTS_DIR)
         .filter(f => IMAGE_EXTENSIONS.has(path.extname(f).toLowerCase()));
 
+    let skipped = 0;
     for (const img of images) {
         const srcPath = path.join(SRC_SCREENSHOTS_DIR, img);
         const ext = path.extname(img).toLowerCase();
+        const destName = CONVERT_WEBP && WEBP_CONVERTIBLE.has(ext)
+            ? img.slice(0, -ext.length) + ".webp"
+            : img;
+
+        if (!referenced.has(destName)) {
+            skipped++;
+            continue;
+        }
 
         if (CONVERT_WEBP && WEBP_CONVERTIBLE.has(ext)) {
-            const destName = img.slice(0, -ext.length) + ".webp";
             const destPath = path.join(DEST_IMAGES_DIR, destName);
 
             if (DRY_RUN) {
@@ -280,6 +316,18 @@ function processImages() {
             written.add(img);
         }
     }
+
+    if (skipped > 0) {
+        console.log(`Skipped ${skipped} screenshot(s) no synced page references.`);
+    }
+
+    // A page citing an image that isn't in the source directory renders a broken
+    // image on the site. Cheap to surface here, where both sets are in hand.
+    const missing = [...referenced].filter(name => !written.has(name)).sort();
+    for (const name of missing) {
+        console.warn(`Warning: referenced image has no source screenshot: ${name}`);
+    }
+
     return written;
 }
 
@@ -398,6 +446,9 @@ function main() {
         "developer/_category_.yml",
     ]);
 
+    // Destination image names cited by the pages below; only these get published.
+    const referencedImages = new Set();
+
     // Section overview pages: docs/en/user.md → user/index.md and
     // docs/en/developer.md → developer/index.md. Docusaurus uses <dir>/index.md
     // as the category landing page, so the index.md "User Guide" / "Developer
@@ -409,7 +460,7 @@ function main() {
     for (const { src, dest, section, key } of sections) {
         const overview = path.join(SRC_DOCS_DIR, src);
         if (fs.existsSync(overview)) {
-            processMarkdown(overview, path.join(DEST_DOCS_DIR, ...dest), section, true);
+            processMarkdown(overview, path.join(DEST_DOCS_DIR, ...dest), section, true, referencedImages);
             expectedDocPaths.add(key);
         }
     }
@@ -422,6 +473,8 @@ function main() {
                 path.join(userDir, file),
                 path.join(DEST_DOCS_DIR, "user", file),
                 "user",
+                false,
+                referencedImages,
             );
             expectedDocPaths.add(`user/${file}`);
         }
@@ -435,6 +488,8 @@ function main() {
                 path.join(devDir, file),
                 path.join(DEST_DOCS_DIR, "developer", file),
                 "developer",
+                false,
+                referencedImages,
             );
             expectedDocPaths.add(`developer/${file}`);
         }
@@ -444,8 +499,8 @@ function main() {
     createIndexPage();
     createCategoryFiles();
 
-    // Process images
-    const expectedImageNames = processImages();
+    // Process images — only those the pages above reference.
+    const expectedImageNames = processImages(referencedImages);
 
     // Remove anything left over from a previous sync or the old hand-written docs.
     pruneStale(expectedDocPaths, expectedImageNames);


### PR DESCRIPTION
The weekly [sync-android-docs](https://github.com/meshtastic/meshtastic/blob/master/.github/workflows/sync-android-docs.yml) workflow republishes 7 screenshots that no page has referenced for months, so they sit on meshtastic.org indefinitely. `pruneStale()` only removes destination files this run did not produce — it catches screenshots *deleted* from `docs/assets/screenshots`, but not ones still present in source that nothing cites any more. Those get copied, converted and re-committed on every sync.

### 🐛 Bug Fixes

- Collect the `/img/android/docs/` basenames each transformed page references, and publish only those. Because skipped images are absent from the set `pruneStale()` deletes against, a screenshot that loses its last reference is now dropped from the site on the next sync instead of lingering.
- Reference collection runs on the *transformed* content, so relative paths are already rewritten to the site path and convertible extensions already renamed to `.webp` — the collected names are destination names, and the WebP mapping needs no separate handling.

### 🧹 Chores

- Warn when a page references an image with no source screenshot. That combination renders a broken image on the site, and both sets are already in hand at that point. Non-fatal; the remaining images still publish.
- Log a count of skipped screenshots so the sync run says what it left out rather than silently narrowing.

## Testing Performed

No unit test — `scripts/` has no JS harness (no `package.json`, no `*.test.js`), so this was verified by running the current `main` script and the patched one against a clean clone of `meshtastic/meshtastic@master` from the same source tree and comparing the outputs:

- Markdown/YAML output: `diff -r` reports **identical**
- The 44 kept images: **byte-identical** (`cmp` per file)
- Removed: **exactly the 7 unreferenced images**, 51 → 44, with no other change in the resulting `git status`
- `--dry-run`: reports all 7 as "Would remove", changes **0 files**, leaves all 51 in place
- Referenced-but-missing case (source screenshot deleted for a page that still cites it): warning fires, exit 0, the other 43 still publish

Gradle baseline not run: this touches only a standalone Node script with no Gradle inputs, spotless has no JS coverage, detekt is Kotlin-only, and the `android` paths filter in `pull-request.yml` excludes `scripts/**`, so CI runs no Gradle job for this diff either.

## Rollout note

The org workflow clones this repo **at the latest non-prerelease tag** and runs that tag's copy of the script, so this takes effect once a release tag contains it (2.8.1). The 7 files already on the site are being deleted by hand on meshtastic/meshtastic#2476; this change is what stops them coming back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation pages now publish only screenshots referenced by the content, keeping image assets focused and relevant.
  * Unused source images are skipped, while missing screenshots referenced in documentation generate warnings.
  * Image cleanup now removes outdated assets that are no longer associated with published pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->