### PR TITLE
fix(android): preserve shared text in deep links

### DIFF
--- a/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
@@ -368,9 +368,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun createShareIntent(message: String): PendingIntent {
-        val deepLink = "$DEEP_LINK_BASE_URI/share?message=$message"
         val startActivityIntent =
-            Intent(Intent.ACTION_VIEW, deepLink.toUri(), this, MainActivity::class.java).apply {
+            Intent(Intent.ACTION_VIEW, createShareMessageDeepLink(message), this, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
             }
 
@@ -393,3 +392,6 @@ class MainActivity : AppCompatActivity() {
         const val EXTRA_SKIP_ONBOARDING = "skip_onboarding"
     }
 }
+
+internal fun createShareMessageDeepLink(message: String): Uri =
+    "$DEEP_LINK_BASE_URI/share".toUri().buildUpon().appendQueryParameter("message", message).build()

--- a/androidApp/src/test/kotlin/org/meshtastic/app/ShareMessageDeepLinkTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/ShareMessageDeepLinkTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app
+
+import android.app.PendingIntent
+import android.content.Intent
+import org.junit.runner.RunWith
+import org.meshtastic.core.common.util.CommonUri
+import org.meshtastic.core.navigation.ContactsRoute
+import org.meshtastic.core.navigation.DeepLinkRouter
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ShareMessageDeepLinkTest {
+
+    @Test
+    fun `shared text round trips through the deep link query`() {
+        val messages =
+            listOf(
+                "camp & ridge #4",
+                "question? answer=yes + backup",
+                "line one\nline two",
+                "emoji 🦙 and non-Latin 北山",
+            )
+
+        messages.forEach { message ->
+            val deepLink = createShareMessageDeepLink(message)
+
+            assertEquals(message, deepLink.getQueryParameter("message"))
+            assertEquals(setOf("message"), deepLink.queryParameterNames)
+            assertNull(deepLink.fragment)
+            assertEquals(
+                listOf(ContactsRoute.Contacts, ContactsRoute.Share(message)),
+                DeepLinkRouter.route(CommonUri.parse(deepLink.toString())),
+            )
+        }
+    }
+
+    @Test
+    fun `share callback pending intent carries the encoded message deep link`() {
+        val message = "camp & ridge #4? answer=yes + backup"
+        val activity = Robolectric.buildActivity(MainActivity::class.java).get()
+
+        val pendingIntent =
+            ReflectionHelpers.callInstanceMethod<PendingIntent>(
+                activity,
+                "createShareIntent",
+                ReflectionHelpers.ClassParameter.from(String::class.java, message),
+            )
+        val callbackIntent = shadowOf(pendingIntent).savedIntent
+
+        assertEquals(Intent.ACTION_VIEW, callbackIntent.action)
+        assertEquals(MainActivity::class.java.name, callbackIntent.component?.className)
+        assertEquals(Intent.FLAG_ACTIVITY_SINGLE_TOP, callbackIntent.flags and Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        assertEquals(message, callbackIntent.data?.getQueryParameter("message"))
+        assertEquals(setOf("message"), callbackIntent.data?.queryParameterNames)
+        assertNull(callbackIntent.data?.fragment)
+        assertEquals(
+            listOf(ContactsRoute.Contacts, ContactsRoute.Share(message)),
+            DeepLinkRouter.route(CommonUri.parse(callbackIntent.data.toString())),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- encode shared message text as a URI query parameter instead of interpolating it into the deep-link string
- preserve ampersands, fragments, query delimiters, plus signs, line breaks, emoji, and non-Latin text
- add a Robolectric regression covering exact Android URI construction and the full `CommonUri` through `DeepLinkRouter` decode path

## Root cause

`MainActivity` previously appended the raw message after `?message=`. URI delimiter characters in user text were therefore interpreted as query or fragment syntax, truncating or changing the text delivered to the share screen.

`Uri.Builder.appendQueryParameter` applies the platform's query encoding while preserving the existing deep-link contract.

## Impact

Plain-text sharing now delivers the exact selected message even when it contains URI-significant or Unicode characters. Messages without those characters are unchanged.

## Testing

- `:androidApp:testFdroidDebugUnitTest --tests org.meshtastic.app.ShareMessageDeepLinkTest`
- `:androidApp:testGoogleDebugUnitTest --tests org.meshtastic.app.ShareMessageDeepLinkTest`
- `:androidApp:spotlessApply :androidApp:spotlessCheck :androidApp:detekt :androidApp:assembleDebug`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sharing of messages containing special characters, spaces, line breaks, emoji, and non-Latin text.
  * Ensured shared links preserve message content accurately and avoid unintended URL fragments or extra parameters.

* **Tests**
  * Added coverage for sharing and restoring a wide range of message formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->