### PR TITLE
build: vendor secrets-gradle-plugin with an Isolated-Projects fix

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
     alias(libs.plugins.meshtastic.android.application.compose)
     alias(libs.plugins.meshtastic.kotlinx.serialization)
     alias(libs.plugins.meshtastic.koin)
-    alias(libs.plugins.secrets)
+    alias(libs.plugins.meshtastic.android.secrets)
     alias(libs.plugins.androidx.baselineprofile)
     alias(libs.plugins.meshtastic.aboutlibraries)
     // Version-less on purpose: mokkery is embedded in the convention-plugin jar (build-logic

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -78,7 +78,8 @@ spotless {
     ratchetFrom("origin/main")
     kotlin {
         target("src/*/kotlin/**/*.kt", "src/*/java/**/*.kt")
-        targetExclude("**/build/**/*.kt")
+        // secrets_gradle_plugin is vendored third-party code (Apache-2.0) keeping Google's header.
+        targetExclude("**/build/**/*.kt", "**/secrets_gradle_plugin/**")
         ktfmt().kotlinlangStyle().configure { it.setMaxWidth(120) }
         ktlint(libs.versions.ktlint.get())
             .setEditorConfigPath(rootProject.file("../config/spotless/.editorconfig").path)
@@ -101,6 +102,9 @@ detekt {
     baseline = file("detekt-baseline.xml")
     source.setFrom(files("src/main/java", "src/main/kotlin"))
 }
+
+// Vendored third-party code stays as close to upstream as possible — don't lint it to house style.
+tasks.withType<dev.detekt.gradle.Detekt>().configureEach { exclude("**/secrets_gradle_plugin/**") }
 
 gradlePlugin {
     plugins {
@@ -127,6 +131,11 @@ gradlePlugin {
         register("androidLibraryCompose") {
             id = "meshtastic.android.library.compose"
             implementationClass = "AndroidLibraryComposeConventionPlugin"
+        }
+        register("androidSecrets") {
+            id = "meshtastic.android.secrets"
+            implementationClass =
+                "com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPlugin"
         }
         register("androidScreenshot") {
             id = "meshtastic.android.screenshot"

--- a/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
@@ -1,0 +1,86 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Vendored from google/secrets-gradle-plugin v2.0.1 — see SecretsPlugin.kt for why.
+// Modifications Copyright 2026 Meshtastic LLC:
+//  - loadPropertiesFile resolves via isolated.rootProject instead of Project.file so it can be
+//    called from a subproject under Isolated Projects (upstream google/secrets-gradle-plugin#104).
+//  - Legacy Variant API helpers (AppExtension/LibraryExtension/InternalBaseVariant) removed and
+//    buildConfigFields null-safe (nullable since AGP 9):
+//    the legacy classes no longer exist in AGP 9 and were dead code paths here.
+
+@file:Suppress("UnstableApiUsage")
+
+package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
+
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.BuildConfigField
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import com.android.build.api.variant.Variant
+import org.gradle.api.Project
+import java.io.FileNotFoundException
+import java.util.Properties
+
+fun Project.androidAppComponent(): ApplicationAndroidComponentsExtension? =
+    extensions.findByType(ApplicationAndroidComponentsExtension::class.java)
+
+fun Project.androidLibraryComponent(): LibraryAndroidComponentsExtension? =
+    extensions.findByType(LibraryAndroidComponentsExtension::class.java)
+
+fun Project.loadPropertiesFile(fileName: String): Properties {
+    // Load file, resolved against the root project directory. Upstream reached through
+    // project.rootProject.file(), which Isolated Projects forbids from a subproject.
+    val propertiesFile = isolated.rootProject.projectDirectory.file(fileName).asFile
+    if (!propertiesFile.exists()) {
+        throw FileNotFoundException(
+            "The file '${propertiesFile.absolutePath}' could not be found"
+        )
+    }
+
+    // Load contents into properties object
+    val properties = Properties()
+    properties.load(propertiesFile.inputStream())
+    return properties
+}
+
+private val javaVarRegexp = Regex(pattern = "((?![a-zA-Z_\$0-9]).)")
+
+fun Variant.inject(properties: Properties, ignore: List<String>) {
+    val ignoreRegexs = ignore.map { Regex(pattern = it) }
+    properties.keys.map { key ->
+        key as String
+    }.filter { key ->
+        key.isNotEmpty() && !ignoreRegexs.any { it.containsMatchIn(key) }
+    }.forEach { key ->
+        val value = properties.getProperty(key).removeSurrounding("\"")
+        val translatedKey = key.replace(javaVarRegexp, "")
+        // Nullable since AGP 9: null when the buildConfig build feature is disabled.
+        buildConfigFields?.put(
+            translatedKey,
+            BuildConfigField("String", value.addParenthesisIfNeeded(), null)
+        )
+        manifestPlaceholders.put(translatedKey, value)
+    }
+}
+
+fun String.addParenthesisIfNeeded(): String {
+    if (isEmpty()) {
+        return this
+    }
+    val charArray = this.toCharArray()
+    if (length > 1 && charArray[0] == '"' && charArray[charArray.size - 1] == '"') {
+        return this
+    }
+    return "\"$this\""
+}

--- a/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
@@ -19,6 +19,7 @@
 //  - Legacy Variant API helpers (AppExtension/LibraryExtension/InternalBaseVariant) removed and
 //    buildConfigFields null-safe (nullable since AGP 9):
 //    the legacy classes no longer exist in AGP 9 and were dead code paths here.
+//  - the properties stream is closed via use {} instead of leaking a descriptor per load.
 
 @file:Suppress("UnstableApiUsage")
 
@@ -50,7 +51,7 @@ fun Project.loadPropertiesFile(fileName: String): Properties {
 
     // Load contents into properties object
     val properties = Properties()
-    properties.load(propertiesFile.inputStream())
+    propertiesFile.inputStream().use { properties.load(it) }
     return properties
 }
 

--- a/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPlugin.kt
@@ -1,0 +1,106 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Vendored from google/secrets-gradle-plugin v2.0.1 (Apache-2.0). The published plugin reads
+// properties through project.rootProject.file(), which Isolated Projects forbids and Gradle 9.7+
+// fails the build over; upstream is dormant and the one-line fix (#104) has shipped in no release.
+// Modifications Copyright 2026 Meshtastic LLC: property files load via isolated.rootProject (see
+// Extensions.kt). Delete this vendored copy if upstream ever releases > 2.0.1 with that fix.
+
+@file:Suppress("UnstableApiUsage")
+
+package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
+
+import com.android.build.api.variant.Variant
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import java.io.FileNotFoundException
+import java.util.Properties
+
+/**
+ * Plugin that reads secrets from a properties file and injects manifest build and BuildConfig
+ * variables into an Android project. Since property keys are turned into Java variables,
+ * invalid variable characters from the property key are removed.
+ *
+ * e.g.
+ * A key defined as "sdk.dir" in the properties file will be converted to "sdkdir".
+ */
+class SecretsPlugin : Plugin<Project> {
+
+    private val extensionName = "secrets"
+
+    override fun apply(project: Project) {
+        val extension = project.extensions.create(
+            extensionName,
+            SecretsPluginExtension::class.java
+        )
+        val supportedComponents =
+            listOf(project.androidAppComponent(), project.androidLibraryComponent())
+        supportedComponents.forEach { component ->
+            component?.onVariants { variant ->
+                val defaultProperties = extension.defaultPropertiesFileName?.let {
+                    project.loadPropertiesFile(it)
+                }
+
+                val properties: Properties? = try {
+                    project.loadPropertiesFile(
+                        extension.propertiesFileName
+                    )
+                } catch (e: FileNotFoundException) {
+                    defaultProperties ?: throw e
+                }
+                generateConfigKey(project, extension, defaultProperties, properties, variant)
+            }
+        }
+    }
+
+    private fun generateConfigKey(
+        project: Project,
+        extension: SecretsPluginExtension,
+        defaultProperties: Properties?,
+        properties: Properties?,
+        variant: Variant
+    ) {
+        // Inject defaults first
+        defaultProperties?.let {
+            variant.inject(it, extension.ignoreList)
+        }
+
+        properties?.let {
+            variant.inject(properties, extension.ignoreList)
+        }
+
+        // Inject build-type specific properties
+        val buildTypeFileName = "${variant.buildType}.properties"
+        val buildTypeProperties = try {
+            project.loadPropertiesFile(buildTypeFileName)
+        } catch (e: FileNotFoundException) {
+            null
+        }
+        buildTypeProperties?.let {
+            variant.inject(it, extension.ignoreList)
+        }
+
+        // Inject flavor-specific properties
+        val flavorFileName = "${variant.flavorName}.properties"
+        val flavorProperties = try {
+            project.loadPropertiesFile(flavorFileName)
+        } catch (e: FileNotFoundException) {
+            null
+        }
+        flavorProperties?.let {
+            variant.inject(it, extension.ignoreList)
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginExtension.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginExtension.kt
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Vendored unmodified from google/secrets-gradle-plugin v2.0.1 — see SecretsPlugin.kt for why.
+// Vendored from google/secrets-gradle-plugin v2.0.1 — see SecretsPlugin.kt for why.
+// Deviation from upstream: ignoreList copies defaultIgnoreList so projects don't share one mutable list.
 
 package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 
@@ -28,7 +29,7 @@ open class SecretsPluginExtension {
     /**
      * A list of keys this plugin should ignore and not inject. Defaults to $defaultIgnoreList
      */
-    var ignoreList: MutableList<String> = defaultIgnoreList
+    var ignoreList: MutableList<String> = defaultIgnoreList.toMutableList()
 
     /**
      * The name of the properties file containing secrets' default values.

--- a/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginExtension.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginExtension.kt
@@ -1,0 +1,42 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Vendored unmodified from google/secrets-gradle-plugin v2.0.1 — see SecretsPlugin.kt for why.
+
+package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
+
+/**
+ * Configuration object for [SecretsPlugin].
+ */
+open class SecretsPluginExtension {
+    /**
+     * The name of the properties file containing secrets. Defaults to "$defaultPropertiesFile"
+     */
+    var propertiesFileName: String = defaultPropertiesFile
+
+    /**
+     * A list of keys this plugin should ignore and not inject. Defaults to $defaultIgnoreList
+     */
+    var ignoreList: MutableList<String> = defaultIgnoreList
+
+    /**
+     * The name of the properties file containing secrets' default values.
+     */
+    var defaultPropertiesFileName: String? = null
+
+    companion object {
+        const val defaultPropertiesFile = "local.properties"
+        val defaultIgnoreList = mutableListOf("sdk.dir")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,6 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.aboutlibraries) apply false
-    alias(libs.plugins.secrets) apply false
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.kover)
     alias(libs.plugins.spotless) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -370,7 +370,6 @@ mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
 # Google
 devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "devtools-ksp" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services-gradle" }
-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version = "2.0.1" }
 
 # Firebase
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics-gradle" }
@@ -395,6 +394,8 @@ meshtastic-android-library-compose = { id = "meshtastic.android.library.compose"
 meshtastic-android-library-flavors = { id = "meshtastic.android.library.flavors" }
 meshtastic-android-room = { id = "meshtastic.android.room" }
 meshtastic-android-screenshot = { id = "meshtastic.android.screenshot" }
+# Vendored google/secrets-gradle-plugin (Isolated-Projects-safe) — see build-logic/convention.
+meshtastic-android-secrets = { id = "meshtastic.android.secrets" }
 meshtastic-detekt = { id = "meshtastic.detekt" }
 meshtastic-docs = { id = "meshtastic.docs" }
 meshtastic-koin = { id = "meshtastic.koin" }


### PR DESCRIPTION
### Why

Gradle 9.7.0 (Renovate #6589) hard-fails every `androidApp` build: Google's secrets-gradle-plugin 2.0.1 reads its properties files through `project.rootProject.file()`, which Isolated Projects forbids and 9.7+ enforces. There is no upstream escape hatch — 2.0.1 is the latest release (Feb 2022), the tagged 2.0.2 was never published, and the one-line fix has sat unmerged in [google/secrets-gradle-plugin#104](https://github.com/google/secrets-gradle-plugin/issues/104) since March on a repo with no release in four years. This unblocks #6589 without giving up Isolated Projects.

### 🛠️ Improvements

- Vendor the plugin (Apache-2.0, ~180 lines) into `build-logic` as `meshtastic.android.secrets`, byte-identical to upstream v2.0.1 except:
  - property files resolve via `isolated.rootProject` — the IP-safe idiom the rest of `build-logic` already uses
  - legacy Variant API helpers (`AppExtension`/`InternalBaseVariant`) dropped — dead code paths here, and the classes no longer exist in AGP 9
  - `buildConfigFields` made null-safe (nullable since AGP 9)
  - `ignoreList` copies `defaultIgnoreList` per project instead of sharing one mutable list (CodeRabbit finding)
  - the properties stream is closed via `use {}` instead of leaking a descriptor per load (CodeRabbit finding)
- The vendored files keep Google's license header and are excluded from spotless/detekt so they stay trivially diffable against upstream; delete the copy if upstream ever ships a release > 2.0.1 with the fix.

### 🧹 Cleanup

- Drop the `secrets` plugin from the version catalog and the root `apply false` line; `androidApp` now applies `meshtastic.android.secrets`.

### Testing Performed

- `spotlessApply spotlessCheck detekt assembleDebug test allTests` — green (the sole `allTests` failure is `BleAddressLoggingTest`'s scope guard, which pre-exists on a clean `main` tree when run from a `.claude/worktrees` checkout and is unrelated; tracked separately).
- Injection verified byte-for-byte against the binary plugin: merged `googleDebug` manifest carries `com.google.android.geo.API_KEY` from `local.properties`, and `BuildConfig` carries `MAPS_API_KEY` / `datadogApplicationId` / `datadogClientToken`.
- On the Gradle 9.7.0 branch, `:androidApp` configuration passes with this plugin where 2.0.1 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android secrets configuration support for securely loading property values.
  * Supports default, build-type, and flavor-specific property files.
  * Injects configured values into app builds and manifests.

* **Bug Fixes**
  * Missing optional configuration files are now handled gracefully.
  * Improved compatibility with newer Android build tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
