### PR TITLE
chore(compose): follow-ups from the Compose 1.12 bump

### DIFF
--- a/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/NumberFormatter.kt
+++ b/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/NumberFormatter.kt
@@ -35,6 +35,19 @@ object NumberFormatter {
         return format(value.toDouble(), decimalPlaces)
     }
 
+    /**
+     * Parses a user-entered decimal whose separator follows the keyboard locale — `48,21` on a comma locale, which
+     * [String.toDoubleOrNull] rejects. A lone separator is always the decimal mark; grouping is only recognised when
+     * more than one appears, in which case the last one is the decimal mark. Returns null for anything unparseable.
+     */
+    fun parseDecimalOrNull(text: String): Double? {
+        val stripped = text.filterNot { it.isWhitespace() || it == ' ' || it == ' ' || it == '\'' }
+        val lastSeparator = stripped.indexOfLast { it in DECIMAL_SEPARATORS }
+        if (lastSeparator < 0) return stripped.toDoubleOrNull()
+        val integerPart = stripped.take(lastSeparator).filterNot { it in DECIMAL_SEPARATORS }
+        return "$integerPart.${stripped.substring(lastSeparator + 1)}".toDoubleOrNull()
+    }
+
     private fun formatFixedPoint(scaledValue: Long, decimalPlaces: Int): String {
         if (decimalPlaces == 0) return scaledValue.toString()
 
@@ -47,4 +60,10 @@ object NumberFormatter {
         val sign = if (isNegative) "-" else ""
         return "$sign$intPart.${fracPart.toString().padStart(decimalPlaces, '0')}"
     }
+
+    /** True when [char] is a decimal mark reachable from a `Decimal`/`DecimalSigned` keyboard. */
+    fun isDecimalSeparator(char: Char): Boolean = char in DECIMAL_SEPARATORS
+
+    /** Decimal marks reachable from a `Decimal`/`DecimalSigned` keyboard, across keyboard locales. */
+    private val DECIMAL_SEPARATORS = setOf('.', ',', '٫', '、', '·')
 }

--- a/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/NumberFormatter.kt
+++ b/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/NumberFormatter.kt
@@ -64,6 +64,14 @@ object NumberFormatter {
     /** True when [char] is a decimal mark reachable from a `Decimal`/`DecimalSigned` keyboard. */
     fun isDecimalSeparator(char: Char): Boolean = char in DECIMAL_SEPARATORS
 
+    /**
+     * True when [text] could still become a number as the user types — an empty field, a lone sign, or a trailing
+     * separator. A controlled field consults this after [parseDecimalOrNull] returns null, so transient input like `-`
+     * or `-.` survives on the way to `-1.5` instead of snapping back to the last committed value.
+     */
+    fun isPartialDecimal(text: String): Boolean =
+        text.removePrefix("-").all { it.isDigit() || isDecimalSeparator(it) || it.isWhitespace() || it == '\'' }
+
     /** Decimal marks reachable from a `Decimal`/`DecimalSigned` keyboard, across keyboard locales. */
     private val DECIMAL_SEPARATORS = setOf('.', ',', '٫', '、', '·')
 }

--- a/core/common/src/commonTest/kotlin/org/meshtastic/core/common/util/NumberFormatterTest.kt
+++ b/core/common/src/commonTest/kotlin/org/meshtastic/core/common/util/NumberFormatterTest.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.common.util
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class NumberFormatterTest {
 
@@ -47,5 +48,57 @@ class NumberFormatterTest {
         assertEquals("—", NumberFormatter.format(Double.POSITIVE_INFINITY, 2))
         assertEquals("—", NumberFormatter.format(Double.NEGATIVE_INFINITY, 2))
         assertEquals("—", NumberFormatter.format(Float.POSITIVE_INFINITY, 1))
+    }
+
+    @Test
+    fun testParseDecimalDotLocale() {
+        assertEquals(48.21, NumberFormatter.parseDecimalOrNull("48.21"))
+        assertEquals(-150.0, NumberFormatter.parseDecimalOrNull("-150"))
+        assertEquals(-1.5, NumberFormatter.parseDecimalOrNull("-1.5"))
+        assertEquals(906.875, NumberFormatter.parseDecimalOrNull("906.875"))
+    }
+
+    @Test
+    fun testParseDecimalCommaLocale() {
+        assertEquals(48.21, NumberFormatter.parseDecimalOrNull("48,21"))
+        assertEquals(-73.935, NumberFormatter.parseDecimalOrNull("-73,935"))
+        assertEquals(0.5, NumberFormatter.parseDecimalOrNull("0,5"))
+    }
+
+    @Test
+    fun testParseDecimalOtherSeparators() {
+        assertEquals(1.5, NumberFormatter.parseDecimalOrNull("1٫5"))
+        assertEquals(1.5, NumberFormatter.parseDecimalOrNull("1·5"))
+        assertEquals(1.5, NumberFormatter.parseDecimalOrNull("1、5"))
+    }
+
+    @Test
+    fun testParseDecimalStripsGrouping() {
+        // More than one separator: the last is the decimal mark, the rest are grouping.
+        assertEquals(1234.56, NumberFormatter.parseDecimalOrNull("1.234,56"))
+        assertEquals(1234.56, NumberFormatter.parseDecimalOrNull("1,234.56"))
+        assertEquals(1234567.8, NumberFormatter.parseDecimalOrNull("1.234.567,8"))
+        assertEquals(-1234.5, NumberFormatter.parseDecimalOrNull("-1.234,5"))
+    }
+
+    @Test
+    fun testParseDecimalStripsWhitespaceGrouping() {
+        assertEquals(1234.5, NumberFormatter.parseDecimalOrNull("1 234,5"))
+        assertEquals(48.21, NumberFormatter.parseDecimalOrNull("  48.21  "))
+    }
+
+    @Test
+    fun testParseDecimalRejectsGarbage() {
+        assertNull(NumberFormatter.parseDecimalOrNull(""))
+        assertNull(NumberFormatter.parseDecimalOrNull("   "))
+        assertNull(NumberFormatter.parseDecimalOrNull("abc"))
+        assertNull(NumberFormatter.parseDecimalOrNull("."))
+        assertNull(NumberFormatter.parseDecimalOrNull("1.2.3.4a"))
+    }
+
+    @Test
+    fun testParseDecimalRoundTripsFormatOutput() {
+        // format() always emits '.', so its output must survive the parser unchanged.
+        assertEquals(-42.75, NumberFormatter.parseDecimalOrNull(NumberFormatter.format(-42.75, 2)))
     }
 }

