### PR TITLE
fix(lora): keep a deliberately pinned preset at fresh setup

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
@@ -75,6 +75,29 @@ fun LoRaRegionPresetMap?.repairPresetFor(region: RegionCode, current: ModemPrese
 }
 
 /**
+ * Returns the modem preset the LoRa form should hold when the region changes from [previousRegion] to [newRegion] with
+ * [current] selected.
+ *
+ * Keeps [current] (legality-repaired via [repairPresetFor]) except at fresh setup: when [previousRegion] is UNSET and
+ * [current] is the [ModemPreset.LONG_FAST] placeholder a factory-flashed node reports (proto default), the region's
+ * advertised default is adopted instead (the firmware map's when present, else the app's built-in default). Any other
+ * preset at UNSET was set deliberately (e.g. a vendor build pinning USERPREFS_LORACONFIG_MODEM_PRESET) and is kept.
+ */
+fun LoRaRegionPresetMap?.presetForRegionChange(
+    previousRegion: RegionCode,
+    newRegion: RegionCode,
+    current: ModemPreset,
+): ModemPreset {
+    val repaired = repairPresetFor(newRegion, current)
+    val freshSetup = previousRegion == RegionCode.UNSET && current == ModemPreset.LONG_FAST
+    return if (freshSetup) {
+        constraintFor(newRegion)?.defaultPreset ?: defaultPresetFor(newRegion) ?: repaired
+    } else {
+        repaired
+    }
+}
+
+/**
  * The app's built-in default modem presets for regions whose default differs from the global [ChannelOption.DEFAULT].
  * Mirrors the per-region defaults newer firmware advertises in [LoRaRegionPresetMap], so the default channel and a
  * fresh setup over old firmware (which sends no map) land on the same preset a new node would.

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
@@ -91,7 +91,9 @@ fun LoRaRegionPresetMap?.presetForRegionChange(
     val repaired = repairPresetFor(newRegion, current)
     val freshSetup = previousRegion == RegionCode.UNSET && current == ModemPreset.LONG_FAST
     return if (freshSetup) {
-        constraintFor(newRegion)?.defaultPreset ?: defaultPresetFor(newRegion) ?: repaired
+        // Re-repair the adopted default: a malformed map's advertised default may not be in its own legal set.
+        val preferred = constraintFor(newRegion)?.defaultPreset ?: defaultPresetFor(newRegion) ?: repaired
+        repairPresetFor(newRegion, preferred)
     } else {
         repaired
     }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
@@ -129,20 +129,22 @@ class LoRaRegionPresetsTest {
         assertEquals(ModemPreset.LONG_FAST, map.repairPresetFor(RegionCode.US, ModemPreset.SHORT_TURBO))
     }
 
+    // A malformed map whose advertised default is not in its own legal set.
+    private val oddMap =
+        LoRaRegionPresetMap(
+            groups =
+            listOf(
+                LoRaPresetGroup(
+                    presets = listOf(ModemPreset.MEDIUM_FAST, ModemPreset.MEDIUM_SLOW),
+                    default_preset = ModemPreset.LONG_FAST, // not in presets
+                    licensed_only = false,
+                ),
+            ),
+            region_groups = listOf(LoRaRegionPresets(region = RegionCode.US, group_index = 0)),
+        )
+
     @Test
     fun `repair falls back to the first legal preset when the default is not in the group`() {
-        val oddMap =
-            LoRaRegionPresetMap(
-                groups =
-                listOf(
-                    LoRaPresetGroup(
-                        presets = listOf(ModemPreset.MEDIUM_FAST, ModemPreset.MEDIUM_SLOW),
-                        default_preset = ModemPreset.LONG_FAST, // not in presets
-                        licensed_only = false,
-                    ),
-                ),
-                region_groups = listOf(LoRaRegionPresets(region = RegionCode.US, group_index = 0)),
-            )
         assertEquals(ModemPreset.MEDIUM_FAST, oddMap.repairPresetFor(RegionCode.US, ModemPreset.SHORT_FAST))
     }
 
@@ -201,6 +203,14 @@ class LoRaRegionPresetsTest {
         assertEquals(
             ModemPreset.LONG_FAST,
             map.presetForRegionChange(RegionCode.UNSET, RegionCode.US, ModemPreset.SHORT_TURBO),
+        )
+    }
+
+    @Test
+    fun `fresh setup never adopts a malformed map's illegal advertised default`() {
+        assertEquals(
+            ModemPreset.MEDIUM_FAST,
+            oddMap.presetForRegionChange(RegionCode.UNSET, RegionCode.US, ModemPreset.LONG_FAST),
         )
     }
 }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
@@ -44,11 +44,18 @@ class LoRaRegionPresetsTest {
                     default_preset = ModemPreset.TINY_FAST,
                     licensed_only = true,
                 ),
+                // group 2: models EU_N_868's superset advertising - LONG_FAST is legal but not the default.
+                LoRaPresetGroup(
+                    presets = listOf(ModemPreset.LONG_FAST, ModemPreset.MEDIUM_FAST),
+                    default_preset = ModemPreset.MEDIUM_FAST,
+                    licensed_only = false,
+                ),
             ),
             region_groups =
             listOf(
                 LoRaRegionPresets(region = RegionCode.US, group_index = 0),
                 LoRaRegionPresets(region = RegionCode.UA_433, group_index = 1),
+                LoRaRegionPresets(region = RegionCode.EU_N_868, group_index = 2),
             ),
         )
 
@@ -143,5 +150,57 @@ class LoRaRegionPresetsTest {
     fun `region default preset is LongTurbo for US and absent for other regions`() {
         assertEquals(ModemPreset.LONG_TURBO, defaultPresetFor(RegionCode.US))
         assertNull(defaultPresetFor(RegionCode.EU_868))
+    }
+
+    @Test
+    fun `region change keeps a legal preset when not fresh setup`() {
+        assertEquals(
+            ModemPreset.SHORT_FAST,
+            map.presetForRegionChange(RegionCode.EU_868, RegionCode.US, ModemPreset.SHORT_FAST),
+        )
+    }
+
+    @Test
+    fun `region change keeps a legal placeholder when not fresh setup`() {
+        // Default adoption is a fresh-setup rule only: an already-configured node moving regions keeps LONG_FAST.
+        assertEquals(
+            ModemPreset.LONG_FAST,
+            map.presetForRegionChange(RegionCode.US, RegionCode.EU_N_868, ModemPreset.LONG_FAST),
+        )
+    }
+
+    @Test
+    fun `fresh setup keeps a deliberately pinned legal preset`() {
+        // UNSET + a non-placeholder preset is a deliberate pin (e.g. USERPREFS_LORACONFIG_MODEM_PRESET, #6704).
+        assertEquals(
+            ModemPreset.SHORT_FAST,
+            map.presetForRegionChange(RegionCode.UNSET, RegionCode.US, ModemPreset.SHORT_FAST),
+        )
+    }
+
+    @Test
+    fun `fresh setup placeholder adopts the region's advertised default`() {
+        // LONG_FAST is legal in the EU_N_868 group, but the placeholder still adopts the advertised default.
+        assertEquals(
+            ModemPreset.MEDIUM_FAST,
+            map.presetForRegionChange(RegionCode.UNSET, RegionCode.EU_N_868, ModemPreset.LONG_FAST),
+        )
+    }
+
+    @Test
+    fun `fresh setup placeholder adopts the built-in default when unconstrained`() {
+        val nullMap: LoRaRegionPresetMap? = null
+        assertEquals(
+            ModemPreset.LONG_TURBO,
+            nullMap.presetForRegionChange(RegionCode.UNSET, RegionCode.US, ModemPreset.LONG_FAST),
+        )
+    }
+
+    @Test
+    fun `fresh setup pin that is illegal in the region is still repaired`() {
+        assertEquals(
+            ModemPreset.LONG_FAST,
+            map.presetForRegionChange(RegionCode.UNSET, RegionCode.US, ModemPreset.SHORT_TURBO),
+        )
     }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -33,9 +33,8 @@ import org.meshtastic.core.model.ChannelOption
 import org.meshtastic.core.model.RegionInfo
 import org.meshtastic.core.model.RegionPresetConstraint
 import org.meshtastic.core.model.constraintFor
-import org.meshtastic.core.model.defaultPresetFor
 import org.meshtastic.core.model.numChannels
-import org.meshtastic.core.model.repairPresetFor
+import org.meshtastic.core.model.presetForRegionChange
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.advanced
 import org.meshtastic.core.resources.bandwidth
@@ -183,21 +182,14 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     },
                     selectedItem = formState.value.region,
                     onItemSelected = { region ->
-                        val freshSetup = formState.value.region == RegionCode.UNSET
-                        // When the region changes, snap the preset to the region's default if the current one is
-                        // no longer legal there (R7); a no-op when the region is unconstrained.
-                        val repaired = regionPresetMap.repairPresetFor(region, formState.value.modem_preset)
-                        // At fresh setup (region was UNSET) adopt the region's advertised default rather than keeping
-                        // a merely-legal preset: the firmware map's default when present, else the app's built-in
-                        // default (e.g. US -> LongTurbo on pre-2.8 firmware that sends no map).
+                        // Keeps the current preset (legality-repaired, R7); at fresh setup a placeholder LongFast
+                        // adopts the region's advertised/built-in default instead (#6704).
                         val preset =
-                            if (freshSetup) {
-                                regionPresetMap.constraintFor(region)?.defaultPreset
-                                    ?: defaultPresetFor(region)
-                                    ?: repaired
-                            } else {
-                                repaired
-                            }
+                            regionPresetMap.presetForRegionChange(
+                                previousRegion = formState.value.region,
+                                newRegion = region,
+                                current = formState.value.modem_preset,
+                            )
                         formState.value = formState.value.copy(region = region, modem_preset = preset)
                     },
                 )


### PR DESCRIPTION
## Why

Fixes #6704.

Community/vendor firmware builds can pin a modem preset (`USERPREFS_LORACONFIG_MODEM_PRESET`) while leaving the region unset, so a fresh flash reaches the app as region `UNSET` + the pinned preset. The LoRa form's fresh-setup rule (from #6009) unconditionally replaced the preset with the region default the moment a region was picked, so a mesh pinned to ShortTurbo silently lost every new node to LongFast/LongTurbo. Firmware deliberately preserves that pin across boots since meshtastic/firmware#11496; the app was the one destroying it.

## What changed

🐛 Fresh setup (region `UNSET` → a region) now adopts the region's advertised/built-in default **only when the current preset is the `LONG_FAST` placeholder**. `LONG_FAST` is proto-zero, so a factory-flashed node that never had a preset pinned reports it by construction; any other preset at `UNSET` was set deliberately and is kept (legality-repaired only).

🛠️ Extracted the region-change preset decision into a pure `presetForRegionChange()` in `core:model` next to `repairPresetFor()`, so the rule is unit-testable instead of living inline in the composable (mirrors iOS's pure `ModemPresets.presetToSelect`).

Every case #6009 cared about is preserved: a stock placeholder still adopts the firmware map's advertised default where present (e.g. EU_N_868 → NarrowSlow), else the app's built-in default (US → LongTurbo on pre-2.8 firmware).

## Notes for reviewers

- A vendor build that deliberately pins `LONG_FAST` is indistinguishable from stock today; meshtastic/firmware#11507 makes the intent explicit and the next PR in this stack consumes it.
- Illegal pins are still repaired: legality wins over intent, same as before.

## Testing Performed

- `:core:model:allTests` — new tests covering: pinned legal preset kept at fresh setup, placeholder adopts the advertised default (including when the placeholder is legal, the EU superset case), placeholder adopts the built-in default on a null map, illegal pin still repaired, and no default adoption outside fresh setup.
- `:feature:settings:allTests`, `spotlessCheck`, `detekt`, `kmpSmokeCompile` — green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regional preset handling when changing regions.
  * Automatically repairs presets that are not legal for the selected region.
  * Preserves deliberately selected legal presets.
  * Applies the region’s advertised default during fresh setup when appropriate.
  * Falls back to a built-in default when no regional default is available.

* **Tests**
  * Added coverage for region changes, fresh setup defaults, preserved selections, and invalid preset repair.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->