### PR TITLE
fix(map): scope location tracking to the visible lifecycle

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -147,6 +147,7 @@ import org.meshtastic.core.ui.icon.Lens
 import org.meshtastic.core.ui.icon.Map
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.PinDrop
+import org.meshtastic.core.ui.util.KeepScreenOn
 import org.meshtastic.core.ui.util.PermissionStatus
 import org.meshtastic.core.ui.util.formatAgo
 import org.meshtastic.core.ui.util.rememberLocationPermissionState
@@ -419,15 +420,7 @@ fun MapView(
         }
     }
 
-    // Keep screen on while location tracking is active
-    LaunchedEffect(myLocationOverlay) {
-        val activity = context as? android.app.Activity ?: return@LaunchedEffect
-        if (myLocationOverlay != null) {
-            activity.window.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        } else {
-            activity.window.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
-    }
+    KeepScreenOn(myLocationOverlay != null && locationPermission.isGranted)
 
     val waypoints by mapViewModel.waypoints.collectAsStateWithLifecycle(emptyMap())
     val selectedWaypointId by mapViewModel.selectedWaypointId.collectAsStateWithLifecycle()

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -23,7 +23,6 @@ import android.app.Activity
 import android.content.Intent
 import android.graphics.Bitmap
 import android.location.Location
-import android.view.WindowManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatDelegate
@@ -158,6 +157,7 @@ import org.meshtastic.core.ui.icon.Map
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.TripOrigin
 import org.meshtastic.core.ui.theme.TracerouteColors
+import org.meshtastic.core.ui.util.KeepScreenOn
 import org.meshtastic.core.ui.util.PermissionStatus
 import org.meshtastic.core.ui.util.formatAgo
 import org.meshtastic.core.ui.util.formatPositionTime
@@ -346,27 +346,24 @@ fun MapView(
         }
     }
 
-    LaunchedEffect(isLocationTrackingEnabled, locationPermission.isGranted) {
-        if (isLocationTrackingEnabled && locationPermission.isGranted) {
-            val locationRequest =
-                LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 5000L)
-                    .setMinUpdateIntervalMillis(2000L)
-                    .build()
-            try {
-                @Suppress("MissingPermission")
-                fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, null)
-                Logger.d { "Started location tracking" }
-            } catch (e: SecurityException) {
-                Logger.d { "Location permission not available: ${e.message}" }
-                isLocationTrackingEnabled = false
-            }
-        } else {
+    ActiveWhileStarted(isLocationTrackingEnabled && locationPermission.isGranted) {
+        val locationRequest =
+            LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 5000L).setMinUpdateIntervalMillis(2000L).build()
+        try {
+            @Suppress("MissingPermission")
+            fusedLocationClient.requestLocationUpdates(locationRequest, locationCallback, null)
+            Logger.d { "Started location tracking" }
+        } catch (e: SecurityException) {
+            Logger.d { "Location permission not available: ${e.message}" }
+            isLocationTrackingEnabled = false
+        }
+
+        val cleanup: () -> Unit = {
             fusedLocationClient.removeLocationUpdates(locationCallback)
             Logger.d { "Stopped location tracking" }
         }
+        cleanup
     }
-
-    DisposableEffect(Unit) { onDispose { fusedLocationClient.removeLocationUpdates(locationCallback) } }
 
     // --- Node & waypoint data ---
     val allNodes by mapViewModel.nodesWithPosition.collectAsStateWithLifecycle(listOf())
