### PR TITLE
revert: restore the "Site Planner" sheet title

### DIFF
--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1584,7 +1584,7 @@
     <string name="signal">Signal</string>
     <string name="signal_quality">Signal Quality</string>
     <!-- SITE -->
-    <string name="site_planner">Estimate Coverage</string>
+    <string name="site_planner">Site Planner</string>
     <string name="site_planner_antenna_gain_dbi">Antenna gain (dBi)</string>
     <string name="site_planner_antenna_height_meters">Antenna height (m)</string>
     <string name="site_planner_color_scale">Color palette</string>


### PR DESCRIPTION
## Why

#6577 renamed the Site Planner sheet title to "Estimate Coverage" to match iOS, acting on a Discord report. On reflection that's the wrong call: the sheet **is** the Site Planner tool, and the action that opens it already reads "Estimate coverage" via the separate `site_planner_estimate` string.

Naming the tool after the tool and the button after the action is clearer than making both read the same, so this reverts just the title.

## 🛠️ Change

One line — `site_planner` goes back to `Site Planner`. The resource key is unchanged, so nothing regenerates and no other string is touched.

The camera/navigation fixes from #6577 are unaffected and stay in place; only the label diverges from iOS, deliberately.

## Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt :androidApp:assembleGoogleDebug :androidApp:assembleFdroidDebug test allTests` — green.
- Confirmed no test asserts on the literal "Estimate Coverage".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Estimate Coverage” label to “Site Planner” for clearer navigation and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->