### PR TITLE
ci: move the remaining lightweight jobs to ubuntu-slim

### DIFF
--- a/.github/instructions/ci-workflows.instructions.md
+++ b/.github/instructions/ci-workflows.instructions.md
@@ -10,5 +10,10 @@ excludeAgent: "code-review"
 - CI passes `-Pci=true` to enable full processor usage via `maxParallelForks`.
 - Use `fetch-depth: 0` only where needed (spotless ratcheting, version code). Use `fetch-depth: 1` otherwise.
 - Desktop build matrix: `macos-latest`, `windows-latest`, `ubuntu-24.04`, `ubuntu-24.04-arm`.
-- Lightweight jobs (labelers, triage, stale): use `ubuntu-24.04-arm` runners.
+- Lightweight jobs (status gates, labelers, triage, stale, run-cancellers, changelog/release
+  cleanup): use `ubuntu-slim`. It is container-backed and starts in seconds, but it is
+  single-CPU, unprivileged, x64-only, and its 15-minute job cap is a hard platform limit — so it
+  fits API/script work (`gh`, `jq`, `git`, stdlib `python3`, `github-script`) and nothing that
+  needs `sudo`, `apt-get`, Docker, a mounted filesystem, or a long full-history clone.
+- Lightweight jobs that break any of those constraints: use `ubuntu-24.04-arm` runners.
 - Gradle-heavy jobs: use `ubuntu-24.04` runners.

--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -19,10 +19,12 @@ jobs:
   # new merge group but does NOT cancel the workflow runs of the destroyed one. Those stale
   # runs sit queued/running and starve the runner pool. Cancel any older merge-queue run
   # for the same PR — only the newest merge group per PR is ever valid.
+  # No checkout, no toolchain — just gh api + jq. ubuntu-slim starts sooner than a VM, which
+  # matters most here: every second before this runs is a second the superseded run keeps a slot.
   cancel-superseded:
     name: Cancel Superseded Queue Runs
     if: github.repository == 'meshtastic/Meshtastic-Android'
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
       actions: write

--- a/.github/workflows/post-release-cleanup.yml
+++ b/.github/workflows/post-release-cleanup.yml
@@ -24,7 +24,11 @@ concurrency:
 
 jobs:
   cleanup_prereleases:
-    runs-on: ubuntu-24.04-arm
+    # ubuntu-slim: gh + git + jq + stdlib python is the whole toolchain, and the gh-pages
+    # worktree needs no privileges. Slim is single-CPU (the full-history clone below is slower
+    # than on a VM) and its 15-minute platform cap is hard, matching the timeout already set
+    # here. Each step is independently re-runnable, so a capped run is retryable.
+    runs-on: ubuntu-slim
     timeout-minutes: 15
     # Dispatch inputs reach the shell as environment variables rather than being
     # interpolated into the script text: base_version is free-form and feeds a

--- a/.github/workflows/pr-closed-cleanup.yml
+++ b/.github/workflows/pr-closed-cleanup.yml
@@ -21,7 +21,9 @@ permissions:
 jobs:
   cancel-pr-runs:
     if: github.repository == 'meshtastic/Meshtastic-Android'
-    runs-on: ubuntu-24.04-arm
+    # Actions API only, no checkout (and must stay that way — see the
+    # pull_request_target note above), so ubuntu-slim's container is sufficient.
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: Cancel in-flight CI runs for the closed PR

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -14,7 +14,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-24.04-arm
+    # github-script only, no checkout, so ubuntu-slim's container is sufficient.
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
     - name: Auto-label PR

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,9 @@ concurrency:
 jobs:
   stale_issues:
     name: Close Stale Issues
-    runs-on: ubuntu-24.04-arm
+    # actions/stale is pure API work with no checkout, so ubuntu-slim's container is
+    # sufficient. Its 15-minute platform cap matches the timeout already set here.
+    runs-on: ubuntu-slim
     timeout-minutes: 15
     if: github.repository == 'meshtastic/Meshtastic-Android'
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -18,7 +18,11 @@ concurrency:
 
 jobs:
   update-changelog:
-    runs-on: ubuntu-24.04-arm
+    # ubuntu-slim: git + gh + coreutils is the whole toolchain here. Note this job checks out
+    # full history below and slim is single-CPU, so the clone is slower than on a VM — and
+    # slim's 15-minute platform cap is hard, matching the timeout already set here. A run that
+    # outgrows that budget fails; it regenerates CHANGELOG.md from scratch, so a retry is safe.
+    runs-on: ubuntu-slim
     timeout-minutes: 15
     steps:
       - name: Checkout code

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   update-changelog:
-    # ubuntu-slim: git + gh + coreutils is the whole toolchain here. Note this job checks out
+    # ubuntu-slim: git + gh + coreutils + stdlib python3 is the whole toolchain here. Note this job checks out
     # full history below and slim is single-CPU, so the clone is slower than on a VM — and
     # slim's 15-minute platform cap is hard, matching the timeout already set here. A run that
     # outgrows that budget fails; it regenerates CHANGELOG.md from scratch, so a retry is safe.


### PR DESCRIPTION
## Why

