### PR TITLE
fix(deps): update takpacket-sdk to v0.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -98,7 +98,7 @@ kable = "0.44.3"
 mqttastic = "0.8.1"
 jmdns = "3.6.3"
 qrcode-kotlin = "4.5.0"
-takpacket-sdk = "0.8.1"
+takpacket-sdk = "0.9.0"
 meshtastic-protobufs = "2.7.26.142-gf3c374d-SNAPSHOT"
 
 # Gradle Plugins


### PR DESCRIPTION
## Why

`takpacket-sdk` (org.meshtastic:takpacket-sdk) was pinned at 0.8.1. The
0.9.0 release ships a curated, re-baselined zstd dictionary for the
CoT/TAKPacketV2 codec — real held-out-traffic improvement (over-MTU
messages: 160 → 6; p95 wire size: 128 B → 97 B). See
[meshtastic/TAKPacket-SDK#126](https://github.com/meshtastic/TAKPacket-SDK/pull/126)
for the full rationale and benchmarks.

⚠️ **Wire-incompatible by design** — that's exactly why upstream shipped it
as a minor version (0.8.1 → 0.9.0): a dictionary change is a lockstep mesh
upgrade for TAK traffic specifically. No Kotlin API changed (upstream's
only code changes were two markdownlint fixes), so this is a pure
dependency bump on our side.

## Changes

- 🐛 **Bug Fixes**
  - Bump `takpacket-sdk` 0.8.1 → 0.9.0 in `gradle/libs.versions.toml`.

## Testing Performed

`:core:model:allTests` (166 tests) and `:core:takserver:allTests` (38
tests, including `TAKPacketConversionTest` and
`TakV2CompressorTaktalkTest`'s compression round-trips) — all pass against
the new dictionary, no call-site changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TakPacket SDK to version 0.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->