### PR TITLE
chore(coderabbit): align review config with a problems-only contract

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -43,6 +43,84 @@ reviews:
     - "!.specify/**"
 
   path_instructions:
+    # Global review contract. Everything below this entry is area-specific detail;
+    # this is what "a finding" means in this repo at all.
+    - path: "**"
+      instructions: >-
+        Report problems only. Every comment must name a concrete defect with evidence in the diff.
+        No praise, no style preferences, no speculative design feedback, no "consider extracting this"
+        on code that works.
+
+
+        FLAG these categories:
+
+        1. Bugs — logic errors, off-by-one, null dereference, a missing `await`/`join`, dropped
+        cancellation, incorrect disposal order.
+
+        2. Security — credential or key exposure, injection, insecure defaults, PII/location/crypto-key
+        material reaching a log sink or analytics payload.
+
+        3. Correctness — behaviour that contradicts the PR description, the linked issue, or an existing
+        contract; a breaking public-API change with no justification.
+
+        4. Behavioural contract changes — when a type is replaced, removed, or refactored, diff the OLD
+        implementation against the NEW one. Look for a removed `override`, a property that used to throw
+        on invalid access and now returns a default, an exception type that changed, and call sites that
+        depended on the removed type's specific behaviour.
+
+        5. Weakened invariants — validation quietly relaxed during a refactor. Kotlin shapes:
+        `single()`/`first()` (throws) swapped for `firstOrNull()` (silently picks nothing);
+        a deleted `require`/`check`/`error`; `!!` replaced by `?: <default>` so a broken state becomes a
+        plausible value; an exhaustive `when` gaining an `else ->` branch that swallows new cases.
+
+        6. Missing error handling at system boundaries — unvalidated input from the radio, a peer, an
+        MQTT broker, a deep link, or an intent extra. Do NOT flag missing null checks the Kotlin type
+        system already guarantees.
+
+        7. Performance regressions — allocation in a hot path or a recomposition scope, N+1 database
+        queries, `runBlocking`/`Thread.sleep`/`.get()` on a coroutine or UI path, blocking
+        `getString()` on `Dispatchers.Default`, an unstable Compose parameter type that defeats skipping.
+
+        8. Concurrency — unguarded shared mutable state, a read-decide-write sequence spanning a suspend
+        boundary, a mutex held across a suspending call, deadlock and lock-ordering risk.
+
+        9. Temporal coupling and initialisation safety — `lateinit var` paired with a separate
+        `initialize()`/`start()` that a caller must remember, DI registrations that only work in one
+        resolution order, any pattern where a forgotten call is a runtime crash with no compile-time
+        signal.
+
+        10. Resource leaks — a `CoroutineScope` created and never cancelled, a `Closeable`/`AutoCloseable`
+        outside `use {}`, a registered receiver/listener/callback with no matching unregister, a BLE or
+        socket connection not closed on every exit path. Flag these even when the pattern was moved in
+        from elsewhere.
+
+        11. Dead code and stale comments — a comment describing behaviour the code no longer has, an
+        unused local or parameter, a materialising call whose result is never consumed.
+
+        12. Repository convention violations — see AGENTS.md and .skills/. Highest value: `java.*` or
+        `android.*` in `commonMain`, hardcoded user-facing strings, `runCatching` in a suspend context
+        instead of `safeCatching`, OkHttp instead of Ktor, hand-edits to generated or Crowdin-owned files.
+
+        13. Comment problems — a comment that contradicts the code, a workaround with no tracking link, a
+        parser or protocol handler that omits the raw wire shape needed to read the edge cases, and
+        privacy- or security-sensitive behaviour whose comment fails to explain scope and WHY. Do not ask
+        for comments on obvious code.
+
+
+        Do NOT flag: style already enforced by detekt, spotless, or .editorconfig; missing KDoc, unless a
+        new public API is entirely undocumented; refactoring suggestions for code the PR did not touch;
+        generated output (Wire protos, Crowdin locale files, baseline profiles, docs screenshots);
+        missing tests for docs-only, comment-only, or mechanical-rename changes.
+
+
+        Moved or extracted code counts as newly written. Review it on its merits and flag pre-existing
+        defects that came along with it, labelled "pre-existing — good opportunity to fix during this
+        refactor" so the author can weigh scope.
+
+
+        One problem per comment. Cite the exact line, symbol, or condition. Give a fix direction — a
+        snippet when the fix is not obvious. Never restate a finding already raised in an existing
+        review thread.
     - path: "**/commonMain/**"
       instructions: >
         KMP common code. Flag any import of java.* or android.* — these break non-Android targets. Expect KMP equivalents instead (Okio, kotlinx Mutex/atomicfu, NumberFormatter.format() for floats).
