### PR TITLE
fix(messaging): disambiguate sender-scoped packet IDs

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
@@ -345,7 +345,7 @@ class MeshDataHandlerImpl(
     ) {
         val decoded = packet.decoded ?: return
         if (decoded.reply_id != 0 && decoded.emoji != 0) {
-            rememberReaction(packet, session)
+            rememberReaction(packet, dataPacket, session)
         } else {
             rememberDataPacket(dataPacket, myNodeNum, session = session)
         }
@@ -405,8 +405,12 @@ class MeshDataHandlerImpl(
     ) {
         radioInterfaceService.launchSessionWork(scope, session) {
             val isAck = routingError == Routing.Error.NONE.value
-            val p = packetRepository.value.getPacketByPacketId(requestId)
-            val reaction = packetRepository.value.getReactionByPacketId(requestId)
+            val packets =
+                packetRepository.value.findPacketsWithId(requestId).filter { it.status != MessageStatus.RECEIVED }
+            val reactions =
+                packetRepository.value.findReactionsWithId(requestId).filter { it.status != MessageStatus.RECEIVED }
+            val p = packets.filter { it.to == fromId }.singleOrNull() ?: packets.singleOrNull()
+            val reaction = reactions.filter { it.to == fromId }.singleOrNull() ?: reactions.singleOrNull()
 
             @Suppress("MaxLineLength")
             Logger.d {
@@ -460,16 +464,12 @@ class MeshDataHandlerImpl(
      */
     private suspend fun persistDataPacket(dataPacket: DataPacket, myNodeNum: Int, updateNotification: Boolean) {
         val fromLocal = dataPacket.isFromLocal(myNodeNum)
-        val toBroadcast = dataPacket.isBroadcast
-        val contactId = if (fromLocal || toBroadcast) dataPacket.to else dataPacket.from
-
-        // contactKey: unique contact key filter (channel)+(nodeId)
-        val contactKey = "${dataPacket.channel}$contactId"
+        val contactKey = dataPacket.contactKey(myNodeNum)
 
         packetRepository.value.apply {
             // Check for duplicates before inserting
             val existingPackets = findPacketsWithId(dataPacket.id)
-            if (existingPackets.isNotEmpty()) {
+            if (existingPackets.any { it.hasSameSenderAs(dataPacket, myNodeNum) }) {
                 Logger.d {
                     "Skipping duplicate packet: packetId=${dataPacket.id} from=${dataPacket.from} " +
                         "to=${dataPacket.to} contactKey=$contactKey" +
@@ -574,19 +574,22 @@ class MeshDataHandlerImpl(
     }
 
     @Suppress("LongMethod", "KotlinConstantConditions")
-    private fun rememberReaction(packet: MeshPacket, session: RadioSessionContext) =
+    private fun rememberReaction(packet: MeshPacket, dataPacket: DataPacket, session: RadioSessionContext) =
         radioInterfaceService.launchSessionWork(scope, session) {
             val decoded = packet.decoded ?: return@launchSessionWork
             val emoji = decoded.payload.toByteArray().decodeToString()
             val fromId = nodeManager.toNodeID(packet.from)
+            val toId = nodeManager.toNodeID(packet.to)
+            val myNodeNum = nodeManager.myNodeNum.value ?: 0
+            val contactKey = dataPacket.contactKey(myNodeNum)
 
             val fromNode = nodeManager.nodeDBbyNodeNum[packet.from] ?: Node(num = packet.from)
-            val toNode = nodeManager.nodeDBbyNodeNum[packet.to] ?: Node(num = packet.to)
+            val fromUser = fromNode.user.copy(id = fromNode.user.id.ifEmpty { fromId })
 
             val reaction =
                 Reaction(
                     replyId = decoded.reply_id,
-                    user = fromNode.user,
+                    user = fromUser,
                     emoji = emoji,
                     timestamp = nowMillis,
                     // [Reaction.snr] is not nullable, so absent narrows to 0f here. See [snrOrNull].
@@ -600,55 +603,64 @@ class MeshDataHandlerImpl(
                     },
                     packetId = packet.id,
                     status = MessageStatus.RECEIVED,
-                    to = toNode.user.id,
-                    channel = packet.channel,
+                    to = toId,
+                    channel = dataPacket.channel,
                 )
 
             // Check for duplicates before inserting
             val existingReactions = packetRepository.value.findReactionsWithId(packet.id)
-            if (existingReactions.isNotEmpty()) {
+            if (existingReactions.any { it.user.id == fromId }) {
                 Logger.d {
                     "Skipping duplicate reaction: packetId=${packet.id} replyId=${decoded.reply_id} " +
-                        "from=$fromId emoji=$emoji (already have ${existingReactions.size} reaction(s))"
+                        "(already have ${existingReactions.size} reaction(s))"
                 }
                 return@launchSessionWork
             }
 
-            packetRepository.value.insertReaction(reaction, nodeManager.myNodeNum.value ?: 0)
+            packetRepository.value.insertReaction(reaction, myNodeNum)
 
-            // Find the original packet to get the contactKey
-            packetRepository.value.getPacketByPacketId(decoded.reply_id)?.let { originalPacket ->
-                // Skip notification if the original message was filtered
-                val targetId =
-                    if (originalPacket.source is NodeAddress.Local) originalPacket.to else originalPacket.from
-                val contactKey = "${originalPacket.channel}$targetId"
-                val conversationMuted = packetRepository.value.getContactSettings(contactKey).isMuted
-                val nodeMuted = nodeManager.getNodeById(fromId)?.isMuted == true
-                val isSilent = conversationMuted || nodeMuted
+            // A reply ID is sender-scoped, so only use a parent that is unique within this reaction's conversation.
+            packetRepository.value
+                .findPacketsWithId(decoded.reply_id)
+                .filter { it.contactKey(myNodeNum) == contactKey }
+                .singleOrNull()
+                ?.let { originalPacket ->
+                    // Skip notification if the original message was filtered
+                    val conversationMuted = packetRepository.value.getContactSettings(contactKey).isMuted
+                    val nodeMuted = nodeManager.getNodeById(fromId)?.isMuted == true
+                    val isSilent = conversationMuted || nodeMuted
 
-                if (!isSilent) {
-                    val isBroadcast = originalPacket.destination is NodeAddress.Broadcast
-                    val channelName =
-                        if (isBroadcast) {
-                            radioConfigRepository.channelSetFlow
-                                .first()
-                                .settings
-                                .getOrNull(originalPacket.channel)
-                                ?.name
-                        } else {
-                            null
-                        }
-                    serviceNotifications.updateReactionNotification(
-                        contactKey,
-                        getSenderName(dataMapper.toDataPacket(packet)!!),
-                        emoji,
-                        isBroadcast,
-                        channelName,
-                        isSilent,
-                    )
+                    if (!isSilent) {
+                        val isBroadcast = originalPacket.destination is NodeAddress.Broadcast
+                        val channelName =
+                            if (isBroadcast) {
+                                radioConfigRepository.channelSetFlow
+                                    .first()
+                                    .settings
+                                    .getOrNull(originalPacket.channel)
+                                    ?.name
+                            } else {
+                                null
+                            }
+                        serviceNotifications.updateReactionNotification(
+                            contactKey,
+                            getSenderName(dataPacket),
+                            emoji,
+                            isBroadcast,
+                            channelName,
+                            isSilent,
+                        )
+                    }
                 }
-            }
         }
+
+    private fun DataPacket.contactKey(myNodeNum: Int): String {
+        val contactId = if (isFromLocal(myNodeNum) || isBroadcast) to else from
+        return "$channel$contactId"
+    }
+
+    private fun DataPacket.hasSameSenderAs(other: DataPacket, myNodeNum: Int): Boolean =
+        source == other.source || (isFromLocal(myNodeNum) && other.isFromLocal(myNodeNum))
 
     companion object {
         private const val HOPS_AWAY_UNAVAILABLE = -1

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/PacketHandlerImpl.kt
@@ -34,7 +34,6 @@ import org.meshtastic.core.common.di.ServiceScope
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.model.ConnectionState
-import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.RadioNotConnectedException
@@ -44,6 +43,7 @@ import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketHandler
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.proto.FromRadio
 import org.meshtastic.proto.MeshPacket
@@ -106,14 +106,14 @@ class PacketHandlerImpl(
     private val routingResponse = mutableMapOf<Int, CompletableDeferred<Boolean>>()
 
     private val timeoutMutex = Mutex()
-    private val sendAckTimeoutJobs = mutableMapOf<Int, Job>()
+    private val sendAckTimeoutJobs = mutableMapOf<PersistedPacketId, Job>()
 
     override fun sendToRadio(p: ToRadio) {
         Logger.d { "Sending to radio ${p.toPIIString()}" }
         val b = p.encode()
 
         radioInterfaceService.sendToRadio(b)
-        p.packet?.id?.let { changeStatus(it, MessageStatus.ENROUTE) }
+        p.packet?.let { changeStatus(it, MessageStatus.ENROUTE) }
 
         val packet = p.packet
         if (packet?.decoded != null) {
@@ -274,24 +274,26 @@ class PacketHandlerImpl(
             }
     }
 
-    private fun changeStatus(packetId: Int, m: MessageStatus) = scope.handledLaunch {
-        if (packetId != 0) {
-            getDataPacketById(packetId)?.let { p ->
-                if (p.status != m) {
-                    packetRepository.value.updateMessageStatus(p, m)
+    private fun changeStatus(packet: MeshPacket, status: MessageStatus) = scope.handledLaunch {
+        if (packet.id != 0) {
+            val persistedId =
+                withTimeoutOrNull(1.seconds) {
+                    var id: PersistedPacketId? = null
+                    while (id == null) {
+                        id = packetRepository.value.updateOutgoingMessageStatus(packet, status)
+                        if (id == null) delay(100.milliseconds)
+                    }
+                    id
                 }
-                if (m == MessageStatus.ENROUTE) {
-                    scheduleSendAckTimeout(packetId)
-                }
-            }
+            if (status == MessageStatus.ENROUTE && persistedId != null) scheduleSendAckTimeout(persistedId)
         }
     }
 
     override fun rearmSendAckTimeouts() {
         scope.handledLaunch {
-            packetRepository.value.getEnroutePackets().forEach { p ->
-                val remaining = p.time + SEND_ACK_TIMEOUT.inWholeMilliseconds - nowMillis
-                scheduleSendAckTimeout(p.id, remaining.milliseconds.coerceAtLeast(REARM_GRACE))
+            packetRepository.value.getEnroutePackets().forEach { persisted ->
+                val remaining = persisted.packet.time + SEND_ACK_TIMEOUT.inWholeMilliseconds - nowMillis
+                scheduleSendAckTimeout(persisted.id, remaining.milliseconds.coerceAtLeast(REARM_GRACE))
             }
         }
     }
@@ -301,30 +303,21 @@ class PacketHandlerImpl(
      * response arrived) would stay ENROUTE — "Sending…" — forever. Stamp it as a retryable timeout instead; a late ACK
      * still upgrades it via handleAckNak.
      *
-     * One timer per packet: re-arming supersedes the pending one, so repeated reconnects cannot pile up timers for the
-     * same send. Timers deliberately survive a disconnect — the ack genuinely never arrived, and the resulting state is
-     * retryable — so a user who never reconnects still sees the send resolve.
+     * One timer per persisted row: re-arming supersedes the pending one, so repeated reconnects cannot pile up timers
+     * for same send. Timers deliberately survive a disconnect — the ack genuinely never arrived, and the resulting
+     * state is retryable — so a user who never reconnects still sees the send resolve.
      */
-    private suspend fun scheduleSendAckTimeout(packetId: Int, delayFor: Duration = SEND_ACK_TIMEOUT) {
+    private suspend fun scheduleSendAckTimeout(id: PersistedPacketId, delayFor: Duration = SEND_ACK_TIMEOUT) {
         timeoutMutex.withLock {
-            sendAckTimeoutJobs.remove(packetId)?.cancel()
+            sendAckTimeoutJobs.remove(id)?.cancel()
             sendAckTimeoutJobs.values.removeAll { it.isCompleted }
-            sendAckTimeoutJobs[packetId] =
+            sendAckTimeoutJobs[id] =
                 scope.handledLaunch {
                     delay(delayFor)
                     // Conditional in the DAO transaction: an ACK/NAK landing while this timer waited must win.
-                    packetRepository.value.timeOutEnroutePacket(packetId, Routing.Error.TIMEOUT.value)
+                    packetRepository.value.timeOutEnroutePacket(id, Routing.Error.TIMEOUT.value)
                 }
         }
-    }
-
-    private suspend fun getDataPacketById(packetId: Int): DataPacket? = withTimeoutOrNull(1.seconds) {
-        var dataPacket: DataPacket? = null
-        while (dataPacket == null) {
-            dataPacket = packetRepository.value.getPacketById(packetId)
-            if (dataPacket == null) delay(100.milliseconds)
-        }
-        dataPacket
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt
@@ -40,7 +40,10 @@ import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.Reaction
+import org.meshtastic.core.repository.PersistedPacket
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.PortNum
 import org.meshtastic.core.database.entity.ContactSettings as ContactSettingsEntity
 import org.meshtastic.core.database.entity.Packet as RoomPacket
@@ -109,21 +112,30 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         }
     }
 
-    override suspend fun getQueuedPackets(): List<DataPacket> = withContext(dispatchers.io) {
-        dbManager.currentDb.value.packetDao().getAllDataPackets().filter { it.status == MessageStatus.QUEUED }
+    override suspend fun getQueuedPackets(): List<PersistedPacket> = withContext(dispatchers.io) {
+        dbManager.currentDb.value
+            .packetDao()
+            .getAllPersistedPackets()
+            .filter { it.data.status == MessageStatus.QUEUED }
+            .map { PersistedPacket(id = PersistedPacketId(it.myNodeNum, it.uuid), packet = it.data) }
     }
 
-    override suspend fun getEnroutePackets(): List<DataPacket> = withContext(dispatchers.io) {
-        dbManager.currentDb.value.packetDao().getAllDataPackets().filter { it.status == MessageStatus.ENROUTE }
+    override suspend fun getEnroutePackets(): List<PersistedPacket> = withContext(dispatchers.io) {
+        dbManager.currentDb.value
+            .packetDao()
+            .getAllPersistedPackets()
+            .filter { it.data.status == MessageStatus.ENROUTE }
+            .map { PersistedPacket(id = PersistedPacketId(it.myNodeNum, it.uuid), packet = it.data) }
     }
 
     // A null from withDb means no database was available, so nothing was timed out.
-    override suspend fun timeOutEnroutePacket(packetId: Int, routingError: Int): Boolean = withContext(dispatchers.io) {
-        dbManager.withDb { it.packetDao().timeOutEnroutePacket(packetId, routingError) } ?: false
-    }
+    override suspend fun timeOutEnroutePacket(id: PersistedPacketId, routingError: Int): Boolean =
+        withContext(dispatchers.io + NonCancellable) {
+            dbManager.withDb { it.packetDao().timeOutEnroutePacket(id.myNodeNum, id.uuid, routingError) } ?: false
+        }
 
-    suspend fun insertRoomPacket(packet: RoomPacket) {
-        withContext(dispatchers.io + NonCancellable) { dbManager.withDb { it.packetDao().insert(packet) } }
+    suspend fun insertRoomPacket(packet: RoomPacket): Long = withContext(dispatchers.io + NonCancellable) {
+        checkNotNull(dbManager.withDb { it.packetDao().insertAndGetId(packet) })
     }
 
     override suspend fun savePacket(
@@ -133,7 +145,7 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         receivedTime: Long,
         read: Boolean,
         filtered: Boolean,
-    ) {
+    ): PersistedPacketId {
         val packetToSave =
             RoomPacket(
                 uuid = 0L,
@@ -150,7 +162,8 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
                 filtered = filtered,
                 messageText = packet.text.orEmpty(),
             )
-        insertRoomPacket(packetToSave)
+        val uuid = insertRoomPacket(packetToSave)
+        return PersistedPacketId(myNodeNum = myNodeNum, uuid = uuid)
     }
 
     override suspend fun getMessagesFrom(
@@ -169,7 +182,7 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         flow.mapLatest { packets ->
             val cachedGetNode = memoize(getNode)
             val replyIds = packets.mapNotNull { it.packet.data.replyId?.takeIf { id -> id != 0 } }.distinct()
-            val replyMap = batchGetPacketsByIds(replyIds)
+            val replyMap = batchGetReplyParents(replyIds, contact)
             packets.map { packet ->
                 val message = packet.toMessage(cachedGetNode)
                 val replyId = message.replyId?.takeIf { it != 0 }
@@ -198,7 +211,7 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
                     val replyId = message.replyId?.takeIf { it != 0 }
                     val originalMessage =
                         replyId
-                            ?.let { id -> replyCache.getOrPut(id) { getPacketByPacketIdInternal(id) } }
+                            ?.let { id -> replyCache.getOrPut(id) { getReplyParent(id, contact) } }
                             ?.toMessage(cachedGetNode)
                     if (originalMessage != null) message.copy(originalMessage = originalMessage) else message
                 }
@@ -228,7 +241,7 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
                 val replyId = message.replyId?.takeIf { it != 0 }
                 val originalMessage =
                     replyId
-                        ?.let { id -> replyCache.getOrPut(id) { getPacketByPacketIdInternal(id) } }
+                        ?.let { id -> replyCache.getOrPut(id) { getReplyParent(id, contactKey) } }
                         ?.toMessage(cachedGetNode)
                 if (originalMessage != null) message.copy(originalMessage = originalMessage) else message
             }
@@ -237,6 +250,38 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
     override suspend fun updateMessageStatus(d: DataPacket, m: MessageStatus) {
         withContext(dispatchers.io) { dbManager.withDb { it.packetDao().updateMessageStatus(d, m) } }
     }
+
+    override suspend fun updateMessageStatus(id: PersistedPacketId, status: MessageStatus) {
+        withContext(dispatchers.io) {
+            dbManager.withDb { it.packetDao().updateMessageStatusByPersistedId(id.myNodeNum, id.uuid, status) }
+        }
+    }
+
+    override suspend fun claimQueuedPacket(id: PersistedPacketId): PersistedPacket? =
+        withContext(dispatchers.io + NonCancellable) {
+            dbManager
+                .withDb { it.packetDao().claimQueuedPacket(id.myNodeNum, id.uuid) }
+                ?.let { packet -> PersistedPacket(PersistedPacketId(packet.myNodeNum, packet.uuid), packet.data) }
+        }
+
+    override suspend fun claimQueuedPacketByPacketIdIfUnique(packetId: Int): PersistedPacket? =
+        withContext(dispatchers.io + NonCancellable) {
+            dbManager
+                .withDb { it.packetDao().claimQueuedPacketByPacketIdIfUnique(packetId) }
+                ?.let { packet -> PersistedPacket(PersistedPacketId(packet.myNodeNum, packet.uuid), packet.data) }
+        }
+
+    override suspend fun rollbackEnroutePacket(id: PersistedPacketId): Boolean =
+        withContext(dispatchers.io + NonCancellable) {
+            dbManager.withDb { it.packetDao().rollbackEnroutePacket(id.myNodeNum, id.uuid) } ?: false
+        }
+
+    override suspend fun updateOutgoingMessageStatus(packet: MeshPacket, status: MessageStatus): PersistedPacketId? =
+        withContext(dispatchers.io) {
+            dbManager
+                .withDb { it.packetDao().updateOutgoingMessageStatus(packet, status) }
+                ?.let { PersistedPacketId(it.myNodeNum, it.uuid) }
+        }
 
     override suspend fun updateMessageId(d: DataPacket, id: Int) {
         withContext(dispatchers.io) { dbManager.withDb { it.packetDao().updateMessageId(d, id) } }
@@ -257,19 +302,31 @@ class PacketRepositoryImpl(private val dbManager: DatabaseProvider, private val 
         dbManager.currentDb.value.packetDao().getPacketByPacketId(packetId)?.packet?.data
     }
 
-    private suspend fun getPacketByPacketIdInternal(packetId: Int) =
-        withContext(dispatchers.io) { dbManager.currentDb.value.packetDao().getPacketByPacketId(packetId) }
-
-    private suspend fun batchGetPacketsByIds(ids: List<Int>): Map<Int, PacketEntity> = if (ids.isEmpty()) {
-        emptyMap()
-    } else {
-        withContext(dispatchers.io) {
-            val dao = dbManager.currentDb.value.packetDao()
-            ids.chunked(NodeInfoDao.MAX_BIND_PARAMS)
-                .flatMap { dao.getPacketsByPacketIds(it) }
-                .associateBy { it.packet.packetId }
-        }
+    override suspend fun getPacketByPacketIdIfUnique(packetId: Int): DataPacket? = withContext(dispatchers.io) {
+        dbManager.currentDb.value.packetDao().findPacketsWithId(packetId).singleOrNull()?.data
     }
+
+    override suspend fun getPacketByPersistedId(id: PersistedPacketId): DataPacket? = withContext(dispatchers.io) {
+        dbManager.currentDb.value.packetDao().getPacketByPersistedId(id.myNodeNum, id.uuid)?.data
+    }
+
+    private suspend fun getReplyParent(packetId: Int, contactKey: String) = withContext(dispatchers.io) {
+        dbManager.currentDb.value.packetDao().getPacketsByPacketIdAndContact(packetId, contactKey).singleOrNull()
+    }
+
+    private suspend fun batchGetReplyParents(ids: List<Int>, contactKey: String): Map<Int, PacketEntity> =
+        if (ids.isEmpty()) {
+            emptyMap()
+        } else {
+            withContext(dispatchers.io) {
+                val dao = dbManager.currentDb.value.packetDao()
+                ids.chunked(NodeInfoDao.MAX_BIND_PARAMS)
+                    .flatMap { dao.getPacketsByPacketIdsAndContact(it, contactKey) }
+                    .groupBy { it.packet.packetId }
+                    .mapNotNull { (packetId, candidates) -> candidates.singleOrNull()?.let { packetId to it } }
+                    .toMap()
+            }
+        }
 
     private fun memoize(getNode: suspend (String?) -> Node): suspend (String?) -> Node {
         val cache = mutableMapOf<String?, Node>()

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
@@ -52,6 +52,8 @@ import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketHandler
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PersistedPacket
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioInterfaceService
@@ -314,8 +316,8 @@ class MeshConnectionManagerImplTest {
     @Test
     fun `onRadioConfigLoaded enqueues queued packets and sets time`() = runTest(testDispatcher) {
         manager = createManager(backgroundScope)
-        val packetId = 456
-        everySuspend { packetRepository.getQueuedPackets() } returns listOf(dataPacket)
+        val packetId = PersistedPacketId(myNodeNum = 123, uuid = 456L)
+        everySuspend { packetRepository.getQueuedPackets() } returns listOf(PersistedPacket(packetId, dataPacket))
         every { workerManager.enqueueSendMessage(any()) } returns Unit
 
         manager.onRadioConfigLoaded()

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
@@ -43,6 +43,7 @@ import org.meshtastic.core.model.ContactSettings
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.model.Reaction
 import org.meshtastic.core.model.util.MeshDataMapper
 import org.meshtastic.core.repository.AdminPacketHandler
 import org.meshtastic.core.repository.MeshBeaconPrefs
@@ -194,6 +195,8 @@ class MeshDataHandlerTest {
         every { radioConfigRepository.channelSetFlow } returns MutableStateFlow(ChannelSet())
         // GeofenceMonitor collects this on init; stub it so the launched collector doesn't NPE on the test scope.
         every { packetRepository.getWaypoints() } returns emptyFlow()
+        everySuspend { packetRepository.findPacketsWithId(any()) } returns emptyList()
+        everySuspend { packetRepository.findReactionsWithId(any()) } returns emptyList()
     }
 
     @Test
@@ -583,7 +586,8 @@ class MeshDataHandlerTest {
         handler.handleReceivedData(packet, 123)
         advanceUntilIdle()
 
-        verifySuspend(exactly(0)) { packetRepository.getPacketByPacketId(any()) }
+        verifySuspend(exactly(0)) { packetRepository.findPacketsWithId(any()) }
+        verifySuspend(exactly(0)) { packetRepository.findReactionsWithId(any()) }
         verifySuspend(exactly(0)) { packetRepository.update(any(), any()) }
         verifySuspend(exactly(0)) { packetHandler.removeResponse(any(), any()) }
     }
@@ -756,6 +760,45 @@ class MeshDataHandlerTest {
         }
     }
 
+    @Test
+    fun `same packet id from a different sender is persisted`() = testScope.runTest {
+        val packet =
+            MeshPacket(
+                id = 42,
+                from = 789,
+                decoded =
+                Data(portnum = PortNum.TEXT_MESSAGE_APP, payload = "second".encodeToByteArray().toByteString()),
+            )
+        val existing =
+            DataPacket(
+                id = 42,
+                from = "!000001c8",
+                to = NodeAddress.ID_BROADCAST,
+                bytes = "first".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+            )
+        val incoming =
+            DataPacket(
+                id = 42,
+                from = "!00000315",
+                to = NodeAddress.ID_BROADCAST,
+                bytes = "second".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+            )
+        every { dataMapper.toDataPacket(packet) } returns incoming
+        everySuspend { packetRepository.findPacketsWithId(42) } returns listOf(existing)
+        everySuspend { packetRepository.getContactSettings(any()) } returns
+            ContactSettings(contactKey = "test", isMuted = true)
+        every { messageFilter.shouldFilter(any(), any()) } returns false
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend {
+            packetRepository.insert(incoming, 123, "0${NodeAddress.ID_BROADCAST}", any(), false, false)
+        }
+    }
+
     // --- Reaction handling ---
 
     @Test
@@ -788,9 +831,140 @@ class MeshDataHandlerTest {
                 456 to Node(num = 456, user = User(id = "!remote")),
                 123 to Node(num = 123, user = User(id = "!local")),
             )
+        every { nodeManager.toNodeID(456) } returns "!remote"
+        every { nodeManager.toNodeID(123) } returns "!local"
         everySuspend { packetRepository.findReactionsWithId(99) } returns emptyList()
         every { nodeManager.myNodeNum } returns MutableStateFlow(123)
-        everySuspend { packetRepository.getPacketByPacketId(42) } returns null
+        everySuspend { packetRepository.findPacketsWithId(42) } returns emptyList()
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend { packetRepository.insertReaction(any(), 123) }
+    }
+
+    @Test
+    fun `PKI reaction persists normalized channel and finds its notification parent`() = testScope.runTest {
+        val emoji = "+1"
+        val packet =
+            MeshPacket(
+                id = 99,
+                from = 456,
+                to = 123,
+                channel = 0,
+                pki_encrypted = true,
+                decoded =
+                Data(
+                    portnum = PortNum.TEXT_MESSAGE_APP,
+                    payload = emoji.encodeToByteArray().toByteString(),
+                    reply_id = 42,
+                    emoji = 1,
+                ),
+            )
+        val dataPacket =
+            DataPacket(
+                id = 99,
+                from = "!remote",
+                to = NodeAddress.ID_LOCAL,
+                bytes = emoji.encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                channel = NodeAddress.PKC_CHANNEL_INDEX,
+            )
+        val parent =
+            DataPacket(
+                id = 42,
+                from = NodeAddress.ID_LOCAL,
+                to = "!remote",
+                bytes = "parent".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                channel = NodeAddress.PKC_CHANNEL_INDEX,
+            )
+        val otherConversationParent =
+            parent.copy(to = "!other", bytes = "wrong parent".encodeToByteArray().toByteString())
+        var persistedReaction: Reaction? = null
+        every { dataMapper.toDataPacket(packet) } returns dataPacket
+        every { nodeManager.nodeDBbyNodeNum } returns
+            mapOf(
+                456 to Node(num = 456, user = User(id = "!remote", long_name = "Remote User")),
+                123 to Node(num = 123, user = User(id = NodeAddress.ID_LOCAL)),
+            )
+        every { nodeManager.toNodeID(456) } returns "!remote"
+        every { nodeManager.toNodeID(123) } returns NodeAddress.ID_LOCAL
+        every { nodeManager.myNodeNum } returns MutableStateFlow(123)
+        every { nodeManager.getNodeById("!remote") } returns
+            Node(num = 456, user = User(id = "!remote", long_name = "Remote User"))
+        everySuspend { packetRepository.findReactionsWithId(99) } returns emptyList()
+        everySuspend { packetRepository.findPacketsWithId(42) } returns listOf(otherConversationParent, parent)
+        everySuspend { packetRepository.getContactSettings("8!remote") } returns
+            ContactSettings(contactKey = "8!remote")
+        everySuspend { packetRepository.insertReaction(any(), 123) } calls
+            {
+                persistedReaction = it.args[0] as Reaction
+            }
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        assertEquals(NodeAddress.PKC_CHANNEL_INDEX, assertNotNull(persistedReaction).channel)
+        verifySuspend {
+            serviceNotifications.updateReactionNotification(
+                contactKey = "8!remote",
+                name = "Remote User",
+                emoji = emoji,
+                isBroadcast = false,
+                channelName = null,
+                isSilent = false,
+            )
+        }
+    }
+
+    @Test
+    fun `same reaction packet id from a different sender is persisted`() = testScope.runTest {
+        val emojiBytes = "ðŸ‘".encodeToByteArray()
+        val packet =
+            MeshPacket(
+                id = 99,
+                from = 456,
+                to = 123,
+                decoded =
+                Data(
+                    portnum = PortNum.TEXT_MESSAGE_APP,
+                    payload = emojiBytes.toByteString(),
+                    reply_id = 42,
+                    emoji = 1,
+                ),
+            )
+        val dataPacket =
+            DataPacket(
+                id = 99,
+                from = "!remote",
+                to = "!local",
+                bytes = emojiBytes.toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+            )
+        val existing =
+            Reaction(
+                replyId = 42,
+                user = User(id = "!other"),
+                emoji = "ðŸ‘",
+                timestamp = 1L,
+                snr = null,
+                rssi = null,
+                hopsAway = 1,
+                packetId = 99,
+            )
+        every { dataMapper.toDataPacket(packet) } returns dataPacket
+        every { nodeManager.nodeDBbyNodeNum } returns
+            mapOf(
+                456 to Node(num = 456, user = User(id = "!remote")),
+                123 to Node(num = 123, user = User(id = "!local")),
+            )
+        every { nodeManager.toNodeID(456) } returns "!remote"
+        every { nodeManager.toNodeID(123) } returns "!local"
+        every { nodeManager.myNodeNum } returns MutableStateFlow(123)
+        everySuspend { packetRepository.findReactionsWithId(99) } returns listOf(existing)
+        everySuspend { packetRepository.getReactionByPacketId(99) } returns existing
+        everySuspend { packetRepository.findPacketsWithId(42) } returns emptyList()
 
         handler.handleReceivedData(packet, 123)
         advanceUntilIdle()

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/PacketHandlerImplTest.kt
@@ -41,6 +41,8 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PersistedPacket
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.proto.Data
@@ -59,6 +61,10 @@ import kotlin.time.Duration.Companion.seconds
 
 class PacketHandlerImplTest {
 
+    companion object {
+        private val PERSISTED_ID = PersistedPacketId(myNodeNum = 123, uuid = 456L)
+    }
+
     private val packetRepository: PacketRepository = mock(MockMode.autofill)
     private val radioInterfaceService: RadioInterfaceService = mock(MockMode.autofill)
     private val meshLogRepository: MeshLogRepository = mock(MockMode.autofill)
@@ -74,6 +80,7 @@ class PacketHandlerImplTest {
     @BeforeTest
     fun setUp() {
         every { serviceRepository.connectionState } returns connectionStateFlow
+        everySuspend { packetRepository.updateOutgoingMessageStatus(any(), any()) } returns PERSISTED_ID
 
         handler =
             PacketHandlerImpl(
@@ -97,6 +104,22 @@ class PacketHandlerImplTest {
         handler.sendToRadio(toRadio)
 
         verify { radioInterfaceService.sendToRadio(any()) }
+    }
+
+    @Test
+    fun `sendToRadio updates status using the full outgoing packet identity`() = runTest(testDispatcher) {
+        val packet =
+            MeshPacket(
+                from = 0x11111111,
+                to = 0x22222222,
+                id = 123,
+                decoded = Data(portnum = PortNum.TEXT_MESSAGE_APP),
+            )
+
+        handler.sendToRadio(ToRadio(packet = packet))
+        testScheduler.runCurrent()
+
+        verifySuspend { packetRepository.updateOutgoingMessageStatus(packet, MessageStatus.ENROUTE) }
     }
 
     @Test
@@ -289,19 +312,17 @@ class PacketHandlerImplTest {
     @Test
     fun `unacked ENROUTE send times out to a retryable ERROR TIMEOUT`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
-        everySuspend { packetRepository.getPacketById(123) } returns enrouteDataPacket(123)
 
         handler.sendToRadio(ToRadio(packet = MeshPacket(id = 123)))
         testScheduler.advanceTimeBy(PacketHandlerImpl.SEND_ACK_TIMEOUT + 1.seconds)
         testScheduler.runCurrent()
 
-        verifySuspend { packetRepository.timeOutEnroutePacket(123, Routing.Error.TIMEOUT.value) }
+        verifySuspend { packetRepository.timeOutEnroutePacket(PERSISTED_ID, Routing.Error.TIMEOUT.value) }
     }
 
     @Test
     fun `the timeout never fires before its deadline`() = runTest(testDispatcher) {
         connectionStateFlow.value = ConnectionState.Connected
-        everySuspend { packetRepository.getPacketById(124) } returns enrouteDataPacket(124)
 
         handler.sendToRadio(ToRadio(packet = MeshPacket(id = 124)))
         testScheduler.advanceTimeBy(PacketHandlerImpl.SEND_ACK_TIMEOUT - 1.seconds)
@@ -313,19 +334,19 @@ class PacketHandlerImplTest {
     @Test
     fun `rearm times out a stale persisted ENROUTE packet after the reconnect grace`() = runTest(testDispatcher) {
         val stale = enrouteDataPacket(321, time = 0L)
-        everySuspend { packetRepository.getEnroutePackets() } returns listOf(stale)
+        everySuspend { packetRepository.getEnroutePackets() } returns listOf(PersistedPacket(PERSISTED_ID, stale))
 
         handler.rearmSendAckTimeouts()
         testScheduler.advanceTimeBy(PacketHandlerImpl.REARM_GRACE + 1.seconds)
         testScheduler.runCurrent()
 
-        verifySuspend { packetRepository.timeOutEnroutePacket(321, Routing.Error.TIMEOUT.value) }
+        verifySuspend { packetRepository.timeOutEnroutePacket(PERSISTED_ID, Routing.Error.TIMEOUT.value) }
     }
 
     @Test
     fun `rearm gives a fresh ENROUTE packet its full ack window`() = runTest(testDispatcher) {
         val fresh = enrouteDataPacket(322, time = nowMillis)
-        everySuspend { packetRepository.getEnroutePackets() } returns listOf(fresh)
+        everySuspend { packetRepository.getEnroutePackets() } returns listOf(PersistedPacket(PERSISTED_ID, fresh))
 
         handler.rearmSendAckTimeouts()
         testScheduler.advanceTimeBy(PacketHandlerImpl.REARM_GRACE + 1.seconds)
@@ -334,7 +355,7 @@ class PacketHandlerImplTest {
 
         testScheduler.advanceTimeBy(PacketHandlerImpl.SEND_ACK_TIMEOUT + 1.seconds)
         testScheduler.runCurrent()
-        verifySuspend { packetRepository.timeOutEnroutePacket(322, Routing.Error.TIMEOUT.value) }
+        verifySuspend { packetRepository.timeOutEnroutePacket(PERSISTED_ID, Routing.Error.TIMEOUT.value) }
     }
 
     @Test
@@ -343,8 +364,7 @@ class PacketHandlerImplTest {
         // fire on its own original deadline.
         connectionStateFlow.value = ConnectionState.Connected
         val packet = enrouteDataPacket(325, time = nowMillis)
-        everySuspend { packetRepository.getPacketById(325) } returns packet
-        everySuspend { packetRepository.getEnroutePackets() } returns listOf(packet)
+        everySuspend { packetRepository.getEnroutePackets() } returns listOf(PersistedPacket(PERSISTED_ID, packet))
 
         handler.sendToRadio(ToRadio(packet = MeshPacket(id = 325)))
         testScheduler.runCurrent()
@@ -356,6 +376,24 @@ class PacketHandlerImplTest {
         testScheduler.advanceTimeBy(PacketHandlerImpl.SEND_ACK_TIMEOUT * 2 + 1.seconds)
         testScheduler.runCurrent()
 
-        verifySuspend(exactly(1)) { packetRepository.timeOutEnroutePacket(325, Routing.Error.TIMEOUT.value) }
+        verifySuspend(exactly(1)) {
+            packetRepository.timeOutEnroutePacket(PERSISTED_ID, Routing.Error.TIMEOUT.value)
+        }
+    }
+
+    @Test
+    fun `rearm keeps independent timers for persisted rows sharing one mesh packet id`() = runTest(testDispatcher) {
+        val firstId = PersistedPacketId(myNodeNum = 123, uuid = 456L)
+        val secondId = PersistedPacketId(myNodeNum = 123, uuid = 789L)
+        val first = PersistedPacket(firstId, enrouteDataPacket(id = 326, time = 0L))
+        val second = PersistedPacket(secondId, enrouteDataPacket(id = 326, time = 0L))
+        everySuspend { packetRepository.getEnroutePackets() } returns listOf(first, second)
+
+        handler.rearmSendAckTimeouts()
+        testScheduler.advanceTimeBy(PacketHandlerImpl.REARM_GRACE + 1.seconds)
+        testScheduler.runCurrent()
+
+        verifySuspend { packetRepository.timeOutEnroutePacket(firstId, Routing.Error.TIMEOUT.value) }
+        verifySuspend { packetRepository.timeOutEnroutePacket(secondId, Routing.Error.TIMEOUT.value) }
     }
 }

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/CommonPacketRepositoryTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/CommonPacketRepositoryTest.kt
@@ -16,16 +16,34 @@
  */
 package org.meshtastic.core.data.repository
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.DataPacket
+import org.meshtastic.core.model.MessageStatus
+import org.meshtastic.core.model.Node
 import org.meshtastic.core.testing.FakeDatabaseProvider
+import org.meshtastic.proto.Data
+import org.meshtastic.proto.MeshPacket
+import org.meshtastic.proto.PortNum
+import org.meshtastic.proto.User
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 abstract class CommonPacketRepositoryTest {
 
@@ -83,4 +101,306 @@ abstract class CommonPacketRepositoryTest {
         repository.clearAllUnreadCounts()
         // No exception thrown
     }
+
+    @Test
+    fun `same mesh packet id persists as distinct durable rows`() = runTest(testDispatcher) {
+        val first =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "first".encodeToByteArray().toByteString(),
+                dataType = 1,
+                id = 77,
+                status = MessageStatus.QUEUED,
+            )
+        val second =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "second".encodeToByteArray().toByteString(),
+                dataType = 1,
+                id = 77,
+                status = MessageStatus.QUEUED,
+            )
+
+        val firstId = repository.savePacket(0, "0!aaaa0001", first, 1L)
+        val secondId = repository.savePacket(0, "0!aaaa0001", second, 2L)
+        val meshPacket =
+            MeshPacket(
+                from = 1,
+                to = 0xAAAA0001.toInt(),
+                id = 77,
+                decoded = Data(portnum = PortNum.TEXT_MESSAGE_APP),
+            )
+
+        assertNotEquals(firstId, secondId)
+        assertEquals("first", repository.getPacketByPersistedId(firstId)?.text)
+        assertEquals("second", repository.getPacketByPersistedId(secondId)?.text)
+        assertEquals(setOf(firstId, secondId), repository.getQueuedPackets().map { it.id }.toSet())
+        assertNull(repository.getPacketByPacketIdIfUnique(77))
+        assertNull(repository.updateOutgoingMessageStatus(meshPacket, MessageStatus.ENROUTE))
+        assertEquals(MessageStatus.QUEUED, repository.getPacketByPersistedId(firstId)?.status)
+        assertEquals(MessageStatus.QUEUED, repository.getPacketByPersistedId(secondId)?.status)
+
+        repository.updateMessageStatus(firstId, MessageStatus.ENROUTE)
+
+        assertEquals(firstId, repository.updateOutgoingMessageStatus(meshPacket, MessageStatus.ENROUTE))
+        assertEquals(MessageStatus.ENROUTE, repository.getPacketByPersistedId(firstId)?.status)
+        assertEquals(MessageStatus.QUEUED, repository.getPacketByPersistedId(secondId)?.status)
+    }
+
+    @Test
+    fun `queued row can be claimed for send only once`() = runTest(testDispatcher) {
+        val queued =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "claim".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 81,
+                status = MessageStatus.QUEUED,
+            )
+        val id = repository.savePacket(0, "0!aaaa0001", queued, 1L)
+
+        val firstClaim = assertNotNull(repository.claimQueuedPacket(id))
+        val secondClaim = assertNotNull(repository.claimQueuedPacket(id))
+
+        assertEquals(MessageStatus.QUEUED, firstClaim.packet.status, "first caller owns the send")
+        assertEquals(MessageStatus.ENROUTE, secondClaim.packet.status, "later caller must not send again")
+        assertEquals(MessageStatus.ENROUTE, repository.getPacketByPersistedId(id)?.status)
+    }
+
+    @Test
+    fun `concurrent UUID and legacy claims produce one send owner`() = runTest(testDispatcher) {
+        val racingRepository =
+            PacketRepositoryImpl(
+                dbProvider,
+                CoroutineDispatchers(
+                    main = testDispatcher,
+                    io = Dispatchers.Default,
+                    default = Dispatchers.Default,
+                ),
+            )
+        val queued =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "upgrade race".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 86,
+                status = MessageStatus.QUEUED,
+            )
+        val id = repository.savePacket(0, "0!aaaa0001", queued, 1L)
+        val start = CompletableDeferred<Unit>()
+        val enteredProvider = Channel<Unit>(capacity = 2)
+        val releaseProvider = CompletableDeferred<Unit>()
+        dbProvider.beforeWithDb = {
+            enteredProvider.send(Unit)
+            releaseProvider.await()
+        }
+        val stableClaim =
+            async(Dispatchers.Default) {
+                start.await()
+                racingRepository.claimQueuedPacket(id)
+            }
+        val legacyClaim =
+            async(Dispatchers.Default) {
+                start.await()
+                racingRepository.claimQueuedPacketByPacketIdIfUnique(queued.id)
+            }
+
+        start.complete(Unit)
+        repeat(2) { enteredProvider.receive() }
+        releaseProvider.complete(Unit)
+        val claims = listOf(stableClaim, legacyClaim).awaitAll().map { assertNotNull(it) }
+        dbProvider.beforeWithDb = {}
+
+        assertEquals(setOf(id), claims.map { it.id }.toSet())
+        assertEquals(1, claims.count { it.packet.status == MessageStatus.QUEUED }, "one caller owns the send")
+        assertEquals(1, claims.count { it.packet.status == MessageStatus.ENROUTE }, "one caller observes the claim")
+        assertEquals(MessageStatus.ENROUTE, racingRepository.getPacketByPersistedId(id)?.status)
+    }
+
+    @Test
+    fun `legacy claim returns exact row identity and fails closed when ambiguous`() = runTest(testDispatcher) {
+        val unique =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "unique".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 82,
+                status = MessageStatus.QUEUED,
+            )
+        val uniqueId = repository.savePacket(0, "0!aaaa0001", unique, 1L)
+
+        val claim = assertNotNull(repository.claimQueuedPacketByPacketIdIfUnique(unique.id))
+
+        assertEquals(uniqueId, claim.id)
+        assertEquals(MessageStatus.QUEUED, claim.packet.status)
+        assertEquals(MessageStatus.ENROUTE, repository.getPacketByPersistedId(uniqueId)?.status)
+
+        val colliding = unique.copy(id = 83, bytes = "first".encodeToByteArray().toByteString())
+        val firstId = repository.savePacket(0, "0!aaaa0001", colliding, 2L)
+        val secondId =
+            repository.savePacket(
+                0,
+                "0!aaaa0001",
+                colliding.copy(bytes = "second".encodeToByteArray().toByteString()),
+                3L,
+            )
+
+        assertNull(repository.claimQueuedPacketByPacketIdIfUnique(colliding.id))
+        assertEquals(MessageStatus.QUEUED, repository.getPacketByPersistedId(firstId)?.status)
+        assertEquals(MessageStatus.QUEUED, repository.getPacketByPersistedId(secondId)?.status)
+    }
+
+    @Test
+    fun `failed-send rollback is exact and preserves a racing ACK`() = runTest(testDispatcher) {
+        val packet =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "rollback".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 84,
+                status = MessageStatus.QUEUED,
+            )
+        val ackedId = repository.savePacket(0, "0!aaaa0001", packet, 1L)
+        val failedId = repository.savePacket(0, "0!aaaa0001", packet.copy(id = 85), 2L)
+        repository.claimQueuedPacket(ackedId)
+        repository.claimQueuedPacket(failedId)
+
+        repository.updateMessageStatus(ackedId, MessageStatus.DELIVERED)
+
+        assertFalse(repository.rollbackEnroutePacket(ackedId), "ACK advanced the row beyond ENROUTE")
+        assertTrue(repository.rollbackEnroutePacket(failedId), "the exact failed row is still ENROUTE")
+        assertEquals(MessageStatus.DELIVERED, repository.getPacketByPersistedId(ackedId)?.status)
+        assertEquals(MessageStatus.QUEUED, repository.getPacketByPersistedId(failedId)?.status)
+    }
+
+    @Test
+    fun `outgoing status update ignores inbound and different-port ID collisions`() = runTest(testDispatcher) {
+        val packetId = 91
+        val outgoing =
+            DataPacket(
+                from = "^local",
+                to = "!22222222",
+                bytes = "outgoing".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = packetId,
+                status = MessageStatus.QUEUED,
+            )
+        val inbound =
+            DataPacket(
+                from = "!33333333",
+                to = "!11111111",
+                bytes = "inbound".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = packetId,
+                status = MessageStatus.RECEIVED,
+            )
+        val otherPort =
+            DataPacket(
+                from = "^local",
+                to = "!22222222",
+                bytes = byteArrayOf(1).toByteString(),
+                dataType = PortNum.ADMIN_APP.value,
+                id = packetId,
+                status = MessageStatus.QUEUED,
+            )
+        val inboundId = repository.savePacket(0, "0!33333333", inbound, 1L)
+        val otherPortId = repository.savePacket(0, "0!22222222", otherPort, 2L)
+        val outgoingId = repository.savePacket(0, "0!22222222", outgoing, 3L)
+
+        val updated =
+            repository.updateOutgoingMessageStatus(
+                MeshPacket(
+                    from = 0x11111111,
+                    to = 0x22222222,
+                    id = packetId,
+                    decoded = Data(portnum = PortNum.TEXT_MESSAGE_APP),
+                ),
+                MessageStatus.ENROUTE,
+            )
+
+        assertEquals(outgoingId, updated)
+        assertEquals(MessageStatus.ENROUTE, repository.getPacketByPersistedId(outgoingId)?.status)
+        assertEquals(MessageStatus.RECEIVED, repository.getPacketByPersistedId(inboundId)?.status)
+        assertEquals(MessageStatus.QUEUED, repository.getPacketByPersistedId(otherPortId)?.status)
+    }
+
+    @Test
+    fun `reply lookups stay in the current conversation when packet IDs collide`() = runTest(testDispatcher) {
+        val contactA = "0!aaaa0001"
+        val contactB = "0!bbbb0002"
+        val parentId = 77
+        val parentB =
+            DataPacket(
+                from = "!bbbb0002",
+                to = "^local",
+                bytes = "parent B".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = parentId,
+                status = MessageStatus.RECEIVED,
+            )
+        val parentA = parentB.copy(from = "!aaaa0001", bytes = "parent A".encodeToByteArray().toByteString())
+        val replyB =
+            DataPacket(
+                from = "!bbbb0002",
+                to = "^local",
+                bytes = "reply B".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 78,
+                status = MessageStatus.RECEIVED,
+                replyId = parentId,
+            )
+        // Insert the wrong-conversation parent first so an old global LIMIT 1 lookup selects the wrong row.
+        repository.savePacket(0, contactA, parentA, 1L)
+        repository.savePacket(0, contactB, parentB, 2L)
+        repository.savePacket(0, contactB, replyB, 3L)
+
+        val messages = repository.getMessagesFrom(contactB, getNode = ::testNode).first()
+        val reply = messages.single { it.packetId == replyB.id }
+        val pagedParent =
+            dbProvider.currentDb.value.packetDao().getPacketsByPacketIdAndContact(parentId, contactB).singleOrNull()
+
+        assertEquals("parent B", reply.originalMessage?.text)
+        assertEquals("parent B", pagedParent?.packet?.data?.text)
+    }
+
+    @Test
+    fun `reply parent fails closed for same-conversation ID collisions`() = runTest(testDispatcher) {
+        val contact = "0^all"
+        val parentId = 44
+        val firstParent =
+            DataPacket(
+                from = "!aaaa0001",
+                to = "^all",
+                bytes = "first parent".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = parentId,
+                status = MessageStatus.RECEIVED,
+            )
+        val secondParent =
+            firstParent.copy(from = "!bbbb0002", bytes = "second parent".encodeToByteArray().toByteString())
+        val reply =
+            DataPacket(
+                from = "!cccc0003",
+                to = "^all",
+                bytes = "ambiguous reply".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = 45,
+                status = MessageStatus.RECEIVED,
+                replyId = parentId,
+            )
+        repository.savePacket(0, contact, firstParent, 1L)
+        repository.savePacket(0, contact, secondParent, 2L)
+        repository.savePacket(0, contact, reply, 3L)
+
+        val replyMessage =
+            repository.getMessagesFrom(contact, getNode = ::testNode).first().single { it.packetId == reply.id }
+        val pagedCandidates =
+            dbProvider.currentDb.value.packetDao().getPacketsByPacketIdAndContact(parentId, contact)
+
+        assertNull(replyMessage.originalMessage)
+        assertEquals(2, pagedCandidates.size)
+        assertNull(pagedCandidates.singleOrNull())
+    }
+
+    private fun testNode(id: String?): Node = Node(num = 0, user = User(id = id.orEmpty()))
 }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/PacketDao.kt
@@ -37,6 +37,7 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.MeshPacket
 
 @Suppress("TooManyFunctions", "LargeClass")
 @Dao
@@ -164,6 +165,9 @@ interface PacketDao {
 
     @Upsert suspend fun insert(packet: Packet)
 
+    /** Inserts a new packet row and returns its auto-generated stable database UUID. */
+    @Insert suspend fun insertAndGetId(packet: Packet): Long
+
     @Transaction
     @Query(
         """
@@ -272,6 +276,66 @@ interface PacketDao {
     }
 
     @Transaction
+    suspend fun updateMessageStatusByPersistedId(myNodeNum: Int, uuid: Long, status: MessageStatus) {
+        getPacketByPersistedId(myNodeNum, uuid)?.let { update(it.copy(data = it.data.copy(status = status))) }
+    }
+
+    /**
+     * Atomically claims one stable packet row for sending. A returned QUEUED packet means this call performed the
+     * QUEUED -> ENROUTE transition and owns the send; any other returned status means another path already handled it.
+     */
+    @Transaction
+    suspend fun claimQueuedPacket(myNodeNum: Int, uuid: Long): Packet? {
+        val packet = getPacketByPersistedId(myNodeNum, uuid) ?: return null
+        if (packet.data.status == MessageStatus.QUEUED) {
+            update(packet.copy(data = packet.data.copy(status = MessageStatus.ENROUTE)))
+        }
+        return packet
+    }
+
+    /** Legacy claim used only by pre-upgrade WorkManager jobs whose mesh packet ID still resolves to one row. */
+    @Transaction
+    suspend fun claimQueuedPacketByPacketIdIfUnique(packetId: Int): Packet? {
+        val packet = findPacketsWithId(packetId).singleOrNull() ?: return null
+        if (packet.data.status == MessageStatus.QUEUED) {
+            update(packet.copy(data = packet.data.copy(status = MessageStatus.ENROUTE)))
+        }
+        return packet
+    }
+
+    /** Rolls back a failed send only while the exact claimed row is still ENROUTE, preserving any racing ACK update. */
+    @Transaction
+    suspend fun rollbackEnroutePacket(myNodeNum: Int, uuid: Long): Boolean {
+        val packet = getPacketByPersistedId(myNodeNum, uuid)
+        val canRollback = packet?.data?.status == MessageStatus.ENROUTE
+        if (canRollback) update(packet.copy(data = packet.data.copy(status = MessageStatus.QUEUED)))
+        return canRollback
+    }
+
+    /**
+     * Updates only an unambiguous row matching the identity available on an outgoing protobuf packet. Mesh packet IDs
+     * are sender-scoped, so ID-only lookup can select an inbound packet or an unrelated command with the same ID.
+     */
+    @Transaction
+    suspend fun updateOutgoingMessageStatus(packet: MeshPacket, status: MessageStatus): Packet? {
+        val portNum = packet.decoded?.portnum?.value
+        val matches =
+            findPacketsWithId(packet.id).filter { stored ->
+                stored.data.from.matchesNodeNum(packet.from, packet.from) &&
+                    stored.data.to.matchesNodeNum(packet.to, packet.from) &&
+                    (portNum == null || stored.data.dataType == portNum)
+            }
+        val alreadyAtStatus = matches.filter { it.data.status == status }
+        val match =
+            when {
+                alreadyAtStatus.size == 1 -> alreadyAtStatus.single()
+                alreadyAtStatus.isNotEmpty() -> null
+                else -> matches.singleOrNull()
+            }
+        return match?.also { if (it.data.status != status) update(it.copy(data = it.data.copy(status = status))) }
+    }
+
+    @Transaction
     suspend fun updateMessageId(data: DataPacket, id: Int) {
         val new = data.copy(id = id)
         // Match on key fields that identify the packet
@@ -315,11 +379,44 @@ interface PacketDao {
     @Query(
         """
         SELECT * FROM packet
+        WHERE packet_id = :packetId
+        AND contact_key = :contactKey
+        AND (myNodeNum = 0 OR myNodeNum = (SELECT myNodeNum FROM my_node))
+        """,
+    )
+    suspend fun getPacketsByPacketIdAndContact(packetId: Int, contactKey: String): List<PacketEntity>
+
+    @Query(
+        """
+        SELECT * FROM packet
+        WHERE uuid = :uuid
+        AND myNodeNum = :myNodeNum
+        AND (myNodeNum = 0 OR myNodeNum = (SELECT myNodeNum FROM my_node))
+        LIMIT 1
+        """,
+    )
+    suspend fun getPacketByPersistedId(myNodeNum: Int, uuid: Long): Packet?
+
+    @Transaction
+    @Query(
+        """
+        SELECT * FROM packet
         WHERE packet_id IN (:packetIds)
         AND (myNodeNum = 0 OR myNodeNum = (SELECT myNodeNum FROM my_node))
         """,
     )
     suspend fun getPacketsByPacketIds(packetIds: List<Int>): List<PacketEntity>
+
+    @Transaction
+    @Query(
+        """
+        SELECT * FROM packet
+        WHERE packet_id IN (:packetIds)
+        AND contact_key = :contactKey
+        AND (myNodeNum = 0 OR myNodeNum = (SELECT myNodeNum FROM my_node))
+        """,
+    )
+    suspend fun getPacketsByPacketIdsAndContact(packetIds: List<Int>, contactKey: String): List<PacketEntity>
 
     @Query(
         """
@@ -350,6 +447,15 @@ interface PacketDao {
     """,
     )
     suspend fun getAllDataPackets(): List<DataPacket>
+
+    @Query(
+        """
+        SELECT * FROM packet
+        WHERE (myNodeNum = 0 OR myNodeNum = (SELECT myNodeNum FROM my_node))
+        ORDER BY received_time ASC
+        """,
+    )
+    suspend fun getAllPersistedPackets(): List<Packet>
 
     @Query(
         """
@@ -639,12 +745,13 @@ interface PacketDao {
      * @return true if a row was timed out.
      */
     @Transaction
-    suspend fun timeOutEnroutePacket(packetId: Int, routingError: Int): Boolean {
-        val enroute = findPacketsWithId(packetId).filter { it.data.status == MessageStatus.ENROUTE }
-        enroute.forEach { existing ->
+    suspend fun timeOutEnroutePacket(myNodeNum: Int, uuid: Long, routingError: Int): Boolean {
+        val existing = getPacketByPersistedId(myNodeNum, uuid)
+        val canTimeOut = existing?.data?.status == MessageStatus.ENROUTE
+        if (canTimeOut) {
             update(existing.copy(data = existing.data.copy(status = MessageStatus.ERROR), routingError = routingError))
         }
-        return enroute.isNotEmpty()
+        return canTimeOut
     }
 
     /**
@@ -805,3 +912,11 @@ interface PacketDao {
 
     // endregion
 }
+
+private fun String?.matchesNodeNum(nodeNum: Int, localNodeNum: Int): Boolean =
+    when (val address = NodeAddress.fromString(this)) {
+        NodeAddress.Broadcast -> nodeNum == NodeAddress.NODENUM_BROADCAST
+        NodeAddress.Local -> nodeNum == localNodeNum
+        is NodeAddress.ByNum -> address.num == nodeNum
+        is NodeAddress.ById -> false
+    }

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/Packet.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/Packet.kt
@@ -24,6 +24,7 @@ import androidx.room3.PrimaryKey
 import androidx.room3.Relation
 import okio.ByteString
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.model.ContactKey
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Message
 import org.meshtastic.core.model.MessageStatus
@@ -58,6 +59,7 @@ data class PacketEntity(
             emojis =
             reactions
                 .filter { it.myNodeNum == myNodeNum || it.myNodeNum == 0 }
+                .filter { it.belongsTo(packet) }
                 // myNodeNum is part of the reactions primary key, so the legacy 0 bucket can hold the same
                 // (user, emoji) as this node's. The UI keys reaction rows on that pair, so keep one — the
                 // current node's, which carries the live delivery status.
@@ -75,6 +77,33 @@ data class PacketEntity(
             showTranslated = showTranslated,
         )
     }
+}
+
+/**
+ * A reaction references its parent by mesh packet ID, which is only unique per sender. The wire format does not carry
+ * the parent's sender, but it does carry enough addressing information to keep reactions scoped to the conversation in
+ * which they were sent. Legacy rows without addressing metadata retain the historical ID-only behavior.
+ */
+@Suppress("ReturnCount")
+private fun ReactionEntity.belongsTo(packet: Packet): Boolean {
+    if (to == null || userId.isEmpty()) return true
+
+    val sender = NodeAddress.fromString(userId)
+    val recipient = NodeAddress.fromString(to)
+    val packetContact = ContactKey(packet.contact_key)
+    val isLegacyInboundPkiChannel =
+        packetContact.channel == NodeAddress.PKC_CHANNEL_INDEX &&
+            channel == 0 &&
+            status == MessageStatus.RECEIVED &&
+            recipient !is NodeAddress.Broadcast
+    if (packetContact.channel != channel && !isLegacyInboundPkiChannel) return false
+
+    val senderIsLocal =
+        status != MessageStatus.RECEIVED ||
+            sender is NodeAddress.Local ||
+            (myNodeNum != 0 && sender is NodeAddress.ByNum && sender.num == myNodeNum)
+    val reactionContact = if (recipient is NodeAddress.Broadcast || senderIsLocal) recipient else sender
+    return reactionContact == packetContact.address
 }
 
 @Suppress("ConstructorParameterNaming")

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonPacketDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonPacketDaoTest.kt
@@ -153,34 +153,32 @@ abstract class CommonPacketDaoTest {
         assertEquals(MessageStatus.DELIVERED, updatedMessages.first { it.packet.data.id == 999 }.packet.data.status)
     }
 
-    private suspend fun insertSentPacket(packetId: Int, status: MessageStatus) {
-        packetDao.insert(
-            Packet(
-                uuid = 0L,
-                myNodeNum = myNodeNum,
-                port_num = PortNum.TEXT_MESSAGE_APP.value,
-                contact_key = "sent",
-                received_time = nowMillis,
-                read = true,
-                packetId = packetId,
-                data =
-                DataPacket(
-                    to = NodeAddress.ID_BROADCAST,
-                    bytes = "Sent".encodeToByteArray().toByteString(),
-                    dataType = PortNum.TEXT_MESSAGE_APP.value,
-                    id = packetId,
-                    status = status,
-                ),
+    private suspend fun insertSentPacket(packetId: Int, status: MessageStatus): Long = packetDao.insertAndGetId(
+        Packet(
+            uuid = 0L,
+            myNodeNum = myNodeNum,
+            port_num = PortNum.TEXT_MESSAGE_APP.value,
+            contact_key = "sent",
+            received_time = nowMillis,
+            read = true,
+            packetId = packetId,
+            data =
+            DataPacket(
+                to = NodeAddress.ID_BROADCAST,
+                bytes = "Sent".encodeToByteArray().toByteString(),
+                dataType = PortNum.TEXT_MESSAGE_APP.value,
+                id = packetId,
+                status = status,
             ),
-        )
-    }
+        ),
+    )
 
     @Test
     fun timeOutEnroutePacketFailsOnlyStillEnroutePackets() = runTest {
         createDb()
-        insertSentPacket(packetId = 8001, status = MessageStatus.ENROUTE)
+        val uuid = insertSentPacket(packetId = 8001, status = MessageStatus.ENROUTE)
 
-        assertTrue(packetDao.timeOutEnroutePacket(8001, TIMEOUT_ROUTING_ERROR))
+        assertTrue(packetDao.timeOutEnroutePacket(myNodeNum, uuid, TIMEOUT_ROUTING_ERROR))
 
         val timedOut = packetDao.getPacketByPacketId(8001)
         assertNotNull(timedOut)
@@ -193,13 +191,25 @@ abstract class CommonPacketDaoTest {
         createDb()
         // The ACK that resolved this packet landed while a send-ack timeout was pending; the timeout must not
         // overwrite the delivered status it sampled before the ACK arrived.
-        insertSentPacket(packetId = 8002, status = MessageStatus.DELIVERED)
+        val uuid = insertSentPacket(packetId = 8002, status = MessageStatus.DELIVERED)
 
-        assertFalse(packetDao.timeOutEnroutePacket(8002, TIMEOUT_ROUTING_ERROR))
+        assertFalse(packetDao.timeOutEnroutePacket(myNodeNum, uuid, TIMEOUT_ROUTING_ERROR))
 
         val untouched = packetDao.getPacketByPacketId(8002)
         assertNotNull(untouched)
         assertEquals(MessageStatus.DELIVERED, untouched.packet.data.status)
+    }
+
+    @Test
+    fun timeOutEnroutePacketTargetsOnlyOnePersistedRowWhenMeshIdsCollide() = runTest {
+        createDb()
+        val firstUuid = insertSentPacket(packetId = 8003, status = MessageStatus.ENROUTE)
+        val secondUuid = insertSentPacket(packetId = 8003, status = MessageStatus.ENROUTE)
+
+        assertTrue(packetDao.timeOutEnroutePacket(myNodeNum, firstUuid, TIMEOUT_ROUTING_ERROR))
+
+        assertEquals(MessageStatus.ERROR, packetDao.getPacketByPersistedId(myNodeNum, firstUuid)?.data?.status)
+        assertEquals(MessageStatus.ENROUTE, packetDao.getPacketByPersistedId(myNodeNum, secondUuid)?.data?.status)
     }
 
     @Test

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/entity/ReactionKeyTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/entity/ReactionKeyTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.Node
+import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.proto.User
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -98,13 +99,87 @@ class ReactionKeyTest {
         assertEquals(emptyList(), entity.toMessage(getNode).emojis)
     }
 
-    private fun packetEntity(reactions: List<ReactionEntity>) = PacketEntity(
+    @Test
+    fun `same reply id reaction attaches only to its conversation`() = runTest {
+        val reaction =
+            reaction(
+                myNodeNum = MY_NODE_NUM,
+                userId = "!bbbb0002",
+                emoji = "ðŸ‘",
+                status = MessageStatus.RECEIVED,
+                to = "!0000002a",
+            )
+        val collidingParent = packetEntity(reactions = listOf(reaction), contactKey = "0!aaaa0001")
+        val intendedParent = packetEntity(reactions = listOf(reaction), contactKey = "0!bbbb0002")
+
+        assertEquals(emptyList(), collidingParent.toMessage(getNode).emojis)
+        assertEquals(listOf("ðŸ‘"), intendedParent.toMessage(getNode).emojis.map { it.emoji })
+    }
+
+    @Test
+    fun `normalized inbound PKI reaction attaches to its direct-message parent`() = runTest {
+        val reaction =
+            reaction(
+                myNodeNum = MY_NODE_NUM,
+                userId = "!bbbb0002",
+                emoji = "PKI",
+                status = MessageStatus.RECEIVED,
+                to = "!0000002a",
+                channel = NodeAddress.PKC_CHANNEL_INDEX,
+            )
+
+        val intendedMessage = packetEntity(listOf(reaction), contactKey = "8!bbbb0002").toMessage(getNode)
+        val otherConversation = packetEntity(listOf(reaction), contactKey = "8!aaaa0001").toMessage(getNode)
+        val otherChannel = packetEntity(listOf(reaction), contactKey = "7!bbbb0002").toMessage(getNode)
+
+        assertEquals(listOf("PKI"), intendedMessage.emojis.map { it.emoji })
+        assertEquals(emptyList(), otherConversation.emojis)
+        assertEquals(emptyList(), otherChannel.emojis)
+    }
+
+    @Test
+    fun `pre-fix raw-channel inbound PKI reaction remains visible`() = runTest {
+        val legacyReaction =
+            reaction(
+                myNodeNum = MY_NODE_NUM,
+                userId = "!bbbb0002",
+                emoji = "legacy PKI",
+                status = MessageStatus.RECEIVED,
+                to = "!0000002a",
+                channel = 0,
+            )
+
+        val intendedMessage = packetEntity(listOf(legacyReaction), contactKey = "8!bbbb0002").toMessage(getNode)
+        val otherConversation = packetEntity(listOf(legacyReaction), contactKey = "8!aaaa0001").toMessage(getNode)
+
+        assertEquals(listOf("legacy PKI"), intendedMessage.emojis.map { it.emoji })
+        assertEquals(emptyList(), otherConversation.emojis)
+    }
+
+    @Test
+    fun `wrong non-PKI reaction channel remains excluded`() = runTest {
+        val reaction =
+            reaction(
+                myNodeNum = MY_NODE_NUM,
+                userId = "!bbbb0002",
+                emoji = "wrong channel",
+                status = MessageStatus.RECEIVED,
+                to = "!0000002a",
+                channel = 1,
+            )
+
+        val message = packetEntity(listOf(reaction), contactKey = "8!bbbb0002").toMessage(getNode)
+
+        assertEquals(emptyList(), message.emojis)
+    }
+
+    private fun packetEntity(reactions: List<ReactionEntity>, contactKey: String = "0^all") = PacketEntity(
         packet =
         Packet(
             uuid = 1L,
             myNodeNum = MY_NODE_NUM,
             port_num = 1,
-            contact_key = "0^all",
+            contact_key = contactKey,
             received_time = 1_000L,
             read = true,
             data = DataPacket(bytes = null, dataType = 1, from = "!abcd1234", time = 1_000L),
@@ -113,16 +188,24 @@ class ReactionKeyTest {
         reactions = reactions,
     )
 
-    private fun reaction(myNodeNum: Int, userId: String, emoji: String, status: MessageStatus = MessageStatus.UNKNOWN) =
-        ReactionEntity(
-            myNodeNum = myNodeNum,
-            replyId = PACKET_ID,
-            userId = userId,
-            emoji = emoji,
-            timestamp = 1_000L,
-            packetId = PACKET_ID,
-            status = status,
-        )
+    private fun reaction(
+        myNodeNum: Int,
+        userId: String,
+        emoji: String,
+        status: MessageStatus = MessageStatus.UNKNOWN,
+        to: String? = null,
+        channel: Int = 0,
+    ) = ReactionEntity(
+        myNodeNum = myNodeNum,
+        replyId = PACKET_ID,
+        userId = userId,
+        emoji = emoji,
+        timestamp = 1_000L,
+        packetId = PACKET_ID,
+        status = status,
+        to = to,
+        channel = channel,
+    )
 
     private val getNode: suspend (String?) -> Node = { userId -> Node(num = 1, user = User(id = userId.orEmpty())) }
 

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshWorkerManager.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshWorkerManager.kt
@@ -19,5 +19,5 @@ package org.meshtastic.core.repository
 /** Interface for managing background workers for mesh-related tasks. */
 interface MeshWorkerManager {
     /** Enqueues a worker to send a specific packet. */
-    fun enqueueSendMessage(packetId: Int)
+    fun enqueueSendMessage(persistedId: PersistedPacketId)
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MessageQueue.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MessageQueue.kt
@@ -21,5 +21,5 @@ package org.meshtastic.core.repository
  * transmission without depending on Android-specific WorkManager.
  */
 interface MessageQueue {
-    suspend fun enqueue(packetId: Int)
+    suspend fun enqueue(persistedId: PersistedPacketId)
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketRepository.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PacketRepository.kt
@@ -25,6 +25,13 @@ import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.Reaction
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.MeshPacket
+
+/** Stable identity of one persisted packet row within its owning node database. */
+data class PersistedPacketId(val myNodeNum: Int, val uuid: Long)
+
+/** A persisted packet paired with the stable row identity needed by durable background work. */
+data class PersistedPacket(val id: PersistedPacketId, val packet: DataPacket)
 
 /**
  * Repository interface for managing mesh packets and message history.
@@ -70,11 +77,11 @@ interface PacketRepository {
     /** Updates the identifier of the last read message in a conversation. */
     suspend fun updateLastReadMessage(contact: String, messageUuid: Long, lastReadTimestamp: Long)
 
-    /** Returns all packets currently queued for transmission. */
-    suspend fun getQueuedPackets(): List<DataPacket>
+    /** Returns all packets currently queued for transmission, including their stable persisted-row identities. */
+    suspend fun getQueuedPackets(): List<PersistedPacket>
 
-    /** Returns all sent packets still awaiting a routing ACK/NAK (status [MessageStatus.ENROUTE]). */
-    suspend fun getEnroutePackets(): List<DataPacket>
+    /** Returns all sent packets still awaiting a routing ACK/NAK, including stable persisted-row identities. */
+    suspend fun getEnroutePackets(): List<PersistedPacket>
 
     /**
      * Atomically marks a still-[MessageStatus.ENROUTE] packet as failed with [routingError], leaving it untouched if an
@@ -82,7 +89,7 @@ interface PacketRepository {
      *
      * @return true if the packet was timed out.
      */
-    suspend fun timeOutEnroutePacket(packetId: Int, routingError: Int): Boolean
+    suspend fun timeOutEnroutePacket(id: PersistedPacketId, routingError: Int): Boolean
 
     /**
      * Persists a packet in the database.
@@ -101,7 +108,7 @@ interface PacketRepository {
         receivedTime: Long,
         read: Boolean = true,
         filtered: Boolean = false,
-    )
+    ): PersistedPacketId
 
     /**
      * Returns a reactive flow of messages for a conversation.
@@ -130,6 +137,28 @@ interface PacketRepository {
 
     /** Updates the transmission status of a packet. */
     suspend fun updateMessageStatus(d: DataPacket, m: MessageStatus)
+
+    /** Updates exactly one persisted packet row without relying on its mesh packet ID. */
+    suspend fun updateMessageStatus(id: PersistedPacketId, status: MessageStatus)
+
+    /**
+     * Atomically claims a stable row for sending. A returned packet with QUEUED status is owned by this caller and has
+     * already been persisted as ENROUTE; another status means the row was already handled.
+     */
+    suspend fun claimQueuedPacket(id: PersistedPacketId): PersistedPacket?
+
+    /** Legacy equivalent of [claimQueuedPacket], available only when the mesh packet ID identifies exactly one row. */
+    suspend fun claimQueuedPacketByPacketIdIfUnique(packetId: Int): PersistedPacket?
+
+    /** Restores the exact row to QUEUED only if it is still ENROUTE, without overwriting a racing ACK/NAK status. */
+    suspend fun rollbackEnroutePacket(id: PersistedPacketId): Boolean
+
+    /**
+     * Updates the single persisted row matching an outgoing mesh packet and returns its stable identity. Returns null
+     * when the row has not been persisted yet or when the mesh identity is ambiguous, so callers can retry without
+     * updating the wrong packet.
+     */
+    suspend fun updateOutgoingMessageStatus(packet: MeshPacket, status: MessageStatus): PersistedPacketId?
 
     /** Updates the identifier of a persisted packet. */
     suspend fun updateMessageId(d: DataPacket, id: Int)
@@ -178,6 +207,12 @@ interface PacketRepository {
 
     /** Returns a packet by its mesh-layer packet ID. */
     suspend fun getPacketByPacketId(packetId: Int): DataPacket?
+
+    /** Returns a packet by mesh-layer ID only when exactly one row has that ID in the current node database. */
+    suspend fun getPacketByPacketIdIfUnique(packetId: Int): DataPacket?
+
+    /** Returns exactly one persisted packet row by its node-scoped database identity. */
+    suspend fun getPacketByPersistedId(id: PersistedPacketId): DataPacket?
 
     /** Returns a packet by its internal database ID. */
     suspend fun getPacketById(id: Int): DataPacket?

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCase.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCase.kt
@@ -123,15 +123,16 @@ class SendMessageUseCaseImpl(
 
         try {
             // Write to the DB to immediately reflect the queued state on the UI
-            packetRepository.savePacket(
-                myNodeNum = ourNode?.num ?: 0,
-                contactKey = contactKey,
-                packet = packet,
-                receivedTime = nowMillis,
-            )
+            val persistedId =
+                packetRepository.savePacket(
+                    myNodeNum = ourNode?.num ?: 0,
+                    contactKey = contactKey,
+                    packet = packet,
+                    receivedTime = nowMillis,
+                )
 
             // Enqueue for durable transmission via the platform-specific queue
-            messageQueue.enqueue(packetId)
+            messageQueue.enqueue(persistedId)
             // Reported here rather than at transmission: the queue worker can run long after the RUM
             // session ended, and re-runs the send on retry.
             analytics.trackAction(

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCaseTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCaseTest.kt
@@ -17,14 +17,19 @@
 package org.meshtastic.core.repository.usecase
 
 import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verifySuspend
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.repository.MessageQueue
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.testing.FakeAppPreferences
 import org.meshtastic.core.testing.FakeNodeRepository
@@ -53,6 +58,9 @@ class SendMessageUseCaseTest {
         appPreferences = FakeAppPreferences()
         messageQueue = mock(MockMode.autofill)
         analytics = mock(MockMode.autofill)
+        everySuspend { packetRepository.savePacket(any(), any(), any(), any(), any(), any()) } returns
+            PersistedPacketId(myNodeNum = 1, uuid = 10L)
+        everySuspend { messageQueue.enqueue(any()) } returns Unit
 
         useCase =
             SendMessageUseCaseImpl(
@@ -92,6 +100,16 @@ class SendMessageUseCaseTest {
 
         // Assert
         verify { analytics.trackAction("message_send", mapOf("num_bytes" to 5, "is_reply" to false)) }
+    }
+
+    @Test
+    fun `invoke queues the stable id returned by persistence`() = runTest {
+        val persistedId = PersistedPacketId(myNodeNum = 42, uuid = 9001L)
+        everySuspend { packetRepository.savePacket(any(), any(), any(), any(), any(), any()) } returns persistedId
+
+        useCase("persisted identity", "0${NodeAddress.ID_BROADCAST}", null)
+
+        verifySuspend { messageQueue.enqueue(persistedId) }
     }
 
     @Test

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidMeshWorkerManagerTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidMeshWorkerManagerTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.service
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker
+import androidx.work.WorkManager
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import kotlinx.coroutines.awaitCancellation
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.meshtastic.core.repository.PersistedPacketId
+import org.meshtastic.core.service.worker.SendMessageWorker
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AndroidMeshWorkerManagerTest {
+
+    @Test
+    fun `repeated persisted row scheduling keeps the active unique worker`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val configuration =
+            Configuration.Builder()
+                .setExecutor(SynchronousExecutor())
+                .setWorkerFactory(BlockingWorkerFactory())
+                .setMinimumLoggingLevel(android.util.Log.DEBUG)
+                .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, configuration)
+        val workManager = WorkManager.getInstance(context)
+        val persistedId = PersistedPacketId(myNodeNum = 42, uuid = 99L)
+        val manager = AndroidMeshWorkerManager(workManager)
+
+        manager.enqueueSendMessage(persistedId)
+        val first = workManager.getWorkInfosForUniqueWork(workName(persistedId)).get().single()
+        manager.enqueueSendMessage(persistedId)
+        val retained = workManager.getWorkInfosForUniqueWork(workName(persistedId)).get().single()
+
+        assertFalse(first.state.isFinished, "The first request must remain active for KEEP to apply")
+        assertEquals(first.id, retained.id, "KEEP must retain the active work request instead of replacing it")
+        workManager.cancelUniqueWork(workName(persistedId)).result.get()
+    }
+
+    private fun workName(id: PersistedPacketId) = "${SendMessageWorker.WORK_NAME_PREFIX}${id.myNodeNum}_${id.uuid}"
+
+    private class BlockingWorkerFactory : WorkerFactory() {
+        override fun createWorker(
+            appContext: Context,
+            workerClassName: String,
+            workerParameters: WorkerParameters,
+        ): ListenableWorker? = if (workerClassName == SendMessageWorker::class.java.name) {
+            BlockingWorker(appContext, workerParameters)
+        } else {
+            null
+        }
+    }
+
+    private class BlockingWorker(appContext: Context, workerParameters: WorkerParameters) :
+        CoroutineWorker(appContext, workerParameters) {
+        override suspend fun doWork(): Result = awaitCancellation()
+    }
+}

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/SendMessageWorkerTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/SendMessageWorkerTest.kt
@@ -29,6 +29,8 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
 import okio.ByteString.Companion.toByteString
 import org.junit.Before
@@ -38,6 +40,8 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PersistedPacket
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.core.service.worker.SendMessageWorker
 import org.meshtastic.core.testing.FakeRadioController
 import org.robolectric.RobolectricTestRunner
@@ -63,14 +67,24 @@ class SendMessageWorkerTest {
     @Test
     fun `doWork returns success when packet is sent successfully`() = runTest {
         // Arrange
-        val packetId = 12345
-        val dataPacket = DataPacket(to = "dest", bytes = "Hello".encodeToByteArray().toByteString(), dataType = 0)
-        everySuspend { packetRepository.getPacketByPacketId(packetId) } returns dataPacket
-        everySuspend { packetRepository.updateMessageStatus(any(), any()) } returns Unit
+        val packetId = PersistedPacketId(myNodeNum = 123, uuid = 12345L)
+        val dataPacket =
+            DataPacket(
+                to = "dest",
+                bytes = "Hello".encodeToByteArray().toByteString(),
+                dataType = 0,
+                status = MessageStatus.QUEUED,
+            )
+        everySuspend { packetRepository.claimQueuedPacket(packetId) } returns PersistedPacket(packetId, dataPacket)
 
         val worker =
             TestListenableWorkerBuilder<SendMessageWorker>(context)
-                .setInputData(workDataOf(SendMessageWorker.KEY_PACKET_ID to packetId))
+                .setInputData(
+                    workDataOf(
+                        SendMessageWorker.KEY_PACKET_UUID to packetId.uuid,
+                        SendMessageWorker.KEY_MY_NODE_NUM to packetId.myNodeNum,
+                    ),
+                )
                 .setWorkerFactory(
                     object : androidx.work.WorkerFactory() {
                         override fun createWorker(
@@ -89,20 +103,24 @@ class SendMessageWorkerTest {
         // Assert
         assertEquals(ListenableWorker.Result.success(), result)
         assertEquals(listOf(dataPacket), radioController.sentPackets)
-        verifySuspend { packetRepository.updateMessageStatus(dataPacket, MessageStatus.ENROUTE) }
+        verifySuspend { packetRepository.claimQueuedPacket(packetId) }
+        verifySuspend(mode = VerifyMode.exactly(0)) { packetRepository.rollbackEnroutePacket(any()) }
     }
 
     @Test
     fun `doWork returns retry when radio is disconnected`() = runTest {
         // Arrange
-        val packetId = 12345
-        val dataPacket = DataPacket(to = "dest", bytes = "Hello".encodeToByteArray().toByteString(), dataType = 0)
-        everySuspend { packetRepository.getPacketByPacketId(packetId) } returns dataPacket
+        val packetId = PersistedPacketId(myNodeNum = 123, uuid = 12345L)
         radioController.setConnectionState(ConnectionState.Disconnected)
 
         val worker =
             TestListenableWorkerBuilder<SendMessageWorker>(context)
-                .setInputData(workDataOf(SendMessageWorker.KEY_PACKET_ID to packetId))
+                .setInputData(
+                    workDataOf(
+                        SendMessageWorker.KEY_PACKET_UUID to packetId.uuid,
+                        SendMessageWorker.KEY_MY_NODE_NUM to packetId.myNodeNum,
+                    ),
+                )
                 .setWorkerFactory(
                     object : androidx.work.WorkerFactory() {
                         override fun createWorker(
@@ -121,7 +139,7 @@ class SendMessageWorkerTest {
         // Assert
         assertEquals(ListenableWorker.Result.retry(), result)
         assertEquals(emptyList<DataPacket>(), radioController.sentPackets)
-        verifySuspend(mode = VerifyMode.exactly(0)) { packetRepository.updateMessageStatus(any(), any()) }
+        verifySuspend(mode = VerifyMode.exactly(0)) { packetRepository.claimQueuedPacket(any()) }
     }
 
     @Test
@@ -143,20 +161,31 @@ class SendMessageWorkerTest {
         val result = worker.doWork()
 
         assertEquals(ListenableWorker.Result.failure(), result)
-        verifySuspend(mode = VerifyMode.exactly(0)) { packetRepository.getPacketByPacketId(any()) }
+        verifySuspend(mode = VerifyMode.exactly(0)) { packetRepository.claimQueuedPacket(any()) }
     }
 
     @Test
     fun `doWork returns retry and marks queued when send throws`() = runTest {
-        val packetId = 12345
-        val dataPacket = DataPacket(to = "dest", bytes = "Hello".encodeToByteArray().toByteString(), dataType = 0)
-        everySuspend { packetRepository.getPacketByPacketId(packetId) } returns dataPacket
-        everySuspend { packetRepository.updateMessageStatus(any(), any()) } returns Unit
+        val packetId = PersistedPacketId(myNodeNum = 123, uuid = 12345L)
+        val dataPacket =
+            DataPacket(
+                to = "dest",
+                bytes = "Hello".encodeToByteArray().toByteString(),
+                dataType = 0,
+                status = MessageStatus.QUEUED,
+            )
+        everySuspend { packetRepository.claimQueuedPacket(packetId) } returns PersistedPacket(packetId, dataPacket)
+        everySuspend { packetRepository.rollbackEnroutePacket(packetId) } returns true
         radioController.throwOnSend = true
 
         val worker =
             TestListenableWorkerBuilder<SendMessageWorker>(context)
-                .setInputData(workDataOf(SendMessageWorker.KEY_PACKET_ID to packetId))
+                .setInputData(
+                    workDataOf(
+                        SendMessageWorker.KEY_PACKET_UUID to packetId.uuid,
+                        SendMessageWorker.KEY_MY_NODE_NUM to packetId.myNodeNum,
+                    ),
+                )
                 .setWorkerFactory(
                     object : androidx.work.WorkerFactory() {
                         override fun createWorker(
@@ -172,6 +201,156 @@ class SendMessageWorkerTest {
         val result = worker.doWork()
 
         assertEquals(ListenableWorker.Result.retry(), result)
-        verifySuspend { packetRepository.updateMessageStatus(dataPacket, MessageStatus.QUEUED) }
+        verifySuspend { packetRepository.rollbackEnroutePacket(packetId) }
     }
+
+    @Test
+    fun `two queued rows with the same mesh packet id both survive and send`() = runTest {
+        val firstId = PersistedPacketId(myNodeNum = 123, uuid = 1L)
+        val secondId = PersistedPacketId(myNodeNum = 123, uuid = 2L)
+        val first =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "first".encodeToByteArray().toByteString(),
+                dataType = 1,
+                id = 77,
+                status = MessageStatus.QUEUED,
+            )
+        val second =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "second".encodeToByteArray().toByteString(),
+                dataType = 1,
+                id = 77,
+                status = MessageStatus.QUEUED,
+            )
+        everySuspend { packetRepository.claimQueuedPacket(firstId) } returns PersistedPacket(firstId, first)
+        everySuspend { packetRepository.claimQueuedPacket(secondId) } returns PersistedPacket(secondId, second)
+
+        val firstResult = worker(packetRepository, firstId).doWork()
+        val secondResult = worker(packetRepository, secondId).doWork()
+
+        assertEquals(ListenableWorker.Result.success(), firstResult)
+        assertEquals(ListenableWorker.Result.success(), secondResult)
+        assertEquals(listOf("first", "second"), radioController.sentPackets.map { it.text })
+        verifySuspend { packetRepository.claimQueuedPacket(firstId) }
+        verifySuspend { packetRepository.claimQueuedPacket(secondId) }
+    }
+
+    @Test
+    fun `a stalled radio send does not block an unrelated claimed row`() = runTest {
+        val stalledId = PersistedPacketId(myNodeNum = 123, uuid = 1L)
+        val otherId = PersistedPacketId(myNodeNum = 123, uuid = 2L)
+        val stalled =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "stalled".encodeToByteArray().toByteString(),
+                dataType = 1,
+                status = MessageStatus.QUEUED,
+            )
+        val other =
+            DataPacket(
+                to = "!bbbb0002",
+                bytes = "other".encodeToByteArray().toByteString(),
+                dataType = 1,
+                status = MessageStatus.QUEUED,
+            )
+        everySuspend { packetRepository.claimQueuedPacket(stalledId) } returns PersistedPacket(stalledId, stalled)
+        everySuspend { packetRepository.claimQueuedPacket(otherId) } returns PersistedPacket(otherId, other)
+        val stalledSendStarted = CompletableDeferred<Unit>()
+        val releaseStalledSend = CompletableDeferred<Unit>()
+        radioController.onSendMessage = { packet ->
+            if (packet.text == "stalled") {
+                stalledSendStarted.complete(Unit)
+                releaseStalledSend.await()
+            }
+        }
+
+        val stalledResult = async { worker(packetRepository, stalledId).doWork() }
+        stalledSendStarted.await()
+
+        val otherResult = worker(packetRepository, otherId).doWork()
+
+        assertEquals(ListenableWorker.Result.success(), otherResult)
+        assertEquals(listOf("other"), radioController.sentPackets.map { it.text })
+        releaseStalledSend.complete(Unit)
+        assertEquals(ListenableWorker.Result.success(), stalledResult.await())
+        assertEquals(setOf("stalled", "other"), radioController.sentPackets.mapNotNull { it.text }.toSet())
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `legacy and UUID jobs coexist without duplicate send`() = runTest {
+        val meshPacketId = 77
+        val persistedId = PersistedPacketId(myNodeNum = 123, uuid = 9L)
+        val queued =
+            DataPacket(
+                to = "!aaaa0001",
+                bytes = "upgrade".encodeToByteArray().toByteString(),
+                dataType = 1,
+                id = meshPacketId,
+                status = MessageStatus.QUEUED,
+            )
+        everySuspend { packetRepository.claimQueuedPacketByPacketIdIfUnique(meshPacketId) } returns
+            PersistedPacket(persistedId, queued)
+
+        val legacyResult = legacyWorker(packetRepository, meshPacketId).doWork()
+
+        everySuspend { packetRepository.claimQueuedPacket(persistedId) } returns
+            PersistedPacket(persistedId, queued.copy(status = MessageStatus.ENROUTE))
+        val stableResult = worker(packetRepository, persistedId).doWork()
+
+        assertEquals(ListenableWorker.Result.success(), legacyResult)
+        assertEquals(ListenableWorker.Result.success(), stableResult)
+        assertEquals(listOf("upgrade"), radioController.sentPackets.map { it.text })
+        verifySuspend { packetRepository.claimQueuedPacketByPacketIdIfUnique(meshPacketId) }
+        verifySuspend { packetRepository.claimQueuedPacket(persistedId) }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `legacy job fails without sending when packet id is ambiguous`() = runTest {
+        val meshPacketId = 77
+        everySuspend { packetRepository.claimQueuedPacketByPacketIdIfUnique(meshPacketId) } returns null
+
+        val result = legacyWorker(packetRepository, meshPacketId).doWork()
+
+        assertEquals(ListenableWorker.Result.failure(), result)
+        assertEquals(emptyList<DataPacket>(), radioController.sentPackets)
+        verifySuspend(mode = VerifyMode.exactly(0)) { packetRepository.rollbackEnroutePacket(any()) }
+    }
+
+    private fun worker(repository: PacketRepository, persistedId: PersistedPacketId): SendMessageWorker =
+        TestListenableWorkerBuilder<SendMessageWorker>(context)
+            .setInputData(
+                workDataOf(
+                    SendMessageWorker.KEY_PACKET_UUID to persistedId.uuid,
+                    SendMessageWorker.KEY_MY_NODE_NUM to persistedId.myNodeNum,
+                ),
+            )
+            .setWorkerFactory(
+                object : androidx.work.WorkerFactory() {
+                    override fun createWorker(
+                        appContext: Context,
+                        workerClassName: String,
+                        workerParameters: WorkerParameters,
+                    ): ListenableWorker? = SendMessageWorker(appContext, workerParameters, repository, radioController)
+                },
+            )
+            .build()
+
+    @Suppress("DEPRECATION")
+    private fun legacyWorker(repository: PacketRepository, packetId: Int): SendMessageWorker =
+        TestListenableWorkerBuilder<SendMessageWorker>(context)
+            .setInputData(workDataOf(SendMessageWorker.KEY_PACKET_ID to packetId))
+            .setWorkerFactory(
+                object : androidx.work.WorkerFactory() {
+                    override fun createWorker(
+                        appContext: Context,
+                        workerClassName: String,
+                        workerParameters: WorkerParameters,
+                    ): ListenableWorker? = SendMessageWorker(appContext, workerParameters, repository, radioController)
+                },
+            )
+            .build()
 }

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidMeshWorkerManager.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidMeshWorkerManager.kt
@@ -22,19 +22,28 @@ import androidx.work.WorkManager
 import androidx.work.workDataOf
 import org.koin.core.annotation.Single
 import org.meshtastic.core.repository.MeshWorkerManager
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.core.service.worker.SendMessageWorker
 
 @Single
 class AndroidMeshWorkerManager(private val workManager: WorkManager) : MeshWorkerManager {
-    override fun enqueueSendMessage(packetId: Int) {
+    override fun enqueueSendMessage(persistedId: PersistedPacketId) {
         val workRequest =
             OneTimeWorkRequestBuilder<SendMessageWorker>()
-                .setInputData(workDataOf(SendMessageWorker.KEY_PACKET_ID to packetId))
+                .setInputData(
+                    workDataOf(
+                        SendMessageWorker.KEY_PACKET_UUID to persistedId.uuid,
+                        SendMessageWorker.KEY_MY_NODE_NUM to persistedId.myNodeNum,
+                    ),
+                )
                 .build()
 
+        // This UUID name does not replace a persisted legacy `send_message_<packetId>` job. Both can briefly coexist
+        // after upgrade, but their transactional row claim allows only one send owner. KEEP also prevents repeated
+        // scheduling of this exact row from cancelling an active worker after it has handed the packet to the radio.
         workManager.enqueueUniqueWork(
-            "${SendMessageWorker.WORK_NAME_PREFIX}$packetId",
-            ExistingWorkPolicy.REPLACE,
+            "${SendMessageWorker.WORK_NAME_PREFIX}${persistedId.myNodeNum}_${persistedId.uuid}",
+            ExistingWorkPolicy.KEEP,
             workRequest,
         )
     }

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/worker/SendMessageWorker.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/worker/SendMessageWorker.kt
@@ -19,10 +19,13 @@ package org.meshtastic.core.service.worker
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import kotlinx.coroutines.CancellationException
 import org.koin.android.annotation.KoinWorker
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PersistedPacket
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.core.repository.RadioController
 
 @KoinWorker
@@ -35,30 +38,47 @@ class SendMessageWorker(
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException", "ReturnCount")
     override suspend fun doWork(): Result {
-        val packetId = inputData.getInt(KEY_PACKET_ID, 0)
-        if (packetId == 0) return Result.failure()
+        val packetUuid = inputData.getLong(KEY_PACKET_UUID, 0L)
+        val myNodeNum = inputData.getInt(KEY_MY_NODE_NUM, 0)
+        val persistedId = packetUuid.takeIf { it > 0L }?.let { PersistedPacketId(myNodeNum = myNodeNum, uuid = it) }
+
+        @Suppress("DEPRECATION")
+        val legacyPacketId = if (persistedId == null) inputData.getInt(KEY_PACKET_ID, 0) else 0
+        if (persistedId == null && legacyPacketId == 0) return Result.failure()
 
         // Verify we are connected before attempting to send to avoid unnecessary Exception bubbling
         if (radioController.connectionState.value != ConnectionState.Connected) {
             return Result.retry()
         }
 
-        val packetData =
-            packetRepository.getPacketByPacketId(packetId)
-                ?: return Result.failure() // Packet no longer exists in DB? Do not retry.
+        val claimed = claimPacket(persistedId, legacyPacketId) ?: return Result.failure()
+        // The DAO returns the pre-transition packet only to the caller that atomically claimed QUEUED -> ENROUTE.
+        if (claimed.packet.status != MessageStatus.QUEUED) return Result.success()
 
         return try {
-            radioController.sendMessage(packetData)
-            packetRepository.updateMessageStatus(packetData, MessageStatus.ENROUTE)
+            radioController.sendMessage(claimed.packet)
             Result.success()
         } catch (e: Exception) {
-            packetRepository.updateMessageStatus(packetData, MessageStatus.QUEUED)
+            packetRepository.rollbackEnroutePacket(claimed.id)
+            if (e is CancellationException) throw e
             Result.retry()
         }
     }
 
+    private suspend fun claimPacket(id: PersistedPacketId?, legacyPacketId: Int): PersistedPacket? = if (id != null) {
+        packetRepository.claimQueuedPacket(id)
+    } else {
+        packetRepository.claimQueuedPacketByPacketIdIfUnique(legacyPacketId)
+    }
+
     companion object {
+        const val KEY_PACKET_UUID = "packet_uuid"
+        const val KEY_MY_NODE_NUM = "my_node_num"
+
+        /** Input key retained only so WorkManager jobs persisted by older app versions can finish after an upgrade. */
+        @Deprecated("New work must use KEY_PACKET_UUID and KEY_MY_NODE_NUM")
         const val KEY_PACKET_ID = "packet_id"
-        const val WORK_NAME_PREFIX = "send_message_"
+
+        const val WORK_NAME_PREFIX = "send_message_uuid_"
     }
 }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDatabaseProvider.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeDatabaseProvider.kt
@@ -33,11 +33,17 @@ class FakeDatabaseProvider : DatabaseProvider {
     private val _currentDb = MutableStateFlow(db)
     override val currentDb: StateFlow<MeshtasticDatabase> = _currentDb
 
+    /** Optional barrier/fault hook used to prove overlapping repository writes before they enter Room. */
+    var beforeWithDb: suspend () -> Unit = {}
+
     override fun <T> observeCurrentDb(query: (MeshtasticDatabase) -> Flow<T>): Flow<T> = currentDb.flatMapLatest(query)
 
     override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = block(db)
 
-    override suspend fun <T> withDb(block: suspend (MeshtasticDatabase) -> T): T? = block(db)
+    override suspend fun <T> withDb(block: suspend (MeshtasticDatabase) -> T): T? {
+        beforeWithDb()
+        return block(db)
+    }
 
     /**
      * Simulates the active-DB switch that happens when the app selects a different device — the new DB has no rows, so

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioController.kt
@@ -58,6 +58,9 @@ class FakeRadioController :
 
     var throwOnSend: Boolean = false
 
+    /** Deterministic suspension/fault hook invoked before a packet is recorded as sent. */
+    var onSendMessage: suspend (DataPacket) -> Unit = {}
+
     /** When true, [setLocalConfig] throws — simulates the radio link dropping mid config write. */
     var throwOnSetLocalConfig: Boolean = false
 
@@ -87,6 +90,7 @@ class FakeRadioController :
             localConfigs.clear()
             localChannels.clear()
             throwOnSend = false
+            onSendMessage = {}
             throwOnSetLocalConfig = false
             failChannelWriteAfter = null
             lastSetDeviceAddress = null
@@ -100,6 +104,7 @@ class FakeRadioController :
     }
 
     override suspend fun sendMessage(packet: DataPacket) {
+        onSendMessage(packet)
         if (throwOnSend) error("Fake send failure")
         sentPackets.add(packet)
     }

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -30,6 +30,8 @@ plugins {
     alias(libs.plugins.meshtastic.koin)
     alias(libs.plugins.meshtastic.kover)
     alias(libs.plugins.meshtastic.aboutlibraries)
+    // Version-less because Mokkery is embedded in the convention-plugin classpath.
+    id("dev.mokkery")
 }
 
 configureGraphTasks()

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/radio/DesktopMessageQueue.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/radio/DesktopMessageQueue.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.desktop.radio
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
@@ -25,6 +26,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.MessageStatus
 import org.meshtastic.core.repository.MessageQueue
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.core.repository.RadioController
 
 /**
@@ -40,9 +42,9 @@ class DesktopMessageQueue(
 ) : MessageQueue {
     private val scope = CoroutineScope(SupervisorJob() + dispatchers.io)
 
-    override suspend fun enqueue(packetId: Int) {
+    override suspend fun enqueue(persistedId: PersistedPacketId) {
         scope.launch {
-            if (packetId == 0) return@launch
+            if (persistedId.uuid <= 0L) return@launch
 
             // Verify we are connected before attempting to send to avoid unnecessary Exception bubbling
             if (radioController.connectionState.value != ConnectionState.Connected) {
@@ -52,16 +54,15 @@ class DesktopMessageQueue(
                 return@launch
             }
 
-            val packetData =
-                packetRepository.getPacketByPacketId(packetId)
-                    ?: return@launch // Packet no longer exists in DB? Do not retry.
+            val claimed = packetRepository.claimQueuedPacket(persistedId) ?: return@launch
+            if (claimed.packet.status != MessageStatus.QUEUED) return@launch
 
             try {
-                radioController.sendMessage(packetData)
-                packetRepository.updateMessageStatus(packetData, MessageStatus.ENROUTE)
+                radioController.sendMessage(claimed.packet)
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                Logger.w(e) { "Failed to send packet ${packetData.id}, re-queuing" }
-                packetRepository.updateMessageStatus(packetData, MessageStatus.QUEUED)
+                Logger.w(e) { "Failed to send packet ${claimed.packet.id}, re-queuing" }
+                packetRepository.rollbackEnroutePacket(claimed.id)
+                if (e is CancellationException) throw e
             }
         }
     }

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -38,6 +38,7 @@ import org.meshtastic.core.repository.Location
 import org.meshtastic.core.repository.LocationRepository
 import org.meshtastic.core.repository.MeshLocationManager
 import org.meshtastic.core.repository.MeshWorkerManager
+import org.meshtastic.core.repository.PersistedPacketId
 import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.RadioSessionContext
@@ -150,7 +151,7 @@ class NoopAppWidgetUpdater : AppWidgetUpdater {
 // region WorkManager / Location Stubs (Android-only)
 
 class NoopMeshWorkerManager : MeshWorkerManager {
-    override fun enqueueSendMessage(packetId: Int) {}
+    override fun enqueueSendMessage(persistedId: PersistedPacketId) {}
 }
 
 class NoopMeshLocationManager : MeshLocationManager {

--- a/desktopApp/src/test/kotlin/org/meshtastic/desktop/radio/DesktopMessageQueueTest.kt
+++ b/desktopApp/src/test/kotlin/org/meshtastic/desktop/radio/DesktopMessageQueueTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.desktop.radio
+
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.DataPacket
+import org.meshtastic.core.model.MessageStatus
+import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PersistedPacket
+import org.meshtastic.core.repository.PersistedPacketId
+import org.meshtastic.core.testing.FakeRadioController
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DesktopMessageQueueTest {
+
+    @Test
+    fun `concurrent enqueue sends only the caller that owns the queued claim`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repository = mock<PacketRepository>(MockMode.autofill)
+        val radio = connectedRadio()
+        val id = PersistedPacketId(myNodeNum = 42, uuid = 99L)
+        val packet = queuedPacket()
+        var claimCount = 0
+        everySuspend { repository.claimQueuedPacket(id) } calls
+            {
+                claimCount += 1
+                PersistedPacket(
+                    id,
+                    packet.copy(status = if (claimCount == 1) MessageStatus.QUEUED else MessageStatus.ENROUTE),
+                )
+            }
+        val sendStarted = CompletableDeferred<Unit>()
+        val releaseSend = CompletableDeferred<Unit>()
+        radio.onSendMessage = {
+            sendStarted.complete(Unit)
+            releaseSend.await()
+        }
+        val queue = queue(repository, radio, dispatcher)
+
+        queue.enqueue(id)
+        runCurrent()
+        assertTrue(sendStarted.isCompleted)
+
+        queue.enqueue(id)
+        runCurrent()
+        assertEquals(2, claimCount)
+
+        releaseSend.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(listOf(packet), radio.sentPackets)
+        verifySuspend(mode = VerifyMode.exactly(2)) { repository.claimQueuedPacket(id) }
+        verifySuspend(mode = VerifyMode.exactly(0)) { repository.rollbackEnroutePacket(any()) }
+    }
+
+    @Test
+    fun `send failure rolls back only the exact claimed row`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repository = mock<PacketRepository>(MockMode.autofill)
+        val radio = connectedRadio().apply { throwOnSend = true }
+        val id = PersistedPacketId(myNodeNum = 42, uuid = 99L)
+        val packet = queuedPacket()
+        everySuspend { repository.claimQueuedPacket(id) } returns PersistedPacket(id, packet)
+        everySuspend { repository.rollbackEnroutePacket(id) } returns true
+
+        queue(repository, radio, dispatcher).enqueue(id)
+        advanceUntilIdle()
+
+        assertEquals(emptyList(), radio.sentPackets)
+        verifySuspend { repository.rollbackEnroutePacket(id) }
+    }
+
+    @Test
+    fun `missing claim neither sends nor rolls back`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repository = mock<PacketRepository>(MockMode.autofill)
+        val radio = connectedRadio()
+        val id = PersistedPacketId(myNodeNum = 42, uuid = 99L)
+        everySuspend { repository.claimQueuedPacket(id) } returns null
+
+        queue(repository, radio, dispatcher).enqueue(id)
+        advanceUntilIdle()
+
+        assertEquals(emptyList(), radio.sentPackets)
+        verifySuspend(mode = VerifyMode.exactly(0)) { repository.rollbackEnroutePacket(any()) }
+    }
+
+    private fun queue(repository: PacketRepository, radio: FakeRadioController, dispatcher: TestDispatcher) =
+        DesktopMessageQueue(
+            packetRepository = repository,
+            radioController = radio,
+            dispatchers = CoroutineDispatchers(main = dispatcher, io = dispatcher, default = dispatcher),
+        )
+
+    private fun connectedRadio() = FakeRadioController().apply { setConnectionState(ConnectionState.Connected) }
+
+    private fun queuedPacket() = DataPacket(
+        id = 7,
+        from = "^local",
+        to = "!remote",
+        bytes = "hello".encodeToByteArray().toByteString(),
+        dataType = 1,
+        status = MessageStatus.QUEUED,
+    )
+}

--- a/feature/messaging/src/androidMain/kotlin/org/meshtastic/feature/messaging/worker/WorkManagerMessageQueue.kt
+++ b/feature/messaging/src/androidMain/kotlin/org/meshtastic/feature/messaging/worker/WorkManagerMessageQueue.kt
@@ -16,28 +16,14 @@
  */
 package org.meshtastic.feature.messaging.worker
 
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkManager
-import androidx.work.workDataOf
 import org.koin.core.annotation.Single
+import org.meshtastic.core.repository.MeshWorkerManager
 import org.meshtastic.core.repository.MessageQueue
-import org.meshtastic.core.service.worker.SendMessageWorker
+import org.meshtastic.core.repository.PersistedPacketId
 
 /** Android implementation of [MessageQueue] that uses [WorkManager] for reliable background transmission. */
 @Single
-class WorkManagerMessageQueue(private val workManager: WorkManager) : MessageQueue {
+class WorkManagerMessageQueue(private val workerManager: MeshWorkerManager) : MessageQueue {
 
-    override suspend fun enqueue(packetId: Int) {
-        val workRequest =
-            OneTimeWorkRequestBuilder<SendMessageWorker>()
-                .setInputData(workDataOf(SendMessageWorker.KEY_PACKET_ID to packetId))
-                .build()
-
-        workManager.enqueueUniqueWork(
-            "${SendMessageWorker.WORK_NAME_PREFIX}$packetId",
-            ExistingWorkPolicy.REPLACE,
-            workRequest,
-        )
-    }
+    override suspend fun enqueue(persistedId: PersistedPacketId) = workerManager.enqueueSendMessage(persistedId)
 }

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.emitAll
@@ -61,6 +63,7 @@ import org.meshtastic.core.resources.translation_failed
 import org.meshtastic.core.resources.translation_model_download_failed
 import org.meshtastic.core.resources.translation_not_required
 import org.meshtastic.core.ui.util.SnackbarManager
+import org.meshtastic.core.ui.viewmodel.errorEventFlow
 import org.meshtastic.core.ui.viewmodel.safeLaunch
 import org.meshtastic.core.ui.viewmodel.stateInWhileSubscribed
 import org.meshtastic.feature.messaging.translation.DownloadResult
@@ -110,6 +113,8 @@ class MessageViewModel(
 
     private val _draftMessage = MutableStateFlow(savedStateHandle.get<String>("draftMessage") ?: "")
     val draftMessage: StateFlow<String> = _draftMessage.asStateFlow()
+
+    private val sendErrorEvents = errorEventFlow()
 
     private var pendingDraftPersistence: Job? = null
 
@@ -275,6 +280,9 @@ class MessageViewModel(
     // endregion
 
     init {
+        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            sendErrorEvents.collect { snackbarManager.showSnackbar(MessagingUiTextResolver.resolve(it)) }
+        }
         val contactKey = savedStateHandle.get<String>("contactKey")
         if (contactKey != null) {
             contactKeyForPagedMessages.value = contactKey
@@ -344,7 +352,9 @@ class MessageViewModel(
      * @param replyId The ID of the message this is a reply to, if any.
      */
     fun sendMessage(str: String, contactKey: String = "0${NodeAddress.ID_BROADCAST}", replyId: Int? = null) {
-        safeLaunch(tag = "sendMessage") { sendMessageUseCase.invoke(str, contactKey, replyId) }
+        safeLaunch(errorEvents = sendErrorEvents, tag = "sendMessage") {
+            sendMessageUseCase.invoke(str, contactKey, replyId)
+        }
     }
 
     fun sendReaction(emoji: String, replyId: Int, contactKey: String) =

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageViewModelTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageViewModelTest.kt
@@ -19,6 +19,7 @@ package org.meshtastic.feature.messaging
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -247,6 +248,24 @@ class MessageViewModelTest {
         advanceUntilIdle()
 
         // Verify via mokkery
+        verifySuspend { sendMessageUseCase.invoke("Hello", "0!12345678", null) }
+    }
+
+    @Test
+    fun `send persistence failure is shown through the snackbar manager`() = runTest {
+        everySuspend { sendMessageUseCase.invoke(any(), any(), any()) } calls
+            {
+                throw IllegalStateException("Message could not be saved")
+            }
+
+        snackbarManager.events.test {
+            viewModel.sendMessage("Hello", "0!12345678", null)
+            advanceUntilIdle()
+
+            assertEquals("Message could not be saved", awaitItem().message)
+            cancelAndIgnoreRemainingEvents()
+        }
+
         verifySuspend { sendMessageUseCase.invoke("Hello", "0!12345678", null) }
     }
 


### PR DESCRIPTION
## Summary

- preserve packets and reactions when different senders reuse the same mesh packet ID
- normalize PKI reaction conversation identity for persistence, parent lookup, and notifications, including compatibility for previously stored raw-channel rows
- resolve reply and reaction parents within the current conversation, failing closed if multiple candidates remain
- atomically claim durable Android and Desktop sends by persisted row identity instead of serializing every worker behind one process-wide mutex
- retain an active persisted-row WorkManager request rather than replacing it, and restore only the exact claimed row on send failure
- match outgoing delivery updates using packet ID, sender, recipient, and decoded port, refusing ambiguous updates
- preserve orphaned-`ENROUTE` timeout and reconnect rearming while keying every timer and timeout update by the exact persisted row
- surface send-persistence failures through the messaging snackbar path and keep duplicate-reaction logs free of sender or payload content

## Root cause and impact

Mesh packet IDs are sender-scoped and are not suitable as globally unique database or work identifiers. Several paths previously relied on ID-only queries. In addition, the first revision compared a normalized PKI parent channel with a raw reaction channel, held a global mutex across the full radio send, replaced active persisted-row work, and left the Desktop sender on a non-atomic load/send/update sequence.

Those paths could discard a legitimate packet or reaction, hide PKI direct-message reactions, associate a reply/reaction with the wrong message, update the wrong delivery state, replace/load the wrong durable job, send the same durable Desktop row twice, or block unrelated workers behind a stalled radio call.

## Behavior after this change

- packets with the same ID from different senders are retained
- inbound PKI reactions use the normalized `DataPacket` contact/channel, while legacy received PKI reactions stored on raw channel 0 remain visible
- reply/reaction attachment fails closed when the conversation-scoped result is still ambiguous
- delivery updates exclude inbound and different-port candidates; multiple exact outgoing matches produce no database update
- UUID and uniquely resolved legacy Android workers transactionally claim an exact row from `QUEUED` to `ENROUTE`; only the successful claimant sends
- repeated scheduling for the same persisted Android row uses WorkManager `KEEP`, preserving an already active request
- the Desktop queue uses the same exact-row claim before sending and skips disconnected, missing, or already claimed rows
- Android and Desktop send failure restores only that exact row and only if it remains `ENROUTE`, so a concurrent ACK/NAK is not overwritten
- ACK timeouts and reconnect rearming use `(myNodeNum, uuid)`, so rows sharing one mesh packet ID retain independent timers and only the exact still-`ENROUTE` row can time out
- unrelated workers are no longer blocked by a process-wide send mutex
- a persistence exception from the messaging send path is shown through `SnackbarManager`; normal input clearing remains unchanged
- duplicate-reaction diagnostics retain packet/reply IDs and the count, but no sender identifier or emoji payload

## Explicit fail-closed limitations

- When multiple outgoing rows still match an ACK/NAK exactly, the app leaves their delivery state unchanged rather than guessing; the exact persisted send later follows the normal timeout path.
- Reply and reaction payloads carry only `reply_id`, not parent sender/conversation identity. A cross-conversation reply therefore omits the quote bubble under contact-scoped lookup, and same-conversation ID ambiguity remains unattached.
- A pre-upgrade legacy WorkManager job whose `packet_id` maps to zero or multiple rows fails without sending or retrying because no safe persisted row can be selected.

## Regression coverage

Added coverage for PKI channel-8 persistence and notification lookup, legacy raw-channel PKI rendering, opposite-conversation/channel exclusion, sender collisions, scoped/ambiguous parents, full-packet delivery matching, real multithreaded provider overlap around Room UUID/legacy claims, unique and ambiguous legacy jobs, exact-row failure rollback, ACK-race preservation, stalled unrelated sends, and two durable rows sharing a mesh packet ID. Additional regressions prove that WorkManager keeps the first active persisted-row request, the Desktop queue has one concurrent send owner and exact failure rollback, a missing Desktop claim does not send, send-persistence exceptions reach the messaging snackbar manager, an already-claimed row is selected unambiguously for timeout ownership, colliding mesh IDs receive independent rearmed timers, and timeout mutates only the targeted persisted row.

## Validation

The rebased head passed global `spotlessCheck` and `detekt`; the affected `core:data`, `core:repository`, and `feature:messaging` suites; exact `PacketDaoTest`, `ReactionKeyTest`, `SendMessageWorkerTest`, and `AndroidMeshWorkerManagerTest` Android-host regressions; Desktop tests and compilation; `kmpSmokeCompile`; and `git diff --check`, using at most four workers.

## Coordination

Rebased as one logical commit onto current `main` at `d8361ccd`, including #6664's Compose rollback. `git range-diff` from the prior head is unchanged. The earlier rebase overlap in the foreground `message_send` analytics path still retains upstream analytics after the exact persisted row is durably enqueued. This also keeps #6630's orphaned-`ENROUTE` timeout/rearm behavior integrated with this PR's sender-scoped matching and atomic claim/rollback semantics. Draft PR #6598 remains complementary rather than a duplicate, but overlaps packet admission, queue lifecycle, and status persistence.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate packets and reactions from being incorrectly discarded when they share an ID but come from different senders.
  * Improved reaction matching and notifications within the correct conversation, contact, and channel.
  * Improved message delivery status updates, retries, and failure recovery.
  * Prevented duplicate or ambiguous queued messages from being sent more than once.
* **Reliability**
  * Improved handling of concurrent sends, acknowledgements, and stalled or failed transmissions.
  * Preserved compatibility with previously queued messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
