### PR TITLE
fix(data): stop "1 hour" log retention from wiping the MeshLog table

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/MeshLogRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/MeshLogRepositoryImpl.kt
@@ -36,6 +36,7 @@ import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.repository.MeshLogPrefs
 import org.meshtastic.core.repository.MeshLogRepository
 import org.meshtastic.core.repository.MeshLogRepository.Companion.DEFAULT_MAX_LOGS
+import org.meshtastic.core.repository.MeshLogRetention
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.MyNodeInfo
 import org.meshtastic.proto.PortNum
@@ -226,10 +227,14 @@ open class MeshLogRepositoryImpl(
         Unit
     }
 
-    /** Prunes the log database based on the configured [retentionDays]. */
-    @Suppress("MagicNumber")
+    /**
+     * Prunes the log database based on the configured [retentionDays]. The sentinel values are resolved by
+     * [MeshLogRetention], so "never delete" is a no-op and "1 hour" trims to the last hour rather than scaling the
+     * sentinel by days.
+     */
     override suspend fun deleteLogsOlderThan(retentionDays: Int) = withContext(dispatchers.io) {
-        val cutoffTime = nowMillis - (retentionDays.toLong() * 24 * 60 * 60 * 1000)
+        val window = MeshLogRetention.windowOrNull(retentionDays) ?: return@withContext
+        val cutoffTime = nowMillis - window.inWholeMilliseconds
         dbManager.withDb { it.meshLogDao().deleteOlderThan(cutoffTime) }
         Unit
     }

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/CommonMeshLogRepositoryTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/CommonMeshLogRepositoryTest.kt
@@ -29,6 +29,7 @@ import org.meshtastic.core.data.datasource.NodeInfoReadDataSource
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.MeshLog
+import org.meshtastic.core.repository.MeshLogRetention
 import org.meshtastic.core.testing.FakeDatabaseProvider
 import org.meshtastic.core.testing.FakeMeshLogPrefs
 import org.meshtastic.proto.Data
