### PR TITLE
docs(agents): teach gradle-runner to use a shared build queue when present

### DIFF
--- a/.claude/agents/gradle-runner.md
+++ b/.claude/agents/gradle-runner.md
@@ -8,19 +8,18 @@ model: haiku
 You run Gradle commands for the Meshtastic-Android KMP project and report back a tight, structured result. Your entire value is keeping huge build logs out of the calling agent's context — so you read the full output, but you return only the distilled signal.
 
 ## Setup (always, before any Gradle command)
-**Run from the repository root for THIS session — in a git worktree that is the worktree, NOT the main checkout. Never hardcode a repo path; resolve it.** If the caller's prompt names a specific project/worktree path, `cd` into that; otherwise use the git top-level of your current directory. `ANDROID_HOME` is usually unset. Combine it on one line, and `pwd` so the caller can confirm the right tree was built:
-```bash
-cd "$(git rev-parse --show-toplevel)" && pwd && export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}" && ./gradlew <tasks>
-```
-If a build complains `local.properties` is missing (Google-flavor tasks), `cp secrets.defaults.properties local.properties` first — it's git-ignored. Do not `cd` elsewhere mid-command.
+**Run from the repository root for THIS session — in a git worktree that is the worktree, NOT the main checkout. Never hardcode a repo path; resolve it.** If the caller's prompt names a specific project/worktree path, `cd` into that; otherwise use the git top-level of your current directory. `ANDROID_HOME` is usually unset.
 
-## If a build queue is installed, use it
-Some machines run many Claude sessions against one shared `~/.gradle`, where unqueued parallel builds cause daemon-registry and cache-lock contention. Those machines install a wrapper that admits N builds at a time and queues the rest FIFO. Probe once, and use it only if present — it is machine-local, not part of this repo:
+Some machines run many Claude sessions against one shared `~/.gradle`, where unqueued parallel builds cause daemon-registry and cache-lock contention; those machines install a queue wrapper (see below). Probe for it and fall back to `./gradlew`, so this works identically with or without one. Use this as your single build command, and `pwd` so the caller can confirm the right tree was built:
 ```bash
-GQ="$HOME/.claude/bin/gradle-queue"; [ -x "$GQ" ] && BUILD="$GQ --" || BUILD="./gradlew"
-cd "$(git rev-parse --show-toplevel)" && export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}" && $BUILD <tasks>
+GQ="$HOME/.claude/bin/gradle-queue"
+if [ -x "$GQ" ]; then BUILD=("$GQ" --); else BUILD=(./gradlew); fi
+cd "$(git rev-parse --show-toplevel)" && pwd && export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}" && "${BUILD[@]}" <tasks>
 ```
-When the wrapper is in use, a PreToolUse hook also denies raw `./gradlew`; the denial text names the exact replacement command, so follow it rather than retrying. Then:
+Keep `BUILD` an array and invoke it as `"${BUILD[@]}"` — a plain string would word-split on a `$HOME` containing spaces or glob characters. If a build complains `local.properties` is missing (Google-flavor tasks), `cp secrets.defaults.properties local.properties` first — it's git-ignored. Do not `cd` elsewhere mid-command.
+
+## When the queue wrapper is in use
+The wrapper admits N builds at a time and queues the rest FIFO; it is machine-local, not part of this repo. A PreToolUse hook also denies raw `./gradlew`, and its denial text names the exact replacement command — follow that rather than retrying. Then:
 - It blocks until a slot frees, so **always pass `timeout: 600000` or use `run_in_background: true`** — a queued wait plus a cold build far exceeds the 120s default, and a Bash timeout here looks exactly like the "daemon disappeared" failure.
 - `gradle-queue: all N slots busy; queued at position N` on stderr is normal progress. Never report it as a build failure.
 - **Exit code 75 is a queue-wait timeout, not a build failure.** The build never started, so nothing in the source tree caused it and there is nothing to fix — report `CONFIG-ERROR` with the output of `gradle-queue --status`. Never edit or revert files to make a 75 go away.

