### PR TITLE
chore(deps): bump the Compose stack to CMP 1.12.0-rc01 in lockstep

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,8 +47,8 @@ profileinstaller = "1.4.1"
 androidx-uiautomator = "2.4.0"
 
 # Compose Multiplatform
-compose-multiplatform = "1.11.1"
-compose-multiplatform-material3 = "1.11.0-alpha07"
+compose-multiplatform = "1.12.0-rc01"
+compose-multiplatform-material3 = "1.12.0-alpha03"
 # `androidx-compose-bom-aligned` tracks androidx.compose.{runtime,ui,foundation,animation}
 # artifacts that ship in lockstep with CMP. Kept as a separate version ref so Renovate
 # can bump androidx releases (which often land first) without dragging the
@@ -57,7 +57,7 @@ compose-multiplatform-material3 = "1.11.0-alpha07"
 # current `compose-multiplatform` release maps to (see CMP release notes).
 # AndroidCompose.kt's resolutionStrategy force-aligns these groups to *this* version
 # at resolution time, so it is the source of truth for the Android target.
-androidx-compose-bom-aligned = "1.11.4"
+androidx-compose-bom-aligned = "1.12.0"
 jetbrains-adaptive = "1.3.0-beta02"
 
 # Google


### PR DESCRIPTION
Renovate PR #6659 bumped `androidx-compose-bom-aligned` on its own and turned CI red: that ref is not an independently bumpable version, so moving it alone desynchronizes the Compose stack. This moves all three Compose refs together to the coherent CMP `1.12.0-rc01` set, which restores a green screenshot suite. Supersedes #6659.

### Why #6659 fails

`androidx-compose-bom-aligned` is a **force**, not an ordinary dependency version — `AndroidCompose.kt` applies it to `androidx.compose.{ui,foundation,runtime,animation}` graph-wide, and the comment there states it must mirror whatever the current CMP release maps to. Material3 is deliberately excluded from that force and ships from CMP on a separate version line.

Bumping only the androidx half puts a 1.11-era material3 on top of a 1.12 foundation. Material3's measure policies then fail their `layoutId` lookups, and every preview containing an `OutlinedTextField`, `TopAppBar`, or `SearchBar` fails to render:

```
View measure failed
java.util.NoSuchElementException: Collection contains no element matching the predicate.
  at androidx.compose.ui.util.ListUtilsKt.throwNoSuchElementException(ListUtils.kt:615)
  at androidx.compose.material3.OutlinedTextFieldMeasurePolicy.measure(OutlinedTextField.kt:1509)
  at androidx.compose.material3.TopAppBarMeasurePolicy.measure(AppBar.kt:3924)
```

That surfaces in CI only as `initializationError` / `RuntimeException at PreviewAnnotationDescriptor.kt:138`; the real message lives in the JUnit XML, since the HTML report artifact does not carry it.

### 🧹 Chores

- `compose-multiplatform` `1.11.1` → `1.12.0-rc01`
- `compose-multiplatform-material3` `1.11.0-alpha07` → `1.12.0-alpha03` (the material3 line CMP `1.12.0-rc01` ships)
- `androidx-compose-bom-aligned` `1.11.4` → `1.12.0`

`jetbrains-adaptive` stays at `1.3.0-beta02` — already the newest published.

### Testing Performed

No test sources changed; this is a dependency-alignment change validated against the existing suites.

- `:screenshot-tests:validateDebugScreenshotTest` — **298/298 pass**, versus 47 failures on #6659's version set. Every existing golden still matches pixel-for-pixel, so no references were re-baselined and there is no visual regression.
- Baseline verification (`spotlessCheck detekt assembleDebug test allTests`) — passes. The only failing task is `:core:konsist:allTests`, which fails identically on an unmodified tree: konsist's path filter excludes `/.claude/`, so its own self-check ("the scan actually reaches commonMain sources") matches zero files in a git-worktree checkout. Unrelated to this change; CI is konsist's real gate.

For comparison, all three sets were run locally on the same tree:

| Version set | `screenshot-check` |
|---|---|
| `main` (1.11.1 / alpha07 / 1.11.4) | 298 pass |
| #6659 (androidx alone → 1.12.0) | **47 fail** |
| this PR (1.12.0-rc01 / 1.12.0-alpha03 / 1.12.0) | 298 pass |

### Reviewer notes

- **This ships a release candidate.** CMP stable is still 1.11.1; 1.12.0 exists only as `rc01` (Aug 11). Pre-release Compose artifacts are already normal in this catalog (`material3 1.11.0-alpha07`, `adaptive 1.3.0-beta02`), but this does move the whole toolkit onto an RC.
- **`material3 1.12.0-alpha03` is a maturity sidestep**, not a step up, from the `1.11.0-alpha07` on `main` — and material3 is exactly where the #6659 breakage lives. Worth weighing against simply holding `main` on stable until CMP 1.12.0 ships.
- **CMP `1.12.0-rc01` documents alignment with androidx `1.12.0-rc01`**, but androidx `1.12.0` stable works and is what Renovate wants, so this uses stable.
- If this is **not** the direction you want, the alternative is to close #6659 and add a Renovate constraint pinning those three androidx artifacts below 1.12.0 (mirroring the existing Gradle 9.7 block), otherwise Renovate will keep regenerating the broken PR.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
