### PR TITLE
ci: run the workflow status gates on ubuntu-slim

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -94,9 +94,11 @@ jobs:
       upload_artifacts: false
     secrets: inherit
 
+  # Pure gate job: no checkout, no toolchain, just reads `needs` results. ubuntu-slim is a
+  # container-backed single-CPU runner that starts faster than a VM (15-min job cap, x64 only).
   check-workflow-status:
     name: Check Workflow Status
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions: {}
     needs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -248,9 +248,11 @@ jobs:
     secrets: inherit
 
   # 3. WORKFLOW STATUS: Ensures required checks are satisfied
+  # Pure gate job: no checkout, no toolchain, just reads `needs` results. ubuntu-slim is a
+  # container-backed single-CPU runner that starts faster than a VM (15-min job cap, x64 only).
   check-workflow-status:
     name: Check Workflow Status
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions: {}
     needs: [check-changes, check-metadata, validate-and-build]


### PR DESCRIPTION
## Why

The two `check-workflow-status` jobs are the last thing standing between a green build and a mergeable PR — the required status check on `pull_request`, and the gate the merge queue waits on. They do no work: no checkout, no toolchain, a single `run:` block that reads `needs.*.result` and exits. Running them on a full `ubuntu-24.04-arm` VM means every PR and every queue entry pays VM boot latency for a job that finishes in under a second.

`ubuntu-slim` is GA, container-backed rather than a VM, and starts in seconds. Its constraints — single CPU, unprivileged, 15-minute job cap, x64 only — are all irrelevant to a job whose entire body is a `bash` `if`. This repo is public, so there is no cost angle either way; the win is purely time-to-green on the critical path.

## 🛠️ Changes

- `.github/workflows/pull-request.yml` — `check-workflow-status` moved from `ubuntu-24.04-arm` to `ubuntu-slim`.
- `.github/workflows/merge-queue.yml` — same job, same move.
- Two comment lines recording why slim is safe here, so the next person doesn't "fix" it back.

Deliberately **not** moved:

- `check-metadata` — real checks with real tools (curl-installed actionlint, shellcheck, four Python scripts over a checkout). Slim ships all of them, but one CPU plus the 15-minute ceiling buys nothing.
- `validate-and-build` / `reusable-check.yml` — Gradle, JDK, Android SDK. Explicitly what slim is not for.

The remaining lightweight jobs (`cancel-superseded`, `labeler`, `stale`, `pr-closed-cleanup`, `update-changelog`, `post-release-cleanup`) follow in a separate PR.

## Reviewer notes

The `name:` values are unchanged (`Check Workflow Status`), so the branch-protection required check and the merge-queue rule still resolve — no settings change needed alongside this.

The only behavioural loss is arm64, which these gates never used. It would matter if a future step ever compiled or ran a native binary in this job.

## Testing Performed

- `actionlint` v1.7.12 over both modified workflows: clean.
- **Verified end-to-end on this PR.** Run [31716076263](https://github.com/meshtastic/Meshtastic-Android/actions/runs/31716076263) concluded `success`, and its `Check Workflow Status` job reports `labels: ["ubuntu-slim"]` with a 3-second wall time (15:47:03 → 15:47:06). Note a workflow-only change still trips the `android` path filter, so that run was a full build, not a skip.
- The merge-queue half proved out on enqueue.
- Runner constraints checked against the [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) and the [ubuntu-slim image manifest](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)