### PR TITLE
fix(test): stop leaked coroutine scopes poisoning tests

### DIFF
--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -20,6 +20,7 @@ import android.app.Application
 import android.appwidget.AppWidgetProviderInfo
 import android.content.Context
 import android.os.Build
+import androidx.annotation.VisibleForTesting
 import androidx.collection.intSetOf
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.work.Configuration
@@ -30,6 +31,7 @@ import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -68,7 +70,14 @@ open class MeshUtilApplication :
     Configuration.Provider,
     SingletonImageLoader.Factory {
 
-    protected val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    // SupervisorJob alone only isolates siblings: a failed child still reaches the global uncaught
+    // handler. These launches are best-effort background init, so report rather than escalate.
+    private val applicationScopeExceptionHandler = CoroutineExceptionHandler { context, throwable ->
+        Logger.e(throwable) { "Background application init failed in $context" }
+    }
+
+    protected val applicationScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.Default + applicationScopeExceptionHandler)
 
     /** Supplies Coil's process-wide loader without retaining an Activity in its singleton factory. */
     override fun newImageLoader(context: Context): ImageLoader = get<ImageLoader>()
@@ -144,10 +153,19 @@ open class MeshUtilApplication :
         }
     }
 
-    override fun onTerminate() {
-        // Robolectric never calls this, so unit tests booting this Application cannot rely on it.
-        // cancel() not cancelAndJoin(): joining under runBlocking on the main thread can deadlock.
+    /**
+     * Stops the background init launched by [onCreate]. Robolectric never calls [onTerminate], so a unit test that
+     * boots this Application must call this itself — otherwise those jobs outlive the test on real
+     * [Dispatchers.Default] threads and their failures surface against whichever test is running next.
+     */
+    @VisibleForTesting
+    fun cancelBackgroundInit() {
         applicationScope.cancel()
+    }
+
+    override fun onTerminate() {
+        // cancel() not cancelAndJoin(): joining under runBlocking on the main thread can deadlock.
+        cancelBackgroundInit()
         try {
             runBlocking { get<DatabaseManager>().close() }
         } finally {

--- a/androidApp/src/test/kotlin/org/meshtastic/app/CoilImageLoaderLifecycleTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/CoilImageLoaderLifecycleTest.kt
@@ -33,7 +33,12 @@ import kotlin.test.assertSame
 class CoilImageLoaderLifecycleTest {
     @After
     @OptIn(DelicateCoilApi::class)
-    fun tearDown() = SingletonImageLoader.reset()
+    fun tearDown() {
+        // Booting the real Application starts background init on Dispatchers.Default; leaving it running
+        // leaks failures into later tests in this JVM (Robolectric never calls onTerminate).
+        ApplicationProvider.getApplicationContext<MeshUtilApplication>().cancelBackgroundInit()
+        SingletonImageLoader.reset()
+    }
 
     @Test
     fun productionApplicationProvidesConfiguredKoinImageLoader() {

--- a/androidApp/src/test/kotlin/org/meshtastic/app/ShareMessageDeepLinkTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/ShareMessageDeepLinkTest.kt
@@ -18,6 +18,8 @@ package org.meshtastic.app
 
 import android.app.PendingIntent
 import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
 import org.junit.runner.RunWith
 import org.meshtastic.core.common.util.CommonUri
 import org.meshtastic.core.navigation.ContactsRoute
@@ -34,6 +36,13 @@ import kotlin.test.assertNull
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class ShareMessageDeepLinkTest {
+
+    @After
+    fun tearDown() {
+        // No `application =` override, so Robolectric boots the manifest's real MeshUtilApplication and its
+        // background init; stop it here or its failures land on whichever test runs next in this JVM.
+        ApplicationProvider.getApplicationContext<MeshUtilApplication>().cancelBackgroundInit()
+    }
 
     @Test
     fun `shared text round trips through the deep link query`() {

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/ProjectExtensions.kt
@@ -127,7 +127,9 @@ internal fun Project.configureTestOptions() {
         extensions.findByType(DevelocityTestConfiguration::class.java)?.testRetry {
             maxRetries.set(MAX_TEST_RETRIES)
             maxFailures.set(MAX_TEST_FAILURES)
-            failOnPassedAfterRetry.set(false)
+            // Retry still isolates an ordering flake to one worker, but the build must not report success:
+            // a green tick over a recorded <failure> hid a real cross-test coroutine leak for weeks.
+            failOnPassedAfterRetry.set(true)
         }
     }
 }

--- a/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
+++ b/feature/connections/src/androidHostTest/kotlin/org/meshtastic/feature/connections/AndroidScannerViewModelBondingTest.kt
@@ -90,6 +90,8 @@ class AndroidScannerViewModelBondingTest {
 
     @AfterTest
     fun tearDown() {
+        // Order matters: the ViewModel's coroutines must be gone before Main is unset.
+        harness.clearViewModel(viewModel)
         Dispatchers.resetMain()
     }
 

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelHarness.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelHarness.kt
@@ -16,6 +16,8 @@
  */
 package org.meshtastic.feature.connections
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -23,6 +25,7 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -135,6 +138,18 @@ class ScannerViewModelHarness(val testDispatcher: TestDispatcher = UnconfinedTes
         firmwareRecoveryDataSource = firmwareRecoveryDataSource,
         bleScanner = bleScanner,
     )
+
+    /**
+     * Ends [viewModel]'s lifetime. Call from `@AfterTest` **before** `Dispatchers.resetMain()`.
+     *
+     * `viewModelScope` is never cleared for a hand-built ViewModel, so without this its coroutines outlive the test.
+     * One suspended on a real-dispatcher result (compose-resources resolves on an internal `Dispatchers.Default` scope)
+     * then resumes onto a `Dispatchers.Main` that `resetMain()` has already unset, which throws. Nothing handles it, so
+     * it lands as `UncaughtExceptionsBeforeTest` on whichever test starts next.
+     */
+    fun clearViewModel(viewModel: ViewModel) {
+        viewModel.viewModelScope.cancel()
+    }
 
     companion object {
         /** A scanned-but-unbonded BLE entry — the input that routes through `requestBonding`. */

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
@@ -90,6 +90,8 @@ class ScannerViewModelTest {
 
     @AfterTest
     fun tearDown() {
+        // Order matters: the ViewModel's coroutines must be gone before Main is unset.
+        harness.clearViewModel(viewModel)
         Dispatchers.resetMain()
     }
 


### PR DESCRIPTION
A full `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` run reported **BUILD SUCCESSFUL** while the JUnit XML recorded a real failure. Develocity test retry was configured with `failOnPassedAfterRetry = false`, so an ordering flake that passed on retry was reported as success. Reproducing the underlying flake showed **5 of 10 runs failing — every one of them green**. The cause was two independent coroutine leaks that let a job outlive the test that started it and fail whichever test happened to run next.

## 🐛 Bug Fixes

- **`MeshUtilApplication`: don't escalate background-init failures to the global uncaught handler.** `onCreate` launches four best-effort init jobs on the real `Dispatchers.Default`, and Robolectric never calls `onTerminate()` to cancel them. The test body finishes in milliseconds while a background thread is still resolving the Koin graph (`DiscoveryScanEngine` → `RadioController` → `CommandSenderImpl` → `PacketHandlerImpl`) against a torn-down environment. It throws, and with no `CoroutineExceptionHandler` on the scope the failure reached the global uncaught handler and was attributed to an unrelated test. `SupervisorJob` already declares that a child's failure must not take down its siblings, so escalating to a process-level crash contradicted that intent; the handler completes it and `Logger.e` still reports the failure.
- **Stop `ScannerViewModel` tests leaking their ViewModel.** `ScannerViewModelTest` and `AndroidScannerViewModelBondingTest` hand-build a ViewModel and call `Dispatchers.resetMain()` without ever clearing it, so `viewModelScope` jobs survive every test. A job suspended on a real-dispatcher result — compose-resources resolves on an internal `Dispatchers.Default` scope — then resumes onto a `Main` that `resetMain()` has already unset, which throws and surfaces as `UncaughtExceptionsBeforeTest` on the next test. The window between `resetMain()` and the next `setMain()` is microseconds wide, which is why this flaked so rarely.

## 🛠️ Refactoring & Architecture

- Added `MeshUtilApplication.cancelBackgroundInit()` (`@VisibleForTesting`) as the single shutdown seam, called by `onTerminate()` and by the two Robolectric tests that boot the real Application (`CoilImageLoaderLifecycleTest` explicitly, `ShareMessageDeepLinkTest` implicitly via the manifest).
- Added `ScannerViewModelHarness.clearViewModel(viewModel)` so the shared harness owns the teardown and any future test built on it inherits the fix.

## 🧹 Chores

- `failOnPassedAfterRetry = true`. Retry still isolates an ordering flake to one worker, but the build no longer reports success over a recorded `<failure>`. **This will make genuinely flaky runs red rather than silently green**, which may surface other latent flakes.

## Testing Performed

Judged by counting `<failure>` elements in `build/test-results/**/TEST-*.xml`, never by the Gradle verdict — retry masking is exactly what hid the original bug.

- `:androidApp:testGoogleDebugUnitTest` x10: **5/10 failed before, 10/10 clean after.** Every pre-fix failure reported `gradleExit=0`. The failure moved between `MapViewModelSitePlannerRequestTest` and `NavigationAssemblyTest` across runs — the signature of a cross-class leak landing on an innocent test.
- `ScannerViewModelTest` / `AndroidScannerViewModelBondingTest`: verified with a temporary probe that armed a `viewModelScope.launch { awaitCancellation() }` in `@BeforeTest` and asserted in a later test that the *previous* test's job was cancelled. Failed before the fix (`StandaloneCoroutine{Active}`), passed after. Probe removed before commit; no new test cases added.
- `spotlessCheck detekt assembleGoogleDebug test allTests`: green, with **zero** `<failure>`/`<error>` elements across all 685 result XMLs. `MapViewModelSitePlannerRequestTest` is back to `tests="3"` (the `tests="4"` retry entry is gone).

Note: the pre-existing `warmScanFailureStrings()` helper is retained — it fixes the *timing* race those tests need for virtual-time cooldown assertions, but it is opt-in per test and never addressed the leak.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling and logging of background initialization failures.
  - Reduced the risk of asynchronous background work affecting app shutdown and test environments.

- **Tests**
  - Improved cleanup of image loading, deep-link, and connection-related test scenarios.
  - Ensured ViewModel activity is stopped cleanly before test environments are reset.
  - Test retries now correctly flag cases that only pass after retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->