### PR TITLE
fix(build): declare navigationevent-compose explicitly, fixing Dokka's metadata compile

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -58,7 +58,11 @@ kotlin {
             implementation(libs.jetbrains.compose.material3.adaptive.layout)
             implementation(libs.jetbrains.compose.material3.adaptive.navigation)
             implementation(libs.jetbrains.compose.material3.adaptive.navigation.suite)
-            implementation(libs.jetbrains.navigation3.ui)
+            api(libs.jetbrains.navigation3.ui)
+            // navigation3-ui's own POM marks this runtime-scope, so it never reaches any
+            // compile classpath transitively — declare it directly. Consumers (e.g.
+            // feature:docs) import androidx.navigationevent.compose.* directly.
+            api(libs.jetbrains.navigationevent.compose)
             implementation(libs.jetbrains.compose.material3.adaptive.navigation3)
             implementation(libs.jetbrains.lifecycle.viewmodel.navigation3)
             implementation(libs.jetbrains.lifecycle.viewmodel.compose)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ glance = "1.2.0-rc01"
 lifecycle = "2.11.0"
 jetbrains-lifecycle = "2.11.0"
 navigation3 = "1.1.1"
+navigationevent = "1.1.0"
 paging = "3.5.1"
 room = "3.0.1"
 koin = "4.2.2"
@@ -148,6 +149,7 @@ jetbrains-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecyc
 jetbrains-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "jetbrains-lifecycle" }
 jetbrains-lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "jetbrains-lifecycle" }
 jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+jetbrains-navigationevent-compose = { module = "org.jetbrains.androidx.navigationevent:navigationevent-compose", version.ref = "navigationevent" }
 androidx-paging-common = { module = "androidx.paging:paging-common", version.ref = "paging" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }
 androidx-room-compiler = { module = "androidx.room3:room3-compiler", version.ref = "room" }


### PR DESCRIPTION
## Why

`docs-deploy.yml` has been failing on every push to `main` since at least
this afternoon. `:feature:docs:compileCommonMainKotlinMetadata` — the
Dokka-only KMP metadata target; normal Android-target builds never exercise
it, which is why nothing else caught this — fails with unresolved
references to `androidx.navigationevent.compose.NavigationBackHandler` and
`rememberNavigationEventState` in `DocsNavigation.kt`.

Root cause: `org.jetbrains.androidx.navigation3:navigation3-ui`'s own POM
declares its dependency on `navigationevent-compose` with
`<scope>runtime</scope>`, so that transitive dependency never reaches any
compile classpath — `implementation` or `api`, doesn't matter. `core:ui`'s
other consumers apparently reach `NavigationBackHandler` some other way (or
are equally broken but untested at this target); `feature:docs`'s narrower
dependency set doesn't.

## Changes

- 🐛 **Bug Fixes**
  - Declare `navigationevent-compose` explicitly in `core/ui/build.gradle.kts`
    instead of relying on the broken transitive path (new catalog entry,
    version 1.1.0 — latest available, matching the navigation3 1.1.1 train).
  - Promote `navigation3-ui` from `implementation` to `api`, since `core:ui`'s
    consumers use its symbols directly.

## Testing Performed

`:feature:docs:compileCommonMainKotlinMetadata`, `:core:ui:allTests`,
`:feature:docs:allTests`, and the actual `dokkaGeneratePublicationHtml`
aggregation across all 20+ modules (the exact task `docs-deploy.yml` runs)
all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved navigation support for Compose-based screens.
  * Added support for handling navigation events more consistently across the app.

* **Improvements**
  * Navigation components are now more readily available to app modules, enabling smoother integration and a more consistent navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->