### PR TITLE
chore(build): drop unused Kotest JUnit Platform runner from jvmTest

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/KotlinAndroid.kt
@@ -207,10 +207,6 @@ internal fun Project.configureKmpTestDependencies() {
                         implementation(libs.library("androidx-test-ext-junit"))
                     }
                 }
-
-            // Configure jvmTest lazily for the same reason.
-            matching { it.name == "jvmTest" }
-                .configureEach { dependencies { implementation(libs.library("kotest-runner-junit6")) } }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -251,7 +251,6 @@ junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", vers
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
-kotest-runner-junit6 = { module = "io.kotest:kotest-runner-junit6", version.ref = "kotest" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.16.1" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }


### PR DESCRIPTION
## Why

The repo uses Kotest as an **assertions-and-property library only**. There are zero Kotest specs anywhere — no `io.kotest.core`, no `FunSpec`/`StringSpec`/`DescribeSpec`/`BehaviorSpec`/`ShouldSpec`/`WordSpec`/`FreeSpec`/`AnnotationSpec`/`ExpectSpec`/`FeatureSpec`, no `AbstractProjectConfig`, no `kotest.properties`. The entire imported Kotest surface is 10 symbols: 4 matchers (`shouldBe`, `shouldNotBeNull`, `shouldBeInRange`, `string.shouldContain`) and 6 property-test symbols (`Arb`, `arbitrary.int/byte/byteArray/filter`, `checkAll`).

Despite that, the convention plugin added `kotest-runner-junit6` to every KMP module's `jvmTest`. That artifact's job is to register a Kotest `TestEngine` with the JUnit Platform via `META-INF/services`. So on 10 module classpaths the platform was instantiating a second test engine and running its classgraph classpath scan per test fork — to discover nothing. `isFailOnNoMatchingTests = false` (`ProjectExtensions.kt:115`) meant the silently-empty engine never complained.

Surfaced while mining the `chore(deps): update kotest to v6.2.4` bump (#6626). The bump itself was routine; this is the pre-existing dead config it exposed.

### The runner is not load-bearing for `kotlin("test")` variant selection

Worth stating explicitly, because if it were, this change would silently produce zero tests. JUnit Platform reaches the classpath by two routes that have nothing to do with Kotest:

- `useJUnitPlatform()` is applied to every `Test` task except `testAndroidHostTest` — `ProjectExtensions.kt:78-85`
- `junit-platform-launcher` is unconditionally added to every `*TestRuntimeClasspath` / `*UnitTestRuntimeClasspath` — `ProjectExtensions.kt:71-76`

`kotlin-test-junit5` brings `junit-jupiter-engine` in on its own. Verified empirically below.

## 🧹 Cleanup

- Removed the `jvmTest` `matching { }.configureEach { }` block that added `kotest-runner-junit6` — `KotlinAndroid.kt`
- Removed the now-unreferenced `kotest-runner-junit6` library entry — `gradle/libs.versions.toml`

The shared `kotest` version ref is **kept** — `kotest-assertions` and `kotest-property` still consume it.

Note on scope: `kotest-framework-engine` remains on the classpath transitively via `kotest-assertions-core`/`kotest-property`. What this removes is the JUnit Platform **engine registration and its per-fork classpath scan**, not the engine jar itself.

## Testing Performed

The entire correctness argument is "the numbers did not move", so both runs used `--rerun-tasks --no-build-cache --continue` (a green tick in this repo can be a cache replay), and each executed 316 actionable tasks. Per-module totals summed from the JUnit XML under `<module>/build/test-results/jvmTest/*.xml`. This is required because `isFailOnNoMatchingTests = false` plus `failOnNoDiscoveredTests.set(false)` mean a module dropping to zero tests would **not** fail the build.

Coverage is wider than the 10 modules with a `src/jvmTest` directory: `jvmTest` inherits `commonTest`, so 26 modules produce jvmTest results.

| module | before | after |
|---|---|---|
| core/ble | 72 / 9 | 72 / 9 |
| core/common | 118 / 13 | 118 / 13 |
| core/data | 547 / 40 | 547 / 40 |
| core/database | 171 / 23 | 171 / 23 |
| core/datastore | 17 / 1 | 17 / 1 |
| core/domain | 65 / 13 | 65 / 13 |
| core/konsist | 10 / 2 | 10 / 2 |
| core/model | 251 / 32 | 251 / 32 |
| core/navigation | 73 / 6 | 73 / 6 |
| core/network | 177 / 17 | 177 / 17 |
| core/prefs | 56 / 7 | 56 / 7 |
| core/repository | 26 / 7 | 26 / 7 |
| core/service | 107 / 5 | 107 / 5 |
| core/takserver | 128 / 17 | 128 / 17 |
| core/testing | 26 / 4 | 26 / 4 |
| core/ui | 215 / 27 | 215 / 27 |
| feature/connections | 76 / 6 | 76 / 6 |
| feature/discovery | 110 / 8 | 110 / 8 |
| feature/docs | 89 / 12 | 89 / 12 |
| feature/firmware | 376 / 29 | 376 / 29 |
| feature/intro | 6 / 1 | 6 / 1 |
| feature/map | 28 / 6 | 28 / 6 |
| feature/messaging | 97 / 12 | 97 / 12 |
| feature/node | 162 / 24 (1 fail) | 161 / 24 (0 fail) |
| feature/settings | 178 / 21 | 178 / 21 |
| feature/wifi-provision | 64 / 5 | 64 / 5 |
| **total** | **3245** | **3244** |

25 of 26 modules are byte-identical on tests, suites, failures and errors. The single delta is a flaky-retry duplicate disappearing: `NodeDetailCompassLifecycleTest` hit a `ComposeTimeoutException: Condition still not satisfied after 1000 ms` in the before-run on a loaded machine, and Develocity's retry recorded an extra testcase entry (162 = 161 real + 1 retry). The after-run had no flake: 161 tests, 0 failures. No test was lost.

### Dependency resolution unchanged

`dependencies --configuration jvmTestRuntimeClasspath` after the change:

| | before | after |
|---|---|---|
| kotlin-test variant | `kotlin-test-junit5:2.4.10` | `kotlin-test-junit5:2.4.10` |
| junit-jupiter-engine | `6.1.3` | `6.1.3` |
| `kotest-runner-*` | present | **absent** |
| kotest-assertions-core / kotest-property | `6.2.4` | `6.2.4` |

## Reviewer notes

- **`core/konsist` cannot be validated from a worktree under `.claude/`.** `CommonMainFrameworkBoundaryTest.kt:38` does `filterNot { "/.claude/" in it.path.normalizedProjectPath() }`. This work was done in a git worktree at `.claude/worktrees/…`, so that filter excluded every source file in the repo and the "scan actually reaches sources" guard tripped — 3 tests failing identically on clean `main` and after this change. It is an environmental artifact of the checkout location, not a regression, and no workaround was added for it. Its counts still diff cleanly (10 / 2 both runs, i.e. the tests are discovered and run in both cases), but **konsist's real green tick has to come from CI on this PR.** The filter looks intended to skip `.claude/` scratch sources rather than the checkout root — probably worth its own issue.
- `core/konsist` also pulls JUnit 4 (`libs.junit`) into its `jvmTest` and consequently resolves `kotlin-test-junit` alongside `junit-jupiter-engine:5.10.1`. Pre-existing and untouched here, but a second place where variant selection is non-obvious.
