### PR TITLE
fix(map): allow layers with generic MIME types

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -359,17 +359,8 @@ fun MapView(
         val intent =
             Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                 addCategory(Intent.CATEGORY_OPENABLE)
+                // Providers may assign generic MIME types to valid map files; validate the extension after selection.
                 type = "*/*"
-                putExtra(
-                    Intent.EXTRA_MIME_TYPES,
-                    arrayOf(
-                        "application/vnd.google-earth.kml+xml",
-                        "application/vnd.google-earth.kmz",
-                        "application/vnd.geo+json",
-                        "application/geo+json",
-                        "application/json",
-                    ),
-                )
             }
         filePickerLauncher.launch(intent)
     }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -576,16 +576,8 @@ fun MapView(
         val intent =
             Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                 addCategory(Intent.CATEGORY_OPENABLE)
+                // Providers may assign generic MIME types to valid map files; validate the extension after selection.
                 type = "*/*"
-                val mimeTypes =
-                    arrayOf(
-                        "application/vnd.google-earth.kml+xml",
-                        "application/vnd.google-earth.kmz",
-                        "application/vnd.geo+json",
-                        "application/geo+json",
-                        "application/json",
-                    )
-                putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
             }
         filePickerLauncher.launch(intent)
     }


### PR DESCRIPTION
## Summary

Android document providers can report valid GeoJSON or KML files with generic MIME types. The existing MIME allowlist then disables those files before Meshtastic can inspect their extensions.

- remove the picker MIME allowlist from the Google and F-Droid map implementations
- keep ACTION_OPEN_DOCUMENT, CATEGORY_OPENABLE, and wildcard selection
- retain the existing post-selection extension validation, so supported import formats do not change

## Testing

- ./gradlew spotlessCheck detekt
- ./gradlew :androidApp:testFdroidDebugUnitTest :androidApp:testGoogleDebugUnitTest
- ./gradlew :androidApp:assembleFdroidDebug :androidApp:assembleGoogleDebug
- ./gradlew :androidApp:lintFdroidDebug :androidApp:lintGoogleDebug

The full baseline command was also attempted. It reached unrelated pre-existing Windows failures in core:datastore RecentAddressesDataSourceTest caused by temporary-file IOException errors; the affected app tests and both flavor builds pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map layer file selection by allowing supported documents to be chosen regardless of their reported MIME type.
  * File extensions are now checked after selection to confirm compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->