### PR TITLE
fix(ci): sync Flatpak Gradle distribution

### DIFF
--- a/scripts/verify-flatpak/desktop-offline.yaml
+++ b/scripts/verify-flatpak/desktop-offline.yaml
@@ -99,8 +99,8 @@ modules:
       - type: file
         # Must be the EXACT distribution from gradle-wrapper.properties (version AND
         # -bin flavor) — distributionSha256Sum verifies this file. Update together.
-        url: https://services.gradle.org/distributions/gradle-9.7.0-bin.zip
-        sha256: 84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
+        url: https://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+        sha256: 9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
         dest: "gradle/wrapper"
         dest-filename: "gradle-bin.zip"
       - flatpak-sources.json


### PR DESCRIPTION
## Summary

Keep the offline Flatpak manifest's bundled Gradle distribution in sync with the checked-in wrapper:

- use `gradle-9.6.1-bin.zip`
- use the wrapper's `9c0f…e14` SHA-256

## Root cause

#6611 pinned the repository wrapper back from Gradle 9.7.0 to 9.6.1, but `scripts/verify-flatpak/desktop-offline.yaml` still downloaded the 9.7.0 binary.

The Flatpak build rewrites `distributionUrl` to that bundled ZIP while retaining `distributionSha256Sum` from `gradle-wrapper.properties`. Both architectures therefore fail before project compilation:

```text
Expected checksum: 9c0f7fae...32c9e14
Actual checksum:   84fbba45...d873ae
```

This surfaced in the Flatpak checks on #6624 and is independent of that PR's messaging changes.

## Validation

- parsed the wrapper properties and Flatpak manifest and asserted exact URL/SHA equality
- `git diff --check`
- the existing x86_64 and aarch64 Flatpak workflow provides the end-to-end offline build check