### PR TITLE
fix(desktop): restore BLE scanning and connecting in packaged builds

### DIFF
--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -24,6 +24,9 @@ import com.juul.kable.PooledThreadingStrategy
 import com.juul.kable.toIdentifier
 import org.meshtastic.core.model.util.anonymize
 
+/** Android's scanner filters on address in hardware, so Kable's `Filter.Address` works natively here. */
+internal actual val supportsNativeAddressScanFilter: Boolean = true
+
 /**
  * Shared thread pool for Kable BLE connections.
  *

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.core.annotation.Single
@@ -42,8 +43,19 @@ internal sealed interface KableScanFilter {
 
 internal data class KableScanResult(val identifier: String, val name: String?, val advertisement: Advertisement?)
 
-internal fun resolveKableScanFilter(serviceUuid: Uuid?, address: String?): KableScanFilter = when {
-    address != null -> KableScanFilter.Address(address)
+/**
+ * Picks the native filter to hand Kable: address only where the platform honours it
+ * ([supportsNativeAddressScanFilter]), otherwise the service UUID, since a filter the platform ignores matches nothing.
+ * [KableBleScanner.scan] narrows to the address client-side either way.
+ *
+ * [supportsAddressFilter] is a parameter so both platform behaviours are reachable from commonTest.
+ */
+internal fun resolveKableScanFilter(
+    serviceUuid: Uuid?,
+    address: String?,
+    supportsAddressFilter: Boolean = supportsNativeAddressScanFilter,
+): KableScanFilter = when {
+    address != null && supportsAddressFilter -> KableScanFilter.Address(address)
     serviceUuid != null -> KableScanFilter.ServiceUuid(serviceUuid)
     else -> KableScanFilter.None
 }
