### PR TITLE
feat(settings): warn before enabling licensed (ham) mode

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -861,8 +861,13 @@ led_heartbeat
 led_state
 legacy_admin_channel
 library_count
+### LICENSED ###
 licensed_amateur_radio
 licensed_amateur_radio_text
+licensed_mode_enable_confirm
+licensed_mode_enable_title
+licensed_mode_enable_warning
+licensed_mode_enable_warning_signed
 ### LOAD ###
 load
 load_15_min

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -888,8 +888,13 @@
     <string name="led_state">LED state</string>
     <string name="legacy_admin_channel">Legacy Admin channel</string>
     <string name="library_count">%1$d libraries</string>
+    <!-- LICENSED -->
     <string name="licensed_amateur_radio">Licensed amateur radio (Ham)</string>
     <string name="licensed_amateur_radio_text">Enabling this option disables encryption and is not compatible with the default Meshtastic network.</string>
+    <string name="licensed_mode_enable_confirm">Enable licensed mode</string>
+    <string name="licensed_mode_enable_title">Enable licensed (Ham) mode?</string>
+    <string name="licensed_mode_enable_warning">Licensed mode removes channel encryption keys and disables the admin channel. All traffic is sent as plaintext that anyone can read, and it is not compatible with the default Meshtastic network. You are responsible for meeting the requirements of your amateur radio license and local regulations.</string>
+    <string name="licensed_mode_enable_warning_signed">Licensed mode removes channel encryption keys and disables the admin channel. All traffic is sent as plaintext that anyone can read, but it is digitally signed so other nodes can verify it came from you. Your node number may change one time to match your identity key, so favorites, message history, remote admin references, and other nodes may initially treat this node as new. You are responsible for meeting the requirements of your amateur radio license and local regulations.</string>
     <!-- LOAD -->
     <string name="load">Load</string>
     <string name="load_15_min">Load 15m</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -894,7 +894,7 @@
     <string name="licensed_mode_enable_confirm">Enable licensed mode</string>
     <string name="licensed_mode_enable_title">Enable licensed (Ham) mode?</string>
     <string name="licensed_mode_enable_warning">Licensed mode removes channel encryption keys and disables the admin channel. All traffic is sent as plaintext that anyone can read, and it is not compatible with the default Meshtastic network. You are responsible for meeting the requirements of your amateur radio license and local regulations.</string>
-    <string name="licensed_mode_enable_warning_signed">Licensed mode removes channel encryption keys and disables the admin channel. All traffic is sent as plaintext that anyone can read, but it is digitally signed so other nodes can verify it came from you. Your node number may change one time to match your identity key, so favorites, message history, remote admin references, and other nodes may initially treat this node as new. You are responsible for meeting the requirements of your amateur radio license and local regulations.</string>
+    <string name="licensed_mode_enable_warning_signed">Licensed mode removes channel encryption keys and disables the admin channel, so all traffic is sent as plaintext that anyone can read — but it is digitally signed, letting other nodes verify it came from you. Your node number may change once to match your identity key, so favorites, message history, remote admin, and other nodes may initially treat it as new; you remain responsible for meeting your amateur radio license requirements and local regulations.</string>
     <!-- LOAD -->
     <string name="load">Load</string>
     <string name="load_15_min">Load 15m</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -893,7 +893,7 @@
     <string name="licensed_amateur_radio_text">Enabling this option disables encryption and is not compatible with the default Meshtastic network.</string>
     <string name="licensed_mode_enable_confirm">Enable licensed mode</string>
     <string name="licensed_mode_enable_title">Enable licensed (Ham) mode?</string>
