### PR TITLE
fix(fdroid): ship 16 KB-compatible GeoPackage SQLite

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -317,6 +317,10 @@ dependencies {
 
     fdroidImplementation(libs.osmdroid.android)
     fdroidImplementation(libs.osmdroid.geopackage) { exclude(group = "com.j256.ormlite") }
+    fdroidImplementation(libs.geopackage.android) {
+        because("6.7.5 depends on 16 KB page-size compatible SQLite Android Bindings")
+        exclude(group = "com.j256.ormlite")
+    }
     fdroidImplementation(libs.osmbonuspack)
 
     testImplementation(kotlin("test-junit"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,6 +91,7 @@ markdownRenderer = "0.43.0"
 okio = "3.18.1"
 uri-kmp = "0.0.21"
 osmdroid-android = "6.1.20"
+geopackage-android = "6.7.5"
 spotless = "8.9.0"
 vico = "3.3.0-next.1"
 kable = "0.44.3"
@@ -289,6 +290,7 @@ uri-kmp = { module = "com.eygraber:uri-kmp", version.ref = "uri-kmp" }
 osmbonuspack = { module = "com.github.MKergall:osmbonuspack", version = "6.9.0" }
 osmdroid-android = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroid-android" }
 osmdroid-geopackage = { module = "org.osmdroid:osmdroid-geopackage", version.ref = "osmdroid-android" }
+geopackage-android = { module = "mil.nga.geopackage:geopackage-android", version.ref = "geopackage-android" }
 kermit = { module = "co.touchlab:kermit", version = "2.1.0" }
 # Debug-only leak/GC-thrash detector -- see feature/settings/.../debugging/DebugViewModel.kt and
 # core/data/.../manager/MeshMessageProcessorImpl.kt for the adversarial-mesh-fuzz bugs this class of


### PR DESCRIPTION
## Summary

- Override the F-Droid GeoPackage dependency to 6.7.5, which depends on `sqlite-android:3500400` with 16 KB page-size-compatible 64-bit native libraries.
- Preserve the existing ORMLite exclusion and leave the Google flavor unchanged.

`osmdroid-geopackage:6.1.20` currently resolves `geopackage-android:6.7.3` and `sqlite-android:3440200`. Its arm64-v8a and x86_64 `libsqliteX.so` use 4 KB ELF `LOAD` alignment, so Android reports the F-Droid APK as not 16 KB compatible even though the APK's ZIP alignment is correct.

GeoPackage 6.7.5 is the coherent upstream release that moves its SQLite Android Bindings dependency to 3500400. That artifact uses 16 KB ELF alignment for both 64-bit ABIs.

See Android's [16 KB page-size guidance](https://developer.android.com/guide/practices/page-sizes).

## Testing

- `./gradlew :androidApp:spotlessKotlinCheck :androidApp:detekt :androidApp:assembleFdroidDebug`
- `zipalign -c -P 16 -v 4` passes for the generated APK.
- `llvm-readelf -lW` confirms every arm64-v8a native library in the APK uses `0x4000` `LOAD` alignment, including `libsqliteX.so` (previously `0x1000`).
- Pixel 7a A/B install on Android 16: the prior APK reports `pageSizeCompat=4` and shows the compatibility warning; the fixed APK reports `pageSizeCompat=0` and does not show the warning after relaunch.
- Cold-launched the F-Droid app and opened Mesh Map; no native loader or SQLite errors were logged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GeoPackage support for improved compatibility with GeoPackage-formatted spatial data.
  * Updated SQLite compatibility to support 16 KB page sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->