@@ -72,6 +150,35 @@ reviews:
       instructions: Route map access through the injected `CompositionLocal` provider contracts; do not depend directly on Google Maps or osmdroid from feature code.
     - path: feature/car/
       instructions: Run unit tests with `./gradlew :feature:car:testGoogleDebugUnitTest`, and keep Robolectric pinned to SDK 36 for this module.
+    - path: core/database/
+      instructions: >-
+        Review focus: schema compatibility. A `@Database` version bump must ship a new
+        `core/database/schemas/<n>.json` AND an (n-1)→n test under `androidHostTest` that inserts rows at
+        the old version, migrates, and asserts row count and column values survive — not merely that the
+        migration executes. A column going nullable must assert both that pre-existing values are retained
+        and that the new NULL state is reachable. Flag `@Insert`+`@Update` pairs that should be `@Upsert`,
+        single-row queries missing `LIMIT 1`, and N+1 patterns (a loop issuing single-row queries) that
+        should be a chunked `WHERE IN`.
+    - path: core/network/
+      instructions: >-
+        Review focus: request lifecycle. Timeouts and base URLs come from `HttpClientDefaults`; flag
+        hardcoded timeouts or absolute URLs in callers. Check every failure path for cancellation
+        propagation (`safeCatching`, not `runCatching`) and for a response body that is closed on error as
+        well as success.
+    - path: .github/workflows/
+      instructions: >-
+        Review focus: unintended side effects. Flag a change that widens a trigger (especially
+        `pull_request_target` and anything granting write scopes to fork-authored code), a secret exposed
+        to an untrusted context, a cache key that lets one job poison another, and an unpinned third-party
+        action. Job-level `continue-on-error` or a removed `--fail`-style guard silently converts a broken
+        gate into a green tick — flag it.
+    - path: "**/*.gradle.kts"
+      instructions: >-
+        Review focus: build correctness over cleanliness. Several idioms here are load-bearing and look
+        redundant — do not suggest removing an explicit dependency declaration, a duplicated exclusion, or
+        an apparently no-op configuration block without evidence from the diff that it is dead. Flag
+        changes that alter variant/flavor wiring, drop a keep rule, or make a task's inputs/outputs
+        untracked (which silently disables caching and up-to-date checks).
 
   # Every CodeRabbit tool is enabled by default, so this block only ever needs to
   # turn things OFF or configure them. detekt is off because CI owns it (Zero Lint
@@ -102,10 +209,12 @@ reviews:
   pre_merge_checks:
     docstrings:
       mode: "off"
-    # The two defect classes that survive review-by-prose because they are about
-    # what's ABSENT from a diff — a sibling call site left unfixed, or a test that
-    # would still pass with the fix reverted. Warning, not error: these are
-    # judgment calls and a false positive must not block a merge.
+    # Defect classes that survive review-by-prose because they are about what is
+    # ABSENT from a diff — a sibling call site left unfixed, a test that would still
+    # pass with the fix reverted, a regression nobody covered, a behaviour quietly
+    # dropped while code moved files. A per-file reviewer never sees these; a
+    # whole-PR check does. Warning, not error: all four are judgment calls and a
+    # false positive must not block a merge.
     custom_checks:
       - name: "Sibling call sites and presence semantics"
         mode: "warning"
