### PR TITLE
fix(ui): move event firmware branding off the app bar

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -582,6 +582,7 @@ establishing_session
 ethernet_config
 ethernet_enabled
 ethernet_ip
+event_firmware_running
 event_use_event_theme
 exchange_position
 expand_chart

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -609,6 +609,7 @@
     <string name="ethernet_config">Ethernet Options</string>
     <string name="ethernet_enabled">Ethernet enabled</string>
     <string name="ethernet_ip">Ethernet IP:</string>
+    <string name="event_firmware_running">Running event firmware</string>
     <string name="event_use_event_theme">Use event theme</string>
     <string name="exchange_position">Exchange position</string>
     <string name="expand_chart">Expand chart</string>

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EventInfoSheet.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EventInfoSheet.kt
@@ -69,8 +69,9 @@ import org.meshtastic.core.ui.util.brandPalette
 import org.meshtastic.core.ui.util.safeLinks
 
 /**
- * Bottom sheet shown when the user taps the event branding in [MainAppBar]. Surfaces the event metadata the bundled
- * `event_firmware.json` carries — welcome message, location, dates, and links — themed with the edition's accent color.
+ * Bottom sheet shown when the user taps the event card on the Connections screen. Surfaces the event metadata the
+ * bundled `event_firmware.json` carries — welcome message, location, dates, and links — themed with the edition's
+ * accent color.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MainAppBar.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MainAppBar.kt
@@ -19,12 +19,9 @@ package org.meshtastic.core.ui.component
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -34,14 +31,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.compositeOver
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
@@ -53,8 +44,6 @@ import org.meshtastic.core.resources.navigate_back
 import org.meshtastic.core.ui.icon.ArrowBack
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.theme.LocalEventTheme
-import org.meshtastic.core.ui.util.EventBrandingIcon
-import org.meshtastic.core.ui.util.LocalEventBranding
 
 /** Alpha for the ambient event accent wash over the app bar — subtle enough to keep title text legible. */
 private const val EVENT_ACCENT_ALPHA = 0.12f
@@ -72,9 +61,9 @@ fun MainAppBar(
     showNodeChip: Boolean,
     canNavigateUp: Boolean,
     onNavigateUp: () -> Unit,
-    actions: @Composable () -> Unit,
     onClickChip: (Node) -> Unit,
-    brandingContent: @Composable () -> Unit = { EventAwareBranding() },
+    // Trailing slot: a @Composable content lambda, not an event handler (detekt LambdaParameterEventTrailing).
+    actions: @Composable () -> Unit,
 ) {
     // Ambient event theming: when connected to event firmware (and not opted out), tint the bar with a faint wash of
     // the edition's accent color. Gated with the app-wide fonts via LocalEventTheme / the "Use event theme" toggle.
@@ -122,7 +111,9 @@ fun MainAppBar(
                     }
                 }
             } else {
-                { brandingContent() }
+                // The Meshtastic logo is never swapped for event branding — the app's identity stays put. Event
+                // firmware is surfaced on the Connections screen instead (EventFirmwareCard).
+                { Icon(imageVector = vectorResource(Res.drawable.ic_meshtastic), contentDescription = null) }
             },
             actions = {
                 TopBarActions(
@@ -134,24 +125,6 @@ fun MainAppBar(
             },
         )
         EventPaletteStrip(palette = eventTheme?.palette.orEmpty(), height = EVENT_BRAND_RULE_HEIGHT)
-    }
-}
-
-/** Reads [LocalEventBranding] to show event branding (tap → [EventInfoSheet]), or the default Meshtastic logo. */
-@Composable
-private fun EventAwareBranding() {
-    val eventEdition = LocalEventBranding.current
-    if (eventEdition == null) {
-        Icon(imageVector = vectorResource(Res.drawable.ic_meshtastic), contentDescription = null)
-        return
-    }
-    // Every event edition is tappable for its info sheet. The icon prefers the hosted iconUrl, then a bundled
-    // drawable, then the Meshtastic logo — see EventBrandingIcon.
-    var showSheet by remember { mutableStateOf(false) }
-    val brandingModifier = Modifier.size(32.dp).clip(CircleShape).clickable(role = Role.Button) { showSheet = true }
-    EventBrandingIcon(edition = eventEdition, modifier = brandingModifier)
-    if (showSheet) {
-        EventInfoSheet(edition = eventEdition, onDismiss = { showSheet = false })
     }
 }
 

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/LocalEventBranding.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/LocalEventBranding.kt
@@ -40,9 +40,10 @@ import kotlin.time.Clock
 
 /**
  * Provides the active [EventFirmwareEdition] (if any) to the composition tree. When a connected device reports an event
- * firmware edition, this local is populated at the app root so that
- * [MainAppBar][org.meshtastic.core.ui.component.MainAppBar] can display event branding automatically — no per-screen
- * wiring needed.
+ * firmware edition, this local is populated at the app root so consumers can pick it up without per-screen wiring: the
+ * Connections screen surfaces the edition itself, and [LocalEventTheme][org.meshtastic.core.ui.theme.LocalEventTheme]
+ * derives the ambient theme from it. The app-bar logo is deliberately *not* one of those consumers — the Meshtastic
+ * identity stays in place regardless of the firmware running on the device.
  */
 @Suppress("CompositionLocalAllowlist")
 val LocalEventBranding = compositionLocalOf<EventFirmwareEdition?> { null }

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -115,6 +115,7 @@ import org.meshtastic.feature.connections.ui.components.ConnectingDeviceInfo
 import org.meshtastic.feature.connections.ui.components.CurrentlyConnectedInfo
 import org.meshtastic.feature.connections.ui.components.CurrentlyConnectedText
 import org.meshtastic.feature.connections.ui.components.DeviceList
