### PR TITLE
fix(ui): add MQTT context to channel uplink/downlink toggle labels

### DIFF
--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -558,7 +558,7 @@
     <string name="done">Done</string>
     <string name="dont_show_again_for_device">Don't show again for this device</string>
     <string name="double_tap_as_button_press">Double Tap as Button</string>
-    <string name="downlink_enabled">Downlink enabled</string>
+    <string name="downlink_enabled">MQTT Downlink Enabled</string>
     <string name="downlink_feature_description">Messages from a public internet gateway are forwarded to the local mesh. Due to the zero-hop policy, traffic from the default MQTT server will not propagate further than this device.</string>
     <string name="download">Download</string>
     <string name="duplicated_public_key_title">Duplicate Public Key Detected</string>
@@ -1811,7 +1811,7 @@
     <string name="update_interval">GPS Polling Interval</string>
     <string name="update_interval_seconds">Update interval (seconds)</string>
     <string name="updated">Updated</string>
-    <string name="uplink_enabled">Uplink enabled</string>
+    <string name="uplink_enabled">MQTT Uplink Enabled</string>
     <string name="uplink_feature_description">Messages from the mesh will be sent to the public internet through any node's configured gateway.</string>
     <string name="uptime">Uptime</string>
     <!-- URL -->


### PR DESCRIPTION
## Why

Garth's 2026-08-11 design audit (meshtastic/design#80) flagged that the channel editor's "Uplink enabled" / "Downlink enabled" toggles give no hint that they control MQTT gateway behavior — users toggle them without knowing what they gate. The audit agreed on shared cross-platform wording so Android, Apple, and web all use the same labels.

## 🐛 What changed

- Base-locale `uplink_enabled` → **"MQTT Uplink Enabled"** and `downlink_enabled` → **"MQTT Downlink Enabled"** in `core/resources` strings. These back the toggles in `EditChannelDialog` and the channel legend.
- Base `strings.xml` only — Crowdin picks up the translations.

## Notes for reviewers

- Wording is verbatim from the cross-platform agreement in meshtastic/design#80.
- `scripts/sort-strings.py` ran (via hook); index regenerated with no reordering needed.
- Local baseline (`spotlessApply spotlessCheck detekt assembleDebug test allTests`) — spotless/detekt/assemble green; full test suite still finishing locally, no failures so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Clarified MQTT connection status labels to explicitly distinguish downlink and uplink functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->