### PR TITLE
fix(analytics): cover local firmware sideloads and report message_send in the foreground

### DIFF
--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/di/CoreRepositoryModule.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/di/CoreRepositoryModule.kt
@@ -28,6 +28,7 @@ import org.meshtastic.core.repository.MessageQueue
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.NodeRestartTracker
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.repository.usecase.SendMessageUseCase
 import org.meshtastic.core.repository.usecase.SendMessageUseCaseImpl
@@ -54,6 +55,13 @@ class CoreRepositoryModule {
         @Provided radioController: RadioController,
         @Provided homoglyphEncodingPrefs: HomoglyphPrefs,
         @Provided messageQueue: MessageQueue,
-    ): SendMessageUseCase =
-        SendMessageUseCaseImpl(nodeRepository, packetRepository, radioController, homoglyphEncodingPrefs, messageQueue)
+        @Provided analytics: PlatformAnalytics,
+    ): SendMessageUseCase = SendMessageUseCaseImpl(
+        nodeRepository,
+        packetRepository,
+        radioController,
+        homoglyphEncodingPrefs,
+        messageQueue,
+        analytics,
+    )
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCase.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCase.kt
@@ -29,6 +29,7 @@ import org.meshtastic.core.repository.HomoglyphPrefs
 import org.meshtastic.core.repository.MessageQueue
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioController
 import org.meshtastic.proto.Config
 import kotlin.random.Random
