### PR TITLE
test(compose): prepare tests for re-landing CMP 1.12 (fixes 8 of 10 regressions)

### DIFF
--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
@@ -44,6 +44,7 @@ import org.meshtastic.core.model.Node
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.RadioConfigRepository
+import org.meshtastic.core.testing.runUntilSettled
 import org.meshtastic.core.testing.runWithRenderScope
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.User
@@ -217,7 +218,10 @@ class MeshNotificationManagerImplConversationTest {
             // SERVICE_NOTIFY_ID is 101; a node whose num is also 101 used to overwrite the foreground notification.
             manager.updateServiceStateNotification(ConnectionState.Connected, telemetry = null)
             manager.showOrUpdateLowBatteryNotification(Node(num = 101), isRemote = false)
-            advanceUntilIdle()
+            runUntilSettled {
+                systemNotificationManager.activeNotifications.any { it.id == 101 && it.tag == null } &&
+                    activeByTag("low_battery").any { it.id == 101 }
+            }
 
             val service = systemNotificationManager.activeNotifications.filter { it.id == 101 && it.tag == null }
             val battery = activeByTag("low_battery").filter { it.id == 101 }

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplTest.kt
@@ -43,6 +43,7 @@ import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.disconnected
 import org.meshtastic.core.resources.getString
 import org.meshtastic.core.resources.local_stats_nodes
+import org.meshtastic.core.testing.runUntilSettled
 import org.meshtastic.core.testing.runWithRenderScope
 import org.meshtastic.proto.LocalStats
 import org.meshtastic.proto.Telemetry
@@ -121,7 +122,7 @@ class MeshNotificationManagerImplTest {
         notifications.updateServiceStateNotification(ConnectionState.Disconnected, populatedTelemetry())
 
         assertNull(activeServiceNotification())
-        advanceUntilIdle()
+        runUntilSettled { activeServiceNotification() != null }
         assertNotNull(activeServiceNotification())
     }
 
@@ -167,7 +168,7 @@ class MeshNotificationManagerImplTest {
         notifications.initChannels()
 
         notifications.updateServiceStateNotification(ConnectionState.Disconnected, telemetry = null)
-        advanceUntilIdle()
+        runUntilSettled { activeServiceNotification() != null }
 
         val text = activeServiceNotification()?.notification?.extras?.getCharSequence(Notification.EXTRA_TEXT)
         assertNotNull(text)

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/TestScopes.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/TestScopes.kt
@@ -17,11 +17,19 @@
 package org.meshtastic.core.testing
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 /** Runs a test with a structured child scope driven by the test scheduler and always cancels it afterward. */
 fun runWithRenderScope(block: suspend TestScope.(CoroutineScope) -> Unit) = runTest {
@@ -30,5 +38,27 @@ fun runWithRenderScope(block: suspend TestScope.(CoroutineScope) -> Unit) = runT
         block(renderScope)
     } finally {
         renderScope.cancel()
+    }
+}
+
+private val SETTLE_POLL_INTERVAL = 5.milliseconds
+
+/**
+ * Runs the test scheduler until [isSettled] holds, waiting in real time between passes.
+ *
+ * Compose resources are loaded on an internal `Dispatchers.Default` scope, so state derived from a string resource
+ * lands outside the test scheduler and cannot be observed by draining it.
+ *
+ * Not safe in a test that asserts on exact virtual time: waiting in real time suspends the test coroutine, and
+ * `runTest` advances the virtual clock to the next scheduled task whenever that happens, firing pending `delay`s early.
+ * Such a test should instead load the resources it needs before scheduling anything it later advances past.
+ */
+suspend fun TestScope.runUntilSettled(timeout: Duration = 10.seconds, isSettled: () -> Boolean) {
+    val start = TimeSource.Monotonic.markNow()
+    while (true) {
+        runCurrent()
+        if (isSettled()) return
+        check(start.elapsedNow() < timeout) { "condition was still not settled after $timeout" }
+        withContext(Dispatchers.Default) { delay(SETTLE_POLL_INTERVAL) }
     }
 }

--- a/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
+++ b/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
@@ -33,6 +33,7 @@ import org.meshtastic.core.testing.FakeBleDevice
 import org.meshtastic.core.testing.failBondAfterRecording
 import org.meshtastic.core.testing.failBondWith
 import org.meshtastic.core.testing.failBondWithSecurityException
+import org.meshtastic.core.testing.runUntilSettled
 import org.meshtastic.feature.connections.model.DeviceListEntry
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
@@ -135,6 +136,7 @@ class AndroidScannerViewModelBondingTest {
 
         assertEquals(1, harness.bluetoothRepository.bondCalls.size)
         assertNull(harness.radioController.lastSetDeviceAddress)
+        runUntilSettled { harness.serviceRepository.errorMessage.value != null }
         assertEquals(getString(Res.string.bonding_failed_retry), harness.serviceRepository.errorMessage.value)
     }
 
@@ -160,6 +162,7 @@ class AndroidScannerViewModelBondingTest {
 
         assertEquals(1, harness.bluetoothRepository.bondCalls.size)
         assertNull(harness.radioController.lastSetDeviceAddress)
+        runUntilSettled { harness.serviceRepository.errorMessage.value != null }
         assertNotNull(harness.serviceRepository.errorMessage.value)
     }
 

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.test.setMain
 import org.meshtastic.core.ble.BleDevice
 import org.meshtastic.core.ble.BleScanStartException
 import org.meshtastic.core.ble.BleScanStartFailureReason
+import org.meshtastic.core.common.util.safeCatchingAll
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.network.repository.DiscoveredService
@@ -748,11 +749,12 @@ class ScannerViewModelTest {
  * the caller has moved on. Warming keeps the error message observable synchronously, which these tests need because
  * they also assert on exact virtual-time retry cooldowns and so cannot wait in real time.
  *
- * Best-effort: the androidHostTest stubs leave `Resources.getSystem()` unmocked, so resources never resolve there and
- * the ViewModel's untranslated fallback — identical text, produced synchronously — is what the assertions match.
+ * Best-effort via [safeCatchingAll], mirroring the ViewModel: the androidHostTest stubs leave `Resources.getSystem()`
+ * unmocked and skiko's initializer can raise an `Error` here, so resources never resolve and the untranslated fallback
+ * — identical text, produced synchronously — is what the assertions match. Cancellation still propagates.
  */
 private suspend fun warmScanFailureStrings() {
-    runCatching {
+    safeCatchingAll {
         getStringSuspend(Res.string.bluetooth_scan_start_failed)
         getStringSuspend(Res.string.bluetooth_scan_missing_permission)
         getStringSuspend(Res.string.bluetooth_disabled)

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
@@ -34,6 +34,14 @@ import org.meshtastic.core.ble.BleScanStartFailureReason
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.network.repository.DiscoveredService
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.bluetooth_disabled
+import org.meshtastic.core.resources.bluetooth_scan_location_services_disabled
+import org.meshtastic.core.resources.bluetooth_scan_missing_permission
+import org.meshtastic.core.resources.bluetooth_scan_start_failed
+import org.meshtastic.core.resources.bluetooth_scan_too_frequent
+import org.meshtastic.core.resources.getPluralStringSuspend
+import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.core.testing.FakeBleDevice
 import org.meshtastic.feature.connections.model.DeviceListEntry
 import org.meshtastic.feature.connections.model.DiscoveredDevices
@@ -114,6 +122,7 @@ class ScannerViewModelTest {
 
     @Test
     fun `scan startup failure clears scanning state disables auto-scan and surfaces error`() = runTest {
+        warmScanFailureStrings()
         harness.uiPrefs.setBleAutoScan(true)
         every { bleScanner.scan(any(), any()) } returns failingScanFlow()
 
@@ -154,6 +163,7 @@ class ScannerViewModelTest {
 
     @Test
     fun `bluetooth-disabled failure allows an immediate retry once the user re-enables it`() = runTest {
+        warmScanFailureStrings()
         // No cooldown for preconditions the user clears with a system toggle — a dead scan button right after they
         // switched Bluetooth back on reads as a broken app.
         var scanAttempts = 0
@@ -178,6 +188,7 @@ class ScannerViewModelTest {
 
     @Test
     fun `location-services-disabled failure allows an immediate retry`() = runTest {
+        warmScanFailureStrings()
         var scanAttempts = 0
         every { bleScanner.scan(any(), any()) } returns
             flow {
@@ -201,6 +212,7 @@ class ScannerViewModelTest {
 
     @Test
     fun `scan quota failure honors retry-after cooldown`() = runTest {
+        warmScanFailureStrings()
         var scanAttempts = 0
         every { bleScanner.scan(any(), any()) } returns
             flow {
@@ -726,5 +738,25 @@ class ScannerViewModelTest {
             reason = BleScanStartFailureReason.ApplicationRegistrationFailed,
             cause = IllegalStateException("Failed to start scan as app cannot be registered"),
         )
+    }
+}
+
+/**
+ * Loads the scan-failure strings into the compose-resources cache up front.
+ *
+ * The first read of a resource completes on an internal `Dispatchers.Default` scope, so an un-warmed lookup lands after
+ * the caller has moved on. Warming keeps the error message observable synchronously, which these tests need because
+ * they also assert on exact virtual-time retry cooldowns and so cannot wait in real time.
+ *
+ * Best-effort: the androidHostTest stubs leave `Resources.getSystem()` unmocked, so resources never resolve there and
+ * the ViewModel's untranslated fallback — identical text, produced synchronously — is what the assertions match.
+ */
+private suspend fun warmScanFailureStrings() {
+    runCatching {
+        getStringSuspend(Res.string.bluetooth_scan_start_failed)
+        getStringSuspend(Res.string.bluetooth_scan_missing_permission)
+        getStringSuspend(Res.string.bluetooth_disabled)
+        getStringSuspend(Res.string.bluetooth_scan_location_services_disabled)
+        getPluralStringSuspend(Res.plurals.bluetooth_scan_too_frequent, 1, 1L)
     }
 }


### PR DESCRIPTION
## Why

#6664 reverted CMP 1.12.0-rc01 because it broke 10 tests. This PR fixes 8 of them, so that work does not have to be redone when the bump is re-landed.

**This has no effect on current `main`, which is on CMP 1.11.1.** The changes are test-only and correct under both 1.11.1 and 1.12.x. Their value is as re-land groundwork.

The cause is a behaviour change in `compose-resources`, not a bug in our code and not a wrong resource lookup. Between 1.11.1 and 1.12.0-rc01, `AsyncCache.getOrLoad` moved the load out of the caller's scope:

```kotlin
// 1.11.1 — ran in the CALLER's scope, i.e. inline on the test dispatcher
suspend fun getOrLoad(key: K, load: suspend () -> V): V = coroutineScope {
    val deferred = mutex.withLock { ... async(start = CoroutineStart.LAZY) { load() } ... }
    deferred.await()
}

// 1.12.0-rc01 — private scope with NO dispatcher, so Dispatchers.Default
private val cacheScope = CoroutineScope(SupervisorJob())
cached = SharedRequest(cacheScope.async { load() })
```

Every string-resource read becomes genuinely asynchronous. Lookup is still correct — values come back `null`, never wrong. Tests running on `UnconfinedTestDispatcher` that read `.value` on the next line, and tests that pump only `advanceUntilIdle()`, observe the state before it lands.

This also explains why only *some* tests in each class failed: the cache is process-wide, so whichever test touches a given string first pays the async cost and the rest hit it warm.

## 🛠️ Changes

Tests only. **No production change.**

- `core/testing` gains `TestScope.runUntilSettled { }` — pumps `runCurrent()` and waits in real time between passes. Used by the notification and bonding tests. On 1.11.1 the predicate is already satisfied on the first pass, so it returns immediately.
- `ScannerViewModelTest` instead pre-loads its five scan-failure strings. It asserts on exact virtual-time BLE retry cooldowns and therefore **cannot** wait in real time: any real-time suspension inside `runTest` causes the virtual clock to advance to the next scheduled task, firing the 30s cooldown early. That constraint is documented in the helper's KDoc so the next person doesn't rediscover it.
- The pre-load is best-effort via `safeCatchingAll` (the same wrapper `ScannerViewModel` uses around these lookups), which absorbs both the unmocked-`Resources` exception and the `Error` skiko's initializer can raise on the JVM test classpath, while still re-throwing `CancellationException`. `ScannerViewModelTest` is in `commonTest`, so it also runs under `testAndroidHostTest`, where the stubs leave `Resources.getSystem()` unmocked; resources never resolve there and the ViewModel's untranslated fallback — byte-identical text, produced synchronously — is what the assertions match. That is why CI only ever showed `[jvm]` failures for this class.

## Testing Performed

> **Read the CMP version column.** Now that `main` is on 1.11.1, all 8 of these tests pass *without* this PR. So this PR's own CI going green proves only that nothing is broken on 1.11.1 — it is **not** evidence the fixes work. The evidence for that comes from the runs below marked 1.12.0-rc01, executed while the branch was based on rc01.

| Check | CMP | Result |
| --- | --- | --- |
| 3× repeat, `:feature:connections:testAndroidHostTest` (50 tests), `--rerun-tasks` | 1.12.0-rc01 | 3/3 pass |
| 3× repeat, `:core:service:testAndroidHostTest` (11 tests), `--rerun-tasks` | 1.12.0-rc01 | 3/3 pass |
| 2× consecutive `:feature:connections:jvmTest --tests "*ScannerViewModelTest*"` | 1.12.0-rc01 | 2/2 pass |
| 9 per-method cold-JVM isolation runs (one test per JVM) | 1.12.0-rc01 | 9/9 pass |
| Full `spotlessApply spotlessCheck detekt assembleDebug test allTests` | 1.12.0-rc01 | green except known pre-existing failures |
| CI run 31657204256, `reports-shard-feature` artifact | 1.12.0-rc01 | all 8 pass, first attempt |
| Post-rebase re-verification (44 + 50 + 11 tests, `--rerun-tasks`) | 1.11.1 | pass, `entries == distinct`, no hangs |

Retry verification, from the JUnit XML rather than from log markers — this repo retries tests and caches a task that passes after a retry, so a test that flipped would otherwise be invisible. From CI run 31657204256 (rc01):

```
total entries: 2241   distinct: 2240
repeated (retried): NodeDetailCompassLifecycleTest  (the known flake — retried, failed both times)
```

| Class | CI entries | source `@Test` |
| --- | --- | --- |
| `ScannerViewModelTest` | 88 | 44 × 2 targets |
| `AndroidScannerViewModelBondingTest` | 6 | 6 |
| `MeshNotificationManagerImplTest` | 6 | 6 |
| `MeshNotificationManagerImplConversationTest` | 5 | 5 |

Counts match exactly with no repeats, so all 8 previously-failing tests passed on **first attempt** — none skipped, none passing only after a retry.

On 1.11.1 the per-test times are 0.002–0.134s, confirming `runUntilSettled` returns on its first pass rather than polling to its 10s timeout when the resource has already resolved inline. Passing alone would not have distinguished those two cases.

The per-method isolation runs were done specifically to rule out tests passing only because an earlier test in the same JVM warmed the process-wide cache — the order-dependence this root cause predicts. All nine pass alone on a cold cache.

## Re-land prerequisites — this PR is not sufficient on its own

Re-landing CMP 1.12 needs all of the following. This PR is only the first:

1. **These test fixes** (this PR) — covers 8 of the 10 failures.
2. **`core/ui` `ConnectionsViewModelTest` and `feature/settings` `RadioConfigViewModelTest`** — the other 2. Same `AsyncCache` cause: `ConnectionsViewModel` dispatches its firmware notification via `getStringSuspend`, including `title = getStringSuspend(Res.string.firmware_update_available)`, and the test asserts the dispatch happened after `advanceUntilIdle()`. They pass on 1.11.1 today only because the revert stepped off rc01; they will fail again the moment the bump returns.
3. **The blocking `runBlocking` resource lookup** at `core/resources/.../GetString.kt:26` — **29 call sites across 6 files**. This is the production-side face of the same finding, and on 1.12 it is a **permanent, unrecoverable hang, not a slow call**:

   `ServiceScope` is `CoroutineScope(dispatchers.default + SupervisorJob())` (`core/service/.../di/CoreServiceModule.kt:33`), so the packet/notification pipeline runs on `Dispatchers.Default`. On 1.12 `getString()` blocks its calling thread while the load it awaits is dispatched to `Dispatchers.Default` — so a blocking caller *on* a Default worker parks that worker awaiting work that needs a Default worker. Once enough callers do this concurrently, the pool is starved: every subsequent `getString` in the process hangs forever, main thread included, with no recovery short of a restart. `jstack` shows Default workers parked on `BlockingCoroutine`. **A message burst is the trigger.**

   The measured threshold was 16 concurrent blocking callers, but that number is the `Dispatchers.Default` parallelism of the machine it was measured on (= CPU count). **On an 8-core phone it wedges at 8**, so real devices are easier to wedge than the dev machine, not harder.

   Separately, the first cold `getString` costs ~197.7ms on the main thread, paid by `initChannels()` during `MeshService.onCreate`.

   Benign on 1.11.1 only because resolution was inline. A mitigation migrating Default-reachable sites to `getStringSuspend` is staged on `claude/sad-gagarin-2f1ff1`. **CMP 1.12 must not be re-landed before this is resolved.**
4. **Removing the Renovate rule** #6664 added to `.github/renovate.json` blocking `1.12.0-rc01`, which is now on `main`.

## Out of scope

- **`NodeDetailCompassLifecycleTest`** — genuinely *not* a CMP regression. Codecov reports a 66.67% failure rate on `main` and it reproduces on 1.11.1. An earlier revision of this branch raised its `waitUntil` timeout; that was reverted once the flake data showed the timeout was treating a pre-existing flake as CMP fallout. Owned separately.
