### PR TITLE
fix(notifications): stop repeated protected position alerts

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImpl.kt
@@ -35,6 +35,7 @@ import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.RadioSessionContext
 import org.meshtastic.core.repository.ServiceStateWriter
 import org.meshtastic.core.repository.XModemManager
+import org.meshtastic.core.repository.notificationId
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.client_notification
 import org.meshtastic.core.resources.duplicated_public_key_title
@@ -154,7 +155,11 @@ class FromRadioPacketHandlerImpl(
 
     private fun handleClientNotification(cn: ClientNotification, session: RadioSessionContext) {
         val admitted =
-            radioInterfaceService.runIfSessionActive(session) { serviceStateWriter.setClientNotification(cn) }
+            radioInterfaceService.runIfSessionActive(session) {
+                if (!notificationManager.suppressClientNotificationModal(cn)) {
+                    serviceStateWriter.setClientNotification(cn)
+                }
+            }
         if (!admitted) {
             Logger.d { "Discarding client notification from stale transport session" }
             return
@@ -207,8 +212,15 @@ class FromRadioPacketHandlerImpl(
                 else -> Pair(getStringSuspend(Res.string.client_notification), Notification.Type.Info)
             }
 
-        notificationManager.dispatch(
-            Notification(title = title, type = type, message = cn.message, category = Notification.Category.Alert),
+        notificationManager.dispatchClientNotification(
+            Notification(
+                title = title,
+                type = type,
+                message = cn.message,
+                category = Notification.Category.Alert,
+                id = cn.notificationId(),
+            ),
+            cn,
         )
     }
 }

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/FromRadioPacketHandlerImplTest.kt
@@ -46,6 +46,7 @@ import org.meshtastic.proto.DeviceMetadata
 import org.meshtastic.proto.FromRadio
 import org.meshtastic.proto.LoRaRegionPresetMap
 import org.meshtastic.proto.LockdownStatus
+import org.meshtastic.proto.LogRecord
 import org.meshtastic.proto.ModuleConfig
 import org.meshtastic.proto.MqttClientProxyMessage
 import org.meshtastic.proto.MyNodeInfo
@@ -313,6 +314,28 @@ class FromRadioPacketHandlerImplTest {
     }
 
     @Test
+    fun `platform-suppressed client notification skips modal state but preserves system delivery`() {
+        val notification = protectedPositionAdvisory(replyId = 100, time = 1_000)
+        every { notificationManager.suppressClientNotificationModal(notification) } returns true
+
+        handle(FromRadio(clientNotification = notification))
+
+        verify(mode = VerifyMode.exactly(0)) { serviceRepository.setClientNotification(any()) }
+        verifySuspend(mode = VerifyMode.exactly(1)) { radioInterfaceService.runWithSessionLease(session, any()) }
+    }
+
+    @Test
+    fun `default platform policy preserves modal and system delivery for exact advisory`() {
+        val notification = protectedPositionAdvisory(replyId = 200, time = 2_000)
+        every { notificationManager.suppressClientNotificationModal(notification) } returns false
+
+        handle(FromRadio(clientNotification = notification))
+
+        verify { serviceRepository.setClientNotification(notification) }
+        verifySuspend { radioInterfaceService.runWithSessionLease(session, any()) }
+    }
+
+    @Test
     fun `stale client notification is discarded before publication`() {
         val notification = ClientNotification(message = "stale")
         every { radioInterfaceService.runIfSessionActive(session, any()) } returns false
@@ -320,7 +343,7 @@ class FromRadioPacketHandlerImplTest {
         handle(FromRadio(clientNotification = notification))
 
         verify(mode = VerifyMode.exactly(0)) { serviceRepository.setClientNotification(any()) }
-        verifySuspend(mode = VerifyMode.exactly(0)) { notificationManager.dispatch(any()) }
+        verifySuspend(mode = VerifyMode.exactly(0)) { notificationManager.dispatchClientNotification(any(), any()) }
     }
 
     @Test
@@ -331,7 +354,7 @@ class FromRadioPacketHandlerImplTest {
         handle(FromRadio(clientNotification = notification))
 
         verify { serviceRepository.setClientNotification(notification) }
-        verifySuspend(mode = VerifyMode.exactly(0)) { notificationManager.dispatch(any()) }
+        verifySuspend(mode = VerifyMode.exactly(0)) { notificationManager.dispatchClientNotification(any(), any()) }
     }
 
     @Test
@@ -351,4 +374,11 @@ class FromRadioPacketHandlerImplTest {
         assertFalse(ClientNotification(message = "ROTATE credentials").isOtaStatusNotification())
         assertFalse(ClientNotification(message = "Quota exceeded").isOtaStatusNotification())
     }
+
+    private fun protectedPositionAdvisory(replyId: Int, time: Int) = ClientNotification(
+        message = "Location sharing is disabled on this channel",
+        reply_id = replyId,
+        time = time,
+        level = LogRecord.Level.WARNING,
+    )
 }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ClientNotificationIdentity.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ClientNotificationIdentity.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import org.meshtastic.proto.ClientNotification
+
+/** Stable platform-notification identity shared by posting and cancellation paths. */
+fun ClientNotification.notificationId(): Int = toString().hashCode()

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ClientNotificationIdentity.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ClientNotificationIdentity.kt
@@ -18,5 +18,23 @@ package org.meshtastic.core.repository
 
 import org.meshtastic.proto.ClientNotification
 
-/** Stable platform-notification identity shared by posting and cancellation paths. */
-fun ClientNotification.notificationId(): Int = toString().hashCode()
+/**
+ * Stable platform-notification identity shared by posting and cancellation paths.
+ *
+ * Deliberately excludes `reply_id` and `time`: both change on every firmware reply, so hashing the full notification
+ * (e.g. via `toString()`) mints a fresh id per occurrence and defeats coalescing — a repeated advisory would stack up
+ * as a new tray entry every time instead of updating the same one.
+ *
+ * Hashes only strings and the enum's wire value, never the enum object: enum hashCodes are identity-based, and the tray
+ * outlives the process — a repost after a service restart must land on the same id.
+ */
+fun ClientNotification.notificationId(): Int = listOf(message, level.value, payloadVariantKey()).hashCode()
+
+private fun ClientNotification.payloadVariantKey(): String = when {
+    key_verification_number_inform != null -> "key_verification_number_inform"
+    key_verification_number_request != null -> "key_verification_number_request"
+    key_verification_final != null -> "key_verification_final"
+    duplicated_public_key != null -> "duplicated_public_key"
+    low_entropy_key != null -> "low_entropy_key"
+    else -> "generic"
+}

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NotificationManager.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NotificationManager.kt
@@ -16,6 +16,8 @@
  */
 package org.meshtastic.core.repository
 
+import org.meshtastic.proto.ClientNotification
+
 /**
  * Platform-agnostic notification dispatch primitive. Posts opaque [Notification] records, cancels by id, or wipes all
  * active notifications. Intended as the lowest layer of the notification stack.
@@ -30,6 +32,15 @@ interface NotificationManager {
      * out to OS tools and complete asynchronously).
      */
     suspend fun dispatch(notification: Notification): Boolean
+
+    /** Platform hook for ClientNotifications that should use a native presentation instead of the global modal. */
+    fun suppressClientNotificationModal(notification: ClientNotification): Boolean = false
+
+    /** Platform-specific ClientNotification delivery; defaults to the ordinary notification path. */
+    suspend fun dispatchClientNotification(
+        notification: Notification,
+        clientNotification: ClientNotification,
+    ): Boolean = dispatch(notification)
 
     fun cancel(id: Int)
 

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ClientNotificationIdentityTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ClientNotificationIdentityTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import org.meshtastic.proto.ClientNotification
+import org.meshtastic.proto.DuplicatedPublicKey
+import org.meshtastic.proto.LogRecord
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class ClientNotificationIdentityTest {
+
+    @Test
+    fun `identity is stable across reply_id and time on an otherwise identical repeat`() {
+        val first = ClientNotification(message = "Location sharing is disabled", reply_id = 100, time = 1_000)
+        val second = ClientNotification(message = "Location sharing is disabled", reply_id = 200, time = 2_000)
+
+        assertEquals(first.notificationId(), second.notificationId())
+    }
+
+    @Test
+    fun `identity differs when the message differs`() {
+        val first = ClientNotification(message = "Location sharing is disabled", reply_id = 100)
+        val second = ClientNotification(message = "Quota exceeded", reply_id = 100)
+
+        assertNotEquals(first.notificationId(), second.notificationId())
+    }
+
+    @Test
+    fun `identity differs when the payload variant differs`() {
+        val generic = ClientNotification(message = "Compromised keys detected", level = LogRecord.Level.WARNING)
+        val structured =
+            ClientNotification(
+                message = "Compromised keys detected",
+                level = LogRecord.Level.WARNING,
+                duplicated_public_key = DuplicatedPublicKey(),
+            )
+
+        assertNotEquals(generic.notificationId(), structured.notificationId())
+    }
+}

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidNotificationManagerTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidNotificationManagerTest.kt
@@ -27,12 +27,21 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.meshtastic.core.repository.Notification
+import org.meshtastic.core.repository.notificationId
+import org.meshtastic.proto.ClientNotification
+import org.meshtastic.proto.DuplicatedPublicKey
+import org.meshtastic.proto.KeyVerificationFinal
+import org.meshtastic.proto.KeyVerificationNumberInform
+import org.meshtastic.proto.KeyVerificationNumberRequest
+import org.meshtastic.proto.LogRecord
+import org.meshtastic.proto.LowEntropyKey
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [34])
@@ -187,6 +196,99 @@ class AndroidNotificationManagerTest {
         assertEquals(0, shadowOf(systemNotificationManager).allNotifications.size)
     }
 
+    @Test
+    fun `client notification identity cancels the notification posted with that identity`() = runTest {
+        val manager = AndroidNotificationManager(context)
+        val clientNotification = ClientNotification(message = "Protected position advisory", reply_id = 123)
+        val id = clientNotification.notificationId()
+
+        manager.dispatch(
+            Notification(
+                title = "Client notification",
+                message = clientNotification.message,
+                category = Notification.Category.Alert,
+                id = id,
+            ),
+        )
+
+        assertEquals(1, shadowOf(systemNotificationManager).allNotifications.size)
+        manager.cancel(clientNotification.notificationId())
+        assertEquals(0, shadowOf(systemNotificationManager).allNotifications.size)
+    }
+
+    @Test
+    fun `exact protected position advisory is recognized`() {
+        val manager = AndroidNotificationManager(context)
+
+        assertTrue(manager.suppressClientNotificationModal(protectedPositionAdvisory(replyId = 123, time = 1_000)))
+    }
+
+    @Test
+    fun `protected position advisory predicate rejects every near miss`() {
+        val manager = AndroidNotificationManager(context)
+        val advisory = protectedPositionAdvisory(replyId = 123, time = 1_000)
+        val nearMisses =
+            listOf(
+                advisory.copy(message = "Location sharing is disabled"),
+                advisory.copy(level = LogRecord.Level.INFO),
+                advisory.copy(reply_id = 0),
+                advisory.copy(reply_id = null),
+                advisory.copy(key_verification_number_inform = KeyVerificationNumberInform()),
+                advisory.copy(key_verification_number_request = KeyVerificationNumberRequest()),
+                advisory.copy(key_verification_final = KeyVerificationFinal()),
+                advisory.copy(duplicated_public_key = DuplicatedPublicKey()),
+                advisory.copy(low_entropy_key = LowEntropyKey()),
+                advisory.copy(message = "Rebooting to WiFi OTA"),
+            )
+
+        nearMisses.forEach { notification ->
+            assertFalse(manager.suppressClientNotificationModal(notification), notification.toString())
+        }
+    }
+
+    @Test
+    fun `protected position advisories replace one stable only-alert-once system notification`() = runTest {
+        val manager = AndroidNotificationManager(context)
+        val first = protectedPositionAdvisory(replyId = 123, time = 1_000)
+        val second = protectedPositionAdvisory(replyId = 456, time = 2_000)
+
+        listOf(first, second).forEach { advisory ->
+            manager.dispatchClientNotification(
+                Notification(
+                    title = "Client notification",
+                    message = advisory.message,
+                    category = Notification.Category.Alert,
+                ),
+                advisory,
+            )
+        }
+
+        val posted = shadowOf(systemNotificationManager).allNotifications.single()
+        assertTrue(posted.flags and android.app.Notification.FLAG_ONLY_ALERT_ONCE != 0)
+        val active = systemNotificationManager.activeNotifications.single()
+        assertEquals(PROTECTED_POSITION_ADVISORY_NOTIFICATION_TAG, active.tag)
+        assertEquals(PROTECTED_POSITION_ADVISORY_NOTIFICATION_ID, active.id)
+    }
+
+    @Test
+    fun `generic client notification does not enable only-alert-once`() = runTest {
+        val manager = AndroidNotificationManager(context)
+        val clientNotification = ClientNotification(message = "Generic warning", reply_id = 123)
+
+        manager.dispatchClientNotification(
+            Notification(
+                title = "Client notification",
+                message = clientNotification.message,
+                category = Notification.Category.Alert,
+                id = clientNotification.notificationId(),
+            ),
+            clientNotification,
+        )
+
+        val posted = shadowOf(systemNotificationManager).allNotifications.single()
+        assertEquals(0, posted.flags and android.app.Notification.FLAG_ONLY_ALERT_ONCE)
+    }
+
     private suspend fun assertDispatchesToChannel(
         manager: AndroidNotificationManager,
         category: Notification.Category,
@@ -239,4 +341,11 @@ class AndroidNotificationManagerTest {
 
         channelIds.forEach { channelId -> systemNotificationManager.deleteNotificationChannel(channelId) }
     }
+
+    private fun protectedPositionAdvisory(replyId: Int, time: Int) = ClientNotification(
+        message = "Location sharing is disabled on this channel",
+        reply_id = replyId,
+        time = time,
+        level = LogRecord.Level.WARNING,
+    )
 }

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidNotificationManagerTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidNotificationManagerTest.kt
@@ -258,6 +258,7 @@ class AndroidNotificationManagerTest {
                     title = "Client notification",
                     message = advisory.message,
                     category = Notification.Category.Alert,
+                    id = advisory.notificationId(),
                 ),
                 advisory,
             )
