### PR TITLE
fix(ci): replace 9.7-only --no-isolated-projects flag with property form

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -110,7 +110,7 @@ jobs:
             --baseurl /${{ github.event.repository.name }}/main &
           jekyll_pid=$!
           if [ "$BUILD_DOKKA" = "true" ]; then
-            ./gradlew dokkaGeneratePublicationHtml --no-isolated-projects --no-configuration-cache
+            ./gradlew dokkaGeneratePublicationHtml -Dorg.gradle.isolated-projects=false --no-configuration-cache
           else
             echo "No Dokka-relevant changes — skipping API reference rebuild."
           fi

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -104,7 +104,7 @@ jobs:
       # Dokka API reference (/api/) — production releases only.
       - name: Build Dokka HTML documentation
         if: steps.version.outputs.is_production == 'true'
-        run: ./gradlew dokkaGeneratePublicationHtml --no-isolated-projects --no-configuration-cache
+        run: ./gradlew dokkaGeneratePublicationHtml -Dorg.gradle.isolated-projects=false --no-configuration-cache
 
       - name: Compile Jekyll Sites
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,7 +459,7 @@ jobs:
       # are runtime-only and would be missed by :assemble).
       - name: Generate Flatpak Sources
         run: >
-          ./gradlew --no-build-cache --no-isolated-projects --no-configuration-cache -Pmeshtastic.flatpakSources=true
+          ./gradlew --no-build-cache -Dorg.gradle.isolated-projects=false --no-configuration-cache -Pmeshtastic.flatpakSources=true
           -Dgradle.user.home=${{ runner.temp }}/flatpak-gradle-home
           :desktopApp:packageUberJarForCurrentOS :captureFlatpakSources
 

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -131,9 +131,9 @@ jobs:
           cache_configuration_cache: 'true' # VERSION_CODE pinned -> entries actually reuse
 
       - name: Screenshot Test Validation
-        # --no-isolated-projects: AGP's screenshot plugin iterates BuildServicesRegistry at
+        # -Dorg.gradle.isolated-projects=false: AGP's screenshot plugin iterates BuildServicesRegistry at
         # execution time, which Isolated Projects forbids (fatal since Gradle 9.7).
-        run: ./gradlew :screenshot-tests:validateDebugScreenshotTest -Pci=true --no-isolated-projects
+        run: ./gradlew :screenshot-tests:validateDebugScreenshotTest -Pci=true -Dorg.gradle.isolated-projects=false
 
       - name: Upload screenshot diff report
         if: failure()
@@ -452,9 +452,11 @@ jobs:
           echo "VERSION_NAME=${BASE}-SNAPSHOT" >> "$GITHUB_ENV"
 
       - name: Build Android APKs
-        # --no-isolated-projects: the dependency-graph plugin injected by setup-gradle force-resolves
-        # via allprojects{}, which Isolated Projects forbids (fatal since Gradle 9.7).
-        run: ./gradlew androidApp:assembleFdroidDebug androidApp:assembleGoogleDebug -Pci=true --parallel --configuration-cache --no-isolated-projects --continue
+        # -Dorg.gradle.isolated-projects=false: the dependency-graph plugin injected by setup-gradle force-resolves
+        # via allprojects{}, which Isolated Projects forbids (fatal since Gradle 9.7). The property form is
+        # used everywhere instead of --no-isolated-projects: that flag only exists on Gradle 9.7+, and the
+        # wrapper is pinned to 9.6.1 until gradle/gradle#38787 ships in 9.7.1.
+        run: ./gradlew androidApp:assembleFdroidDebug androidApp:assembleGoogleDebug -Pci=true --parallel --configuration-cache -Dorg.gradle.isolated-projects=false --continue
 
       - name: Upload debug artifact
         if: ${{ inputs.upload_artifacts }}
@@ -578,7 +580,7 @@ jobs:
       # runtime classpath. :assemble alone would miss runtime-only deps (skiko, ktor-cio, …).
       - name: Generate Flatpak Sources
         run: >
-          ./gradlew --no-build-cache --no-isolated-projects --no-configuration-cache -Pmeshtastic.flatpakSources=true
+          ./gradlew --no-build-cache -Dorg.gradle.isolated-projects=false --no-configuration-cache -Pmeshtastic.flatpakSources=true
           -Dgradle.user.home=${{ runner.temp }}/flatpak-gradle-home
           :desktopApp:packageUberJarForCurrentOS :captureFlatpakSources
 

--- a/.github/workflows/scheduled-baseline.yml
+++ b/.github/workflows/scheduled-baseline.yml
@@ -65,9 +65,9 @@ jobs:
           # --no-configuration-cache: the underlying connectedGoogleNonMinifiedReleaseAndroidTest task is not
           # config-cache serializable (SeparateTestModuleTestData / ResolutionBackedFileCollection), and the
           # project enables org.gradle.configuration-cache by default — same workaround used in reusable-check.yml.
