### PR TITLE
test(settings): fix flaky installProfile snackbar test

### DIFF
--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -28,6 +28,7 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode.Companion.exactly
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -1037,9 +1038,13 @@ class RadioConfigViewModelTest {
             {
                 throw MalformedMeshtasticUrlException("bad profile")
             }
+        // UiText.resolve() loads the string on real Dispatchers.Default, outside the test scheduler,
+        // so await the snackbar call instead of draining with runCurrent().
+        val snackbarShown = CompletableDeferred<Unit>()
+        every { snackbarManager.showSnackbar(any(), any(), any(), any(), any()) } calls { snackbarShown.complete(Unit) }
 
         viewModel.installProfile(profile)
-        runCurrent()
+        snackbarShown.await()
 
         verify { snackbarManager.showSnackbar(message = "This Channel URL is invalid and can not be used") }
     }


### PR DESCRIPTION
## Why

`installProfile surfaces malformed channel URL in snackbar` in `RadioConfigViewModelTest` is flaky — it failed 2 of 3 attempts in a local `allTests` run with Mokkery's "Expected showSnackbar() call but received none", passing on retry.

The root cause is not the ViewModel's dispatcher wiring: `installProfile`'s catch block calls `UiText.Resource(Res.string.channel_invalid).resolve()`, which goes through CMP `getString()`. Since CMP 1.12 the resource async cache loads on real `Dispatchers.Default` — outside the `runTest` scheduler. The coroutine suspends there, so `runCurrent()` (and even `advanceUntilIdle()`) returns with nothing to drain, and the `verify` races the real Default thread. Passing runs were just the real thread winning.

## 🧹 Changes

- Stub `snackbarManager.showSnackbar` to complete a `CompletableDeferred`, and replace `runCurrent()` with awaiting that deferred, so the test deterministically waits for the effect. The exact-message assertion is unchanged.
- Deliberately no inner `withTimeout` — inside `runTest` it runs on virtual time and would fire spuriously while waiting on the real dispatcher; a genuine hang is still caught by `runTest`'s 60s real-time timeout.

Note for future tests in this file: any assertion downstream of `UiText.resolve()` has the same trap; reuse this await-the-effect pattern instead of `runCurrent()`/`advanceUntilIdle()`.

## Testing Performed

- `:feature:settings:allTests` run 3× (twice with `--rerun-tasks` to defeat caching; 205 tests executed each run, verified no FROM-CACHE) — target test passed all runs.
- `:feature:settings:detekt spotlessCheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of malformed-profile URL validation tests by properly waiting for asynchronous snackbar notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->