### PR TITLE
perf(startup): move WorkManager and AppFunctions init off the main thread

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/GoogleMeshUtilApplication.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/GoogleMeshUtilApplication.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.app
 
 import androidx.appfunctions.AppFunctionConfiguration
+import kotlinx.coroutines.launch
 import org.koin.java.KoinJavaComponent.getKoin
 import org.meshtastic.app.ai.appfunctions.AppFunctionStateSync
 import org.meshtastic.app.ai.appfunctions.MeshtasticAppFunctions
@@ -36,7 +37,8 @@ class GoogleMeshUtilApplication :
         // Start the AppFunctions enabled-state sync. Resolved here (after startKoin has bound
         // androidContext) rather than via createdAtStart so that Koin graphs built outside a
         // running app — verification tests, previews — stay lazily constructible.
-        getKoin().get<AppFunctionStateSync>()
+        // Off-main: construction forces the AppFunctionsPrefs subgraph and fires AppSearch binder calls.
+        applicationScope.launch { getKoin().get<AppFunctionStateSync>() }
     }
 
     override val appFunctionConfiguration: AppFunctionConfiguration

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -68,7 +68,7 @@ open class MeshUtilApplication :
     Configuration.Provider,
     SingletonImageLoader.Factory {
 
-    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    protected val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /** Supplies Coil's process-wide loader without retaining an Activity in its singleton factory. */
     override fun newImageLoader(context: Context): ImageLoader = get<ImageLoader>()
@@ -83,8 +83,9 @@ open class MeshUtilApplication :
             workManagerFactory()
         }
 
-        // Schedule periodic MeshLog cleanup
-        scheduleMeshLogCleanup()
+        // Schedule periodic MeshLog cleanup. Off-main: WorkManager uses on-demand init here
+        // (the startup provider is removed), so getInstance() opens WorkManager's Room DB.
+        applicationScope.launch { scheduleMeshLogCleanup() }
 
         // Generate and publish widget preview for Android 15+ widget picker
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {


### PR DESCRIPTION
## Why

Datadog flags Android cold-start as the worst vital on the board. Investigating it turned up two calls in `Application.onCreate` that block the main thread inside the cold-start window for no reason — neither has an ordering dependency on anything else in `onCreate`.

(The headline "5,800 ms p75 vs iOS 1,156 ms" turns out to be mostly a metric artifact — see the note at the bottom — but these two remain real main-thread work worth reclaiming.)

## 🛠️ Changes

- **`scheduleMeshLogCleanup()` moved to `applicationScope`.** It calls `WorkManager.getInstance()`, and since `WorkManagerInitializer` is removed from the startup provider (`AndroidManifest.xml`) in favour of on-demand init, that call is what actually initializes WorkManager — constructing `WorkManagerImpl` and opening/migrating its Room database (`androidx.work.workdb`) on the calling thread. Deferring it out of the provider only to force it back onto the main thread three statements into `onCreate` was the worst of both worlds.
- **`AppFunctionStateSync` resolution moved to `applicationScope`** (google flavor). Its construction forces the `AppFunctionsPrefs` DI subgraph and a 10-way `combine`, then fires nine `setAppFunctionEnabled` AppSearch binder calls.
- `applicationScope` is now `protected` so `GoogleMeshUtilApplication` can use it.

Estimated saving is roughly 80–400 ms on mid-range hardware, most of it the WorkManager database open. Behaviour is unchanged: the periodic-work enqueue is already asynchronous past `getInstance()`, and `AppFunctionStateSync` only subscribes to flows.

## Testing Performed

`./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green except `:core:konsist:allTests`, which fails **pre-existing and environment-only** in this worktree: the checkout lives under `.claude/worktrees/`, and `CommonMainFrameworkBoundaryTest` / `BleAddressLoggingTest` filter out every path containing `/.claude/`, so their scans match zero files and the "scan actually reaches …" tripwires fire. Both changed files are in `androidApp` (not `commonMain`, no BLE), so they cannot affect those rules. CI, which checks out normally, is unaffected — filed separately.

No macrobenchmark run: `:baselineprofile` needs a connected device. `./gradlew :androidApp:benchmarkGoogleReleaseBaselineProfile` is the verification path if someone wants numbers on hardware.

## Note on the 5.8 s figure

Per-version RUM data (7 d, `@view.name:ApplicationLaunch`) shows the current release is already fast:

| version | n | p50 | p75 |
|---|---|---|---|
| 2.7.14 (29321034) | 43,005 | 38.4 s | **149.5 s** |
| 2.8.0 (29321705) | 1,045 | 0.40 s | **0.81 s** |

2.8.0's launch p75 (~808 ms) already beats iOS's 1,156 ms. The app-wide 5.8 s is dominated by the 2.7.14 fleet, where `trackBackgroundEvents(true)` plus the 24/7 foreground `MeshService` keeps `ApplicationLaunch` views open for minutes on UI-less process starts (those views carry no `loading_time` at all). The highest-leverage fix there is dashboard hygiene — split by version, exclude background launches — not app code. Full ranked analysis, including a start-destination race that sends paired users to the Connections tab on cold start, is in `.agent_plans/cold-start-ttid-analysis.md` (git-ignored; happy to paste it into an issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup by moving background initialization and mesh log cleanup scheduling off the main thread.
  * Reduced the risk of startup delays or unresponsive behavior during application launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->