### PR TITLE
fix(ui): surface watchdog-forced reconnects in the nav connection icon

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavigationSuite.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavigationSuite.kt
@@ -63,6 +63,7 @@ import org.meshtastic.core.resources.connecting
 import org.meshtastic.core.resources.device_sleeping
 import org.meshtastic.core.resources.disconnected
 import org.meshtastic.core.resources.node_restarting
+import org.meshtastic.core.resources.reconnecting
 import org.meshtastic.core.ui.navigation.icon
 import org.meshtastic.core.ui.viewmodel.UIViewModel
 
@@ -82,6 +83,7 @@ fun MeshtasticNavigationSuite(
 ) {
     val connectionState by uiViewModel.connectionState.collectAsStateWithLifecycle()
     val nodeRestartExpected by uiViewModel.nodeRestartExpected.collectAsStateWithLifecycle()
+    val watchdogReconnectInFlight by uiViewModel.watchdogReconnectInFlight.collectAsStateWithLifecycle()
     val unreadMessageCount by uiViewModel.unreadMessageCount.collectAsStateWithLifecycle()
     val selectedDevice by uiViewModel.currentDeviceAddressFlow.collectAsStateWithLifecycle()
 
@@ -108,6 +110,7 @@ fun MeshtasticNavigationSuite(
                             isSelected = isSelected,
                             connectionState = connectionState,
                             nodeRestartExpected = nodeRestartExpected,
+                            watchdogReconnectInFlight = watchdogReconnectInFlight,
                             unreadMessageCount = unreadMessageCount,
                             selectedDevice = selectedDevice,
                             meshActivityFlow = uiViewModel.meshActivity,
@@ -185,13 +188,16 @@ private fun NavigationIconContent(
     selectedDevice: String?,
     meshActivityFlow: Flow<MeshActivity>,
     nodeRestartExpected: Boolean = false,
+    watchdogReconnectInFlight: Boolean = false,
 ) {
     val isConnectionsRoute = destination == TopLevelDestination.Connect
     // An expected node restart (reboot-applying config save) presents as an in-progress state, not a scary
-    // red disconnect: the icon borrows the Connecting treatment and the tooltip says "Restarting".
+    // red disconnect: the icon borrows the Connecting treatment and the tooltip says "Restarting". A
+    // watchdog-forced handshake recovery gets the same treatment with a "Reconnecting…" tooltip.
     val restarting = nodeRestartExpected && connectionState != ConnectionState.Connected
+    val reconnecting = watchdogReconnectInFlight && !restarting
     val presentedState =
-        if (restarting && connectionState == ConnectionState.Disconnected) {
+        if ((restarting || reconnecting) && connectionState == ConnectionState.Disconnected) {
             ConnectionState.Connecting
         } else {
             connectionState
@@ -203,7 +209,7 @@ private fun NavigationIconContent(
             PlainTooltip {
                 Text(
                     if (isConnectionsRoute) {
-                        connectionTooltipLabel(restarting, connectionState)
+                        connectionTooltipLabel(restarting, reconnecting, connectionState)
                     } else {
                         stringResource(destination.label)
                     },
@@ -249,8 +255,13 @@ private fun NavigationIconContent(
 }
 
 @Composable
-private fun connectionTooltipLabel(restarting: Boolean, connectionState: ConnectionState): String = when {
+private fun connectionTooltipLabel(
+    restarting: Boolean,
+    reconnecting: Boolean,
+    connectionState: ConnectionState,
+): String = when {
     restarting -> stringResource(Res.string.node_restarting)
+    reconnecting -> stringResource(Res.string.reconnecting)
     connectionState == ConnectionState.Connected -> stringResource(Res.string.connected)
     connectionState == ConnectionState.Connecting -> stringResource(Res.string.connecting)
     connectionState == ConnectionState.DeviceSleep -> stringResource(Res.string.device_sleeping)

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
@@ -108,6 +108,18 @@ class UIViewModel(
     /** True while the connected node is expected to be mid-restart (reboot-applying config save or reboot command). */
     val nodeRestartExpected: StateFlow<Boolean> = nodeRestartTracker.restartExpected
 
+    /**
+     * True while the handshake-stall watchdog is force-reconnecting the transport, so the UI can present the transient
+     * Disconnected window as an in-progress recovery rather than a user-visible disconnect. Same signal contract as
+     * [ConnectionsViewModel.connectionStatus]'s RECONNECTING case.
+     */
+    val watchdogReconnectInFlight: StateFlow<Boolean> =
+        combine(serviceRepository.connectionState, serviceRepository.connectionProgress) { state, progress ->
+            state is ConnectionState.Disconnected && progress == ServiceRepository.RECONNECTING_PROGRESS_TEXT
+        }
+            .distinctUntilChanged()
+            .stateInWhileSubscribed(initialValue = false)
+
     private val _navigationDeepLink = MutableSharedFlow<List<NavKey>>(replay = 1)
     val navigationDeepLink = _navigationDeepLink.asSharedFlow()
 


### PR DESCRIPTION
## Why

The handshake-stall watchdog touched **9% of on-site DEF CON 34 users** under BLE congestion. It works — users get force-reconnected rather than left wedged — but it is invisible: the connection just blips.

The recovery path already publishes a UI signal. `runSiblingHandshakeRecovery()` writes `ServiceRepository.RECONNECTING_PROGRESS_TEXT` immediately before flipping to `Disconnected`, and the Connections screen already renders that as "Reconnecting…" via `ConnectionStatus.RECONNECTING`.

What was missing is the **persistent nav-bar connection icon**, which reads raw `ConnectionState` and therefore flashed the red disconnected treatment during the watchdog's transient teardown. That flash is the blip users saw — a scary-looking failure for what is actually a successful automatic recovery.

## 🛠️ What changed

- **`UIViewModel`** — new `watchdogReconnectInFlight` StateFlow: true when the state is `Disconnected` **and** progress equals `RECONNECTING_PROGRESS_TEXT`. Same cross-track signal contract `ConnectionsViewModel.connectionStatus` already uses for its RECONNECTING case (and which `ConnectionsViewModelTest` pins to the literal `"Reconnecting…"`).
- **`MeshtasticNavigationSuite`** — during a watchdog reconnect the connection icon borrows the Connecting presentation and the tooltip reads "Reconnecting…", mirroring the existing `nodeRestartExpected` → RESTARTING pattern. An expected node restart still takes precedence over the watchdog signal.

## Notes for reviewers

- **No reconnect-logic changes.** This is state plumbing plus one indicator; the watchdog, its budgets, and the recovery sibling are untouched.
- **No new string.** `reconnecting` ("Reconnecting…") already exists in the base `strings.xml`, so this adds no Crowdin churn.
- **No test added.** `watchdogReconnectInFlight` duplicates a mapping `ConnectionsViewModelTest` already covers on the parallel path. Happy to add a focused test for the new flow if reviewers want the cross-track literal coupling pinned in both places.
- The log line for this watchdog is `"Fast-handshake watchdog expired after progress stalled — requesting forced transport restart"`.

Related context: #6587 (stale-Connected pipeline wedge), #6256 (session-lease logic).

## Testing performed

Baseline verification run twice locally, both green: `spotlessApply spotlessCheck detekt assembleDebug test allTests`. The second run executed 114 test tasks for real rather than replaying cache. No screenshot goldens dirtied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watchdog recovery feedback when the service disconnects.
  * Navigation now shows a connecting state while reconnection is in progress.
  * Added a tooltip indicating that the service is reconnecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->