--- a/core/common/src/commonTest/kotlin/org/meshtastic/core/common/util/NumberFormatterTest.kt
+++ b/core/common/src/commonTest/kotlin/org/meshtastic/core/common/util/NumberFormatterTest.kt
@@ -18,7 +18,9 @@ package org.meshtastic.core.common.util
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class NumberFormatterTest {
 
@@ -94,6 +96,26 @@ class NumberFormatterTest {
         assertNull(NumberFormatter.parseDecimalOrNull("abc"))
         assertNull(NumberFormatter.parseDecimalOrNull("."))
         assertNull(NumberFormatter.parseDecimalOrNull("1.2.3.4a"))
+    }
+
+    @Test
+    fun testIsPartialDecimalAcceptsTransientInput() {
+        // What a controlled field must keep on the way to "-1.5" or ".5".
+        assertTrue(NumberFormatter.isPartialDecimal(""))
+        assertTrue(NumberFormatter.isPartialDecimal("-"))
+        assertTrue(NumberFormatter.isPartialDecimal("."))
+        assertTrue(NumberFormatter.isPartialDecimal(","))
+        assertTrue(NumberFormatter.isPartialDecimal("-."))
+        assertTrue(NumberFormatter.isPartialDecimal("-1."))
+        assertTrue(NumberFormatter.isPartialDecimal("1 "))
+    }
+
+    @Test
+    fun testIsPartialDecimalRejectsNonNumeric() {
+        assertFalse(NumberFormatter.isPartialDecimal("abc"))
+        assertFalse(NumberFormatter.isPartialDecimal("1a"))
+        assertFalse(NumberFormatter.isPartialDecimal("1-2"))
+        assertFalse(NumberFormatter.isPartialDecimal("--1"))
     }
 
     @Test

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
@@ -145,13 +145,13 @@ fun EditTextPreference(
         KeyboardOptions.Default.copy(keyboardType = KeyboardType.DecimalSigned, imeAction = ImeAction.Done),
         keyboardActions = keyboardActions,
         onValueChanged = {
-            if (it.isEmpty()) {
+            val parsed = NumberFormatter.parseDecimalOrNull(it)?.toFloat()
+            if (parsed != null) {
                 valueState = it
-            } else {
-                NumberFormatter.parseDecimalOrNull(it)?.toFloat()?.let { float ->
-                    valueState = it
-                    onValueChanged(float)
-                }
+                onValueChanged(parsed)
+            } else if (NumberFormatter.isPartialDecimal(it)) {
+                // Keep transient input ("", "-", "-.") so the field doesn't snap back mid-entry of "-1.5".
+                valueState = it
             }
         },
         onFocusChanged = onFocusChanged,
@@ -183,13 +183,13 @@ fun EditTextPreference(
         KeyboardOptions.Default.copy(keyboardType = KeyboardType.DecimalSigned, imeAction = ImeAction.Done),
         keyboardActions = keyboardActions,
         onValueChanged = {
-            if (it.length <= 1 || NumberFormatter.isDecimalSeparator(it.first())) {
+            val parsed = NumberFormatter.parseDecimalOrNull(it)
+            if (parsed != null) {
                 valueState = it
-            } else {
-                NumberFormatter.parseDecimalOrNull(it)?.let { double ->
-                    valueState = it
-                    onValueChanged(double)
-                }
+                onValueChanged(parsed)
+            } else if (NumberFormatter.isPartialDecimal(it)) {
+                // Keep transient input ("", "-", "-.") so the field doesn't snap back mid-entry of "-1.5".
+                valueState = it
             }
         },
         onFocusChanged = onFocusChanged,

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.common.util.NumberFormatter
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.error
 import org.meshtastic.core.ui.icon.Info
@@ -67,7 +68,9 @@ fun SignedIntegerEditTextPreference(
         enabled = enabled,
         summary = summary,
         isError = valueState.toIntOrNull() == null,
-        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number, imeAction = ImeAction.Done),
+        // Signed by contract: RSSI thresholds and tx power are negative, and Number has no minus key.
+        keyboardOptions =
+        KeyboardOptions.Default.copy(keyboardType = KeyboardType.NumberSigned, imeAction = ImeAction.Done),
         keyboardActions = keyboardActions,
         onValueChanged = {
             valueState = it
@@ -136,14 +139,16 @@ fun EditTextPreference(
         value = valueState,
         enabled = enabled,
         summary = summary,
-        isError = value.toString() != valueState,
-        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number, imeAction = ImeAction.Done),
+        // Compare parsed values, not strings: a comma-locale "3,7" is correct input but never string-equals "3.7".
+        isError = NumberFormatter.parseDecimalOrNull(valueState)?.toFloat() != value,
+        keyboardOptions =
+        KeyboardOptions.Default.copy(keyboardType = KeyboardType.DecimalSigned, imeAction = ImeAction.Done),
         keyboardActions = keyboardActions,
         onValueChanged = {
             if (it.isEmpty()) {
                 valueState = it
             } else {
-                it.toFloatOrNull()?.let { float ->
+                NumberFormatter.parseDecimalOrNull(it)?.toFloat()?.let { float ->
                     valueState = it
                     onValueChanged(float)
                 }
@@ -166,21 +171,22 @@ fun EditTextPreference(
     onFocusChanged: (FocusState) -> Unit = {},
 ) {
     var valueState by remember(value) { mutableStateOf(value.toString()) }
-    val decimalSeparators = setOf('.', ',', '٫', '、', '·') // set of possible decimal separators
 
     EditTextPreference(
         title = title,
         value = valueState,
         enabled = enabled,
         summary = summary,
-        isError = value.toString() != valueState,
-        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number, imeAction = ImeAction.Done),
+        // Compare parsed values, not strings: a comma-locale "48,21" is correct input but never string-equals "48.21".
+        isError = NumberFormatter.parseDecimalOrNull(valueState) != value,
+        keyboardOptions =
+        KeyboardOptions.Default.copy(keyboardType = KeyboardType.DecimalSigned, imeAction = ImeAction.Done),
         keyboardActions = keyboardActions,
         onValueChanged = {
-            if (it.length <= 1 || it.first() in decimalSeparators) {
+            if (it.length <= 1 || NumberFormatter.isDecimalSeparator(it.first())) {
                 valueState = it
             } else {
-                it.toDoubleOrNull()?.let { double ->
+                NumberFormatter.parseDecimalOrNull(it)?.let { double ->
                     valueState = it
                     onValueChanged(double)
                 }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EventInfoSheet.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EventInfoSheet.kt
@@ -34,9 +34,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -75,7 +76,11 @@ import org.meshtastic.core.ui.util.safeLinks
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EventInfoSheet(edition: EventFirmwareEdition, onDismiss: () -> Unit) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        )
     val uriHandler = LocalUriHandler.current
     val accent = edition.accentColorOrNull()
     val palette = edition.brandPalette()

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/emoji/EmojiPickerDialog.kt
@@ -53,12 +53,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.PrimaryScrollableTabRow
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -171,7 +172,11 @@ fun EmojiPickerDialog(
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        ),
     ) {
         if (loadError) {
             Box(modifier = Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/theme/AppThemePreviewWrapper.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/theme/AppThemePreviewWrapper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+
+/**
+ * Supplies [AppTheme] to previews annotated with `@PreviewWrapper(AppThemePreviewWrapper::class)`, replacing a manual
+ * `AppTheme { }` in the preview body. Only the renderer of the annotated function applies this — a preview invoked as a
+ * plain function call from another composable does not inherit it.
+ */
+class AppThemePreviewWrapper : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) {
+        AppTheme { content() }
+    }
+}

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/DeviceList.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/components/DeviceList.kt
@@ -40,9 +40,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldLabelPosition
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -121,7 +122,11 @@ fun DeviceList(
     modifier: Modifier = Modifier,
 ) {
     var showAddDialog by remember { mutableStateOf(false) }
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        )
     val scope = rememberCoroutineScope()
 
     val hideAndDismiss: () -> Unit = {

--- a/feature/connections/src/jvmTest/kotlin/org/meshtastic/feature/connections/ui/components/CurrentlyConnectedInfoRssiLifecycleTest.kt
+++ b/feature/connections/src/jvmTest/kotlin/org/meshtastic/feature/connections/ui/components/CurrentlyConnectedInfoRssiLifecycleTest.kt
@@ -82,7 +82,7 @@ class CurrentlyConnectedInfoRssiLifecycleTest {
             }
         }
 
-        waitUntil { device.readRssiCalls >= 1 }
+        waitUntil("initial RSSI read", SETTLE_TIMEOUT_MS) { device.readRssiCalls >= 1 }
         val firstReadCount = device.readRssiCalls
 
         lifecycleOwner.moveTo(Lifecycle.State.CREATED)
@@ -92,7 +92,7 @@ class CurrentlyConnectedInfoRssiLifecycleTest {
         assertEquals(firstReadCount, device.readRssiCalls, "RSSI reads must stop below STARTED")
 
         lifecycleOwner.moveTo(Lifecycle.State.STARTED)
-        waitUntil { device.readRssiCalls > firstReadCount }
+        waitUntil("polling resumed at STARTED", SETTLE_TIMEOUT_MS) { device.readRssiCalls > firstReadCount }
 
         device.setState(BleConnectionState.Disconnected())
         waitForIdle()
@@ -102,7 +102,7 @@ class CurrentlyConnectedInfoRssiLifecycleTest {
         assertEquals(disconnectedReadCount, device.readRssiCalls, "disconnected devices must not be polled")
 
         device.setState(BleConnectionState.Connected)
-        waitUntil { device.readRssiCalls > disconnectedReadCount }
+        waitUntil("polling resumed on reconnect", SETTLE_TIMEOUT_MS) { device.readRssiCalls > disconnectedReadCount }
         assertTrue(
             device.readRssiCalls > disconnectedReadCount,
             "reconnect must resume RSSI reads without a timer poll",
@@ -141,5 +141,14 @@ class CurrentlyConnectedInfoRssiLifecycleTest {
         fun setState(newState: BleConnectionState) {
             mutableState.value = newState
         }
+    }
+
+    private companion object {
+        /**
+         * `waitUntil` defaults to 1s, which asserts rendering speed rather than liveness: CI runners are several times
+         * slower than local, and `waitForIdle` alone has been observed taking 6s on passing runs. Budget for the
+         * slowest runner — a genuine regression still fails, just later.
+         */
+        const val SETTLE_TIMEOUT_MS = 30_000L
     }
 }

--- a/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/ui/ChirpyAssistantSheet.kt
+++ b/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/ui/ChirpyAssistantSheet.kt
@@ -52,11 +52,12 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -127,7 +128,11 @@ private fun ChirpyChatSheet(
     onNavigateToPage: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        )
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState, modifier = modifier) {
         Column(modifier = Modifier.fillMaxSize().imePadding().padding(16.dp)) {
@@ -203,7 +208,11 @@ private fun ChirpyDownloadingSheet(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    val sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.PartiallyExpanded, SheetValue.Expanded),
+        )
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState, modifier = modifier) {
         Column(modifier = Modifier.fillMaxWidth().padding(32.dp), horizontalAlignment = Alignment.CenterHorizontally) {
             Image(

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/SitePlannerSheet.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/SitePlannerSheet.kt
@@ -273,10 +273,12 @@ private fun TransmitterSection(
 @Composable
 private fun ReceiverSection(state: SiteFormState) {
     FormSection(stringResource(Res.string.site_planner_section_receiver), defaultExpanded = false) {
+        // The whole valid range is negative (-150..-30 dBm), so an unsigned keypad reaches no valid value.
         SiteField(
             state.rxSensitivity,
             { state.rxSensitivity = it },
             Res.string.site_planner_rx_sensitivity_dbm,
+            keyboardType = KeyboardType.DecimalSigned,
             error = if (state.rxSensBad) stringResource(Res.string.site_planner_invalid_rx_sensitivity) else null,
         )
         SiteField(state.rxHeight, { state.rxHeight = it }, Res.string.site_planner_rx_height_meters)
@@ -339,12 +341,30 @@ private fun TransmitterFields(
     freqError: String?,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        SiteField(state.lat, { state.lat = it }, Res.string.latitude, error = latError)
-        SiteField(state.lon, { state.lon = it }, Res.string.longitude, error = lonError)
+        // Southern/western hemispheres and lossy antennas are negative, so these need a sign key.
+        SiteField(
+            state.lat,
+            { state.lat = it },
+            Res.string.latitude,
+            keyboardType = KeyboardType.DecimalSigned,
+            error = latError,
+        )
+        SiteField(
+            state.lon,
+            { state.lon = it },
+            Res.string.longitude,
+            keyboardType = KeyboardType.DecimalSigned,
+            error = lonError,
+        )
         SiteField(state.power, { state.power = it }, Res.string.site_planner_tx_power_watts, error = powerError)
         SiteField(state.freq, { state.freq = it }, Res.string.site_planner_frequency_mhz, error = freqError)
         SiteField(state.height, { state.height = it }, Res.string.site_planner_antenna_height_meters)
-        SiteField(state.gain, { state.gain = it }, Res.string.site_planner_antenna_gain_dbi)
+        SiteField(
+            state.gain,
+            { state.gain = it },
+            Res.string.site_planner_antenna_gain_dbi,
+            keyboardType = KeyboardType.DecimalSigned,
+        )
     }
 }
 
@@ -354,7 +374,8 @@ private fun SiteField(
     onValueChange: (String) -> Unit,
     label: StringResource,
     modifier: Modifier = Modifier,
-    keyboardType: KeyboardType = KeyboardType.Number,
+    // Every numeric field here is fractional (MHz, watts, dBi, km), so Decimal — not Number — is the floor.
+    keyboardType: KeyboardType = KeyboardType.Decimal,
     error: String? = null,
 ) {
     OutlinedTextField(

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/SitePlannerSheet.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/SitePlannerSheet.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.common.util.NumberFormatter
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.latitude
 import org.meshtastic.core.resources.longitude
@@ -131,10 +132,10 @@ private class SiteFormState(initial: SitePlannerParams) {
 
     // Validation — computed from the (observable) string fields, so callers just read the booleans.
     private val latValue
-        get() = lat.toDoubleOrNull()
+        get() = NumberFormatter.parseDecimalOrNull(lat)
 
     private val lonValue
-        get() = lon.toDoubleOrNull()
+        get() = NumberFormatter.parseDecimalOrNull(lon)
 
     val latBad
         get() = latValue.let { it == null || it !in -LAT_LIMIT..LAT_LIMIT }
@@ -143,14 +144,14 @@ private class SiteFormState(initial: SitePlannerParams) {
         get() = lonValue.let { it == null || it !in -LON_LIMIT..LON_LIMIT }
 
     val powerBad
-        get() = (power.toDoubleOrNull() ?: 0.0) <= 0.0
+        get() = (NumberFormatter.parseDecimalOrNull(power) ?: 0.0) <= 0.0
 
     val freqBad
-        get() = (freq.toDoubleOrNull() ?: 0.0) <= 0.0
+        get() = (NumberFormatter.parseDecimalOrNull(freq) ?: 0.0) <= 0.0
 
     val rxSensBad
         get() =
-            rxSensitivity.toDoubleOrNull()?.let {
+            NumberFormatter.parseDecimalOrNull(rxSensitivity)?.let {
                 it !in SitePlannerParams.MIN_RX_SENSITIVITY_DBM..SitePlannerParams.MAX_RX_SENSITIVITY_DBM
             } ?: false
 
@@ -447,16 +448,16 @@ private fun paletteStops(name: String): List<Color> {
 /** Build params from the (string) form fields, falling back to the matching [initial] value when a field is invalid. */
 private fun buildSubmitParams(state: SiteFormState, initial: SitePlannerParams): SitePlannerParams = SitePlannerParams(
     name = state.name.ifBlank { initial.name },
-    latitude = state.lat.toDoubleOrNull() ?: initial.latitude,
-    longitude = state.lon.toDoubleOrNull() ?: initial.longitude,
-    txPowerWatts = state.power.toDoubleOrNull() ?: initial.txPowerWatts,
-    txFreqMhz = state.freq.toDoubleOrNull() ?: initial.txFreqMhz,
-    txHeightMeters = state.height.toDoubleOrNull() ?: initial.txHeightMeters,
-    txGainDbi = state.gain.toDoubleOrNull() ?: initial.txGainDbi,
+    latitude = NumberFormatter.parseDecimalOrNull(state.lat) ?: initial.latitude,
+    longitude = NumberFormatter.parseDecimalOrNull(state.lon) ?: initial.longitude,
+    txPowerWatts = NumberFormatter.parseDecimalOrNull(state.power) ?: initial.txPowerWatts,
+    txFreqMhz = NumberFormatter.parseDecimalOrNull(state.freq) ?: initial.txFreqMhz,
+    txHeightMeters = NumberFormatter.parseDecimalOrNull(state.height) ?: initial.txHeightMeters,
+    txGainDbi = NumberFormatter.parseDecimalOrNull(state.gain) ?: initial.txGainDbi,
     colorScale = state.colorScale,
-    rxSensitivityDbm = state.rxSensitivity.toDoubleOrNull() ?: initial.rxSensitivityDbm,
-    rxHeightMeters = state.rxHeight.toDoubleOrNull() ?: initial.rxHeightMeters,
-    maxRangeKm = state.maxRange.toDoubleOrNull() ?: initial.maxRangeKm,
+    rxSensitivityDbm = NumberFormatter.parseDecimalOrNull(state.rxSensitivity) ?: initial.rxSensitivityDbm,
+    rxHeightMeters = NumberFormatter.parseDecimalOrNull(state.rxHeight) ?: initial.rxHeightMeters,
+    maxRangeKm = NumberFormatter.parseDecimalOrNull(state.maxRange) ?: initial.maxRangeKm,
     highResolution = state.highResolution,
     minDbm = initial.minDbm,
     maxDbm = initial.maxDbm,

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/SitePlannerSheet.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/SitePlannerSheet.kt
@@ -49,9 +49,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -172,7 +173,11 @@ fun SitePlannerSheet(
     onUseNodeLocation: (() -> Unit)? = null,
     onUseMapCenter: (() -> Unit)? = null,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        )
     val state = remember { SiteFormState(initial) }
     // Re-seed only the coordinates when a shortcut changes them; other fields keep the user's edits.
     LaunchedEffect(initial.latitude, initial.longitude) {

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
@@ -34,9 +34,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -155,7 +156,11 @@ fun MessageItem(
     var activeSheet by remember { mutableStateOf<ActiveSheet?>(null) }
     val clipboardManager = LocalClipboard.current
     val coroutineScope = rememberCoroutineScope()
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        )
     val isLocal = node.num == ourNode.num
     val timestamp = formatMessageTimestamp(message, showFullMessageTimestamp)
     val statusString = message.getStatusStringRes(isDirectMessage)

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/Reaction.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/Reaction.kt
@@ -38,10 +38,11 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -196,7 +197,11 @@ internal fun ReactionDialog(
     onResend: (Reaction) -> Unit = {},
 ) = ModalBottomSheet(
     onDismissRequest = onDismiss,
-    sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    sheetState =
+    rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+    ),
 ) {
     val groupedEmojis = reactions.groupBy { it.emoji }
     var selectedEmoji by remember { mutableStateOf<String?>(null) }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeHopHistogram.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeHopHistogram.kt
@@ -32,8 +32,9 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -84,7 +85,11 @@ fun hopHistogram(nodes: List<Node>, cutoffSecs: Int?): List<Int> {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NodeHopHistogramSheet(nodes: List<Node>, onDismiss: () -> Unit) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        )
     var window by remember { mutableStateOf(HopWindow.EIGHT_HOURS) }
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         HopHistogramContent(nodes = nodes, window = window, onSelectWindow = { window = it })

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeListHelp.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeListHelp.kt
@@ -29,8 +29,9 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -55,7 +56,11 @@ private const val ICON_SIZE = 24
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NodeListHelp(onDismiss: () -> Unit) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        )
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
             modifier =

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeDetailScreens.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeDetailScreens.kt
@@ -21,7 +21,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -212,6 +213,10 @@ private fun NodeDetailOverlays(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun NodeDetailBottomSheet(onDismiss: () -> Unit, content: @Composable () -> Unit) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    val sheetState =
+        rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.PartiallyExpanded, SheetValue.Expanded),
+        )
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) { content() }
 }

--- a/screenshot-tests/src/screenshotTest/kotlin/org/meshtastic/screenshots/core/ComponentScreenshotTests.kt
+++ b/screenshot-tests/src/screenshotTest/kotlin/org/meshtastic/screenshots/core/ComponentScreenshotTests.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import com.android.tools.screenshot.PreviewTest
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.ui.component.ChannelInfoPreview
@@ -35,7 +36,7 @@ import org.meshtastic.core.ui.component.SignalInfo
 import org.meshtastic.core.ui.component.SwitchListItemPreview
 import org.meshtastic.core.ui.component.TitledCardPreview
 import org.meshtastic.core.ui.component.preview.NodePreviewParameterProvider
-import org.meshtastic.core.ui.theme.AppTheme
+import org.meshtastic.core.ui.theme.AppThemePreviewWrapper
 
 @PreviewTest
 @PreviewLightDark
@@ -74,16 +75,18 @@ fun ScreenshotHopsInfo() {
 
 @PreviewTest
 @PreviewLightDark
+@PreviewWrapper(AppThemePreviewWrapper::class)
 @Composable
 fun ScreenshotSignalInfoSimple() {
-    AppTheme { SignalInfo(node = Node(num = 1, lastHeard = 0, channel = 0, snr = 12.5F, rssi = -42, hopsAway = 0)) }
+    SignalInfo(node = Node(num = 1, lastHeard = 0, channel = 0, snr = 12.5F, rssi = -42, hopsAway = 0))
 }
 
 @PreviewTest
 @PreviewLightDark
+@PreviewWrapper(AppThemePreviewWrapper::class)
 @Composable
 fun ScreenshotSignalInfo(@PreviewParameter(NodePreviewParameterProvider::class) node: Node) {
-    AppTheme { SignalInfo(node = node) }
+    SignalInfo(node = node)
 }
 
 @PreviewTest
@@ -102,9 +105,10 @@ fun ScreenshotLastHeardInfo() {
 
 @PreviewTest
 @PreviewLightDark
+@PreviewWrapper(AppThemePreviewWrapper::class)
 @Composable
 fun ScreenshotMaterialBatteryInfo() {
-    AppTheme { MaterialBatteryInfo(level = 85, voltage = 3.7F) }
+    MaterialBatteryInfo(level = 85, voltage = 3.7F)
 }
 
 @PreviewTest
@@ -123,7 +127,8 @@ fun ScreenshotChannelInfo() {
 
 @PreviewTest
 @PreviewLightDark
+@PreviewWrapper(AppThemePreviewWrapper::class)
 @Composable
 fun ScreenshotMaterialBluetoothSignalInfo() {
-    AppTheme { Surface { MaterialBluetoothSignalInfo(rssi = -65) } }
+    Surface { MaterialBluetoothSignalInfo(rssi = -65) }
 }

--- a/screenshot-tests/src/screenshotTest/kotlin/org/meshtastic/screenshots/feature/MessagingScreenshotTests.kt
+++ b/screenshot-tests/src/screenshotTest/kotlin/org/meshtastic/screenshots/feature/MessagingScreenshotTests.kt
@@ -19,12 +19,13 @@ package org.meshtastic.screenshots.feature
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import com.android.tools.screenshot.PreviewTest
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.error
 import org.meshtastic.core.resources.message_routing_error_max_retransmit
 import org.meshtastic.core.resources.message_routing_error_max_retransmit_detail
-import org.meshtastic.core.ui.theme.AppTheme
+import org.meshtastic.core.ui.theme.AppThemePreviewWrapper
 import org.meshtastic.feature.messaging.DeliveryInfo
 import org.meshtastic.feature.messaging.EditQuickChatDialogPreview
 import org.meshtastic.feature.messaging.MessageInputPreview
@@ -88,16 +89,15 @@ fun ScreenshotMessageItemStatusStates() {
 
 @PreviewTest
 @PreviewLightDark
+@PreviewWrapper(AppThemePreviewWrapper::class)
 @Composable
 fun ScreenshotMessageStatusFailureDetails() {
-    AppTheme {
-        DeliveryInfo(
-            title = Res.string.error,
-            text = Res.string.message_routing_error_max_retransmit,
-            detail = Res.string.message_routing_error_max_retransmit_detail,
-            resendOption = true,
-        )
-    }
+    DeliveryInfo(
+        title = Res.string.error,
+        text = Res.string.message_routing_error_max_retransmit,
+        detail = Res.string.message_routing_error_max_retransmit_detail,
+        resendOption = true,
+    )
 }
 
 @PreviewTest


### PR DESCRIPTION
The Compose stack moved to 1.12 in #6672, but nothing followed up on what the release actually offers or breaks for us. This audits the [August 2026 Compose release](https://android-developers.googleblog.com/2026/08/jetpack-compose-august-2026-release.html) against this codebase and lands what earns its place — three user-facing input bugs, one deprecation cleanup, one flake fix, and one new capability proven end-to-end.

The input bugs are the substance here. 1.12 added `NumberSigned`/`DecimalSigned` keyboard types, and looking for places to use them surfaced numeric fields that **could not accept their own valid ranges** — a device's fixed-position latitude limited to whole positive degrees, and Paxcounter RSSI thresholds (negative, firmware default −80) not enterable at all. All pre-existing, and unfixable before these constants existed.

Most of the release has no surface here, and that is part of the finding: `Modifier.onFirstVisible` (the headline deprecation), `BasicSecureTextField`'s changed obfuscation default, `DeferredTargetAnimation`, MeshGradient, P3/HDR, `LayerOutsets`, Grid named areas and Credential Manager all have **zero** usages, so they need no work. There are also no opt-ins that 1.12 made redundant.

## 🐛 Signed and fractional input in the site planner

Every numeric `SiteField` used `KeyboardType.Number`, which maps to a bare numeric `InputType` with neither the signed nor the decimal flag. Decimal degrees were untypeable, and **no valid RX sensitivity was reachable at all** — its whole range is negative (−150..−30 dBm).

The default is now `Decimal` (every field there is fractional: MHz, watts, dBi, km), with `DecimalSigned` on the fields whose validation accepts negatives: latitude, longitude, RX sensitivity, and antenna gain (negative dBi is real for a lossy antenna).

Pre-existing bug; 1.12 just supplies the constant. Note the release blog names it `SignedDecimal`, which is not the shipped name — it is `DecimalSigned`, confirmed against `KeyboardType$Companion` in `ui-text-android/1.12.0`.

## 🐛 Locale decimal separators in the site planner

Enabling a decimal key has a consequence: comma-locale keyboards offer `,` as the decimal mark, and `toDoubleOrNull` rejects it. So `48,21` read as an invalid latitude and blocked submission. Validation and `buildSubmitParams` also parsed separately — two paths free to disagree.

Adds `NumberFormatter.parseDecimalOrNull` beside the `format()` it inverts (`format` always emits `.`, and had no parse counterpart), and routes all **14** site-planner parse sites through it. A lone separator is the decimal mark; when several appear the last is decimal and the rest are stripped as grouping. Reported by CodeRabbit on this PR.

## 🐛 Signed and fractional preferences in device config

The same defect class as the site planner, in `EditTextPreference`, where three of four numeric overloads were on a keyboard that could not reach their valid ranges:

| overload | was | now | impact |
|---|---|---|---|
| `Double` | `Number` | `DecimalSigned` | Only caller is **fixed-position latitude/longitude**, validated to −90..90 / −180..180. Neither minus nor decimal point was typeable, so fixed position accepted only whole positive degrees. |
| `SignedIntegerEditTextPreference` | `Number` | `NumberSigned` | Signed by name, unsigned by keyboard. Callers are `tx_power_dbm` and the Paxcounter **wifi/ble RSSI thresholds, which are negative** (default −80) — not enterable. |
| `Float` | `Number` | `DecimalSigned` | No callers; fixed for consistency as public API. |
| `Int` | `Number` | unchanged | UInt-backed, unsigned by design. |

Both fractional overloads now parse through the shared parser and compare **parsed values** for `isError` — string comparison would flag a correctly parsed comma entry as an error, since `48,21` never equals `48.21`. Also drops a duplicated separator set in favour of `NumberFormatter.isDecimalSeparator`.

Enabling those keys then exposed the handlers' entry rules, which had been unreachable while the characters themselves were untypeable. `Float` kept only empty input, so `"-"` and `"."` were rejected before `valueState` changed and the controlled field snapped back — `-1.5` and `.5` could not be typed at all. `Double`'s `length <= 1` guard admitted those but still rejected `"-."`, so `-.5` was unreachable, and `Double` is the overload backing fixed-position lat/lon. Both now share one rule: commit whatever parses, else keep the text if it could still become a number (`NumberFormatter.isPartialDecimal`), else drop it — one rule instead of two divergent ones.

## 🧹 Off the deprecated `rememberModalBottomSheetState`

All 10 call sites across 9 files, migrated using the deprecation's own `ReplaceWith` expression rather than a guess: `skipPartiallyExpanded = true` → `setOf(Hidden, Expanded)`, and the two `false` sites (`ChirpyAssistantSheet`, `NodeDetailScreens`) → `setOf(Hidden, PartiallyExpanded, Expanded)`. Both functions return the same `SheetState`, so no call site changes behaviour and nothing downstream is affected.

The `enabledValues` parameter name was verified against the iOS `.klib` (which preserves Kotlin parameter names) before editing, not left to the compiler.

⚠️ This targets an API in `compose-multiplatform-material3 1.12.0-alpha03` — the one alpha pin in the catalog, in the sheet area the release notes flag as still subject to breaking changes. Deliberate trade-off: 10 deprecation warnings now, possible churn on the next alpha bump.

## 🛠️ Bounded `waitUntil` timeouts in the RSSI lifecycle test

Three `waitUntil` calls used the 1s default, which asserts rendering speed rather than liveness. CI runners are several times slower than local, and `waitForIdle` alone has been observed taking 6s on runs that pass. They now share a 30s `SETTLE_TIMEOUT_MS` and carry descriptions, so a timeout names which lifecycle transition failed to resume polling.

Mirrors the pattern `NodeDetailCompassLifecycleTest` already established for exactly this reason. Live flake risk, not cleanup.

## 🌟 `@PreviewWrapper` supplies `AppTheme`

New `AppThemePreviewWrapper` in `core:ui`, adopted on the five screenshot tests that wrapped `AppTheme` inline.

**Scoped deliberately to those five.** The other screenshot tests invoke app previews as plain function calls (`ScreenshotTextAlert { PreviewTextAlert() }`), and the renderer only applies the wrapper to the function it renders — so moving `AppTheme` out of a preview body would leave it **unthemed** when called that way, silently regressing goldens at the 0.0005 diff threshold. A wider sweep across the 513 `@Preview` functions has to annotate the preview and its screenshot entry point in lockstep; the mechanism is now proven, so that is a decision rather than a gamble.

## Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — green.
- Test counts read from JUnit XML rather than the build verdict, since a cached or retried task can report green without running: **6511 tests, 0 failures, 0 errors**, all result files freshly written.
- **11 new tests** in `NumberFormatterTest`: dot and comma locales, the alternate separators `٫ · 、`, both grouping conventions, whitespace grouping, garbage rejection, a round-trip of `format()`'s own output, and the transient-input forms (`"" - . , -. -1. "1 "` accepted; `abc 1a 1-2 --1` rejected). Passing on `jvmTest` and `testAndroidHostTest`.
- `:screenshot-tests:validateDebugScreenshotTest` — **298 tests, 0 failures**, and `diffPercent = 0.0` for all 18 renderings of the five converted entry points (Light + Dark + every `PreviewParameter` variant). **No reference image was rebaselined** — the wrapper produces the same pixels as the inline `AppTheme` it replaced.
- Confirmed 0 remaining `rememberModalBottomSheetState` warnings in the build log.

Two notes on what the green tick does and doesn't prove, both verified rather than assumed:

- A run of the full gate reported `BUILD SUCCESSFUL` while the XML held a real failure — `MapViewModelSitePlannerRequestTest` hit `UncaughtExceptionsBeforeTest` and the retry re-ran it green. Not reproducible: the class passes in isolation and the whole task passes under `--rerun-tasks`. It is an order-dependent leak from an earlier test in the same JVM, **unattributed** (never reproduced twice, so never bisected) and in a module this diff does not touch. Tracked separately.
- 22 screenshot renderings show a **nonzero** `diffPercent` (max `0.00046`, threshold `0.0005`). Confirmed pre-existing: stashing this work and re-running on the parent commit gives the identical 22 names and identical max. Host rendering noise against CI-generated goldens — but note the largest sits at 93% of the threshold, so those screens have almost no headroom left.

## Not in scope

Audited and left out, with reasons:

- **Keyed `SideEffect`** (~10 eligible sites): tidiness, not perf — all fire on navigation or config edits, none per-frame. The `commonMain` sites also depend on JetBrains mirroring the overload into CMP.
- **`hasPendingWork()`** for the three `advanceTimeBy`-based negative assertions in the RSSI test: real cleanup, secondary to bounding the timeouts.
- **`onRootWithViewInteraction`**: the 12 `AndroidView` map surfaces have no interaction tests today. New coverage, not a fix.
- **`SelectionState` / `selectedTexts`**: would enable reactive "copy selected message text" across the 14 `SelectionContainer` sites. A feature.
- **Baseline profile**: `androidApp/src/google/generated/baselineProfiles/**` has never been committed and the nightly job fails silently — tracked separately. Worth real cold-start latency now that 1.12 claims TTID parity with Views.

## Reviewer note on scope

The last two commits go beyond the Compose audit: fixing the locale-parsing issue CodeRabbit raised in the site planner exposed the same defect class in `core:ui`'s config preferences, which is why `EditTextPreference` and `PositionConfigScreen`'s fields are in here. `91e49c86d` is self-contained and cherry-picks out cleanly if you would rather ship the audit on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