+import org.meshtastic.feature.connections.ui.components.EventFirmwareCard
 import org.meshtastic.feature.connections.ui.components.TransportSelector
 import org.meshtastic.feature.settings.navigation.ConfigRoute
 import org.meshtastic.feature.settings.navigation.getNavRouteFrom
@@ -339,6 +340,18 @@ fun ConnectionsScreen(
                                 }
                             }
                         }
+
+                        // Event firmware is reported here rather than by swapping the app-bar logo: the Meshtastic
+                        // identity stays put, and the edition reads as one more fact about the connected device.
+                        // LocalEventBranding is only populated while connected to event firmware, so the card comes
+                        // and goes with the device. Hidden once the event is over — the ended-event card below takes
+                        // over from here, and celebrating an event that has passed would undercut its nudge.
+                        LocalEventBranding.current
+                            ?.takeIf { !it.hasEnded() }
+                            ?.let { edition ->
+                                Spacer(modifier = Modifier.height(8.dp))
+                                EventFirmwareCard(edition = edition)
+                            }
 
                         firmwareUpdateNotice?.let { notice ->
                             FirmwareUpdateNoticeCard(

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/EventFirmwareCard.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/EventFirmwareCard.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.connections.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.model.EventFirmwareEdition
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.event_firmware_running
+import org.meshtastic.core.ui.component.EventInfoSheet
+import org.meshtastic.core.ui.component.EventPaletteStrip
+import org.meshtastic.core.ui.icon.ChevronRight
+import org.meshtastic.core.ui.icon.MeshtasticIcons
+import org.meshtastic.core.ui.util.EventBrandingIcon
+import org.meshtastic.core.ui.util.brandPalette
+
+/** Size of the event icon in the card — matches the node avatar in the connected-device card above it. */
+private val EVENT_ICON_SIZE = 40.dp
+
+/** Closing brand rule under the card, thicker than the app-bar hairline since this is the branding's home. */
+private val PALETTE_STRIP_HEIGHT = 4.dp
+
+/**
+ * Card announcing that the connected device is running an event firmware edition, and the entry point to
+ * [EventInfoSheet] for that event's welcome message, venue, dates, and links.
+ *
+ * This is where event branding lives: the app bar keeps the Meshtastic logo, so the edition is reported alongside the
+ * other facts about the connected device rather than replacing the app's own identity.
+ *
+ * The caller is responsible for hiding this once the event has ended
+ * ([hasEnded][org.meshtastic.core.ui.util.hasEnded]); a finished event gets the "return to standard firmware" card
+ * instead.
+ */
+@Composable
+fun EventFirmwareCard(edition: EventFirmwareEdition, modifier: Modifier = Modifier) {
+    var showSheet by remember { mutableStateOf(false) }
+    Card(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().clickable(role = Role.Button) { showSheet = true }.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Prefers the hosted iconUrl, then a bundled drawable, then the Meshtastic logo — see EventBrandingIcon.
+            EventBrandingIcon(
+                edition = edition,
+                modifier = Modifier.size(EVENT_ICON_SIZE).clip(CircleShape),
+                contentDescription = null,
+            )
+            Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = edition.displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = stringResource(Res.string.event_firmware_running),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = MeshtasticIcons.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        EventPaletteStrip(palette = edition.brandPalette(), height = PALETTE_STRIP_HEIGHT)
+    }
+    if (showSheet) {
+        EventInfoSheet(edition = edition, onDismiss = { showSheet = false })
+    }
+}


### PR DESCRIPTION
Replacing the Meshtastic icon in the main app bar with the event logo was rejected in post-DEF CON review — the app's identity shouldn't change based on the firmware running on the connected device. Event firmware is now surfaced on the Connections screen instead, alongside the other facts about the connected device.

## 🌟 New Features

- **`EventFirmwareCard`** (`feature/connections/.../ui/components/`) — event icon, edition display name, and "Running event firmware", closed by the edition's brand palette strip. Tapping it opens `EventInfoSheet`, which otherwise would have lost its only entry point when the app-bar logo went away.
- Rendered on the Connections screen directly under the connected-device card, above the firmware-update notice. Gated on `!hasEnded()`, so once an event is over the card disappears and the existing "return to standard firmware" card takes over — the two never stack, and a passed event is never celebrated.

## 🛠️ Refactoring & Architecture

- `MainAppBar` always renders `ic_meshtastic` as its navigation icon. `EventAwareBranding` and the `brandingContent` parameter are removed — nothing overrode the latter.
- `actions: @Composable () -> Unit` moved to the trailing parameter slot. Dropping `brandingContent` left the `onClickChip` event lambda trailing, which trips detekt's `LambdaParameterEventTrailing`; every `MainAppBar` call site uses named arguments, so the reorder is source-compatible.

## 🧹 Chores

- New string `event_firmware_running`; `scripts/sort-strings.py` re-sorted the base `strings.xml` and regenerated `strings-index.txt`.
- KDoc updated on `LocalEventBranding` and `EventInfoSheet` to name the Connections card as the entry point, and to record that the app bar is deliberately *not* an event-branding consumer.

## Scope note

The ambient accent wash, the `EventPaletteStrip` hairline under the app bar, and the app-wide event fonts are unchanged. All three already sit behind the opt-out "Use event theme" toggle, and the objection was specifically to the icon swap.

## Testing Performed

No test files changed — this is a UI composition change with no new branching logic to cover, and the affected modules have no existing app-bar or event-branding tests.

- `spotlessKotlinCheck` and `detekt` on `:feature:connections` and `:core:ui` — re-run with `--rerun-tasks` and confirmed **EXECUTED** rather than replayed from cache; zero violations.
- `assembleDebug` — success.
- `:feature:connections:allTests` — 154 tests, 0 failures. `:core:ui:allTests` — 215 tests, 0 failures. Counts read from the JUnit XML rather than the Gradle exit status.

### Pre-existing failure, not from this branch

`feature:settings` → `RadioConfigViewModelTest."installProfile surfaces malformed channel URL in snackbar"` fails in a full `allTests` run. It also fails **3/3 on a pristine checkout of the base commit `2f387369c`**, so it is not caused by this change and is left alone here. The `SnackbarManager` mock receives zero calls because the expected message resolves through a CMP string resource that `runCurrent()` can't drain. Worth its own fix.

### Not verified

Nothing here has been exercised against a physically connected event-firmware device — the card only renders while connected to one, so a stock debug install shows nothing.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an event firmware card to the Connections screen for active event firmware.
  * The card displays the firmware edition, running status, branding, and navigation option.
  * Selecting the card opens detailed event information.

* **Bug Fixes**
  * The app bar now consistently displays the Meshtastic logo instead of event branding.

* **Documentation**
  * Updated event branding and event information guidance to reflect the revised navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->