### PR TITLE
fix(konsist): anchor path rules to the scanned checkout root so the commonMain guard isn't vacuously green in agent worktrees

### DIFF
--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/BleAddressLoggingTest.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/BleAddressLoggingTest.kt
@@ -53,17 +53,15 @@ class BleAddressLoggingTest {
      */
     private fun scannedFiles() = Konsist.scopeFromProject()
         .files
-        // scopeFromProject sweeps .claude/worktrees/ checkouts too; stale copies there
-        // resurface long-fixed lines as phantom offenders (paths match "/core/ble/").
-        .filterNot { "/.claude/" in it.path.normalizedProjectPath() }
-        .filter { file -> scannedPathFragments.any { it in file.path.normalizedProjectPath() } }
-        .filterNot { file -> identityUseAllowlist.any { file.path.normalizedProjectPath().endsWith(it) } }
+        .filterNot { it.isNestedAgentWorktree() }
+        .filter { file -> scannedPathFragments.any { it in file.scanPath } }
+        .filterNot { file -> identityUseAllowlist.any { file.scanPath.endsWith(it) } }
 
     @Test
     fun `the scan actually reaches the BLE sources`() {
-        val paths = scannedFiles().map { it.path.normalizedProjectPath() }
+        val paths = scannedFiles().map { it.scanPath }
 
-        assertTrue(paths.isNotEmpty(), "scoped scan matched no files at all — the path filter is wrong")
+        assertTrue(paths.isNotEmpty(), emptyScanMessage("BLE-scoped scan"))
         assertTrue(
             paths.any { it.endsWith("KableBleConnection.kt") },
             "expected core/ble sources in scope; got ${paths.size} files, e.g. ${paths.take(3)}",
@@ -79,8 +77,7 @@ class BleAddressLoggingTest {
                     val interpolates = interpolatedAddress.containsMatchIn(line)
                     val anonymised = "anonymize" in line
                     if (isDiagnostic && interpolates && !anonymised) {
-                        "${file.path.normalizedProjectPath().substringAfterLast("/kotlin/")}:${index + 1}: " +
-                            line.trim()
+                        "${file.scanPath.substringAfterLast("/kotlin/")}:${index + 1}: " + line.trim()
                     } else {
                         null
                     }
@@ -102,13 +99,12 @@ class BleAddressLoggingTest {
         val offenders =
             Konsist.scopeFromProject()
                 .files
-                .filterNot { "/.claude/" in it.path.normalizedProjectPath() } // see scannedFiles()
-                .filter { "/core/ble/" in it.path.normalizedProjectPath() }
+                .filterNot { it.isNestedAgentWorktree() }
+                .filter { "/core/ble/" in it.scanPath }
                 .flatMap { file ->
                     file.text.lines().withIndex().mapNotNull { (index, line) ->
                         if ("identifier =" in line && "address" in line && "anonymize" !in line) {
-                            "${file.path.normalizedProjectPath().substringAfterLast("/kotlin/")}:${index + 1}: " +
-                                line.trim()
+                            "${file.scanPath.substringAfterLast("/kotlin/")}:${index + 1}: " + line.trim()
                         } else {
                             null
                         }

--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/CommonMainFrameworkBoundaryTest.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/CommonMainFrameworkBoundaryTest.kt
@@ -35,14 +35,14 @@ class CommonMainFrameworkBoundaryTest {
     private val commonMainFiles =
         Konsist.scopeFromProject()
             .files
-            .filterNot { "/.claude/" in it.path.normalizedProjectPath() }
-            .filter { "/src/commonMain/" in it.path.normalizedProjectPath() }
+            .filterNot { it.isNestedAgentWorktree() }
+            .filter { "/src/commonMain/" in it.scanPath }
 
     @Test
     fun `the scan actually reaches commonMain sources`() {
-        val paths = commonMainFiles.map { it.path.normalizedProjectPath() }
+        val paths = commonMainFiles.map { it.scanPath }
 
-        assertTrue(paths.isNotEmpty(), "commonMain scan matched no files at all — the path filter is wrong")
+        assertTrue(paths.isNotEmpty(), emptyScanMessage("commonMain scan"))
         assertTrue(
             paths.any { it.endsWith("/core/model/src/commonMain/kotlin/org/meshtastic/core/model/Message.kt") },
             "expected core/model commonMain sources in scope; got ${paths.size} files, e.g. ${paths.take(3)}",

--- a/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/ProjectPath.kt
+++ b/core/konsist/src/jvmTest/kotlin/org/meshtastic/core/konsist/ProjectPath.kt
@@ -16,5 +16,37 @@
  */
 package org.meshtastic.core.konsist
 
+import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
+
 /** Makes project-relative path rules independent of the host filesystem separator. */
 internal fun String.normalizedProjectPath(): String = replace('\\', '/')
+
+/**
+ * Path relative to the checkout being scanned, e.g. `/core/ble/src/commonMain/kotlin/…`.
+ *
+ * Every path rule here must key off this rather than the absolute [KoFileDeclaration.path]: agent sessions run from
+ * worktrees under `<main checkout>/.claude/worktrees/<name>`, so an absolute path carries `.claude` for every file in
+ * the checkout.
+ */
+internal val KoFileDeclaration.scanPath: String
+    get() = projectPath.normalizedProjectPath()
+
+/**
+ * A file belonging to an agent worktree nested inside the checkout being scanned.
+ *
+ * `scopeFromProject` sweeps `<root>/.claude/worktrees/` too, and stale copies there resurface long-fixed lines as
+ * phantom offenders. This matches only at the root of the scanned checkout, so a scan that itself runs from a worktree
+ * still sees its own sources.
+ */
+internal fun KoFileDeclaration.isNestedAgentWorktree(): Boolean = scanPath.removePrefix("/").startsWith(".claude/")
+
+/**
+ * Failure message for a scope that matched nothing.
+ *
+ * Names the historical cause up front: a too-broad `.claude` exclusion silently emptied the whole scan for worktree
+ * sessions, and the empty result is the only symptom.
+ */
+internal fun emptyScanMessage(scopeDescription: String): String =
+    "$scopeDescription matched no files at all, so this rule verified nothing. " +
+        "Check the path filters in ProjectPath.kt — an exclusion that matches the whole checkout (rather than a " +
+        "directory relative to its root) empties the scan without any other symptom."


### PR DESCRIPTION
## Why

`CommonMainFrameworkBoundaryTest` enforces the **No Framework Bleed** rule from `AGENTS.md` — no `java.*` or `android.*` imports in any `commonMain` source set. It was silently verifying **nothing** for any agent session working from a worktree.

Both guards excluded agent scratch sources with `"/.claude/" in it.path` — matched against the **absolute** path. Agent worktrees are rooted at `<main checkout>/.claude/worktrees/<name>`, so that substring is present in *every file of the entire checkout*. The scan set became empty.

Today that surfaces as a confusing failure, because the "scan actually reaches sources" self-check trips. But the guard was one relaxed assertion away from a vacuous green — and a rule that passes without scanning anything is worse than no rule, because it reads as verification. CI checks out at a normal path, so CI has been the only real gate for these two rules.

## 🛠️ What changed

Konsist resolves its project root by walking up for `gradlew` (`GradleProjectRootDirResolver`), so `KoFileDeclaration.projectPath` is relative to **whichever checkout is being scanned**. That is the correct anchor, and every path rule now keys off it:

- **`scanPath`** (`ProjectPath.kt`) — normalized `projectPath`; replaces all uses of the absolute `path`, in filters and in offender messages alike.
- **`isNestedAgentWorktree()`** — matches `.claude/` only as the *first segment* relative to the scanned root. Excludes nested worktrees when scanning the main checkout; excludes nothing when the scan runs from a worktree.
- **`emptyScanMessage()`** — the empty-scan self-check stays a hard failure (it did its job here), but now names the cause rather than the symptom and points at `ProjectPath.kt`.

The exclusion is **not** vestigial and was deliberately kept: `scopeFromProject` genuinely does sweep nested `.claude/worktrees/` checkouts, whose stale copies resurface long-fixed lines as phantom offenders. Correct scoping — not deletion — is the fix. See the control run below.

## Testing Performed

`:core:konsist:allTests`, both path shapes, plus a negative test and a control for each direction:

| Scenario | Result |
|---|---|
| From `.claude/worktrees/<name>` (this branch's worktree) | ✅ 6/6, both scan-reaches self-checks green |
| ⬆ same, with `import java.util.UUID` injected into `core/model` commonMain | ❌ **fails as intended** — `commonMain declares no java imports` names `Message.kt`; injection reverted |
| From a normal path (fresh worktree under `/private/tmp`) | ✅ 6/6 |
| ⬆ same, with a violating file planted at `.claude/worktrees/fake-agent-session/core/ble/.../StaleOffender.kt` | ✅ passes — exclusion still holds |
| ⬆ same, control run with `isNestedAgentWorktree()` forced to `false` | ❌ **fails**, naming `StaleOffender.kt` — proving the nested sweep is real and the exclusion is load-bearing |

That last row is the one worth a reviewer's attention: it rules out the tempting simpler "fix" of just deleting the filter.

`spotlessApply spotlessCheck detekt` — clean, no findings.

## Reviewer notes

- Test-only change; scoped to `core/konsist`, no production code touched.
- Any **new** path rule added to this module must use `scanPath`, never the absolute `path`.
- Konsist failures seen from an agent worktree are now *real findings* — the previous advice to dismiss them as an environment artifact (and to pass `--continue` so they don't abort a baseline run) no longer applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved architectural validation scans for BLE-related and shared application code.
  * Added clearer diagnostics when scans return no results.
  * Standardized path handling and exclusions to make checks more reliable across development environments.

* **Chores**
  * Centralized project-path utilities used by validation checks.
  * Improved handling of nested development worktrees without affecting application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->