### PR TITLE
feat(analytics): report key user interactions as named RUM actions

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/analytics/GooglePlatformAnalytics.kt
@@ -275,6 +275,11 @@ class GooglePlatformAnalytics(private val context: Context, private val analytic
         GlobalRumMonitor.get().addAction(RumActionType.CUSTOM, "connect", attributes)
     }
 
+    override fun trackAction(name: String, attributes: Map<String, Any>) {
+        if (!Datadog.isInitialized() || !GlobalRumMonitor.isRegistered()) return
+        GlobalRumMonitor.get().addAction(RumActionType.CUSTOM, name, attributes)
+    }
+
     override fun startScreenView(key: String, name: String) {
         if (!Datadog.isInitialized() || !GlobalRumMonitor.isRegistered()) return
         GlobalRumMonitor.get().startView(key = key, name = name)

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PlatformAnalytics.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PlatformAnalytics.kt
@@ -53,6 +53,17 @@ interface PlatformAnalytics {
     }
 
     /**
+     * Tracks a key user interaction as a named custom RUM action. Auto-tracked tap targets are R8-obfuscated in
+     * release builds, so analytically important interactions must be reported explicitly with a stable name.
+     *
+     * @param name Stable snake_case action name (e.g. "message_send", "traceroute_request").
+     * @param attributes Optional structured attributes attached to the action.
+     */
+    fun trackAction(name: String, attributes: Map<String, Any> = emptyMap()) {
+        // Default no-op for platforms that don't support RUM (fdroid, desktop)
+    }
+
+    /**
      * Starts tracking a screen as a RUM view, aligned with the Meshtastic-Apple Datadog integration (which auto-tracks
      * SwiftUI views) so per-screen RUM data lines up across platforms.
      *

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PlatformAnalytics.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/PlatformAnalytics.kt
@@ -53,8 +53,8 @@ interface PlatformAnalytics {
     }
 
     /**
-     * Tracks a key user interaction as a named custom RUM action. Auto-tracked tap targets are R8-obfuscated in
-     * release builds, so analytically important interactions must be reported explicitly with a stable name.
+     * Tracks a key user interaction as a named custom RUM action. Auto-tracked tap targets are R8-obfuscated in release
+     * builds, so analytically important interactions must be reported explicitly with a stable name.
      *
      * @param name Stable snake_case action name (e.g. "message_send", "traceroute_request").
      * @param attributes Optional structured attributes attached to the action.

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
@@ -62,6 +62,13 @@ internal class MessagingControllerImpl(
         dataHandler.value.rememberDataPacket(packet, myNodeNum, false)
         val bytes = packet.bytes ?: ByteString.EMPTY
         analytics.track("data_send", DataPair("num_bytes", bytes.size), DataPair("type", packet.dataType))
+        val actionName =
+            when (packet.dataType) {
+                PortNum.TEXT_MESSAGE_APP.value -> "message_send"
+                PortNum.WAYPOINT_APP.value -> "waypoint_send"
+                else -> "data_send"
+            }
+        analytics.trackAction(actionName, mapOf("port_num" to packet.dataType, "num_bytes" to bytes.size))
     }
 
     override suspend fun sendReaction(emoji: String, replyId: Int, contactKey: String) {
@@ -81,6 +88,7 @@ internal class MessagingControllerImpl(
             )
                 .apply { from = nodeManager.getMyId().takeIf { it.isNotEmpty() } ?: NodeAddress.ID_LOCAL }
         commandSender.sendData(dataPacket)
+        analytics.trackAction("reaction_send")
         val user = nodeManager.nodeDBbyNodeNum[myNum]?.user ?: User(id = nodeManager.getMyId())
         packetRepository.value.insertReaction(
             Reaction(

--- a/feature/firmware/build.gradle.kts
+++ b/feature/firmware/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
             implementation(projects.core.navigation)
             implementation(projects.core.network)
             implementation(projects.core.prefs)
+            implementation(projects.core.repository)
             implementation(libs.meshtastic.protobufs)
             implementation(projects.core.service)
             implementation(projects.core.resources)

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -55,6 +55,7 @@ import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.repository.DeviceHardwareRepository
 import org.meshtastic.core.repository.FirmwareReleaseRepository
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.repository.RadioPrefs
 import org.meshtastic.core.repository.isBle
@@ -113,6 +114,7 @@ class FirmwareUpdateViewModel(
     private val fileHandler: FirmwareFileHandler,
     private val applicationScope: ApplicationCoroutineScope,
     private val hiddenFeaturesUnlock: HiddenFeaturesUnlock,
+    private val analytics: PlatformAnalytics,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow<FirmwareUpdateState>(FirmwareUpdateState.Idle)
@@ -321,6 +323,22 @@ class FirmwareUpdateViewModel(
     fun startUpdate() {
         val currentState = _state.value as? FirmwareUpdateState.Ready ?: return
         val release = currentState.release ?: return
+        // Explicit mapping instead of class-name reflection: FirmwareUpdateMethod is R8-obfuscated in release.
+        val updateMethod =
+            when (currentState.updateMethod) {
+                FirmwareUpdateMethod.Usb -> "usb"
+                FirmwareUpdateMethod.Ble -> "ble"
+                FirmwareUpdateMethod.Wifi -> "wifi"
+                FirmwareUpdateMethod.Unknown -> "unknown"
+            }
+        analytics.trackAction(
+            "firmware_update_start",
+            mapOf(
+                "update_method" to updateMethod,
+                "is_recovery" to currentState.isRecovery,
+                "release_version" to release.id,
+            ),
+        )
         if (currentState.isRecovery) {
             startRecoveryUpdate(currentState, release)
         } else {

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateIntegrationTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateIntegrationTest.kt
@@ -115,6 +115,7 @@ class FirmwareUpdateIntegrationTest {
         fileHandler,
         TestApplicationCoroutineScope(testDispatcher),
         HiddenFeaturesUnlock(),
+        mock(MockMode.autofill),
     )
 
     @Test

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
@@ -138,6 +138,7 @@ class FirmwareUpdateViewModelTest {
         fileHandler,
         TestApplicationCoroutineScope(testDispatcher),
         hiddenFeaturesUnlock,
+        mock(MockMode.autofill),
     )
 
     @Test

--- a/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
+++ b/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
@@ -137,6 +137,7 @@ class FirmwareUpdateViewModelFileTest {
         fileHandler,
         TestApplicationCoroutineScope(testDispatcher),
         HiddenFeaturesUnlock(),
+        mock(MockMode.autofill),
     )
 
     private fun firmwareUri(fileName: String): CommonUri = CommonUri.parse("file:///downloads/$fileName")

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/CommonNodeRequestActions.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/CommonNodeRequestActions.kt
@@ -25,6 +25,7 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.nowMillis
 import org.meshtastic.core.model.Position
 import org.meshtastic.core.model.TelemetryType
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.UiText
@@ -47,6 +48,7 @@ class CommonNodeRequestActions
 constructor(
     private val radioController: RadioController,
     private val snackbarManager: SnackbarManager,
+    private val analytics: PlatformAnalytics,
 ) : NodeRequestActions {
 
     private val _lastTracerouteTime = MutableStateFlow<Long?>(null)
@@ -62,6 +64,7 @@ constructor(
     override suspend fun requestUserInfo(destNum: Int, longName: String) {
         Logger.i { "Requesting UserInfo for '$destNum'" }
         radioController.requestUserInfo(destNum)
+        analytics.trackAction("user_info_request")
         showFeedback(UiText.Resource(Res.string.requesting_from, Res.string.user_info, longName))
     }
 
@@ -76,6 +79,7 @@ constructor(
     override suspend fun requestPosition(destNum: Int, longName: String, position: Position) {
         Logger.i { "Requesting position for '$destNum'" }
         radioController.requestPosition(destNum, position)
+        analytics.trackAction("position_request")
         showFeedback(UiText.Resource(Res.string.requesting_from, Res.string.position, longName))
     }
 
@@ -83,6 +87,7 @@ constructor(
         Logger.i { "Requesting telemetry for '$destNum'" }
         val packetId = radioController.generatePacketId()
         radioController.requestTelemetry(packetId, destNum, type.ordinal)
+        analytics.trackAction("telemetry_request", mapOf("telemetry_type" to type.name))
 
         val typeRes =
             when (type) {
@@ -102,6 +107,7 @@ constructor(
         Logger.i { "Requesting traceroute for '$destNum'" }
         val packetId = radioController.generatePacketId()
         radioController.requestTraceroute(packetId, destNum)
+        analytics.trackAction("traceroute_request")
         _lastTracerouteTime.value = nowMillis
         showFeedback(UiText.Resource(Res.string.requesting_from, Res.string.traceroute, longName))
     }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeManagementActions.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeManagementActions.kt
@@ -23,6 +23,7 @@ import org.jetbrains.compose.resources.getString
 import org.koin.core.annotation.Single
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.favorite
@@ -46,6 +47,7 @@ constructor(
     private val nodeRepository: NodeRepository,
     private val radioController: RadioController,
     private val alertManager: AlertManager,
+    private val analytics: PlatformAnalytics,
 ) {
     open fun requestRemoveNode(scope: CoroutineScope, node: Node, onAfterRemove: () -> Unit = {}) {
         alertManager.showAlert(
@@ -114,6 +116,7 @@ constructor(
 
     open suspend fun setFavorite(nodeNum: Int, favorite: Boolean) {
         radioController.setFavorite(nodeNum, favorite)
+        analytics.trackAction("node_favorite", mapOf("favorite" to favorite))
     }
 
     open suspend fun setNodeNotes(nodeNum: Int, notes: String) {

--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/detail/NodeManagementActionsTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/detail/NodeManagementActionsTest.kt
@@ -45,6 +45,7 @@ class NodeManagementActionsTest {
             nodeRepository = nodeRepository,
             radioController = radioController,
             alertManager = alertManager,
+            analytics = mock(MockMode.autofill),
         )
 
     @Test
@@ -76,6 +77,7 @@ class NodeManagementActionsTest {
                 nodeRepository = nodeRepository,
                 radioController = radioController,
                 alertManager = realAlertManager,
+                analytics = mock(MockMode.autofill),
             )
         val node = Node(num = 123, user = User(long_name = "Test Node"))
         var afterRemoveCalled = false

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/channel/ChannelViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/channel/ChannelViewModel.kt
@@ -84,8 +84,10 @@ class ChannelViewModel(
     }
 
     /** Set the radio config (also updates our saved copy in preferences). */
-    fun setChannels(channelSet: ChannelSet) =
-        safeLaunch(tag = "setChannels") { importChannelSet(channelSet, radioController, radioConfigRepository) }
+    fun setChannels(channelSet: ChannelSet) = safeLaunch(tag = "setChannels") {
+        importChannelSet(channelSet, radioController, radioConfigRepository)
+        analytics.trackAction("channel_update", mapOf("num_channels" to channelSet.settings.size))
+    }
 
     // Set the radio config (also updates our saved copy in preferences)
     fun setConfig(config: Config) {
@@ -94,6 +96,7 @@ class ChannelViewModel(
 
     fun trackShare() {
         analytics.track("share", DataPair("content_type", "channel"))
+        analytics.trackAction("channel_share")
     }
 
     private inline fun updateLoraConfig(crossinline body: (Config.LoRaConfig) -> Config.LoRaConfig) {

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -592,12 +592,10 @@ open class RadioConfigViewModel(
 
     private fun sendAdminRequest(destNum: Int) {
         val route = radioConfigState.value.route
+        val isLocal = radioConfigState.value.isLocal
         _radioConfigState.update { it.copy(route = "") } // setter (response is PortNum.ROUTING_APP)
 
-        analytics.trackAction(
-            "admin_action",
-            mapOf("route" to route.lowercase(), "is_remote" to (destNum != myNodeNum)),
-        )
+        analytics.trackAction("admin_action", mapOf("route" to route.lowercase(), "is_remote" to !isLocal))
 
         val preserveFavorites = radioConfigState.value.nodeDbResetPreserveFavorites
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -68,6 +68,7 @@ import org.meshtastic.core.repository.LockdownPassphraseStore
 import org.meshtastic.core.repository.MapConsentPrefs
 import org.meshtastic.core.repository.MqttManager
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioConfigRepository
@@ -161,6 +162,7 @@ open class RadioConfigViewModel(
     private val securityKeyBackupStore: SecurityKeyBackupStore,
     private val snackbarManager: SnackbarManager,
     private val nodeRestartTracker: NodeRestartTracker,
+    private val analytics: PlatformAnalytics,
 ) : ViewModel() {
 
     val lockdownTokenInfo = serviceRepository.lockdownTokenInfo
@@ -591,6 +593,11 @@ open class RadioConfigViewModel(
     private fun sendAdminRequest(destNum: Int) {
         val route = radioConfigState.value.route
         _radioConfigState.update { it.copy(route = "") } // setter (response is PortNum.ROUTING_APP)
+
+        analytics.trackAction(
+            "admin_action",
+            mapOf("route" to route.lowercase(), "is_remote" to (destNum != myNodeNum)),
+        )
 
         val preserveFavorites = radioConfigState.value.nodeDbResetPreserveFavorites
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -68,9 +68,9 @@ import org.meshtastic.core.repository.LockdownPassphraseStore
 import org.meshtastic.core.repository.MapConsentPrefs
 import org.meshtastic.core.repository.MqttManager
 import org.meshtastic.core.repository.NodeRepository
-import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.SecurityKeyBackupStore
 import org.meshtastic.core.repository.ServiceRepository

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/channel/ChannelScreen.kt
@@ -257,7 +257,10 @@ fun ChannelScreen(
                         isWaiting = true
                         radioConfigViewModel.setResponseStateLoading(ConfigRoute.CHANNELS)
                     },
-                    onClickShare = { showShareDialog = true },
+                    onClickShare = {
+                        viewModel.trackShare()
+                        showShareDialog = true
+                    },
                 )
             }
             item {

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/ProfileRoundTripTest.kt
@@ -142,6 +142,7 @@ class ProfileRoundTripTest {
                 fileService = fileService,
                 mqttManager = mqttManager,
                 lockdownCoordinator = FakeLockdownCoordinator(),
+                analytics = mock(MockMode.autofill),
                 securityKeyBackupStore = securityKeyBackupStore,
                 snackbarManager = snackbarManager,
                 nodeRestartTracker = nodeRestartTracker,

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -184,6 +184,7 @@ class RadioConfigViewModelTest {
         fileService = fileService,
         mqttManager = mqttManager,
         lockdownCoordinator = FakeLockdownCoordinator(),
+        analytics = mock(MockMode.autofill),
     )
 
     @Test
@@ -975,6 +976,7 @@ class RadioConfigViewModelTest {
                 fileService = fileService,
                 mqttManager = mqttManager,
                 lockdownCoordinator = FakeLockdownCoordinator(),
+                analytics = mock(MockMode.autofill),
             )
         assertEquals(456, viewModel.destNode.value?.num)
     }


### PR DESCRIPTION
## Why

Datadog RUM tap actions from release builds are unreadable. R8 renames the Compose/View classes that the SDK's auto-tracker uses to label a tap, so the dashboard shows `tap on fhy(0x-1)` and `tap on ImageView(0x-1)`. The only legible action today is the custom `connect` one, because it is the only action the app names explicitly.

That made feature-level usage analysis impossible for the DEF CON 34 telemetry report — we could see that people tapped, but never what they tapped.

This names the interactions that actually carry analytical value, so RUM can answer "how many people sent a message / ran a traceroute / started a firmware update" instead of counting anonymous taps.

## 🌟 What

Adds `PlatformAnalytics.trackAction(name, attributes)`, following the same shape as the existing `trackConnect`:

- **Default no-op** on the interface, so fdroid and desktop are untouched (neither has RUM).
- **google flavor only** overrides it, emitting a Datadog `RumActionType.CUSTOM` action behind the same `isInitialized` / `isRegistered` guard the other RUM calls use.

Datadog's `interactionPredicate` was evaluated and rejected: it hooks the Android View system and cannot name Compose Multiplatform targets, which is what this app's UI is built from. Explicit calls at the handler layer are also the pattern already established here by `trackConnect` and `track("data_send")`.

Instrumented at the ViewModel/controller layer rather than in composable click lambdas, so one call site covers every entry point into the action:

| Action | Attributes | Where |
| --- | --- | --- |
| `message_send` / `waypoint_send` / `data_send` | `port_num`, `num_bytes` | `MessagingControllerImpl.sendMessage` |
| `reaction_send` | — | `MessagingControllerImpl.sendReaction` |
| `traceroute_request` | — | `CommonNodeRequestActions` |
| `position_request` | — | `CommonNodeRequestActions` |
| `user_info_request` | — | `CommonNodeRequestActions` |
| `telemetry_request` | `telemetry_type` | `CommonNodeRequestActions` |
| `node_favorite` | `favorite` | `NodeManagementActions.setFavorite` |
| `channel_update` | `num_channels` | `ChannelViewModel.setChannels` |
| `channel_share` | — | `ChannelViewModel.trackShare` |
| `firmware_update_start` | `update_method`, `is_recovery`, `release_version` | `FirmwareUpdateViewModel.startUpdate` |
| `admin_action` | `route`, `is_remote` | `RadioConfigViewModel.sendAdminRequest` |

Two notes on placement:

- `sendMessage` is a single funnel for both messaging and map waypoint sends, so one call covers both without touching `MessageViewModel` or `BaseMapViewModel`.
- `admin_action` sits at the `when (route)` dispatch, so reboot, shutdown, factory reset, nodedb reset and set-time are all covered by one call, keyed by route.

Deliberately **not** instrumented: contact open, map open, and settings entries. Those are navigations and already arrive in RUM as named views via `startScreenView`; adding actions would double-count them.

## 🛠️ Housekeeping

- `ChannelViewModel.trackShare()` was dead code — defined and unit-tested, but never called from production. Wired it to the QR/share button in `ChannelScreen`, so the existing `share` event starts firing too.
- `feature/firmware` gains an explicit `implementation(projects.core.repository)`; it was relying on a transitive `api` from `:core:service`.
- `FirmwareUpdateMethod` is a sealed class, so its update-method label is mapped explicitly rather than read from a class name that R8 would rename — the same failure mode this PR exists to fix.

## Privacy

No PII, location, or key material. Every attribute is a count, boolean, enum name, or firmware version string. In particular there are no node numbers or long names, no coordinates, no message content, and `channel_share` carries no channel URL (that URL embeds the PSK).

## Testing Performed

`spotlessApply spotlessCheck detekt assembleDebug test allTests` — spotless/detekt/assembleDebug green, 250 tests passed.

Two failures surfaced in that run, `:core:navigation:jvmTest` and `:core:network:jvmTest`, both `java.nio.file.NoSuchFileException: in-progress-results-generic.bin`. Both are unrelated to this change and were confirmed as such:

- `:core:navigation` does not depend on `:core:repository` at all (only `core:common` + `core:resources`), so nothing in this diff can reach it.
- Re-running both modules in isolation: **BUILD SUCCESSFUL in 51s.**

The signature is a test worker killed mid-run under host memory pressure, not a failing assertion.

Targeted re-verification after the final refinement — `spotlessApply spotlessCheck detekt :feature:settings:allTests :feature:node:allTests :feature:firmware:allTests :core:service:allTests` — **BUILD SUCCESSFUL in 2m 9s.**

Existing tests were updated for the new constructor parameters; analytics call sites are not separately asserted, matching how the pre-existing `track("data_send")` call is treated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom analytics tracking for messaging, reactions, firmware updates, node requests, favorites, channel changes and sharing, and radio administration actions.
  * Added support for sending tracked actions to Datadog on Android.
  * Recorded relevant context such as action type, update method, recovery status, channel count and remote-target status.
* **Tests**
  * Updated test fixtures to support the new analytics tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->