### PR TITLE
fix(build): pin Gradle back to 9.6.1 to unbreak desktop ProGuard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -95,6 +95,13 @@
       "automerge": false
     },
     {
+      "description": "Block Gradle 9.7.0: its ExecOperations.exec spec defaults standardOutput to null, crashing the Compose Multiplatform proguardReleaseJars task (ExternalToolRunner reads the stream back). Lift once a fixed Gradle patch or a CMP release that stops reading spec.standardOutput is out.",
+      "matchManagers": [
+        "gradle-wrapper"
+      ],
+      "allowedVersions": "!/^9\\.7\\.0$/"
+    },
+    {
       "description": "Disable automerge for major updates (safety net)",
       "matchUpdateTypes": [
         "major"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,8 +2,10 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # -bin: nothing here reads -all's docs/sources. Update sha256 with the URL on upgrades
 # (official .sha256 sits next to the distribution; renovate does both).
-distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+# Pinned back to 9.6.1: Gradle 9.7.0's ExecOperations.exec spec defaults standardOutput to
+# null, which crashes CMP's proguardReleaseJars (ExternalToolRunner reads it back).
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=30000
 retries=3
 retryBackOffMs=500


### PR DESCRIPTION
## Why

Main CI's desktop builds are red on every OS since the Gradle 9.7.0 bump (#6589): `:desktopApp:proguardReleaseJars` fails with `getStandardOutput(...) must not be null`.

Gradle 9.7.0 regressed `BaseExecSpec`: the exec spec handed to `ExecOperations.exec {}` now defaults `standardOutput` to **null** instead of `System.out` as documented. Upstream has acknowledged it as a regression introduced by gradle/gradle#38061 — tracked in [gradle/gradle#38787](https://github.com/gradle/gradle/issues/38787), milestoned **9.7.1**, fix PR [gradle/gradle#38799](https://github.com/gradle/gradle/pull/38799) open.

The Compose Multiplatform plugin's `ExternalToolRunner` reads `spec.standardOutput` back to tee it to a log file, but only on the `LogToConsole.Always` path — which only `AbstractProguardTask` uses. Hence exactly the ProGuard task failing, everywhere, and no CMP-side workaround (the read happens inside the plugin's exec closure; nothing user-configurable reaches it). CMP is unchanged through v1.12.0-rc01 and master, and per Gradle's documented API its code is correct — the fix belongs in Gradle.

## 🛠️ Changes

- Pin `gradle-wrapper.properties` back to 9.6.1 (URL + sha256), with a comment explaining why.
- Add a Renovate rule blocking **exactly 9.7.0** for the `gradle-wrapper` manager, so 9.7.1 is offered the moment it ships with the fix.
- Everything else from the 9.7 bump (Isolated Projects flags, CC cache keys, build-logic `isolated.rootProject` paths) is 9.6-compatible and stays.

## Testing Performed

- Reproduced the CI failure locally on 9.7.0: `:desktopApp:proguardReleaseJars` fails with the identical stack (`ExternalToolRunner.kt:68`).
- With this pin: `:desktopApp:proguardReleaseJars` BUILD SUCCESSFUL.
- `spotlessCheck detekt` pass.

## Reviewer notes

The bump PR merged green because PR CI intentionally skips desktop packaging jobs (`:desktopApp:test` covers compilation but not ProGuard packaging) — only Main CI caught it. Worth considering a targeted desktop packaging check for toolchain-touching PRs; kept out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored compatibility by reverting the Gradle wrapper to version 9.6.1.
  - Prevented automatic updates to the incompatible Gradle 9.7.0 release.
  - Updated the wrapper checksum and documented the related compatibility issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->