### PR TITLE
fix: Site Planner map/camera parity with iOS

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -898,6 +898,9 @@ fun MapView(
     LaunchedEffect(sitePlannerRequest) {
         sitePlannerRequest?.let { node ->
             sitePlannerInitial = node.toSitePlannerParams(channelSet)
+            if (node.validPosition != null) {
+                map.controller.animateTo(GeoPoint(node.latitude, node.longitude))
+            }
             mapViewModel.consumeSitePlannerRequest()
         }
     }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/node/component/InlineMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/node/component/InlineMap.kt
@@ -45,7 +45,7 @@ fun InlineMap(node: Node, modifier: Modifier = Modifier) {
         }
     }
 
-    LaunchedEffect(node.num) {
+    LaunchedEffect(node.latitude, node.longitude) {
         val point = GeoPoint(node.latitude, node.longitude)
 
         map.overlays.clear()

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -988,6 +988,9 @@ fun MapView(
     LaunchedEffect(sitePlannerRequest) {
         sitePlannerRequest?.let { node ->
             sitePlannerInitial = node.toSitePlannerParams(channelSet)
+            if (node.validPosition != null) {
+                cameraPositionState.animate(CameraUpdateFactory.newLatLng(LatLng(node.latitude, node.longitude)))
+            }
             mapViewModel.consumeSitePlannerRequest()
         }
     }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/node/component/InlineMap.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/node/component/InlineMap.kt
@@ -18,9 +18,11 @@ package org.meshtastic.app.node.component
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.Circle
@@ -51,6 +53,7 @@ fun InlineMap(node: Node, modifier: Modifier = Modifier) {
         val cameraState = rememberCameraPositionState {
             position = CameraPosition.fromLatLngZoom(location, DEFAULT_ZOOM)
         }
+        LaunchedEffect(node.latitude, node.longitude) { cameraState.animate(CameraUpdateFactory.newLatLng(location)) }
 
         GoogleMap(
             mapColorScheme = mapColorScheme,

--- a/androidApp/src/google/kotlin/org/meshtastic/app/node/component/InlineMap.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/node/component/InlineMap.kt
@@ -53,7 +53,13 @@ fun InlineMap(node: Node, modifier: Modifier = Modifier) {
         val cameraState = rememberCameraPositionState {
             position = CameraPosition.fromLatLngZoom(location, DEFAULT_ZOOM)
         }
-        LaunchedEffect(node.latitude, node.longitude) { cameraState.animate(CameraUpdateFactory.newLatLng(location)) }
+        // Follow live position updates. Guarded on the current target so the initial composition, which
+        // rememberCameraPositionState has already centred, doesn't animate to where the camera sits.
+        LaunchedEffect(node.latitude, node.longitude) {
+            if (cameraState.position.target != location) {
+                cameraState.animate(CameraUpdateFactory.newLatLng(location))
+            }
+        }
 
         GoogleMap(
             mapColorScheme = mapColorScheme,

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1584,7 +1584,7 @@
     <string name="signal">Signal</string>
     <string name="signal_quality">Signal Quality</string>
     <!-- SITE -->
-    <string name="site_planner">Site Planner</string>
+    <string name="site_planner">Estimate Coverage</string>
     <string name="site_planner_antenna_gain_dbi">Antenna gain (dBi)</string>
     <string name="site_planner_antenna_height_meters">Antenna height (m)</string>
     <string name="site_planner_color_scale">Color palette</string>


### PR DESCRIPTION
## Summary

Fixes UX parity issues reported on Discord by pedrom comparing Android's Site Planner / Estimate Coverage feature to iOS:

- 🐛 Tapping a node's "Estimate coverage" action from the node detail screen opened the Site Planner sheet on the map, but the map camera never moved to that node's location (marker/form pre-filled, camera stayed put). Fixed in both Google Maps and F-Droid (osmdroid) flavors.
- 🐛 The node detail mini-map didn't recenter when a node's position updated live — only the marker moved to the new position, leaving the camera pointed at the stale location. Fixed in both flavors.
- 🛠️ Renamed the "Site Planner" title/FAB label to "Estimate Coverage" to match iOS and the existing node-detail button text (`site_planner_estimate`).

## Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt :androidApp:assembleGoogleDebug :androidApp:assembleFdroidDebug test allTests` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maps now automatically center on a node’s location when processing coverage estimation requests.
  * Inline maps reposition and animate to updated node coordinates.

* **UI Updates**
  * Renamed “Site Planner” to “Estimate Coverage” in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->