### PR TITLE
test: keep ViewModel coroutines inside the test that started them

### DIFF
--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.meshtastic.core.common.util.safeCatchingAll
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceHardware
@@ -296,11 +297,14 @@ class ConnectionsViewModelTest {
     /**
      * From CMP 1.12 compose resources load each string once on a library-owned `Dispatchers.Default` scope, which
      * `advanceUntilIdle` cannot drain, so the notification dispatch lands after the assertions. Pre-loading keeps the
-     * path inside virtual time on any CMP version; must run before `setMain`.
+     * path inside virtual time on any CMP version; must run before `setMain`. Best-effort: a warm-up that cannot load
+     * (skiko's static initializer on the desktop test classpath) must leave the suite as it was, not fail every test.
      */
     private fun warmFirmwareNotificationStrings() {
-        getString(Res.string.firmware_update_available)
-        getString(Res.string.firmware_update_notification_android, "", "")
-        getString(Res.string.firmware_update_notification_flasher, "", "")
+        safeCatchingAll {
+            getString(Res.string.firmware_update_available)
+            getString(Res.string.firmware_update_notification_android, "", "")
+            getString(Res.string.firmware_update_notification_flasher, "", "")
+        }
     }
 }

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
@@ -40,6 +40,11 @@ import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.ServiceRepository
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.firmware_update_available
+import org.meshtastic.core.resources.firmware_update_notification_android
+import org.meshtastic.core.resources.firmware_update_notification_flasher
+import org.meshtastic.core.resources.getString
 import org.meshtastic.core.testing.FakeDeviceHardwareRepository
 import org.meshtastic.core.testing.FakeFirmwareReleaseRepository
 import org.meshtastic.core.testing.FakeNodeRepository