@@ -585,16 +582,7 @@ fun MapView(
 
     var showClusterItemsDialog by remember { mutableStateOf<List<NodeClusterItem>?>(null) }
 
-    // --- Keep screen on while location tracking ---
-    LaunchedEffect(isLocationTrackingEnabled) {
-        val activity = context as? Activity ?: return@LaunchedEffect
-        val window = activity.window
-        if (isLocationTrackingEnabled) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        } else {
-            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
-    }
+    KeepScreenOn(isLocationTrackingEnabled && locationPermission.isGranted)
 
     // --- Main UI ---
     val isMainMode = mode is GoogleMapMode.Main

--- a/androidApp/src/main/kotlin/org/meshtastic/app/map/MapLifecycleEffects.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/map/MapLifecycleEffects.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app.map
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.lifecycle.compose.LifecycleStartEffect
+
+/**
+ * Runs [effect] only while the current lifecycle is at least STARTED and [enabled] is true.
+ *
+ * The cleanup returned by [effect] runs synchronously on ON_STOP, disable, or composition disposal. This is important
+ * for hardware work: a coroutine launched from an ON_STOP state change may not run after the host recomposer pauses.
+ */
+@Composable
+internal fun ActiveWhileStarted(enabled: Boolean, effect: () -> () -> Unit) {
+    val currentEffect by rememberUpdatedState(effect)
+
+    LifecycleStartEffect(enabled) {
+        val cleanup = if (enabled) currentEffect() else ({})
+        onStopOrDispose { cleanup() }
+    }
+}

--- a/androidApp/src/test/kotlin/org/meshtastic/app/map/MapLifecycleEffectsTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/map/MapLifecycleEffectsTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app.map
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class MapLifecycleEffectsTest {
+
+    @Test
+    fun activeEffectStopsInBackgroundAndResumesOnlyWhenEnabled() = runComposeUiTest {
+        val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.CREATED)
+        var enabled by mutableStateOf(true)
+        var composed by mutableStateOf(true)
+        var starts = 0
+        var stops = 0
+
+        setContent {
+            CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                if (composed) {
+                    ActiveWhileStarted(enabled) {
+                        starts += 1
+                        { stops += 1 }
+                    }
+                }
+            }
+        }
+
+        assertEquals(0, starts)
+        lifecycleOwner.moveTo(Lifecycle.State.STARTED)
+        waitForIdle()
+        assertEquals(1, starts)
+
+        lifecycleOwner.moveTo(Lifecycle.State.CREATED)
+        waitForIdle()
+        assertEquals(1, stops, "ON_STOP must synchronously release active map work")
+
+        lifecycleOwner.moveTo(Lifecycle.State.STARTED)
+        waitForIdle()
+        assertEquals(2, starts, "ON_START must resume an enabled map tracker")
+
+        runOnIdle { enabled = false }
+        waitForIdle()
+        assertEquals(2, stops, "disabling tracking must release active work")
+
+        lifecycleOwner.moveTo(Lifecycle.State.CREATED)
+        lifecycleOwner.moveTo(Lifecycle.State.STARTED)
+        waitForIdle()
+        assertEquals(2, starts, "a disabled tracker must remain stopped after resume")
+
+        runOnIdle { enabled = true }
+        waitForIdle()
+        assertEquals(3, starts)
+
+        runOnIdle { composed = false }
+        waitForIdle()
+        assertEquals(3, stops, "composition disposal must release active map work")
+    }
+
+    private class TestLifecycleOwner(initialState: Lifecycle.State) : LifecycleOwner {
+        override val lifecycle: LifecycleRegistry =
+            LifecycleRegistry.createUnsafe(this).apply { currentState = initialState }
+
+        fun moveTo(state: Lifecycle.State) {
+            lifecycle.currentState = state
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The Google map starts a high-accuracy fused-location request from a Compose effect. Backgrounding the activity does not remove the map from composition, so callbacks can continue every 2–5 seconds after `ON_STOP`.

### Bug fixes

- Run Google map location updates only while the lifecycle is at least `STARTED` and tracking plus permission remain enabled.
- Remove location callbacks on stop, disable, permission loss, or disposal, and resume them on start only when tracking is still enabled.
- Replace direct window flag mutation in both map flavors with the project's disposal-safe `KeepScreenOn` utility.
- Add regression coverage for stop, resume, disable, and composition disposal.

This addresses only map-owned tracking; it does not change the separate "provide phone location" flow or BLE connection behavior.

Related to #2659, specifically https://github.com/meshtastic/Meshtastic-Android/issues/2659#issuecomment-3728447817

## Root cause

The previous `LaunchedEffect` was keyed only to the tracking toggle and permission. Activity lifecycle changes did not cancel it, and the `DisposableEffect` cleanup ran only when the composable left composition. `LifecycleStartEffect` gives the callback registration an explicit `STARTED`-lifecycle owner while preserving the user's tracking toggle across background/foreground transitions.

## Testing Performed

- `:androidApp:spotlessKotlinCheck`
- `:androidApp:detekt`
- `:androidApp:compileFdroidDebugKotlin`
- `:androidApp:compileGoogleDebugKotlin`
- `:androidApp:testFdroidDebugUnitTest --tests org.meshtastic.app.map.MapLifecycleEffectsTest`
- `:androidApp:testGoogleDebugUnitTest --tests org.meshtastic.app.map.MapLifecycleEffectsTest`

Both flavor lifecycle tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Location tracking now starts and stops reliably as the app moves between foreground and background.
  * The screen remains awake only while active location tracking is enabled and permission is granted.
  * Improved cleanup when tracking is disabled or the map screen is closed.

* **Tests**
  * Added coverage verifying lifecycle-aware tracking behavior, including backgrounding, disabling, and resuming tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->