### PR TITLE
fix(database): prune nodes absent from radio snapshot

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
@@ -298,6 +298,13 @@ class MeshConfigFlowManagerImpl(
             nodeManager.applyTrustedIdentityMigrations(removedNums)
         }
 
+        val installedNums = entities.mapTo(mutableSetOf()) { it.num }
+        val staleNums = nodeManager.nodeDBbyNodeNum.keys.filterNot { it in installedNums }
+        staleNums.forEach(nodeManager::removeByNodenum)
+        if (staleNums.isNotEmpty()) {
+            Logger.i { "Removed ${staleNums.size} node(s) absent from the completed radio snapshot" }
+        }
+
         val published =
             runForSession(session) {
                 nodeManager.setNodeDbReady(true)

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImplTest.kt
@@ -659,6 +659,38 @@ class MeshConfigFlowManagerImplTest {
     }
 
     @Test
+    fun `Stage 2 removes cached nodes absent from the completed radio snapshot before readiness`() = testScope.runTest {
+        val currentNode = NodeInfo(num = 100)
+        val staleNum = 200
+        val current = org.meshtastic.core.testing.TestDataFactory.createTestNode(num = currentNode.num)
+        val stale = org.meshtastic.core.testing.TestDataFactory.createTestNode(num = staleNum)
+        val callOrder = mutableListOf<String>()
+        every { nodeManager.nodeDBbyNodeNum } returns mapOf(current.num to current, stale.num to stale)
+        everySuspend { nodeRepository.installConfig(any(), any()) } calls
+            {
+                callOrder.add("installConfig")
+                emptyList()
+            }
+        every { nodeManager.removeByNodenum(any()) } calls { callOrder.add("removeStale") }
+        every { nodeManager.setNodeDbReady(true) } calls { callOrder.add("nodeDbReady") }
+
+        handleMyInfo(protoMyNodeInfo)
+        advanceUntilIdle()
+        manager.handleLocalMetadata(metadata)
+        advanceUntilIdle()
+        manager.handleConfigComplete(HandshakeConstants.CONFIG_NONCE)
+        advanceTimeBy(STAGE_TRANSITION_ADVANCE_MS)
+        runCurrent()
+        manager.handleNodeInfo(currentNode)
+        manager.handleConfigComplete(HandshakeConstants.NODE_INFO_NONCE)
+        advanceUntilIdle()
+
+        assertEquals(listOf("installConfig", "removeStale", "nodeDbReady"), callOrder)
+        verify { nodeManager.removeByNodenum(staleNum) }
+        verify(mode = VerifyMode.exactly(0)) { nodeManager.removeByNodenum(current.num) }
+    }
+
+    @Test
     fun `Stage 2 complete id ignored when not in ReceivingNodeInfo state`() = testScope.runTest {
         manager.handleConfigComplete(HandshakeConstants.NODE_INFO_NONCE)
         advanceUntilIdle()

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/dao/NodeInfoDao.kt
@@ -585,8 +585,11 @@ interface NodeInfoDao {
     }
 
     /**
-     * Installs the config download from the connected device, reconciling any node-number change of the device itself
-     * (firmware 2.8 renumber, erase-and-reflash, manual re-key) before the new `my_node` row lands.
+     * Replaces the stored node snapshot with the complete config download from the connected device, reconciling any
+     * node-number change of the device itself (firmware 2.8 renumber, erase-and-reflash, manual re-key) before the new
+     * `my_node` row lands. Rows absent from the completed download are removed so an old or wiped radio NodeDB cannot
+     * leave app-only ghost nodes behind. Existing app-local fields on nodes that remain are preserved by
+     * [getVerifiedNodesForUpsert].
      *
      * @return node numbers whose rows were removed by identity migration, so callers can evict them from in-memory
      *   caches.
@@ -601,7 +604,12 @@ interface NodeInfoDao {
         }
         clearMyNodeInfo()
         setMyNodeInfo(mi)
-        putAll(getVerifiedNodesForUpsert(nodes, selfNum = mi.myNodeNum, removedNums = removedNums))
+        val verifiedNodes = getVerifiedNodesForUpsert(nodes, selfNum = mi.myNodeNum, removedNums = removedNums)
+        putAll(verifiedNodes)
+
+        val installedNums = verifiedNodes.mapTo(mutableSetOf()) { it.num }
+        val staleNums = getAllNodesSnapshot().mapNotNull { node -> node.num.takeIf { it !in installedNums } }
+        deleteNodesAndMetadata(staleNums)
         return removedNums
     }
 

--- a/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonNodeInfoDaoTest.kt
+++ b/core/database/src/commonTest/kotlin/org/meshtastic/core/database/dao/CommonNodeInfoDaoTest.kt
@@ -24,11 +24,13 @@ import org.meshtastic.core.database.entity.MyNodeEntity
 import org.meshtastic.core.database.entity.NodeEntity
 import org.meshtastic.core.database.getInMemoryDatabaseBuilder
 import org.meshtastic.core.testing.setupTestContext
+import org.meshtastic.proto.HardwareModel
 import org.meshtastic.proto.User
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 abstract class CommonNodeInfoDaoTest {
@@ -118,5 +120,24 @@ abstract class CommonNodeInfoDaoTest {
         val nodes = dao.nodeDBbyNum().first()
         assertEquals(1, nodes.size)
         assertTrue(nodes.containsKey(1))
+    }
+
+    @Test
+    fun installConfigReplacesThePreviousNodeSnapshot() = runTest {
+        createDb()
+        val retained = NodeEntity(num = 1, user = User(id = "!1"), notes = "app-local note")
+        val stale = NodeEntity(num = 2, user = User(id = "!2"), isFavorite = true)
+        dao.putAll(listOf(retained, stale))
+
+        dao.installConfig(
+            myNodeInfo,
+            listOf(
+                NodeEntity(num = 1, user = User(id = "!1", long_name = "Fresh name", hw_model = HardwareModel.TBEAM)),
+            ),
+        )
+
+        assertEquals("Fresh name", dao.getNodeByNum(1)?.node?.longName)
+        assertEquals("app-local note", dao.getNodeByNum(1)?.node?.notes)
+        assertNull(dao.getNodeByNum(2), "a node absent from the complete radio snapshot must not survive")
     }
 }


### PR DESCRIPTION
## Summary

A completed Stage 2 NodeDB download is an authoritative snapshot of the radio's current nodes, but Android retained database and in-memory entries that were absent from that snapshot. Reconnecting to a wiped or different radio could therefore leave stale app-only nodes visible.

- delete absent node rows and metadata transactionally after a complete Stage 2 snapshot
- remove absent in-memory nodes before publishing readiness
- preserve app-local fields for nodes that remain in the snapshot
- cover DAO pruning and the Stage 2 cache transition with deterministic regressions

Addresses #6263.

## Testing

- `spotlessCheck detekt assembleDebug kmpSmokeCompile :core:data:allTests :core:database:jvmTest --max-workers=4 --console=plain`
- branch-relevant DAO and flow-manager regressions passed
- the canonical all-target gate stops in unchanged Windows Android-host DataStore/database failures previously reproduced on clean official main

Packaged emulator or physical-device UI acceptance was not performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved radio configuration synchronization by removing outdated nodes that are no longer included in the latest snapshot.
  * Ensured refreshed node information is applied while retaining local notes.
  * Prevented stale node metadata from remaining after configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->