### PR TITLE
fix(connections): hide the replay demo entry when its capture asset is absent

### DIFF
--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/AndroidRadioTransportFactory.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/AndroidRadioTransportFactory.kt
@@ -55,6 +55,14 @@ class AndroidRadioTransportFactory(
     override fun isMockTransport(): Boolean =
         buildConfigProvider.isDebug || Settings.System.getString(context.contentResolver, "firebase.test.lab") == "true"
 
+    /**
+     * Probed once: the asset is baked into the APK, so its presence cannot change while the process lives. Empty counts
+     * as absent to match [createReplayTransport]'s own guard.
+     */
+    override val isReplayTransportAvailable: Boolean by lazy {
+        runCatching { context.assets.open(REPLAY_ASSET_NAME).use { it.read() != -1 } }.getOrDefault(false)
+    }
+
     override fun isPlatformAddressValid(address: String): Boolean {
         val interfaceId = address.firstOrNull()?.let { InterfaceId.forIdChar(it) } ?: return false
         val rest = address.substring(1)

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioInterfaceService.kt
@@ -126,6 +126,12 @@ interface RadioInterfaceService :
     fun isMockTransport(): Boolean
 
     /**
+     * Whether this build carries the packet capture the replay transport needs. False means selecting a replay address
+     * would fall back to the plain mock, so callers offering a replay device must hide it.
+     */
+    val isReplayTransportAvailable: Boolean
+
+    /**
      * Flow of raw data received from the radio, bound to the transport session that admitted each frame.
      *
      * Emissions preserve the order in which bytes arrived from the hardware — this is required because the firmware

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioTransportFactory.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/RadioTransportFactory.kt
@@ -31,6 +31,12 @@ interface RadioTransportFactory {
     /** Whether we are currently forced into using a mock transport (e.g., Firebase Test Lab). */
     fun isMockTransport(): Boolean
 
+    /**
+     * Whether this build can actually replay a packet capture rather than silently degrading to the plain mock. The
+     * capture is a locally generated artifact that is not checked in, so most builds ship without it.
+     */
+    val isReplayTransportAvailable: Boolean
+
     /** Creates a transport for the given [address], or a NOP implementation if invalid/unsupported. */
     fun createTransport(address: String, service: RadioInterfaceService): RadioTransport
 

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/SharedRadioInterfaceService.kt
@@ -726,6 +726,9 @@ class SharedRadioInterfaceService(
 
     override fun isMockTransport(): Boolean = transportFactory.isMockTransport()
 
+    override val isReplayTransportAvailable: Boolean
+        get() = transportFactory.isReplayTransportAvailable
+
     override fun toInterfaceAddress(interfaceId: InterfaceId, rest: String): String =
         transportFactory.toInterfaceAddress(interfaceId, rest)
 

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeRadioInterfaceService.kt
@@ -152,6 +152,9 @@ class FakeRadioInterfaceService(override val serviceScope: CoroutineScope = Main
 
     override fun isMockTransport(): Boolean = true
 
+    /** No capture asset in tests; flip per-test when exercising replay-gated behaviour. */
+    override var isReplayTransportAvailable: Boolean = false
+
     override fun sendToRadio(bytes: ByteArray) {
         sentToRadio.add(bytes)
     }

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/radio/DesktopRadioTransportFactory.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/radio/DesktopRadioTransportFactory.kt
@@ -47,6 +47,9 @@ class DesktopRadioTransportFactory(
 
     override fun isMockTransport(): Boolean = false
 
+    /** Desktop bundles no capture asset, and [createPlatformTransport] does not wire a replay address. */
+    override val isReplayTransportAvailable: Boolean = false
+
     override fun createPlatformTransport(address: String, service: RadioInterfaceService): RadioTransport = when {
         address.startsWith(InterfaceId.TCP.id) -> {
             TcpRadioTransport(

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/stub/NoopStubs.kt
@@ -86,6 +86,8 @@ class NoopRadioInterfaceService : RadioInterfaceService {
 
     override fun isMockTransport(): Boolean = false
 
+    override val isReplayTransportAvailable: Boolean = false
+
     override val receivedData = MutableSharedFlow<ReceivedRadioFrame>()
     override val meshActivity: Flow<MeshActivity> = MutableSharedFlow<MeshActivity>()
     override val connectionError: Flow<String> = MutableSharedFlow<String>()

--- a/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
+++ b/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
@@ -32,8 +32,6 @@ import org.meshtastic.core.network.repository.UsbRepository
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.resources.Res
-import org.meshtastic.core.resources.demo_mode
-import org.meshtastic.core.resources.demo_mode_replay
 import org.meshtastic.core.resources.meshtastic
 import org.meshtastic.feature.connections.model.AndroidUsbDeviceData
 import org.meshtastic.feature.connections.model.DeviceListEntry
@@ -162,18 +160,7 @@ class AndroidGetDiscoveredDevicesUseCase(
         showMock: Boolean,
         showReplay: Boolean,
         db: Map<Int, Node>,
-    ): List<DeviceListEntry> = (
-        usbDevices +
-            if (showMock) {
-                buildList<DeviceListEntry> {
-                    add(DeviceListEntry.Mock(getString(Res.string.demo_mode)))
-                    if (showReplay) add(DeviceListEntry.Replay(getString(Res.string.demo_mode_replay)))
-                }
-            } else {
-                emptyList()
-            }
-        )
-        .map { entry ->
-            entry.copy(node = findNodeByNameSuffix(entry.name, entry.fullAddress, db, databaseManager))
-        }
+    ): List<DeviceListEntry> = (usbDevices + virtualDeviceEntries(showMock, showReplay)).map { entry ->
+        entry.copy(node = findNodeByNameSuffix(entry.name, entry.fullAddress, db, databaseManager))
+    }
 }

--- a/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
+++ b/feature/connections/src/androidMain/kotlin/org/meshtastic/feature/connections/domain/usecase/AndroidGetDiscoveredDevicesUseCase.kt
@@ -56,7 +56,11 @@ class AndroidGetDiscoveredDevicesUseCase(
     private val macSuffixLength = 8
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
-    override fun invoke(showMock: Boolean, resolvedList: Flow<List<DiscoveredService>>): Flow<DiscoveredDevices> {
+    override fun invoke(
+        showMock: Boolean,
+        showReplay: Boolean,
+        resolvedList: Flow<List<DiscoveredService>>,
+    ): Flow<DiscoveredDevices> {
         val nodeDb = nodeRepository.nodeDBbyNum
 
         // Filter out non-Meshtastic peripherals (headphones, cars, watches, etc.).
@@ -119,7 +123,7 @@ class AndroidGetDiscoveredDevicesUseCase(
             val recentList = args[5] as List<RecentAddress>
 
             val bleForUi = matchBleNodes(bondedBle, db)
-            val usbForUi = matchUsbNodes(usbDevices, showMock, db)
+            val usbForUi = matchUsbNodes(usbDevices, showMock, showReplay, db)
 
             val discoveredTcpForUi = matchDiscoveredTcpNodes(processedTcp, db, resolved, databaseManager)
             val discoveredTcpAddresses = processedTcp.map { it.fullAddress }.toSet()
@@ -156,14 +160,15 @@ class AndroidGetDiscoveredDevicesUseCase(
     private suspend fun matchUsbNodes(
         usbDevices: List<DeviceListEntry.Usb>,
         showMock: Boolean,
+        showReplay: Boolean,
         db: Map<Int, Node>,
     ): List<DeviceListEntry> = (
         usbDevices +
             if (showMock) {
-                listOf(
-                    DeviceListEntry.Mock(getString(Res.string.demo_mode)),
-                    DeviceListEntry.Replay(getString(Res.string.demo_mode_replay)),
-                )
+                buildList<DeviceListEntry> {
+                    add(DeviceListEntry.Mock(getString(Res.string.demo_mode)))
+                    if (showReplay) add(DeviceListEntry.Replay(getString(Res.string.demo_mode_replay)))
+                }
             } else {
                 emptyList()
             }

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ScannerViewModel.kt
@@ -155,6 +155,15 @@ open class ScannerViewModel(
     /** Whether the mock/demo transport is currently selected. */
     val showMockTransport: StateFlow<Boolean> = _showMockTransport.asStateFlow()
 
+    private val _showReplayTransport = MutableStateFlow(false)
+
+    /**
+     * Whether the replay demo entry should be offered alongside [showMockTransport]. The capture asset is a locally
+     * generated artifact that no clean-checkout build carries, and without it replay silently degrades to the plain
+     * mock — so the entry stays hidden rather than advertising behaviour it cannot deliver.
+     */
+    val showReplayTransport: StateFlow<Boolean> = _showReplayTransport.asStateFlow()
+
     // ── Connection-progress chatter (surfaced as the bottom status pill) ──────────────────────
     private val _connectionProgressText = MutableStateFlow<String?>(null)
 
@@ -209,12 +218,15 @@ open class ScannerViewModel(
         }
 
     private val discoveredDevicesFlow: StateFlow<DiscoveredDevices> =
-        showMockTransport
-            .flatMapLatest { showMock -> getDiscoveredDevicesUseCase.invoke(showMock, gatedResolvedList) }
+        combine(showMockTransport, showReplayTransport, ::Pair)
+            .flatMapLatest { (showMock, showReplay) ->
+                getDiscoveredDevicesUseCase.invoke(showMock, showReplay, gatedResolvedList)
+            }
             .stateInWhileSubscribed(initialValue = DiscoveredDevices())
 
     init {
         _showMockTransport.value = radioInterfaceService.isMockTransport()
+        _showReplayTransport.value = radioInterfaceService.isReplayTransportAvailable
         serviceRepository.connectionProgress.onEach { _connectionProgressText.value = it }.launchIn(viewModelScope)
         serviceRepository.connectionState
             .onEach { state ->

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCase.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCase.kt
@@ -48,7 +48,11 @@ open class CommonGetDiscoveredDevicesUseCase(
     private val usbScanner: UsbScanner? = null,
 ) : GetDiscoveredDevicesUseCase {
 
-    override fun invoke(showMock: Boolean, resolvedList: Flow<List<DiscoveredService>>): Flow<DiscoveredDevices> {
+    override fun invoke(
+        showMock: Boolean,
+        showReplay: Boolean,
+        resolvedList: Flow<List<DiscoveredService>>,
+    ): Flow<DiscoveredDevices> {
         val nodeDb = nodeRepository.nodeDBbyNum
         val usbFlow = usbScanner?.scanUsbDevices() ?: flowOf(emptyList())
 
@@ -69,10 +73,12 @@ open class CommonGetDiscoveredDevicesUseCase(
                 if (showMock) {
                     val label = safeCatchingAll { getStringSuspend(Res.string.demo_mode) }.getOrDefault("Demo Mode")
                     add(DeviceListEntry.Mock(label))
-                    val replayLabel =
-                        safeCatchingAll { getStringSuspend(Res.string.demo_mode_replay) }
-                            .getOrDefault("Demo Mode (Replay)")
-                    add(DeviceListEntry.Replay(replayLabel))
+                    if (showReplay) {
+                        val replayLabel =
+                            safeCatchingAll { getStringSuspend(Res.string.demo_mode_replay) }
+                                .getOrDefault("Demo Mode (Replay)")
+                        add(DeviceListEntry.Replay(replayLabel))
+                    }
                 }
             }
 

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCase.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCase.kt
@@ -25,11 +25,8 @@ import org.meshtastic.core.datastore.RecentAddressesDataSource
 import org.meshtastic.core.network.repository.DiscoveredService
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.resources.Res
-import org.meshtastic.core.resources.demo_mode
-import org.meshtastic.core.resources.demo_mode_replay
 import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.core.resources.meshtastic
-import org.meshtastic.feature.connections.model.DeviceListEntry
 import org.meshtastic.feature.connections.model.DiscoveredDevices
 import org.meshtastic.feature.connections.model.GetDiscoveredDevicesUseCase
 
@@ -69,18 +66,7 @@ open class CommonGetDiscoveredDevicesUseCase(
             val discoveredTcpForUi = matchDiscoveredTcpNodes(processedTcp, db, resolved, databaseManager)
             val recentTcpForUi = buildRecentTcpEntries(recentList, discoveredTcpAddresses, db, databaseManager)
 
-            val mockEntries = buildList {
-                if (showMock) {
-                    val label = safeCatchingAll { getStringSuspend(Res.string.demo_mode) }.getOrDefault("Demo Mode")
-                    add(DeviceListEntry.Mock(label))
-                    if (showReplay) {
-                        val replayLabel =
-                            safeCatchingAll { getStringSuspend(Res.string.demo_mode_replay) }
-                                .getOrDefault("Demo Mode (Replay)")
-                        add(DeviceListEntry.Replay(replayLabel))
-                    }
-                }
-            }
+            val mockEntries = virtualDeviceEntries(showMock, showReplay)
 
             DiscoveredDevices(
                 discoveredTcpDevices = discoveredTcpForUi,

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/TcpDiscoveryHelpers.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/domain/usecase/TcpDiscoveryHelpers.kt
@@ -17,10 +17,15 @@
 package org.meshtastic.feature.connections.domain.usecase
 
 import org.meshtastic.core.common.database.DatabaseManager
+import org.meshtastic.core.common.util.safeCatchingAll
 import org.meshtastic.core.datastore.model.RecentAddress
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.network.repository.DiscoveredService
 import org.meshtastic.core.network.repository.NetworkRepository.Companion.toAddressString
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.demo_mode
+import org.meshtastic.core.resources.demo_mode_replay
+import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.feature.connections.model.DeviceListEntry
 
 private const val SUFFIX_LENGTH = 4
@@ -115,4 +120,27 @@ internal fun findNodeByNameSuffix(
     } else {
         nodeDb.values.find { it.user.id.lowercase().endsWith(suffix) }
     }
+}
+
+/**
+ * The virtual devices offered behind the Demo Mode gate, shared so the common and Android discovery paths cannot
+ * diverge on visibility policy.
+ *
+ * [showReplay] is nested inside [showMock]: replay is an extra entry *within* Demo Mode, never a device on its own. It
+ * additionally requires the build to carry the capture asset (`RadioTransportFactory.isReplayTransportAvailable`) —
+ * without it the replay transport falls back to the plain mock, so the entry would advertise something it cannot do.
+ */
+internal suspend fun virtualDeviceEntries(showMock: Boolean, showReplay: Boolean): List<DeviceListEntry> {
+    if (!showMock) return emptyList()
+    val mock =
+        DeviceListEntry.Mock(safeCatchingAll { getStringSuspend(Res.string.demo_mode) }.getOrDefault("Demo Mode"))
+    val replay =
+        if (showReplay) {
+            val label =
+                safeCatchingAll { getStringSuspend(Res.string.demo_mode_replay) }.getOrDefault("Demo Mode (Replay)")
+            DeviceListEntry.Replay(label)
+        } else {
+            null
+        }
+    return listOfNotNull(mock, replay)
 }

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/model/DiscoveredDevices.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/model/DiscoveredDevices.kt
@@ -30,9 +30,16 @@ interface GetDiscoveredDevicesUseCase {
     /**
      * Returns a flow of all discovered devices (BLE, USB, TCP).
      *
+     * @param showMock whether the Demo Mode gate is open at all.
+     * @param showReplay whether the replay capture asset ships in this build. Nested inside [showMock] — a replay
+     *   device is never offered on its own, and without the asset the entry would just duplicate Demo Mode.
      * @param resolvedList the NSD/mDNS resolved services flow. On Android 15+, subscribing to
      *   `NetworkRepository.resolvedList` triggers a system consent dialog, so callers should pass `flowOf(emptyList())`
      *   unless the user has explicitly requested a network scan.
      */
-    fun invoke(showMock: Boolean, resolvedList: Flow<List<DiscoveredService>>): Flow<DiscoveredDevices>
+    fun invoke(
+        showMock: Boolean,
+        showReplay: Boolean,
+        resolvedList: Flow<List<DiscoveredService>>,
+    ): Flow<DiscoveredDevices>
 }

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelHarness.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelHarness.kt
@@ -92,8 +92,15 @@ class ScannerViewModelHarness(val testDispatcher: TestDispatcher = UnconfinedTes
     val dispatchers = CoroutineDispatchers(io = testDispatcher, main = testDispatcher, default = testDispatcher)
 
     /**
+     * The `(showMock, showReplay)` pairs the ViewModel has asked for, in call order. Without this the fake would return
+     * the same devices for every visibility combination, so a test could pass while the ViewModel requested the wrong
+     * one — assert against this to prove the production path actually forwarded the intended flags.
+     */
+    val discoveryRequests = mutableListOf<Pair<Boolean, Boolean>>()
+
+    /**
      * A fake [GetDiscoveredDevicesUseCase] that mirrors the real behavior: it combines [baseDevicesFlow] with the
-     * provided resolved list so tests can verify NSD gating.
+     * provided resolved list so tests can verify NSD gating, and records each request in [discoveryRequests].
      */
     val getDiscoveredDevicesUseCase =
         object : GetDiscoveredDevicesUseCase {
@@ -101,10 +108,13 @@ class ScannerViewModelHarness(val testDispatcher: TestDispatcher = UnconfinedTes
                 showMock: Boolean,
                 showReplay: Boolean,
                 resolvedList: Flow<List<DiscoveredService>>,
-            ): Flow<DiscoveredDevices> = combine(baseDevicesFlow, resolvedList) { base, resolved ->
-                val tcpDevices =
-                    resolved.map { DeviceListEntry.Tcp(name = it.name, fullAddress = "t${it.hostAddress}") }
-                base.copy(discoveredTcpDevices = tcpDevices)
+            ): Flow<DiscoveredDevices> {
+                discoveryRequests += showMock to showReplay
+                return combine(baseDevicesFlow, resolvedList) { base, resolved ->
+                    val tcpDevices =
+                        resolved.map { DeviceListEntry.Tcp(name = it.name, fullAddress = "t${it.hostAddress}") }
+                    base.copy(discoveredTcpDevices = tcpDevices)
+                }
             }
         }
 

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelHarness.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelHarness.kt
@@ -99,6 +99,7 @@ class ScannerViewModelHarness(val testDispatcher: TestDispatcher = UnconfinedTes
         object : GetDiscoveredDevicesUseCase {
             override fun invoke(
                 showMock: Boolean,
+                showReplay: Boolean,
                 resolvedList: Flow<List<DiscoveredService>>,
             ): Flow<DiscoveredDevices> = combine(baseDevicesFlow, resolvedList) { base, resolved ->
                 val tcpDevices =
@@ -109,6 +110,7 @@ class ScannerViewModelHarness(val testDispatcher: TestDispatcher = UnconfinedTes
 
     init {
         every { radioInterfaceService.isMockTransport() } returns false
+        every { radioInterfaceService.isReplayTransportAvailable } returns false
         every { radioInterfaceService.currentDeviceAddressFlow } returns currentDeviceAddressFlow
         every { recentAddressesDataSource.recentAddresses } returns MutableStateFlow(emptyList())
         every { firmwareRecoveryDataSource.pending } returns flowOf(null)

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/ScannerViewModelTest.kt
@@ -354,6 +354,44 @@ class ScannerViewModelTest {
         }
     }
 
+    /**
+     * The replay demo entry only makes sense in a build carrying the capture asset; without it the replay transport
+     * degrades to the plain mock. These two pin the ViewModel as the thing that forwards that capability, so the gate
+     * cannot regress into "always offer replay whenever Demo Mode is on".
+     */
+    @Test
+    fun `replay is requested only when the transport reports the capture asset`() = runTest {
+        assertEquals(listOf(true to true), requestedVisibility(mockTransport = true, replayAvailable = true))
+    }
+
+    @Test
+    fun `replay is not requested when the capture asset is absent`() = runTest {
+        assertEquals(listOf(true to false), requestedVisibility(mockTransport = true, replayAvailable = false))
+    }
+
+    /**
+     * Builds a ViewModel against the given transport capabilities and returns the distinct `(showMock, showReplay)`
+     * pairs it asked the use case for. A fresh ViewModel is required because both flags are latched in `init`.
+     */
+    private suspend fun requestedVisibility(
+        mockTransport: Boolean,
+        replayAvailable: Boolean,
+    ): List<Pair<Boolean, Boolean>> {
+        every { harness.radioInterfaceService.isMockTransport() } returns mockTransport
+        every { harness.radioInterfaceService.isReplayTransportAvailable } returns replayAvailable
+        harness.discoveryRequests.clear()
+        val subject = harness.buildBase()
+        try {
+            subject.usbDevicesForUi.test {
+                awaitItem()
+                cancelAndIgnoreRemainingEvents()
+            }
+            return harness.discoveryRequests.distinct()
+        } finally {
+            harness.clearViewModel(subject)
+        }
+    }
+
     @Test
     fun `bleDevicesForUi shows bonded devices only once they are visible via scan`() = runTest {
         val device1 = FakeBleDevice(address = "01:02:03:04:05:06", name = "Node B", rssi = -50)

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCaseTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCaseTest.kt
@@ -31,6 +31,7 @@ import org.meshtastic.core.datastore.model.RecentAddress
 import org.meshtastic.core.network.repository.DiscoveredService
 import org.meshtastic.core.testing.FakeNodeRepository
 import org.meshtastic.core.testing.TestDataFactory
+import org.meshtastic.feature.connections.model.DeviceListEntry
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -61,7 +62,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
     @Test
     fun testEmptyRecentAddresses() = runTest {
         setUp()
-        useCase.invoke(showMock = false, resolvedList = resolvedServicesFlow).test {
+        useCase.invoke(showMock = false, showReplay = false, resolvedList = resolvedServicesFlow).test {
             val result = awaitItem()
             assertTrue(result.recentTcpDevices.isEmpty(), "No recent TCP devices when empty")
             assertTrue(result.usbDevices.isEmpty(), "No USB devices when showMock=false")
@@ -76,7 +77,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
         recentAddressesFlow.value =
             listOf(RecentAddress("t192.168.1.100", "Zebra_Node"), RecentAddress("t192.168.1.101", "Alpha_Node"))
 
-        useCase.invoke(showMock = false, resolvedList = resolvedServicesFlow).test {
+        useCase.invoke(showMock = false, showReplay = false, resolvedList = resolvedServicesFlow).test {
             val result = awaitItem()
             result.recentTcpDevices.size shouldBe 2
             result.recentTcpDevices[0].name shouldBe "Alpha_Node"
@@ -86,11 +87,33 @@ class CommonGetDiscoveredDevicesUseCaseTest {
     }
 
     @Test
-    fun testShowMockAddsDemo() = runTest {
+    fun testShowMockAddsDemoOnly() = runTest {
         setUp()
-        useCase.invoke(showMock = true, resolvedList = resolvedServicesFlow).test {
+        useCase.invoke(showMock = true, showReplay = false, resolvedList = resolvedServicesFlow).test {
             val result = awaitItem()
-            result.usbDevices.size shouldBe 2
+            result.usbDevices.map { it::class } shouldBe listOf(DeviceListEntry.Mock::class)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun testShowReplayAddsReplayAlongsideDemo() = runTest {
+        setUp()
+        useCase.invoke(showMock = true, showReplay = true, resolvedList = resolvedServicesFlow).test {
+            val result = awaitItem()
+            result.usbDevices.map { it::class } shouldBe
+                listOf(DeviceListEntry.Mock::class, DeviceListEntry.Replay::class)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    /** Replay is nested inside the demo gate: it is never offered on its own. */
+    @Test
+    fun testShowReplayIgnoredWhenMockHidden() = runTest {
+        setUp()
+        useCase.invoke(showMock = false, showReplay = true, resolvedList = resolvedServicesFlow).test {
+            val result = awaitItem()
+            assertTrue(result.usbDevices.isEmpty(), "No replay device when showMock=false")
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -98,7 +121,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
     @Test
     fun testHideMockNoDemo() = runTest {
         setUp()
-        useCase.invoke(showMock = false, resolvedList = resolvedServicesFlow).test {
+        useCase.invoke(showMock = false, showReplay = false, resolvedList = resolvedServicesFlow).test {
             val result = awaitItem()
             assertTrue(result.usbDevices.isEmpty(), "No mock device when showMock=false")
             cancelAndIgnoreRemainingEvents()
@@ -121,7 +144,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
 
         recentAddressesFlow.value = listOf(RecentAddress("tMeshtastic_1234", "Meshtastic_1234"))
 
-        useCase.invoke(showMock = false, resolvedList = resolvedServicesFlow).test {
+        useCase.invoke(showMock = false, showReplay = false, resolvedList = resolvedServicesFlow).test {
             val result = awaitItem()
             result.recentTcpDevices.size shouldBe 1
             assertNotNull(result.recentTcpDevices[0].node, "Node should be matched by suffix")
@@ -138,7 +161,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
 
         recentAddressesFlow.value = listOf(RecentAddress("tMeshtastic_1234", "Meshtastic_1234"))
 
-        useCase.invoke(showMock = false, resolvedList = resolvedServicesFlow).test {
+        useCase.invoke(showMock = false, showReplay = false, resolvedList = resolvedServicesFlow).test {
             val result = awaitItem()
             result.recentTcpDevices.size shouldBe 1
             assertNull(result.recentTcpDevices[0].node, "Node should not be matched when no database")
@@ -151,7 +174,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
         setUp()
         recentAddressesFlow.value = listOf(RecentAddress("t192.168.1.100", "Node_A"))
 
-        useCase.invoke(showMock = false, resolvedList = resolvedServicesFlow).test {
+        useCase.invoke(showMock = false, showReplay = false, resolvedList = resolvedServicesFlow).test {
             val firstResult = awaitItem()
             firstResult.recentTcpDevices.size shouldBe 1
 
@@ -176,7 +199,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
                 ),
             )
 
-        useCase.invoke(showMock = false, resolvedList = resolvedServicesFlow).test {
+        useCase.invoke(showMock = false, showReplay = false, resolvedList = resolvedServicesFlow).test {
             val result = awaitItem()
             result.discoveredTcpDevices.size shouldBe 1
             result.discoveredTcpDevices[0].name shouldBe "Mesh_1234"
@@ -210,7 +233,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
                 ),
             )
 
-        useCase.invoke(showMock = false, resolvedList = resolvedServicesFlow).test {
+        useCase.invoke(showMock = false, showReplay = false, resolvedList = resolvedServicesFlow).test {
             val result = awaitItem()
             result.discoveredTcpDevices.size shouldBe 1
             assertNotNull(result.discoveredTcpDevices[0].node)
@@ -225,7 +248,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
         setUp()
         recentAddressesFlow.value = listOf(RecentAddress("t192.168.1.100", "Recent_Node"))
 
-        useCase.invoke(showMock = false, resolvedList = flowOf(emptyList())).test {
+        useCase.invoke(showMock = false, showReplay = false, resolvedList = flowOf(emptyList())).test {
             val result = awaitItem()
             assertTrue(result.discoveredTcpDevices.isEmpty(), "No NSD devices when resolvedList is empty")
             result.recentTcpDevices.size shouldBe 1
@@ -237,7 +260,7 @@ class CommonGetDiscoveredDevicesUseCaseTest {
     @Test
     fun testEmptyResolvedListIncludesMock() = runTest {
         setUp()
-        useCase.invoke(showMock = true, resolvedList = flowOf(emptyList())).test {
+        useCase.invoke(showMock = true, showReplay = true, resolvedList = flowOf(emptyList())).test {
             val result = awaitItem()
             result.usbDevices.size shouldBe 2
             cancelAndIgnoreRemainingEvents()

--- a/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCaseTest.kt
+++ b/feature/connections/src/commonTest/kotlin/org/meshtastic/feature/connections/domain/usecase/CommonGetDiscoveredDevicesUseCaseTest.kt
@@ -262,7 +262,8 @@ class CommonGetDiscoveredDevicesUseCaseTest {
         setUp()
         useCase.invoke(showMock = true, showReplay = true, resolvedList = flowOf(emptyList())).test {
             val result = awaitItem()
-            result.usbDevices.size shouldBe 2
+            result.usbDevices.map { it::class } shouldBe
+                listOf(DeviceListEntry.Mock::class, DeviceListEntry.Replay::class)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
The Connections screen's USB pane offered two virtual devices behind the Demo Mode gate — "Demo Mode" and "Demo Mode (Replay)" — but the `burningmesh.fromradio` capture that `ReplayRadioTransport` needs is generated locally by the burningmesh-replay tool and is not checked into the repo, so no clean-checkout build carries it. `createReplayTransport()` always logged "asset is missing — falling back to mock" and returned a plain `MockRadioTransport`, leaving two picker entries with identical behaviour, one of them advertising a replay it cannot perform. That was harmless while Demo Mode was debug-only; it became user-visible once Demo Mode was made reachable in release builds.

## 🐛 Bug Fixes

- Hide `DeviceListEntry.Replay` in builds that do not carry the capture asset, so the picker no longer shows a second Demo Mode entry that silently degrades to the first.

## 🛠️ Refactoring & Architecture

- Added `isReplayTransportAvailable` to `RadioTransportFactory` and `RadioInterfaceService`. `AndroidRadioTransportFactory` probes the APK assets once via `by lazy` (an empty asset counts as absent, matching `createReplayTransport`'s own guard); `DesktopRadioTransportFactory` and `NoopRadioInterfaceService` return `false`; `SharedRadioInterfaceService` delegates to the factory.
- Declared as a `val` rather than a `fun`. Asset presence is fixed for the process lifetime, so a `StateFlow` would be machinery wrapping a constant — and `RadioInterfaceService` sits exactly at detekt's `TooManyFunctions` interface cap (11), where a twelfth `fun` fails `:core:repository:detekt` while properties are not counted.
- Widened `GetDiscoveredDevicesUseCase.invoke(showMock, showReplay, resolvedList)` and threaded the flag from `ScannerViewModel`. The two flags are nested — `showReplay` is only honoured inside `showMock` — so "replay offered without Demo Mode" is unrepresentable in the picker. Kept as a parameter rather than injecting `RadioInterfaceService` into `CommonGetDiscoveredDevicesUseCase`, which today takes only data sources; as a parameter the use case stays a pure function of its inputs, exactly like `showMock`. `JvmGetDiscoveredDevicesUseCase` inherits the new signature unchanged.
- Extracted the entry-visibility policy into a shared `virtualDeviceEntries()` in `commonMain`, beside the existing TCP discovery helpers. The common and Android paths previously built the Demo Mode entries independently and could drift; Android also picks up the safe label resolution the common path already had (`getStringSuspend` under `safeCatchingAll` with an English fallback, instead of a bare `getString` that throws when the resource cannot resolve).
- `FakeRadioInterfaceService` exposes the flag as a `var` so future replay-gated tests can flip it.

### Reviewer note

`BaseRadioTransportFactory.isAddressValid` is deliberately **not** tightened: it still accepts an `r…` address whenever `isMockTransport()` is true. Requiring the asset there would invalidate a persisted replay selection in a build that later lost it, whereas the existing fallback keeps that user on a working virtual device. Hiding the picker entry is the fix; the fallback stays as the safety net.

## Testing Performed

`feature/connections` `commonTest` — `CommonGetDiscoveredDevicesUseCaseTest`:

- **Replaced** `testShowMockAddsDemo` with `testShowMockAddsDemoOnly` — asserts the entry *types*, not just the count, so a regression that swaps Mock for Replay cannot pass.
- **Added** `testShowReplayAddsReplayAlongsideDemo` — both entries, in order, when the asset is present.
- **Added** `testShowReplayIgnoredWhenMockHidden` — pins the nesting contract: `showReplay = true` with `showMock = false` yields nothing.
- **Updated** `testEmptyResolvedListIncludesMock` to assert entry identity rather than `size shouldBe 2`, which held for any two entries.

`feature/connections` `commonTest` — `ScannerViewModelTest` / `ScannerViewModelHarness`:

- **Added** `replay is requested only when the transport reports the capture asset` and `replay is not requested when the capture asset is absent`. The harness fake previously accepted `showMock`/`showReplay` and ignored both, returning identical devices for every combination — so a ViewModel test could pass while the ViewModel requested the wrong visibility. It now records the requested pairs, and these two assert against them, which is the only coverage that pins the capability-to-picker wiring this branch introduces.

Full baseline on this branch: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` → BUILD SUCCESSFUL. All six tests above were confirmed `PASSED` in the log on both the `jvm` and `androidHostTest` variants, not inferred from the exit code.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting whether Replay transport is available.
  - Demo Mode can now display a Replay device alongside the demo device when replay data is bundled.
  - Replay devices are shown only when Demo Mode is enabled and supported by the platform.
- **Compatibility**
  - Platforms without replay data continue to operate normally without displaying the Replay option.
- **Tests**
  - Added coverage for Replay visibility and device-list behavior across supported and unsupported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->