--- a/.claude/agents/gradle-runner.md
+++ b/.claude/agents/gradle-runner.md
@@ -14,6 +14,18 @@ cd "$(git rev-parse --show-toplevel)" && pwd && export ANDROID_HOME="${ANDROID_H
 ```
 If a build complains `local.properties` is missing (Google-flavor tasks), `cp secrets.defaults.properties local.properties` first — it's git-ignored. Do not `cd` elsewhere mid-command.
 
+## If a build queue is installed, use it
+Some machines run many Claude sessions against one shared `~/.gradle`, where unqueued parallel builds cause daemon-registry and cache-lock contention. Those machines install a wrapper that admits N builds at a time and queues the rest FIFO. Probe once, and use it only if present — it is machine-local, not part of this repo:
+```bash
+GQ="$HOME/.claude/bin/gradle-queue"; [ -x "$GQ" ] && BUILD="$GQ --" || BUILD="./gradlew"
+cd "$(git rev-parse --show-toplevel)" && export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}" && $BUILD <tasks>
+```
+When the wrapper is in use, a PreToolUse hook also denies raw `./gradlew`; the denial text names the exact replacement command, so follow it rather than retrying. Then:
+- It blocks until a slot frees, so **always pass `timeout: 600000` or use `run_in_background: true`** — a queued wait plus a cold build far exceeds the 120s default, and a Bash timeout here looks exactly like the "daemon disappeared" failure.
+- `gradle-queue: all N slots busy; queued at position N` on stderr is normal progress. Never report it as a build failure.
+- **Exit code 75 is a queue-wait timeout, not a build failure.** The build never started, so nothing in the source tree caused it and there is nothing to fix — report `CONFIG-ERROR` with the output of `gradle-queue --status`. Never edit or revert files to make a 75 go away.
+- `--version`/`--status` pass through. `./gradlew --stop` is denied: it stops every daemon on the machine, including ones other sessions are mid-build on, which surfaces there as "daemon has been stopped: stop command received". Use `GRADLE_QUEUE_BYPASS=1` only if the caller explicitly asked.
+
 ## Hard constraints — you are a RUNNER, not a fixer
 Past runs of this agent have silently edited/reverted files to make builds pass and even made git commits (once bundling stray screenshot PNGs). Never again:
 - NEVER modify the working tree: no creating/editing/deleting/reverting files, no `sed -i`, no redirecting output into tracked files.


### PR DESCRIPTION
## Why

On a machine running many concurrent Claude Code sessions, every session builds against the **same** `~/.gradle`. Unqueued, that is not merely slow — it is self-defeating. Measured on one such machine with ~11 live sessions:

- load average **44** on 10 cores, with **15 MB** free RAM of 32 GB and 4.5 GB in the compressor
- **3,722** `waiting to acquire shared lock on daemon addresses registry` events in two hours, plus journal / file-hash / artifact cache lock waits
- four live daemons at `-Xmx8g` each, promising 32 GB of heap on a 32 GB box

The fix on that machine is a local wrapper that admits N builds at a time and queues the rest FIFO. This PR teaches the `gradle-runner` subagent about that contract.

## 🛠️ What changed

One file, `.claude/agents/gradle-runner.md`:

- **One build command, probe-and-fallback.** The wrapper is machine-local and deliberately *not* checked in. The agent tests for it and falls back to plain `./gradlew`, so contributors without it are completely unaffected:
  ```bash
  GQ="$HOME/.claude/bin/gradle-queue"
  if [ -x "$GQ" ]; then BUILD=("$GQ" --); else BUILD=(./gradlew); fi
  cd "$(git rev-parse --show-toplevel)" && pwd && export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}" && "${BUILD[@]}" <tasks>
  ```
- **Three failure modes a runner agent would otherwise misreport**, spelled out:
  - `all N slots busy; queued at position N` on stderr is progress, not a build failure.
  - **Exit 75 is a queue-wait timeout — the build never started.** Nothing in the source tree caused it, so there is nothing to fix. This one matters: the file's own "Hard constraints" section documents that past runs of this agent silently edited and even committed files to force a build green. An unexplained exit 75 is exactly the kind of thing that invites that.
  - Stopping the daemon is machine-wide and kills daemons other sessions are mid-build on, surfacing there as `daemon has been stopped: stop command received`.
- Keeps the blocking-call guidance aligned with the existing `timeout: 600000` / background-bash convention, since a queued wait plus a cold build is indistinguishable from the "daemon disappeared" Bash-timeout failure.

## Reviewer notes

- **Docs only** — no Gradle config, no build logic, no source. Nothing in this diff changes what any build does.
- **Nothing here is required.** Without the wrapper installed, the resolved command is byte-for-byte the previous one.
- The wrapper itself, the enforcing hook, and the heap retune live outside the repo (`~/.claude/`, `~/.gradle/gradle.properties`) on the affected machine. Deliberately not proposed for check-in: they are host-specific and would be wrong for CI and for contributors with a single session.

## Review follow-ups (both CodeRabbit findings were real)

- **Major — self-contradicting instructions.** The Setup section still issued a raw `./gradlew` while a separate queue section issued a wrapper-aware one. On a machine with the wrapper installed, the agent would follow Setup first and be denied by the hook before ever reaching the probe. The two blocks are now collapsed into a single build command, so there is one source of truth rather than two competing ones.
- **Minor — quoting.** `BUILD` held `"$GQ --"` as one string and was expanded unquoted, which word-splits on a `$HOME` containing spaces or glob characters. Now a Bash array invoked as `"${BUILD[@]}"`. Verified against a `$HOME` with a space: the array form resolves correctly and the old string form does genuinely break (path split mid-directory), so this was a real defect rather than a theoretical one.

## Testing performed

No test code changed, so no test run applies. The tooling this documents was verified directly:

- Semaphore admits exactly 2 concurrent jobs and queues the rest in arrival order; slots release cleanly on exit.
- A `SIGKILL`ed holder's slot is reclaimed automatically and the next waiter acquires it — no manual unwedging.
- The guard denies raw `./gradlew` and daemon-stop, while `--version` / `--status` and an explicit bypass pass through.
- The guard ignores heredoc bodies, so a commit message or doc that merely *mentions* `./gradlew` is not blocked, while a real build following a heredoc still is. (Found the hard way — an earlier revision blocked this PR's own commit.)
- The documented probe was exercised both ways — wrapper present under a `$HOME` containing a space, and wrapper absent falling back to `./gradlew`.
- Observed live under real load: 2 builds running, 3 queued, across separate worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)