@@ -85,6 +90,7 @@ class ConnectionsViewModelTest {
 
     @BeforeTest
     fun setUp() {
+        warmFirmwareNotificationStrings()
         Dispatchers.setMain(testDispatcher)
         dispatchedNotifications.clear()
         notificationsCanBeScheduled = true
@@ -285,5 +291,16 @@ class ConnectionsViewModelTest {
     @Test
     fun `RECONNECTING_PROGRESS_TEXT pins the cross-track literal value`() {
         assertEquals("Reconnecting\u2026", ServiceRepository.RECONNECTING_PROGRESS_TEXT)
+    }
+
+    /**
+     * From CMP 1.12 compose resources load each string once on a library-owned `Dispatchers.Default` scope, which
+     * `advanceUntilIdle` cannot drain, so the notification dispatch lands after the assertions. Pre-loading keeps the
+     * path inside virtual time on any CMP version; must run before `setMain`.
+     */
+    private fun warmFirmwareNotificationStrings() {
+        getString(Res.string.firmware_update_available)
+        getString(Res.string.firmware_update_notification_android, "", "")
+        getString(Res.string.firmware_update_notification_flasher, "", "")
     }
 }

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.feature.settings.radio
 
+import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
@@ -31,6 +32,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -123,7 +125,15 @@ class RadioConfigViewModelTest {
     private val uiPrefs: UiPrefs = mock(MockMode.autofill)
     private val securityKeyBackupStore: SecurityKeyBackupStore = mock(MockMode.autofill)
     private val snackbarManager: SnackbarManager = mock(MockMode.autofill)
-    private val nodeRestartTracker = NodeRestartTracker(CoroutineScope(SupervisorJob()))
+    private val trackerScope = CoroutineScope(SupervisorJob())
+    private val nodeRestartTracker = NodeRestartTracker(trackerScope)
+
+    /**
+     * A `viewModelScope` is not a child of `runTest`, so work still in flight when a test ends would resume on
+     * `Dispatchers.Main` after [Dispatchers.resetMain] and fail an unrelated later test. Every ViewModel is tracked
+     * here so [tearDown] can cancel it.
+     */
+    private val createdViewModels = mutableListOf<RadioConfigViewModel>()
 
     private lateinit var viewModel: RadioConfigViewModel
 
@@ -157,6 +167,9 @@ class RadioConfigViewModelTest {
 
     @AfterTest
     fun tearDown() {
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
+        trackerScope.cancel()
         Dispatchers.resetMain()
     }
 
@@ -186,6 +199,7 @@ class RadioConfigViewModelTest {
         lockdownCoordinator = FakeLockdownCoordinator(),
         analytics = mock(MockMode.autofill),
     )
+        .also { createdViewModels += it }
 
     @Test
     fun `setConfig calls useCase`() = runTest {
@@ -951,33 +965,7 @@ class RadioConfigViewModelTest {
     fun `destNum from SavedStateHandle resolves destNode`() = runTest {
         val node = Node(num = 456, user = User(id = "!456"))
         nodeRepository.setNodes(listOf(node))
-        viewModel =
-            RadioConfigViewModel(
-                destNum = 456,
-                radioConfigRepository = radioConfigRepository,
-                packetRepository = packetRepository,
-                serviceRepository = serviceRepository,
-                nodeRepository = nodeRepository,
-                locationRepository = locationRepository,
-                mapConsentPrefs = mapConsentPrefs,
-                analyticsPrefs = analyticsPrefs,
-                homoglyphEncodingPrefs = homoglyphEncodingPrefs,
-                importProfileUseCase = importProfileUseCase,
-                exportProfileUseCase = exportProfileUseCase,
-                importSecurityConfigUseCase = importSecurityConfigUseCase,
-                securityKeyBackupStore = securityKeyBackupStore,
-                snackbarManager = snackbarManager,
-                nodeRestartTracker = nodeRestartTracker,
-                installProfileUseCase = installProfileUseCase,
-                radioConfigUseCase = radioConfigUseCase,
-                adminActionsUseCase = adminActionsUseCase,
-                processRadioResponseUseCase = processRadioResponseUseCase,
-                locationService = locationService,
-                fileService = fileService,
-                mqttManager = mqttManager,
-                lockdownCoordinator = FakeLockdownCoordinator(),
-                analytics = mock(MockMode.autofill),
-            )
+        viewModel = createViewModel(destNum = 456)
         assertEquals(456, viewModel.destNode.value?.num)
     }
 


### PR DESCRIPTION
## Why

`RadioConfigViewModelTest` and `ConnectionsViewModelTest` were red for two days and cost several sessions a lot of misattribution. The root cause was the CMP 1.12.0-rc01 bump (#6662), reverted by #6664 — so **both classes are green on `main` today and this PR does not fix a live failure.**

It is prevention. CMP 1.12 will be re-landed (#6666 is the groundwork; the Renovate block is marked liftable), and one of these two defects is latent right now and will come straight back with it.

CMP 1.12.0-rc01 changed `compose-resources`' `AsyncCache`:

```kotlin
// 1.11.1 — load runs in the CALLER's context
coroutineScope { async(start = LAZY) { load() } }
// 1.12.0-rc01 — load runs on a library-owned scope == Dispatchers.Default
private val cacheScope = CoroutineScope(SupervisorJob())
cached = SharedRequest(cacheScope.async { load() }); ... request.deferred.await()
```

A cold `getStringSuspend` now completes on a real thread, which breaks two test assumptions:

1. `advanceUntilIdle()` cannot drain it, so anything downstream of a string lookup lands *after* the assertions.
2. A `viewModelScope` still awaiting one at test end resumes on `Dispatchers.Main` after `Dispatchers.resetMain()` → `Module with the Main dispatcher is missing`, reported as `UncaughtExceptionsBeforeTest` against whichever test starts **next**.

The second one is the important part: **`viewModelScope` is not a child of `runTest`, so nothing cancels it when the test body returns.** That was true on 1.11.1 too — the bump only made it reachable. Leaving it unfixed means the re-land reintroduces two red classes.

## 🧹 Changes

**`RadioConfigViewModelTest`** — track every ViewModel the class builds and cancel its scope in `tearDown` before `resetMain()`. Cancelling the awaiting continuation disposes the `ResumeAwaitOnCompletion` handler, so a deferred completing later on a background thread no longer touches `Main`. Also cancels the previously uncancelled `NodeRestartTracker` scope, and folds the one hand-inlined ViewModel construction into `createViewModel` so it cannot escape registration.

**`ConnectionsViewModelTest`** — pre-load the three firmware-notification strings before the test dispatcher is installed, so the awaits are already complete and the notification path stays inside virtual time. The warm-up is wrapped in `safeCatchingAll`: it runs on the desktop JVM test classpath where compose-resources can raise `ExceptionInInitializerError` from skiko's lazy static init, and warming is an optimisation rather than an assertion — if it cannot load, the suite must behave exactly as it did before it existed.

Test-only; no production code touched.

## Testing Performed

Counted `<failure>` elements in the JUnit XML rather than trusting the Gradle result — this build retries twice with `failOnPassedAfterRetry=false`, so a green build can hide a failed first attempt.

| what | CMP | result |
|---|---|---|
| before, `RadioConfigViewModelTest` | 1.12.0-rc01 | fails (`UncaughtExceptionsBeforeTest` / missing Main dispatcher) |
| before, `ConnectionsViewModelTest` | 1.12.0-rc01 | fails 5/5, incl. as a single method in isolation |
| **after**, `RadioConfigViewModelTest` | **1.12.0-rc01** | **3/3 runs, 58 tests, 0 failures** |
| **after**, `ConnectionsViewModelTest` | **1.12.0-rc01** | **5/5 runs, 10 tests, 0 failures** |
| after, both | 1.11.1 (this base) | 3/3 each; both modules fully green, 372 testcases, 0 failures |
| after review fix, `ConnectionsViewModelTest` | 1.11.1 | 3/3 runs, 10 tests, 0 failures |

The rc01 rows are the load-bearing evidence — on this base these tests pass without the change, so CI green here does not demonstrate the fix.

Full baseline on this base: `spotlessApply spotlessCheck` ✅ · `detekt` ✅ · `assembleDebug` ✅ · `:core:ui` + `:feature:settings` tests ✅.

### Notes for reviewers

- `ConnectionsViewModelTest` was **not** order-dependent, despite being described that way — it failed 100% as a single method in isolation.
- A cheap flake tell that came out of this: `RadioConfigViewModelTest` has 58 `@Test` methods but reported 59 and 60 `<testcase>` entries while flaking. Retry attempts appear as extra entries, so **a testcase count above the source count is a retry signal needing no failure text.**
- `NodeDetailCompassLifecycleTest` is unrelated to this PR — CMP-version-independent and still flaky on `main`; being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)