### PR TITLE
fix(test): isolate androidApp unit tests from the production Application

### DIFF
--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -144,9 +144,8 @@ open class MeshUtilApplication :
     }
 
     override fun onTerminate() {
-        // Shutdown managers (useful for Robolectric tests).
-        // Non-blocking: cancelAndJoin inside runBlocking on the main thread can deadlock
-        // if any active coroutine is dispatching to Dispatchers.Main.
+        // Robolectric never calls this, so unit tests booting this Application cannot rely on it.
+        // cancel() not cancelAndJoin(): joining under runBlocking on the main thread can deadlock.
         applicationScope.cancel()
         try {
             runBlocking { get<DatabaseManager>().close() }

--- a/androidApp/src/test/kotlin/org/meshtastic/app/ui/NavigationAssemblyTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/ui/NavigationAssemblyTest.kt
@@ -36,9 +36,11 @@ import org.meshtastic.feature.settings.radio.channel.channelsGraph
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
+// Graph assembly only builds entry providers, so a bare Application is enough. Booting
+// MeshUtilApplication here leaks its applicationScope launches into the rest of the fork.
 @OptIn(ExperimentalTestApi::class)
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34])
+@Config(sdk = [34], application = android.app.Application::class)
 class NavigationAssemblyTest {
 
     @Test

--- a/androidApp/src/test/resources/robolectric.properties
+++ b/androidApp/src/test/resources/robolectric.properties
@@ -1,1 +1,6 @@
+# Legacy SQLite keeps Robolectric's native SQLite off androidApp's unit-test path. The native
+# implementation segfaults the whole test fork if its nativeruntime temp dir is torn down while a
+# background database open is still in flight, which fails the task outright (retry cannot help).
+# No androidApp unit test asserts database behaviour -- :core:database owns that and stays native.
 sdk=34
+sqliteMode=LEGACY

--- a/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/MapNodeClusterItemsTest.kt
+++ b/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/MapNodeClusterItemsTest.kt
@@ -44,9 +44,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 
+// A bare Application keeps MeshUtilApplication.onCreate out of this test: its fire-and-forget
+// applicationScope launches outlive the class and surface here as UncaughtExceptionsBeforeTest.
 @OptIn(ExperimentalTestApi::class, ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34])
