### PR TITLE
chore: remove stray .gitmodules from vendored spec-kit review extension

### DIFF
--- a/.specify/extensions/review/.gitmodules
+++ b/.specify/extensions/review/.gitmodules
@@ -1,9 +1,0 @@
-[submodule "tests/bats/lib/bats-core"]
-	path = tests/bats/lib/bats-core
-	url = https://github.com/bats-core/bats-core.git
-[submodule "tests/bats/lib/bats-support"]
-	path = tests/bats/lib/bats-support
-	url = https://github.com/bats-core/bats-support.git
-[submodule "tests/bats/lib/bats-assert"]
-	path = tests/bats/lib/bats-assert
-	url = https://github.com/bats-core/bats-assert.git


### PR DESCRIPTION
## Summary
- Removes `.specify/extensions/review/.gitmodules`, a leftover from vendoring the spec-kit review extension (#5410) that declared submodules for bats-core test libs which were never actually checked out.
- This stray file was causing Mend/Renovate to fail with "Error mapping git submodules during extraction" on every scan, even though the repo has no real submodules.

## Testing Performed
No code changes — config file removal only. Verified `git ls-files` shows no gitlinks anywhere in the repo.