### PR TITLE
refactor(compose): adopt keyed SideEffect and drop redundant config write-back effects

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapViewProvider.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapViewProvider.kt
@@ -17,7 +17,7 @@
 package org.meshtastic.app.map
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.Single
@@ -34,8 +34,8 @@ class FdroidMapViewProvider : MapViewProvider {
         sitePlannerNodeNum: Int?,
     ) {
         val mapViewModel: MapViewModel = koinViewModel()
-        LaunchedEffect(waypointId) { mapViewModel.setWaypointId(waypointId) }
-        LaunchedEffect(sitePlannerNodeNum) { mapViewModel.setSitePlannerNodeNum(sitePlannerNodeNum) }
+        SideEffect(waypointId) { mapViewModel.setWaypointId(waypointId) }
+        SideEffect(sitePlannerNodeNum) { mapViewModel.setSitePlannerNodeNum(sitePlannerNodeNum) }
         org.meshtastic.app.map.MapView(
             modifier = modifier,
             mapViewModel = mapViewModel,

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/GoogleMapViewProvider.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/GoogleMapViewProvider.kt
@@ -17,7 +17,7 @@
 package org.meshtastic.app.map
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.Single
@@ -34,8 +34,8 @@ class GoogleMapViewProvider : MapViewProvider {
         sitePlannerNodeNum: Int?,
     ) {
         val mapViewModel: MapViewModel = koinViewModel()
-        LaunchedEffect(waypointId) { mapViewModel.setWaypointId(waypointId) }
-        LaunchedEffect(sitePlannerNodeNum) { mapViewModel.setSitePlannerNodeNum(sitePlannerNodeNum) }
+        SideEffect(waypointId) { mapViewModel.setWaypointId(waypointId) }
+        SideEffect(sitePlannerNodeNum) { mapViewModel.setSitePlannerNodeNum(sitePlannerNodeNum) }
         org.meshtastic.app.map.MapView(
             modifier = modifier,
             mapViewModel = mapViewModel,

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -192,7 +193,7 @@ fun MessageScreen(
     }
 
     // Prevent the message TextField from stealing focus when the screen opens
-    LaunchedEffect(contactKey) { focusManager.clearFocus() }
+    SideEffect(contactKey) { focusManager.clearFocus() }
 
     // Derived state, memoized for performance
     val channelInfo =

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeDetailScreens.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/detail/NodeDetailScreens.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,7 +68,7 @@ fun NodeDetailScreen(
     onNavigateUp: () -> Unit = {},
     compassViewModel: CompassViewModel? = null,
 ) {
-    LaunchedEffect(nodeId) { viewModel.start(nodeId) }
+    SideEffect(nodeId) { viewModel.start(nodeId) }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     LaunchedEffect(viewModel) { viewModel.navigationEvents.collect { onNavigate(it) } }
     NodeDetailScaffold(

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/debugging/Debug.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -115,7 +116,7 @@ fun DebugScreen(onNavigateUp: () -> Unit, viewModel: DebugViewModel) {
         }
     val filteredLogs = filteredLogsState
 
-    LaunchedEffect(filteredLogs) { viewModel.updateFilteredLogs(filteredLogs) }
+    SideEffect(filteredLogs) { viewModel.updateFilteredLogs(filteredLogs) }
 
     val shouldAutoScroll by remember { derivedStateOf { listState.firstVisibleItemIndex < 3 } }
     if (shouldAutoScroll) {

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/CleanNodeDatabaseScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/CleanNodeDatabaseScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -60,7 +60,7 @@ fun CleanNodeDatabaseScreen(viewModel: CleanNodeDatabaseViewModel, onBack: () ->
     val onlyUnknownNodes by viewModel.onlyUnknownNodes.collectAsStateWithLifecycle()
     val nodesToDelete by viewModel.nodesToDelete.collectAsStateWithLifecycle()
 
-    LaunchedEffect(olderThanDays, onlyUnknownNodes) { viewModel.getNodesToDelete() }
+    SideEffect(olderThanDays, onlyUnknownNodes) { viewModel.getNodesToDelete() }
 
     Scaffold(
         topBar = {

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MapReportingPreference.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MapReportingPreference.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -71,8 +70,9 @@ fun MapReportingPreference(
     enabled: Boolean,
 ) {
     Column {
-        var showMapReportingWarning by rememberSaveable { mutableStateOf(mapReportingEnabled) }
-        LaunchedEffect(mapReportingEnabled) { showMapReportingWarning = mapReportingEnabled }
+        // Tracks the switch locally so the consent card can show before the config round-trips; re-keyed on
+        // [mapReportingEnabled] so an externally-changed config wins over a stale local toggle.
+        var showMapReportingWarning by rememberSaveable(mapReportingEnabled) { mutableStateOf(mapReportingEnabled) }
         SwitchPreference(
             title = stringResource(Res.string.map_reporting),
             summary = stringResource(Res.string.map_reporting_summary),

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/StatusMessageConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/StatusMessageConfigItemList.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalFocusManager
@@ -60,8 +59,6 @@ fun StatusMessageConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Uni
 
     val formState = rememberConfigState(initialValue = statusMessageConfig)
     val focusManager = LocalFocusManager.current
-
-    LaunchedEffect(statusMessageConfig) { formState.value = statusMessageConfig }
 
     RadioConfigScreenList(
         rebootBehavior = RebootBehavior.NEVER,

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TAKConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TAKConfigItemList.kt
@@ -38,7 +38,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -114,8 +113,6 @@ fun TAKConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
     val state by viewModel.radioConfigState.collectAsStateWithLifecycle()
     val takConfig = state.moduleConfig.tak ?: ModuleConfig.TAKConfig()
     val formState = rememberConfigState(initialValue = takConfig)
-
-    LaunchedEffect(takConfig) { formState.value = takConfig }
 
     val effectiveResponseState =
         when (state.responseState) {


### PR DESCRIPTION
## Why

Compose 1.12 added `SideEffect` overloads that take 1, 2, 3, or `vararg` keys. Disassembling the 1-key overload shows it is simply:

```
Composer.changed(key) -> ifeq -> recordSideEffectWithTracing(composer, block)
```

So it runs the block at the apply/commit phase, once per key change, with no cancellation and no cleanup. That is exactly the contract our `LaunchedEffect(key) { nonSuspendingBody }` sites were already relying on — they just paid for a coroutine launch they never used to suspend, cancel, or clean up.

**This is tidiness, not a performance fix.** The "up to 90% faster than `LaunchedEffect`" figure floating around is per-effect overhead; every site here fires on navigation or a config edit, never per frame. What it buys is that the code now says what it means: no coroutine implies no cancellation semantics to reason about.

Auditing the candidates turned up something more interesting than the conversion itself — see 🐛 below.

## 🧹 Adopt the keyed `SideEffect` overload (8 sites)

Converted only where the body is non-suspending and needs no cancellation on key change:

| File | Sites |
|---|---|
| `GoogleMapViewProvider.kt` / `FdroidMapViewProvider.kt` | 2 each — `setWaypointId`, `setSitePlannerNodeNum` |
| `NodeDetailScreens.kt` | `viewModel.start(nodeId)` |
| `Debug.kt` | `viewModel.updateFilteredLogs(...)` |
| `CleanNodeDatabaseScreen.kt` | `viewModel.getNodesToDelete()` (2-key overload) |
| `Message.kt` | `focusManager.clearFocus()` |

Deliberately **not** converted: the 16 keyless (`Unit`/`true`) effects, the 32 with suspending bodies, and — worth flagging for reviewers, since a naive regex sweep flags them as one-liners — the nine vico chart effects (`DeviceMetrics`, `SignalMetrics`, `EnvironmentCharts`, `PowerMetrics`, `AirQualityMetrics`, `PaxMetrics`, `HostMetricsChart`, `TracerouteChart`), which call the **suspending** `modelProducer.runTransaction { }`.

## 🛠️ Three sites wanted no effect at all

`rememberConfigState` already re-keys on its argument, and its own KDoc says so:

```kotlin
// ConfigState.kt:62 — "When the initialValue changes, the config state will be reset."
rememberSaveable(initialValue, saver = ConfigState.saver(initialValue)) { ConfigState(initialValue) }
```

So the `LaunchedEffect(config) { formState.value = config }` write-backs on the Status Message and TAK screens were pure redundancy — the effect could never fire without the `remember` having already re-keyed, since both compare by equality. The other 24 `rememberConfigState` call sites have no such effect; these two were the outliers. Both deleted.

`MapReportingPreference` was the one where the effect was load-bearing, because its `rememberSaveable` had no input key. It now carries the key instead:

```kotlin
var showMapReportingWarning by rememberSaveable(mapReportingEnabled) { mutableStateOf(mapReportingEnabled) }
```

A local toggle still survives recomposition (key unchanged), and an externally-changed config still wins (key changed) — but now during composition rather than a frame later, so there is no one-frame stale value and no extra recomposition pass.

## 🐛 Closes a latent restore bug

A keyed effect **always fires on first composition** — `Composer.changed` compares a fresh slot against the `Empty` sentinel — and that includes the composition rebuilt after process death.

On the Status Message and TAK screens that meant: `rememberSaveable` restores the user's in-progress edit through `ConfigState.saver`, then the effect immediately overwrites it with the pristine config from the ViewModel. The custom `Saver` exists precisely to preserve that edit, and the effect was defeating it. `MapReportingPreference` had the same shape.

**Confidence:** reasoned from the code, not empirically confirmed — I did not kill and restore the app on a device. The conversion in this PR is safe either way; this is a claim about what the deletion additionally fixes.

## Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — all pass.
- Counted `<failure>` across every `**/build/test-results/**/TEST-*.xml` rather than trusting the build verdict (test retry can mask a real failure in this repo): **0**.
- Existing coverage over the touched screens passes: `MapReportingPreferenceTest` (2), `TAKConfigPermissionDeniedTest` (3), `SecurityConfigScreenTest` (4), `LoRaBandwidthUiTest`, `LoRaBandwidthPolicyTest` (11), and the `RadioConfigViewModelTest` suite.
- Confirmed the keyed overloads are reachable from `commonMain`: `org.jetbrains.compose.runtime:runtime:1.12.0-rc01` is a facade whose own klib holds only an empty `root_package`; its pom depends on `androidx.compose.runtime:runtime:1.12.0-rc01`, where the overloads live in `commonMain/androidx/compose/runtime/Effects.kt`. Verified in the sources jar, then confirmed by compilation.

Not verified: process-death restore on a device (see 🐛).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization of map markers, node details, message focus, filtered logs, and database preview updates.
  - Updated map reporting settings to refresh local state when the external setting changes.
  - Prevented status message and TAK configuration forms from resetting unexpectedly when related settings update.
  - Improved consistency when switching contacts, nodes, or configuration views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->