### PR TITLE
fix(i18n): localize emoji picker strings

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -542,6 +542,19 @@ edit
 edit_custom_tile_source
 eight_hours
 elevation_suffix
+### EMOJI ###
+emoji_category_activities
+emoji_category_animals_nature
+emoji_category_flags
+emoji_category_food_drink
+emoji_category_objects
+emoji_category_people_body
+emoji_category_smileys_emotion
+emoji_category_symbols
+emoji_category_travel_places
+emoji_load_error
+emoji_no_results
+emoji_recently_used
 enable_power_saving_mode
 enabled
 ### ENCRYPTION ###

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -569,6 +569,19 @@
     <string name="edit_custom_tile_source">Edit Network Tile Source</string>
     <string name="eight_hours">8 Hours</string>
     <string name="elevation_suffix" translatable="false">MSL</string>
+    <!-- EMOJI -->
+    <string name="emoji_category_activities">Activities</string>
+    <string name="emoji_category_animals_nature">Animals &amp; Nature</string>
+    <string name="emoji_category_flags">Flags</string>
+    <string name="emoji_category_food_drink">Food &amp; Drink</string>
+    <string name="emoji_category_objects">Objects</string>
+    <string name="emoji_category_people_body">People &amp; Body</string>
+    <string name="emoji_category_smileys_emotion">Smileys &amp; Emotion</string>
+    <string name="emoji_category_symbols">Symbols</string>
+    <string name="emoji_category_travel_places">Travel &amp; Places</string>
+    <string name="emoji_load_error">Unable to load emoji</string>
+    <string name="emoji_no_results">No emoji found</string>
+    <string name="emoji_recently_used">Recently Used</string>
     <string name="enable_power_saving_mode">Enable power saving mode</string>
     <string name="enabled">Enabled</string>
     <!-- ENCRYPTION -->

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerDialog.kt
@@ -81,6 +81,18 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.clear
+import org.meshtastic.core.resources.emoji_category_activities
+import org.meshtastic.core.resources.emoji_category_animals_nature
+import org.meshtastic.core.resources.emoji_category_flags
+import org.meshtastic.core.resources.emoji_category_food_drink
+import org.meshtastic.core.resources.emoji_category_objects
+import org.meshtastic.core.resources.emoji_category_people_body
+import org.meshtastic.core.resources.emoji_category_smileys_emotion
+import org.meshtastic.core.resources.emoji_category_symbols
+import org.meshtastic.core.resources.emoji_category_travel_places
+import org.meshtastic.core.resources.emoji_load_error
+import org.meshtastic.core.resources.emoji_no_results
+import org.meshtastic.core.resources.emoji_recently_used
 import org.meshtastic.core.resources.search_emoji
 import org.meshtastic.core.ui.icon.Close
 import org.meshtastic.core.ui.icon.MeshtasticIcons