-    <string name="licensed_mode_enable_warning">Licensed mode removes channel encryption keys and disables the admin channel. All traffic is sent as plaintext that anyone can read, and it is not compatible with the default Meshtastic network. You are responsible for meeting the requirements of your amateur radio license and local regulations.</string>
+    <string name="licensed_mode_enable_warning">Licensed mode removes channel encryption keys and disables the admin channel, so all traffic is sent as plaintext that anyone can read — and this firmware cannot sign it, so other nodes cannot verify it came from you. This is not compatible with the default Meshtastic network, and you remain responsible for meeting your amateur radio license requirements and local regulations.</string>
     <string name="licensed_mode_enable_warning_signed">Licensed mode removes channel encryption keys and disables the admin channel, so all traffic is sent as plaintext that anyone can read — but it is digitally signed, letting other nodes verify it came from you. Your node number may change once to match your identity key, so favorites, message history, remote admin, and other nodes may initially treat it as new; you remain responsible for meeting your amateur radio license requirements and local regulations.</string>
     <!-- LOAD -->
     <string name="load">Load</string>

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LicensedModeSetting.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LicensedModeSetting.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio.component
+
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.licensed_amateur_radio
+import org.meshtastic.core.resources.licensed_amateur_radio_text
+import org.meshtastic.core.resources.licensed_mode_enable_confirm
+import org.meshtastic.core.resources.licensed_mode_enable_title
+import org.meshtastic.core.resources.licensed_mode_enable_warning
+import org.meshtastic.core.resources.licensed_mode_enable_warning_signed
+import org.meshtastic.core.ui.component.MeshtasticResourceDialog
+import org.meshtastic.core.ui.component.SwitchPreference
+
+internal const val LICENSED_MODE_SWITCH_TEST_TAG = "licensed_mode_switch"
+
+/**
+ * The licensed (ham) mode toggle. Enabling is staged behind a confirmation dialog: on firmware that signs licensed
+ * traffic (design#122, `has_xeddsa`), the copy explains authenticated-but-plaintext operation and the one-time node
+ * number migration; otherwise it carries the legacy plaintext/compatibility warning. Disabling applies immediately.
+ */
+@Composable
+internal fun LicensedModeSetting(
+    checked: Boolean,
+    enabled: Boolean,
+    signingSupported: Boolean?,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    var showEnableConfirmation by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(enabled) {
+        if (!enabled) {
+            showEnableConfirmation = false
+        }
+    }
+
+    if (showEnableConfirmation) {
+        MeshtasticResourceDialog(
+            titleRes = Res.string.licensed_mode_enable_title,
+            messageRes =
+            if (signingSupported == true) {
+                Res.string.licensed_mode_enable_warning_signed
+            } else {
+                Res.string.licensed_mode_enable_warning
+            },
+            confirmTextRes = Res.string.licensed_mode_enable_confirm,
+            onConfirm = {
+                showEnableConfirmation = false
+                if (enabled) {
+                    onCheckedChange(true)
+                }
+            },
+            onDismiss = { showEnableConfirmation = false },
+        )
+    }
+
+    SwitchPreference(
+        title = stringResource(Res.string.licensed_amateur_radio),
+        summary = stringResource(Res.string.licensed_amateur_radio_text),
+        checked = checked,
+        enabled = enabled,
+        modifier = Modifier.testTag(LICENSED_MODE_SWITCH_TEST_TAG),
+        onCheckedChange = { licensed ->
+            if (licensed && !checked) {
+                showEnableConfirmation = true
+            } else {
+                onCheckedChange(licensed)
+            }
+        },
+        containerColor = CardDefaults.cardColors().containerColor,
+    )
+}

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/UserConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/UserConfigItemList.kt
@@ -34,8 +34,6 @@ import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.call_sign
 import org.meshtastic.core.resources.call_sign_summary
 import org.meshtastic.core.resources.hardware_model
-import org.meshtastic.core.resources.licensed_amateur_radio
-import org.meshtastic.core.resources.licensed_amateur_radio_text
 import org.meshtastic.core.resources.long_name
 import org.meshtastic.core.resources.node_id
 import org.meshtastic.core.resources.short_name
@@ -127,11 +125,10 @@ fun UserConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     containerColor = CardDefaults.cardColors().containerColor,
                 )
                 HorizontalDivider()
