### PR TITLE
chore(build): bump flatpak-sources plugin to 0.1.7, drop Isolated Projects workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,7 +459,7 @@ jobs:
       # are runtime-only and would be missed by :assemble).
       - name: Generate Flatpak Sources
         run: >
-          ./gradlew --no-build-cache -Dorg.gradle.isolated-projects=false --no-configuration-cache -Pmeshtastic.flatpakSources=true
+          ./gradlew --no-build-cache
           -Dgradle.user.home=${{ runner.temp }}/flatpak-gradle-home
           :desktopApp:packageUberJarForCurrentOS :captureFlatpakSources
 

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -580,7 +580,7 @@ jobs:
       # runtime classpath. :assemble alone would miss runtime-only deps (skiko, ktor-cio, …).
       - name: Generate Flatpak Sources
         run: >
-          ./gradlew --no-build-cache -Dorg.gradle.isolated-projects=false --no-configuration-cache -Pmeshtastic.flatpakSources=true
+          ./gradlew --no-build-cache
           -Dgradle.user.home=${{ runner.temp }}/flatpak-gradle-home
           :desktopApp:packageUberJarForCurrentOS :captureFlatpakSources
 

--- a/.github/workflows/verify-flatpak.yml
+++ b/.github/workflows/verify-flatpak.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Generate flatpak-sources.json
         run: |
-          ./gradlew --no-build-cache -Dorg.gradle.isolated-projects=false --no-configuration-cache -Pmeshtastic.flatpakSources=true \
+          ./gradlew --no-build-cache \
             -Dgradle.user.home="$RUNNER_TEMP/flatpak-gradle-home" \
             :desktopApp:packageUberJarForCurrentOS :captureFlatpakSources
           cp build/flatpak-sources.json flatpak-sources.json

--- a/scripts/verify-flatpak/verify.sh
+++ b/scripts/verify-flatpak/verify.sh
@@ -79,7 +79,7 @@ if [[ $SKIP_REGEN -eq 0 ]]; then
     rm -rf "$GRADLE_HOME_ISOLATED"
     # The settings plugin (org.meshtastic.flatpak.sources.settings) captures URLs from
     # build start — no init script or -I flag needed.
-    (cd "$REPO_ROOT" && ./gradlew --no-build-cache -Dorg.gradle.isolated-projects=false --no-configuration-cache -Pmeshtastic.flatpakSources=true \
+    (cd "$REPO_ROOT" && ./gradlew --no-build-cache \
         -Dgradle.user.home="$GRADLE_HOME_ISOLATED" \
         :desktopApp:packageUberJarForCurrentOS :captureFlatpakSources)
     cp "$REPO_ROOT/build/flatpak-ops-sources.json" "$SOURCES_JSON"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,16 +36,9 @@ plugins {
     // Develocity + CCUD + build cache; shared with build-logic, versions from the catalog.
     id("meshtastic.develocity")
     id("org.gradle.toolchains.foojay-resolver") version "1.0.0"
-    // Applied on demand only — see below.
-    id("org.meshtastic.flatpak.sources.settings") version "0.1.5" apply false
-}
-
-// The flatpak-sources plugin reads Gradle.extensions, which Isolated Projects forbids; Gradle 9.7
-// enforces that and fails every task in the build. Only :captureFlatpakSources needs the plugin, and
-// its callers already pass -Dorg.gradle.isolated-projects=false, so gate it on an opt-in property. Remove the gate
-// once org.meshtastic.flatpak.sources.settings > 0.1.5 ships an Isolated-Projects-safe release.
-if (providers.gradleProperty("meshtastic.flatpakSources").isPresent) {
-    pluginManager.apply("org.meshtastic.flatpak.sources.settings")
+    // 0.1.7 fixed the Isolated Projects incompatibility (shares state via a BuildService instead of
+    // gradle.extensions) that previously required gating this behind an opt-in property.
+    id("org.meshtastic.flatpak.sources.settings") version "0.1.7"
 }
 
 @Suppress("UnstableApiUsage")


### PR DESCRIPTION
## Why

`org.meshtastic.flatpak.sources.settings` was pinned at 0.1.5 because it read
`Gradle.extensions` in a way Isolated Projects forbids — this repo runs with
Isolated Projects on by default (`org.gradle.isolated-projects=true`), so
every flatpak-sources generation call had to disable IP + config cache, and
the plugin itself was gated behind an opt-in property in
`settings.gradle.kts`. Upstream 0.1.7
([meshtastic/gradle-flatpak-sources#36](https://github.com/meshtastic/gradle-flatpak-sources/pull/36))
fixes the incompatibility by sharing state via a `BuildService` instead.

## Changes

- 🛠️ **Refactoring & Architecture**
  - Bump `org.meshtastic.flatpak.sources.settings` 0.1.5 → 0.1.7 and apply it
    unconditionally again (removed the `apply false` + opt-in-property gate).
  - Drop `-Dorg.gradle.isolated-projects=false --no-configuration-cache
    -Pmeshtastic.flatpakSources=true` from the four call sites that carried
    it: `verify-flatpak.yml`, `release.yml`, `reusable-check.yml`,
    `verify.sh`.

## Testing Performed

Verified end-to-end, not just compiled: ran the real
`:desktopApp:packageUberJarForCurrentOS :captureFlatpakSources` pipeline
with Isolated Projects left **on** (this repo's default) and none of the
removed workaround flags — 189 tasks, zero IP/config-cache violations,
`flatpak-sources.json` emitted with 2808 captured URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Verification**
  * Updated Flatpak source generation and verification workflows to use the current Gradle configuration.
  * Improved consistency across release, reusable-check, and Flatpak verification processes.
* **Maintenance**
  * Upgraded Flatpak source tooling to the latest supported version.
  * Simplified Flatpak source configuration and removed obsolete compatibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->