-          # --no-isolated-projects must accompany it: Isolated Projects implies the configuration cache, and
+          # -Dorg.gradle.isolated-projects=false must accompany it: Isolated Projects implies the configuration cache, and
           # Gradle 9.7+ hard-errors when the cache is disabled while Isolated Projects is on.
-          script: ./gradlew :androidApp:generateGoogleReleaseBaselineProfile -Pci=true --no-isolated-projects --no-configuration-cache
+          script: ./gradlew :androidApp:generateGoogleReleaseBaselineProfile -Pci=true -Dorg.gradle.isolated-projects=false --no-configuration-cache
 
       - name: Detect baseline profile changes
         id: baseline

--- a/.github/workflows/verify-flatpak.yml
+++ b/.github/workflows/verify-flatpak.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Generate flatpak-sources.json
         run: |
-          ./gradlew --no-build-cache --no-isolated-projects --no-configuration-cache -Pmeshtastic.flatpakSources=true \
+          ./gradlew --no-build-cache -Dorg.gradle.isolated-projects=false --no-configuration-cache -Pmeshtastic.flatpakSources=true \
             -Dgradle.user.home="$RUNNER_TEMP/flatpak-gradle-home" \
             :desktopApp:packageUberJarForCurrentOS :captureFlatpakSources
           cp build/flatpak-sources.json flatpak-sources.json

--- a/.skills/project-overview/SKILL.md
+++ b/.skills/project-overview/SKILL.md
@@ -74,5 +74,5 @@ Agents **MUST** perform these steps automatically at the start of every session 
 
 ## Troubleshooting
 - **Build Failures:** Check `gradle/libs.versions.toml` for dependency conflicts.
-- **Configuration Cache:** Add `--no-isolated-projects --no-configuration-cache` if cache-related issues persist. Both flags are required: Isolated Projects (on by default here) implies the configuration cache, and Gradle 9.7+ fails the build if you disable the cache without also disabling Isolated Projects.
+- **Configuration Cache:** Add `-Dorg.gradle.isolated-projects=false --no-configuration-cache` if cache-related issues persist. Both flags are required: Isolated Projects (on by default here) implies the configuration cache, and Gradle 9.7+ fails the build if you disable the cache without also disabling Isolated Projects.
 - **Koin Injection Failures:** Verify the component is included in `AppKoinModule`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for your interest in contributing to Meshtastic-Android! We welcome co
 - Follow the [Kotlin Coding Conventions](https://kotlinlang.org/docs/coding-conventions.html) for Kotlin code.
 - Use Android Studio's default formatting settings.
 - We use [spotless](https://github.com/diffplug/spotless) for automated code formatting. You can run `./gradlew spotlessApply` to format your code automatically.
-  - You can also run `./gradlew spotlessInstallGitPrePushHook --no-isolated-projects --no-configuration-cache` to install a pre-push Git hook that will run a `spotlessCheck`.
+  - You can also run `./gradlew spotlessInstallGitPrePushHook -Dorg.gradle.isolated-projects=false --no-configuration-cache` to install a pre-push Git hook that will run a `spotlessCheck`.
 - Write clear, descriptive variable and function names.
 - Add comments where necessary, especially for complex logic.
 - Keep methods and classes focused and concise.


### PR DESCRIPTION
## Why

Main CI broke again after #6611: the `--no-isolated-projects` CLI flag added by the Gradle 9.7 bump (#6589) **only exists on Gradle 9.7+**. With the wrapper pinned back to 9.6.1, every job passing it fails instantly with `Unknown command-line option '--no-isolated-projects'` — first seen on Build Android APKs, but it also affects screenshot validation, flatpak sources (reusable-check + release + verify-flatpak), Dokka docs (deploy + release), and the scheduled baseline profile.

## 🛠️ Changes

- Swap `--no-isolated-projects` → `-Dorg.gradle.isolated-projects=false` in all seven workflow occurrences plus the CONTRIBUTING.md / project-overview skill mentions.
- The property form is version-portable: accepted on 9.6.1 and the documented way to disable Isolated Projects on 9.7+, so the eventual 9.7.1 re-bump (tracked via gradle/gradle#38787) needs no workflow edits.
- Added a comment at the APK-build site explaining the choice.

## Testing Performed

- `./gradlew help -Dorg.gradle.isolated-projects=false --no-configuration-cache` accepted on 9.6.1 locally (the flag form errors at CLI parsing).
- YAML syntax of all six edited workflows validated.

## Reviewer notes

On 9.6.1 these jobs were green even with Isolated Projects enabled globally (9.6 doesn't hard-error on the violations 9.7 does), so the property's effect there is belt-and-suspenders; its real purpose is keeping 9.7.1 compatibility ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)