### PR TITLE
fix(messaging): wait for shared-contact routing ACK

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
@@ -436,7 +436,7 @@ class MeshDataHandlerImpl(
                     packetRepository.value.updateReaction(updated)
                 }
             }
-            packetHandler.removeResponse(requestId, complete = true)
+            packetHandler.removeResponse(requestId, complete = isAck)
         }
     }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -190,10 +190,14 @@ class PacketHandlerImpl(
                         routingResponse.remove(requestId)?.complete(success)
                     }
                 } else {
-                    queueResponse.values.firstOrNull { !it.isCompleted }?.complete(success)
-                    if (!success || queueStatus.res == ERRNO_SHOULD_RELEASE) {
-                        routingResponse.values.firstOrNull { !it.isCompleted }?.complete(success)
-                    }
+                    queueResponse.entries
+                        .firstOrNull { !it.value.isCompleted }
+                        ?.let { (packetId, response) ->
+                            response.complete(success)
+                            if (!success || queueStatus.res == ERRNO_SHOULD_RELEASE) {
+                                routingResponse.remove(packetId)?.complete(success)
+                            }
+                        }
                 }
             }
         }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -87,6 +87,7 @@ class PacketHandlerImpl(
 
     private val responseMutex = Mutex()
     private val queueResponse = mutableMapOf<Int, CompletableDeferred<Boolean>>()
+    private val routingResponse = mutableMapOf<Int, CompletableDeferred<Boolean>>()
 
     override fun sendToRadio(p: ToRadio) {
         Logger.d { "Sending to radio ${p.toPIIString()}" }
@@ -127,16 +128,17 @@ class PacketHandlerImpl(
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     override suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean {
-        // Pre-register the deferred so the queue processor and QueueStatus handler
-        // can find it immediately — no polling required.
-        val deferred = CompletableDeferred<Boolean>()
-        responseMutex.withLock { queueResponse[packet.id] = deferred }
-        queueMutex.withLock {
-            queueStopped = false // Allow queue to resume after a disconnect/reconnect cycle.
-            queuedPackets.add(packet)
-            startPacketQueueLocked()
+        if (connectionStateProvider.connectionState.value != ConnectionState.Connected) {
+            Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} skipped: not connected" }
+            return false
         }
+
+        // QueueStatus(res=0) only means that firmware queued the packet. Keep a separate
+        // routing response so this strict caller waits for the later Routing ACK/NAK.
+        val deferred = CompletableDeferred<Boolean>()
+        responseMutex.withLock { routingResponse[packet.id] = deferred }
         return try {
+            sendToRadio(packet)
             withTimeout(TIMEOUT) { deferred.await() }
         } catch (e: TimeoutCancellationException) {
             Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} timeout" }
@@ -147,7 +149,7 @@ class PacketHandlerImpl(
             Logger.d { "sendToRadioAndAwait packet id=${packet.id.toUInt()} failed: ${e.message}" }
             false
         } finally {
-            responseMutex.withLock { queueResponse.remove(packet.id) }
+            responseMutex.withLock { routingResponse.remove(packet.id) }
         }
     }
 
@@ -165,6 +167,8 @@ class PacketHandlerImpl(
             responseMutex.withLock {
                 queueResponse.values.forEach { if (!it.isCompleted) it.complete(false) }
                 queueResponse.clear()
+                routingResponse.values.forEach { if (!it.isCompleted) it.complete(false) }
+                routingResponse.clear()
             }
         }
     }
@@ -182,15 +186,24 @@ class PacketHandlerImpl(
             responseMutex.withLock {
                 if (requestId != 0) {
                     queueResponse.remove(requestId)?.complete(success)
+                    if (!success || queueStatus.res == ERRNO_SHOULD_RELEASE) {
+                        routingResponse.remove(requestId)?.complete(success)
+                    }
                 } else {
                     queueResponse.values.firstOrNull { !it.isCompleted }?.complete(success)
+                    if (!success || queueStatus.res == ERRNO_SHOULD_RELEASE) {
+                        routingResponse.values.firstOrNull { !it.isCompleted }?.complete(success)
+                    }
                 }
             }
         }
     }
 
     override suspend fun removeResponse(dataRequestId: Int, complete: Boolean) {
-        responseMutex.withLock { queueResponse.remove(dataRequestId)?.complete(complete) }
+        responseMutex.withLock {
+            queueResponse.remove(dataRequestId)?.complete(complete)
+            routingResponse.remove(dataRequestId)?.complete(complete)
+        }
     }
 
     /**
@@ -213,8 +226,7 @@ class PacketHandlerImpl(
                             Logger.d { "queueJob packet id=${packet.id.toUInt()} success $success" }
                         } catch (e: TimeoutCancellationException) {
                             Logger.d { "queueJob packet id=${packet.id.toUInt()} timeout" }
-                            // Clean up the deferred for this packet. sendToRadioAndAwait callers
-                            // also clean up in their own finally block (idempotent remove).
+                            // Clean up the transport-queue deferred for this packet.
                             responseMutex.withLock { queueResponse.remove(packet.id) }
                         } catch (e: CancellationException) {
                             throw e // Preserve structured concurrency cancellation propagation.
@@ -259,7 +271,7 @@ class PacketHandlerImpl(
 
     @Suppress("TooGenericExceptionCaught")
     private suspend fun sendPacket(packet: MeshPacket): Deferred<Boolean> {
-        // Reuse a deferred pre-registered by sendToRadioAndAwait, or create a new one.
+        // Register the transport-queue response before sending so an immediate QueueStatus cannot be missed.
         val deferred = responseMutex.withLock { queueResponse.getOrPut(packet.id) { CompletableDeferred() } }
         try {
             if (connectionStateProvider.connectionState.value != ConnectionState.Connected) {
@@ -268,10 +280,10 @@ class PacketHandlerImpl(
             sendToRadio(ToRadio(packet = packet))
         } catch (ex: RadioNotConnectedException) {
             Logger.w(ex) { "sendToRadio skipped: Not connected to radio" }
-            deferred.complete(false)
+            removeResponse(packet.id, complete = false)
         } catch (ex: Exception) {
             Logger.e(ex) { "sendToRadio error: ${ex.message}" }
-            deferred.complete(false)
+            removeResponse(packet.id, complete = false)
         }
         // Return a read-only Deferred view (kotlinx.coroutines 1.11+) so callers can await it
         // without being able to complete the underlying CompletableDeferred; cancellation is

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
@@ -532,6 +532,35 @@ class MeshDataHandlerTest {
     }
 
     @Test
+    fun `routing packet with nak fails pending response`() = testScope.runTest {
+        val routing = Routing(error_reason = Routing.Error.NO_ROUTE)
+        val packet =
+            MeshPacket(
+                from = 456,
+                decoded =
+                Data(
+                    portnum = PortNum.ROUTING_APP,
+                    payload = routing.encode().toByteString(),
+                    request_id = 100,
+                ),
+            )
+        val dataPacket =
+            DataPacket(
+                from = "!remote",
+                to = NodeAddress.ID_BROADCAST,
+                bytes = routing.encode().toByteString(),
+                dataType = PortNum.ROUTING_APP.value,
+            )
+        every { dataMapper.toDataPacket(packet) } returns dataPacket
+        every { nodeManager.toNodeID(456) } returns "!remote"
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend { packetHandler.removeResponse(100, complete = false) }
+    }
+
+    @Test
     fun `routing ack from a retired generation cannot update the replacement database`() = testScope.runTest {
         val routing = Routing(error_reason = Routing.Error.NONE)
         val packet =

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.data.manager
 
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
@@ -44,6 +45,7 @@ import org.meshtastic.proto.QueueStatus
 import org.meshtastic.proto.ToRadio
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -121,7 +123,7 @@ class PacketHandlerImplTest {
     }
 
     @Test
-    fun `handleQueueStatus treats ERRNO_SHOULD_RELEASE as success`() = runTest(testDispatcher) {
+    fun `strict await treats ERRNO_SHOULD_RELEASE as immediate delivery success`() = runTest(testDispatcher) {
         // Firmware 2.8+ returns ErrorCode 35 (ERRNO_SHOULD_RELEASE) for self-addressed packets delivered
         // through the synchronous local loopback — a success, not a queue failure.
         connectionStateFlow.value = ConnectionState.Connected
@@ -136,7 +138,7 @@ class PacketHandlerImplTest {
     }
 
     @Test
-    fun `handleQueueStatus completes ERRNO_SHOULD_RELEASE even when queue is full`() = runTest(testDispatcher) {
+    fun `strict await completes ERRNO_SHOULD_RELEASE even when queue is full`() = runTest(testDispatcher) {
         // Regression: a self-addressed local-loopback delivery (res=35) can coincide with a full TX queue (free=0).
         // The success+full early return must not swallow it, or the response hangs until TIMEOUT (the very stall
         // this fix targets). Only the plain res=0 "accepted, now full" echo should be skipped.
@@ -152,7 +154,7 @@ class PacketHandlerImplTest {
     }
 
     @Test
-    fun `handleQueueStatus treats other nonzero res as failure`() = runTest(testDispatcher) {
+    fun `strict await treats queue rejection as failure`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
 
         val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 791)) }
@@ -160,6 +162,70 @@ class PacketHandlerImplTest {
 
         handler.handleQueueStatus(QueueStatus(mesh_packet_id = 791, res = 33, free = 16))
         testScheduler.runCurrent()
+
+        assertFalse(result.await())
+    }
+
+    @Test
+    fun `strict await fails immediately while disconnected`() = runTest(testDispatcher) {
+        val result = handler.sendToRadioAndAwait(MeshPacket(id = 796))
+
+        assertFalse(result)
+        assertEquals(0, testScheduler.currentTime)
+    }
+
+    @Test
+    fun `strict await fails immediately when transport send throws`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+        every { radioInterfaceService.sendToRadio(any()) } throws IllegalStateException("transport failed")
+
+        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 797)) }
+        testScheduler.runCurrent()
+
+        assertTrue(result.isCompleted)
+        assertFalse(result.await())
+    }
+
+    @Test
+    fun `strict await does not complete on ordinary queue acceptance`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 793)) }
+        testScheduler.runCurrent()
+
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 793, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        assertFalse(result.isCompleted)
+
+        handler.removeResponse(793, complete = true)
+        assertTrue(result.await())
+    }
+
+    @Test
+    fun `strict await succeeds on routing ack`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 794)) }
+        testScheduler.runCurrent()
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 794, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        handler.removeResponse(794, complete = true)
+
+        assertTrue(result.await())
+    }
+
+    @Test
+    fun `strict await fails on routing nak`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val result = async { handler.sendToRadioAndAwait(MeshPacket(id = 795)) }
+        testScheduler.runCurrent()
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 795, res = 0, free = 16))
+        testScheduler.runCurrent()
+
+        handler.removeResponse(795, complete = false)
 
         assertFalse(result.await())
     }

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -211,9 +211,33 @@ class PacketHandlerImplTest {
         handler.handleQueueStatus(QueueStatus(mesh_packet_id = 794, res = 0, free = 16))
         testScheduler.runCurrent()
 
+        assertFalse(result.isCompleted)
+
         handler.removeResponse(794, complete = true)
 
         assertTrue(result.await())
+    }
+
+    @Test
+    fun `zero id queue status completes only its correlated routing response`() = runTest(testDispatcher) {
+        connectionStateFlow.value = ConnectionState.Connected
+
+        val awaitingRoutingAck = async { handler.sendToRadioAndAwait(MeshPacket(id = 798)) }
+        testScheduler.runCurrent()
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 798, res = 0, free = 16))
+        testScheduler.runCurrent()
+        assertFalse(awaitingRoutingAck.isCompleted)
+
+        val synchronousLoopback = async { handler.sendToRadioAndAwait(MeshPacket(id = 799)) }
+        testScheduler.runCurrent()
+        handler.handleQueueStatus(QueueStatus(mesh_packet_id = 0, res = 35, free = 16))
+        testScheduler.runCurrent()
+
+        assertTrue(synchronousLoopback.await())
+        assertFalse(awaitingRoutingAck.isCompleted)
+
+        handler.removeResponse(798, complete = true)
+        assertTrue(awaitingRoutingAck.await())
     }
 
     @Test

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
@@ -61,7 +61,8 @@ interface CommandSender {
      * This is used when the caller needs a processing barrier before proceeding, such as sending a shared contact
      * before the first DM to a node.
      *
-     * @return `true` on a routing ACK, `false` on a routing NAK, queue rejection, or timeout.
+     * @return `true` on a routing ACK or synchronous local-loopback delivery (`ERRNO_SHOULD_RELEASE`); `false` when
+     *   disconnected, transport sending fails, a routing NAK or queue rejection arrives, or the operation times out.
      */
     suspend fun sendAdminAwait(
         destNum: Int,

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/CommandSender.kt
@@ -56,12 +56,12 @@ interface CommandSender {
     fun sendAdminImmediate(destNum: Int, initFn: () -> AdminMessage)
 
     /**
-     * Sends an admin message and suspends until the radio acknowledges it.
+     * Sends an admin message and suspends until firmware processes it and returns a routing acknowledgement.
      *
-     * This is used when the caller needs to guarantee a packet has been accepted by the radio before proceeding, such
-     * as sending a shared contact before the first DM to a node.
+     * This is used when the caller needs a processing barrier before proceeding, such as sending a shared contact
+     * before the first DM to a node.
      *
-     * @return `true` if the radio accepted the packet, `false` on timeout or failure.
+     * @return `true` on a routing ACK, `false` on a routing NAK, queue rejection, or timeout.
      */
     suspend fun sendAdminAwait(
         destNum: Int,

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
@@ -29,13 +29,13 @@ interface PacketHandler {
     suspend fun sendToRadio(packet: MeshPacket)
 
     /**
-     * Adds a mesh packet to the queue and suspends until the radio acknowledges it via [QueueStatus].
+     * Adds a mesh packet to the queue and suspends until its routing acknowledgement arrives.
      *
-     * Unlike [sendToRadio], which is fire-and-forget, this method provides back-pressure so the caller can ensure a
-     * packet has been accepted by the radio before proceeding. This is critical for operations where ordering matters
-     * (e.g., sending a shared contact before the first DM).
+     * A successful [QueueStatus] only means that firmware accepted the packet into its transport queue; it does not
+     * prove that a self-addressed admin command has been processed. This stricter acknowledgement is required when a
+     * later packet depends on that command, such as installing a shared contact before sending the first DM.
      *
-     * @return `true` if the radio accepted the packet, `false` on timeout or failure.
+     * @return `true` on a routing ACK, `false` on a routing NAK, queue rejection, or timeout.
      */
     suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean
 

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketHandler.kt
@@ -35,7 +35,8 @@ interface PacketHandler {
      * prove that a self-addressed admin command has been processed. This stricter acknowledgement is required when a
      * later packet depends on that command, such as installing a shared contact before sending the first DM.
      *
-     * @return `true` on a routing ACK, `false` on a routing NAK, queue rejection, or timeout.
+     * @return `true` on a routing ACK or synchronous local-loopback delivery (`ERRNO_SHOULD_RELEASE`); `false` when
+     *   disconnected, transport sending fails, a routing NAK or queue rejection arrives, or the operation times out.
      */
     suspend fun sendToRadioAndAwait(packet: MeshPacket): Boolean
 


### PR DESCRIPTION
## Summary

### Bug fixes

- Keep transport queue admission separate from the routing ACK/NAK awaited by `sendAdminAwait`.
- Prevent an ordinary `QueueStatus(res = 0)` from releasing the first PKI DM before the local `add_contact` packet is processed.
- Correlate zero-ID queue-status fallbacks by packet ID instead of completing an unrelated pending routing response.
- Propagate routing NAKs, queue rejection, disconnected state, and transport-send failure as failed awaited sends.
- Fail a strict await immediately when disconnected instead of retaining its packet for transmission after reconnect.
- When a routing NAK arrives before `QueueStatus`, fail both deferred phases so the packet-queue worker is released.
- Cover queue admission, routing ACK/NAK, and immediate transport failure with regression tests.

## Root cause

This is a residual sequencing path from #4988 and a follow-up to #4992 and #5005.

#4992 made shared-contact installation suspending, but `sendToRadioAndAwait` used the same deferred that the packet-queue worker uses for `QueueStatus`. `QueueStatus(res = 0)` reports that firmware accepted or queued the packet; it is not the later routing acknowledgement. On firmware 2.7.20, a self-addressed packet is queued for local processing and QueueStatus is returned before `AdminModule` runs. That allowed `SendMessageUseCase` to enqueue the dependent PKI DM before `add_contact` reached the firmware NodeDB.

The fix tracks those two phases separately. QueueStatus continues to release the transport queue worker, while the strict caller remains suspended until the correlated routing ACK/NAK arrives. A queue or local transport failure still fails both phases, and the existing synchronous `ERRNO_SHOULD_RELEASE` success remains supported.

This intentionally changes two shared-path behaviors: `sendToRadioAndAwait` now returns failure immediately while disconnected rather than leaving the packet queued for post-reconnect transmission, and a routing NAK received before its `QueueStatus` also fails the queue deferred so queue processing cannot remain blocked.

Firmware registers `RoutingModule` last, after `AdminModule`; for a valid shared contact, `NodeDB::addFromContact` completes before the routing ACK is generated. This makes that ACK a processing barrier for this path without changing the wire protocol.

Relevant protocol and firmware paths:

- QueueStatus schema: https://github.com/meshtastic/protobufs/blob/master/meshtastic/mesh.proto#L2309-L2320
- Local packet enqueue: https://github.com/meshtastic/firmware/blob/v2.7.20.6658ec2/src/mesh/Router.cpp#L239-L248
- `add_contact` handling: https://github.com/meshtastic/firmware/blob/v2.7.20.6658ec2/src/modules/AdminModule.cpp#L355-L363
- RoutingModule registration order: https://github.com/meshtastic/firmware/blob/v2.7.20.6658ec2/src/modules/Modules.cpp#L252-L254
- NodeDB mutation and save: https://github.com/meshtastic/firmware/blob/v2.7.20.6658ec2/src/mesh/NodeDB.cpp#L1756-L1814

## Related work

- Addresses the residual ordering race reported in #4988.
- Follow-up to #4992, #4996, and #5005.
- #6598 overlaps the packet-admission files, but its current implementation still completes awaited sends on ordinary QueueStatus; this PR separates the routing phase.

## Testing Performed

- `:core:data:testAndroidHostTest` — 464/464 after the review follow-up.
- `:core:repository:testAndroidHostTest` — 21/21.
- Final focused `PacketHandlerImplTest` — 15/15, including zero-ID response correlation.
- `:core:data:spotlessCheck :core:repository:spotlessCheck`
- `:core:data:detekt :core:repository:detekt`
- `kmpSmokeCompile`

## Limitations

A missing routing ACK is not proof that firmware failed to install the contact, so the existing caller remains best-effort after a NAK or timeout and still enqueues the DM. This PR fixes the deterministic queue-admission ordering race; it does not change message failure UX or retry policy.