@@ -266,8 +267,30 @@ class AndroidNotificationManagerTest {
         val posted = shadowOf(systemNotificationManager).allNotifications.single()
         assertTrue(posted.flags and android.app.Notification.FLAG_ONLY_ALERT_ONCE != 0)
         val active = systemNotificationManager.activeNotifications.single()
-        assertEquals(PROTECTED_POSITION_ADVISORY_NOTIFICATION_TAG, active.tag)
-        assertEquals(PROTECTED_POSITION_ADVISORY_NOTIFICATION_ID, active.id)
+        assertEquals(first.notificationId(), active.id)
+    }
+
+    @Test
+    fun `repeated generic client notifications with the same message coalesce into one tray entry`() = runTest {
+        val manager = AndroidNotificationManager(context)
+        // A near-miss of the protected-position predicate (message differs slightly), so it takes the plain
+        // dispatch path — but reply_id/time still change on every firmware reply, exactly like the real advisory.
+        val first = ClientNotification(message = "Location sharing is disabled", reply_id = 100, time = 1_000)
+        val second = ClientNotification(message = "Location sharing is disabled", reply_id = 200, time = 2_000)
+
+        listOf(first, second).forEach { cn ->
+            manager.dispatchClientNotification(
+                Notification(
+                    title = "Client notification",
+                    message = cn.message,
+                    category = Notification.Category.Alert,
+                    id = cn.notificationId(),
+                ),
+                cn,
+            )
+        }
+
+        assertEquals(1, shadowOf(systemNotificationManager).allNotifications.size)
     }
 
     @Test

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidNotificationManager.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidNotificationManager.kt
@@ -133,20 +133,15 @@ class AndroidNotificationManager(private val context: Context) : NotificationMan
     override fun suppressClientNotificationModal(notification: ClientNotification): Boolean =
         notification.isProtectedPositionAdvisory()
 