@@ -60,6 +61,7 @@ class SendMessageUseCaseImpl(
     private val radioController: RadioController,
     private val homoglyphEncodingPrefs: HomoglyphPrefs,
     private val messageQueue: MessageQueue,
+    private val analytics: PlatformAnalytics,
 ) : SendMessageUseCase {
 
     /**
@@ -130,6 +132,12 @@ class SendMessageUseCaseImpl(
 
             // Enqueue for durable transmission via the platform-specific queue
             messageQueue.enqueue(packetId)
+            // Reported here rather than at transmission: the queue worker can run long after the RUM
+            // session ended, and re-runs the send on retry.
+            analytics.trackAction(
+                "message_send",
+                mapOf("num_bytes" to finalMessageText.length, "is_reply" to (replyId != null)),
+            )
         } catch (ex: Exception) {
             Logger.e(ex) { "Failed to enqueue message packet" }
             throw ex

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCase.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCase.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.repository.usecase
 import co.touchlab.kermit.Logger
 import org.meshtastic.core.common.util.HomoglyphCharacterStringTransformer
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.model.Capabilities
 import org.meshtastic.core.model.ContactKey
 import org.meshtastic.core.model.DataPacket
@@ -132,16 +133,22 @@ class SendMessageUseCaseImpl(
 
             // Enqueue for durable transmission via the platform-specific queue
             messageQueue.enqueue(packetId)
-            // Reported here rather than at transmission: the queue worker can run long after the RUM
-            // session ended, and re-runs the send on retry.
-            analytics.trackAction(
-                "message_send",
-                mapOf("num_bytes" to finalMessageText.length, "is_reply" to (replyId != null)),
-            )
         } catch (ex: Exception) {
             Logger.e(ex) { "Failed to enqueue message packet" }
             throw ex
         }
+
+        // Outside the enqueue error boundary: the message is already queued, so a telemetry failure must not
+        // surface as a send failure and drive the caller into a retry that queues a second packet. Reported
+        // here rather than at transmission because the queue worker can run after the RUM session ended, and
+        // re-runs the send on retry.
+        safeCatching {
+            analytics.trackAction(
+                "message_send",
+                mapOf("num_bytes" to finalMessageText.encodeToByteArray().size, "is_reply" to (replyId != null)),
+            )
+        }
+            .onFailure { Logger.w(it) { "Failed to report message_send action" } }
 
         return packetId
     }

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCaseTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCaseTest.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.repository.usecase
 import dev.mokkery.MockMode
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode.Companion.exactly
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.model.Node
@@ -81,7 +82,7 @@ class SendMessageUseCaseTest {
     }
 
     @Test
-    fun `invoke reports a message_send analytics action`() = runTest {
+    fun `invoke reports a message_send analytics action exactly once`() = runTest {
         // Arrange
         val ourNode = Node(num = 1, user = User(id = "!1234"))
         nodeRepository.setOurNode(ourNode)
@@ -91,7 +92,21 @@ class SendMessageUseCaseTest {
         useCase("Hello", "0${NodeAddress.ID_BROADCAST}", null)
 
         // Assert
-        verify { analytics.trackAction("message_send", mapOf("num_bytes" to 5, "is_reply" to false)) }
+        verify(exactly(1)) { analytics.trackAction("message_send", mapOf("num_bytes" to 5, "is_reply" to false)) }
+    }
+
+    @Test
+    fun `invoke reports message_send num_bytes as utf-8 length not character count`() = runTest {
+        // Arrange
+        val ourNode = Node(num = 1, user = User(id = "!1234"))
+        nodeRepository.setOurNode(ourNode)
+        appPreferences.homoglyph.setHomoglyphEncodingEnabled(false)
+
+        // Act — 3 characters, 6 UTF-8 bytes; must match the byte count DataPacket actually carries
+        useCase("é☃!", "0${NodeAddress.ID_BROADCAST}", null)
+
+        // Assert
+        verify(exactly(1)) { analytics.trackAction("message_send", mapOf("num_bytes" to 6, "is_reply" to false)) }
     }
 
     @Test

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCaseTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/usecase/SendMessageUseCaseTest.kt
@@ -18,12 +18,14 @@ package org.meshtastic.core.repository.usecase
 
 import dev.mokkery.MockMode
 import dev.mokkery.mock
+import dev.mokkery.verify
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.repository.MessageQueue
 import org.meshtastic.core.repository.PacketRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.testing.FakeAppPreferences
 import org.meshtastic.core.testing.FakeNodeRepository
 import org.meshtastic.core.testing.FakeRadioController
@@ -40,6 +42,7 @@ class SendMessageUseCaseTest {
     private lateinit var radioController: FakeRadioController
     private lateinit var appPreferences: FakeAppPreferences
     private lateinit var messageQueue: MessageQueue
+    private lateinit var analytics: PlatformAnalytics
     private lateinit var useCase: SendMessageUseCase
 
     @BeforeTest
@@ -49,6 +52,7 @@ class SendMessageUseCaseTest {
         radioController = FakeRadioController()
         appPreferences = FakeAppPreferences()
         messageQueue = mock(MockMode.autofill)
+        analytics = mock(MockMode.autofill)
 
         useCase =
             SendMessageUseCaseImpl(
@@ -57,6 +61,7 @@ class SendMessageUseCaseTest {
                 radioController = radioController,
                 homoglyphEncodingPrefs = appPreferences.homoglyph,
                 messageQueue = messageQueue,
+                analytics = analytics,
             )
     }
 
@@ -73,6 +78,20 @@ class SendMessageUseCaseTest {
         // Assert
         radioController.favoritedNodes.size shouldBe 0
         radioController.sentSharedContacts.size shouldBe 0
+    }
+
+    @Test
+    fun `invoke reports a message_send analytics action`() = runTest {
+        // Arrange
+        val ourNode = Node(num = 1, user = User(id = "!1234"))
+        nodeRepository.setOurNode(ourNode)
+        appPreferences.homoglyph.setHomoglyphEncodingEnabled(false)
+
+        // Act
+        useCase("Hello", "0${NodeAddress.ID_BROADCAST}", null)
+
+        // Assert
+        verify { analytics.trackAction("message_send", mapOf("num_bytes" to 5, "is_reply" to false)) }
     }
 
     @Test

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MessagingControllerImpl.kt
@@ -62,13 +62,12 @@ internal class MessagingControllerImpl(
         dataHandler.value.rememberDataPacket(packet, myNodeNum, false)
         val bytes = packet.bytes ?: ByteString.EMPTY
         analytics.track("data_send", DataPair("num_bytes", bytes.size), DataPair("type", packet.dataType))
-        val actionName =
-            when (packet.dataType) {
-                PortNum.TEXT_MESSAGE_APP.value -> "message_send"
-                PortNum.WAYPOINT_APP.value -> "waypoint_send"
-                else -> "data_send"
-            }
-        analytics.trackAction(actionName, mapOf("port_num" to packet.dataType, "num_bytes" to bytes.size))
+        // Text messages report their own action from SendMessageUseCase, where the user acted; this path runs on
+        // the send-queue worker and re-runs on retry, so counting them here would double up.
+        if (packet.dataType != PortNum.TEXT_MESSAGE_APP.value) {
+            val actionName = if (packet.dataType == PortNum.WAYPOINT_APP.value) "waypoint_send" else "data_send"
+            analytics.trackAction(actionName, mapOf("port_num" to packet.dataType, "num_bytes" to bytes.size))
+        }
     }
 
     override suspend fun sendReaction(emoji: String, replyId: Int, contactKey: String) {

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -320,12 +320,13 @@ class FirmwareUpdateViewModel(
         }
     }
 
-    fun startUpdate() {
-        val currentState = _state.value as? FirmwareUpdateState.Ready ?: return
-        val release = currentState.release ?: return
-        // Explicit mapping instead of class-name reflection: FirmwareUpdateMethod is R8-obfuscated in release.
+    /**
+     * Emitted from every path that begins a flash, so the RUM action counts local-file sideloads alongside release
+     * updates. The method label is mapped explicitly because [FirmwareUpdateMethod] is obfuscated in release builds.
+     */
+    private fun trackUpdateStart(state: FirmwareUpdateState.Ready, releaseId: String) {
         val updateMethod =
-            when (currentState.updateMethod) {
+            when (state.updateMethod) {
                 FirmwareUpdateMethod.Usb -> "usb"
                 FirmwareUpdateMethod.Ble -> "ble"
                 FirmwareUpdateMethod.Wifi -> "wifi"
@@ -333,12 +334,14 @@ class FirmwareUpdateViewModel(
             }
         analytics.trackAction(
             "firmware_update_start",
-            mapOf(
-                "update_method" to updateMethod,
-                "is_recovery" to currentState.isRecovery,
-                "release_version" to release.id,
-            ),
+            mapOf("update_method" to updateMethod, "is_recovery" to state.isRecovery, "release_version" to releaseId),
         )
+    }
+
+    fun startUpdate() {
+        val currentState = _state.value as? FirmwareUpdateState.Ready ?: return
+        val release = currentState.release ?: return
+        trackUpdateStart(currentState, release.id)
         if (currentState.isRecovery) {
             startRecoveryUpdate(currentState, release)
         } else {
@@ -727,6 +730,7 @@ class FirmwareUpdateViewModel(
             cleanupPendingLocalFirmwareArtifact(pendingArtifact)
             return
         }
+        trackUpdateStart(currentState, LOCAL_RELEASE_ID)
         originalDeviceAddress = radioPrefs.devAddr.value
 
         updateJob?.cancel()

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateIntegrationTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateIntegrationTest.kt
@@ -39,6 +39,7 @@ import org.meshtastic.core.datastore.FirmwareRecoveryDataSource
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.repository.DeviceHardwareRepository
 import org.meshtastic.core.repository.FirmwareReleaseRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioPrefs
 import org.meshtastic.core.testing.FakeNodeRepository
 import org.meshtastic.core.testing.FakeRadioController
@@ -68,6 +69,7 @@ class FirmwareUpdateIntegrationTest {
     private val firmwareUpdateManager: FirmwareUpdateManager = mock(MockMode.autofill)
     private val usbManager: FirmwareUsbManager = mock(MockMode.autofill)
     private val fileHandler: FirmwareFileHandler = mock(MockMode.autofill)
+    private val analytics: PlatformAnalytics = mock(MockMode.autofill)
 
     private val stableRelease = FirmwareRelease(id = "1", title = "2.5.0", zipUrl = "url", releaseNotes = "")
     private val hardware = DeviceHardware(hwModel = 1, architecture = "esp32", platformioTarget = "tbeam")
@@ -115,7 +117,7 @@ class FirmwareUpdateIntegrationTest {
         fileHandler,
         TestApplicationCoroutineScope(testDispatcher),
         HiddenFeaturesUnlock(),
-        mock(MockMode.autofill),
+        analytics,
     )
 
     @Test

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelTest.kt
@@ -23,6 +23,7 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,6 +43,7 @@ import org.meshtastic.core.datastore.model.PendingFirmwareRecovery
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.repository.DeviceHardwareRepository
 import org.meshtastic.core.repository.FirmwareReleaseRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioPrefs
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.UiText
@@ -76,6 +78,7 @@ class FirmwareUpdateViewModelTest {
     private val firmwareUpdateManager: FirmwareUpdateManager = mock(MockMode.autofill)
     private val usbManager: FirmwareUsbManager = mock(MockMode.autofill)
     private val fileHandler: FirmwareFileHandler = mock(MockMode.autofill)
+    private val analytics: PlatformAnalytics = mock(MockMode.autofill)
 
     private lateinit var viewModel: FirmwareUpdateViewModel
 
@@ -138,7 +141,7 @@ class FirmwareUpdateViewModelTest {
         fileHandler,
         TestApplicationCoroutineScope(testDispatcher),
         hiddenFeaturesUnlock,
-        mock(MockMode.autofill),
+        analytics,
     )
 
     @Test
@@ -190,6 +193,28 @@ class FirmwareUpdateViewModelTest {
         val error = errorState.error
         assertTrue(error is UiText.Resource)
         assertEquals(Res.string.firmware_update_battery_low, error.res)
+    }
+
+    @Test
+    fun `startUpdate reports a firmware_update_start action with the release version`() = runTest {
+        // isBle() checks devAddr.value?.startsWith("x"), so use a BLE-prefixed address
+        every { radioPrefs.devAddr } returns MutableStateFlow("x1234abcd")
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val currentState = viewModel.state.value
+        assertIs<FirmwareUpdateState.Ready>(currentState)
+        assertIs<FirmwareUpdateMethod.Ble>(currentState.updateMethod)
+
+        viewModel.startUpdate()
+        advanceUntilIdle()
+
+        verify {
+            analytics.trackAction(
+                "firmware_update_start",
+                mapOf("update_method" to "ble", "is_recovery" to false, "release_version" to "1"),
+            )
+        }
     }
 
     @Test

--- a/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
+++ b/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
@@ -24,6 +24,7 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.atLeast
 import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
@@ -46,6 +47,7 @@ import org.meshtastic.core.datastore.FirmwareRecoveryDataSource
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.repository.DeviceHardwareRepository
 import org.meshtastic.core.repository.FirmwareReleaseRepository
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.RadioPrefs
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.UiText
@@ -82,6 +84,7 @@ class FirmwareUpdateViewModelFileTest {
     private val firmwareUpdateManager: FirmwareUpdateManager = mock(MockMode.autofill)
     private val usbManager: FirmwareUsbManager = mock(MockMode.autofill)
     private val fileHandler: FirmwareFileHandler = mock(MockMode.autofill)
+    private val analytics: PlatformAnalytics = mock(MockMode.autofill)
 
     private lateinit var viewModel: FirmwareUpdateViewModel
 
@@ -137,7 +140,7 @@ class FirmwareUpdateViewModelFileTest {
         fileHandler,
         TestApplicationCoroutineScope(testDispatcher),
         HiddenFeaturesUnlock(),
-        mock(MockMode.autofill),
+        analytics,
     )
 
     private fun firmwareUri(fileName: String): CommonUri = CommonUri.parse("file:///downloads/$fileName")
@@ -194,6 +197,41 @@ class FirmwareUpdateViewModelFileTest {
         advanceUntilIdle()
 
         assertIs<FirmwareUpdateState.Error>(viewModel.state.value)
+    }
+
+    @Test
+    fun `confirmLocalFirmwareFile reports a firmware_update_start action for the local file`() = runTest {
+        every { radioPrefs.devAddr } returns MutableStateFlow("s/dev/ttyUSB0")
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.prepareLocalFirmwareFile(firmwareUri("firmware-tbeam-2.8.0.uf2"))
+        advanceUntilIdle()
+        viewModel.confirmLocalFirmwareFile()
+        advanceUntilIdle()
+
+        verify {
+            analytics.trackAction(
+                "firmware_update_start",
+                mapOf("update_method" to "usb", "is_recovery" to false, "release_version" to "local"),
+            )
+        }
+    }
+
+    @Test
+    fun `confirmLocalFirmwareFile with BLE and invalid address reports no analytics action`() = runTest {
+        every { radioPrefs.devAddr } returns MutableStateFlow("xnot-a-mac-address")
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.prepareLocalFirmwareFile(firmwareUri("firmware-tbeam-2.8.0-ota.zip"))
+        advanceUntilIdle()
+        viewModel.confirmLocalFirmwareFile()
+        advanceUntilIdle()
+
+        verify(exactly(0)) { analytics.trackAction("firmware_update_start", any()) }
     }
 
     @Test

--- a/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
+++ b/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
@@ -231,6 +231,9 @@ class FirmwareUpdateViewModelFileTest {
         viewModel.confirmLocalFirmwareFile()
         advanceUntilIdle()
 
+        // Prove the absent action came from the address rejection, not from an earlier bail-out.
+        assertIs<FirmwareUpdateState.Error>(viewModel.state.value)
+        verifySuspend(exactly(0)) { firmwareUpdateManager.startUpdate(any(), any(), any(), any(), any()) }
         verify(exactly(0)) { analytics.trackAction("firmware_update_start", any()) }
     }
 


### PR DESCRIPTION
## Why

Follow-up to #6654, which merged before its review feedback was applied. Two gaps in the named-RUM-action coverage that shipped:

1. **Local firmware sideloads are invisible.** `firmware_update_start` is only emitted from `startUpdate()`. Picking a firmware file from disk goes through `confirmLocalFirmwareFile()` → `startUpdateFromFile()`, a completely separate entry point that emits nothing. Firmware-update counts in RUM currently undercount, showing release-channel updates only. (Caught by CodeRabbit on #6654.)

2. **`message_send` fires outside the user's session.** Text sends are not transmitted synchronously — `SendMessageUseCase` enqueues, and a WorkManager `SendMessageWorker` performs the actual `radioController.sendMessage`. Emitting the action there means it lands on a background thread, potentially long after the RUM session ended, and re-fires whenever the worker retries.

## 🐛 Fixes

**Cover both firmware entry points.** Extracted `trackUpdateStart(state, releaseId)` and call it from `startUpdate()` and `startUpdateFromFile()`. The local path reports the existing `LOCAL_RELEASE_ID` (`"local"`) as `release_version`, so file-based flashes stay distinguishable from release updates. The call sits after the BLE address-validation guard, so a rejected start is not counted.

**Report `message_send` where the user acted.** Moved to `SendMessageUseCase.invoke`. Coverage is unchanged — every text-send path (messaging UI, notification quick-reply, Android Auto, AI function-calling) routes through this use case. Removed the `TEXT_MESSAGE_APP` branch from `MessagingControllerImpl` so messages are not counted twice. `waypoint_send` stays in the controller, since `BaseMapViewModel` calls `radioController.sendMessage` directly and never touches the use case.

## 🧹 Tests

The firmware fixtures passed an anonymous autofilled mock for the new constructor parameter, so they could pass without ever observing `trackAction`. Named the mock in all four fixtures and added assertions:

- `startUpdate` reports `firmware_update_start` with the release version
- `confirmLocalFirmwareFile` reports it with `release_version=local` — the newly covered path
- an invalid BLE address reports **no** action — guards the early-return
- `SendMessageUseCase.invoke` reports `message_send`

## Testing Performed

`spotlessCheck detekt assembleDebug :core:repository:allTests :core:service:allTests :feature:firmware:allTests` on this branch's base — **BUILD SUCCESSFUL in 2m 24s** (Gradle exit 0), with all six analytics assertions confirmed executing and passing rather than replayed from cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Message-send activity is now tracked consistently, including message size and reply status.
  * Duplicate text-message tracking has been prevented.
  * Firmware update tracking now includes transport type, recovery status, release version, and local-file updates.
  * Invalid firmware update attempts no longer generate misleading tracking events.
* **Tests**
  * Added coverage for message and firmware update activity tracking across supported update methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->