@@ -45,6 +46,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import org.meshtastic.core.common.util.nowMillis as realNowMillis
 
 abstract class CommonMeshLogRepositoryTest {
 
@@ -189,6 +194,44 @@ abstract class CommonMeshLogRepositoryTest {
         val remainingIds = repository.getAllLogsUnbounded().first().map { it.uuid }.toSet()
         assertEquals(setOf("device", "environment", "local-stats-request"), remainingIds)
     }
+
+    @Test
+    fun `deleteLogsOlderThan one hour sentinel keeps the last hour instead of wiping the table`() =
+        runTest(testDispatcher) {
+            val now = realNowMillis
+            repository.insert(retentionLog("recent", now - 30.minutes.inWholeMilliseconds))
+            repository.insert(retentionLog("stale", now - 2.hours.inWholeMilliseconds))
+
+            repository.deleteLogsOlderThan(MeshLogRetention.ONE_HOUR)
+
+            assertEquals(setOf("recent"), repository.getAllLogsUnbounded().first().map { it.uuid }.toSet())
+        }
+
+    @Test
+    fun `deleteLogsOlderThan keep forever sentinel deletes nothing`() = runTest(testDispatcher) {
+        val now = realNowMillis
+        repository.insert(retentionLog("ancient", now - 400.days.inWholeMilliseconds))
+        repository.insert(retentionLog("recent", now))
+
+        repository.deleteLogsOlderThan(MeshLogRetention.KEEP_FOREVER)
+
+        assertEquals(setOf("ancient", "recent"), repository.getAllLogsUnbounded().first().map { it.uuid }.toSet())
+    }
+
+    @Test
+    fun `deleteLogsOlderThan trims to the configured day count`() = runTest(testDispatcher) {
+        val now = realNowMillis
+        repository.insert(retentionLog("within", now - 6.days.inWholeMilliseconds))
+        repository.insert(retentionLog("outside", now - 8.days.inWholeMilliseconds))
+
+        repository.deleteLogsOlderThan(7)
+
+        assertEquals(setOf("within"), repository.getAllLogsUnbounded().first().map { it.uuid }.toSet())
+    }
+
+    /** Retention is measured against the real clock, so these rows are stamped relative to it. */
+    private fun retentionLog(uuid: String, receivedDate: Long) =
+        MeshLog(uuid = uuid, message_type = "TEXT", received_date = receivedDate, raw_message = "")
 
     private fun telemetryLog(
         uuid: String,

--- a/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/SetMeshLogSettingsUseCaseTest.kt
+++ b/core/domain/src/commonTest/kotlin/org/meshtastic/core/domain/usecase/settings/SetMeshLogSettingsUseCaseTest.kt
@@ -17,11 +17,17 @@
 package org.meshtastic.core.domain.usecase.settings
 
 import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.model.MeshLog
+import org.meshtastic.core.repository.MeshLogRetention
 import org.meshtastic.core.testing.FakeMeshLogPrefs
 import org.meshtastic.core.testing.FakeMeshLogRepository
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 class SetMeshLogSettingsUseCaseTest {
 
@@ -41,6 +47,54 @@ class SetMeshLogSettingsUseCaseTest {
         useCase.setRetentionDays(500) // Max is 365
         assertEquals(365, meshLogPrefs.retentionDays.value)
         assertEquals(365, meshLogRepository.lastDeletedOlderThan)
+    }
+
+    @Test
+    fun `setRetentionDays one hour keeps the last hour instead of every log`() = runTest {
+        val now = nowMillis
+        meshLogRepository.setLogs(
+            listOf(
+                MeshLog("recent", "TEXT", now - 30.minutes.inWholeMilliseconds, ""),
+                MeshLog("stale", "TEXT", now - 2.hours.inWholeMilliseconds, ""),
+            ),
+        )
+
+        useCase.setRetentionDays(MeshLogRetention.ONE_HOUR)
+
+        assertEquals(MeshLogRetention.ONE_HOUR, meshLogPrefs.retentionDays.value)
+        assertEquals(listOf("recent"), meshLogRepository.currentLogs.map { it.uuid })
+    }
+
+    @Test
+    fun `setRetentionDays never keeps every log`() = runTest {
+        val now = nowMillis
+        meshLogRepository.setLogs(
+            listOf(
+                MeshLog("ancient", "TEXT", now - 400.days.inWholeMilliseconds, ""),
+                MeshLog("recent", "TEXT", now, ""),
+            ),
+        )
+
+        useCase.setRetentionDays(MeshLogRetention.KEEP_FOREVER)
+
+        assertEquals(MeshLogRetention.KEEP_FOREVER, meshLogPrefs.retentionDays.value)
+        assertEquals(listOf("ancient", "recent"), meshLogRepository.currentLogs.map { it.uuid })
+    }
+
+    @Test
+    fun `setLoggingEnabled true trims to the one hour sentinel`() = runTest {
+        val now = nowMillis
+        meshLogPrefs.setRetentionDays(MeshLogRetention.ONE_HOUR)
+        meshLogRepository.setLogs(
+            listOf(
+                MeshLog("recent", "TEXT", now - 30.minutes.inWholeMilliseconds, ""),
+                MeshLog("stale", "TEXT", now - 2.hours.inWholeMilliseconds, ""),
+            ),
+        )
+
+        useCase.setLoggingEnabled(true)
+
+        assertEquals(listOf("recent"), meshLogRepository.currentLogs.map { it.uuid })
     }
 
     @Test

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AppPreferences.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AppPreferences.kt
@@ -58,7 +58,9 @@ interface MeshLogPrefs {
 
     companion object {
         const val DEFAULT_RETENTION_DAYS = 30
-        const val MIN_RETENTION_DAYS = -1
+
+        /** The lowest selectable setting is the one-hour sentinel, not a day count. */
+        const val MIN_RETENTION_DAYS = MeshLogRetention.ONE_HOUR
         const val MAX_RETENTION_DAYS = 365
     }
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshLogRepository.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshLogRepository.kt
@@ -76,7 +76,10 @@ interface MeshLogRepository {
     /** Deletes only local stats telemetry logs for [nodeNum], preserving other telemetry logs. */
     suspend fun deleteLocalStatsLogs(nodeNum: Int)
 
-    /** Prunes the log database based on the configured [retentionDays]. */
+    /**
+     * Prunes the log database based on the configured [retentionDays], which carries the [MeshLogRetention] sentinels:
+     * [MeshLogRetention.KEEP_FOREVER] deletes nothing and [MeshLogRetention.ONE_HOUR] keeps only the last hour.
+     */
     suspend fun deleteLogsOlderThan(retentionDays: Int)
 
     companion object {

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshLogRetention.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshLogRetention.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * Decodes [MeshLogPrefs.retentionDays], which overloads two sentinels onto the day count: [KEEP_FOREVER] never prunes
+ * and [ONE_HOUR] keeps only the last hour.
+ *
+ * Both sentinels are real user selections rather than "unset", so pruning callers must resolve the window here instead
+ * of treating the setting as a plain day count.
+ */
+object MeshLogRetention {
+
+    /** Retention setting for "never delete". */
+    const val KEEP_FOREVER: Int = 0
+
+    /** Retention setting for "keep the last hour", which cannot be expressed as a whole number of days. */
+    const val ONE_HOUR: Int = -1
+
+    /** The retention window for [retentionDays], or `null` when logs are never pruned. */
+    fun windowOrNull(retentionDays: Int): Duration? = when {
+        retentionDays == KEEP_FOREVER -> null
+
+        // Every negative value resolves to the one-hour sentinel; scaling one by days would put the cutoff in the
+        // future, matching the whole table.
+        retentionDays < 0 -> 1.hours
+
+        else -> retentionDays.days
+    }
+}

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/MeshLogRetentionTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/MeshLogRetentionTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+
+class MeshLogRetentionTest {
+
+    @Test
+    fun `one hour sentinel resolves to an hour and not a negative day count`() {
+        assertEquals(1.hours, MeshLogRetention.windowOrNull(MeshLogRetention.ONE_HOUR))
+    }
+
+    @Test
+    fun `keep forever sentinel resolves to no window`() {
+        assertNull(MeshLogRetention.windowOrNull(MeshLogRetention.KEEP_FOREVER))
+    }
+
+    @Test
+    fun `positive settings resolve to that many days`() {
+        assertEquals(1.days, MeshLogRetention.windowOrNull(1))
+        assertEquals(7.days, MeshLogRetention.windowOrNull(7))
+        assertEquals(30.days, MeshLogRetention.windowOrNull(MeshLogPrefs.DEFAULT_RETENTION_DAYS))
+        assertEquals(365.days, MeshLogRetention.windowOrNull(MeshLogPrefs.MAX_RETENTION_DAYS))
+    }
+
+    @Test
+    fun `out of range negative settings still resolve to an hour`() {
+        assertEquals(1.hours, MeshLogRetention.windowOrNull(-2))
+        assertEquals(1.hours, MeshLogRetention.windowOrNull(Int.MIN_VALUE))
+    }
+
+    @Test
+    fun `every window is positive so the cutoff never lands in the future`() {
+        val settings = listOf(Int.MIN_VALUE, -2, MeshLogRetention.ONE_HOUR, 1, 7, 365, Int.MAX_VALUE)
+        settings.forEach { setting ->
+            val window = MeshLogRetention.windowOrNull(setting)
+            assertTrue(window == null || window.isPositive(), "window for $setting was $window")
+        }
+    }
+
+    @Test
+    fun `the lowest selectable setting is the one hour sentinel`() {
+        assertEquals(MeshLogRetention.ONE_HOUR, MeshLogPrefs.MIN_RETENTION_DAYS)
+    }
+}

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/worker/MeshLogCleanupWorker.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/worker/MeshLogCleanupWorker.kt
@@ -23,6 +23,7 @@ import co.touchlab.kermit.Logger
 import org.koin.android.annotation.KoinWorker
 import org.meshtastic.core.repository.MeshLogPrefs
 import org.meshtastic.core.repository.MeshLogRepository
+import org.meshtastic.core.repository.MeshLogRetention
 
 @KoinWorker
 class MeshLogCleanupWorker(
@@ -35,18 +36,13 @@ class MeshLogCleanupWorker(
     @Suppress("TooGenericExceptionCaught")
     override suspend fun doWork(): Result = try {
         val retentionDays = meshLogPrefs.retentionDays.value
+        val retentionWindow = MeshLogRetention.windowOrNull(retentionDays)
         if (!meshLogPrefs.loggingEnabled.value) {
             logger.i { "Skipping cleanup because mesh log storage is disabled" }
-        } else if (retentionDays == 0) {
+        } else if (retentionWindow == null) {
             logger.i { "Skipping cleanup because retention is set to never delete" }
         } else {
-            val retentionLabel =
-                if (retentionDays == -1) {
-                    "1 hour"
-                } else {
-                    "$retentionDays days"
-                }
-            logger.d { "Cleaning logs older than $retentionLabel" }
+            logger.d { "Cleaning logs older than $retentionWindow" }
             meshLogRepository.deleteLogsOlderThan(retentionDays)
             logger.i { "Successfully cleaned old MeshLog entries" }
         }

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeMeshLogRepository.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeMeshLogRepository.kt
@@ -19,8 +19,10 @@ package org.meshtastic.core.testing
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
+import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.repository.MeshLogRepository
+import org.meshtastic.core.repository.MeshLogRetention
 import org.meshtastic.proto.MeshPacket
 import org.meshtastic.proto.MyNodeInfo
 import org.meshtastic.proto.PortNum
@@ -96,6 +98,9 @@ class FakeMeshLogRepository :
 
     override suspend fun deleteLogsOlderThan(retentionDays: Int) {
         lastDeletedOlderThan = retentionDays
+        val window = MeshLogRetention.windowOrNull(retentionDays) ?: return
+        val cutoff = nowMillis - window.inWholeMilliseconds
+        logsFlow.value = logsFlow.value.filter { it.received_date >= cutoff }
     }
 
     fun setLogs(logs: List<MeshLog>) {

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
@@ -66,6 +66,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.repository.MeshLogRetention
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.debug_clear
 import org.meshtastic.core.resources.debug_decoded_payload
@@ -237,11 +238,11 @@ private fun DebugLogSettings(viewModel: DebugViewModel) {
     ) {
         @Suppress("MagicNumber")
         val retentionItems =
-            listOf((-1L) to pluralStringResource(Res.plurals.log_retention_hours, 1, 1)) +
+            listOf(MeshLogRetention.ONE_HOUR.toLong() to pluralStringResource(Res.plurals.log_retention_hours, 1, 1)) +
                 listOf(1, 3, 7, 14, 30, 60, 90, 180, 365).map { days ->
                     days.toLong() to pluralStringResource(Res.plurals.log_retention_days_quantity, days, days)
                 } +
-                listOf(0L to stringResource(Res.string.log_retention_never))
+                listOf(MeshLogRetention.KEEP_FOREVER.toLong() to stringResource(Res.string.log_retention_never))
         DropDownPreference(
             title = stringResource(Res.string.log_retention_days),
             enabled = loggingEnabled,

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/debugging/DebugViewModelTest.kt
@@ -29,7 +29,10 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.model.MeshLog
+import org.meshtastic.core.repository.MeshLogRetention
 import org.meshtastic.core.testing.FakeMeshLogPrefs
 import org.meshtastic.core.testing.FakeMeshLogRepository
 import org.meshtastic.core.testing.FakeNodeRepository
@@ -37,6 +40,9 @@ import org.meshtastic.core.ui.util.AlertManager
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DebugViewModelTest {
@@ -82,6 +88,39 @@ class DebugViewModelTest {
         meshLogPrefs.retentionDays.value shouldBe 14
         meshLogRepository.lastDeletedOlderThan shouldBe 14
         viewModel.retentionDays.value shouldBe 14
+    }
+
+    @Test
+    fun `setRetentionDays one hour keeps the last hour instead of clearing the log`() = runTest {
+        val now = nowMillis
+        meshLogRepository.setLogs(
+            listOf(
+                MeshLog("recent", "TEXT", now - 30.minutes.inWholeMilliseconds, ""),
+                MeshLog("stale", "TEXT", now - 2.hours.inWholeMilliseconds, ""),
+            ),
+        )
+
+        viewModel.setRetentionDays(MeshLogRetention.ONE_HOUR)
+
+        meshLogPrefs.retentionDays.value shouldBe MeshLogRetention.ONE_HOUR
+        viewModel.retentionDays.value shouldBe MeshLogRetention.ONE_HOUR
+        meshLogRepository.currentLogs.map { it.uuid } shouldBe listOf("recent")
+    }
+
+    @Test
+    fun `setRetentionDays never keeps every log`() = runTest {
+        val now = nowMillis
+        meshLogRepository.setLogs(
+            listOf(
+                MeshLog("ancient", "TEXT", now - 400.days.inWholeMilliseconds, ""),
+                MeshLog("recent", "TEXT", now, ""),
+            ),
+        )
+
+        viewModel.setRetentionDays(MeshLogRetention.KEEP_FOREVER)
+
+        meshLogPrefs.retentionDays.value shouldBe MeshLogRetention.KEEP_FOREVER
+        meshLogRepository.currentLogs.map { it.uuid } shouldBe listOf("ancient", "recent")
     }
 
     @Test


### PR DESCRIPTION
Selecting **"1 hour"** mesh log retention in Debug settings deleted the **entire** MeshLog table instead of trimming to the last hour. The dropdown persists that choice as the sentinel `-1`, but the pruning math treated it as a plain day count:

```kotlin
val cutoffTime = nowMillis - (retentionDays.toLong() * 24 * 60 * 60 * 1000)
```

For `-1` that resolves to `nowMillis + 86_400_000` — a cutoff **24 hours in the future** — and `DELETE FROM log WHERE received_date < :cutoffTimestamp` then matched every row.

`0` ("Never delete") was broken the same way: it produced a cutoff of exactly *now*, so every existing row was older than it. `MeshLogCleanupWorker` guarded `0`, but the Debug-settings path did not — so **both sentinels destroyed the log the moment they were selected**, with no confirmation and nothing to undo.

This is the repo's known presence-vs-sentinel-zero defect class in a new spot: `0` and `-1` are both *meaningful values* here, not "missing". The root cause was that neither sentinel was decoded anywhere — the raw setting flowed straight into day-based arithmetic — so the fix puts the decoding in exactly one place rather than patching each call site.

## 🐛 Bug fixes

- **"1 hour" retention now retains one hour** instead of clearing the table.
- **"Never delete" now deletes nothing** on the immediate path too. Previously only the scheduled worker guarded it; choosing it in Debug settings wiped the log.
- Any negative value resolves to one hour, so a corrupt or out-of-range preference can never again produce a cutoff in the future.

## 🛠️ Improvements

- New `MeshLogRetention` (in `core:repository`, beside `MeshLogPrefs`) is the single decoder for the overloaded setting. `windowOrNull(retentionDays)` returns a `Duration`, or `null` for "never delete".
- `MeshLogRepositoryImpl.deleteLogsOlderThan` resolves the window before computing a cutoff and no-ops on `null`, so `MeshLogCleanupWorker`, `SetMeshLogSettingsUseCase` (both `setRetentionDays` and the `setLoggingEnabled` re-enable branch) and `DebugViewModel` all agree by construction — no caller does retention arithmetic any more.
- `FakeMeshLogRepository` now honours the same contract instead of only recording the argument, so fake-backed tests at the domain and view-model layers can actually catch a wipe.

## 🧹 Cleanup

- `MeshLogCleanupWorker` no longer carries its own copy of the "`-1` means 1 hour" knowledge for its log label — it logs the resolved window, so the sentinel is described in one place only.
- The Debug dropdown builds its sentinel rows from `MeshLogRetention.ONE_HOUR` / `KEEP_FOREVER` rather than bare `-1L` / `0L` literals, and `MeshLogPrefs.MIN_RETENTION_DAYS` is now defined as `MeshLogRetention.ONE_HOUR`.
- Dropped a `@Suppress("MagicNumber")` that the hand-rolled millisecond arithmetic required.

## Testing Performed

Full baseline on JDK 25: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — **all green, 5107 tests**, no detekt or spotless violations.

New regression coverage, all three required cases plus the guard:

| Layer | Test | Covers |
| --- | --- | --- |
| `MeshLogRetentionTest` (`core:repository`, runs on jvm + androidHostTest + iOS) | 6 tests | `-1` → `1.hours`, `0` → `null`, positive → N days, out-of-range negatives, "every window is positive so the cutoff never lands in the future", `MIN_RETENTION_DAYS` ties to the sentinel |
| `CommonMeshLogRepositoryTest` (real Room DB via `FakeDatabaseProvider`) | `-1` keeps rows newer than an hour and deletes older; `0` deletes nothing (incl. a 400-day-old row); `7` keeps day 6 and drops day 8 | the actual pruning math |
| `SetMeshLogSettingsUseCaseTest` | `-1`, `0`, and the `setLoggingEnabled(true)` re-enable branch | the domain entry points |
| `DebugViewModelTest` | `-1` and `0` via `setRetentionDays` | the exact path a user hits in the UI |

**Negative control** — I reverted the two production files to their pre-fix state and re-ran, to confirm the tests fail on the old code rather than passing vacuously:

- `deleteLogsOlderThan one hour sentinel keeps the last hour...` → `expected: <[recent]> but was: <>` — the empty result *is* the reported data loss, reproduced.
- `deleteLogsOlderThan keep forever sentinel deletes nothing` → `expected: <[ancient, recent]> but was: <>` — the second path, likewise.
- The domain and view-model tests failed too, then all passed once the fix was restored.

## Note on #6621

[#6621](https://github.com/meshtastic/Meshtastic-Android/pull/6621) ("fix(service): load persisted MeshLog cleanup policy") is adjacent and untouched by this PR. It makes the worker read the persisted policy on cold start instead of the synthetic default of `30`, which means once it merges the *scheduled* path would start hitting this `-1` case too. The two are independent, but landing this first removes that edge from #6621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