+    // The advisory's id already comes from ClientNotification.notificationId(), which is stable across repeats (see
+    // its kdoc) — so it lands in the same tray slot without a dedicated tag or fixed id; only onlyAlertOnce is needed
+    // to stop it from re-alerting on every update.
     override suspend fun dispatchClientNotification(
         notification: Notification,
         clientNotification: ClientNotification,
-    ): Boolean = if (clientNotification.isProtectedPositionAdvisory()) {
-        dispatch(
-            notification = notification.copy(id = PROTECTED_POSITION_ADVISORY_NOTIFICATION_ID),
-            onlyAlertOnce = true,
-            tag = PROTECTED_POSITION_ADVISORY_NOTIFICATION_TAG,
-        )
-    } else {
-        dispatch(notification)
-    }
+    ): Boolean = dispatch(notification, onlyAlertOnce = clientNotification.isProtectedPositionAdvisory())
 
-    private suspend fun dispatch(notification: Notification, onlyAlertOnce: Boolean, tag: String? = null): Boolean {
+    private suspend fun dispatch(notification: Notification, onlyAlertOnce: Boolean): Boolean {
         ensureChannelsInitialized()
         val channelId = notification.category.channelConfig().id
         if (!canPostNotifications(channelId)) return false
@@ -169,11 +164,7 @@ class AndroidNotificationManager(private val context: Context) : NotificationMan
         notification.deepLinkUri?.let { uri -> builder.setContentIntent(createDeepLinkPendingIntent(uri, id)) }
 
         return try {
-            if (tag == null) {
-                notificationManager.notify(id, builder.build())
-            } else {
-                notificationManager.notify(tag, id, builder.build())
-            }
+            notificationManager.notify(id, builder.build())
             true
         } catch (_: SecurityException) {
             false

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidNotificationManager.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidNotificationManager.kt
@@ -40,6 +40,7 @@ import org.meshtastic.core.resources.meshtastic_mesh_beacon_notifications
 import org.meshtastic.core.resources.meshtastic_messages_notifications
 import org.meshtastic.core.resources.meshtastic_new_nodes_notifications
 import org.meshtastic.core.resources.meshtastic_service_notifications
+import org.meshtastic.proto.ClientNotification
 import android.app.NotificationManager as SystemNotificationManager
 
 @Single
@@ -127,7 +128,25 @@ class AndroidNotificationManager(private val context: Context) : NotificationMan
             ChannelConfig(id = NotificationChannels.SERVICE, importance = SystemNotificationManager.IMPORTANCE_MIN)
     }
 
-    override suspend fun dispatch(notification: Notification): Boolean {
+    override suspend fun dispatch(notification: Notification): Boolean = dispatch(notification, onlyAlertOnce = false)
+
+    override fun suppressClientNotificationModal(notification: ClientNotification): Boolean =
+        notification.isProtectedPositionAdvisory()
+
+    override suspend fun dispatchClientNotification(
+        notification: Notification,
+        clientNotification: ClientNotification,
+    ): Boolean = if (clientNotification.isProtectedPositionAdvisory()) {
+        dispatch(
+            notification = notification.copy(id = PROTECTED_POSITION_ADVISORY_NOTIFICATION_ID),
+            onlyAlertOnce = true,
+            tag = PROTECTED_POSITION_ADVISORY_NOTIFICATION_TAG,
+        )
+    } else {
+        dispatch(notification)
+    }
+
+    private suspend fun dispatch(notification: Notification, onlyAlertOnce: Boolean, tag: String? = null): Boolean {
         ensureChannelsInitialized()
         val channelId = notification.category.channelConfig().id
         if (!canPostNotifications(channelId)) return false
@@ -141,6 +160,7 @@ class AndroidNotificationManager(private val context: Context) : NotificationMan
                 .setSilent(notification.isSilent)
 
         notification.group?.let { builder.setGroup(it) }
+        if (onlyAlertOnce) builder.setOnlyAlertOnce(true)
 
         if (notification.type == Notification.Type.Error) {
             builder.setPriority(NotificationCompat.PRIORITY_HIGH)
@@ -149,7 +169,11 @@ class AndroidNotificationManager(private val context: Context) : NotificationMan
         notification.deepLinkUri?.let { uri -> builder.setContentIntent(createDeepLinkPendingIntent(uri, id)) }
 
         return try {
-            notificationManager.notify(id, builder.build())
+            if (tag == null) {
+                notificationManager.notify(id, builder.build())
+            } else {
+                notificationManager.notify(tag, id, builder.build())
+            }
             true
         } catch (_: SecurityException) {
             false

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/ProtectedPositionAdvisory.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/ProtectedPositionAdvisory.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.service
+
+import org.meshtastic.core.model.util.isOtaStatusNotification
+import org.meshtastic.proto.ClientNotification
+import org.meshtastic.proto.LogRecord
+
+internal const val PROTECTED_POSITION_ADVISORY_MESSAGE = "Location sharing is disabled on this channel"
+internal const val PROTECTED_POSITION_ADVISORY_NOTIFICATION_ID = 1
+internal const val PROTECTED_POSITION_ADVISORY_NOTIFICATION_TAG = "protected_position_advisory"
+
+/**
+ * Wire currently generates each ClientNotification oneof member as a nullable property rather than exposing a sealed
+ * discriminator. Keep this complete gate aligned with the five payload variants in the pinned protobuf schema.
+ */
+internal fun ClientNotification.isProtectedPositionAdvisory(): Boolean =
+    message == PROTECTED_POSITION_ADVISORY_MESSAGE &&
+        level == LogRecord.Level.WARNING &&
+        reply_id?.let { it != 0 } == true &&
+        key_verification_number_inform == null &&
+        key_verification_number_request == null &&
+        key_verification_final == null &&
+        duplicated_public_key == null &&
+        low_entropy_key == null &&
+        !isOtaStatusNotification()

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/ProtectedPositionAdvisory.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/ProtectedPositionAdvisory.kt
@@ -21,8 +21,6 @@ import org.meshtastic.proto.ClientNotification
 import org.meshtastic.proto.LogRecord
 
 internal const val PROTECTED_POSITION_ADVISORY_MESSAGE = "Location sharing is disabled on this channel"
-internal const val PROTECTED_POSITION_ADVISORY_NOTIFICATION_ID = 1
-internal const val PROTECTED_POSITION_ADVISORY_NOTIFICATION_TAG = "protected_position_advisory"
 
 /**
  * Wire currently generates each ClientNotification oneof member as a nullable property rather than exposing a sealed

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
@@ -67,6 +67,7 @@ import org.meshtastic.core.repository.RadioController
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.core.repository.UiPrefs
+import org.meshtastic.core.repository.notificationId
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.client_notification
 import org.meshtastic.core.resources.compromised_keys
@@ -176,7 +177,7 @@ class UIViewModel(
 
     fun clearClientNotification(notification: ClientNotification) {
         serviceRepository.clearClientNotification()
-        notificationManager.cancel(notification.toString().hashCode())
+        notificationManager.cancel(notification.notificationId())
     }
 
     val lockdownState = serviceRepository.lockdownState


### PR DESCRIPTION
## Summary

- recognize the firmware's protected-position advisory on Android using an exact, fail-closed predicate
- replace repeated advisory alerts in one tagged notification slot with `setOnlyAlertOnce(true)`
- suppress the advisory's blocking global modal on Android while preserving normal behavior on other platforms
- use one shared identity for generic ClientNotification posting and cancellation

## Problem

Event firmware can reject phone-provided coordinates and return a `ClientNotification` with `Location sharing is disabled on this channel`. When phone location updates continue, Android receives a fresh reply roughly every 30 seconds. Each reply previously produced both a global modal and a high-importance system notification, repeatedly interrupting the user.

## Approach

The Android-specific path recognizes only notifications that match all current firmware characteristics: the exact message, `WARNING` level, a nonzero `reply_id`, no structured security payload, and non-OTA status.

Matching advisories:

- do not populate the global modal state on Android
- remain visible as a system notification
- reuse the tagged slot `protected_position_advisory` / ID `1`
- set `onlyAlertOnce`, so subsequent firmware replies update rather than repeatedly alert

All generic, structured security, OTA, Desktop, and other platform behavior keeps the existing path. This is stateless and does not infer event channels, inspect keys, or retain packet/session correlation state.

## Verification

- `./gradlew --rerun-tasks :core:data:jvmTest :core:service:testAndroidHostTest`
- `./gradlew :core:data:allTests :core:service:allTests :core:data:spotlessCheck :core:repository:spotlessCheck :core:service:spotlessCheck :core:ui:spotlessCheck :core:data:detekt :core:repository:detekt :core:service:detekt :core:ui:detekt :androidApp:assembleGoogleDebug`
- `git diff --check`

The Android host tests cover the exact advisory, all current predicate near-misses and structured payload variants, modal suppression/default-platform behavior, tagged replacement, `FLAG_ONLY_ALERT_ONCE`, generic alert behavior, stale sessions, and matched generic post/cancel identity.

No live emulator UI result is claimed because KVM acceleration was unavailable in the test environment; Robolectric/Android host tests and the Google debug assembly passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved handling for client notifications, including platform-specific delivery and modal suppression.
  * Protected-position advisories now use stable notification IDs, tagged updates, and single-alert behavior.
  * Notification clearing now reliably cancels the corresponding alert.

* **Bug Fixes**
  * Prevented stale or retired sessions from updating notification state.
  * Improved replacement and cancellation behavior for recurring alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->