@@ -151,7 +163,7 @@ fun EmojiPickerDialog(
         if (loadError) {
             Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
                 Text(
-                    text = "Unable to load emoji",
+                    text = stringResource(Res.string.emoji_load_error),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -419,7 +431,9 @@ private fun EmojiGrid(
         gridItems.forEach { item ->
             when (item) {
                 is GridItem.Header ->
-                    item(span = { GridItemSpan(maxLineSpan) }, key = item.key) { SectionHeader(title = item.title) }
+                    item(span = { GridItemSpan(maxLineSpan) }, key = item.key) {
+                        SectionHeader(title = localizedHeaderTitle(item))
+                    }
 
                 is GridItem.EmojiCell ->
                     item(key = item.key) {
@@ -437,7 +451,7 @@ private fun EmojiGrid(
         if (gridItems.none { it is GridItem.EmojiCell }) {
             item(span = { GridItemSpan(maxLineSpan) }) {
                 Text(
-                    text = "No emoji found",
+                    text = stringResource(Res.string.emoji_no_results),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.fillMaxWidth().padding(32.dp),
@@ -469,7 +483,8 @@ private fun buildGridItems(
         results.forEachIndexed { i, emoji -> add(GridItem.EmojiCell(emoji, "search_$i")) }
     } else {
         if (recentEmojis.isNotEmpty()) {
-            add(GridItem.Header("Recently Used", RECENTS_HEADER_KEY))
+            // Title resolved at render time via localizedHeaderTitle (recents key → string resource)
+            add(GridItem.Header("", RECENTS_HEADER_KEY))
             recentEmojis.forEachIndexed { i, emojiStr ->
                 add(GridItem.EmojiCell(Emoji(emojiStr), "$RECENTS_KEY_PREFIX$i"))
             }
@@ -525,6 +540,28 @@ private fun scoreEmoji(emoji: Emoji, query: String, recentSet: Set<String>): Flo
 }
 
 // ── Cell Components ────────────────────────────────────────────────────────────
+
+/**
+ * Resolves a grid header to localized text. Category names arrive as raw English strings from `emoji-data.json`, so
+ * they are mapped to string resources here; unknown names fall back to the raw value.
+ */
+@Composable
+private fun localizedHeaderTitle(header: GridItem.Header): String = if (header.key == RECENTS_HEADER_KEY) {
+    stringResource(Res.string.emoji_recently_used)
+} else {
+    when (header.title) {
+        "Smileys & Emotion" -> stringResource(Res.string.emoji_category_smileys_emotion)
+        "People & Body" -> stringResource(Res.string.emoji_category_people_body)
+        "Animals & Nature" -> stringResource(Res.string.emoji_category_animals_nature)
+        "Food & Drink" -> stringResource(Res.string.emoji_category_food_drink)
+        "Travel & Places" -> stringResource(Res.string.emoji_category_travel_places)
+        "Activities" -> stringResource(Res.string.emoji_category_activities)
+        "Objects" -> stringResource(Res.string.emoji_category_objects)
+        "Symbols" -> stringResource(Res.string.emoji_category_symbols)
+        "Flags" -> stringResource(Res.string.emoji_category_flags)
+        else -> header.title
+    }
+}
 
 @Composable
 private fun SectionHeader(title: String) {


### PR DESCRIPTION
The emoji picker rendered its status messages and section headers as hardcoded English literals, so Crowdin never picked them up and they stayed untranslated in every locale. This routes all of them through `stringResource` per the policy established in #6143.

### 🐛 Bug Fixes

- Localize the emoji picker's two status messages — the load-error state (`Unable to load emoji`) and the empty-search state (`No emoji found`) — via `stringResource`.
- Localize the grid section headers, which were also hardcoded: the `Recently Used` recents header and the nine catalog category names (`Smileys & Emotion`, `People & Body`, `Animals & Nature`, `Food & Drink`, `Travel & Places`, `Activities`, `Objects`, `Symbols`, `Flags`).

### 🛠️ Refactoring & Architecture

- Add a `localizedHeaderTitle` composable that resolves a grid header to localized text at render time. Category names arrive as raw English strings from the bundled `emoji-data.json` rather than from code, so they cannot be localized at the source; this maps them onto string resources on the way to the screen, and falls back to the raw name if the catalog ever renames a category.
- The recents header title is now resolved by key, so its English literal is gone from the grid model rather than sitting there dead.

**Reviewer note:** the fallback above is the one fragile spot. If `emoji-data.json` renames a category, that header silently reverts to English instead of failing loudly. I chose the graceful fallback over a crash, and these are stable Unicode CLDR group names, but if you'd prefer the mapping to live in `EmojiRepository` keyed by category index, that's a small follow-up.

### 🧹 Chores

- Add 12 string resources to the base `strings.xml` in `core/resources`, sorted into a new `EMOJI` section by `scripts/sort-strings.py`.
- Regenerate `.skills/compose-ui/strings-index.txt`.

### Validation

No tests changed — this is a string-extraction change with no behavioral difference in English. Full baseline run locally and green: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` (BUILD SUCCESSFUL, no test failures).

No screenshots included: the rendered UI is byte-for-byte identical in the default English locale, so a Before/After table would show two identical images.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized text for emoji categories, loading errors, empty search results, and recently used emojis.
  * Emoji picker messages and category names now adapt to the selected language.

* **Bug Fixes**
  * Improved handling of unknown emoji category labels by preserving their original text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->