Follow-up to #6674, which moved the two `check-workflow-status` gates to `ubuntu-slim`. This finishes the sweep across the rest of the jobs that do no real work — no toolchain, just a `run:` block or a `github-script` that calls the GitHub API and exits. Running those on a full `ubuntu-24.04-arm` VM pays VM boot latency for a job that finishes in seconds.

`ubuntu-slim` is GA, container-backed rather than a VM, and starts in seconds. Its constraints — single CPU, unprivileged, 15-minute job cap, x64 only — don't bind on work that is a REST call in a loop. This repo is public, so there is no cost angle; the win is startup latency plus fewer VM requests against a runner pool this repo has previously seen contention on.

## 🛠️ Changes

| Job | Workflow | Body | Checkout |
|---|---|---|---|
| `cancel-superseded` | `merge-queue.yml` | `gh api` + `jq` | — |
| `cancel-pr-runs` | `pr-closed-cleanup.yml` | Actions API only | — |
| `labeler` | `pull-request-target.yml` | `actions/github-script` | — |
| `stale_issues` | `stale.yml` | `actions/stale` | — |
| `update-changelog` | `update-changelog.yml` | git tags + `gh api` + stdlib python | `fetch-depth: 0` |
| `cleanup_prereleases` | `post-release-cleanup.yml` | `gh release` + `jq` + gh-pages worktree | `fetch-depth: 0` |

Each job carries a comment recording why slim is safe there, so the next person doesn't "fix" it back.

The bottom two check out full history, which is partly CPU-bound and therefore slower on a single-CPU container. They still move, because the tradeoff is bounded: slim's 15-minute cap is exactly the `timeout-minutes: 15` both jobs already carry, so the failure budget is unchanged — a run that outgrows the budget fails either way — and both are re-runnable (`update-changelog` regenerates `CHANGELOG.md` from scratch; `cleanup_prereleases`'s steps are independently repeatable). Toolchain was checked rather than assumed: `scripts/docs/regenerate-versions.py` is stdlib-only, and git, `gh`, `jq` and GNU `findutils` are all in the slim manifest. The gh-pages `git worktree` needs no privileges, so unprivileged mode is not a blocker.

## What stays on a VM

- Anything invoking Gradle — `validate-and-build`/`reusable-check.yml`, `dependency-graph-submit`, `publish-snapshot`, the docs and baseline jobs.
- `verify-flatpak` — needs `sudo apt-get` and flatpak-builder, which unprivileged mode rules out.
- The release/promote path — handles signing secrets and large artifacts, and gains nothing from a faster start.
- `check-metadata` — slim happens to ship every tool it needs (git, python3, node, shellcheck, jq, gh), but it is a real check doing real work, and one CPU plus the 15-minute ceiling buys nothing.

## Reviewer notes

No job names change, so nothing in branch protection or the merge-queue rule needs touching.

The only behavioural loss is arm64, which none of these jobs used. It would matter if a future step ever compiled or ran a native binary in one.

## Testing Performed

- `actionlint` v1.7.12 over the full `.github/workflows` tree: clean.
- `cancel-superseded` proves out when this PR is enqueued — `merge_group` runs the workflow from the merge ref, which contains these commits.
- **`labeler` and `cancel-pr-runs` cannot be verified before merge.** Both are `pull_request_target`, which always runs the workflow definition from the *base* branch, so this PR's own runs use `main`'s copy — the `labeler` run on this branch reports `labels: ["ubuntu-24.04-arm"]`, i.e. the old runner. Their slim move only takes effect once merged. (I had originally claimed this PR exercised `labeler`; it does not.)
- `stale_issues` proves out on its next 06:00 cron, or a manual `workflow_dispatch` after merge.
- The `ubuntu-slim` label itself is already proven in production by #6674, whose gate job ran green on it in 3 seconds ([run 31716076263](https://github.com/meshtastic/Meshtastic-Android/actions/runs/31716076263)).
- **`cleanup_prereleases` verified by a dry-run dispatch on this branch.** Run [31723055616](https://github.com/meshtastic/Meshtastic-Android/actions/runs/31723055616) (`base_version=2.8.0`, `confirm_deletion=false`): `success`, `labels: ["ubuntu-slim"]`, all six steps green, **27s** wall. Both destructive steps reached their `DRY RUN:` branch and listed what they would remove (`v2.8.1-internal.1`) without deleting anything; the gh-pages fail-closed guard found `/v2.8.0/` published and proceeded.
  - This settles the single-CPU worry above: the `fetch-depth: 0` checkout took **~17s** and the whole job used ~3% of the 15-minute cap.
- **Still not exercised:** `update-changelog`, which only fires on push to `main`. Same shape as the job above (full-history checkout, `gh api`, stdlib `python3`) and it opens a PR rather than deleting anything, so the failure mode is a retryable red run.
- Runner constraints checked against the [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) and the [ubuntu-slim image manifest](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository automation to use lightweight runners for routine maintenance tasks.
  * Merge queue handling, cleanup workflows, pull request labeling, stale-item management, and changelog updates continue to operate as before.
  * Improved workflow startup efficiency while preserving existing timeouts, retry behavior, and processing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

