### PR TITLE
feat(lora): honor a pinned-preset intent advertised for UNSET

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/RegionPresetConstraint.kt
@@ -82,6 +82,9 @@ fun LoRaRegionPresetMap?.repairPresetFor(region: RegionCode, current: ModemPrese
  * [current] is the [ModemPreset.LONG_FAST] placeholder a factory-flashed node reports (proto default), the region's
  * advertised default is adopted instead (the firmware map's when present, else the app's built-in default). Any other
  * preset at UNSET was set deliberately (e.g. a vendor build pinning USERPREFS_LORACONFIG_MODEM_PRESET) and is kept.
+ *
+ * A build that pins a preset can also advertise it as an UNSET map entry (firmware #11507), stating outright that the
+ * preset is deliberate; that keeps even a pinned LONG_FAST, which the placeholder heuristic alone cannot distinguish.
  */
 fun LoRaRegionPresetMap?.presetForRegionChange(
     previousRegion: RegionCode,
@@ -89,7 +92,8 @@ fun LoRaRegionPresetMap?.presetForRegionChange(
     current: ModemPreset,
 ): ModemPreset {
     val repaired = repairPresetFor(newRegion, current)
-    val freshSetup = previousRegion == RegionCode.UNSET && current == ModemPreset.LONG_FAST
+    val pinned = constraintFor(RegionCode.UNSET) != null
+    val freshSetup = previousRegion == RegionCode.UNSET && !pinned && current == ModemPreset.LONG_FAST
     return if (freshSetup) {
         // Re-repair the adopted default: a malformed map's advertised default may not be in its own legal set.
         val preferred = constraintFor(newRegion)?.defaultPreset ?: defaultPresetFor(newRegion) ?: repaired

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/LoRaRegionPresetsTest.kt
@@ -213,4 +213,35 @@ class LoRaRegionPresetsTest {
             oddMap.presetForRegionChange(RegionCode.UNSET, RegionCode.US, ModemPreset.LONG_FAST),
         )
     }
+
+    // A pinned build advertises its preset as UNSET's map entry (firmware #11507): the same fixture plus a
+    // single-preset UNSET group, here stating a deliberate LONG_FAST pin.
+    private val pinnedMap =
+        map.copy(
+            groups =
+            map.groups +
+                LoRaPresetGroup(
+                    presets = listOf(ModemPreset.LONG_FAST),
+                    default_preset = ModemPreset.LONG_FAST,
+                    licensed_only = false,
+                ),
+            region_groups = map.region_groups + LoRaRegionPresets(region = RegionCode.UNSET, group_index = 3),
+        )
+
+    @Test
+    fun `an UNSET map entry marks even a LongFast pin as deliberate at fresh setup`() {
+        // Without the entry this placeholder would adopt EU_N_868's MEDIUM_FAST default (asserted above).
+        assertEquals(
+            ModemPreset.LONG_FAST,
+            pinnedMap.presetForRegionChange(RegionCode.UNSET, RegionCode.EU_N_868, ModemPreset.LONG_FAST),
+        )
+    }
+
+    @Test
+    fun `a pin stated via UNSET entry is still repaired when illegal in the region`() {
+        assertEquals(
+            ModemPreset.TINY_FAST,
+            pinnedMap.presetForRegionChange(RegionCode.UNSET, RegionCode.UA_433, ModemPreset.LONG_FAST),
+        )
+    }
 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -169,7 +169,11 @@ fun LoRaConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                 val regionPresetMap = if (capabilities.supportsLoraRegionPresetMap) state.loraRegionPresetMap else null
                 val presetConstraint =
                     remember(regionPresetMap, formState.value.region) {
-                        regionPresetMap.constraintFor(formState.value.region)
+                        // UNSET's map entry states pin intent (firmware #11507), not a constraint: never let it
+                        // narrow the picker while the region is still unset.
+                        formState.value.region
+                            .takeIf { it != RegionCode.UNSET }
+                            ?.let { regionPresetMap.constraintFor(it) }
                     }
                 val presetsGated = presetConstraint?.isGated(state.localIsLicensed) == true
                 DropDownPreference(


### PR DESCRIPTION
## Why

Second half of #6704 (stacked on the placeholder-gate PR).

The placeholder heuristic in the previous PR can't tell a vendor build that deliberately pins `LONG_FAST` from a stock install: both report region `UNSET` + `LONG_FAST`. meshtastic/firmware#11507 closes that gap by advertising an `UNSET` entry in `LoRaRegionPresetMap` when, and only when, the build pins a preset, stating the pin as the group's sole entry and default.

## What changed

🌟 `presetForRegionChange()` now treats a non-null `constraintFor(RegionCode.UNSET)` as an explicit statement that the current preset is deliberate: fresh setup keeps it (legality-repaired only), even when it is `LONG_FAST`. Firmware that sends no `UNSET` entry (stock builds, and everything shipped today) falls through to the placeholder heuristic unchanged.

## Notes for reviewers

- The `UNSET` lookup is scoped to the fresh-setup decision only: the picker's constraint lookup now explicitly skips `UNSET`, so a pinned build's single-entry group never collapses the dropdown while the region is still unset — matching #11507's "intent, not enforcement", and confirmed as the intended reading by the map's author on #6704. Behavior-neutral on firmware without the entry (`constraintFor(UNSET)` was null there anyway).
- Inert on today's firmware: no shipped release emits an `UNSET` entry, so behavior is identical to the previous PR until firmware#11507 lands.

## Testing Performed

- `:core:model:allTests` — new tests: a map with an `UNSET` entry keeps a pinned `LONG_FAST` at fresh setup; the same pin is still legality-repaired when illegal in the chosen region; maps without an `UNSET` entry keep the placeholder heuristic.
- `:feature:settings:allTests`, `spotlessCheck`, `detekt`, `kmpSmokeCompile` — green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves deliberately selected radio presets during fresh setup, including `LONG_FAST`.
  * Repairs presets when they are not valid for the selected region.
  * Keeps preset selection unrestricted while the region remains unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->