### PR TITLE
fix(build): track compose-multiplatform's actual version in the flatpak arm64 force-resolve

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,13 +42,25 @@ plugins.withId("org.meshtastic.flatpak.sources") {
     extensions.configure<org.meshtastic.flatpak.sources.FlatpakSourcesExtension> {
         outputFile.set(layout.buildDirectory.file("flatpak-sources.json"))
         mustRunAfterTasks.set(listOf(":desktopApp:assemble", ":desktopApp:packageUberJarForCurrentOS"))
-        // Force-resolve platform-specific native artifacts not resolved on the generation host.
-        // The compose-desktop version MUST track the compose-multiplatform catalog version, else the
-        // arm64 offline flatpak build fails to resolve desktop-jvm-linux-arm64 (skiko version per its POM).
+        // Force-resolve platform-specific native artifacts not resolved on the generation host (the
+        // manifest is generated on an x86_64 runner, but the offline build also needs to run on arm64).
+        //
+        // KEEP desktop-jvm's version IN SYNC with the compose-multiplatform entry in
+        // gradle/libs.versions.toml — that's exactly the maintenance trap that caused this to break once
+        // already: this block was pinned to 1.11.1 and never updated when the catalog moved to
+        // 1.12.0-rc01, so the arm64 offline flatpak build kept resolving (and shipping) URLs for a version
+        // nothing in the project used anymore. (A `libs.versions.composeMultiplatform` reference here
+        // would auto-track it, but that accessor isn't resolvable in this project's script — tried and
+        // confirmed via a direct `./gradlew help` failure — so it has to stay a literal that a human/agent
+        // updates by hand alongside any compose-multiplatform bump.)
+        //
+        // skiko isn't in this catalog at all — its version must track whatever desktop-jvm-<platform>'s
+        // own POM declares for org.jetbrains.skiko:skiko-awt-runtime-<platform> (0.150.1 for
+        // compose-multiplatform 1.12.0-rc01); check that POM again if this version is bumped.
         targetPlatforms.set(setOf("linux-x64", "linux-arm64"))
         platformDependencies.set(setOf(
-            "org.jetbrains.skiko:skiko-awt-runtime-{platform}:0.144.6",
-            "org.jetbrains.compose.desktop:desktop-jvm-{platform}:1.11.1",
+            "org.jetbrains.skiko:skiko-awt-runtime-{platform}:0.150.1",
+            "org.jetbrains.compose.desktop:desktop-jvm-{platform}:1.12.0-rc01",
         ))
     }
 }


### PR DESCRIPTION
## Why

Follow-up to #6690. `flatpakSources.platformDependencies` was pinned to
`desktop-jvm` 1.11.1 / `skiko` 0.144.6 and never updated when
`compose-multiplatform` moved to 1.12.0-rc01 (skiko 0.150.1 per that
version's own POM). The x86_64 manifest-generation runner only ever
resolves x86_64's own `desktop-jvm` artifact, so this force-resolve block
is the *only* thing that puts the arm64 one into `flatpak-sources.json` —
once it went stale, the offline arm64 build started failing to resolve
`org.jetbrains.compose.desktop:desktop-jvm-linux-arm64:1.12.0-rc01`
(caught in #6690's own CI; confirmed pre-existing and unrelated to that PR
by finding an independent Renovate branch hitting the identical error with
none of that PR's changes).

## Changes

- 🐛 **Bug Fixes**
  - Update the force-resolved `desktop-jvm`/`skiko` versions in
    `build.gradle.kts` to match the project's actual `compose-multiplatform`
    version (1.12.0-rc01 / skiko 0.150.1).

I tried making this self-updating via `libs.versions.composeMultiplatform`
so it can't go stale the same way again, but that accessor isn't
resolvable inside this project's root script (confirmed directly via
`./gradlew help`). Left as a literal with a comment flagging the exact
trap.

## Testing Performed

Verified directly, not just compiled: ran the real
`:desktopApp:packageUberJarForCurrentOS :captureFlatpakSources` pipeline
and grepped the generated manifest for the corrected URLs —
`desktop-jvm-linux-arm64/1.12.0-rc01` (3 matches) and
`skiko-awt-runtime-linux-arm64/0.150.1` (6 matches), both present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Flatpak source support for Linux x64 and ARM64 platforms.
  * Updated desktop artifacts to newer Skiko and Compose versions.

* **Documentation**
  * Added guidance on platform resolution and keeping versions synchronized manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->