### PR TITLE
fix(ui): restore bottom time-axis height at large font scales

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/CommonCharts.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/CommonCharts.kt
@@ -46,11 +46,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.patrykandpatrick.vico.compose.cartesian.axis.Axis
+import com.patrykandpatrick.vico.compose.cartesian.axis.BaseAxis
 import com.patrykandpatrick.vico.compose.cartesian.axis.HorizontalAxis
 import com.patrykandpatrick.vico.compose.cartesian.data.CartesianValueFormatter
 import org.jetbrains.compose.resources.StringResource
@@ -120,9 +122,16 @@ object CommonCharts {
         valueFormatter = dynamicTimeFormatter,
         itemPlacer = HorizontalAxis.ItemPlacer.aligned(spacing = { 1 }, addExtremeLabelPadding = true),
         labelRotationDegrees = LABEL_ROTATION_DEGREES,
+        // Vico caps `Size.Auto` at a fixed 64.dp, which truncates the rotated label above ~1.75x font scale.
+        // `min` is applied after that cap, so it is the only lever that restores the height; it scales with the
+        // font scale because the label is sized in sp.
+        size = BaseAxis.Size.Auto(min = (MIN_HEIGHT_PER_FONT_SCALE_DP * LocalDensity.current.fontScale).dp),
     )
 
     private const val LABEL_ROTATION_DEGREES = 45f
+
+    /** Measured need for the rotated label is ~37.2.dp per unit of font scale; 38 leaves a margin. */
+    private const val MIN_HEIGHT_PER_FONT_SCALE_DP = 38f
 }
 
 data class LegendData(


### PR DESCRIPTION
## Why

The Renovate bump `chore(deps): update vico to v3.3.0-next.2` (#6596) landed on green CI, but it carried a silent behaviour change. Vico changed the horizontal-axis `Size.Auto` cap from a fraction of the canvas to a fixed value:

- **3.3.0-next.1** — `.coerceAtMost(canvasSize.height / MAX_HEIGHT_DIVISOR)` (divisor 3)
- **3.3.0-next.2** — `.coerceAtMost(MAX_AUTO_HEIGHT.pixels)` where `MAX_AUTO_HEIGHT = 64.dp`

Our bottom time axis passes no `size`, so it is `Size.Auto` and inherited the new cap. Its labels are rotated 45°, which makes them expensive in height, so above roughly **1.75x font scale** they no longer fit and get ellipsized. This affects **all seven metric chart screens** — device, signal, environment, power, host, traceroute, pax — since every one of them gets its bottom axis from `CommonCharts.rememberBottomTimeAxis()`.

This is an accessibility regression: it only appears for users running large system font scales.

## 🐛 Fix

`BaseAxis.Size.Auto(min = 38.dp * fontScale)` on the bottom time axis.

Two details drove the shape of this fix:

- **`max` cannot work.** Vico applies `.coerceAtMost(64.dp)` **before** `.coerceIn(size.min, size.max)`, so by the time `Auto`'s own bounds are applied the value has already been clamped. `Size.Auto(max = …)` is a no-op here; `min` is the only lever that can raise the height back.
- **`min` only binds when the cap bit.** Measured need is ~37.2.dp per unit of font scale (39/56/74 dp at 1x/1.5x/2x), so at normal font scales `Auto` still measures naturally and `min` costs nothing. It scales with `fontScale` because the label is sized in `sp`.

## Testing Performed

No automated test accompanies this change — the behaviour is a layout/measurement outcome with no assertable seam, and **Compose Screenshot Testing cannot render these charts at all** (`CartesianChartHost` receives its model via `runTransaction` from an effect that never settles in a static preview, so the plot area comes out empty and only the legend draws). Verification was done on an emulator instead.

Three-way A/B, Pixel-class AVD at `font_scale 2.0`, 7-day synthetic span (the 2-to-14-day two-line label branch):

| build | rendered labels |
|---|---|
| next.1 (pre-bump, original code) | `3/31/…` `4/2/2…` `4/4/2…` `4/6/2…` |
| next.2 (post-bump, no fix) | `3/31…` `4/2/…` `4/4/…` `4/6/…` ← regression |
| next.2 + this fix | `3/31/…` `4/2/2…` `4/4/2…` `4/6/2…` ← parity restored |

The fix reproduces next.1's rendering exactly. The residual trailing ellipsis is **horizontal** truncation from per-label spacing and is present identically under next.1 — pre-existing, not a regression, and deliberately untouched here.

Supporting measurement, taken with the same Compose `TextMeasurer` Vico measures with (density 2.625):

| fontScale | label px | rotated 45° | axis needed | 64.dp cap | result |
|---|---|---|---|---|---|
| 1.0 | 98 × 30 | 90 | 103 | 168 | fits |
| 1.5 | 145 × 47 | 135 | 148 | 168 | fits |
| 2.0 | 195 × 62 | 181 | **194** | 168 | clamped, −26 px |

Baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — BUILD SUCCESSFUL.

**Not verified:** live auto-scroll behaviour with a connected device (next.2's `VicoScrollState` fixes). The emulator's manual-connect dialog would not accept synthetic taps, so no session was established. This change does not touch that path — `rememberVicoScrollState` and the model producer are untouched.

## 🧹 Follow-up (separate defect, not fixed here)

While verifying, I found a **pre-existing** bug unrelated to this bump. `TextComponent.lineCount` defaults to `1` and `ChartStyling.rememberAxisLabel()` never overrides it, so the two-line `"$dateStr\n$timeStr"` label documented in `CommonCharts.dynamicTimeFormatter` is laid out with `maxLines = 1`: **the time of day has never rendered**, at any font scale, on any of these charts. The trailing `…` visible even at 1x is that dropped second line.

The obvious fix does not work, and I have measured it: setting `lineCount = 2` **doubles** `cumulatedHeight`, which shrinks the text width budget via `correctedWidth = (height − cumulatedHeight·cos45) / sin45`, so the date stops fitting on one line and Compose soft-wraps it mid-token (`4/3` / `/2…`) — visibly worse than today. Vico calls `measurer.measure(...)` without `softWrap`, which defaults to `true`, so its API cannot make `\n` the only break point.

A real fix likely belongs in `dynamicTimeFormatter` as a compact single-line format. Filing separately rather than bundling it into a dependency-regression fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart time-axis sizing for larger accessibility font scales.
  * Rotated labels are now less likely to be truncated or clipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->