### PR TITLE
ci: publish desktop installers in the rolling snapshot release

### DIFF
--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -75,6 +75,16 @@ jobs:
           name: app-debug-apks
           path: artifacts
 
+      # Desktop installers land in per-OS artifacts (desktop-app-<os>-<arch>). A matrix leg
+      # failing (e.g. one OS's packaging breaks) shouldn't block publishing the rest, so this
+      # doesn't fail the job if some/all are missing — see the !cancelled() gate above.
+      - name: Download desktop installers
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: desktop-app-*
+          path: desktop-artifacts
+
       # A moving tag reuses the same release URL forever, and Obtainium fingerprints the
       # asset URL — so without a changing filename it would never detect a new build.
       # Embed the (monotonic) versionCode in each APK name; same formula the app build uses.
@@ -90,6 +100,21 @@ jobs:
           done
           ls -l upload
 
+      # Desktop installer filenames already embed the OS/arch (jpackage) plus a "snapshot"
+      # version tag baked into the AppImage step, but stamp the versionCode on too so every
+      # asset in the release moves in lockstep and testers can tell builds apart at a glance.
+      - name: Stage desktop installers
+        run: |
+          mkdir -p desktop-artifacts
+          find desktop-artifacts -type f \( -name '*.dmg' -o -name '*.msi' -o -name '*.exe' \
+            -o -name '*.deb' -o -name '*.rpm' -o -name '*.AppImage' \) | while read -r f; do
+            base="$(basename "$f")"
+            ext="${base##*.}"
+            name="${base%.*}"
+            cp "$f" "upload/${name}-${VERSION_CODE}.${ext}"
+          done
+          ls -l upload
+
       # Delete the previous snapshot release AND its tag, then recreate both at HEAD. This
       # prunes the now-stale (differently-named) APKs so they don't pile up, and sidesteps the
       # Releases API refusing to retarget an already-existing tag.
@@ -102,9 +127,12 @@ jobs:
           Automated debug build from the latest commit on \`main\` ($GITHUB_SHA), versionCode $VERSION_CODE.
           Unsigned/debug-keyed, F-Droid and Google flavors. Not for production use — this release is replaced on every push to main.
 
+          Also includes unsigned desktop installers (macOS .dmg, Windows .msi/.exe, Linux .deb/.rpm/.AppImage)
+          built from the same commit, when that platform's build succeeded.
+
           **Obtainium:** enable *Include prereleases*. Each build's APK filename carries the versionCode, so updates are detected.
           EOF
-          gh release create snapshot upload/*.apk \
+          gh release create snapshot upload/* \
             --title "Snapshot $VERSION_CODE ($GITHUB_SHA)" \
             --target "$GITHUB_SHA" \
             --prerelease \

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -426,19 +426,42 @@ jobs:
           cache_read_only: ${{ env.GRADLE_CACHE_READ_ONLY }}
           install_jetbrains_jdk: 'true'
 
+      - name: Install dependencies for AppImage
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libfuse2t64
+
       - name: Build Desktop
         # proguardReleaseJars is included because it is otherwise only exercised by the
         # release workflow: jlink tolerates a jmods-less JDK (JEP 493) but ProGuard does
         # not, so a broken packaging JDK would surface at release time instead of here.
-        run: ./gradlew :desktopApp:createDistributable :desktopApp:proguardReleaseJars -Pci=true
+        # packageDistributionForCurrentOS (debug build type, no ProGuard) produces real
+        # installers (dmg/msi+exe/deb+rpm+AppImage-dir) so the snapshot release below can
+        # ship something testers can actually install, not just an unpacked app dir.
+        run: ./gradlew :desktopApp:packageDistributionForCurrentOS :desktopApp:proguardReleaseJars -Pci=true
+
+      # CMP's TargetFormat.AppImage is jpackage's "app-image" — an unpacked directory, not
+      # a Linux .AppImage. Wrap it into a real AppImage, same as the release workflow.
+      - name: Build AppImage from jpackage app-image
+        if: runner.os == 'Linux'
+        env:
+          APP_VERSION_NAME: snapshot
+          BINARIES_DIR: desktopApp/build/compose/binaries/main
+        run: scripts/build-appimage.sh
 
       - name: Upload Desktop artifact
         if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@v7
         with:
           name: desktop-app-${{ runner.os }}-${{ runner.arch }}
-          path: desktopApp/build/compose/binaries/main/app/
+          path: |
+            desktopApp/build/compose/binaries/main/*/*.dmg
+            desktopApp/build/compose/binaries/main/*/*.msi
+            desktopApp/build/compose/binaries/main/*/*.exe
+            desktopApp/build/compose/binaries/main/*/*.deb
+            desktopApp/build/compose/binaries/main/*/*.rpm
+            desktopApp/build/compose/binaries/main/*/*.AppImage
           retention-days: 7
+          if-no-files-found: error
 
   # ── Flatpak Sources ───────────────────────────────────────────────────
   build-flatpak-src:


### PR DESCRIPTION
## Why

Testers on #6553 asked for a way to try the automated Linux builds (RPM/AppImage) without building from source — the rolling `snapshot` prerelease only ships APKs today, while the desktop matrix builds an unpacked app dir that dies in Actions artifacts after 7 days (login required).

## 🛠️ Changes

- **`reusable-check.yml` (build-desktop):** switch `createDistributable` → `packageDistributionForCurrentOS` so each matrix leg produces real installers (macOS `.dmg`, Windows `.msi`/`.exe`, Linux `.deb`/`.rpm`); keep `proguardReleaseJars` as the packaging-JDK canary. Wrap the jpackage app-image into a true `.AppImage` with the existing `scripts/build-appimage.sh` (now honoring `BINARIES_DIR` for the non-release output path). Upload only the installers, `if-no-files-found: error`.
- **`main-check.yml` (publish-snapshot):** download the per-OS desktop artifacts (`continue-on-error` — a failed matrix leg shouldn't block the APKs), stamp every installer with the same monotonic versionCode as the APKs, and attach them to the `snapshot` prerelease. Release notes updated to mention the desktop assets.

## Notes for reviewers

- Debug build type: no ProGuard, unsigned — same trust level as the debug APKs already in the snapshot.
- `APPIMAGE_EXTRACT_AND_RUN` is not set at the workflow level; `build-appimage.sh` hardcodes it where appimagetool runs.
- Not yet exercised end-to-end: worth watching the first `main` run to confirm the AppImage step and upload globs on all four legs.

## Testing Performed

`actionlint` and `spotlessCheck` clean; `:desktopApp:packageDistributionForCurrentOS` confirmed to exist via `./gradlew :desktopApp:tasks`. CodeRabbit CLI review run locally (one finding, addressed).

Fixes the "trigger a build that creates the RPM" ask in #6553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshot releases now include desktop installers for macOS, Windows, and Linux.
  * Added support for distributing DMG, MSI, EXE, DEB, RPM, and AppImage packages.
  * Release creation now uploads all available desktop assets alongside mobile packages.

* **Bug Fixes**
  * Improved handling when some desktop installer artifacts are unavailable.
  * Linux desktop packaging now produces a standard AppImage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->