### PR TITLE
reland(deps): bump the Compose stack to CMP 1.12.0-rc01

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -102,13 +102,6 @@
       "allowedVersions": "!/^9\\.7\\.0$/"
     },
     {
-      "description": "Block Compose Multiplatform 1.12.0-rc01: it breaks 8 tests deterministically across :core:service and :feature:connections, and destabilises :core:ui and :feature:settings intermittently. Cause is in compose-resources AsyncCache.getOrLoad, which stopped resolving inline on the caller's dispatcher (1.11.1 used coroutineScope { async(LAZY) }.await()) and now loads on a private CoroutineScope(SupervisorJob()) with no dispatcher, i.e. Dispatchers.Default. Every cold resource read becomes a real cross-thread hop, so advanceUntilIdle() cannot drain it: tests reading state on the next line observe null, and a viewModelScope coroutine still awaiting a load when Dispatchers.resetMain() runs surfaces as 'Module with the Main dispatcher is missing' blamed on the next test. Because the cache is process-wide, whichever test touches a string first pays the cost, which is why the same class can pass or fail depending on execution order. Not in the CMP changelog. Landed as PR #6662, reverted because it merged with its test shards cancelled. Lift once a CMP release restores inline resolution or the affected tests are made robust to async resolution.",
-      "matchPackageNames": [
-        "/^org\\.jetbrains\\.compose/"
-      ],
-      "allowedVersions": "!/^1\\.12\\.0-rc01$/"
-    },
-    {
       "description": "Disable automerge for major updates (safety net)",
       "matchUpdateTypes": [
         "major"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -65,13 +65,14 @@
       "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(\\.\\d+-g[0-9a-f]+-SNAPSHOT)?$/"
     },
     {
-      "description": "Group CMP and the androidx.compose artifacts that track it so Renovate bumps them together (see PR #5180)",
+      "description": "Group CMP and the androidx.compose artifacts that track it so Renovate bumps them together (see PR #5180). Every artifact pinned to the `androidx-compose-bom-aligned` catalog ref must be listed here: bumping any one of them rewrites that shared ref, which AndroidCompose.kt's resolutionStrategy force-aligns across the whole androidx.compose group, so an ungrouped artifact silently drags the entire Android Compose stack out of step with CMP (see PR #6651, where a solo ui-text-google-fonts bump broke screenshot preview discovery).",
       "groupName": "compose-multiplatform",
       "matchPackageNames": [
         "/^org\\.jetbrains\\.compose/",
         "androidx.compose.runtime:runtime-tracing",
         "androidx.compose.ui:ui-test-manifest",
-        "androidx.compose.material:material"
+        "androidx.compose.material:material",
+        "androidx.compose.ui:ui-text-google-fonts"
       ]
     },
     {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,8 +47,8 @@ profileinstaller = "1.4.1"
 androidx-uiautomator = "2.4.0"
 
 # Compose Multiplatform
-compose-multiplatform = "1.11.1"
-compose-multiplatform-material3 = "1.11.0-alpha07"
+compose-multiplatform = "1.12.0-rc01"
+compose-multiplatform-material3 = "1.12.0-alpha03"
 # `androidx-compose-bom-aligned` tracks androidx.compose.{runtime,ui,foundation,animation}
 # artifacts that ship in lockstep with CMP. Kept as a separate version ref so Renovate
 # can bump androidx releases (which often land first) without dragging the
@@ -57,7 +57,7 @@ compose-multiplatform-material3 = "1.11.0-alpha07"
 # current `compose-multiplatform` release maps to (see CMP release notes).
 # AndroidCompose.kt's resolutionStrategy force-aligns these groups to *this* version
 # at resolution time, so it is the source of truth for the Android target.
-androidx-compose-bom-aligned = "1.11.4"
+androidx-compose-bom-aligned = "1.12.0"
 jetbrains-adaptive = "1.3.0-beta02"
 
 # Google


### PR DESCRIPTION
## Why

Re-lands the CMP 1.12.0-rc01 bump (#6662, reverted by #6664). Every regression it caused now has a fix on `main`, and the Renovate rule that blocked the version has met its stated lift condition.

The original bump broke **10 distinct tests** through one mechanism: `compose-resources` `AsyncCache.getOrLoad` stopped resolving inline on the caller's dispatcher and now loads on a private `CoroutineScope(SupervisorJob())` — i.e. `Dispatchers.Default`. Every cold resource read became a real cross-thread hop that `advanceUntilIdle()` cannot drain. Three PRs addressed it:

| PR | what it fixed |
| --- | --- |
| #6666 | settles asynchronous resource loads in the 8 tests that failed deterministically (`:core:service`, `:feature:connections`) |
| #6669 | keeps ViewModel coroutines inside the test that started them — covers `ConnectionsViewModelTest` and `RadioConfigViewModelTest`, the two that failed intermittently |
| #6668 | removes the `runBlocking` `getString` shim from every `Dispatchers.Default`-reachable notification path |

**#6668 is the one that mattered beyond tests.** Under this bump, the blocking shim could wedge `Dispatchers.Default` permanently — every `getString` in the process hanging forever, main thread included, at a concurrency threshold equal to CPU count (so an 8-core phone wedges at 8, easier than a dev machine). `ServiceScope` runs the packet/notification pipeline on `Dispatchers.Default`, so a message burst was the trigger. That is fixed on `main`, which is what makes this bump safe to carry rather than merely green.

## 🛠️ Changes

- Revert `d8361ccd1`: `compose-multiplatform` 1.11.1 → 1.12.0-rc01, `compose-multiplatform-material3` 1.11.0-alpha07 → 1.12.0-alpha03, `androidx-compose-bom-aligned` 1.11.4 → 1.12.0.
- Drop the Renovate rule blocking 1.12.0-rc01. Its recorded lift condition was "once a CMP release restores inline resolution **or the affected tests are made robust to async resolution**" — the second clause is now satisfied.
- Add `androidx.compose.ui:ui-text-google-fonts` to the `compose-multiplatform` Renovate group. It is pinned to the `androidx-compose-bom-aligned` catalog ref but was the only such artifact missing from that group, so Renovate opened a solo bump for it (#6651) that rewrote the shared ref and force-aligned all of `androidx.compose` to 1.12.0 while CMP stayed at 1.11.1. That skew broke screenshot preview discovery (`RuntimeException` at `PreviewAnnotationDescriptor.kt:138`, `initializationError` on every text-input preview). Fixing the grouping here disarms the trap instead of leaving it for the next divergence.

## Testing Performed

The verification that had not been done anywhere: all 10 previously-failing tests, on this branch, i.e. `main` + all three fixes + the bump together. Each run in a **separate** invocation with `--rerun-tasks` so nothing came from the build cache, and CMP confirmed as `1.12.0-rc01` first.

| target | tests | failures | source `@Test` count |
| --- | --- | --- | --- |
| `:feature:connections:jvmTest --tests "*ScannerViewModelTest*"` | 44 | 0 | 44 ✓ |
| `:feature:connections:testAndroidHostTest --tests "*AndroidScannerViewModelBondingTest*"` | 6 | 0 | 6 ✓ |
| `:core:service:testAndroidHostTest --tests "*MeshNotificationManagerImpl*"` | 11 | 0 | 11 ✓ |
| `:core:ui:jvmTest --tests "*ConnectionsViewModelTest*"` | 10 | 0 | 10 ✓ |
| `:feature:settings:jvmTest --tests "*RadioConfigViewModelTest*"` | 58 | 0 | 58 ✓ |

**127 tests, 0 failures.** Counts read from the JUnit XML with an XML parser rather than a regex, since a regex over `<testcase>...</testcase>` mis-associates failures across self-closing elements and produced wrong numbers earlier in this work.

The `@Test`-count column is deliberate: this repo runs Develocity `testRetry` with `maxRetries = 2` and `failOnPassedAfterRetry = false`, so a test that passes only on retry still reports green — and the task is then cached, making the mask persistent. A reported count equal to the source count proves **no retries fired**, so none of these passes is a retry flip.

## Note for review

**Rebased onto `main` at `b4bedd92f`**, which now contains #6670. The pre-rebase CI run failed exactly one test — `NodeDetailCompassLifecycleTest.compassSelectionFollowsScreenLifecycleAndDismissal`, `ComposeTimeoutException` at `NodeDetailCompassLifecycleTest.kt:92` — and #6670 is precisely its fix (bare `waitUntil { … }` → `waitUntil(label, SETTLE_TIMEOUT_MS)`, since the 1s default asserts rendering speed rather than liveness). `merge-base --is-ancestor` confirmed the old base did **not** contain it. That was the only failing test in the entire run, so the flaky-coin-flip caveat this section used to carry no longer applies.

Post-rebase local verification: `:feature:node:allTests`, `spotlessCheck`, `detekt`, and `validateDebugScreenshotTest` all pass. The compass result was read from the JUnit XML (`tests="1" skipped="0" failures="0" errors="0"`, zero `<failure>` elements) rather than inferred from `BUILD SUCCESSFUL`, so it is a genuine execution and not a cached or retried pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Compose Multiplatform to version 1.12.0-rc01.
  * Updated Compose Multiplatform Material 3 and the aligned AndroidX Compose BOM to compatible versions.
  * Enabled automated version updates for the new Compose Multiplatform release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