@@ -78,7 +90,7 @@ open class KableBleScanner(private val loggingConfig: BleLoggingConfig) : BleSca
     // common supertype below Exception, so merging them would mean catching Exception broadly instead.
     @Suppress("ThrowsCount")
     override fun scan(timeout: Duration, serviceUuid: Uuid?, address: String?): Flow<BleDevice> {
-        val filter = resolveKableScanFilter(serviceUuid = serviceUuid, address = address)
+        val nativeFilter = resolveKableScanFilter(serviceUuid = serviceUuid, address = address)
 
         // Kable's Scanner doesn't enforce timeout internally, it runs until the Flow is cancelled.
         // By wrapping it in a channelFlow with a timeout, we enforce the BleScanner contract cleanly.
@@ -86,15 +98,20 @@ open class KableBleScanner(private val loggingConfig: BleLoggingConfig) : BleSca
             withTimeoutOrNull(timeout) {
                 reserveScanStart()
                 try {
-                    advertisements(filter).collect { advertisement ->
-                        send(
-                            MeshtasticBleDevice(
-                                address = advertisement.identifier,
-                                name = advertisement.name,
-                                advertisement = advertisement.advertisement,
-                            ),
-                        )
-                    }
+                    // Re-check the address even when the native filter already covers it: callers such as
+                    // NymeaWifiService take the first emission without their own address check, so an unsupported
+                    // native address filter must never widen the scan to other devices.
+                    advertisements(nativeFilter)
+                        .filter { address == null || it.identifier.equals(address, ignoreCase = true) }
+                        .collect { advertisement ->
+                            send(
+                                MeshtasticBleDevice(
+                                    address = advertisement.identifier,
+                                    name = advertisement.name,
+                                    advertisement = advertisement.advertisement,
+                                ),
+                            )
+                        }
                 } catch (ex: CancellationException) {
                     throw ex
                 } catch (ex: UnmetRequirementException) {

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -19,6 +19,12 @@ package org.meshtastic.core.ble
 import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
 
+/**
+ * Whether Kable honours a scan filter on device address here. Android only: `Filter.Address` throws on Apple/JS, and
+ * the JVM/btleplug backend evaluates predicates with a hardcoded null address so it matches nothing.
+ */
+internal expect val supportsNativeAddressScanFilter: Boolean
+
 /** Platform-specific configuration for the Peripheral builder based on device type. */
 internal expect fun PeripheralBuilder.platformConfig(device: BleDevice, autoConnect: () -> Boolean)
 

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -132,22 +132,82 @@ class KableBleConnectionTest {
     }
 
     @Test
-    fun `address filter is applied`() = runTest {
-        val scanner = TestKableBleScanner(scanResults = emptyFlow())
+    fun `address filter is used natively only where the platform supports it`() {
+        val address = "AA:BB:CC:DD:EE:FF"
 
-        scanner.scan(timeout = 1.seconds, address = "AA:BB:CC:DD:EE:FF").toList()
-
-        assertEquals(KableScanFilter.Address("AA:BB:CC:DD:EE:FF"), scanner.lastFilter)
+        assertEquals(
+            KableScanFilter.Address(address),
+            resolveKableScanFilter(serviceUuid = null, address = address, supportsAddressFilter = true),
+        )
+        // Without native support the scan must stay unfiltered rather than carry a filter that matches nothing.
+        assertEquals(
+            KableScanFilter.None,
+            resolveKableScanFilter(serviceUuid = null, address = address, supportsAddressFilter = false),
+        )
     }
 
     @Test
-    fun `address filter takes priority over service uuid`() = runTest {
+    fun `service uuid wins over address when the platform cannot filter by address`() {
         val serviceUuid = Uuid.parse("12345678-1234-1234-1234-1234567890ab")
-        val scanner = TestKableBleScanner(scanResults = emptyFlow())
+        val address = "AA:BB:CC:DD:EE:FF"
 
-        scanner.scan(timeout = 1.seconds, serviceUuid = serviceUuid, address = "AA:BB:CC:DD:EE:FF").toList()
+        assertEquals(
+            KableScanFilter.Address(address),
+            resolveKableScanFilter(serviceUuid = serviceUuid, address = address, supportsAddressFilter = true),
+        )
+        // Kable's btleplug backend matches address filters against a hardcoded null, so an address filter here would
+        // silently yield no advertisements at all and BLE connect could never find the device.
+        assertEquals(
+            KableScanFilter.ServiceUuid(serviceUuid),
+            resolveKableScanFilter(serviceUuid = serviceUuid, address = address, supportsAddressFilter = false),
+        )
+    }
 
-        assertEquals(KableScanFilter.Address("AA:BB:CC:DD:EE:FF"), scanner.lastFilter)
+    @Test
+    fun `scan narrows to the requested address regardless of the native filter`() = runTest {
+        val wanted = "AA:BB:CC:DD:EE:FF"
+        val scanner =
+            TestKableBleScanner(
+                scanResults =
+                flowOf(
+                    KableScanResult(identifier = "11:22:33:44:55:66", name = "Other", advertisement = null),
+                    KableScanResult(identifier = wanted, name = "Meshtastic", advertisement = null),
+                    KableScanResult(identifier = "77:88:99:AA:BB:CC", name = "Another", advertisement = null),
+                ),
+            )
+
+        val result = scanner.scan(timeout = 1.seconds, address = wanted).toList()
+
+        assertEquals(listOf(wanted), result.map { it.address })
+    }
+
+    @Test
+    fun `scan matches the requested address case-insensitively`() = runTest {
+        val scanner =
+            TestKableBleScanner(
+                scanResults =
+                flowOf(KableScanResult(identifier = "aa:bb:cc:dd:ee:ff", name = "Meshtastic", advertisement = null)),
+            )
+
+        val result = scanner.scan(timeout = 1.seconds, address = "AA:BB:CC:DD:EE:FF").toList()
+
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `scan without an address emits every advertisement`() = runTest {
+        val scanner =
+            TestKableBleScanner(
+                scanResults =
+                flowOf(
+                    KableScanResult(identifier = "11:22:33:44:55:66", name = "One", advertisement = null),
+                    KableScanResult(identifier = "77:88:99:AA:BB:CC", name = "Two", advertisement = null),
+                ),
+            )
+
+        val result = scanner.scan(timeout = 1.seconds).toList()
+
+        assertEquals(2, result.size)
     }
 
     @Test

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -183,15 +183,20 @@ class KableBleConnectionTest {
 
     @Test
     fun `scan matches the requested address case-insensitively`() = runTest {
+        // A second, non-matching advertisement keeps this honest: a scan that ignored the address entirely would
+        // emit both, so the assertion proves the filter ran *and* that it matched across case.
         val scanner =
             TestKableBleScanner(
                 scanResults =
-                flowOf(KableScanResult(identifier = "aa:bb:cc:dd:ee:ff", name = "Meshtastic", advertisement = null)),
+                flowOf(
+                    KableScanResult(identifier = "11:22:33:44:55:66", name = "Other", advertisement = null),
+                    KableScanResult(identifier = "aa:bb:cc:dd:ee:ff", name = "Meshtastic", advertisement = null),
+                ),
             )
 
         val result = scanner.scan(timeout = 1.seconds, address = "AA:BB:CC:DD:EE:FF").toList()
 
-        assertEquals(1, result.size)
+        assertEquals(listOf("aa:bb:cc:dd:ee:ff"), result.map { it.address })
     }
 
     @Test
@@ -207,7 +212,7 @@ class KableBleConnectionTest {
 
         val result = scanner.scan(timeout = 1.seconds).toList()
 
-        assertEquals(2, result.size)
+        assertEquals(listOf("11:22:33:44:55:66", "77:88:99:AA:BB:CC"), result.map { it.address })
     }
 
     @Test

--- a/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
+++ b/core/ble/src/commonTest/kotlin/org/meshtastic/core/ble/KableBleConnectionTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.ble
 
+import app.cash.turbine.test
 import com.juul.kable.Advertisement
 import dev.mokkery.MockMode
 import dev.mokkery.mock
@@ -176,9 +177,10 @@ class KableBleConnectionTest {
                 ),
             )
 
-        val result = scanner.scan(timeout = 1.seconds, address = wanted).toList()
-
-        assertEquals(listOf(wanted), result.map { it.address })
+        scanner.scan(timeout = 1.seconds, address = wanted).test {
+            assertEquals(wanted, awaitItem().address)
+            awaitComplete()
+        }
     }
 
     @Test
@@ -194,9 +196,10 @@ class KableBleConnectionTest {
                 ),
             )
 
-        val result = scanner.scan(timeout = 1.seconds, address = "AA:BB:CC:DD:EE:FF").toList()
-
-        assertEquals(listOf("aa:bb:cc:dd:ee:ff"), result.map { it.address })
+        scanner.scan(timeout = 1.seconds, address = "AA:BB:CC:DD:EE:FF").test {
+            assertEquals("aa:bb:cc:dd:ee:ff", awaitItem().address)
+            awaitComplete()
+        }
     }
 
     @Test
@@ -210,9 +213,11 @@ class KableBleConnectionTest {
                 ),
             )
 
-        val result = scanner.scan(timeout = 1.seconds).toList()
-
-        assertEquals(listOf("11:22:33:44:55:66", "77:88:99:AA:BB:CC"), result.map { it.address })
+        scanner.scan(timeout = 1.seconds).test {
+            assertEquals("11:22:33:44:55:66", awaitItem().address)
+            assertEquals("77:88:99:AA:BB:CC", awaitItem().address)
+            awaitComplete()
+        }
     }
 
     @Test

--- a/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
+++ b/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
@@ -19,6 +19,9 @@ package org.meshtastic.core.ble
 import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
 
+// Kable's `Filter.Address` throws UnsupportedOperationException on Apple.
+internal actual val supportsNativeAddressScanFilter: Boolean = false
+
 /** No-op stubs for iOS target in core:ble. */
 internal actual fun PeripheralBuilder.platformConfig(device: BleDevice, autoConnect: () -> Boolean) {
     // No-op for stubs

--- a/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -20,6 +20,10 @@ import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
 import com.juul.kable.toIdentifier
 
+// Kable's btleplug backend evaluates scan filters with a hardcoded `address = null`, so an address filter matches
+// nothing and the scan yields no advertisements at all.
+internal actual val supportsNativeAddressScanFilter: Boolean = false
+
 internal actual fun PeripheralBuilder.platformConfig(device: BleDevice, autoConnect: () -> Boolean) {
     // Desktop Kable uses direct connections without needing autoConnect.
 }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -290,9 +290,8 @@ class BleRadioTransport(
      */
     private suspend fun scanForFreshDevice(timeout: Duration): BleDevice? = try {
         withTimeoutOrNull(timeout) {
-            // Pass both service UUID and address so the scanner can apply the most efficient platform filter.
-            // Android uses address (OS-level HW filter), while CoreBluetooth (macOS) needs the service UUID because
-            // it caches peripheral identifiers and may not re-report by address alone.
+            // Pass both service UUID and address; the scanner picks whichever filter the platform can honour
+            // (address natively on Android, service UUID elsewhere) and narrows to the address itself.
             scanner.scan(timeout = timeout, serviceUuid = SERVICE_UUID, address = address).first {
                 it.address.equals(address, ignoreCase = true)
             }

--- a/desktopApp/proguard-rules.pro
+++ b/desktopApp/proguard-rules.pro
@@ -40,11 +40,20 @@
 -dontwarn sun.misc.Unsafe
 -dontwarn java.lang.invoke.**
 
-# ---- JNA (Java Native Access) — used by LinuxNotificationSender for libnotify ---
+# ---- JNA (Java Native Access) — libnotify sender + kable's btleplug BLE bindings ---
 # JNA uses reflection to bind native methods; keep its core and callback classes.
 -keep class com.sun.jna.** { *; }
 -keep class com.sun.jna.ptr.** { *; }
 -dontwarn com.sun.jna.**
+
+# JNA callbacks are only ever invoked from native code, so the shrinker sees the
+# abstract methods as unused and empties the interface. JNA then can't resolve
+# the callback method and rejects the whole vtable Structure at <clinit>:
+#   IllegalArgumentException: Structure field "uniffiFree" was declared as
+#   ...UniffiCallbackInterfaceFree, which is not supported within a Structure
+# which killed BLE scanning in every packaged desktop build (#6553).
+-keep class * implements com.sun.jna.Callback { *; }
+-keep class * extends com.sun.jna.Structure { *; }
 
 # ---- jSerialComm Android stubs (cross-platform serial library) --------------
 # jSerialComm bundles Android shims that reference android.* classes; harmless


### PR DESCRIPTION
Fixes #6553.

BLE on the desktop app was broken twice over, and each bug hid behind the other. Fixing only the shrinker still leaves you unable to connect; fixing only the scan filter still leaves the packaged app unable to scan.

## 🐛 Bug 1 — the shrinker empties every JNA callback interface

Not a JNA version or packaging problem — our ProGuard rules.

`kable-btleplug-ffi` (desktop BLE) is uniffi-generated: every JNA callback is a one-method interface extending `com.sun.jna.Callback`, invoked only from Rust. The shrinker sees no Java caller and deletes the method:

```
# before                                 # after
interface UniffiCallbackInterfaceFree    interface UniffiCallbackInterfaceFree
    extends com.sun.jna.Callback {           extends com.sun.jna.Callback {
  void callback(long);                   }
}
```

At `UniffiLib.<clinit>` JNA writes the vtable Structure, calls `CallbackReference.getFunctionPointer()` and gets `IllegalArgumentException: Callback must implement a single public method, or one public method named 'callback'`. `Structure.writeField` rewraps it as the misleading *"…which is not supported within a Structure"*, class init fails, and every later `scan()` throws `NoClassDefFoundError`.

We kept `com.sun.jna.**` but nothing kept the *implementors*. (`-dontoptimize` is already set, so this is pure shrinking.)

Not Linux- or AppImage-specific: **every packaged desktop build on every OS** since ProGuard was enabled. Only unpackaged `./gradlew run` works.

## 🐛 Bug 2 — the connect path scans with a filter the platform ignores

With scanning restored, devices appear in the Connections list but selecting one always fails:

```
Info: [08a7b512-…] BLE connection attempt started
Info: [...873] Device not found in bonded list, scanning
Warn: [08a7b512-…] Failed to connect after 17.024s
org.meshtastic.core.model.RadioNotConnectedException: Device not found at address 08a7b512-…
    at BleRadioTransport.findDevice(BleRadioTransport.kt:274)
```

Kable's `Filter.Address` is **Android-only**, and it fails two different ways elsewhere:

| Backend | Behaviour with an address filter |
|---|---|
| Android | Supported natively (hardware filter) |
| JVM / btleplug (desktop) | `BtleplugScanner` evaluates predicates with `address = null` hardcoded, and `Filter.Address.matches` opens with `if (address == null) return false` → **matches nothing, silently** |
| Apple / JS | Throws `UnsupportedOperationException` |

`resolveKableScanFilter` preferred address whenever it was non-null, and `scanForFreshDevice` always passes one — so every desktop connect scanned with the one filter that can never match. The Connections screen was fine because `ScannerViewModel` passes *only* the service UUID. That asymmetry is the whole bug: a device plainly visible at −57 dBm that `findDevice` could never see.

The existing comment on `scanForFreshDevice` described the right intent ("CoreBluetooth needs the service UUID") but the resolver never delivered it.

## 🛠️ Changes

- `desktopApp/proguard-rules.pro`: keep `* implements com.sun.jna.Callback` and `* extends com.sun.jna.Structure`.
- New `supportsNativeAddressScanFilter` expect/actual (Android `true`, jvm/ios `false`) selects the native scan filter.
- `KableBleScanner.scan` now **always** re-applies the address client-side. This is load-bearing, not belt-and-braces: `NymeaWifiService.connect` takes `.first()` with no address check of its own, so merely flipping the precedence would have it connect to the wrong device on desktop.

Android behaviour is unchanged — the native address filter still applies, with the client-side check as a no-op safety net.

## ✅ Testing Performed

**Bug 1, against the real proguarded jars (macOS, JBR 25).** A harness loads the 181 shipped jars in an isolated classloader, audits every `com.sun.jna.Callback` implementor, and forces `UniffiLib.<clinit>`:

| | before | after |
|---|---|---|
| JNA `Callback` implementors surviving | 20 | 34 |
| of those, uniffi (btleplug) callbacks | 16, **all emptied** | 30, **all intact** |
| `Class.forName("…UniffiLib")` | `ExceptionInInitializerError` → the exact IAE chain from #6553 | `OK: UniffiLib initialized` |

The two interfaces still method-less after the fix are `com.sun.jna.win32.DLLCallback` and `StdCallLibrary$StdCallCallback` — verified with `javap` to be method-less markers in pristine JNA 5.19.1 too, not shrinker casualties.

**Bug 2, on real hardware (macOS 15, arm64).** Connected to a Heltec node from the packaged app — `E2E-DUT-heltec`, firmware 2.8.0.6efce75, PWR 4.21 V, 28 config messages, `MyNodeInfo received`, `onConnectionChanged: Disconnected -> Connected`. Before the fix the same click failed at 17.02s every time.

Verified in **both** app images. The proguarded release image connected on the first attempt with zero failures. Scanning showed three peripherals with continuously updating RSSI, so advertisements really are arriving through the native→Java `ScanCallback` rather than being replayed from the database.

Bug 2 was confirmed independent of ProGuard before fixing it: an unproguarded `createDistributable` image failed identically (17.025s vs 17.024s), with zero `NoClassDefFoundError`/`ClassNotFoundException`/`NoSuchMethodError`/`UnsatisfiedLinkError` in either log.

**Unit tests.** `KableBleConnectionTest` is 15 tests, green on JVM and Android host. The two cases that asserted address-first precedence would now fail on jvm/ios, so they were replaced with direct `resolveKableScanFilter` cases covering both platform behaviours, plus three behavioural tests for the client-side narrowing (multi-device narrowing, case-insensitive match, and no-address pass-through).

The behavioural tests were mutation-checked rather than assumed: neutering the narrowing to `.filter { true }` fails exactly the two address tests and nothing else. That check is what caught their first version, which asserted only `result.size` and so passed against the unfiltered pre-change scanner — they now assert the exact emitted address lists. The no-address test cannot be made to fail under that mutation by construction, since "unfiltered" is the behaviour it asserts; it guards the opposite direction, that the filter does not over-apply when no address is requested.

Baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` green.

## ⚠️ Not covered

Nothing in CI exercises the packaged app's BLE path, and neither of these bugs could have been caught pre-merge. `pull-request.yml` deliberately skips the desktop build to keep feedback under 10 minutes, delegating to `:desktopApp:test` in the shard-app shard — which compiles desktop but never runs ProGuard, so the proguarded jars that Bug 1 lives in are not produced at all on a PR. Bug 2 needs real BLE hardware.

A cheap follow-up for Bug 1's whole class: assert that every `com.sun.jna.Callback` subinterface in the proguarded jars still declares ≥1 method. That is mechanical and needs no hardware, but it does need `proguardReleaseJars` to run somewhere — a nightly or release-gated leg rather than per-PR.

Two things seen while testing, neither addressed here and neither caused by this PR:

- `RuntimeException: Timed out waiting for FROMNUM subscription readiness` at `BleRadioTransport.discoverServicesAndSetupCharacteristics` (~7s) on one unproguarded attempt. `BleReconnectPolicy` retried through it and it did not recur on the release build.
- A stale local database crashed startup with `AutoMigration_42_43` → `duplicate column name: targets`. Pre-existing local state, unrelated to these changes.

Line numbers in the trace reported on #6553 (`writeField:913`, `write:807`, `autoWrite:2368`) match JNA 5.19.1 — the version we ship and the one kable requests, so no conflict there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth device discovery across Android, iOS, desktop, and other supported platforms.
  * Address-based scans now reliably return only the requested device, including case-insensitive address matching.
  * Added fallback behavior for platforms that cannot natively filter by Bluetooth address.
  * Service-based scanning continues to work correctly when address filtering is unavailable.
  * Unfiltered scans now return all detected advertisements as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->