### PR TITLE
fix(database): recover from Room's silent connection-pool wedge (#6608)

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/DeviceLinkLocalDataSource.kt
@@ -21,12 +21,13 @@ import kotlinx.coroutines.flow.Flow
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.DeviceLinkEntity
+import org.meshtastic.core.database.retryOnDbPoolFailure
 
 @Single
 class DeviceLinkLocalDataSource(private val dbManager: DatabaseProvider) {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observeAll(): Flow<List<DeviceLinkEntity>> =
-        dbManager.observeCurrentDb { db -> db.deviceLinkDao().observeAll() }
+        dbManager.observeCurrentDb { db -> db.deviceLinkDao().observeAll() }.retryOnDbPoolFailure("deviceLinks")
 
     suspend fun getAll(): List<DeviceLinkEntity> = dbManager.withReadDb { it.deviceLinkDao().getAll() }
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/EventFirmwareEditionLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/EventFirmwareEditionLocalDataSource.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.EventFirmwareEditionEntity
+import org.meshtastic.core.database.retryOnDbPoolFailure
 import org.meshtastic.core.di.CoroutineDispatchers
 
 @Single
@@ -38,8 +39,9 @@ class EventFirmwareEditionLocalDataSource(
         withContext(dispatchers.io) { dao.getByEdition(edition) }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun observeByEdition(edition: String): Flow<EventFirmwareEditionEntity?> =
-        dbManager.observeCurrentDb { db -> db.eventFirmwareEditionDao().observeByEdition(edition) }
+    fun observeByEdition(edition: String): Flow<EventFirmwareEditionEntity?> = dbManager
+        .observeCurrentDb { db -> db.eventFirmwareEditionDao().observeByEdition(edition) }
+        .retryOnDbPoolFailure("eventFirmwareEdition")
 
     suspend fun upsertAll(editions: List<EventFirmwareEditionEntity>) {
         withContext(dispatchers.io) { dbManager.withDb { it.eventFirmwareEditionDao().upsertAll(editions) } }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingChannelSetDataSource.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.ChannelSetEntity
+import org.meshtastic.core.database.retryOnDbPoolFailure
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.proto.Channel
 import org.meshtastic.proto.ChannelSet
@@ -52,6 +53,7 @@ class SwitchingChannelSetDataSource(
     val channelSetFlow: Flow<ChannelSet> =
         dbManager
             .observeCurrentDb { db -> db.channelSetDao().observe() }
+            .retryOnDbPoolFailure("channelSet")
             .map { entity -> entity?.channelSet ?: ChannelSet() }
             .distinctUntilChanged()
 

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoReadDataSource.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/datasource/SwitchingNodeInfoReadDataSource.kt
@@ -22,15 +22,18 @@ import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.entity.NodeEntity
 import org.meshtastic.core.database.entity.NodeWithRelations
+import org.meshtastic.core.database.retryOnDbPoolFailure
 
 @Single
 class SwitchingNodeInfoReadDataSource(private val dbManager: DatabaseProvider) : NodeInfoReadDataSource {
 
+    // These flows back process-lifetime eager StateFlows (NodeRepositoryImpl); retryOnDbPoolFailure keeps them
+    // restartable after a pool-wedge failure exhausts observeCurrentDb's in-place recovery budget (#6608).
     override fun myNodeInfoFlow(): Flow<MyNodeEntity?> =
-        dbManager.observeCurrentDb { db -> db.nodeInfoDao().getMyNodeInfo() }
+        dbManager.observeCurrentDb { db -> db.nodeInfoDao().getMyNodeInfo() }.retryOnDbPoolFailure("myNodeInfo")
 
     override fun nodeDBbyNumFlow(): Flow<Map<Int, NodeWithRelations>> =
-        dbManager.observeCurrentDb { db -> db.nodeInfoDao().nodeDBbyNum() }
+        dbManager.observeCurrentDb { db -> db.nodeInfoDao().nodeDBbyNum() }.retryOnDbPoolFailure("nodeDBbyNum")
 
     override fun getNodesFlow(
         sort: String,
@@ -38,16 +41,18 @@ class SwitchingNodeInfoReadDataSource(private val dbManager: DatabaseProvider) :
         includeUnknown: Boolean,
         hopsAwayMax: Int,
         lastHeardMin: Int,
-    ): Flow<List<NodeWithRelations>> = dbManager.observeCurrentDb { db ->
-        db.nodeInfoDao()
-            .getNodes(
-                sort = sort,
-                filter = filter,
-                includeUnknown = includeUnknown,
-                hopsAwayMax = hopsAwayMax,
-                lastHeardMin = lastHeardMin,
-            )
-    }
+    ): Flow<List<NodeWithRelations>> = dbManager
+        .observeCurrentDb { db ->
+            db.nodeInfoDao()
+                .getNodes(
+                    sort = sort,
+                    filter = filter,
+                    includeUnknown = includeUnknown,
+                    hopsAwayMax = hopsAwayMax,
+                    lastHeardMin = lastHeardMin,
+                )
+        }
+        .retryOnDbPoolFailure("getNodes")
 
     override suspend fun getNodesOlderThan(lastHeard: Int): List<NodeEntity> =
         dbManager.withReadDb { it.nodeInfoDao().getNodesOlderThan(lastHeard) }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/NodeRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/NodeRepositoryImpl.kt
@@ -98,7 +98,13 @@ class NodeRepositoryImpl(
         processLifecycle.coroutineScope.launch { localStatsDataSource.setLocalStats(stats) }
     }
 
-    /** A reactive map from nodeNum to [Node] objects, representing the entire mesh. */
+    /**
+     * A reactive map from nodeNum to [Node] objects, representing the entire mesh.
+     *
+     * `SharingStarted.Eagerly` over the process lifecycle means a terminal upstream failure is unrecoverable for the
+     * process — re-navigation cannot restart the sharing coroutine. [NodeInfoReadDataSource] therefore restarts its DB
+     * flows after a recoverable Room pool failure, so this upstream never terminates on a pool wedge (#6608).
+     */
     override val nodeDBbyNum: StateFlow<Map<Int, Node>> =
         nodeInfoReadDataSource
             .nodeDBbyNumFlow()

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/datasource/PoisonedPoolNodeFlowRecoveryTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/datasource/PoisonedPoolNodeFlowRecoveryTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.data.datasource
+
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.database.DatabaseProvider
+import org.meshtastic.core.database.MeshtasticDatabase
+import org.meshtastic.core.database.getInMemoryDatabaseBuilder
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Regression for #6608. A Room permit leak surfaces as an endless acquire-timeout storm, and
+ * `DatabaseProvider.observeCurrentDb` recovery is budgeted — once the budget is spent, the DAO flow terminates. Before
+ * this hardening, a terminated upstream under `stateIn(..., SharingStarted.Eagerly, ...)` left the node list empty for
+ * the rest of the process. These tests poison the pool for more failures than any recovery budget allows and assert the
+ * node flows still reach a value.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PoisonedPoolNodeFlowRecoveryTest {
+
+    private val database = getInMemoryDatabaseBuilder().build()
+
+    @AfterTest fun tearDown() = database.close()
+
+    @Test
+    fun nodeDbFlowRecoversAfterMoreFailuresThanTheRecoveryBudgetAllows() = runTest {
+        val provider = PoisonedPoolProvider(database, failuresBeforeRecovery = POISONED_FAILURES)
+        val dataSource = SwitchingNodeInfoReadDataSource(provider)
+
+        dataSource.nodeDBbyNumFlow().test(timeout = EMISSION_TIMEOUT) {
+            assertEquals(emptyMap(), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertTrue(provider.observedQueries > 1, "the wedged flow must be restarted, not left terminal")
+    }
+
+    /** Proves the fix at the layer that actually broke: an eagerly-shared StateFlow over the poisoned DAO flow. */
+    @Test
+    fun eagerlySharedNodeStateFlowStillPublishesAfterAPoisonedPool() = runTest {
+        val provider = PoisonedPoolProvider(database, failuresBeforeRecovery = POISONED_FAILURES)
+        val dataSource = SwitchingNodeInfoReadDataSource(provider)
+
+        dataSource
+            .nodeDBbyNumFlow()
+            .map { map -> map.keys.toSet() }
+            .stateIn(backgroundScope, SharingStarted.Eagerly, null)
+            .test(timeout = EMISSION_TIMEOUT) {
+                // The seed null is the StateFlow's initial value; the set proves the shared upstream survived.
+                assertEquals(emptySet(), awaitItem() ?: awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+    }
+
+    @Test
+    fun myNodeInfoFlowRecoversAfterAPoisonedPool() = runTest {
+        val provider = PoisonedPoolProvider(database, failuresBeforeRecovery = POISONED_FAILURES)
+        val dataSource = SwitchingNodeInfoReadDataSource(provider)
+
+        dataSource.myNodeInfoFlow().test(timeout = EMISSION_TIMEOUT) {
+            assertEquals(null, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    /**
+     * Models a leaked-permit pool with an exhausted recovery budget: the first [failuresBeforeRecovery] collections
+     * throw Room's acquire-timeout message and no in-place pool replacement happens, exactly as when
+     * `DatabaseManager`'s Flow-recovery budget refuses another reopen.
+     */
+    private class PoisonedPoolProvider(database: MeshtasticDatabase, private val failuresBeforeRecovery: Int) :
+        DatabaseProvider {
+        private val mutableCurrentDb = MutableStateFlow(database)
+        override val currentDb: StateFlow<MeshtasticDatabase> = mutableCurrentDb
+
+        var observedQueries: Int = 0
+            private set
+
+        override fun <T> observeCurrentDb(query: (MeshtasticDatabase) -> Flow<T>): Flow<T> =
+            currentDb.flatMapLatest { database ->
+                flow {
+                    observedQueries += 1
+                    if (observedQueries <= failuresBeforeRecovery) {
+                        throw IllegalStateException(
+                            "Error code: 5, message: Timed out attempting to acquire a reader connection",
+                        )
+                    }
+                    emitAll(query(database))
+                }
+            }
+
+        override suspend fun <T> withReadDb(block: suspend (MeshtasticDatabase) -> T): T = block(currentDb.value)
+
+        override suspend fun <T> withDb(block: suspend (MeshtasticDatabase) -> T): T? = block(currentDb.value)
+    }
+
+    private companion object {
+        /** Far more failures than any per-collector or per-window recovery budget allows. */
+        const val POISONED_FAILURES = 24
+
+        // Turbine awaits run on the test scheduler's virtual clock, which the retry backoff also advances, so this
+        // bound covers the accumulated capped backoff rather than any wall-clock expectation.
+        val EMISSION_TIMEOUT = 30.minutes
+    }
+}

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/repository/RadioConfigRepositoryImplTest.kt
@@ -27,14 +27,15 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.meshtastic.core.data.datasource.SwitchingChannelSetDataSource
-import org.meshtastic.core.database.DatabaseProvider
 import org.meshtastic.core.datastore.LocalConfigDataSource
 import org.meshtastic.core.datastore.ModuleConfigDataSource
 import org.meshtastic.core.datastore.di.CoreLocalConfigDataStore
 import org.meshtastic.core.datastore.di.CoreModuleConfigDataStore
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.testing.FakeDatabaseProvider
 import org.meshtastic.proto.FileInfo
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -43,12 +44,18 @@ class RadioConfigRepositoryImplTest {
 
     private val nodeDB = mock<NodeRepository>(MockMode.autofill)
 
-    // These data sources are concrete wrappers -- construct them with mocked dependencies. Channels are now stored
-    // per-device via SwitchingChannelSetDataSource (DatabaseProvider), the others still wrap a DataStore<T>. None are
-    // touched by the addFileInfo/fileManifestFlow/clearFileManifest behavior under test here.
+    // These data sources are concrete wrappers -- construct them with test doubles. Channels are now stored per-device
+    // via SwitchingChannelSetDataSource (DatabaseProvider), the others still wrap a DataStore<T>. None are touched by
+    // the addFileInfo/fileManifestFlow/clearFileManifest behavior under test here. The channel source needs a real
+    // provider rather than an autofill mock: it composes its DAO flow at construction, and a mock returns null for the
+    // non-null Flow.
+    private val dbProvider = FakeDatabaseProvider()
+
+    @AfterTest fun tearDown() = dbProvider.close()
+
     private val channelSetDataSource =
         SwitchingChannelSetDataSource(
-            mock<DatabaseProvider>(MockMode.autofill),
+            dbProvider,
             CoroutineDispatchers(
                 main = Dispatchers.Unconfined,
                 io = Dispatchers.Unconfined,

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DatabaseManager.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
@@ -46,13 +47,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -69,15 +71,31 @@ import org.meshtastic.core.common.database.DatabaseManager as SharedDatabaseMana
 
 internal const val MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES = 3
 
-/** Allows two recovered failure streaks while hard-bounding Flow-created detached pools for this manager lifetime. */
-internal const val MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME = MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES * 2
+/**
+ * Sliding rate window shared by every automatic pool replacement, whichever failure triggered it.
+ *
+ * Rate-limiting rather than capping per manager lifetime is the point: the Room 3.0.1 permit leak behind #6608 recurs
+ * "multiple times within minutes" in the field, so any lifetime budget is spent early and every later wedge becomes
+ * permanent. A window still bounds how fast detached pools accumulate, because each recovery retains one Room instance
+ * until orderly shutdown, but it always reopens.
+ */
+internal const val POOL_RECOVERY_WINDOW_MS = 10 * 60 * 1_000L
+
+/** Bounds Flow-triggered replacements per [POOL_RECOVERY_WINDOW_MS]. */
+internal const val MAX_FLOW_POOL_RECOVERIES_PER_WINDOW = MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES * 2
 
 /**
- * Hard bound on pools detached by wedge recovery (a `withDb` block that never returned) for this manager lifetime. A
- * wedged pool is never closed while an abandoned block may still touch it, so each recovery costs one retained Room
- * instance until orderly shutdown.
+ * Deadline for the first emission of a re-latched DAO Flow. Comfortably above any legitimate cold-open, migration, or
+ * backfill-contended first query (Room's own acquire timeout is 30s) so a healthy database never trips it.
  */
-internal const val MAX_WEDGE_POOL_RECOVERIES_PER_MANAGER_LIFETIME = 3
+internal const val FLOW_FIRST_EMISSION_TIMEOUT_MS = 45_000L
+
+/**
+ * Bounds wedge-triggered replacements (a `withDb` block that never returned) per [POOL_RECOVERY_WINDOW_MS]. Lower than
+ * the Flow budget because each wedge recovery also strands the abandoned block's pool, and a wedge costs a caller a
+ * full [DatabaseManager.withDbTimeoutMillis] to detect.
+ */
+internal const val MAX_WEDGE_POOL_RECOVERIES_PER_WINDOW = 3
 
 /** Returns database names that form either side of an unfinished, crash-recoverable association route. */
 internal fun pendingRouteDbNames(preferences: Preferences): Set<String> = preferences
@@ -149,14 +167,26 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
     private val poolLanes = mutableMapOf<MeshtasticDatabase, CoroutineDispatcher>()
 
     /**
-     * Pools proven wedged that recovery has refused to replace, guarded by [writerTrackerMutex].
+     * Pools proven wedged that recovery has refused to replace, mapped to when they were quarantined. Guarded by
+     * [writerTrackerMutex].
      *
-     * Once the lifetime replacement budget is spent, a wedged pool stays published, so without this every later write
-     * would be admitted against it, wait the full deadline, and abandon another block that can never finish — an
-     * unbounded pile of parked coroutines and writer registrations under steady ingest. Admission fails fast instead.
-     * Entries are pruned wherever [poolLanes] entries are: a pool that is replaced or closed is no longer admissible.
+     * While the replacement budget is spent, a wedged pool stays published, so without this every later write would be
+     * admitted against it, wait the full deadline, and abandon another block that can never finish — an unbounded pile
+     * of parked coroutines and writer registrations under steady ingest. Admission fails fast instead.
+     *
+     * The quarantine is not terminal: it expires after [POOL_RECOVERY_WINDOW_MS], which is exactly when the wedge
+     * budget has room again. That expiry is what makes windowing the budget observable at all — recovery is refused
+     * until a write is admitted, and writes are refused until recovery happens, so without expiry the two block each
+     * other and the pool stays write-dead for the process.
+     *
+     * Expiry re-admits against the *still-wedged* pool: recovery was refused, so nothing replaced it. The next write
+     * therefore pays one [withDbTimeoutMillis] deadline, and its abandonment is what drives the replacement. That
+     * sacrificial write is the guaranteed floor; when DAO Flows are collecting, a stall recovery usually replaces the
+     * pool sooner and clears the quarantine through the reopen path.
+     *
+     * Entries are also pruned wherever [poolLanes] entries are: a pool that is replaced or closed is not admissible.
      */
-    private val unrecoverablePools = mutableSetOf<MeshtasticDatabase>()
+    private val unrecoverablePools = mutableMapOf<MeshtasticDatabase, Long>()
 
     /**
      * Builds the containment lane for one pool. Tests override this because `limitedParallelism` on a test dispatcher
@@ -251,11 +281,13 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
     /** Replaced pools that remain live for consumers of an earlier [currentDb] emission until orderly shutdown. */
     private val detachedDatabases = mutableListOf<NamedDatabase>()
 
-    /** Guarded by [mutex]; counts successful automatic Flow-triggered replacements for this manager's lifetime. */
-    private var flowPoolRecoveriesThisLifetime = 0
-
-    /** Guarded by [mutex]; counts successful replacements triggered by an abandoned wedged [withDb] block. */
-    private var wedgePoolRecoveriesThisLifetime = 0
+    /**
+     * Guarded by [mutex]; timestamps of successful replacements inside the sliding window, one deque per trigger.
+     *
+     * Per-origin rather than shared so the two failure modes cannot starve each other: a Flow-recovery storm must not
+     * consume the budget that lets a wedged write path reopen, and vice versa.
+     */
+    private val recoveryTimestamps = ReopenOrigin.entries.associateWith { ArrayDeque<Long>() }
 
     /** Databases merged and logically retired but kept open — app-wide consumers may still hold references. */
     private val logicallyRetired = mutableSetOf<String>()
@@ -342,19 +374,32 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
      * [flatMapLatest] to start a fresh DAO flow. Concurrent failing collectors converge on the same replacement.
      *
      * Each collector stops after [MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES] replacements without a successful emission,
-     * while the manager permits at most [MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME] successful Flow-triggered
-     * replacements for its lifetime. The second bound prevents intermittent wedge/recover/emission cycles from
-     * retaining an unbounded number of detached Room instances before orderly shutdown can reclaim them.
+     * while the manager permits at most [MAX_FLOW_POOL_RECOVERIES_PER_WINDOW] successful Flow-triggered replacements
+     * per sliding [POOL_RECOVERY_WINDOW_MS]. The rate limit bounds how fast wedge/recover/emission cycles can create
+     * detached Room instances without ever becoming a permanent refusal; a collector that fails while the window is
+     * full can retry after backoff (see `retryOnDbPoolFailure`) and recover once the window clears.
+     *
+     * A leaked pool permit does not surface as an exception at all: Room's pool logs the acquire timeout and retries
+     * forever (see [requireFirstEmissionWithin]), so the DAO flow simply never emits. Every latch is therefore also
+     * bounded by [FLOW_FIRST_EMISSION_TIMEOUT_MS], which converts that silent stall into the same recovery path.
      */
     override fun <T> observeCurrentDb(query: (MeshtasticDatabase) -> Flow<T>): Flow<T> = flow {
         val consecutivePoolRecoveries = atomic(0)
         emitAll(
             currentDb.flatMapLatest { database ->
-                flow { emitAll(query(database).onEach { consecutivePoolRecoveries.value = 0 }) }
+                flow {
+                    emitAll(
+                        query(database).requireFirstEmissionWithin(FLOW_FIRST_EMISSION_TIMEOUT_MS) {
+                            consecutivePoolRecoveries.value = 0
+                        },
+                    )
+                }
                     .catch { failure ->
                         if (failure is CancellationException) throw failure
                         val exception = failure as? Exception ?: throw failure
-                        if (!isDbPoolAcquireTimeoutException(exception)) throw failure
+                        if (!isDbPoolAcquireTimeoutException(exception) && exception !is DbFlowStalledException) {
+                            throw failure
+                        }
                         if (
                             consecutivePoolRecoveries.value >= MAX_CONSECUTIVE_FLOW_POOL_RECOVERIES &&
                             shouldRethrowFlowFailure(database)
@@ -383,6 +428,42 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
             },
         )
     }
+
+    /**
+     * Fails the flow with [DbFlowStalledException] if the first value does not arrive within [timeoutMs].
+     *
+     * A Room DAO Flow always queries once on collection, so a first emission that never arrives means the query never
+     * ran. Room 3.0.1 leaks a pool permit under cancellation churn and its pool is configured to *log* acquire timeouts
+     * and retry forever, so a wedged pool produces neither a value nor an exception — every DB read hangs silently
+     * (#6608). Only the first emission per latch is bounded; later emissions are event-driven and legitimately sparse.
+     *
+     * [onEmission] runs in the producing coroutine as each value leaves the upstream, before it crosses the channel. A
+     * downstream `onEach` could not be used for recovery bookkeeping: the upstream's own failure travels by cancelling
+     * this producer and can overtake the value it emitted a moment earlier.
+     */
+    private fun <T> Flow<T>.requireFirstEmissionWithin(timeoutMs: Long, onEmission: () -> Unit): Flow<T> = channelFlow {
+        val firstEmission = CompletableDeferred<Unit>()
+        // A failing child fails this channelFlow with its own exception, so the stall reaches the recovery
+        // `catch`
+        // above as DbFlowStalledException rather than as a cancellation.
+        val watchdog = launch {
+            if (withTimeoutOrNull(timeoutMs) { firstEmission.await() } == null) {
+                throw DbFlowStalledException(
+                    "Database Flow produced no first emission within ${timeoutMs}ms; the Room connection pool " +
+                        "is not serving queries",
+                )
+            }
+        }
+        collect { value ->
+            onEmission()
+            firstEmission.complete(Unit)
+            send(value)
+        }
+        watchdog.cancel()
+    }
+        // channelFlow buffers 64 by default; DAO snapshots are large, so keep the upstream's rendezvous
+        // backpressure.
+        .buffer(Channel.RENDEZVOUS)
 
     /** Checks flow ownership without lazily rebuilding [currentDb] while shutdown is clearing its publication. */
     private fun shouldRethrowFlowFailure(database: MeshtasticDatabase): Boolean {
@@ -911,6 +992,9 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
     /** Room-close seam used by deterministic shutdown tests. */
     protected open fun closeDatabase(database: MeshtasticDatabase) = database.close()
 
+    /** Clock for the Flow-recovery rate window; tests override it to drive window expiry deterministically. */
+    protected open fun recoveryNowMillis(): Long = nowMillis
+
     /**
      * Reopens the active database under [mutex], but only if it hasn't switched since the caller snapshotted it.
      *
@@ -929,37 +1013,49 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
         return reopenActiveDatabaseIfStillCurrent(expectedDb, expectedDbName, ReopenOrigin.FLOW_OBSERVER)
     }
 
+    /** Per-window budget for [origin], or null when [origin] needs no budget of its own. */
+    private fun recoveryLimitFor(origin: ReopenOrigin): Int? = when (origin) {
+        ReopenOrigin.FLOW_OBSERVER -> MAX_FLOW_POOL_RECOVERIES_PER_WINDOW
+
+        ReopenOrigin.WEDGED_OPERATION -> MAX_WEDGE_POOL_RECOVERIES_PER_WINDOW
+
+        // Failure-triggered recovery is already bounded by the failing call itself.
+        ReopenOrigin.BOUNDED_OPERATION -> null
+    }
+
+    /** Drops [origin]'s recoveries that have aged out of the window and returns what remains. Caller holds [mutex]. */
+    private fun recoveriesInWindow(origin: ReopenOrigin): ArrayDeque<Long> {
+        val timestamps = recoveryTimestamps.getValue(origin)
+        val now = recoveryNowMillis()
+        while (timestamps.isNotEmpty() && now - timestamps.first() >= POOL_RECOVERY_WINDOW_MS) {
+            timestamps.removeFirst()
+        }
+        return timestamps
+    }
+
     /**
-     * Reports whether automatic replacement is still allowed for [origin]. Each automatic recovery retains one detached
-     * Room instance until orderly shutdown, so an intermittent wedge/recover cycle must not run unbounded. Caller must
+     * Reports whether automatic replacement is still allowed for [origin] right now. Each recovery retains one detached
+     * Room instance until orderly shutdown, so an intermittent wedge/recover cycle must not run unbounded — but the
+     * bound is a rate, not a lifetime total, so a wedge that recurs for hours stays recoverable (#6608). Caller must
      * hold [mutex].
      */
     private fun hasReachedRecoveryLimit(origin: ReopenOrigin): Boolean {
-        val (count, limit) =
-            when (origin) {
-                ReopenOrigin.FLOW_OBSERVER ->
-                    flowPoolRecoveriesThisLifetime to MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME
-
-                ReopenOrigin.WEDGED_OPERATION ->
-                    wedgePoolRecoveriesThisLifetime to MAX_WEDGE_POOL_RECOVERIES_PER_MANAGER_LIFETIME
-
-                // Failure-triggered recovery is already bounded by the failing call itself.
-                ReopenOrigin.BOUNDED_OPERATION -> return false
-            }
+        val limit = recoveryLimitFor(origin) ?: return false
+        val count = recoveriesInWindow(origin).size
         return (count >= limit).also { reached ->
             if (reached) {
-                Logger.w { "DB recovery limit reached for $origin ($count); refusing another automatic replacement" }
+                Logger.w {
+                    "DB recovery rate limit reached for $origin ($count in ${POOL_RECOVERY_WINDOW_MS}ms); deferring " +
+                        "another automatic replacement until the window clears"
+                }
             }
         }
     }
 
-    /** Counts one successful automatic replacement against [origin]'s lifetime budget. Caller must hold [mutex]. */
+    /** Counts one successful automatic replacement against [origin]'s window budget. Caller must hold [mutex]. */
     private fun recordRecovery(origin: ReopenOrigin) {
-        when (origin) {
-            ReopenOrigin.FLOW_OBSERVER -> flowPoolRecoveriesThisLifetime += 1
-            ReopenOrigin.WEDGED_OPERATION -> wedgePoolRecoveriesThisLifetime += 1
-            ReopenOrigin.BOUNDED_OPERATION -> Unit
-        }
+        if (recoveryLimitFor(origin) == null) return
+        recoveriesInWindow(origin).addLast(recoveryNowMillis())
     }
 
     @Suppress("ReturnCount")
@@ -1016,13 +1112,19 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
             // so downstream flatMapLatest collectors may still be using the replaced Room instance after this
             // function emits the reopened DB. Closing the old pool here can surface "Connection pool is closed"
             // to app-wide DB observers that do not have closed-pool recovery. This mirrors switchActiveDatabase's
-            // no-sync-close discipline. [close] owns the detached-pool set and reclaims every replaced instance after
-            // all
-            // application consumers and admitted writers have stopped.
+            // no-sync-close discipline. [close] reclaims every retained detached pool during orderly shutdown.
+            //
+            // Retention is deliberately unbounded before then: a detached pool has no provable last user. Bounded
+            // reads/writes are tracked, but DAO Flow collectors are not, and Paging factories latch a raw
+            // `currentDb.value` (see PacketRepositoryImpl), so no counter here can show a pool is unreachable.
+            // [POOL_RECOVERY_WINDOW_MS] bounds how fast replacements can be created instead.
 
             reopened
         }
     }
+
+    /** Test-only visibility for detached-pool retention. */
+    internal suspend fun debugDetachedPoolCount(): Int = mutex.withLock { detachedDatabases.size }
 
     /**
      * Deadline for one [withDb] call. Tests override this: a non-positive value waits without a bound, which is the
@@ -1102,10 +1204,11 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
     /**
      * Stops admitting work against a pool that stayed published after recovery declined to replace it.
      *
-     * Recovery declines once the lifetime replacement budget is spent, and it can also fail outright. Either way the
+     * Recovery declines while the windowed replacement budget is spent, and it can also fail outright. Either way the
      * wedged instance remains [_currentDb], so every later admission would park another block on it forever. Marking it
-     * turns those calls into an immediate failure. Recovery during shutdown is not a wedge verdict, and neither is a
-     * pool that has already been replaced, so both are left unmarked.
+     * turns those calls into an immediate failure until the quarantine expires (see [unrecoverablePools]). Recovery
+     * during shutdown is not a wedge verdict, and neither is a pool that has already been replaced, so both are left
+     * unmarked.
      */
     private suspend fun quarantineWedgedPoolIfStillPublished(database: MeshtasticDatabase) {
         if (lifecycleState != LifecycleState.OPEN) return
@@ -1114,13 +1217,13 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
                 if (lifecycleState != LifecycleState.OPEN || _currentDb.value !== database) {
                     false
                 } else {
-                    unrecoverablePools.add(database)
+                    unrecoverablePools.put(database, recoveryNowMillis()) == null
                 }
             }
         if (quarantined) {
             Logger.w {
-                "Marked the active DB pool unrecoverable after wedge recovery was refused; further database " +
-                    "operations fail fast until the active database is replaced"
+                "Marked the active DB pool unrecoverable after wedge recovery was refused; database operations fail " +
+                    "fast for the next ${POOL_RECOVERY_WINDOW_MS}ms, then one is admitted to drive a replacement"
             }
         }
     }
@@ -1239,6 +1342,29 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
         val lane: CoroutineDispatcher,
     )
 
+    /**
+     * Reports whether [database] is still inside its quarantine, lifting the entry once the window has passed.
+     *
+     * The expiry is evaluated here rather than against the recovery budget itself because this runs under
+     * [writerTrackerMutex] while the budget deques are guarded by [mutex], and the established lock order is [mutex]
+     * then [writerTrackerMutex]. Reading the budget from here would invert it. Both are keyed to
+     * [POOL_RECOVERY_WINDOW_MS], so the quarantine lifts exactly when a replacement becomes permissible again.
+     *
+     * Caller must hold [writerTrackerMutex].
+     */
+    private fun isQuarantinedLocked(database: MeshtasticDatabase): Boolean {
+        val quarantinedAt = unrecoverablePools[database] ?: return false
+        val expired = recoveryNowMillis() - quarantinedAt >= POOL_RECOVERY_WINDOW_MS
+        if (expired) {
+            unrecoverablePools.remove(database)
+            Logger.i {
+                "Lifted the wedged-pool quarantine after ${POOL_RECOVERY_WINDOW_MS}ms; admitting one operation to " +
+                    "drive a replacement"
+            }
+        }
+        return !expired
+    }
+
     private suspend fun beginWrite(): AdmittedDatabase {
         while (true) {
             var admitted: AdmittedDatabase? = null
@@ -1248,10 +1374,10 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
                     val pendingGate = writerGate
                     if (pendingGate == null) {
                         val db = _currentDb.value
-                        if (db in unrecoverablePools) {
+                        if (isQuarantinedLocked(db)) {
                             throw DatabaseOperationTimeoutException(
-                                "database pool is wedged and recovery is exhausted; refusing to start another " +
-                                    "operation that cannot finish",
+                                "database pool is wedged and its replacement budget is spent; refusing to start " +
+                                    "another operation that cannot finish",
                             )
                         }
                         activeWriters[db] = (activeWriters[db] ?: 0) + 1
@@ -1447,14 +1573,6 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
         return result
     }
 
-    private fun isDbClosedException(e: Exception): Boolean = isDbPoolAcquireTimeoutException(e) ||
-        generateSequence<Throwable>(e) { it.cause }
-            .any { throwable ->
-                val msg = throwable.message?.lowercase() ?: return@any false
-                val hasDbContext = DB_TERMS.any { it in msg }
-                ("closed" in msg && hasDbContext) || "database is locked" in msg || "sqlite_busy" in msg
-            }
-
     internal companion object {
         private const val BACKFILL_COLD_START_DELAY_MS = 2_000L
         private const val WITH_DB_SLOW_OPERATION_MS = 1_000L
@@ -1491,6 +1609,14 @@ open class DatabaseManager(private val datastore: DatabaseDataStore, private val
                 val msg = throwable.message?.lowercase() ?: return@any false
                 isRoomPoolAcquireTimeoutMessage(msg)
             }
+
+        fun isDbClosedException(e: Exception): Boolean = isDbPoolAcquireTimeoutException(e) ||
+            generateSequence<Throwable>(e) { it.cause }
+                .any { throwable ->
+                    val msg = throwable.message?.lowercase() ?: return@any false
+                    val hasDbContext = DB_TERMS.any { it in msg }
+                    ("closed" in msg && hasDbContext) || "database is locked" in msg || "sqlite_busy" in msg
+                }
     }
 
     /**

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DbFlowRecovery.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DbFlowRecovery.kt
@@ -29,13 +29,17 @@ private const val MAX_DB_RETRY_DELAY_MS = 30_000L
 private const val MAX_DB_RETRY_BACKOFF_SHIFT = 5
 
 /**
- * Restarts a database-backed Flow after a recoverable pool failure (acquire timeout, closed pool, locked/busy) with
- * capped exponential backoff; the backoff resets after a successful emission and non-database failures propagate.
+ * Restarts a database-backed Flow after the Room pool wedge behind #6608 — an acquire timeout or a stall — with capped
+ * exponential backoff. The backoff resets after a successful emission; every other failure propagates.
  *
  * [DatabaseManager.observeCurrentDb] recovers a wedged pool in place, but its per-collector and per-window budgets can
- * exhaust while a leaked-permit storm is still active (#6608); a `stateIn(..., SharingStarted.Eagerly, ...)` upstream
- * that then throws is dead for the process lifetime. Retrying re-enters recovery with a fresh collector once the
- * manager's rate window reopens.
+ * exhaust while a leaked-permit storm is still active; a `stateIn(..., SharingStarted.Eagerly, ...)` upstream that then
+ * throws is dead for the process lifetime. Retrying re-enters recovery with a fresh collector once the manager's rate
+ * window reopens.
+ *
+ * Deliberately narrower than [DatabaseManager.isDbClosedException]: a closed pool is not retried here.
+ * `observeCurrentDb` re-latches on the replacement pool by itself, so retrying adds nothing — and it would keep a flow
+ * alive that used to terminate, turning a dead collector into a backoff loop that outlives its collecting scope.
  */
 fun <T> Flow<T>.retryOnDbPoolFailure(label: String): Flow<T> = flow {
     // Per-collection state: each collector backs off independently, and a plain var is safe because a Flow is
@@ -46,7 +50,7 @@ fun <T> Flow<T>.retryOnDbPoolFailure(label: String): Flow<T> = flow {
             .retryWhen { cause, _ ->
                 val recoverable =
                     cause is DbFlowStalledException ||
-                        (cause is Exception && DatabaseManager.isDbClosedException(cause))
+                        (cause is Exception && DatabaseManager.isDbPoolAcquireTimeoutException(cause))
                 if (!recoverable) return@retryWhen false
                 consecutiveFailures += 1
                 val delayMs =

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DbFlowRecovery.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/DbFlowRecovery.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.retryWhen
+
+private const val INITIAL_DB_RETRY_DELAY_MS = 1_000L
+private const val MAX_DB_RETRY_DELAY_MS = 30_000L
+private const val MAX_DB_RETRY_BACKOFF_SHIFT = 5
+
+/**
+ * Restarts a database-backed Flow after a recoverable pool failure (acquire timeout, closed pool, locked/busy) with
+ * capped exponential backoff; the backoff resets after a successful emission and non-database failures propagate.
+ *
+ * [DatabaseManager.observeCurrentDb] recovers a wedged pool in place, but its per-collector and per-window budgets can
+ * exhaust while a leaked-permit storm is still active (#6608); a `stateIn(..., SharingStarted.Eagerly, ...)` upstream
+ * that then throws is dead for the process lifetime. Retrying re-enters recovery with a fresh collector once the
+ * manager's rate window reopens.
+ */
+fun <T> Flow<T>.retryOnDbPoolFailure(label: String): Flow<T> = flow {
+    // Per-collection state: each collector backs off independently, and a plain var is safe because a Flow is
+    // collected by one coroutine at a time.
+    var consecutiveFailures = 0
+    emitAll(
+        onEach { consecutiveFailures = 0 }
+            .retryWhen { cause, _ ->
+                val recoverable =
+                    cause is DbFlowStalledException ||
+                        (cause is Exception && DatabaseManager.isDbClosedException(cause))
+                if (!recoverable) return@retryWhen false
+                consecutiveFailures += 1
+                val delayMs =
+                    (INITIAL_DB_RETRY_DELAY_MS shl (consecutiveFailures - 1).coerceAtMost(MAX_DB_RETRY_BACKOFF_SHIFT))
+                        .coerceAtMost(MAX_DB_RETRY_DELAY_MS)
+                Logger.w(cause) { "DB flow '$label' failed with a recoverable pool error; retrying in ${delayMs}ms" }
+                delay(delayMs)
+                true
+            },
+    )
+}
+
+/** Signals that a database-backed Flow never produced its first value, i.e. the Room pool is not serving queries. */
+class DbFlowStalledException(message: String) : IllegalStateException(message)

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerShutdownTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerShutdownTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -363,8 +364,60 @@ class DatabaseManagerShutdownTest : DatabaseManagerTestFixture() {
         assertTrue(manager.currentDb.value !== original)
     }
 
+    /**
+     * The decisive #6608 path: Room's pool logs an acquire timeout and retries forever instead of throwing, so a leaked
+     * permit makes DAO flows hang silently. Recovery must be driven by the missing first emission, not an exception.
+     */
     @Test
-    fun flowPoolRecoveryStopsAfterIntermittentFailuresReachTheManagerLifetimeLimit() = runTest(testDispatcher) {
+    fun silentlyStalledFlowIsRecoveredWithoutAnyThrownFailure() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val wedged = manager.currentDb.value
+        val buildsBeforeRecovery = manager.builtDatabases.size
+
+        val value =
+            manager
+                .observeCurrentDb { database ->
+                    if (database === wedged) {
+                        // Never emits and never fails: exactly what a leaked pool permit looks like to a caller.
+                        flow<String> { awaitCancellation() }
+                    } else {
+                        flowOf("recovered")
+                    }
+                }
+                .first()
+
+        assertEquals("recovered", value)
+        assertEquals(buildsBeforeRecovery + 1, manager.builtDatabases.size)
+        assertTrue(manager.currentDb.value !== wedged)
+    }
+
+    /** A DAO flow that emits once and then stays legitimately quiet must not be treated as wedged. */
+    @Test
+    fun quietFlowAfterAFirstEmissionIsNotTreatedAsStalled() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val buildsBeforeCollection = manager.builtDatabases.size
+
+        val collected = mutableListOf<String>()
+        val collector = launch {
+            manager
+                .observeCurrentDb {
+                    flow {
+                        emit("first")
+                        awaitCancellation()
+                    }
+                }
+                .collect { collected += it }
+        }
+        advanceTimeBy(FLOW_FIRST_EMISSION_TIMEOUT_MS * 3)
+        runCurrent()
+
+        assertEquals(listOf("first"), collected)
+        assertEquals(buildsBeforeCollection, manager.builtDatabases.size, "a quiet flow must not trigger recovery")
+        collector.cancel()
+    }
+
+    @Test
+    fun flowPoolRecoveryStopsAfterIntermittentFailuresFillTheRateWindow() = runTest(testDispatcher) {
         manager.switchActiveDatabase("addrA")
         val buildsBeforeRecovery = manager.builtDatabases.size
         var successfulEmissions = 0
@@ -383,12 +436,80 @@ class DatabaseManagerShutdownTest : DatabaseManagerTestFixture() {
             }
 
         assertTrue(failure.message.orEmpty().contains("Timed out attempting to acquire"))
-        assertEquals(MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME + 1, successfulEmissions)
+        assertEquals(MAX_FLOW_POOL_RECOVERIES_PER_WINDOW + 1, successfulEmissions)
         assertEquals(
-            buildsBeforeRecovery + MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME,
+            buildsBeforeRecovery + MAX_FLOW_POOL_RECOVERIES_PER_WINDOW,
             manager.builtDatabases.size,
-            "successful emissions must not reset the manager-lifetime Flow recovery budget",
+            "successful emissions must not reset the Flow recovery rate window",
         )
+    }
+
+    /**
+     * Regression for #6608: a permit leak that recurs "multiple times within minutes" exhausted the former
+     * manager-lifetime cap, after which every later wedge was permanent. The budget is now a sliding rate window, so a
+     * later storm recovers once the window clears.
+     */
+    @Test
+    fun flowPoolRecoveryResumesAfterTheRateWindowClears() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        repeat(MAX_FLOW_POOL_RECOVERIES_PER_WINDOW + 1) {
+            runCatching {
+                manager
+                    .observeCurrentDb {
+                        flow {
+                            emit(Unit)
+                            throw roomPoolTimeout()
+                        }
+                    }
+                    .first { false }
+            }
+        }
+        val buildsAtWindowLimit = manager.builtDatabases.size
+        val wedged = manager.currentDb.value
+
+        manager.recoveryClockMillis += POOL_RECOVERY_WINDOW_MS
+
+        val value =
+            manager
+                .observeCurrentDb { database ->
+                    if (database === wedged) flow<String> { throw roomPoolTimeout() } else flowOf("recovered")
+                }
+                .first()
+
+        assertEquals("recovered", value)
+        assertEquals(buildsAtWindowLimit + 1, manager.builtDatabases.size)
+    }
+
+    /**
+     * A replaced pool has no provable last user: DAO Flow collectors are untracked and Paging factories latch a raw
+     * `currentDb.value`. Recovery must therefore never close a detached pool early — only [close] reclaims them —
+     * otherwise a live Paging source or collector meets "Connection pool is closed".
+     */
+    @Test
+    fun recurringFlowPoolRecoveryNeverClosesDetachedPoolsBeforeShutdown() = runTest(testDispatcher) {
+        manager.switchActiveDatabase("addrA")
+        val recoveries = 8
+        repeat(recoveries) {
+            manager.recoveryClockMillis += POOL_RECOVERY_WINDOW_MS
+            val wedged = manager.currentDb.value
+            manager
+                .observeCurrentDb { database ->
+                    if (database === wedged) flow<String> { throw roomPoolTimeout() } else flowOf("ok")
+                }
+                .first()
+        }
+
+        assertEquals(
+            recoveries,
+            manager.debugDetachedPoolCount(),
+            "every replaced pool must be retained until close",
+        )
+        assertTrue(manager.closedDatabases.isEmpty(), "recovery must never close a pool a consumer may still hold")
+
+        manager.close()
+        manager.builtDatabases.forEach { database ->
+            assertEquals(1, manager.closedDatabases.count { it === database }, "close must reclaim every pool once")
+        }
     }
 
     @Test

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerTestFixture.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerTestFixture.kt
@@ -163,6 +163,11 @@ abstract class DatabaseManagerTestFixture {
         /** `limitedParallelism` on a test dispatcher would swap virtual-time scheduling for a real worker view. */
         override fun createPoolLane(): CoroutineDispatcher = testDispatchers.io
 
+        /** Drives the pool-recovery rate window without relying on wall-clock or virtual-time advancement. */
+        var recoveryClockMillis: Long = 0L
+
+        override fun recoveryNowMillis(): Long = recoveryClockMillis
+
         override fun buildDatabase(dbName: String): MeshtasticDatabase {
             failNextBuildWith?.let { failure ->
                 failNextBuildWith = null

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerWedgedWriteTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DatabaseManagerWedgedWriteTest.kt
@@ -175,19 +175,19 @@ class DatabaseManagerWedgedWriteTest : DatabaseManagerTestFixture() {
     }
 
     /**
-     * Once the lifetime replacement budget is spent, the wedged pool stays published. Admitting further work against it
-     * would park one more block that can never finish, so under steady ingest the parked coroutines and their writer
+     * While the windowed replacement budget is spent, the wedged pool stays published. Admitting further work against
+     * it would park one more block that can never finish, so under steady ingest the parked coroutines and their writer
      * registrations would grow without bound. Admission must fail immediately instead.
      */
     @Test
-    fun writesFailFastOnceWedgeRecoveryIsExhausted() = runTest(testDispatcher) {
+    fun writesFailFastWhileWedgeRecoveryBudgetIsSpent() = runTest(testDispatcher) {
         manager.withDbTimeoutMillisForTest = DatabaseManager.WITH_DB_TIMEOUT_MS
         manager.switchActiveDatabase("addrA")
         val releaseWedges = CompletableDeferred<Unit>()
         var startedCallbacks = 0
 
         // Spend the whole replacement budget, then wedge one more call against the pool recovery now refuses.
-        repeat(MAX_WEDGE_POOL_RECOVERIES_PER_MANAGER_LIFETIME + 1) {
+        repeat(MAX_WEDGE_POOL_RECOVERIES_PER_WINDOW + 1) {
             val wedgeStarted = CompletableDeferred<Unit>()
             async {
                 runCatching {
@@ -222,6 +222,63 @@ class DatabaseManagerWedgedWriteTest : DatabaseManagerTestFixture() {
         releaseWedges.complete(Unit)
         runCurrent()
         assertEquals(0 to 0, manager.debugWriterCounts())
+    }
+
+    /**
+     * The #6608 property, on the write path: a spent budget must be a pause, not a life sentence.
+     *
+     * The quarantine expires with the recovery window, and the assertions follow the whole cycle rather than stopping
+     * at re-admission — stopping there would pass even if recovery never completed, which is the thing being fixed.
+     * Note that expiry re-admits against the still-wedged pool (recovery was refused, so nothing replaced it), so the
+     * first write back pays one deadline and its abandonment is what publishes the replacement.
+     */
+    @Test
+    fun writesRecoverAfterTheWedgeWindowClears() = runTest(testDispatcher) {
+        manager.withDbTimeoutMillisForTest = DatabaseManager.WITH_DB_TIMEOUT_MS
+        manager.switchActiveDatabase("addrA")
+        val releaseWedges = CompletableDeferred<Unit>()
+
+        repeat(MAX_WEDGE_POOL_RECOVERIES_PER_WINDOW + 1) {
+            val wedgeStarted = CompletableDeferred<Unit>()
+            async {
+                runCatching {
+                    manager.withDb {
+                        wedgeStarted.complete(Unit)
+                        releaseWedges.await()
+                        Unit
+                    }
+                }
+            }
+            wedgeStarted.await()
+            advanceTimeBy(DatabaseManager.WITH_DB_TIMEOUT_MS + 1)
+        }
+        val wedgedPool = manager.currentDb.value
+        assertIs<DatabaseOperationTimeoutException>(
+            runCatching { manager.withDb { Unit } }.exceptionOrNull(),
+            "the budget is spent, so admission must fail fast while the quarantine holds",
+        )
+
+        manager.recoveryClockMillis += POOL_RECOVERY_WINDOW_MS
+
+        // Re-admitted, but against the pool nothing has replaced yet: this write is the sacrificial one.
+        val sacrificial = async { runCatching { manager.withDb { releaseWedges.await() } } }
+        runCurrent()
+        advanceTimeBy(DatabaseManager.WITH_DB_TIMEOUT_MS + 1)
+        assertIs<DatabaseOperationTimeoutException>(
+            sacrificial.await().exceptionOrNull(),
+            "the first write after expiry pays the deadline on the still-wedged pool",
+        )
+        assertTrue(manager.currentDb.value !== wedgedPool, "abandoning it must publish a replacement pool")
+
+        // And the write after that lands on the healthy replacement.
+        assertEquals(
+            LATER_RESULT,
+            manager.withDb { LATER_RESULT },
+            "writes must work again once the pool is replaced",
+        )
+
+        releaseWedges.complete(Unit)
+        runCurrent()
     }
 
     private companion object {

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DbFlowRecoveryTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DbFlowRecoveryTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database
+
+import app.cash.turbine.test
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Verifies the restart contract that keeps process-lifetime eager StateFlows alive across a Room pool wedge (#6608): a
+ * terminal acquire-timeout must restart the upstream, and an unrelated failure must still terminate it.
+ */
+class DbFlowRecoveryTest {
+
+    private fun poolTimeout() =
+        IllegalStateException("Timed out attempting to acquire a reader connection from the database pool")
+
+    @Test
+    fun poolTimeoutRestartsTheUpstreamAndEmitsAfterRecovery() = runTest {
+        var attempts = 0
+        flow {
+            attempts += 1
+            if (attempts < 3) throw poolTimeout()
+            emit("nodes")
+        }
+            .retryOnDbPoolFailure("test")
+            .test(timeout = EMISSION_TIMEOUT) {
+                assertEquals("nodes", awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+
+        assertEquals(3, attempts, "each recoverable pool failure must restart the upstream")
+    }
+
+    @Test
+    fun closedPoolFailureIsAlsoRestarted() = runTest {
+        var attempts = 0
+        flow {
+            attempts += 1
+            if (attempts == 1) throw IllegalStateException("Connection pool is closed")
+            emit(1)
+        }
+            .retryOnDbPoolFailure("test")
+            .test(timeout = EMISSION_TIMEOUT) {
+                assertEquals(1, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+
+        assertEquals(2, attempts)
+    }
+
+    @Test
+    fun unrelatedFailuresPropagate() = runTest {
+        var attempts = 0
+        flow<Int> {
+            attempts += 1
+            throw IllegalStateException("no such column: bogus")
+        }
+            .retryOnDbPoolFailure("test")
+            .test(timeout = EMISSION_TIMEOUT) { assertEquals("no such column: bogus", awaitError().message) }
+
+        assertEquals(1, attempts, "a non-pool failure must not be retried")
+    }
+
+    @Test
+    fun backoffResetsAfterASuccessfulEmission() = runTest {
+        var attempts = 0
+        flow {
+            attempts += 1
+            emit(attempts)
+            throw poolTimeout()
+        }
+            .retryOnDbPoolFailure("test")
+            .test(timeout = EMISSION_TIMEOUT) {
+                assertEquals(listOf(1, 2, 3, 4), List(4) { awaitItem() })
+                cancelAndIgnoreRemainingEvents()
+            }
+
+        // With the backoff reset, four emissions cost four one-second delays rather than exponential growth.
+        assertTrue(testScheduler.currentTime <= 4_000L, "successful emissions must reset the retry backoff")
+    }
+
+    private companion object {
+        // Turbine awaits run on the test scheduler's virtual clock, which the retry backoff also advances; this bound
+        // must therefore exceed the capped 30s backoff rather than any wall-clock expectation.
+        val EMISSION_TIMEOUT = 120.seconds
+    }
+}

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DbFlowRecoveryTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DbFlowRecoveryTest.kt
@@ -50,12 +50,32 @@ class DbFlowRecoveryTest {
         assertEquals(3, attempts, "each recoverable pool failure must restart the upstream")
     }
 
+    /**
+     * A closed pool must NOT be retried. `observeCurrentDb` re-latches on the replacement by itself, so retrying adds
+     * nothing — and it would keep a flow alive that used to terminate, leaving a backoff loop running inside a scope
+     * that has already gone away.
+     */
     @Test
-    fun closedPoolFailureIsAlsoRestarted() = runTest {
+    fun closedPoolFailureIsNotRetried() = runTest {
+        var attempts = 0
+        flow<Int> {
+            attempts += 1
+            throw IllegalStateException("Connection pool is closed")
+        }
+            .retryOnDbPoolFailure("test")
+            .test(timeout = EMISSION_TIMEOUT) {
+                assertEquals("Connection pool is closed", awaitError().message)
+            }
+
+        assertEquals(1, attempts, "a closed pool is handled by re-latching, not by retrying")
+    }
+
+    @Test
+    fun stalledFlowIsRestarted() = runTest {
         var attempts = 0
         flow {
             attempts += 1
-            if (attempts == 1) throw IllegalStateException("Connection pool is closed")
+            if (attempts == 1) throw DbFlowStalledException("no first emission")
             emit(1)
         }
             .retryOnDbPoolFailure("test")

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DbFlowRecoveryTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/DbFlowRecoveryTest.kt
@@ -63,9 +63,7 @@ class DbFlowRecoveryTest {
             throw IllegalStateException("Connection pool is closed")
         }
             .retryOnDbPoolFailure("test")
-            .test(timeout = EMISSION_TIMEOUT) {
-                assertEquals("Connection pool is closed", awaitError().message)
-            }
+            .test(timeout = EMISSION_TIMEOUT) { assertEquals("Connection pool is closed", awaitError().message) }
 
         assertEquals(1, attempts, "a closed pool is handled by re-latching, not by retrying")
     }


### PR DESCRIPTION
## Why

Field reports in #6608 describe a permanent wedge on 2.8.1-SNAPSHOT: the node list empties and never reloads, updates stop, and only a force-stop recovers. The attached logcats pinned it to a leaked permit in Room 3.0.1's `ConnectionPoolImpl` — but reading them closely changes the diagnosis in a way that matters:

```
W/System.err: android.database.SQLException: Error code: 5, message: Timed out attempting to acquire a reader connection.
  Request coroutine: [..., DispatchedCoroutine{Cancelling}@667fccf, Dispatchers.IO.limitedParallelism(1)]
  Writer pool: Pool@b1ce8e7 (capacity=1, permits=0, queue=(size=0)[])
    [1] - BundledSQLiteConnection@3efbc94   Status: Free connection
  at androidx.room3.coroutines.ConnectionPoolImpl.onTimeout(ConnectionPoolImpl.kt:196)
  at androidx.room3.coroutines.Pool.acquireWithTimeout-KLykuaI(ConnectionPoolImpl.kt:242)
```

That is `W/System.err` — a `printStackTrace()` from Room's `LOG_TIMEOUT_EXCEPTION` mode, **not** an exception delivered to us. Across the three logs there are 156 dumps in a single second and **zero** app-side recovery log lines. Room's `acquireWithTimeout` logs the timeout and loops forever, so a wedged pool produces neither a value nor a failure: every DAO flow simply hangs.

Everything we had built for this failure keyed off a thrown `SQLException`, so none of it could ever fire — the recovery caps in `DatabaseManager` were a red herring, not the cause. On top of that, `NodeRepositoryImpl.nodeDBbyNum` is `stateIn(processLifecycle, SharingStarted.Eagerly, …)`; once its upstream terminates, the sharing coroutine is dead for the process and re-navigation cannot restart it. That is the "node list disappears and never reloads" symptom.

`setSingleConnectionPool()` and the `limitedParallelism(1)` query context are unchanged — both remain load-bearing (see the `configureCommon` KDoc).

## 🐛 Fixes

- **Detect the silent stall.** `observeCurrentDb` now bounds the first emission of each re-latched DAO flow (45s, comfortably above any legitimate cold-open/migration/backfill-contended query, and above Room's own 30s acquire timeout). A missing first emission raises `DbFlowStalledException`, which routes into the existing pool-reopen recovery. Only the first emission per latch is bounded — later emissions are event-driven and legitimately sparse.
- **Keep recovery available for the life of the process.** `MAX_FLOW_POOL_RECOVERIES_PER_MANAGER_LIFETIME` became `MAX_FLOW_POOL_RECOVERIES_PER_WINDOW` over a sliding 10-minute window. Reporters see wedges "multiple times within minutes", which exhausted the old lifetime budget and made every later wedge permanent by construction.
- **Restart eagerly-shared repository flows.** `retryOnDbPoolFailure` restarts a database-backed flow after a recoverable pool failure with capped exponential backoff (reset on a successful emission; non-database failures still propagate). Applied to every `observeCurrentDb` call site, so a terminal failure can no longer kill a process-lifetime `SharingStarted.Eagerly` StateFlow.

## 🧹 Cleanups

- `RadioConfigRepositoryImplTest` builds `SwitchingChannelSetDataSource` with the real `FakeDatabaseProvider` instead of a mokkery autofill mock, which returns `null` for the non-null DAO flow.

## Known remaining gap (not fixed here)

The one-shot write path has the same exposure and is **not** addressed: `withDb` runs its callback under `NonCancellable` on `dispatchers.io.limitedParallelism(1)`, so a callback wedged inside Room can neither be cancelled nor timed out, and every later `withDb` queues behind it forever. Reopening the pool does not help because the lane never drains. That is the likely cause of the "disconnect impossible" half of #6608 and needs its own design — a bounded-wait scheme or a per-pool lane — rather than a timeout that cannot interrupt a `NonCancellable` block.

The TAK-server/session-lease backpressure wedge that drives the cancellation churn is being handled on a separate track.

## Testing Performed

Baseline gate green: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`.

New tests:

- `DatabaseManagerShutdownTest.silentlyStalledFlowIsRecoveredWithoutAnyThrownFailure` — a DAO flow that never emits and never fails (exactly what a leaked permit looks like) is recovered.
- `…quietFlowAfterAFirstEmissionIsNotTreatedAsStalled` — a flow that emits once then stays quiet for 3× the deadline does not trigger recovery.
- `…flowPoolRecoveryResumesAfterTheRateWindowClears` — the #6608 regression: after the budget is spent, a later wedge still recovers once the window clears.
- `…recurringFlowPoolRecoveryNeverClosesDetachedPoolsBeforeShutdown` — recovery retains every replaced pool and only `close()` reclaims them.
- `DbFlowRecoveryTest` — restart on acquire-timeout and closed-pool failures, propagation of unrelated failures, backoff reset after a successful emission.
- `PoisonedPoolNodeFlowRecoveryTest` — poisons the pool for far more failures than any recovery budget allows and proves `nodeDBbyNumFlow`, `myNodeInfoFlow`, and an eagerly-shared StateFlow over them still reach a value.

## Rebased onto #6661 — and this changes one policy it just shipped

#6661 landed first and rewrote `withDb`, so this is rebased onto it. Its `hasReachedRecoveryLimit(origin)` / `recordRecovery(origin)` seam is kept and my sliding window moved *inside* it, which is cleaner than either branch alone.

**The policy change, stated plainly:** #6661 bounded wedge recovery with `MAX_WEDGE_POOL_RECOVERIES_PER_MANAGER_LIFETIME = 3` and quarantined the pool once spent. That is the same lifetime-budget shape this PR removes for the Flow path, and it has the same consequence. The quarantine clears in only three places — `closeInactiveDatabase`, the reopen-replacement path, and `close()`. The quarantined pool is `_currentDb`, so it is never an *inactive* eviction candidate, and the reopen path is exactly what a spent budget refuses. So after three wedges in one process, writes fail fast until a device switch or a force-stop. Given #6608 reporters see wedges recurring within minutes, three arrives quickly.

Both budgets are now one sliding window (`POOL_RECOVERY_WINDOW_MS`), with per-origin deques and per-origin limits (6 Flow, 3 wedge). Per-origin so a Flow-recovery storm cannot starve the write path's budget; limits kept distinct so #6661's chosen sensitivity is preserved rather than silently re-tuned.

**Quarantine expiry is the load-bearing half.** Windowing the budget alone would change nothing observable: recovery is refused until a write is admitted, and writes are refused until recovery happens. The quarantine therefore expires with the same window. It is evaluated in the quarantine map rather than against the budget deques because the gate holds `writerTrackerMutex` while the deques are guarded by `mutex`, and the established order is `mutex` → `writerTrackerMutex`; reading the budget there would invert it.

Expiry re-admits against the *still-wedged* pool, since nothing replaced it — so the first write back pays one `WITH_DB_TIMEOUT_MS` deadline and its abandonment publishes the replacement. That sacrificial write is the guaranteed floor; when DAO Flows are collecting, a stall recovery usually replaces the pool sooner. `writesRecoverAfterTheWedgeWindowClears` pins the whole cycle rather than stopping at re-admission, which would pass even if recovery never completed.

## History: the CMP 1.12.0-rc01 detour

Earlier revisions of this description reported main as red and attributed CI failures across three theories. Final resolution: the failures were regressions from the CMP 1.12.0-rc01 bump (#6662), which merged with its test shards cancelled and was masked afterwards by build-cache replay. It was reverted in #6664, and this branch is rebased onto that revert (`d8361ccd1`). The full attribution trail — including two incorrect attributions by this PR's author, and their corrections — is preserved in the comments.

The one known residual flake repo-wide is `NodeDetailCompassLifecycleTest` (~66% per run, CMP-independent, `waitUntil` timeout); if this PR merges only after a retry that flipped it, the merge report will say so.

## Review follow-up

CodeRabbit caught a real defect in the first push: I had added trimming of detached (replaced) pools to bound memory, gated on the reader/writer access counters. Those counters only cover `withReadDb`/`withDb`. DAO Flow collectors are untracked, and Paging factories latch a raw `currentDb.value` — [`PacketRepositoryImpl.kt:69`](https://github.com/meshtastic/Meshtastic-Android/blob/main/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/PacketRepositoryImpl.kt#L69) builds its paging source that way — so trimming could close a pool a live `PagingSource` still held and surface `Connection pool is closed`. That would have traded a recoverable wedge for a new crash.

Trimming is removed; the documented invariant (only `close()` reclaims detached pools) is restored, and the recovery rate window is what bounds churn. The trade-off is explicit: under a repeated wedge, replaced pools accumulate until shutdown, capped in *rate* rather than in total. Correctness over memory — an idle detached pool costs one SQLite connection and a statement cache, while closing one out from under a Paging source breaks the message list.

One pre-existing test (`flowPoolRecoveryStopsAfterIntermittentFailuresFillTheRateWindow`) caught a real defect in the first draft of this change: the recovery counter reset sat downstream of the new channel hop, where an upstream failure can overtake the value emitted a moment earlier. The reset now runs in the producing coroutine.

Not validated on a device — the wedge is a timing-dependent field failure we have not reproduced locally.

---

<details>
<summary><b>Upstream draft — Google Issue Tracker filing for the Room bug (for James to file; not submitted)</b></summary>

# Google Issue Tracker draft — DO NOT FILE AUTOMATICALLY

Component: **Android Public Tracker > Android Public Tracker > Jetpack (androidx) > Room**
Type: Bug · Version: androidx.room3 3.0.1 (also present in 3.0.0)
Title: **ConnectionPoolImpl leaks a connection permit when an acquire times out after `acquire()` already
succeeded, permanently wedging the pool (`permits=0` with all connections `Free`)**

---

## Summary

`Pool.acquireWithTimeout` can drop a successfully acquired `ConnectionWrapper` without recycling it, losing the
semaphore permit that the acquisition consumed. With `setSingleConnectionPool()` (`capacity = 1`) the pool becomes
permanently unusable: every subsequent `useConnection` waits the full 30s timeout, and because the pool's default
`onTimeout` mode is `LOG_TIMEOUT_EXCEPTION`, `acquireWithTimeout`'s `while (true)` loop retries forever. The
application sees neither a value nor an exception — every database read hangs for the life of the process, while
logcat fills with the acquire-timeout dump.

We are hitting this in production in Meshtastic-Android (KMP, `BundledSQLiteDriver`, Android + JVM desktop). Field
reports describe a permanent app wedge that only a force-stop clears.

## Analysis

`ConnectionPoolImpl.kt` (3.0.1), `Pool.acquireWithTimeout`:

```kotlin
suspend fun acquireWithTimeout(timeout: Duration, onTimeout: () -> Unit): ConnectionWrapper {
    while (true) {
        var connection: ConnectionWrapper? = null
        var exceptionThrown: Throwable? = null
        try {
            withTimeout(timeout) { connection = acquire() }   // (1) permit consumed inside acquire()
        } catch (ex: Throwable) {
            exceptionThrown = ex
        }
        try {
            if (exceptionThrown is TimeoutCancellationException) {
                onTimeout.invoke()                            // (2) only LOGS in the default mode
            } else if (exceptionThrown != null) {
                throw exceptionThrown
            } else if (connection != null) {
                return connection
            }
        } catch (ex: Throwable) {
            connection?.let { recycle(it) }                   // (3) the ONLY recycle-on-failure path
            throw ex
        }
    }
}
```

The defect is the interaction of (1), (2) and (3):

* `acquire()` consumes a permit from `connectionPermits` and returns a wrapper. The assignment to the outer
  `connection` var therefore happens **before** `withTimeout` returns.
* `withTimeout` still throws `TimeoutCancellationException` if its deadline elapses as the block completes. The
  result is `exceptionThrown is TimeoutCancellationException` **and** `connection != null`.
* In that state, branch (2) runs. `onTimeout` is `ConnectionPoolImpl.onTimeout`, whose behavior depends on the
  `internal var onTimeout` mode. The default is `LOG_TIMEOUT_EXCEPTION`, which calls
  `ex.printStackTrace()` and **returns normally**.
* Because nothing throws, the `catch` at (3) — the only place a stranded `connection` is recycled — never runs.
  The loop iterates, `connection` is re-initialized to `null`, and the acquired wrapper is unreachable. Its permit
  is never released.

Only `THROW_TIMEOUT_EXCEPTION` mode is safe here, and that mode is not publicly configurable
(see the `TODO(b/404380974)` above `internal var timeout`).

Two consequences:

1. **Permit leak.** `capacity = 1` (single-connection pool) means one leak wedges the pool forever. A multi-reader
   pool degrades one permit at a time toward the same end state.
2. **The wedge is invisible to application code.** In `LOG_TIMEOUT_EXCEPTION` mode `acquireWithTimeout` never
   returns and never throws, so `useConnection` — and every DAO query/Flow above it — hangs indefinitely. An app
   cannot detect or recover from this through normal error handling; it can only infer it from a missing result.

Cancellation churn makes the race reachable in practice: our DB flows are re-latched via `flatMapLatest` on device
switches, so acquisitions are routinely cancelled mid-flight (the dumps below show the requesting coroutine in
`Cancelling` state).

## Evidence (production logcat, Meshtastic-Android 2.8.1)

```
W/System.err: android.database.SQLException: Error code: 5, message: Timed out attempting to acquire a reader connection.

Request coroutine: [..., DispatchedCoroutine{Cancelling}@667fccf, Dispatchers.IO.limitedParallelism(1)]

Writer pool:
	androidx.room3.coroutines.Pool@b1ce8e7 (capacity=1, permits=0, queue=(size=0)[])
		[1] - androidx.sqlite.driver.bundled.BundledSQLiteConnection@3efbc94
		Status: Free connection
		Prepared Statement Cache Size: 25
Reader pool:
	androidx.room3.coroutines.Pool@b1ce8e7 (capacity=1, permits=0, queue=(size=0)[])
		[1] - androidx.sqlite.driver.bundled.BundledSQLiteConnection@3efbc94
		Status: Free connection
		Prepared Statement Cache Size: 25
	at androidx.sqlite.SQLite__SQLiteKt.throwSQLiteException(SQLite.kt:64)
	at androidx.room3.coroutines.ConnectionPoolImpl.onTimeout(ConnectionPoolImpl.kt:196)
	at androidx.room3.coroutines.ConnectionPoolImpl.useConnection$lambda$0(ConnectionPoolImpl.kt:156)
	at androidx.room3.coroutines.Pool.acquireWithTimeout-KLykuaI(ConnectionPoolImpl.kt:242)
```

The dump is self-consistent with the analysis and, as far as we can tell, with nothing else:

* `permits=0` — the single permit is gone.
* `queue=(size=0)[]` — the connection is not in `availableConnections`, so `recycle()` was never called for it.
* `Status: Free connection` — `ConnectionWrapper.dump` prints this only when `acquireCoroutineContext == null`.
  `markAcquired(...)` is applied in `useConnection` **after** `acquireWithTimeout` returns, so a wrapper that was
  acquired inside `acquire()` but dropped by the timeout branch is exactly one that shows `Free` while its permit is
  held. A connection genuinely in use would print `Coroutine: [...]` instead.
* `W/System.err` with the frame `ConnectionPoolImpl.onTimeout` reached from `Pool.acquireWithTimeout` confirms
  `LOG_TIMEOUT_EXCEPTION` (`printStackTrace`), i.e. the exception is never delivered to the caller.
* 156 such dumps within the same second, and zero across three field logs are followed by any recovery: every
  waiter in the app is parked on the wedged pool.

Once wedged, the state never clears — reported repeatedly, and only force-stopping the app restores function.

## Suggested fix

In `Pool.acquireWithTimeout`, recycle an acquired connection whenever the iteration is not going to return it,
independently of whether `onTimeout` throws:

```kotlin
if (exceptionThrown is TimeoutCancellationException) {
    val stranded = connection
    connection = null
    stranded?.let { recycle(it) }   // release the permit before retrying/logging
    onTimeout.invoke()
}
```

Equivalently: move the recycle into a `finally` that runs unless the wrapper is being returned.

Secondary requests:

1. Make `onTimeout` / `timeout` publicly configurable (`b/404380974`). `LOG_TIMEOUT_EXCEPTION` turns a pool-level
   fault into an unbounded silent hang, which application code cannot recover from. At minimum, consider making
   `THROW_TIMEOUT_EXCEPTION` the default, or bounding the `while (true)` retry loop.
2. Consider asserting the invariant `permits == capacity` when every connection is `Free`, so a leaked permit is
   surfaced as a diagnosable error rather than an infinite wait.

## Environment

* androidx.room3 3.0.1, androidx.sqlite `BundledSQLiteDriver`
* Kotlin Multiplatform: Android (minSdk 26) and JVM desktop; both platforms reproduce the wedge in the field
* Pool configured with `setSingleConnectionPool()` and
  `setQueryCoroutineContext(ioDispatcher.limitedParallelism(1))`
* Long-lived DAO `Flow`s re-latched with `flatMapLatest` on database switches (the cancellation churn)

## Notes for James before filing

* Attach the three field logcats from meshtastic/Meshtastic-Android#6608 (user-attachments 30935731 / 30935732 /
  30935733). 30935732 downloaded as a 9-byte file for me — re-fetch it from the issue before attaching.
* We have not reproduced this in an isolated harness; the analysis is from the 3.0.1 sources plus the field dumps.
  If the Room team asks for a repro, the shape to try is: `capacity = 1` pool, a coroutine that cancels acquisitions
  in a tight loop, and `timeout` reduced so the `withTimeout`-completes-as-deadline-elapses window is hit often.

</details>
