### PR TITLE
test(node): give the compass lifecycle waits a CI-sized budget

### DIFF
--- a/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/detail/NodeDetailCompassLifecycleTest.kt
+++ b/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/detail/NodeDetailCompassLifecycleTest.kt
@@ -127,17 +127,17 @@ class NodeDetailCompassLifecycleTest {
             val openCompass = getString(Res.string.open_compass)
             onNodeWithText(openCompass).performScrollTo().performClick()
             onNodeWithText(getString(Res.string.compass_title)).assertExists()
-            waitUntil { headingProvider.starts == 1 }
+            waitUntil("compass started", SETTLE_TIMEOUT_MS) { headingProvider.starts == 1 }
 
             lifecycleOwner.moveTo(Lifecycle.State.CREATED)
-            waitUntil { headingProvider.stops == 1 }
+            waitUntil("compass stopped on STOPPED", SETTLE_TIMEOUT_MS) { headingProvider.stops == 1 }
 
             lifecycleOwner.moveTo(Lifecycle.State.STARTED)
-            waitUntil { headingProvider.starts == 2 }
+            waitUntil("compass restarted on STARTED", SETTLE_TIMEOUT_MS) { headingProvider.starts == 2 }
 
             onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.Dismiss), useUnmergedTree = true)
                 .performSemanticsAction(SemanticsActions.Dismiss)
-            waitUntil { headingProvider.stops == 2 }
+            waitUntil("compass stopped on dismissal", SETTLE_TIMEOUT_MS) { headingProvider.stops == 2 }
             onNodeWithText(getString(Res.string.compass_title)).assertDoesNotExist()
 
             lifecycleOwner.moveTo(Lifecycle.State.CREATED)
@@ -205,5 +205,14 @@ class NodeDetailCompassLifecycleTest {
 
     private data object ZeroMagneticFieldProvider : MagneticFieldProvider {
         override fun getDeclination(latitude: Double, longitude: Double, altitude: Double, timeMillis: Long): Float = 0f
+    }
+
+    private companion object {
+        /**
+         * `waitUntil` defaults to 1s, which is a rendering-speed assertion rather than a liveness bound: CI runners
+         * take ~12s for this test against ~2.3s locally, and `waitForIdle` alone has been observed taking 6s on runs
+         * that pass. Budget for the slowest runner — a genuine regression still fails, just later.
+         */
+        const val SETTLE_TIMEOUT_MS = 30_000L
     }
 }


### PR DESCRIPTION
## Why

`NodeDetailCompassLifecycleTest` is the last known-red test on `main` after the CMP revert (#6664). It is not order-dependent, not CMP-version-dependent, and does not reproduce locally — it passed **24/24** here. The answer was only visible in CI artifacts.

```
androidx.compose.ui.test.ComposeTimeoutException: Condition still not satisfied after 1000 ms
  at NodeDetailCompassLifecycleTest.kt:140     ← waitUntil { headingProvider.stops == 2 }
```

`waitUntil` defaults to **1000 ms**. On CI that is a rendering-speed assertion, not a liveness bound:

| where | wall time | evidence from `<system-out>` |
|---|---|---|
| local (macOS) | ~2.3 s | every `waitUntil` 0–55 ms |
| CI, **passing** | 11.9 s / 12.8 s | `waitForIdle has not finished after 5 seconds` / **`6 seconds`** |
| CI, **failing** | 17.1 / 18.2 / 30.7 s | timeout at 1000 ms, line 140 |

`waitForIdle` has no cap — it warns and keeps waiting. `waitUntil` does. So the same underlying slowness is harmless in one and fatal in the other, which is exactly the coin-flip we've been seeing. Sampled across four CI runs: **3 failed attempts out of 7**.

The condition is satisfiable. Only the budget was wrong.

**Correction to an earlier revision of this description:** I first wrote that failing attempts take ~35–50 s, derived by dividing suite totals by attempt count. Per-attempt data refutes that. Failing attempts are 17.1 / 18.2 / 30.7 s (mean ~22 s) and passing ones 18.3 / 14.6 / 12.8 / 11.9 s (mean ~14 s) — failures skew slower but **overlap**: in run 31657204256 the passing attempt (18.3 s) was slower than the failing one (17.1 s). So "failures are simply the slowest runs" is not supported; what matters is whether that one wait crossed 1000 ms, not the total.

### Could this be masking a real race rather than fixing a timeout?

A fair challenge, and worth stating the bound explicitly. Every sampled failure is `ComposeTimeoutException` at line 140 — **no assertion failure has ever been observed**, including the `starts == 2` / `stops == 2` assertions that a genuine lifecycle race would be expected to trip. But a race in which cleanup *never* runs would also surface as this timeout, so that alone does not separate the two.

What bounds the risk: **raising a timeout cannot hide a race that never completes** — the test still fails, 30 s later instead of 1 s later. It can only absorb a race that completes *late*, and "completes late" is what "slow" means. So the failure mode this change could conceal is the one it is meant to tolerate.

The discriminator is this PR's own CI. If the compass test still times out at 30 s, the race hypothesis is right and this change should be rejected.

## 🐛 Changes

Raise the four lifecycle waits to a 30 s liveness bound. A genuine regression still fails — just later. **5 s would not have been enough:** 6 s waits occur on runs that *pass*, which is why the earlier 1 s → 5 s attempt was directionally right but numerically short.

Each wait also gets a `conditionDescription`, so a future timeout names which of the four conditions was not met rather than reporting only a duration — the missing detail that made the original failures expensive to read.

Test-only; no production code touched.

## Testing Performed

`:feature:node:spotlessCheck` ✅ · `detekt` ✅ · 3 fresh runs of the test, 1 testcase / 0 `<failure>` elements each, XML timestamps confirmed fresh (Develocity retries twice with `failOnPassedAfterRetry=false`, so build result alone is not evidence).

**Local green proves only "no regression" — it passed locally before this change too.** The real evidence is the CI artifact analysis above. At a ~43% base rate, one green CI run would not demonstrate a fix either; several are needed to be meaningful.

### Hypotheses tested and falsified, so nobody re-runs them

- **Cold compose-resources load** — cold 2.52 s vs warm 2.38 s average. No effect.
- **`UnconfinedTestDispatcher` with no scheduler advancement** — swapping in `StandardTestDispatcher`, which queues *everything*, still passed 3/3. Something does drain it.
- **CMP 1.12.0-rc01** — fails on 1.11.1 and rc01 alike; unrelated to #6662/#6664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved compass lifecycle test reliability in slower environments.
  * Added clearer timeout handling and documentation while preserving existing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