-                SwitchPreference(
-                    title = stringResource(Res.string.licensed_amateur_radio),
-                    summary = stringResource(Res.string.licensed_amateur_radio_text),
+                LicensedModeSetting(
                     checked = formState.value.is_licensed,
                     enabled = state.connected,
+                    signingSupported = state.metadata?.has_xeddsa,
                     onCheckedChange = { licensed ->
                         val longName = formState.value.long_name
                         // The field becomes the callsign: clear an over-long name so the user enters one.
@@ -142,7 +139,6 @@ fun UserConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                                 long_name = if (clearForCallsign) "" else longName,
                             )
                     },
-                    containerColor = CardDefaults.cardColors().containerColor,
                 )
             }
         }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/LicensedModeSettingTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/LicensedModeSettingTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio.component
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.cancel
+import org.meshtastic.core.resources.getString
+import org.meshtastic.core.resources.licensed_mode_enable_confirm
+import org.meshtastic.core.resources.licensed_mode_enable_warning
+import org.meshtastic.core.resources.licensed_mode_enable_warning_signed
+import org.meshtastic.core.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalTestApi::class)
+class LicensedModeSettingTest {
+
+    @Test
+    fun `enabling licensed mode requires confirmation`() = runComposeUiTest {
+        var checked: Boolean? = null
+        setContent {
+            AppTheme {
+                LicensedModeSetting(
+                    checked = false,
+                    enabled = true,
+                    signingSupported = true,
+                    onCheckedChange = { checked = it },
+                )
+            }
+        }
+
+        onNodeWithTag(LICENSED_MODE_SWITCH_TEST_TAG).performClick()
+
+        assertNull(checked)
+        onNodeWithText(getString(Res.string.licensed_mode_enable_confirm)).assertIsDisplayed()
+        onNodeWithText(getString(Res.string.cancel)).performClick()
+        assertNull(checked)
+        onNodeWithText(getString(Res.string.licensed_mode_enable_confirm)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `confirmed enable applies the change`() = runComposeUiTest {
+        var checked: Boolean? = null
+        setContent {
+            AppTheme {
+                LicensedModeSetting(
+                    checked = false,
+                    enabled = true,
+                    signingSupported = true,
+                    onCheckedChange = { checked = it },
+                )
+            }
+        }
+
+        onNodeWithTag(LICENSED_MODE_SWITCH_TEST_TAG).performClick()
+        onNodeWithText(getString(Res.string.licensed_mode_enable_confirm)).performClick()
+
+        assertEquals(true, checked)
+    }
+
+    @Test
+    fun `signing firmware shows authenticated plaintext and migration copy`() = runComposeUiTest {
+        setContent { AppTheme { LicensedModeSetting(checked = false, enabled = true, signingSupported = true) {} } }
+
+        onNodeWithTag(LICENSED_MODE_SWITCH_TEST_TAG).performClick()
+
+        onNodeWithText(getString(Res.string.licensed_mode_enable_warning_signed)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `non-signing firmware shows legacy plaintext copy`() = runComposeUiTest {
+        setContent { AppTheme { LicensedModeSetting(checked = false, enabled = true, signingSupported = false) {} } }
+
+        onNodeWithTag(LICENSED_MODE_SWITCH_TEST_TAG).performClick()
+
+        onNodeWithText(getString(Res.string.licensed_mode_enable_warning)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `unknown capability shows legacy plaintext copy`() = runComposeUiTest {
+        setContent { AppTheme { LicensedModeSetting(checked = false, enabled = true, signingSupported = null) {} } }
+
+        onNodeWithTag(LICENSED_MODE_SWITCH_TEST_TAG).performClick()
+
+        onNodeWithText(getString(Res.string.licensed_mode_enable_warning)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `disabling licensed mode applies immediately without confirmation`() = runComposeUiTest {
+        var checked: Boolean? = null
+        setContent {
+            AppTheme {
+                LicensedModeSetting(
+                    checked = true,
+                    enabled = true,
+                    signingSupported = true,
+                    onCheckedChange = { checked = it },
+                )
+            }
+        }
+
+        onNodeWithTag(LICENSED_MODE_SWITCH_TEST_TAG).performClick()
+
+        assertEquals(false, checked)
+        onNodeWithText(getString(Res.string.licensed_mode_enable_confirm)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `connection loss dismisses confirmation without changing state`() = runComposeUiTest {
+        var enabled by mutableStateOf(true)
+        var checked: Boolean? = null
+        setContent {
+            AppTheme {
+                LicensedModeSetting(
+                    checked = false,
+                    enabled = enabled,
+                    signingSupported = true,
+                    onCheckedChange = { checked = it },
+                )
+            }
+        }
+
+        onNodeWithTag(LICENSED_MODE_SWITCH_TEST_TAG).performClick()
+        onNodeWithText(getString(Res.string.licensed_mode_enable_confirm)).assertIsDisplayed()
+
+        enabled = false
+        waitForIdle()
+
+        onNodeWithText(getString(Res.string.licensed_mode_enable_confirm)).assertDoesNotExist()
+        assertNull(checked)
+    }
+}


### PR DESCRIPTION
## Why

Firmware 2.8.0 changes what licensed (ham) mode means. [meshtastic/firmware#10969](https://github.com/meshtastic/firmware/pull/10969) (merged Jul 27, tracked by [meshtastic/design#122](https://github.com/meshtastic/design/issues/122)) now generates and publishes an identity keypair in licensed mode and XEdDSA-signs every locally originated plaintext packet, including direct messages. Traffic stays readable on air — signatures authenticate origin, they do not encrypt — but because `NodeNum` is derived as `crc32(public_key)`, **enabling licensed mode on an existing node can change its node number one time.** design#122 asks clients to warn before that migration and to say that favorites, message history, remote-admin references, and peer caches may initially treat the node as new.

Today the Android toggle flips the form immediately, carrying only the pre-2.8 one-liner: *"Enabling this option disables encryption and is not compatible with the default Meshtastic network."* That is now both incomplete (no migration warning) and, on signing firmware, misleading about what the node actually transmits. Per garth's Aug 11 status update on design#122, this client-side copy work had not been started on any client.

## 🌟 What this adds

Enabling licensed mode is now staged behind a confirmation dialog; **disabling still applies immediately** (no reason to gate the safe direction). The message is chosen from the firmware capability, reusing the exact pattern `PacketAuthenticitySetting` established in #6178 — `MeshtasticResourceDialog` plus a nullable tri-state capability gate.

On firmware that signs licensed traffic (`DeviceMetadata.has_xeddsa`), the dialog explains authenticated-but-plaintext operation and the identity migration. On older firmware — or before metadata is known — it keeps a plaintext-only warning and makes no migration claim, since neither signing nor the NodeNum derivation applies there.

## 🛠️ Implementation notes

The switch moved out of `UserConfigItemList` into a new `LicensedModeSetting` component, which holds the staged-confirmation state; the callsign-clearing behaviour on enable is unchanged, just deferred until after confirm. The pending dialog is dropped if the device disconnects, so a stale confirm can never apply a config change to a device that went away.

`has_xeddsa` (field 14) is the only signing-capability bit in `DeviceMetadata` — there is no design#122-specific flag — so it is used as the proxy for "this firmware signs licensed traffic," consistent with how #6178 gates the Strict policy. Worth noting for reviewers: past "packet authenticity disabled on nightly" reports were old-firmware artifacts, not app bugs, and the same gate applies here.

## ⚠️ Copy needs review

**Neither design thread specifies wording**, so the four new strings are my draft against the requirements in design#122's *Identity migration* section and its jurisdiction disclaimer. Please review before this merges and translations are seeded:

- **`licensed_mode_enable_title`** — Enable licensed (Ham) mode?
- **`licensed_mode_enable_confirm`** — Enable licensed mode
- **`licensed_mode_enable_warning`** (pre-2.8 / capability unknown) — Licensed mode removes channel encryption keys and disables the admin channel, so all traffic is sent as plaintext that anyone can read — and this firmware cannot sign it, so other nodes cannot verify it came from you. This is not compatible with the default Meshtastic network, and you remain responsible for meeting your amateur radio license requirements and local regulations.
- **`licensed_mode_enable_warning_signed`** (2.8.0+) — Licensed mode removes channel encryption keys and disables the admin channel, so all traffic is sent as plaintext that anyone can read — but it is digitally signed, letting other nodes verify it came from you. Your node number may change once to match your identity key, so favorites, message history, remote admin, and other nodes may initially treat it as new; you remain responsible for meeting your amateur radio license requirements and local regulations.

Open questions for you:
1. ~~The signed variant is long (four sentences).~~ **Resolved:** both variants tightened to two sentences at James's request, joining clauses rather than dropping required facts. They now share an opening and an em-dash pivot to the signing status, so the only visible difference between firmware versions is the fact that actually differs.

    One thing to eyeball: matching the structure meant filling the slot where the signed variant says "but it is digitally signed…" — so the non-signing variant now states the converse (this firmware cannot sign, so peers cannot verify the sender). That is **new information not in the original string**, though accurate: design#122's *Current firmware behavior* notes licensed mode blocks key generation and strips `User.public_key`, which is exactly why Strict rejects pre-2.8 licensed traffic. If you would rather the older-firmware dialog not editorialise about signing, drop that clause and let sentence one end at "anyone can read" — shorter, but the variants stop mirroring.
2. design#122 also mentions callsign-identification requirements. The screen already repurposes the long-name field as the callsign with its own summary, so I folded this into the general licence-responsibility line rather than restating it. Enough?
3. Should the migration warning be conditional on *actually* migrating (i.e. only when the node's current number is not already `crc32(public_key)`)? The app cannot cheaply predict this pre-enable, so the copy hedges with "may change." Left as-is deliberately.
4. Existing strict-policy copy says "licensed or ham nodes without PKI keys… may disappear." That remains accurate for pre-2.8 licensed nodes, but 2.8 licensed nodes now pass Strict. Follow-up to reword, or leave until 2.8 is broadly deployed?

Deliberately out of scope: shield/lock semantics are unchanged (design#122 confirms licensed DMs use the verified-signature shield, not the PKI lock — already the app's behaviour), and no screenshot references were added, to keep this copy-only.

## 🧹 Testing Performed

`LicensedModeSettingTest` — 7 tests, all passing:

| Case | Asserts |
| --- | --- |
| enabling requires confirmation | switch alone does not mutate; cancel leaves it off |
| confirmed enable applies | confirm propagates `true` |
| signing firmware copy | signed variant shown when `has_xeddsa = true` |
| non-signing firmware copy | legacy variant when `false` |
| unknown capability | legacy variant when `null` |
| disabling | applies immediately, no dialog |
| connection loss | pending dialog dismissed, no config change |

Full baseline green on this branch: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests`.

Reference: meshtastic/design#122

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a licensed amateur-radio mode setting with a dedicated toggle.
  * Enabling licensed mode now requires confirmation.
  * Added warnings explaining unsigned and digitally signed mode behavior, network compatibility, identity changes, and regulatory responsibilities.
  * Disabling licensed mode takes effect immediately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->