### PR TITLE
ci(codecov): decouple Codecov flags from CI shard names

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -310,26 +310,101 @@ jobs:
           ./gradlew ${{ matrix.shard.tasks }} $kover_tasks -Pci=true --continue \
             "-Dscan.value.CI shard=${{ matrix.shard.name }}"
 
-      - name: Upload test results to Codecov
+      # Flags are tagged by logical module group (core/feature/app/desktop), matching
+      # codecov.yml's flags/component_management — NOT by shard name. Shards are a CI
+      # load-balancing detail; which shard happens to run a module must not change
+      # which Codecov flag its coverage lands under.
+      - name: Upload test results to Codecov (core)
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: meshtastic/Meshtastic-Android
-          flags: ${{ matrix.shard.name }}
+          flags: core
           fail_ci_if_error: false
+          disable_search: true
           report_type: test_results
-          files: "**/build/test-results/**/*.xml"
+          files: "core/**/build/test-results/**/*.xml"
 
-      - name: Upload coverage to Codecov
+      - name: Upload test results to Codecov (feature)
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: meshtastic/Meshtastic-Android
+          flags: feature
+          fail_ci_if_error: false
+          disable_search: true
+          report_type: test_results
+          files: "feature/**/build/test-results/**/*.xml"
+
+      - name: Upload test results to Codecov (app)
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: meshtastic/Meshtastic-Android
+          flags: app
+          fail_ci_if_error: false
+          disable_search: true
+          report_type: test_results
+          files: "androidApp/build/test-results/**/*.xml"
+
+      - name: Upload test results to Codecov (desktop)
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: meshtastic/Meshtastic-Android
+          flags: desktop
+          fail_ci_if_error: false
+          disable_search: true
+          report_type: test_results
+          files: "desktopApp/build/test-results/**/*.xml"
+
+      - name: Upload coverage to Codecov (core)
         if: ${{ !cancelled() && inputs.run_coverage }}
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: meshtastic/Meshtastic-Android
-          flags: ${{ matrix.shard.name }}
+          flags: core
           fail_ci_if_error: false
-          files: "**/build/reports/kover/report*.xml"
+          disable_search: true
+          files: "core/**/build/reports/kover/report*.xml"
+
+      - name: Upload coverage to Codecov (feature)
+        if: ${{ !cancelled() && inputs.run_coverage }}
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: meshtastic/Meshtastic-Android
+          flags: feature
+          fail_ci_if_error: false
+          disable_search: true
+          files: "feature/**/build/reports/kover/report*.xml"
+
+      - name: Upload coverage to Codecov (app)
+        if: ${{ !cancelled() && inputs.run_coverage }}
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: meshtastic/Meshtastic-Android
+          flags: app
+          fail_ci_if_error: false
+          disable_search: true
+          files: "androidApp/build/reports/kover/report*.xml"
+
+      - name: Upload coverage to Codecov (desktop)
+        if: ${{ !cancelled() && inputs.run_coverage }}
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: meshtastic/Meshtastic-Android
+          flags: desktop
+          fail_ci_if_error: false
+          disable_search: true
+          files: "desktopApp/build/reports/kover/report*.xml"
 
       - name: Upload shard reports
         if: ${{ always() && inputs.upload_artifacts }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,13 +25,21 @@ comment:
   require_changes: false  # Post a comment even if coverage doesn't change
 
 flags:
-  host-unit:
+  core:
     paths:
-      - .
+      - core/**
     carryforward: true
-  android-instrumented:
+  feature:
     paths:
-      - .
+      - feature/**
+    carryforward: true
+  app:
+    paths:
+      - androidApp/**
+    carryforward: true
+  desktop:
+    paths:
+      - desktopApp/**
     carryforward: true
 
 component_management:


### PR DESCRIPTION
### Why

The `codecov.yml` flags (`host-unit`/`android-instrumented`) were dead config — nothing ever uploaded under those names. CI actually tagged uploads with the shard names (`shard-core`/`shard-feature`/`shard-app`), and since shards are balanced by test-execution time rather than module boundary (shard-app mixes androidApp, desktopApp, and stray core/feature modules), coverage for unrelated logical areas was being conflated under load-balancing artifact names. Codecov's own docs say flags should reflect logical components, not CI topology.

### 🧹 Changes

- **codecov.yml**: replace the dead `host-unit`/`android-instrumented` flags with `core`/`feature`/`app`/`desktop`, path-scoped to match the existing `component_management` boundaries.
- **reusable-check.yml**: each test shard now uploads test-results and kover coverage once per logical group with a path-scoped `files:` glob, instead of one blanket upload tagged with the shard name. Cross-shard placement no longer affects attribution — e.g. `:core:service` (runs on shard-feature) and `:core:database`/`:core:network` (run on shard-app) all land under the `core` flag, and Codecov merges same-flag uploads per commit.
- Added `disable_search: true` on every upload step: without it the uploader auto-searches the whole workspace in addition to the `files:` glob, which would silently re-attribute other groups' reports to the wrong flag whenever a glob matches nothing on a given shard.

### Notes for reviewers

- Kover's default XML output path (`build/reports/kover/report<Variant>.xml`, flavored variants included) was verified against the kover 0.9.9 plugin source; the globs cover both plain and flavored reports.
- Upload steps whose glob matches nothing on a given shard log a "no files found" warning and pass (`fail_ci_if_error: false`) — intentional, so shards can be rebalanced without touching the upload steps.
- The old flag names will linger in the Codecov UI until they age out or are deleted there; harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test result and code coverage reporting by separating uploads across core, feature, app, and desktop modules.
  * Updated coverage tracking to provide clearer module-level visibility.
  * Coverage uploads remain optional and resilient to reporting service failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->