### PR TITLE
fix(ble): enable Kable preConflate to prevent scan-callback ANRs

### DIFF
--- a/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/androidMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -21,8 +21,15 @@ import com.juul.kable.AndroidPeripheral
 import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
 import com.juul.kable.PooledThreadingStrategy
+import com.juul.kable.ScannerBuilder
 import com.juul.kable.toIdentifier
 import org.meshtastic.core.model.util.anonymize
+
+// Kable's default trySendBlocking can park the scan-callback (sometimes main) thread in dense BLE
+// environments, causing ANRs; preConflate drops excess advertisements instead (kable#654).
+internal actual fun ScannerBuilder.platformScanConfig() {
+    preConflate = true
+}
 
 /** Android's scanner filters on address in hardware, so Kable's `Filter.Address` works natively here. */
 internal actual val supportsNativeAddressScanFilter: Boolean = true

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KableBleScanner.kt
@@ -75,6 +75,7 @@ open class KableBleScanner(private val loggingConfig: BleLoggingConfig) : BleSca
 
     internal open fun advertisements(filter: KableScanFilter): Flow<KableScanResult> {
         val scanner = Scanner {
+            platformScanConfig()
             logging { applyConfig(loggingConfig) }
             when (filter) {
                 KableScanFilter.None -> Unit

--- a/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/commonMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -18,6 +18,10 @@ package org.meshtastic.core.ble
 
 import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
+import com.juul.kable.ScannerBuilder
+
+/** Platform-specific configuration for the Scanner builder (e.g. Android's `preConflate`). */
+internal expect fun ScannerBuilder.platformScanConfig()
 
 /**
  * Whether Kable honours a scan filter on device address here. Android only: `Filter.Address` throws on Apple/JS, and

--- a/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
+++ b/core/ble/src/iosMain/kotlin/org/meshtastic/core/ble/NoopStubs.kt
@@ -18,9 +18,14 @@ package org.meshtastic.core.ble
 
 import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
+import com.juul.kable.ScannerBuilder
 
 // Kable's `Filter.Address` throws UnsupportedOperationException on Apple.
 internal actual val supportsNativeAddressScanFilter: Boolean = false
+
+internal actual fun ScannerBuilder.platformScanConfig() {
+    // No-op: preConflate is Android-only.
+}
 
 /** No-op stubs for iOS target in core:ble. */
 internal actual fun PeripheralBuilder.platformConfig(device: BleDevice, autoConnect: () -> Boolean) {

--- a/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
+++ b/core/ble/src/jvmMain/kotlin/org/meshtastic/core/ble/KablePlatformSetup.kt
@@ -18,7 +18,12 @@ package org.meshtastic.core.ble
 
 import com.juul.kable.Peripheral
 import com.juul.kable.PeripheralBuilder
+import com.juul.kable.ScannerBuilder
 import com.juul.kable.toIdentifier
+
+internal actual fun ScannerBuilder.platformScanConfig() {
+    // No-op: preConflate is Android-only.
+}
 
 // Kable's btleplug backend evaluates scan filters with a hardcoded `address = null`, so an address filter matches
 // nothing and the scan yields no advertisements at all.


### PR DESCRIPTION
## Why

Kable's Android scanner delivers scan results to its `advertisements` flow via `trySendBlocking`, invoked on Android's scan-callback thread — which on some devices is the main thread. In dense BLE environments, results arrive faster than the flow drains and the callback thread parks until the OS declares an ANR. We logged **8 production ANRs during DEF CON 34** ([Datadog issue fcecaf92](https://us5.datadoghq.com/error-tracking/issue/fcecaf92-415e-11f1-b429-da7ad0900000)), all parked in `BluetoothLeScannerAndroidScanner$advertisements$1$callback$1.onScanResult`.

## 🐛 Fix

- New `ScannerBuilder.platformScanConfig()` expect/actual seam in `core:ble` (follows the existing `KablePlatformSetup` pattern).
- Android actual sets Kable's `preConflate = true`: scan results are delivered with a non-blocking `trySend`, dropping excess advertisements under burst instead of blocking. Dropping is acceptable here — advertisements are connectionless and repeat continuously; scanning UI only needs a recent one per device.
- iOS/JVM actuals are no-ops (`preConflate` is Android-only).

Upstream fix proposed in [JuulLabs/kable#1253](https://github.com/JuulLabs/kable/pull/1253) (makes the default path non-blocking *and* lossless); this app-side mitigation protects users now and remains harmless once upstream lands.

## Testing Performed

Full baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android Bluetooth scanning stability by reducing excess advertisement events before processing.
  * Helps prevent scan callback delays and keeps Bluetooth device discovery responsive.

* **Compatibility**
  * Preserved existing scanning behavior on iOS and desktop platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->