### PR TITLE
fix(ci): unbreak the merge queue on Gradle 9.6.1

### DIFF
--- a/scripts/verify-flatpak/verify.sh
+++ b/scripts/verify-flatpak/verify.sh
@@ -79,7 +79,7 @@ if [[ $SKIP_REGEN -eq 0 ]]; then
     rm -rf "$GRADLE_HOME_ISOLATED"
     # The settings plugin (org.meshtastic.flatpak.sources.settings) captures URLs from
     # build start — no init script or -I flag needed.
-    (cd "$REPO_ROOT" && ./gradlew --no-build-cache --no-isolated-projects --no-configuration-cache -Pmeshtastic.flatpakSources=true \
+    (cd "$REPO_ROOT" && ./gradlew --no-build-cache -Dorg.gradle.isolated-projects=false --no-configuration-cache -Pmeshtastic.flatpakSources=true \
         -Dgradle.user.home="$GRADLE_HOME_ISOLATED" \
         :desktopApp:packageUberJarForCurrentOS :captureFlatpakSources)
     cp "$REPO_ROOT/build/flatpak-ops-sources.json" "$SOURCES_JSON"

--- a/scripts/verify-rb.sh
+++ b/scripts/verify-rb.sh
@@ -12,11 +12,11 @@ trap 'rm -rf "$WORKDIR"' EXIT
 
 echo "── Step 1: Verify aboutlibraries.json determinism ──"
 rm -f androidApp/src/main/resources/aboutlibraries.json
-./gradlew :androidApp:exportLibraryDefinitions -Pci=true --no-isolated-projects --no-configuration-cache
+./gradlew :androidApp:exportLibraryDefinitions -Pci=true -Dorg.gradle.isolated-projects=false --no-configuration-cache
 cp androidApp/src/main/resources/aboutlibraries.json "$WORKDIR/aboutlibraries-run1.json"
 
 rm -f androidApp/src/main/resources/aboutlibraries.json
-./gradlew :androidApp:exportLibraryDefinitions -Pci=true --no-isolated-projects --no-configuration-cache --rerun-tasks
+./gradlew :androidApp:exportLibraryDefinitions -Pci=true -Dorg.gradle.isolated-projects=false --no-configuration-cache --rerun-tasks
 cp androidApp/src/main/resources/aboutlibraries.json "$WORKDIR/aboutlibraries-run2.json"
 
 if ! diff -q "$WORKDIR/aboutlibraries-run1.json" "$WORKDIR/aboutlibraries-run2.json"; then
@@ -27,7 +27,7 @@ fi
 echo "✅ aboutlibraries.json is deterministic"
 
 echo "── Step 2: Build fdroid release APK ──"
-./gradlew :androidApp:assembleFdroidRelease -Pci=true -Pmeshtastic.disableAbiSplits=true --no-isolated-projects --no-configuration-cache
+./gradlew :androidApp:assembleFdroidRelease -Pci=true -Pmeshtastic.disableAbiSplits=true -Dorg.gradle.isolated-projects=false --no-configuration-cache
 
 APK=$(find androidApp/build/outputs/apk/fdroid/release -name "*.apk" | head -1)
 if [ -z "$APK" ]; then

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,7 +42,7 @@ plugins {
 
 // The flatpak-sources plugin reads Gradle.extensions, which Isolated Projects forbids; Gradle 9.7
 // enforces that and fails every task in the build. Only :captureFlatpakSources needs the plugin, and
-// its callers already pass --no-isolated-projects, so gate it on an opt-in property. Remove the gate
+// its callers already pass -Dorg.gradle.isolated-projects=false, so gate it on an opt-in property. Remove the gate
 // once org.meshtastic.flatpak.sources.settings > 0.1.5 ships an Isolated-Projects-safe release.
 if (providers.gradleProperty("meshtastic.flatpakSources").isPresent) {
     pluginManager.apply("org.meshtastic.flatpak.sources.settings")


### PR DESCRIPTION
### Why

**The merge queue is currently broken for every PR in the repo.** Merge-group runs fail with:

```
Problem configuring task :androidApp:exportLibraryDefinitions from command line.
> Unknown command-line option '--no-isolated-projects'.
```

`--no-isolated-projects` only exists on Gradle 9.7+. When #6611 pinned the wrapper back to 9.6.1 (to unbreak CMP desktop ProGuard), #6613 swept that flag out of `.github/workflows/**` but missed the two verification **scripts**, which still pass it.

This hid because of how `rb-check` is gated — `if: … github.event_name == 'merge_group'` (`reusable-check.yml:159`). It never runs on pull requests, so PRs go green, enter the queue, and die there. Observed fallout: #6623 and #6625 were both silently dropped from the queue with auto-merge disabled, and #6614/#6628 cycled for over an hour.

`scripts/verify-flatpak/verify.sh` carries the same flag. It isn't part of the queue failure (the CI flatpak job invokes Gradle directly and was already fixed by #6613), but it's the local developer entry point and is equally broken on 9.6.1 — fixing both keeps the sweep complete.

### 🐛 Bug fixes

- `scripts/verify-rb.sh` — replace `--no-isolated-projects` with the version-portable `-Dorg.gradle.isolated-projects=false` in all three Gradle invocations (steps 1 and 2).
- `scripts/verify-flatpak/verify.sh` — same swap for the sources-regeneration invocation.
- `settings.gradle.kts` — update the flatpak-sources gate comment, which still told readers that callers pass the removed flag.

This is the same substitution #6613 applied to the workflows, so the repo is now consistent: `-Dorg.gradle.isolated-projects=false` everywhere, and no reference to the 9.7-only flag outside the explanatory comment at `reusable-check.yml:457`.

### Testing Performed

- Reproduced the failure: merge-group run [31550351253](https://github.com/meshtastic/Meshtastic-Android/actions/runs/31550351253) fails in `android-check / rb-check` on the flag parse, 35s in, before any real work.
- Verified the fix locally on the pinned 9.6.1 wrapper — the exact failing command now succeeds:
  ```
  ./gradlew :androidApp:exportLibraryDefinitions -Pci=true -Dorg.gradle.isolated-projects=false --no-configuration-cache
  → Task :androidApp:exportLibraryDefinitions UP-TO-DATE
  → BUILD SUCCESSFUL in 27s
  ```
- Repo-wide sweep confirms no remaining `--no-isolated-projects` usages outside the comment that documents why it must not be used.
- `rb-check` itself only runs in the merge queue, so this PR's own green checks do **not** exercise the fix — the queue run on merge is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Flatpak and Ruby verification workflows to remain compatible with current Gradle versions.
  * Preserved existing configuration-cache and task rerun behavior.

* **Documentation**
  * Updated related build configuration guidance to reflect the current Gradle option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->