### PR TITLE
fix(konsist): normalize source paths on Windows

### DIFF
--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/BleAddressLoggingTest.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/BleAddressLoggingTest.kt
@@ -55,13 +55,13 @@ class BleAddressLoggingTest {
         .files
         // scopeFromProject sweeps .claude/worktrees/ checkouts too; stale copies there
         // resurface long-fixed lines as phantom offenders (paths match "/core/ble/").
-        .filterNot { "/.claude/" in it.path }
-        .filter { file -> scannedPathFragments.any { it in file.path } }
-        .filterNot { file -> identityUseAllowlist.any { file.path.endsWith(it) } }
+        .filterNot { "/.claude/" in it.path.normalizedProjectPath() }
+        .filter { file -> scannedPathFragments.any { it in file.path.normalizedProjectPath() } }
+        .filterNot { file -> identityUseAllowlist.any { file.path.normalizedProjectPath().endsWith(it) } }
 
     @Test
     fun `the scan actually reaches the BLE sources`() {
-        val paths = scannedFiles().map { it.path }
+        val paths = scannedFiles().map { it.path.normalizedProjectPath() }
 
         assertTrue(paths.isNotEmpty(), "scoped scan matched no files at all — the path filter is wrong")
         assertTrue(
@@ -79,7 +79,8 @@ class BleAddressLoggingTest {
                     val interpolates = interpolatedAddress.containsMatchIn(line)
                     val anonymised = "anonymize" in line
                     if (isDiagnostic && interpolates && !anonymised) {
-                        "${file.path.substringAfterLast("/kotlin/")}:${index + 1}: ${line.trim()}"
+                        "${file.path.normalizedProjectPath().substringAfterLast("/kotlin/")}:${index + 1}: " +
+                            line.trim()
                     } else {
                         null
                     }
@@ -101,12 +102,13 @@ class BleAddressLoggingTest {
         val offenders =
             Konsist.scopeFromProject()
                 .files
-                .filterNot { "/.claude/" in it.path } // see scannedFiles()
-                .filter { "/core/ble/" in it.path }
+                .filterNot { "/.claude/" in it.path.normalizedProjectPath() } // see scannedFiles()
+                .filter { "/core/ble/" in it.path.normalizedProjectPath() }
                 .flatMap { file ->
                     file.text.lines().withIndex().mapNotNull { (index, line) ->
                         if ("identifier =" in line && "address" in line && "anonymize" !in line) {
-                            "${file.path.substringAfterLast("/kotlin/")}:${index + 1}: ${line.trim()}"
+                            "${file.path.normalizedProjectPath().substringAfterLast("/kotlin/")}:${index + 1}: " +
+                                line.trim()
                         } else {
                             null
                         }

--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/CommonMainFrameworkBoundaryTest.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/CommonMainFrameworkBoundaryTest.kt
@@ -21,6 +21,7 @@ package org.meshtastic.core.konsist
 import com.lemonappdev.konsist.api.Konsist
 import com.lemonappdev.konsist.api.verify.assertFalse
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 /**
  * Enforces the KMP framework-bleed rule from AGENTS.md: shared code in any `commonMain` source set must never depend on
@@ -31,7 +32,22 @@ import kotlin.test.Test
  * (Konsist is JVM-only) under the existing `allTests` baseline gate.
  */
 class CommonMainFrameworkBoundaryTest {
-    private val commonMainFiles = Konsist.scopeFromProject().files.filter { "/src/commonMain/" in it.path }
+    private val commonMainFiles =
+        Konsist.scopeFromProject()
+            .files
+            .filterNot { "/.claude/" in it.path.normalizedProjectPath() }
+            .filter { "/src/commonMain/" in it.path.normalizedProjectPath() }
+
+    @Test
+    fun `the scan actually reaches commonMain sources`() {
+        val paths = commonMainFiles.map { it.path.normalizedProjectPath() }
+
+        assertTrue(paths.isNotEmpty(), "commonMain scan matched no files at all — the path filter is wrong")
+        assertTrue(
+            paths.any { it.endsWith("/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Message.kt") },
+            "expected core/model commonMain sources in scope; got ${paths.size} files, e.g. ${paths.take(3)}",
+        )
+    }
 
     @Test
     fun `commonMain declares no android imports`() {

--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/ProjectPath.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/ProjectPath.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.konsist
+
+/** Makes project-relative path rules independent of the host filesystem separator. */
+internal fun String.normalizedProjectPath(): String = replace('\\', '/')


### PR DESCRIPTION
## Summary

Konsist returns backslash-delimited source paths on Windows, while the architecture tests match slash-delimited project fragments. This makes the BLE privacy guard fail its scope assertion and lets the commonMain framework guard pass without inspecting any source files.

### Bug fixes

- Normalize project paths before filtering, excluding, and allowlisting files.
- Apply the same path handling to the BLE and commonMain architecture guards.
- Assert that the commonMain scan reaches a known source so an empty scope cannot pass silently.
- Normalize file paths in failure diagnostics.

## Testing Performed

- `:core:konsist:allTests` — 6/6 architecture tests passed on Windows.
- `:core:konsist:spotlessCheck`
- `:core:konsist:detekt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved project file scanning and path handling across platform environments.
  * Added validation that shared source files are discovered correctly.
  * Enhanced BLE scan checks with more consistent filtering, allowlist validation, and diagnostic reporting.
  * Added exclusions for internal configuration files to reduce false positives in automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->