### PR TITLE
fix(node): scroll traceroute/log history detail popups

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
@@ -16,8 +16,12 @@
  */
 package org.meshtastic.feature.node.metrics
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -294,7 +298,11 @@ open class MetricsViewModel(
     fun showLogDetail(titleRes: StringResource, annotatedMessage: AnnotatedString) {
         alertManager.showAlert(
             titleRes = titleRes,
-            composableMessage = { SelectionContainer { Text(text = annotatedMessage) } },
+            composableMessage = {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    SelectionContainer { Text(text = annotatedMessage) }
+                }
+            },
         )
     }
 
@@ -309,7 +317,11 @@ open class MetricsViewModel(
             val snapshotPositions = tracerouteSnapshotRepository.getSnapshotPositions(responseLogUuid).first()
             alertManager.showAlert(
                 titleRes = Res.string.traceroute,
-                composableMessage = { SelectionContainer { Text(text = annotatedMessage) } },
+                composableMessage = {
+                    Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                        SelectionContainer { Text(text = annotatedMessage) }
+                    }
+                },
                 confirmTextRes = Res.string.view_on_map,
                 onConfirm = {
                     val positionedNodeNums =

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/MetricsViewModel.kt
@@ -16,8 +16,12 @@
  */
 package org.meshtastic.feature.node.metrics
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.lifecycle.ViewModel
 import co.touchlab.kermit.Logger
@@ -296,7 +300,11 @@ open class MetricsViewModel(
     fun showLogDetail(titleRes: StringResource, annotatedMessage: AnnotatedString) {
         alertManager.showAlert(
             titleRes = titleRes,
-            composableMessage = { SelectionContainer { Text(text = annotatedMessage) } },
+            composableMessage = {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    SelectionContainer { Text(text = annotatedMessage) }
+                }
+            },
         )
     }
 
@@ -311,7 +319,11 @@ open class MetricsViewModel(
             val snapshotPositions = tracerouteSnapshotRepository.getSnapshotPositions(responseLogUuid).first()
             alertManager.showAlert(
                 titleRes = Res.string.traceroute,
-                composableMessage = { SelectionContainer { Text(text = annotatedMessage) } },
+                composableMessage = {
+                    Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                        SelectionContainer { Text(text = annotatedMessage) }
+                    }
+                },
                 confirmTextRes = Res.string.view_on_map,
                 onConfirm = {
                     val positionedNodeNums =

--- a/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/metrics/DetailDialogScrollTest.kt
+++ b/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/metrics/DetailDialogScrollTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.metrics
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.text.buildAnnotatedString
+import org.meshtastic.core.ui.component.MeshtasticDialog
+import org.meshtastic.core.ui.theme.AppTheme
+import kotlin.test.Test
+
+private const val HOP_COUNT = 80
+private const val LAST_HOP_MARKER = "LAST_HOP_MARKER"
+
+/**
+ * #6701: a traceroute with many hops scrolled fine live, but was cut off with no way to scroll when reopened from
+ * history. Root cause: [MetricsViewModel.showTracerouteDetail] and [MetricsViewModel.showLogDetail] passed
+ * [MeshtasticDialog] a bare `SelectionContainer { Text(...) }` as `composableMessage` - [MeshtasticDialog] only adds
+ * `verticalScroll` to its own wrapping column when the dialog has `choices` (a button list), so a plain text dialog's
+ * scrolling is entirely the caller's responsibility.
+ *
+ * A screenshot can't catch this regression: a single frame of "scrolled to top, more content below" looks identical
+ * whether or not scrolling actually works. [performScrollTo] is the right tool instead - it throws when the target node
+ * has no scrollable ancestor, so it fails exactly when the `verticalScroll` wrapper is missing.
+ */
+@OptIn(ExperimentalTestApi::class)
+class DetailDialogScrollTest {
+
+    @Test
+    fun longDetailContentScrollsToRevealTrailingText() = runComposeUiTest {
+        val longRoute = buildAnnotatedString {
+            repeat(HOP_COUNT) { append("Hop $it -> ") }
+            append(LAST_HOP_MARKER)
+        }
+
+        setContent {
+            AppTheme {
+                MeshtasticDialog(
+                    title = "Traceroute",
+                    // Matches the fixed composableMessage shape in showTracerouteDetail/showLogDetail exactly.
+                    text = {
+                        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                            SelectionContainer { Text(text = longRoute) }
+                        }
+                    },
+                    onDismiss = {},
+                )
+            }
+        }
+
+        onNodeWithText(LAST_HOP_MARKER, substring = true).performScrollTo().assertIsDisplayed()
+    }
+}

--- a/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/metrics/DetailDialogScrollTest.kt
+++ b/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/metrics/DetailDialogScrollTest.kt
@@ -16,21 +16,42 @@
  */
 package org.meshtastic.feature.node.metrics
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.repository.FileService
+import org.meshtastic.core.repository.MeshLogRepository
+import org.meshtastic.core.repository.NodeRepository
+import org.meshtastic.core.repository.TracerouteResponseProvider
+import org.meshtastic.core.repository.TracerouteSnapshotRepository
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.traceroute
 import org.meshtastic.core.ui.component.MeshtasticDialog
 import org.meshtastic.core.ui.theme.AppTheme
+import org.meshtastic.core.ui.util.AlertManager
+import org.meshtastic.feature.node.detail.NodeDetailUiState
+import org.meshtastic.feature.node.detail.NodeRequestActions
+import org.meshtastic.feature.node.domain.usecase.GetNodeDetailsUseCase
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 
 private const val HOP_COUNT = 80
 private const val LAST_HOP_MARKER = "LAST_HOP_MARKER"
@@ -45,31 +66,89 @@ private const val LAST_HOP_MARKER = "LAST_HOP_MARKER"
  * A screenshot can't catch this regression: a single frame of "scrolled to top, more content below" looks identical
  * whether or not scrolling actually works. [performScrollTo] is the right tool instead - it throws when the target node
  * has no scrollable ancestor, so it fails exactly when the `verticalScroll` wrapper is missing.
+ *
+ * The dialog content under test is the real one: the ViewModel is driven through the production path and the
+ * `composableMessage` it hands [AlertManager] is what gets rendered, so reverting the fix in [MetricsViewModel] fails
+ * these tests.
  */
-@OptIn(ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class, ExperimentalCoroutinesApi::class)
 class DetailDialogScrollTest {
 
-    @Test
-    fun longDetailContentScrollsToRevealTrailingText() = runComposeUiTest {
-        val longRoute = buildAnnotatedString {
-            repeat(HOP_COUNT) { append("Hop $it -> ") }
-            append(LAST_HOP_MARKER)
-        }
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val dispatchers = CoroutineDispatchers(main = testDispatcher, io = testDispatcher, default = testDispatcher)
 
-        setContent {
-            AppTheme {
-                MeshtasticDialog(
-                    title = "Traceroute",
-                    // Matches the fixed composableMessage shape in showTracerouteDetail/showLogDetail exactly.
-                    text = {
-                        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                            SelectionContainer { Text(text = longRoute) }
-                        }
-                    },
-                    onDismiss = {},
-                )
-            }
-        }
+    private val meshLogRepository: MeshLogRepository = mock()
+    private val tracerouteResponseProvider: TracerouteResponseProvider = mock()
+    private val nodeRepository: NodeRepository = mock()
+    private val tracerouteSnapshotRepository: TracerouteSnapshotRepository = mock()
+    private val nodeRequestActions: NodeRequestActions = mock()
+    private val getNodeDetailsUseCase: GetNodeDetailsUseCase = mock()
+    private val fileService: FileService = mock()
+
+    private val alertManager = AlertManager()
+
+    private lateinit var viewModel: MetricsViewModel
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        every { tracerouteResponseProvider.tracerouteResponse } returns MutableStateFlow(null)
+        every { nodeRequestActions.lastTracerouteTime } returns MutableStateFlow(null)
+        every { nodeRequestActions.lastRequestNeighborTimes } returns MutableStateFlow(emptyMap())
+        every { nodeRepository.nodeDBbyNum } returns MutableStateFlow(emptyMap())
+        every { getNodeDetailsUseCase(any()) } returns flowOf(NodeDetailUiState())
+        every { tracerouteSnapshotRepository.getSnapshotPositions(any()) } returns flowOf(emptyMap())
+
+        viewModel =
+            MetricsViewModel(
+                destNum = 1234,
+                dispatchers = dispatchers,
+                meshLogRepository = meshLogRepository,
+                tracerouteResponseProvider = tracerouteResponseProvider,
+                nodeRepository = nodeRepository,
+                tracerouteSnapshotRepository = tracerouteSnapshotRepository,
+                nodeRequestActions = nodeRequestActions,
+                alertManager = alertManager,
+                getNodeDetailsUseCase = getNodeDetailsUseCase,
+                fileService = fileService,
+            )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun showLogDetailContentScrollsToRevealTrailingText() {
+        viewModel.showLogDetail(titleRes = Res.string.traceroute, annotatedMessage = longRoute())
+        assertShownAlertScrolls()
+    }
+
+    @Test
+    fun showTracerouteDetailContentScrollsToRevealTrailingText() {
+        viewModel.showTracerouteDetail(
+            annotatedMessage = longRoute(),
+            requestId = 1,
+            responseLogUuid = "uuid",
+            overlay = null,
+            onViewOnMap = { _, _ -> },
+        )
+        assertShownAlertScrolls()
+    }
+
+    private fun longRoute(): AnnotatedString = buildAnnotatedString {
+        repeat(HOP_COUNT) { append("Hop $it -> ") }
+        append(LAST_HOP_MARKER)
+    }
+
+    /** Renders whatever `composableMessage` the ViewModel just handed [AlertManager], then scrolls to the last hop. */
+    private fun assertShownAlertScrolls() = runComposeUiTest {
+        val message = alertManager.currentAlert.value?.composableMessage
+        assertNotNull(message, "ViewModel did not raise an alert with composable content")
+
+        setContent { AppTheme { MeshtasticDialog(title = "Traceroute", text = { message.Content() }, onDismiss = {}) } }
 
         onNodeWithText(LAST_HOP_MARKER, substring = true).performScrollTo().assertIsDisplayed()
     }


### PR DESCRIPTION
Fixes #6701.

## Why

A traceroute with many hops scrolls fine in the live/real-time result view, but the same route reopened from history is cut off with no way to see the rest.

Root cause: the shared popup component `MeshtasticDialog` (`core/ui/.../AlertDialogs.kt`) only wraps its content in a scrollable column when the dialog has `choices` (a button list). For a plain text/`composableMessage` dialog, scrolling is the caller's own responsibility.

- The live traceroute view (`TracerouteAlertHandler.kt`) already does this correctly - wraps its `Text` in `Column(Modifier.verticalScroll(rememberScrollState()))`.
- `MetricsViewModel.showTracerouteDetail` (the history case) did not - just a bare `SelectionContainer { Text(...) }` - so long content clips inside the dialog's bounded height with no way to reach the rest.
- `MetricsViewModel.showLogDetail` (used for other detail popups, e.g. neighbor-info logs) had the exact same missing-modifier pattern, one-for-one. Not reported in the issue, but it's the identical mistake in the same file, so it's fixed in the same PR rather than left for someone to report separately.

## What changed

- `showLogDetail` and `showTracerouteDetail` (`feature/node/.../MetricsViewModel.kt`) now wrap their content in `Column(Modifier.verticalScroll(rememberScrollState()))`, matching the working `TracerouteAlertHandler.kt` pattern exactly.
- No changes to `MeshtasticDialog`/`AlertDialogs.kt` itself - a shared-component-level fix (always-scrollable text content regardless of `choices`) was considered but deliberately left out of scope here, since it touches a component used by every dialog in the app and deserves its own separately-reviewed PR.

## Test plan

- New test: `feature/node/src/jvmTest/.../DetailDialogScrollTest.kt`. A static screenshot can't catch this regression - a single frame of "scrolled to top, more content below" looks identical whether or not scrolling actually works. Used a behavioral test instead: `performScrollTo()` throws when the target node has no scrollable ancestor, so it fails exactly when the `verticalScroll` wrapper is missing. Confirmed by hand: temporarily reverted the test to the pre-fix (unwrapped) shape and watched it fail with the expected `AssertionError`, then restored it.
- Local baseline green: `spotlessApply spotlessCheck detekt assembleDebug test allTests` and `kmpSmokeCompile`.

**Not yet verified on real hardware.** I have the fdroid debug build with this fix installed on a Samsung Galaxy S24+, but no nearby node has responded to a traceroute request yet to produce a fresh multi-hop result to test against. Will update here once verified against an actual long route on-device; happy to hold this in draft until then.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long log and traceroute details in alerts can now be vertically scrolled, preventing content from being cut off.
  * Reopened traceroute histories with many hops now display their complete details.

* **Tests**
  * Added coverage to verify scrolling works for both log and traceroute detail dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->