@@ -129,6 +238,76 @@ reviews:
           which items survived, and tests asserting emission ORDER under Dispatchers.Unconfined
           (not a stable contract). A test must assert the side effect only the intended path
           produces — a call counter, a request issued, a cache written.
+      - name: "Regression coverage for changed behavior"
+        mode: "warning"
+        instructions: >-
+          Do not stop at "tests pass" or "there are tests". For each non-trivial production change in
+          the diff, work through four steps and report only the gaps.
+
+
+          1. Changed behaviour — name the concrete code path, function, or configuration key from the
+          diff whose behaviour changed.
+
+          2. Observable surfaces — which of these can see the change: public API, the mesh/radio
+          protocol handling, persisted database rows, DataStore preferences, Compose UI state,
+          navigation, notifications, the foreground service lifecycle, BLE/serial/TCP transport,
+          MQTT, widgets, Android Auto, the desktop app, or R8/ProGuard-shaped release behaviour.
+
+          3. Regression risks — the specific ways this could break a working scenario: ordering and
+          timing changes, reconnect and retry paths, process death and state restore, schema
+          compatibility for rows written by an older build, cross-module call sites, flavor
+          differences (google vs fdroid), and platform differences (Android vs JVM vs iOS targets).
+
+          4. Coverage gap — name the test that should exist and does not.
+
+
+          A bug fix needs a test that FAILS without the fix. A test that only exercises the happy path,
+          or a regenerated snapshot/golden file, does not prove a behaviour change. Flag a PR whose only
+          test evidence is an updated screenshot golden, an updated Room schema JSON, or a regenerated
+          baseline profile when the change is behavioural.
+
+
+          State each finding as: impacted code path, the regression risk, the missing test shape. Be
+          specific enough that the author can write the test from the comment.
+
+
+          Do NOT ask for tests for: documentation-only or comment-only changes, mechanical renames,
+          dependency version bumps, or refactors the diff shows to be behaviour-preserving. Do not
+          demand a test category for a surface the change cannot reach — a `commonMain` formatting
+          helper does not need a transport test.
+      - name: "Moved code diffed against its original"
+        mode: "warning"
+        instructions: >-
+          Applies when the diff deletes a type/function in one file and adds something similar
+          elsewhere, or extracts code into a new file or module. Treat the moved code as newly written
+          and compare the OLD implementation against the NEW one line by line.
+
+
+          Flag any of the following that the move introduced silently:
+
+          - a removed `override`, or an interface member the new type no longer implements;
+
+          - a changed exception contract — something that threw now returns a default, or vice versa;
+
+          - a dropped `require`/`check`/`init` block validation, or a narrowed visibility widened;
+
+          - a default parameter value that changed, which alters every call site that omitted it;
+
+          - a nullability change on a numeric field, which is the presence-vs-sentinel-zero class;
+
+          - a lost `@Serializable`/`@Parcelize`/Koin annotation, or a scope change (`@Single` to
+          `@Factory`) that alters instance lifetime;
+
+          - a coroutine scope, dispatcher, or `SharingStarted` policy that changed during the move.
+
+
+          Then check the call sites of the removed declaration: every caller that relied on the old
+          behaviour must still be correct. Name any caller the PR left on the old assumption.
+
+
+          Pre-existing defects carried into the new location are in scope — label them "pre-existing —
+          good opportunity to fix during this refactor" so the author can decide on scope. Do not flag
+          a move that the diff shows to be genuinely mechanical.
 
 knowledge_base:
   # Learnings are how a confirmed finding stops recurring on the next PR. Pin the

--- a/.skills/code-review/SKILL.md
+++ b/.skills/code-review/SKILL.md
@@ -121,10 +121,24 @@ Kermit is the only logging API, and on the **google** flavor its writers fan eve
 - [ ] **Release Smoke-Test:** For dependency or ProGuard rule changes, verify `assembleRelease` and `./gradlew :desktopApp:runRelease` succeed.
 
 ## Review Output Guidelines
