### PR TITLE
fix(nodes): mark nodes absent from connected radio

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1231,6 +1231,7 @@ node_list_help_title
 node_list_long_click_label
 node_number
 node_restarting
+node_saved_on_phone
 node_sort_alpha
 node_sort_button
 node_sort_channel

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImpl.kt
@@ -298,8 +298,10 @@ class MeshConfigFlowManagerImpl(
             nodeManager.applyTrustedIdentityMigrations(removedNums)
         }
 
+        val currentRadioNodeNums = state.nodes.mapTo(mutableSetOf()) { it.num }.apply { add(info.myNodeNum) }
         val published =
             runForSession(session) {
+                nodeManager.publishRadioNodeSnapshot(session.generation, currentRadioNodeNums)
                 nodeManager.setNodeDbReady(true)
                 nodeManager.setAllowNodeDbWrites(true)
                 serviceStateWriter.setConnectionState(ConnectionState.Connected)
@@ -322,6 +324,7 @@ class MeshConfigFlowManagerImpl(
         val admitted =
             radioInterfaceService.runIfSessionActive(session) {
                 Logger.i { "MyNodeInfo received" }
+                nodeManager.beginRadioNodeSession(session.generation)
                 handshakeState.value = HandshakeState.ReceivingConfig(session = session, rawMyNodeInfo = myInfo)
                 nodeManager.setMyDeviceId(deviceId)
                 nodeManager.setMyNodeNum(myInfo.my_node_num)

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImpl.kt
@@ -35,6 +35,7 @@ import org.meshtastic.core.common.util.nowSeconds
 import org.meshtastic.core.common.util.safeCatching
 import org.meshtastic.core.model.MeshLog
 import org.meshtastic.core.model.Node
+import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.util.isLora
 import org.meshtastic.core.model.util.rxTimeOrNull
 import org.meshtastic.core.model.util.snrOrNull
@@ -194,6 +195,10 @@ class MeshMessageProcessorImpl(
         if (!radioInterfaceService.isSessionActive(session)) {
             Logger.d { "Dropping mesh packet from stale transport session gen=${session.generation}" }
             return
+        }
+
+        if (packet.from != 0 && packet.from != NodeAddress.NODENUM_BROADCAST) {
+            nodeManager.markNodeObserved(session.generation, packet.from)
         }
 
         if (nodeManager.isNodeDbReady.value && myNodeNum != null) {

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/NodeManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/NodeManagerImpl.kt
@@ -18,13 +18,19 @@ package org.meshtastic.core.data.manager
 
 import co.touchlab.kermit.Logger
 import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.atomicfu.update
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okio.ByteString
@@ -43,6 +49,7 @@ import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.RadioInterfaceService
+import org.meshtastic.core.repository.RadioNodeSnapshot
 import org.meshtastic.core.repository.RadioSessionContext
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.getStringSuspend
@@ -78,6 +85,28 @@ private const val KEY_FINGERPRINT_HEX_LENGTH = 8
 internal fun publicKeyLogFingerprint(key: ByteString): String = key.sha256().hex().take(KEY_FINGERPRINT_HEX_LENGTH)
 
 private val DEFAULT_NODE_NAME_REGEX = Regex("^Meshtastic [0-9a-fA-F]{4}$")
+
+/** A synchronous StateFlow view that hides a snapshot as soon as its transport session is no longer active. */
+@OptIn(ExperimentalForInheritanceCoroutinesApi::class)
+private class SessionBoundRadioNodeSnapshotFlow(
+    private val snapshot: StateFlow<RadioNodeSnapshot?>,
+    private val activeSession: StateFlow<RadioSessionContext?>,
+) : StateFlow<RadioNodeSnapshot?> {
+    override val value: RadioNodeSnapshot?
+        get() = snapshot.value?.takeIf { it.sessionGeneration == activeSession.value?.generation }
+
+    override val replayCache: List<RadioNodeSnapshot?>
+        get() = listOf(value)
+
+    override suspend fun collect(collector: FlowCollector<RadioNodeSnapshot?>): Nothing {
+        combine(snapshot, activeSession) { currentSnapshot, session ->
+            currentSnapshot?.takeIf { it.sessionGeneration == session?.generation }
+        }
+            .distinctUntilChanged()
+            .collect(collector)
+        error("StateFlow collection completed unexpectedly")
+    }
+}
 
 /** Implementation of [NodeManager] that maintains an in-memory database of the mesh. */
 @Suppress("LongParameterList", "TooManyFunctions", "CyclomaticComplexMethod", "LargeClass")
@@ -291,12 +320,79 @@ class NodeManagerImpl(
     override val isNodeDbReady = MutableStateFlow(false)
     override val allowNodeDbWrites = MutableStateFlow(false)
 
+    private val radioNodeSessionLock = SynchronizedObject()
+    private var currentRadioNodeSessionGeneration: Long? = null
+    private var stagedRadioNodeNums: PersistentSet<Int> = persistentSetOf()
+    private val _currentRadioNodeSnapshot = MutableStateFlow<RadioNodeSnapshot?>(null)
+    override val currentRadioNodeSnapshot: StateFlow<RadioNodeSnapshot?> =
+        SessionBoundRadioNodeSnapshotFlow(_currentRadioNodeSnapshot, radioInterfaceService.activeSession)
+
     override fun setNodeDbReady(ready: Boolean) {
         isNodeDbReady.value = ready
     }
 
     override fun setAllowNodeDbWrites(allowed: Boolean) {
         allowNodeDbWrites.value = allowed
+    }
+
+    override fun beginRadioNodeSession(sessionGeneration: Long) {
+        synchronized(radioNodeSessionLock) {
+            if (radioInterfaceService.activeSession.value?.generation != sessionGeneration) return@synchronized
+            val currentGeneration = currentRadioNodeSessionGeneration
+            if (currentGeneration == sessionGeneration) return@synchronized
+            if (currentGeneration != null && sessionGeneration < currentGeneration) return@synchronized
+
+            currentRadioNodeSessionGeneration = sessionGeneration
+            stagedRadioNodeNums = persistentSetOf()
+            _currentRadioNodeSnapshot.value = null
+        }
+    }
+
+    override fun publishRadioNodeSnapshot(sessionGeneration: Long, nodeNums: Set<Int>) {
+        synchronized(radioNodeSessionLock) {
+            if (radioInterfaceService.activeSession.value?.generation != sessionGeneration) return@synchronized
+            if (currentRadioNodeSessionGeneration != sessionGeneration) return@synchronized
+
+            var completedNodeNums = persistentSetOf<Int>().addingAll(nodeNums)
+            val remainingCapacity = (MAX_IN_MEMORY_NODES - completedNodeNums.size).coerceAtLeast(0)
+            stagedRadioNodeNums
+                .asSequence()
+                .filterNot { it in completedNodeNums }
+                .take(remainingCapacity)
+                .forEach { completedNodeNums = completedNodeNums.adding(it) }
+            stagedRadioNodeNums = persistentSetOf()
+            _currentRadioNodeSnapshot.value = RadioNodeSnapshot(sessionGeneration, completedNodeNums)
+        }
+    }
+
+    override fun markNodeObserved(sessionGeneration: Long, nodeNum: Int) {
+        if (nodeNum == 0 || nodeNum == NodeAddress.NODENUM_BROADCAST) return
+        synchronized(radioNodeSessionLock) {
+            if (radioInterfaceService.activeSession.value?.generation != sessionGeneration) return@synchronized
+            if (currentRadioNodeSessionGeneration != sessionGeneration) {
+                // A valid packet can precede MyInfo on a fresh transport. Treat the active transport generation as
+                // authority, invalidate any hidden prior state, and stage this sender for Stage 2 publication.
+                currentRadioNodeSessionGeneration = sessionGeneration
+                stagedRadioNodeNums = persistentSetOf()
+                _currentRadioNodeSnapshot.value = null
+            }
+            val snapshot = _currentRadioNodeSnapshot.value
+            if (snapshot == null) {
+                if (stagedRadioNodeNums.size < MAX_IN_MEMORY_NODES) {
+                    stagedRadioNodeNums = stagedRadioNodeNums.adding(nodeNum)
+                }
+            } else if (nodeNum !in snapshot.nodeNums && snapshot.nodeNums.size < MAX_IN_MEMORY_NODES) {
+                val updatedNodeNums = persistentSetOf<Int>().addingAll(snapshot.nodeNums).adding(nodeNum)
+                _currentRadioNodeSnapshot.value = snapshot.copy(nodeNums = updatedNodeNums)
+            }
+        }
+    }
+
+    private fun reconcileRadioNodeSession(activeSessionGeneration: Long?) = synchronized(radioNodeSessionLock) {
+        if (currentRadioNodeSessionGeneration == activeSessionGeneration) return@synchronized
+        currentRadioNodeSessionGeneration = activeSessionGeneration
+        stagedRadioNodeNums = persistentSetOf()
+        _currentRadioNodeSnapshot.value = null
     }
 
     override val myNodeNum = MutableStateFlow<Int?>(null)
@@ -317,12 +413,14 @@ class NodeManagerImpl(
 
     override fun clearConnectionIdentity() {
         _connectionIdentity.value = null
+        reconcileRadioNodeSession(activeSessionGeneration = null)
     }
 
     override fun clearStaleConnectionIdentity(activeSessionGeneration: Long) {
         _connectionIdentity.updateStateFlow { identity ->
             identity?.takeIf { it.sessionGeneration == activeSessionGeneration }
         }
+        reconcileRadioNodeSession(activeSessionGeneration)
     }
 
     override fun publishConnectionIdentity(sessionGeneration: Long, address: String, nodeNum: Int, deviceId: String?) {
@@ -475,6 +573,7 @@ class NodeManagerImpl(
         myDeviceId.value = null
         firmwareEdition.value = null
         _connectionIdentity.value = null
+        reconcileRadioNodeSession(activeSessionGeneration = null)
     }
 
     override fun getMyNodeInfo(): MyNodeInfo? {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConfigFlowManagerImplTest.kt
@@ -188,6 +188,7 @@ class MeshConfigFlowManagerImplTest {
         handleMyInfo(protoMyNodeInfo)
         advanceUntilIdle()
 
+        verify { nodeManager.beginRadioNodeSession(activeSession.generation) }
         verify { nodeManager.setMyNodeNum(myNodeNum) }
         verify {
             nodeManager.publishConnectionIdentity(
@@ -227,6 +228,7 @@ class MeshConfigFlowManagerImplTest {
 
         verify(mode = VerifyMode.exactly(0)) { nodeManager.setMyDeviceId(any()) }
         verify(mode = VerifyMode.exactly(0)) { nodeManager.setMyNodeNum(any()) }
+        verify(mode = VerifyMode.exactly(0)) { nodeManager.beginRadioNodeSession(any()) }
         verify(mode = VerifyMode.exactly(0)) { nodeManager.publishConnectionIdentity(any(), any(), any(), any()) }
     }
 
@@ -238,6 +240,7 @@ class MeshConfigFlowManagerImplTest {
         advanceUntilIdle()
 
         verify(mode = VerifyMode.exactly(0)) { nodeManager.setMyNodeNum(any()) }
+        verify(mode = VerifyMode.exactly(0)) { nodeManager.beginRadioNodeSession(any()) }
         verify(mode = VerifyMode.exactly(0)) { nodeManager.publishConnectionIdentity(any(), any(), any(), any()) }
     }
 
@@ -251,6 +254,7 @@ class MeshConfigFlowManagerImplTest {
 
         verify(mode = VerifyMode.exactly(0)) { nodeManager.setMyDeviceId(any()) }
         verify(mode = VerifyMode.exactly(0)) { nodeManager.setMyNodeNum(any()) }
+        verify(mode = VerifyMode.exactly(0)) { nodeManager.beginRadioNodeSession(any()) }
         verify(mode = VerifyMode.exactly(0)) { nodeManager.publishConnectionIdentity(any(), any(), any(), any()) }
         verifySuspend(mode = VerifyMode.exactly(0)) { nodeRepository.insertMetadata(any(), any()) }
     }
@@ -570,6 +574,7 @@ class MeshConfigFlowManagerImplTest {
         verify { nodeManager.installNodeInfo(nodeInfo) }
         verifySuspend(mode = VerifyMode.exactly(0)) { nodeManager.installNodeInfoAndPersist(any()) }
         verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.installConfig(any(), any()) }
+        verify { nodeManager.publishRadioNodeSnapshot(activeSession.generation, setOf(myNodeNum, nodeInfo.num)) }
         verify { nodeManager.setNodeDbReady(true) }
         verify { nodeManager.setAllowNodeDbWrites(true) }
         verifySuspend { connectionManager.onNodeDbReady() }
@@ -597,6 +602,7 @@ class MeshConfigFlowManagerImplTest {
 
         verify(mode = VerifyMode.exactly(1)) { nodeManager.installNodeInfo(any()) }
         verifySuspend(mode = VerifyMode.exactly(0)) { nodeRepository.installConfig(any(), any()) }
+        verify(mode = VerifyMode.exactly(0)) { nodeManager.publishRadioNodeSnapshot(any(), any()) }
         verify(mode = VerifyMode.exactly(0)) { nodeManager.setNodeDbReady(true) }
         verify(mode = VerifyMode.exactly(0)) { nodeManager.setAllowNodeDbWrites(true) }
         verify(mode = VerifyMode.exactly(0)) { serviceRepository.setConnectionState(ConnectionState.Connected) }
@@ -628,6 +634,37 @@ class MeshConfigFlowManagerImplTest {
     }
 
     @Test
+    fun `Stage 2 publishes exact deduplicated membership plus the local node`() = testScope.runTest {
+        val firstNum = 100
+        val secondNum = 200
+        val nodesByNum =
+            mapOf(
+                firstNum to org.meshtastic.core.testing.TestDataFactory.createTestNode(num = firstNum),
+                secondNum to org.meshtastic.core.testing.TestDataFactory.createTestNode(num = secondNum),
+            )
+        every { nodeManager.nodeDBbyNodeNum } returns nodesByNum
+
+        handleMyInfo(protoMyNodeInfo)
+        advanceUntilIdle()
+        manager.handleLocalMetadata(metadata)
+        advanceUntilIdle()
+        manager.handleConfigComplete(HandshakeConstants.CONFIG_NONCE)
+        advanceTimeBy(STAGE_TRANSITION_ADVANCE_MS)
+        runCurrent()
+        manager.handleNodeInfo(NodeInfo(num = firstNum))
+        manager.handleNodeInfo(NodeInfo(num = firstNum, snr = 4.5f))
+        manager.handleNodeInfo(NodeInfo(num = secondNum))
+        assertEquals(2, manager.newNodeCount)
+
+        manager.handleConfigComplete(HandshakeConstants.NODE_INFO_NONCE)
+        advanceUntilIdle()
+
+        verify {
+            nodeManager.publishRadioNodeSnapshot(activeSession.generation, setOf(myNodeNum, firstNum, secondNum))
+        }
+    }
+
+    @Test
     fun `Stage 2 applies trusted migrations before readiness and replay`() = testScope.runTest {
         val retiredNum = 456
         val callOrder = mutableListOf<String>()
@@ -637,6 +674,7 @@ class MeshConfigFlowManagerImplTest {
                 listOf(retiredNum)
             }
         every { nodeManager.applyTrustedIdentityMigrations(any()) } calls { callOrder.add("applyMigrations") }
+        every { nodeManager.publishRadioNodeSnapshot(any(), any()) } calls { callOrder.add("publishSnapshot") }
         every { nodeManager.setNodeDbReady(true) } calls { callOrder.add("nodeDbReady") }
         every { nodeManager.setAllowNodeDbWrites(true) } calls { callOrder.add("writesReady") }
         everySuspend { connectionManager.onNodeDbReady() } calls { callOrder.add("replayReady") }
@@ -652,7 +690,14 @@ class MeshConfigFlowManagerImplTest {
         advanceUntilIdle()
 
         assertEquals(
-            listOf("installConfig", "applyMigrations", "nodeDbReady", "writesReady", "replayReady"),
+            listOf(
+                "installConfig",
+                "applyMigrations",
+                "publishSnapshot",
+                "nodeDbReady",
+                "writesReady",
+                "replayReady",
+            ),
             callOrder,
         )
         verify { nodeManager.applyTrustedIdentityMigrations(listOf(retiredNum)) }
@@ -679,6 +724,7 @@ class MeshConfigFlowManagerImplTest {
         manager.handleConfigComplete(HandshakeConstants.NODE_INFO_NONCE)
         advanceUntilIdle()
 
+        verify { nodeManager.publishRadioNodeSnapshot(activeSession.generation, setOf(myNodeNum)) }
         verify { nodeManager.setNodeDbReady(true) }
         verifySuspend { connectionManager.onNodeDbReady() }
     }
@@ -727,6 +773,7 @@ class MeshConfigFlowManagerImplTest {
         verify { nodeManager.setNodeDbReady(false) }
         verify { nodeManager.setAllowNodeDbWrites(false) }
         verify { connectionManager.recoverPostHandshakeFailure() }
+        verify(mode = VerifyMode.not) { nodeManager.publishRadioNodeSnapshot(any(), any()) }
         verify(mode = VerifyMode.not) { nodeManager.setNodeDbReady(true) }
         verifySuspend(mode = VerifyMode.not) { connectionManager.onNodeDbReady() }
     }

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshMessageProcessorImplTest.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.test.runTest
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.di.asServiceScope
+import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.repository.FromRadioPacketHandler
 import org.meshtastic.core.repository.MeshDataHandler
 import org.meshtastic.core.repository.MeshLogRepository
@@ -334,6 +335,7 @@ class MeshMessageProcessorImplTest {
         processor.handleReceivedMeshPacket(packet, myNodeNum)
         advanceUntilIdle()
 
+        verify { nodeManager.markNodeObserved(session.generation, packet.from) }
         // Packet should be buffered, not processed
         // (no emitMeshPacket call since DB is not ready)
     }
@@ -626,6 +628,7 @@ class MeshMessageProcessorImplTest {
         advanceUntilIdle()
 
         // Should have called updateNode for the sender
+        verify { nodeManager.markNodeObserved(session.generation, senderNode) }
         verifySuspend { nodeManager.updateNodeAndPersist(senderNode, any(), any()) }
     }
 
@@ -640,7 +643,36 @@ class MeshMessageProcessorImplTest {
 
         processor.handleReceivedMeshPacket(packet, myNodeNum)
         advanceUntilIdle()
-        // No crash, no emitMeshPacket call (decoded is null so processReceivedMeshPacket returns early)
+
+        verify { nodeManager.markNodeObserved(session.generation, packet.from) }
+        verifySuspend(mode = VerifyMode.exactly(0)) { serviceRepository.emitMeshPacket(any()) }
+    }
+
+    @Test
+    fun `invalid and broadcast senders are not marked observed`() = runTest(testDispatcher) {
+        processor = createProcessor(backgroundScope)
+        isNodeDbReady.value = true
+
+        processor.handleReceivedMeshPacket(MeshPacket(id = 1, from = 0, decoded = null), myNodeNum)
+        processor.handleReceivedMeshPacket(
+            MeshPacket(id = 2, from = NodeAddress.NODENUM_BROADCAST, decoded = null),
+            myNodeNum,
+        )
+        advanceUntilIdle()
+
+        verify(mode = VerifyMode.exactly(0)) { nodeManager.markNodeObserved(any(), any()) }
+    }
+
+    @Test
+    fun `stale packet cannot mark its sender observed`() = runTest(testDispatcher) {
+        processor = createProcessor(backgroundScope)
+        isNodeDbReady.value = true
+        activeSession.value = RadioSessionContext(generation = session.generation + 1, address = session.address)
+
+        processor.handleReceivedMeshPacket(MeshPacket(id = 1, from = 999, decoded = null), myNodeNum, session)
+        advanceUntilIdle()
+
+        verify(mode = VerifyMode.exactly(0)) { nodeManager.markNodeObserved(any(), any()) }
     }
 
     // ---------- handleReceivedMeshPacket: myNodeNum not yet known ----------

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerConnectionIdentityTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerConnectionIdentityTest.kt
@@ -32,6 +32,7 @@ import org.meshtastic.core.repository.ConnectionIdentity
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.RadioInterfaceService
+import org.meshtastic.core.repository.RadioSessionContext
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -58,6 +59,7 @@ class NodeManagerConnectionIdentityTest {
     @BeforeTest
     fun setUp() {
         everySuspend { nodeRepository.getNodeDbSnapshot() } returns emptyMap()
+        every { radioInterfaceService.activeSession } returns MutableStateFlow<RadioSessionContext?>(null)
         nodeManager =
             NodeManagerImpl(nodeRepository, notificationManager, radioInterfaceService, testScope.asServiceScope())
     }

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.data.manager
 
+import app.cash.turbine.test
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
@@ -47,6 +48,7 @@ import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.Notification
 import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.RadioInterfaceService
+import org.meshtastic.core.repository.RadioNodeSnapshot
 import org.meshtastic.core.repository.RadioSessionContext
 import org.meshtastic.proto.DeviceMetadata
 import org.meshtastic.proto.DeviceMetrics
@@ -72,17 +74,174 @@ class NodeManagerImplTest {
     private val notificationManager: NotificationManager = mock(MockMode.autofill)
     private val radioInterfaceService: RadioInterfaceService = mock(MockMode.autofill)
     private val testScope = TestScope()
+    private val activeRadioSession = MutableStateFlow<RadioSessionContext?>(null)
 
     private lateinit var nodeManager: NodeManagerImpl
 
     @BeforeTest
     fun setUp() {
+        activeRadioSession.value = null
+        every { radioInterfaceService.activeSession } returns activeRadioSession
         nodeManager =
             NodeManagerImpl(nodeRepository, notificationManager, radioInterfaceService, testScope.asServiceScope())
         // Override the compose-resources formatter so notification dispatch is deterministic in the
         // plain-JVM test env (getStringSuspend does not resolve here). Tests that assert "no dispatch"
         // still hold: the override only changes the title, not whether dispatch fires.
         nodeManager.notificationTitleFormatter = { shortName -> "New node seen: $shortName" }
+    }
+
+    private fun activateRadioSession(generation: Long) {
+        activeRadioSession.value = RadioSessionContext(generation, address = "tcp:test")
+    }
+
+    // ---------- Current-radio membership ----------
+
+    @Test
+    fun `incomplete radio session is distinct from a completed empty snapshot`() {
+        val generation = 10L
+        activateRadioSession(generation)
+
+        nodeManager.beginRadioNodeSession(generation)
+        assertNull(nodeManager.currentRadioNodeSnapshot.value)
+
+        val mutableMembership = mutableSetOf<Int>()
+        nodeManager.publishRadioNodeSnapshot(generation, mutableMembership)
+        mutableMembership += 99
+
+        assertEquals(RadioNodeSnapshot(generation, emptySet()), nodeManager.currentRadioNodeSnapshot.value)
+        assertFalse(nodeManager.currentRadioNodeSnapshot.value?.nodeNums is MutableSet<*>)
+    }
+
+    @Test
+    fun `newer radio session clears membership and rejects every stale generation mutation`() {
+        activateRadioSession(10L)
+        nodeManager.beginRadioNodeSession(10L)
+        nodeManager.publishRadioNodeSnapshot(10L, setOf(1, 2))
+
+        activateRadioSession(11L)
+        nodeManager.beginRadioNodeSession(11L)
+        nodeManager.publishRadioNodeSnapshot(10L, setOf(90))
+        nodeManager.markNodeObserved(10L, 91)
+        nodeManager.beginRadioNodeSession(10L)
+
+        assertNull(nodeManager.currentRadioNodeSnapshot.value)
+
+        nodeManager.publishRadioNodeSnapshot(11L, setOf(3))
+        nodeManager.markNodeObserved(10L, 92)
+        nodeManager.markNodeObserved(11L, 4)
+
+        assertEquals(RadioNodeSnapshot(11L, setOf(3, 4)), nodeManager.currentRadioNodeSnapshot.value)
+    }
+
+    @Test
+    fun `same radio session begin is idempotent after snapshot completion`() {
+        val generation = 12L
+        activateRadioSession(generation)
+        nodeManager.beginRadioNodeSession(generation)
+        nodeManager.publishRadioNodeSnapshot(generation, setOf(1, 2))
+
+        nodeManager.beginRadioNodeSession(generation)
+
+        assertEquals(RadioNodeSnapshot(generation, setOf(1, 2)), nodeManager.currentRadioNodeSnapshot.value)
+    }
+
+    @Test
+    fun `live observation is staged while incomplete and joined on snapshot completion`() {
+        val generation = 13L
+        activateRadioSession(generation)
+
+        nodeManager.beginRadioNodeSession(generation)
+        nodeManager.markNodeObserved(generation, 7)
+        assertNull(nodeManager.currentRadioNodeSnapshot.value)
+
+        nodeManager.publishRadioNodeSnapshot(generation, setOf(8))
+        nodeManager.markNodeObserved(generation, 7)
+
+        assertEquals(RadioNodeSnapshot(generation, setOf(7, 8)), nodeManager.currentRadioNodeSnapshot.value)
+    }
+
+    @Test
+    fun `packet observed before MyInfo is staged for the active generation`() {
+        val generation = 14L
+        activateRadioSession(generation)
+
+        nodeManager.markNodeObserved(generation, 7)
+        assertNull(nodeManager.currentRadioNodeSnapshot.value)
+
+        nodeManager.beginRadioNodeSession(generation)
+        nodeManager.publishRadioNodeSnapshot(generation, setOf(8))
+
+        assertEquals(RadioNodeSnapshot(generation, setOf(7, 8)), nodeManager.currentRadioNodeSnapshot.value)
+    }
+
+    @Test
+    fun `active session replacement and revocation promptly invalidate radio membership`() = testScope.runTest {
+        val generation = 12L
+        activateRadioSession(generation)
+        nodeManager.beginRadioNodeSession(generation)
+        nodeManager.publishRadioNodeSnapshot(generation, setOf(7))
+        runCurrent()
+
+        activateRadioSession(generation + 1)
+        runCurrent()
+        assertNull(nodeManager.currentRadioNodeSnapshot.value)
+
+        nodeManager.beginRadioNodeSession(generation + 1)
+        nodeManager.publishRadioNodeSnapshot(generation + 1, setOf(8))
+        assertEquals(RadioNodeSnapshot(generation + 1, setOf(8)), nodeManager.currentRadioNodeSnapshot.value)
+
+        activeRadioSession.value = null
+        runCurrent()
+        assertNull(nodeManager.currentRadioNodeSnapshot.value)
+    }
+
+    @Test
+    fun `radio snapshot collectors receive null at the active session boundary`() = testScope.runTest {
+        val generation = 14L
+        activateRadioSession(generation)
+        nodeManager.beginRadioNodeSession(generation)
+        nodeManager.publishRadioNodeSnapshot(generation, setOf(7))
+
+        nodeManager.currentRadioNodeSnapshot.test {
+            assertEquals(RadioNodeSnapshot(generation, setOf(7)), awaitItem())
+
+            activeRadioSession.value = RadioSessionContext(generation + 1, address = "tcp:test")
+
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `live observations cannot grow current radio membership past the in-memory bound`() {
+        val generation = 15L
+        val boundedMembership = (1..NodeManagerImpl.MAX_IN_MEMORY_NODES).toSet()
+        activateRadioSession(generation)
+
+        nodeManager.beginRadioNodeSession(generation)
+        nodeManager.publishRadioNodeSnapshot(generation, boundedMembership)
+        nodeManager.markNodeObserved(generation, NodeManagerImpl.MAX_IN_MEMORY_NODES + 1)
+
+        assertEquals(boundedMembership, nodeManager.currentRadioNodeSnapshot.value?.nodeNums)
+    }
+
+    @Test
+    fun `staged observations are bounded before snapshot completion`() {
+        val generation = 16L
+        activateRadioSession(generation)
+        nodeManager.beginRadioNodeSession(generation)
+
+        repeat(NodeManagerImpl.MAX_IN_MEMORY_NODES + 100) { index ->
+            nodeManager.markNodeObserved(generation, index + 1)
+        }
+        assertNull(nodeManager.currentRadioNodeSnapshot.value)
+
+        nodeManager.publishRadioNodeSnapshot(generation, emptySet())
+
+        val boundedMembership = assertNotNull(nodeManager.currentRadioNodeSnapshot.value).nodeNums
+        assertEquals((1..NodeManagerImpl.MAX_IN_MEMORY_NODES).toSet(), boundedMembership)
+        assertFalse(NodeManagerImpl.MAX_IN_MEMORY_NODES + 1 in boundedMembership)
+        assertFalse(NodeManagerImpl.MAX_IN_MEMORY_NODES + 100 in boundedMembership)
     }
 
     // ---------- In-memory index bounding ----------
@@ -514,11 +673,15 @@ class NodeManagerImplTest {
     @Test
     fun `clear resets internal state`() {
         nodeManager.updateNode(1234) { it.copy(user = it.user.copy(long_name = "Test")) }
+        activateRadioSession(20L)
+        nodeManager.beginRadioNodeSession(20L)
+        nodeManager.publishRadioNodeSnapshot(20L, setOf(1234))
         nodeManager.clear()
 
         assertTrue(nodeManager.nodeDBbyNodeNum.isEmpty())
         assertNull(nodeManager.getNodeById("!000004d2"))
         assertNull(nodeManager.myNodeNum.value)
+        assertNull(nodeManager.currentRadioNodeSnapshot.value)
     }
 
     @Test

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeManager.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeManager.kt
@@ -48,6 +48,20 @@ data class ConnectionIdentity(
         "nodeNum=$nodeNum, deviceIdPresent=${deviceId != null})"
 }
 
+/**
+ * Authoritative node membership observed for one completed radio configuration session.
+ *
+ * This is deliberately separate from the cumulative phone database: [nodeNums] contains only the node numbers in the
+ * successfully installed Stage 2 snapshot (including the local node), plus senders observed live afterward. The
+ * nullable [NodeManager.currentRadioNodeSnapshot] distinguishes an incomplete handshake from a completed snapshot whose
+ * membership is empty.
+ */
+data class RadioNodeSnapshot(val sessionGeneration: Long, val nodeNums: Set<Int>) {
+    /** Privacy-safe diagnostic form: node numbers are identifiers and must not enter logs. */
+    override fun toString(): String =
+        "RadioNodeSnapshot(sessionGeneration=$sessionGeneration, nodeCount=${nodeNums.size})"
+}
+
 /** Interface for managing the in-memory node database and processing received node information. */
 @Suppress("TooManyFunctions")
 interface NodeManager : NodeIdLookup {
@@ -68,6 +82,30 @@ interface NodeManager : NodeIdLookup {
 
     /** Sets whether node database writes are allowed. */
     fun setAllowNodeDbWrites(allowed: Boolean)
+
+    /**
+     * Completed membership for the current radio session, or null while no current Stage 2 snapshot has been
+     * successfully installed. This state is connection-scoped and is never persisted to or reconstructed from Room.
+     */
+    val currentRadioNodeSnapshot: StateFlow<RadioNodeSnapshot?>
+
+    /**
+     * Starts an admitted radio handshake for [sessionGeneration] and invalidates an older completed snapshot. Repeated
+     * admission of the same session is idempotent.
+     */
+    fun beginRadioNodeSession(sessionGeneration: Long)
+
+    /**
+     * Publishes the completed, deduplicated Stage 2 membership for [sessionGeneration]. Calls from a generation that no
+     * longer owns the current handshake are ignored.
+     */
+    fun publishRadioNodeSnapshot(sessionGeneration: Long, nodeNums: Set<Int>)
+
+    /**
+     * Records a sender observed in a live admitted packet. Same-generation observations received before Stage 2
+     * completes are staged and joined to the first published snapshot; stale-session observations are ignored.
+     */
+    fun markNodeObserved(sessionGeneration: Long, nodeNum: Int)
 
     /** The local node number as a thread-safe [StateFlow]. */
     val myNodeNum: StateFlow<Int?>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1264,6 +1264,7 @@
     <string name="node_list_long_click_label">Node options</string>
     <string name="node_number">Node Number</string>
     <string name="node_restarting">Restarting…</string>
+    <string name="node_saved_on_phone">Saved on phone</string>
     <string name="node_sort_alpha">A-Z</string>
     <string name="node_sort_button">Node sorting options</string>
     <string name="node_sort_channel">Channel</string>

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/BuildNodeDescription.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/BuildNodeDescription.kt
@@ -31,6 +31,7 @@ import org.meshtastic.core.resources.a11y_node_online
 import org.meshtastic.core.resources.a11y_node_role
 import org.meshtastic.core.resources.a11y_node_signal
 import org.meshtastic.core.resources.node_incomplete
+import org.meshtastic.core.resources.node_saved_on_phone
 import org.meshtastic.core.resources.now
 import org.meshtastic.core.resources.unknown
 import org.meshtastic.core.ui.util.formatAgo
@@ -54,6 +55,7 @@ internal data class NodeDescriptionStrings(
     val unknown: String,
     val now: String,
     val incomplete: String,
+    val savedOnPhone: String,
 )
 
 /** Resolves [NodeDescriptionStrings] from Compose string resources. */
@@ -71,6 +73,7 @@ internal fun rememberNodeDescriptionStrings(): NodeDescriptionStrings = NodeDesc
     unknown = stringResource(Res.string.unknown),
     now = stringResource(Res.string.now),
     incomplete = stringResource(Res.string.node_incomplete),
+    savedOnPhone = stringResource(Res.string.node_saved_on_phone),
 )
 
 /** Builds a TalkBack-friendly description aggregating node state. Shared between [NodeItem] and [NodeItemCompact]. */
@@ -90,6 +93,7 @@ internal fun buildNodeDescription(
     lastHeardIsRelative: Boolean = true,
     modemPreset: ModemPreset? = null,
     isUnknownUser: Boolean = false,
+    isSavedOnPhoneOnly: Boolean = false,
 ): String = buildString {
     append(name)
     if (isUnknownUser) {
@@ -97,7 +101,15 @@ internal fun buildNodeDescription(
         append(strings.incomplete)
     }
     append(", ")
-    append(if (isOnline) strings.online else strings.offline)
+    append(
+        if (isSavedOnPhoneOnly) {
+            strings.savedOnPhone
+        } else if (isOnline) {
+            strings.online
+        } else {
+            strings.offline
+        },
+    )
     if (isFavorite) {
         append(", ")
         append(strings.favorite)

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/CurrentRadioNodePresentation.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/CurrentRadioNodePresentation.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.component
+
+import org.meshtastic.core.model.Node
+
+/**
+ * Current-radio observations for a retained [Node].
+ *
+ * The phone's node database is intentionally cumulative, while one completed radio NodeDB download can be a strict
+ * subset of it. A node absent from that completed download still has useful identity and history, but its cached
+ * receiver-relative fields must not be presented as observations from the current connection.
+ */
+internal data class CurrentRadioNodePresentation(
+    val isSavedOnPhoneOnly: Boolean,
+    val isOnline: Boolean,
+    val lastHeard: Int?,
+    val hopsAway: Int?,
+    val snr: Float?,
+    val rssi: Int?,
+)
+
+/**
+ * Projects cached node data for the current connection.
+ *
+ * [isInCurrentRadioNodeSnapshot] is tri-state: `false` is proof from a completed current-session snapshot that the node
+ * is retained only on the phone; `true` is positive membership; `null` means no completed snapshot is available.
+ * Unknown state deliberately preserves the existing presentation. Numeric zero is never used as absence: 0 hops, 0 dB
+ * SNR, and 0 dBm RSSI remain genuine values when membership is true or unknown.
+ */
+internal fun Node.currentRadioPresentation(isInCurrentRadioNodeSnapshot: Boolean?): CurrentRadioNodePresentation {
+    val isSavedOnPhoneOnly = isInCurrentRadioNodeSnapshot == false
+    return CurrentRadioNodePresentation(
+        isSavedOnPhoneOnly = isSavedOnPhoneOnly,
+        isOnline = !isSavedOnPhoneOnly && isOnline,
+        lastHeard = lastHeard.takeUnless { isSavedOnPhoneOnly },
+        hopsAway = hopsAway.takeUnless { isSavedOnPhoneOnly },
+        snr = snrOrNull.takeUnless { isSavedOnPhoneOnly },
+        rssi = rssiOrNull.takeUnless { isSavedOnPhoneOnly },
+    )
+}

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeCardGlow.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeCardGlow.kt
@@ -51,7 +51,11 @@ fun Modifier.nodeCardGlow(lastHeard: Int, nodeColor: Color): Modifier {
     // Track previous value to distinguish initial composition from actual changes
     val previousLastHeard = remember { mutableIntStateOf(lastHeard) }
     LaunchedEffect(lastHeard) {
-        if (lastHeard > 0 && lastHeard != previousLastHeard.intValue) {
+        if (lastHeard <= 0) {
+            // A completed current-radio snapshot can invalidate a cached last-heard value while a glow is still
+            // animating. Cancellation alone retains Animatable's intermediate alpha, so explicitly clear it.
+            glowAlpha.snapTo(0f)
+        } else if (lastHeard != previousLastHeard.intValue) {
             glowAlpha.animateTo(targetValue = 1f, animationSpec = bloomSpec)
             glowAlpha.animateTo(targetValue = 0f, animationSpec = decaySpec)
         }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItem.kt
@@ -94,11 +94,13 @@ fun NodeItem(
     isActive: Boolean = false,
     showTelemetry: Boolean = true,
     deviceImageUrl: String? = null,
+    isInCurrentRadioNodeSnapshot: Boolean? = null,
 ) {
     val originalLongName = thatNode.user.long_name.ifEmpty { stringResource(Res.string.unknown_username) }
     val isMuted = remember(thatNode) { thatNode.isMuted }
     val isIgnored = thatNode.isIgnored
     val isFavorite = thatNode.isFavorite
+    val currentRadio = thatNode.currentRadioPresentation(isInCurrentRadioNodeSnapshot)
 
     val isThisNode = remember(thatNode) { thisNode?.num == thatNode.num }
     val system =
@@ -135,32 +137,34 @@ fun NodeItem(
     val a11yStrings = rememberNodeDescriptionStrings()
     val modemPreset = LocalModemPreset.current
     val nodeDescription =
-        remember(thatNode, distance, a11yStrings, modemPreset) {
+        remember(thatNode, currentRadio, distance, a11yStrings, modemPreset) {
             buildNodeDescription(
                 name = originalLongName,
-                isOnline = thatNode.isOnline,
+                isOnline = currentRadio.isOnline,
                 isFavorite = isFavorite,
-                lastHeard = thatNode.lastHeard,
+                lastHeard = currentRadio.lastHeard ?: 0,
                 role = thatNode.user.role.name,
-                hopsAway = thatNode.hopsAway,
+                hopsAway = currentRadio.hopsAway ?: -1,
                 batteryLevel = thatNode.batteryLevel,
                 distance = distance,
-                snr = thatNode.snrOrNull,
+                snr = currentRadio.snr,
                 viaMqtt = thatNode.viaMqtt,
                 strings = a11yStrings,
                 modemPreset = modemPreset,
                 isUnknownUser = thatNode.isUnknownUser,
+                isSavedOnPhoneOnly = currentRadio.isSavedOnPhoneOnly,
             )
         }
 
     Card(
         modifier =
-        modifier.nodeCardGlow(lastHeard = thatNode.lastHeard, nodeColor = nodeColor).fillMaxWidth().semantics(
-            mergeDescendants = true,
-        ) {
-            contentDescription = nodeDescription
-            role = Role.Button
-        },
+        modifier
+            .nodeCardGlow(lastHeard = currentRadio.lastHeard ?: 0, nodeColor = nodeColor)
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription = nodeDescription
+                role = Role.Button
+            },
         colors = cardColors,
         border = cardBorder,
     ) {
@@ -188,6 +192,7 @@ fun NodeItem(
                 connectionState = connectionState,
                 deviceType = deviceType,
                 contentColor = contentColor,
+                currentRadio = currentRadio,
             )
 
             thatNode.nodeStatus?.let { status ->
@@ -220,7 +225,12 @@ fun NodeItem(
                 contentColor = contentColor,
             )
 
-            NodeSignalRow(thatNode = thatNode, isThisNode = isThisNode, contentColor = contentColor)
+            NodeSignalRow(
+                thatNode = thatNode,
+                currentRadio = currentRadio,
+                isThisNode = isThisNode,
+                contentColor = contentColor,
+            )
 
             if (showTelemetry) {
                 val sensorItems = gatherSensors(thatNode, tempInFahrenheit, contentColor)
@@ -283,7 +293,12 @@ private fun NodeBatteryPositionRow(
 
 @Suppress("CyclomaticComplexMethod", "LongMethod")
 @Composable
-private fun NodeSignalRow(thatNode: Node, isThisNode: Boolean, contentColor: Color) {
+private fun NodeSignalRow(
+    thatNode: Node,
+    currentRadio: CurrentRadioNodePresentation,
+    isThisNode: Boolean,
+    contentColor: Color,
+) {
     // The signal pill bundles SNR + RSSI + quality into one row. It's wider than a 1/3 grid cell, so it renders on
     // its own line at natural width; the short metrics flow in the grid.
     var signalChip: (@Composable () -> Unit)? = null
@@ -309,11 +324,11 @@ private fun NodeSignalRow(thatNode: Node, isThisNode: Boolean, contentColor: Col
                     )
                 }
             } else {
-                if (thatNode.hopsAway > 0) {
-                    add { HopsInfo(hops = thatNode.hopsAway, contentColor = contentColor) }
-                } else if (thatNode.hopsAway == 0 && !thatNode.viaMqtt) {
-                    val snr = thatNode.snrOrNull
-                    val rssi = thatNode.rssiOrNull
+                if ((currentRadio.hopsAway ?: -1) > 0) {
+                    add { HopsInfo(hops = checkNotNull(currentRadio.hopsAway), contentColor = contentColor) }
+                } else if (currentRadio.hopsAway == 0 && !thatNode.viaMqtt) {
+                    val snr = currentRadio.snr
+                    val rssi = currentRadio.rssi
                     if (snr != null || rssi != null) {
                         signalChip = {
                             // Full-width row: SNR left, RSSI center, quality right.
@@ -501,6 +516,7 @@ private fun NodeItemHeader(
     connectionState: ConnectionState,
     deviceType: DeviceType?,
     contentColor: Color,
+    currentRadio: CurrentRadioNodePresentation,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -531,11 +547,15 @@ private fun NodeItemHeader(
                 )
             }
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                StatusAwareLastHeard(
-                    lastHeard = thatNode.lastHeard,
-                    online = !isThisNode && thatNode.isOnline,
-                    contentColor = contentColor,
-                )
+                if (currentRadio.isSavedOnPhoneOnly) {
+                    SavedOnPhoneInfo()
+                } else {
+                    StatusAwareLastHeard(
+                        lastHeard = currentRadio.lastHeard ?: 0,
+                        online = !isThisNode && currentRadio.isOnline,
+                        contentColor = contentColor,
+                    )
+                }
             }
         }
 

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItemCompact.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/NodeItemCompact.kt
@@ -114,10 +114,12 @@ fun NodeItemCompact(
     showTelemetry: Boolean = true,
     tempInFahrenheit: Boolean = false,
     deviceImageUrl: String? = null,
+    isInCurrentRadioNodeSnapshot: Boolean? = null,
 ) {
     val longName = thatNode.user.long_name.ifEmpty { stringResource(Res.string.unknown_username) }
     val isFavorite = thatNode.isFavorite
     val isIgnored = thatNode.isIgnored
+    val currentRadio = thatNode.currentRadioPresentation(isInCurrentRadioNodeSnapshot)
     val isThisNode = remember(thatNode) { thisNode?.num == thatNode.num }
     val system =
         remember(distanceUnits) {
@@ -147,33 +149,35 @@ fun NodeItemCompact(
     val a11yStrings = rememberNodeDescriptionStrings()
     val modemPreset = LocalModemPreset.current
     val nodeDescription =
-        remember(thatNode, distance, lastHeardIsRelative, a11yStrings, modemPreset) {
+        remember(thatNode, currentRadio, distance, lastHeardIsRelative, a11yStrings, modemPreset) {
             buildNodeDescription(
                 name = longName,
-                isOnline = thatNode.isOnline,
+                isOnline = currentRadio.isOnline,
                 isFavorite = isFavorite,
-                lastHeard = thatNode.lastHeard,
+                lastHeard = currentRadio.lastHeard ?: 0,
                 role = thatNode.user.role.name,
-                hopsAway = thatNode.hopsAway,
+                hopsAway = currentRadio.hopsAway ?: -1,
                 batteryLevel = thatNode.batteryLevel,
                 distance = distance,
-                snr = thatNode.snrOrNull,
+                snr = currentRadio.snr,
                 viaMqtt = thatNode.viaMqtt,
                 strings = a11yStrings,
                 lastHeardIsRelative = lastHeardIsRelative,
                 modemPreset = modemPreset,
                 isUnknownUser = thatNode.isUnknownUser,
+                isSavedOnPhoneOnly = currentRadio.isSavedOnPhoneOnly,
             )
         }
 
     Card(
         modifier =
-        modifier.nodeCardGlow(lastHeard = thatNode.lastHeard, nodeColor = nodeColor).fillMaxWidth().semantics(
-            mergeDescendants = true,
-        ) {
-            contentDescription = nodeDescription
-            role = Role.Button
-        },
+        modifier
+            .nodeCardGlow(lastHeard = currentRadio.lastHeard ?: 0, nodeColor = nodeColor)
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription = nodeDescription
+                role = Role.Button
+            },
         colors = cardColors,
         border = cardBorder,
     ) {
@@ -229,6 +233,7 @@ fun NodeItemCompact(
                     showLocation = showLocation,
                     showSignal = showSignal,
                     contentColor = contentColor,
+                    currentRadio = currentRadio,
                 )
 
                 // Row 3: Environment metrics — temp · humidity · pressure (icon + value only)
@@ -248,6 +253,7 @@ fun NodeItemCompact(
                     showChannel = showChannel,
                     showRole = showRole,
                     deviceImageUrl = deviceImageUrl,
+                    currentRadio = currentRadio,
                 )
             }
         }
@@ -316,15 +322,20 @@ private fun CompactHealthRow(
     showLocation: Boolean,
     showSignal: Boolean,
     contentColor: Color,
+    currentRadio: CurrentRadioNodePresentation,
 ) {
     val segments = buildList {
         // Last heard (tinted by online status)
-        if (showLastHeard && thatNode.lastHeard > 0 && !isFutureDate(thatNode.lastHeard)) {
+        if (currentRadio.isSavedOnPhoneOnly) {
+            add(@Composable { SavedOnPhoneInfo() })
+        } else if (
+            showLastHeard && (currentRadio.lastHeard ?: 0) > 0 && !isFutureDate(checkNotNull(currentRadio.lastHeard))
+        ) {
             add(
                 @Composable {
                     StatusAwareLastHeard(
-                        lastHeard = thatNode.lastHeard,
-                        online = thatNode.isOnline,
+                        lastHeard = checkNotNull(currentRadio.lastHeard),
+                        online = currentRadio.isOnline,
                         contentColor = contentColor,
                         relative = lastHeardIsRelative,
                     )
@@ -361,7 +372,7 @@ private fun CompactHealthRow(
         }
 
         // Signal quality, rated from SNR alone — RSSI is not part of the rating (#5446), so it must not gate it.
-        val directSnr = thatNode.snrOrNull?.takeIf { thatNode.hopsAway == 0 && !thatNode.viaMqtt }
+        val directSnr = currentRadio.snr?.takeIf { currentRadio.hopsAway == 0 && !thatNode.viaMqtt }
         if (showSignal && directSnr != null) {
             val quality = determineSignalQuality(directSnr, LocalModemPreset.current)
             add(
@@ -397,6 +408,7 @@ private fun CompactFooterRow(
     showChannel: Boolean,
     showRole: Boolean,
     deviceImageUrl: String?,
+    currentRadio: CurrentRadioNodePresentation,
 ) {
     val tertiaryColor = MaterialTheme.colorScheme.outline
     val segments =
@@ -418,13 +430,13 @@ private fun CompactFooterRow(
                     )
                 }
             }
-            if (showHops && thatNode.hopsAway > 0 && !isThisNode) {
+            if (showHops && (currentRadio.hopsAway ?: -1) > 0 && !isThisNode) {
                 add {
                     IconInfo(
                         icon = MeshtasticIcons.HopCount,
-                        contentDescription = "${thatNode.hopsAway} hops",
+                        contentDescription = "${currentRadio.hopsAway} hops",
                         contentColor = tertiaryColor,
-                        text = thatNode.hopsAway.toString(),
+                        text = currentRadio.hopsAway.toString(),
                     )
                 }
             }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/SavedOnPhoneInfo.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/SavedOnPhoneInfo.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.component
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.node_saved_on_phone
+import org.meshtastic.core.ui.icon.MeshtasticIcons
+import org.meshtastic.core.ui.icon.PhoneAndroid
+
+/** Labels a retained node that was absent from the current connection's completed radio NodeDB download. */
+@Composable
+internal fun SavedOnPhoneInfo(modifier: Modifier = Modifier) {
+    val label = stringResource(Res.string.node_saved_on_phone)
+    IconInfo(
+        modifier = modifier,
+        icon = MeshtasticIcons.PhoneAndroid,
+        contentDescription = label,
+        text = label,
+        contentColor = MaterialTheme.colorScheme.outline,
+    )
+}

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/BuildNodeDescriptionTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/BuildNodeDescriptionTest.kt
@@ -38,6 +38,7 @@ class BuildNodeDescriptionTest {
             unknown = "unknown",
             now = "now",
             incomplete = "incomplete",
+            savedOnPhone = "saved on phone",
         )
 
     private fun describe(
@@ -53,6 +54,7 @@ class BuildNodeDescriptionTest {
         viaMqtt: Boolean = false,
         lastHeardIsRelative: Boolean = true,
         isUnknownUser: Boolean = false,
+        isSavedOnPhoneOnly: Boolean = false,
     ): String = buildNodeDescription(
         name = name,
         isOnline = isOnline,
@@ -67,6 +69,7 @@ class BuildNodeDescriptionTest {
         strings = testStrings,
         lastHeardIsRelative = lastHeardIsRelative,
         isUnknownUser = isUnknownUser,
+        isSavedOnPhoneOnly = isSavedOnPhoneOnly,
     )
 
     // ---- Basic output ----
@@ -81,6 +84,15 @@ class BuildNodeDescriptionTest {
     fun includes_offline_when_not_online() {
         val result = describe(isOnline = false)
         assertContains(result, "offline")
+    }
+
+    @Test
+    fun saved_only_node_uses_retained_label_instead_of_current_status() {
+        val result = describe(isOnline = true, isSavedOnPhoneOnly = true)
+
+        assertContains(result, "saved on phone")
+        assertFalse(result.contains("online"))
+        assertFalse(result.contains("offline"))
     }
 
     @Test

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/CurrentRadioNodePresentationTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/CurrentRadioNodePresentationTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.component
+
+import org.meshtastic.core.model.Node
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CurrentRadioNodePresentationTest {
+
+    private val measuredZeroNode = Node(num = 1, lastHeard = Int.MAX_VALUE, hopsAway = 0, snr = 0f, rssi = 0)
+
+    @Test
+    fun completedSnapshotAbsenceMasksOnlyCurrentRadioObservations() {
+        val presentation = measuredZeroNode.currentRadioPresentation(isInCurrentRadioNodeSnapshot = false)
+
+        assertTrue(presentation.isSavedOnPhoneOnly)
+        assertFalse(presentation.isOnline)
+        assertNull(presentation.lastHeard)
+        assertNull(presentation.hopsAway)
+        assertNull(presentation.snr)
+        assertNull(presentation.rssi)
+    }
+
+    @Test
+    fun completedSnapshotMembershipPreservesMeasuredZeros() {
+        val presentation = measuredZeroNode.currentRadioPresentation(isInCurrentRadioNodeSnapshot = true)
+
+        assertFalse(presentation.isSavedOnPhoneOnly)
+        assertTrue(presentation.isOnline)
+        assertEquals(Int.MAX_VALUE, presentation.lastHeard)
+        assertEquals(0, presentation.hopsAway)
+        assertEquals(0f, presentation.snr)
+        assertEquals(0, presentation.rssi)
+    }
+
+    @Test
+    fun unknownSnapshotPreservesExistingPresentation() {
+        val presentation = measuredZeroNode.currentRadioPresentation(isInCurrentRadioNodeSnapshot = null)
+
+        assertFalse(presentation.isSavedOnPhoneOnly)
+        assertTrue(presentation.isOnline)
+        assertEquals(Int.MAX_VALUE, presentation.lastHeard)
+        assertEquals(0, presentation.hopsAway)
+        assertEquals(0f, presentation.snr)
+        assertEquals(0, presentation.rssi)
+    }
+}

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/NodeItemZeroMetricsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/NodeItemZeroMetricsTest.kt
@@ -20,12 +20,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.v2.runComposeUiTest
+import org.meshtastic.core.common.util.nowSeconds
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Node
 import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
 import org.meshtastic.proto.EnvironmentMetrics
+import org.meshtastic.proto.HardwareModel
 import org.meshtastic.proto.User
 import kotlin.test.Test
 
@@ -103,6 +106,79 @@ class NodeItemZeroMetricsTest {
         onNodeWithText("0.0°C").assertDoesNotExist()
     }
 
+    @Test
+    fun nodeItem_retainedOnlyDirectNodeHidesCurrentRadioObservationsAndAccessibility() = runComposeUiTest {
+        setCurrentRadioNodeItem(isInCurrentRadioNodeSnapshot = false, hopsAway = 0)
+
+        onNodeWithText("Sensor", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("Saved on phone", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("SNR 0.00 dB", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithText("RSSI 0 dBm", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithText("Good", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithText("Now", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithContentDescription("Sensor, Saved on phone", substring = true).assertIsDisplayed()
+        onNodeWithContentDescription("online", substring = true).assertDoesNotExist()
+        onNodeWithContentDescription("offline", substring = true).assertDoesNotExist()
+        onNodeWithContentDescription("last heard", substring = true).assertDoesNotExist()
+        onNodeWithContentDescription("signal", substring = true).assertDoesNotExist()
+        onNodeWithContentDescription("Last heard", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithContentDescription("Signal quality", useUnmergedTree = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun nodeItem_retainedOnlyMultiHopNodeHidesCachedHops() = runComposeUiTest {
+        setCurrentRadioNodeItem(isInCurrentRadioNodeSnapshot = false, hopsAway = 3)
+
+        onNodeWithText("Saved on phone", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("3", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithContentDescription("Hops away", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithContentDescription("3 hops away", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun nodeItem_currentDirectNodePreservesMeasuredZeroSignal() = runComposeUiTest {
+        setCurrentRadioNodeItem(isInCurrentRadioNodeSnapshot = true, hopsAway = 0)
+
+        onNodeWithText("Saved on phone", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithText("SNR 0.00 dB", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("RSSI 0 dBm", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("Good", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("Now", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithContentDescription("last heard", substring = true).assertIsDisplayed()
+        onNodeWithContentDescription("online", substring = true).assertIsDisplayed()
+        onNodeWithContentDescription("signal good", substring = true).assertIsDisplayed()
+        onNodeWithContentDescription("Last heard", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun nodeItemCompact_retainedOnlyNodeHidesCurrentRadioHealth() = runComposeUiTest {
+        setCurrentRadioNodeItemCompact(isInCurrentRadioNodeSnapshot = false)
+
+        onNodeWithText("Sensor", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("Saved on phone", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("Good", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithText("Now", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithContentDescription("Sensor, Saved on phone", substring = true).assertIsDisplayed()
+        onNodeWithContentDescription("online", substring = true).assertDoesNotExist()
+        onNodeWithContentDescription("offline", substring = true).assertDoesNotExist()
+        onNodeWithContentDescription("last heard", substring = true).assertDoesNotExist()
+        onNodeWithContentDescription("signal", substring = true).assertDoesNotExist()
+        onNodeWithContentDescription("Last heard", useUnmergedTree = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun nodeItemCompact_currentDirectNodePreservesMeasuredZeroSignalQuality() = runComposeUiTest {
+        setCurrentRadioNodeItemCompact(isInCurrentRadioNodeSnapshot = true)
+
+        onNodeWithText("Saved on phone", useUnmergedTree = true).assertDoesNotExist()
+        onNodeWithText("Good", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("Now", useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithContentDescription("last heard", substring = true).assertIsDisplayed()
+        onNodeWithContentDescription("online", substring = true).assertIsDisplayed()
+        onNodeWithContentDescription("signal good", substring = true).assertIsDisplayed()
+        onNodeWithContentDescription("Last heard", useUnmergedTree = true).assertIsDisplayed()
+    }
+
     private fun ComposeUiTest.setNodeItem(metrics: EnvironmentMetrics) = setContent {
         MaterialTheme {
             NodeItem(
@@ -121,6 +197,40 @@ class NodeItemZeroMetricsTest {
         }
     }
 
+    private fun ComposeUiTest.setCurrentRadioNodeItem(isInCurrentRadioNodeSnapshot: Boolean?, hopsAway: Int) =
+        setContent {
+            MaterialTheme {
+                NodeItem(
+                    thisNode = null,
+                    thatNode = currentRadioNode(hopsAway),
+                    distanceUnits = DisplayUnits.METRIC.value,
+                    tempInFahrenheit = false,
+                    connectionState = ConnectionState.Connected,
+                    isInCurrentRadioNodeSnapshot = isInCurrentRadioNodeSnapshot,
+                )
+            }
+        }
+
+    private fun ComposeUiTest.setCurrentRadioNodeItemCompact(isInCurrentRadioNodeSnapshot: Boolean?) = setContent {
+        MaterialTheme {
+            NodeItemCompact(
+                thisNode = null,
+                thatNode = currentRadioNode(hopsAway = 0),
+                distanceUnits = DisplayUnits.METRIC.value,
+                isInCurrentRadioNodeSnapshot = isInCurrentRadioNodeSnapshot,
+            )
+        }
+    }
+
     private fun node(metrics: EnvironmentMetrics) =
         Node(num = 2, user = User(id = "!2", long_name = "Sensor"), environmentMetrics = metrics)
+
+    private fun currentRadioNode(hopsAway: Int) = Node(
+        num = 2,
+        user = User(id = "!2", long_name = "Sensor", short_name = "SN", hw_model = HardwareModel.TBEAM),
+        lastHeard = nowSeconds.toInt(),
+        hopsAway = hopsAway,
+        snr = 0f,
+        rssi = 0,
+    )
 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -116,6 +116,7 @@ fun NodeListScreen(
     val onlineNodeCount by viewModel.onlineNodeCount.collectAsStateWithLifecycle(0)
     val totalNodeCount by viewModel.totalNodeCount.collectAsStateWithLifecycle(0)
     val unfilteredNodes by viewModel.unfilteredNodeList.collectAsStateWithLifecycle()
+    val currentRadioNodeSnapshot by viewModel.currentRadioNodeSnapshot.collectAsStateWithLifecycle()
     val deviceImageUrls by viewModel.deviceImageUrls.collectAsStateWithLifecycle()
     val ignoredNodeCount = unfilteredNodes.count { it.isIgnored }
 
@@ -131,6 +132,7 @@ fun NodeListScreen(
     }
 
     val connectionState by viewModel.connectionState.collectAsStateWithLifecycle()
+    val connectedRadioNodeSnapshot = currentRadioNodeSnapshot.takeIf { connectionState == ConnectionState.Connected }
     val deviceType by viewModel.deviceType.collectAsStateWithLifecycle()
 
     val density by viewModel.nodeListDensity.collectAsStateWithLifecycle()
@@ -155,7 +157,10 @@ fun NodeListScreen(
 
     var showHopHistogram by remember { mutableStateOf(false) }
     if (showHopHistogram) {
-        NodeHopHistogramSheet(nodes = unfilteredNodes, onDismiss = { showHopHistogram = false })
+        val histogramNodes =
+            connectedRadioNodeSnapshot?.let { snapshot -> unfilteredNodes.filter { it.num in snapshot.nodeNums } }
+                ?: unfilteredNodes
+        NodeHopHistogramSheet(nodes = histogramNodes, onDismiss = { showHopHistogram = false })
     }
 
     var showShareContact by remember { mutableStateOf(false) }
@@ -265,6 +270,7 @@ fun NodeListScreen(
                             }
 
                         val isActive = remember(activeNodeId, node.num) { activeNodeId == node.num }
+                        val isInCurrentRadioNodeSnapshot = connectedRadioNodeSnapshot?.nodeNums?.contains(node.num)
 
                         when (density) {
                             NodeListDensity.COMPLETE ->
@@ -281,6 +287,7 @@ fun NodeListScreen(
                                     isActive = isActive,
                                     showTelemetry = showTelemetry,
                                     deviceImageUrl = deviceImageUrls[node.user.hw_model.value],
+                                    isInCurrentRadioNodeSnapshot = isInCurrentRadioNodeSnapshot,
                                 )
 
                             NodeListDensity.COMPACT ->
@@ -303,6 +310,7 @@ fun NodeListScreen(
                                     showTelemetry = showTelemetry,
                                     tempInFahrenheit = state.tempInFahrenheit,
                                     deviceImageUrl = deviceImageUrls[node.user.hw_model.value],
+                                    isInCurrentRadioNodeSnapshot = isInCurrentRadioNodeSnapshot,
                                 )
                         }
                         val isThisNode = remember(node) { ourNode?.num == node.num }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
 import org.meshtastic.core.common.util.MeasurementSystem
 import org.meshtastic.core.common.util.getSystemMeasurementSystem
+import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
@@ -39,6 +40,7 @@ import org.meshtastic.core.model.util.DistanceUnit
 import org.meshtastic.core.repository.AdminController
 import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.DeviceHardwareRepository
+import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.repository.RadioInterfaceService
@@ -54,6 +56,7 @@ import org.meshtastic.proto.Config
 class NodeListViewModel(
     private val savedStateHandle: SavedStateHandle,
     private val nodeRepository: NodeRepository,
+    nodeManager: NodeManager,
     private val radioConfigRepository: RadioConfigRepository,
     private val connectionStateProvider: ConnectionStateProvider,
     private val adminController: AdminController,
@@ -67,7 +70,30 @@ class NodeListViewModel(
 
     val ourNodeInfo: StateFlow<Node?> = nodeRepository.ourNodeInfo
 
-    val onlineNodeCount = nodeRepository.onlineNodeCount.stateInWhileSubscribed(initialValue = 0)
+    val currentRadioNodeSnapshot =
+        combine(connectionStateProvider.connectionState, nodeManager.currentRadioNodeSnapshot) { state, snapshot ->
+            snapshot.takeIf { state == ConnectionState.Connected }
+        }
+            .stateInWhileSubscribed(
+                initialValue =
+                nodeManager.currentRadioNodeSnapshot.value.takeIf {
+                    connectionStateProvider.connectionState.value == ConnectionState.Connected
+                },
+            )
+
+    val onlineNodeCount =
+        combine(
+            nodeRepository.onlineNodeCount,
+            nodeRepository.nodeDBbyNum,
+            currentRadioNodeSnapshot,
+            connectionStateProvider.connectionState,
+        ) { cachedCount, nodesByNum, snapshot, connectionState ->
+            snapshot
+                .takeIf { connectionState == ConnectionState.Connected }
+                ?.let { current -> nodesByNum.values.count { it.num in current.nodeNums && it.isOnline } }
+                ?: cachedCount
+        }
+            .stateInWhileSubscribed(initialValue = 0)
 
     val totalNodeCount = nodeRepository.totalNodeCount.stateInWhileSubscribed(initialValue = 0)
 
@@ -147,7 +173,20 @@ class NodeListViewModel(
 
     val nodeList: StateFlow<List<Node>> =
         combine(nodeFilter, nodeSortOption, ::Pair)
-            .flatMapLatest { (filter, sort) -> getFilteredNodesUseCase.invoke(filter, sort) }
+            .flatMapLatest { (filter, sort) ->
+                combine(
+                    getFilteredNodesUseCase.invoke(filter, sort),
+                    currentRadioNodeSnapshot,
+                    connectionStateProvider.connectionState,
+                ) { nodes, snapshot, connectionState ->
+                    val currentSnapshot = snapshot.takeIf { connectionState == ConnectionState.Connected }
+                    if (currentSnapshot == null || (!filter.onlyOnline && !filter.onlyDirect)) {
+                        nodes
+                    } else {
+                        nodes.filter { it.num in currentSnapshot.nodeNums }
+                    }
+                }
+            }
             .stateInWhileSubscribed(initialValue = emptyList())
 
     val unfilteredNodeList: StateFlow<List<Node>> =

--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/list/NodeListViewModelTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/list/NodeListViewModelTest.kt
@@ -29,7 +29,9 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeSortOption
 import org.meshtastic.core.repository.ConnectionStateProvider
+import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.RadioConfigRepository
+import org.meshtastic.core.repository.RadioNodeSnapshot
 import org.meshtastic.core.testing.FakeDeviceHardwareRepository
 import org.meshtastic.core.testing.FakeNodeRepository
 import org.meshtastic.core.testing.FakeRadioController
@@ -51,26 +53,36 @@ class NodeListViewModelTest {
     private lateinit var radioInterfaceService: FakeRadioInterfaceService
     private val radioConfigRepository: RadioConfigRepository = mock(MockMode.autofill)
     private val connectionStateProvider: ConnectionStateProvider = mock(MockMode.autofill)
+    private val nodeManager: NodeManager = mock(MockMode.autofill)
     private val nodeFilterPreferences: NodeFilterPreferences = mock(MockMode.autofill)
     private val nodeManagementActions: NodeManagementActions = mock(MockMode.autofill)
     private val nodeRequestActions: NodeRequestActions = mock(MockMode.autofill)
     private val getFilteredNodesUseCase: GetFilteredNodesUseCase = mock(MockMode.autofill)
+    private lateinit var connectionState: MutableStateFlow<ConnectionState>
+    private lateinit var currentRadioNodeSnapshot: MutableStateFlow<RadioNodeSnapshot?>
+    private lateinit var onlyOnline: MutableStateFlow<Boolean>
+    private lateinit var onlyDirect: MutableStateFlow<Boolean>
 
     @BeforeTest
     fun setUp() {
         nodeRepository = FakeNodeRepository()
         radioController = FakeRadioController()
         radioInterfaceService = FakeRadioInterfaceService()
+        connectionState = MutableStateFlow(ConnectionState.Disconnected)
+        currentRadioNodeSnapshot = MutableStateFlow(null)
+        onlyOnline = MutableStateFlow(false)
+        onlyDirect = MutableStateFlow(false)
 
         every { radioConfigRepository.localConfigFlow } returns MutableStateFlow(org.meshtastic.proto.LocalConfig())
         every { radioConfigRepository.deviceProfileFlow } returns MutableStateFlow(org.meshtastic.proto.DeviceProfile())
-        every { connectionStateProvider.connectionState } returns MutableStateFlow(ConnectionState.Disconnected)
+        every { connectionStateProvider.connectionState } returns connectionState
+        every { nodeManager.currentRadioNodeSnapshot } returns currentRadioNodeSnapshot
 
         every { nodeFilterPreferences.nodeSortOption } returns MutableStateFlow(NodeSortOption.LAST_HEARD)
         every { nodeFilterPreferences.includeUnknown } returns MutableStateFlow(true)
         every { nodeFilterPreferences.excludeInfrastructure } returns MutableStateFlow(false)
-        every { nodeFilterPreferences.onlyOnline } returns MutableStateFlow(false)
-        every { nodeFilterPreferences.onlyDirect } returns MutableStateFlow(false)
+        every { nodeFilterPreferences.onlyOnline } returns onlyOnline
+        every { nodeFilterPreferences.onlyDirect } returns onlyDirect
         every { nodeFilterPreferences.showIgnored } returns MutableStateFlow(false)
         every { nodeFilterPreferences.excludeMqtt } returns MutableStateFlow(false)
 
@@ -82,6 +94,7 @@ class NodeListViewModelTest {
     private fun createViewModel() = NodeListViewModel(
         savedStateHandle = SavedStateHandle(),
         nodeRepository = nodeRepository,
+        nodeManager = nodeManager,
         radioConfigRepository = radioConfigRepository,
         connectionStateProvider = connectionStateProvider,
         adminController = radioController,
@@ -138,6 +151,75 @@ class NodeListViewModelTest {
             assertEquals(ConnectionState.Disconnected, awaitItem())
             stateFlow.value = ConnectionState.Connected
             assertEquals(ConnectionState.Connected, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `completed snapshot limits online count while connected`() = runTest {
+        nodeRepository.setNodes(
+            listOf(Node(num = 1, lastHeard = Int.MAX_VALUE), Node(num = 2, lastHeard = Int.MAX_VALUE)),
+        )
+        connectionState.value = ConnectionState.Connected
+        currentRadioNodeSnapshot.value = RadioNodeSnapshot(sessionGeneration = 7, nodeNums = setOf(1))
+
+        val vm = createViewModel()
+
+        vm.onlineNodeCount.test {
+            var count = awaitItem()
+            if (count != 1) count = awaitItem()
+            assertEquals(1, count)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `snapshot does not narrow count while disconnected`() = runTest {
+        nodeRepository.setNodes(
+            listOf(Node(num = 1, lastHeard = Int.MAX_VALUE), Node(num = 2, lastHeard = Int.MAX_VALUE)),
+        )
+        currentRadioNodeSnapshot.value = RadioNodeSnapshot(sessionGeneration = 7, nodeNums = setOf(1))
+
+        val vm = createViewModel()
+
+        vm.onlineNodeCount.test {
+            var count = awaitItem()
+            if (count != 2) count = awaitItem()
+            assertEquals(2, count)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `only online excludes retained-only nodes after completed snapshot`() = runTest {
+        onlyOnline.value = true
+        connectionState.value = ConnectionState.Connected
+        currentRadioNodeSnapshot.value = RadioNodeSnapshot(sessionGeneration = 7, nodeNums = setOf(1))
+        every { getFilteredNodesUseCase(any(), any()) } returns MutableStateFlow(listOf(Node(num = 1), Node(num = 2)))
+
+        val vm = createViewModel()
+
+        vm.nodeList.test {
+            var nodeNums = awaitItem().map { it.num }
+            if (nodeNums != listOf(1)) nodeNums = awaitItem().map { it.num }
+            assertEquals(listOf(1), nodeNums)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `only direct excludes retained-only nodes after completed snapshot`() = runTest {
+        onlyDirect.value = true
+        connectionState.value = ConnectionState.Connected
+        currentRadioNodeSnapshot.value = RadioNodeSnapshot(sessionGeneration = 7, nodeNums = setOf(1))
+        every { getFilteredNodesUseCase(any(), any()) } returns MutableStateFlow(listOf(Node(num = 1), Node(num = 2)))
+
+        val vm = createViewModel()
+
+        vm.nodeList.test {
+            var nodeNums = awaitItem().map { it.num }
+            if (nodeNums != listOf(1)) nodeNums = awaitItem().map { it.num }
+            assertEquals(listOf(1), nodeNums)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
## Summary

- keep the phone NodeDB cumulative; this change never removes Room rows or node-local state
- retain the successfully installed Stage 2 membership as connection-scoped state, then add senders observed live in the same connection
- label retained-only rows as **Saved on phone** and suppress cached online, last-heard, hop, SNR, and RSSI claims in the node list and accessibility description
- preserve genuine zero-valued signal readings and direct-hop values for nodes present in the current snapshot
- make online counts, online/direct filters, and the hop histogram use current-radio membership when it is authoritative

The label means that a node was absent from the last completed radio NodeDB download and has not been observed in this connection. It is not a claim about the radio's real-time storage contents.

Related to #6263

## Testing

- PASS: `./gradlew.bat spotlessCheck :core:data:detekt :core:ui:detekt :feature:node:detekt :core:data:allTests :core:ui:jvmTest :feature:node:allTests assembleDebug kmpSmokeCompile --max-workers=4 --console=plain`
- The canonical aggregate gate also ran. Spotless, Detekt, both debug APK assemblies, and the branch's affected tests passed; it stopped only in the unchanged Windows-host FileStorage/DataStore baseline failures in `core:database`, `core:datastore`, and `core:prefs`.
- No emulator or physical-device acceptance was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node lists now reflect nodes detected during the current radio connection.
  * Nodes retained on the phone but not detected nearby are clearly labeled “Saved on phone.”
  * Online and direct-node filters, counts, and hop charts now use current connection data.
* **Bug Fixes**
  * Prevented stale signal, status, accessibility, and glow information from appearing for nodes absent from the current connection.
  * Preserved valid zero-valued signal metrics and improved handling when connection data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->