+@Config(sdk = [34], application = android.app.Application::class)
 class MapNodeClusterItemsTest {
 
     @Test


### PR DESCRIPTION
## Why

`shard-app` has been failing in the merge queue and silently ejecting every PR in the group (auto-merge disabled, no notification). PR #6619 lost ~12 hours to three ejections.

The failing tests named in the logs are **not** the cause. Two separate things were happening, and only one of them fails the build:

**1. The noisy symptom (does not fail the build).** `MapNodeClusterItemsTest` fails with `kotlinx.coroutines.test.UncaughtExceptionsBeforeTest`. That exception is not raised by the test's own assertions — `runTest` reports coroutine exceptions that leaked into the JVM from *elsewhere*. Develocity test retry (`maxRetries = 2`, `failOnPassedAfterRetry = false`) already absorbs it: in run `31601090391` all three counted failures passed on retry.

**2. The actual queue ejector.** The task dies on a JVM crash that retry cannot recover:

```
Invalid ICU dat file path '/tmp/robolectric-nativeruntime<n>/icu/icudt68l.dat'
ERROR: Failed to destroy temp directory
#  SIGSEGV (0xb) ... Problematic frame:
# j org.robolectric.nativeruntime.SQLiteConnectionNatives.nativeOpen(...)+0
> Process 'Gradle Test Executor 19' finished with non-zero exit value 134 (SIGABRT)
```

A dead fork is a hard task failure, so GitHub drops the merge group.

**Correcting one triage assumption:** run `31595306067` (12:11) did *not* pass. It failed with the byte-identical crash signature, but in `:androidApp:testFdroidDebugUnitTest` — a variant that does not contain `MapNodeClusterItemsTest` at all. That is the proof the test is a bystander.

### Shared root cause

Robolectric instantiates `MeshUtilApplication` from the merged manifest for any androidApp test that does not override `@Config(application = ...)`. `onCreate()` enqueues WorkManager periodic work (which opens WorkManager's Room database) and launches three fire-and-forget coroutines on `CoroutineScope(SupervisorJob() + Dispatchers.Default)` — one calls `DatabaseManager.init(...)`, another is documented as never returning.

Nothing cancels them. `onTerminate()` is the intended cleanup and its comment claimed it was "useful for Robolectric tests", but **no class in Robolectric 4.16.1 calls `Application.onTerminate()`** (verified by scanning every class in the jar). So each test class leaves live background work running in the fork, which then:

- throws into kotlinx-coroutines-test's process-wide `ExceptionCollector` (registered as a `CoroutineExceptionHandler` via `META-INF/services`), which attributes it to whichever `runTest` is currently active. `MapNodeClusterItemsTest` is the only `runTest`/`runComposeUiTest` user in the google shard, making it the standing scapegoat; and
- keeps opening SQLite while Robolectric tears down its native-runtime temp directory, invalidating the ICU data path and segfaulting the fork.

## 🛠️ Changes

- `MapNodeClusterItemsTest` and `NavigationAssemblyTest` now use `application = android.app.Application::class`. Neither needs the app graph — one tests a `remember` helper, the other only assembles nav entry providers. This matches the convention already used by `GlanceTrampolineManifestTest`, `MeshtasticAppFunctionsTest` and `feature:widget`.
- `androidApp/src/test/resources/robolectric.properties` sets `sqliteMode=LEGACY`, keeping Robolectric's native SQLite off androidApp's unit-test path. This is deliberate containment of an upstream defect: the native implementation *segfaults* rather than throwing when its ICU data goes missing, which we cannot fix from here. No androidApp unit test asserts database behaviour — `:core:database` owns that and stays on native SQLite.

## 🧹 Cleanup

- Corrected the `onTerminate()` comment, which asserted Robolectric behaviour that does not exist and is what led these tests to rely on cleanup that never runs.

## Deliberate non-changes

- **No `CoroutineExceptionHandler` on `applicationScope`.** It would silence the contamination, but by changing production crash semantics and masking real background failures.
- **No `onTerminate()` call from test teardown.** `DatabaseManager.close()` drains writers under mutexes; invoking it via `runBlocking` on Robolectric's main thread risks a deadlock, which is worse than the flake.
- **No quarantined test methods.** The crash reproduces in a variant that does not contain the suspect test, so disabling those methods would fix nothing and hide the real fault.

## Testing Performed

A single green run proves nothing for a flake, so both states were measured with the same loaded harness: the shard's Robolectric tasks (`:androidApp:testFdroidDebugUnitTest`, `:androidApp:testGoogleDebugUnitTest`, `:core:database:allTests`, `:core:network:allTests`, `:feature:widget:testDebugUnitTest`), forced to re-run, at CI fork parallelism (`-Pci=true` → `maxParallelForks` = 10 cores).

| | iterations | with any crash marker | with `UncaughtExceptionsBeforeTest` |
|---|---|---|---|
| before | 8 | **4** (1, 3, 5, 6) | **3** (1, 6, 7) |
| after | 10 | **0** | **0** |

The before-run was scored over its first 8 iterations; iterations 9–10 were discarded because edits for this fix landed while they were still executing.

Both CI signatures reproduced locally on the unfixed tree, including the one the triage notes could not reproduce:

- `UncaughtExceptionsBeforeTest at MapNodeClusterItemsTest.kt:84`, immediately preceded by `NavigationAssemblyTest ... PASSED` — the same adjacency as the CI log, and the reason `NavigationAssemblyTest` is fixed here too.
- `ERROR: Failed to destroy temp directory`, the Robolectric temp-dir half of the crash.


Failure markers counted per iteration: `SIGSEGV`, `SIGABRT`, `Invalid ICU`, `Failed to destroy temp directory`, `non-zero exit value`, `UncaughtExceptionsBeforeTest`.

Also verified:
- `robolectric.properties` is genuinely honoured by the per-flavour unit-test tasks — probed by setting `sqliteMode=BOGUS_PROBE` and confirming every Robolectric class in `testGoogleDebugUnitTest` hit `initializationError`, then setting the real value.
- Baseline: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests`.

## Known remaining exposure

`CoilImageLoaderLifecycleTest` and `FlavorApplicationStartupTest` still boot the real Application on purpose, so they still leak background coroutines into their fork. `sqliteMode=LEGACY` removes the segfault frame for them, but the exception-contamination channel stays open in principle. Worth a follow-up that gives those two an explicit, deadlock-free app teardown.

An upstream Robolectric issue should be filed for the segfault-instead-of-exception behaviour in `SQLiteConnectionNatives.nativeOpen` when `icu.data.path` is invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved Android test stability by using a minimal application configuration in Robolectric tests.
  - Preserved compatibility with the configured SDK and legacy SQLite test mode.
  - Prevented background application work from causing uncaught test exceptions.

- **Documentation**
  - Clarified application shutdown behavior and why cancellation remains non-blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->