-1. **Be Specific & Constructive:** Provide exact file references and code snippets illustrating the required project pattern.
-2. **Reference the Docs:** Cite `AGENTS.md` and project architecture playbooks to justify change requests (e.g., "Per AGENTS.md, `java.io.*` cannot be used in `commonMain`; please migrate to Okio").
-3. **Enforce Build Health:** Remind authors to run `./gradlew test allTests` locally to verify changes, especially since KMP `test` tasks are ambiguous.
-4. **Praise Good Patterns:** Acknowledge correct usage of complex architecture requirements, like proper Navigation 3 scene transitions or elegant `commonMain` helper extractions.
+
+**Problems only.** Every comment identifies a concrete defect with evidence in the diff. No praise, no style preferences the linters already own, no speculative design feedback, no refactoring suggestions for code the PR did not touch. A review that finds nothing says so in one line.
+
+1. **Be Specific:** Cite the exact file, line, symbol, or condition. Provide a fix direction — a snippet illustrating the canonical project pattern when the fix is not obvious.
+2. **One problem per comment.** Do not bundle several findings into one thread.
+3. **Reference the Docs:** Cite `AGENTS.md` and the architecture playbooks to justify a change request (e.g., "Per AGENTS.md, `java.io.*` cannot be used in `commonMain`; please migrate to Okio").
+4. **Don't repeat what's already flagged.** Check existing review threads before adding a finding.
+5. **Enforce Build Health — only where a gap exists:** If a change lands in a KMP module and the PR's only test evidence is a bare `./gradlew test`, say so: that task is ambiguous in KMP modules and silently skips them, so the code was never exercised and `allTests` is required. Do not append a generic build reminder to a review that has no such gap.
+
+### Analyse impact before judging test coverage
+
+"There are tests" is not coverage. For each non-trivial production change, map: **changed behaviour** (the concrete code path) → **observable surfaces** (public API, protocol handling, persisted rows, DataStore, Compose state, notifications, service lifecycle, transport, MQTT, widgets, Auto, desktop, R8-shaped release behaviour) → **regression risks** (ordering, reconnect/retry, process death, schema compatibility with rows an older build wrote, cross-module call sites, flavor and platform differences) → **the test that should exist and does not**.
+
+A bug fix needs a test that fails *without* the fix. An updated screenshot golden, Room schema JSON, or regenerated baseline profile proves serialisation, not behaviour. Don't demand a test category for a surface the change cannot reach.
+
+### Review moved code as if it were new
+
+When a type moves files or is extracted, diff the old implementation against the new one: a removed `override`, a changed exception contract, a dropped `require`/`check`, a changed default parameter value, a nullability flip on a numeric field (class A), a lost `@Serializable`/`@Parcelize`/Koin annotation, a scope change altering instance lifetime, a changed dispatcher or `SharingStarted`. Then verify every call site of the removed declaration still holds. Pre-existing defects that came along with the move are in scope — label them *"pre-existing — good opportunity to fix during this refactor"* so the author can decide on scope.
 
 ## Git & PR Hygiene Rules
 - **Commit Hygiene:** Squash fixup/polish/review-feedback commits before opening a PR. Each commit should represent a logical, self-contained unit of work — not a back-and-forth conversation.


### PR DESCRIPTION
CodeRabbit knew this repo's conventions but had never been told what counts as a finding. The config carried per-module reminders — keep ProGuard rules aligned, don't hand-edit Crowdin output — and two custom checks for our recurring defect classes. What it lacked was the layer above that: a statement of which categories of problem are worth a comment at all. Whole classes of defect went unasked-for, so they went unreported.

