### PR TITLE
fix(settings): refresh delayed remote public keys

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/SecurityConfigScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/SecurityConfigScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,6 +28,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import okio.ByteString
@@ -86,15 +86,6 @@ fun SecurityConfigScreenCommon(viewModel: RadioConfigViewModel, onBack: () -> Un
     val securityConfig = state.radioConfig.security ?: Config.SecurityConfig()
     val formState = rememberConfigState(initialValue = securityConfig)
 
-    var publicKey by rememberSaveable { mutableStateOf(formState.value.public_key) }
-    LaunchedEffect(formState.value.private_key) {
-        if (formState.value.private_key != securityConfig.private_key) {
-            publicKey = ByteString.EMPTY
-        } else if (formState.value.private_key == securityConfig.private_key) {
-            publicKey = securityConfig.public_key
-        }
-    }
-
     var showKeyGenerationDialog by rememberSaveable { mutableStateOf(false) }
     PrivateKeyRegenerateDialog(
         showKeyGenerationDialog = showKeyGenerationDialog,
@@ -131,19 +122,10 @@ fun SecurityConfigScreenCommon(viewModel: RadioConfigViewModel, onBack: () -> Un
         }
         item {
             TitledCard(title = stringResource(Res.string.direct_message_key)) {
-                EditBase64Preference(
-                    title = stringResource(Res.string.public_key),
-                    summary = stringResource(Res.string.config_security_public_key),
-                    value = publicKey,
+                SecurityPublicKeyPreference(
+                    securityConfig = securityConfig,
+                    formState = formState,
                     enabled = state.connected,
-                    readOnly = true,
-                    keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
-                    onValueChange = {
-                        if (it.size == 32) {
-                            formState.value = formState.value.copy(public_key = it)
-                        }
-                    },
-                    trailingIcon = { CopyIconButton(valueToCopy = formState.value.public_key.encodeToString()) },
                 )
                 HorizontalDivider()
                 EditBase64Preference(
@@ -245,6 +227,46 @@ fun SecurityConfigScreenCommon(viewModel: RadioConfigViewModel, onBack: () -> Un
             }
         }
     }
+}
+
+internal const val SECURITY_PUBLIC_KEY_COPY_TEST_TAG = "security_public_key_copy"
+
+/**
+ * Public keys come from the device. Editing the private key invalidates that derived value until the device responds
+ * with the matching key pair, so display and copy must use the same resolved value.
+ */
+internal fun resolvedPublicKey(securityConfig: Config.SecurityConfig, editedPrivateKey: ByteString): ByteString =
+    if (editedPrivateKey == securityConfig.private_key) securityConfig.public_key else ByteString.EMPTY
+
+@Composable
+internal fun SecurityPublicKeyPreference(
+    securityConfig: Config.SecurityConfig,
+    formState: ConfigState<Config.SecurityConfig>,
+    enabled: Boolean,
+    publicKeyCopyButton: @Composable (ByteString) -> Unit = { publicKey ->
+        CopyIconButton(
+            valueToCopy = publicKey.encodeToString(),
+            modifier = Modifier.testTag(SECURITY_PUBLIC_KEY_COPY_TEST_TAG),
+        )
+    },
+) {
+    val focusManager = LocalFocusManager.current
+    val publicKey = resolvedPublicKey(securityConfig, formState.value.private_key)
+
+    EditBase64Preference(
+        title = stringResource(Res.string.public_key),
+        summary = stringResource(Res.string.config_security_public_key),
+        value = publicKey,
+        enabled = enabled,
+        readOnly = true,
+        keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+        onValueChange = {
+            if (it.size == 32) {
+                formState.value = formState.value.copy(public_key = it)
+            }
+        },
+        trailingIcon = { publicKeyCopyButton(publicKey) },
+    )
 }
 
 @Suppress("MagicNumber")

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/SecurityConfigScreenTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/SecurityConfigScreenTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio.component
+
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.model.util.encodeToString
+import org.meshtastic.core.ui.theme.AppTheme
+import org.meshtastic.proto.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class SecurityConfigScreenTest {
+    @Test
+    fun `delayed remote public key updates display and copy without recreating screen`() = runComposeUiTest {
+        var securityConfig by mutableStateOf(Config.SecurityConfig())
+        var renderedFormState: ConfigState<Config.SecurityConfig>? = null
+        var copiedPublicKey: ByteString? = null
+
+        setContent {
+            AppTheme {
+                val formState = rememberConfigState(securityConfig)
+                renderedFormState = formState
+                SecurityPublicKeyPreference(
+                    securityConfig = securityConfig,
+                    formState = formState,
+                    enabled = true,
+                    publicKeyCopyButton = { publicKey ->
+                        IconButton(
+                            modifier = Modifier.testTag(SECURITY_PUBLIC_KEY_COPY_TEST_TAG),
+                            onClick = { copiedPublicKey = publicKey },
+                        ) {}
+                    },
+                )
+            }
+        }
+
+        val publicKey = ByteArray(32) { (it + 1).toByte() }.toByteString()
+        val encodedPublicKey = publicKey.encodeToString()
+        onNodeWithText(encodedPublicKey).assertDoesNotExist()
+
+        // Firmware 2.8 redacts the remote private key, so only the public key changes when the delayed response lands.
+        securityConfig = Config.SecurityConfig(public_key = publicKey)
+        waitForIdle()
+
+        onNodeWithText(encodedPublicKey).assertIsDisplayed()
+        onNodeWithTag(SECURITY_PUBLIC_KEY_COPY_TEST_TAG).performClick()
+        assertEquals(publicKey, copiedPublicKey)
+        runOnIdle { assertEquals(ByteString.EMPTY, checkNotNull(renderedFormState).value.private_key) }
+
+        // A local private-key edit invalidates the device-derived public key for both render and copy.
+        runOnIdle {
+            val formState = checkNotNull(renderedFormState)
+            formState.value = formState.value.copy(private_key = ByteArray(32) { 7 }.toByteString())
+        }
+        waitForIdle()
+
+        onNodeWithText(encodedPublicKey).assertDoesNotExist()
+        copiedPublicKey = null
+        onNodeWithTag(SECURITY_PUBLIC_KEY_COPY_TEST_TAG).performClick()
+        assertEquals(ByteString.EMPTY, copiedPublicKey)
+    }
+}


### PR DESCRIPTION
## Summary

Remote Security config can arrive after the screen is composed. When firmware omits the remote private key, a delayed response may change only `public_key`; the previous remembered display value did not refresh even though copy used the new form value.

- derive the displayed public key from the latest device config
- use the same resolved value for display and copy
- clear the derived public key after a private-key edit
- add a Compose regression test for a delayed public-only response

This addresses only the app-side delayed public-key display/copy behavior. It does not expose or restore private-key material omitted by firmware.

## Validation

- affected-module Spotless, Detekt, JVM tests, and `kmpSmokeCompile` passed
- the required repository baseline completed Spotless, Detekt, and both debug APK assemblies; all changed and related tests passed
- `allTests` remains blocked only by known Windows Android-host DataStore atomic-rename failures in untouched `core:database`, `core:datastore`, and `core:prefs` fixtures

Physical-device UI validation was not performed.

Refs #6530


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security settings now display the derived public key only when it matches the currently entered private key.
  * Added an option to copy the displayed public key.
  * Public-key editing continues to accept only valid 32-byte values.

* **Bug Fixes**
  * Prevented stale public keys from remaining visible after the private key is changed.
  * Improved handling of delayed security updates and protected display of remote private-key information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->