[microsoft/aspire's code-review skill](https://github.com/microsoft/aspire/blob/main/.agents/skills/code-review/SKILL.md) states that contract explicitly. Most of it is procedural — checkout, gather, present, post — and has no CodeRabbit analogue. This PR ports the part that does: the review substance.

## 🌟 A global review contract

New `path: "**"` instruction carrying aspire's flag / don't-flag taxonomy, translated to Kotlin and KMP. The categories our config never asked for:

- **Behavioural contract changes** — diff the old implementation against the new one when a type is replaced.
- **Weakened invariants** — `single()` swapped for `firstOrNull()`, a deleted `require`/`check`, `!!` replaced by `?: default` so a broken state becomes a plausible value.
- **Temporal coupling** — `lateinit var` paired with a separate `initialize()` a caller must remember.
- **Resource leaks, dead code, stale comments.**

It also states the discipline aspire leads with — problems only, one per comment, cite the line, give fix direction, never restate an existing thread — and an explicit *don't flag* list so `profile: chill` stays honest.

## 🛠️ Two pre-merge checks for what's absent from a diff

Both `warning`, matching the existing two, because both are judgment calls that must not block a merge.

- **Regression coverage for changed behavior** — aspire's impact analysis mapped onto our surfaces (radio protocol, persisted rows, DataStore, service lifecycle, transport, MQTT, widgets, Auto, desktop, R8). Its sharpest clause is one we've earned: a PR whose only test evidence is an updated screenshot golden, Room schema JSON, or regenerated baseline profile has not proven a behaviour change.
- **Moved code diffed against its original** — catches what a move silently drops: a lost `@Parcelize`, a `@Single` → `@Factory` lifetime change, a changed `SharingStarted`, a default parameter value that shifted under every call site.

## 🧹 Area entries for the gaps

`core/database` (a schema bump needs a migration test asserting rows survive, not that the migration runs), `core/network`, `.github/workflows` (widened triggers, `continue-on-error` turning a broken gate green), and `**/*.gradle.kts` — that last one with an explicit *don't* clause, since this build has documented load-bearing idioms that read as redundant.

## 🐛 A contradiction in our own guidance

`.skills/code-review/SKILL.md` is fed to CodeRabbit through `knowledge_base.code_guidelines`, so it shapes real review behaviour. Item 4 of its output guidelines said **"Praise Good Patterns"** — actively instructing CodeRabbit to do the thing aspire's skill forbids in its opening paragraph. Replaced with the problems-only contract, plus impact-analysis and moved-code sections so the skill and the YAML agree rather than pull apart.

## Testing Performed

- `coderabbit config validate .coderabbit.yaml` → **valid against the current CodeRabbit schema** (official CLI validator, v0.7.1).
- Independently validated against the published `schema.v2.json` with `jsonschema`; all four `custom_checks` are within the 50-char name and 10,000-char instruction limits, and the global path instruction is 4.2k of the 20k allowance.
- Ran the tuned config end-to-end: `coderabbit review --agent --base main`. It returned exactly one finding — an unconditional `./gradlew test allTests` reminder I had left in the rewritten output guidelines, which contradicted the problems-only rule two paragraphs above it. Fixed in this branch: the reminder now fires only when a KMP module changed and the PR's evidence is a bare `test` run, which is the case where the code genuinely wasn't exercised.

No Gradle baseline run: this touches only `.coderabbit.yaml` and a Markdown skill file, which `spotless`, `detekt`, and the test tasks do not cover. The CodeRabbit validator is the applicable gate and it passes.

## Notes for reviewers

The calibration is unproven against real code — the only diff it has reviewed is its own. Worth watching the next substantive PR for false positives on the two new checks, particularly the coverage one, before we consider promoting either from `warning`.

Two things deliberately *not* done here: `profile` stays `chill` rather than dropping to `quiet` (the global instruction already carries the no-nits discipline, and `quiet` would suppress more than nitpicks), and nothing was added to the `tools` block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded code review guidance with defect-focused standards, evidence requirements, and documentation citations.
  * Added checks for database, network, workflow, Gradle/Kotlin, regression coverage, and moved-code behavior.
  * Clarified test-coverage analysis, duplicate-thread avoidance, and conditional build-health findings.
  * Refined custom-check commentary to address four defect categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->