### PR TITLE
test: deflake AndroidMeshWorkerManagerTest by rooting the parked worker coroutine

### DIFF
--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidMeshWorkerManagerTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidMeshWorkerManagerTest.kt
@@ -26,7 +26,7 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
-import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.CompletableDeferred
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.meshtastic.core.repository.PersistedPacketId
@@ -56,6 +56,12 @@ class AndroidMeshWorkerManagerTest {
 
         manager.enqueueSendMessage(persistedId)
         val first = workManager.getWorkInfosForUniqueWork(workName(persistedId)).get().single()
+        // Regression guard: GC pressure here used to collect the worker's CallbackToFutureAdapter completer,
+        // marking the running work FAILED so the KEEP enqueue below replaced it (flaky only on loaded CI).
+        repeat(3) {
+            System.gc()
+            System.runFinalization()
+        }
         manager.enqueueSendMessage(persistedId)
         val retained = workManager.getWorkInfosForUniqueWork(workName(persistedId)).get().single()
 
@@ -67,19 +73,29 @@ class AndroidMeshWorkerManagerTest {
     private fun workName(id: PersistedPacketId) = "${SendMessageWorker.WORK_NAME_PREFIX}${id.myNodeNum}_${id.uuid}"
 
     private class BlockingWorkerFactory : WorkerFactory() {
+        // Awaiting this (instead of awaitCancellation) keeps the parked worker coroutine strongly reachable;
+        // startWork()'s future holds its completer only weakly, and a GC'd completer fails the work.
+        val release = CompletableDeferred<Unit>()
+
         override fun createWorker(
             appContext: Context,
             workerClassName: String,
             workerParameters: WorkerParameters,
         ): ListenableWorker? = if (workerClassName == SendMessageWorker::class.java.name) {
-            BlockingWorker(appContext, workerParameters)
+            BlockingWorker(appContext, workerParameters, release)
         } else {
             null
         }
     }
 
-    private class BlockingWorker(appContext: Context, workerParameters: WorkerParameters) :
-        CoroutineWorker(appContext, workerParameters) {
-        override suspend fun doWork(): Result = awaitCancellation()
+    private class BlockingWorker(
+        appContext: Context,
+        workerParameters: WorkerParameters,
+        private val release: CompletableDeferred<Unit>,
+    ) : CoroutineWorker(appContext, workerParameters) {
+        override suspend fun doWork(): Result {
+            release.await()
+            return Result.success()
+        }
     }
 }

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidMeshWorkerManagerTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/AndroidMeshWorkerManagerTest.kt
@@ -21,12 +21,14 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.work.Configuration
 import androidx.work.CoroutineWorker
 import androidx.work.ListenableWorker
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.meshtastic.core.repository.PersistedPacketId
@@ -34,7 +36,6 @@ import org.meshtastic.core.service.worker.SendMessageWorker
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -43,10 +44,11 @@ class AndroidMeshWorkerManagerTest {
     @Test
     fun `repeated persisted row scheduling keeps the active unique worker`() {
         val context = ApplicationProvider.getApplicationContext<Context>()
+        val factory = BlockingWorkerFactory()
         val configuration =
             Configuration.Builder()
                 .setExecutor(SynchronousExecutor())
-                .setWorkerFactory(BlockingWorkerFactory())
+                .setWorkerFactory(factory)
                 .setMinimumLoggingLevel(android.util.Log.DEBUG)
                 .build()
         WorkManagerTestInitHelper.initializeTestWorkManager(context, configuration)
@@ -54,27 +56,33 @@ class AndroidMeshWorkerManagerTest {
         val persistedId = PersistedPacketId(myNodeNum = 42, uuid = 99L)
         val manager = AndroidMeshWorkerManager(workManager)
 
-        manager.enqueueSendMessage(persistedId)
-        val first = workManager.getWorkInfosForUniqueWork(workName(persistedId)).get().single()
-        // Regression guard: GC pressure here used to collect the worker's CallbackToFutureAdapter completer,
-        // marking the running work FAILED so the KEEP enqueue below replaced it (flaky only on loaded CI).
-        repeat(3) {
-            System.gc()
-            System.runFinalization()
-        }
-        manager.enqueueSendMessage(persistedId)
-        val retained = workManager.getWorkInfosForUniqueWork(workName(persistedId)).get().single()
+        try {
+            manager.enqueueSendMessage(persistedId)
+            runBlocking { factory.started.await() }
+            val first = workManager.getWorkInfosForUniqueWork(workName(persistedId)).get().single()
+            assertEquals(WorkInfo.State.RUNNING, first.state, "The worker must be parked before the GC guard runs")
+            // Regression guard (#6720): GC pressure here used to collect the worker's CallbackToFutureAdapter
+            // completer, marking the running work FAILED so the KEEP enqueue below replaced it (flaky on loaded CI).
+            repeat(3) {
+                System.gc()
+                System.runFinalization()
+            }
+            manager.enqueueSendMessage(persistedId)
+            val retained = workManager.getWorkInfosForUniqueWork(workName(persistedId)).get().single()
 
-        assertFalse(first.state.isFinished, "The first request must remain active for KEEP to apply")
-        assertEquals(first.id, retained.id, "KEEP must retain the active work request instead of replacing it")
-        workManager.cancelUniqueWork(workName(persistedId)).result.get()
+            assertEquals(first.id, retained.id, "KEEP must retain the active work request instead of replacing it")
+        } finally {
+            factory.release.complete(Unit)
+            workManager.cancelUniqueWork(workName(persistedId)).result.get()
+        }
     }
 
     private fun workName(id: PersistedPacketId) = "${SendMessageWorker.WORK_NAME_PREFIX}${id.myNodeNum}_${id.uuid}"
 
     private class BlockingWorkerFactory : WorkerFactory() {
-        // Awaiting this (instead of awaitCancellation) keeps the parked worker coroutine strongly reachable;
-        // startWork()'s future holds its completer only weakly, and a GC'd completer fails the work.
+        // Awaiting release (instead of awaitCancellation) keeps the parked worker coroutine strongly reachable;
+        // startWork()'s future holds its completer only weakly, and a GC'd completer fails the work (#6720).
+        val started = CompletableDeferred<Unit>()
         val release = CompletableDeferred<Unit>()
 
         override fun createWorker(
@@ -82,7 +90,7 @@ class AndroidMeshWorkerManagerTest {
             workerClassName: String,
             workerParameters: WorkerParameters,
         ): ListenableWorker? = if (workerClassName == SendMessageWorker::class.java.name) {
-            BlockingWorker(appContext, workerParameters, release)
+            BlockingWorker(appContext, workerParameters, started, release)
         } else {
             null
         }
@@ -91,9 +99,11 @@ class AndroidMeshWorkerManagerTest {
     private class BlockingWorker(
         appContext: Context,
         workerParameters: WorkerParameters,
+        private val started: CompletableDeferred<Unit>,
         private val release: CompletableDeferred<Unit>,
     ) : CoroutineWorker(appContext, workerParameters) {
         override suspend fun doWork(): Result {
+            started.complete(Unit)
             release.await()
             return Result.success()
         }


### PR DESCRIPTION
## Why

`AndroidMeshWorkerManagerTest > repeated persisted row scheduling keeps the active unique worker` passed full PR CI twice on fe46acff8, then failed both Develocity retry attempts in merge-group run 31892825244 on byte-identical content, ejecting an unrelated LoRa change from the merge queue. The flake was GC pressure, not test-order contamination:

1. `CoroutineWorker.startWork()` observes the worker through a `CallbackToFutureAdapter` future, and that future holds its `Completer` only weakly.
2. The test's blocking worker parked in `awaitCancellation()`, the one suspension that registers with nothing external. Once suspended, the whole cluster (completer, coroutine, detached `Job()`) is a reference cycle with no strong GC root.
3. On a loaded 2-core CI runner, GC collected the completer in the window between the two enqueues. The adapter completed the future exceptionally, `WorkerWrapper` mapped that to `Resolution.Failed()`, and the work row flipped to FAILED.
4. The second `enqueueUniqueWork(KEEP)` saw a finished spec, deleted it, and inserted a new request, so the id-equality assertion failed.

Reproduced deterministically by forcing GC between the enqueues: 3/3 failures with the exact CI assertion message. Real workers are unaffected because their suspensions (Room, radio I/O, `delay()`) register with strongly rooted machinery; a repo sweep found no other worker or test with this shape.

## 🐛 Bug Fixes (test-only)

- The blocking worker now awaits a `CompletableDeferred` held by the `WorkerFactory` instead of `awaitCancellation()`, keeping the parked continuation strongly reachable for the life of the test.
- A forced `System.gc()` block stays between the two enqueues as a deterministic regression guard: it fails every run with the old worker and never with the fix.
- Per review: the worker emits a started signal that the test awaits, and the test asserts `WorkInfo.State.RUNNING` before forcing GC, so the guard provably exercises the parked-coroutine window; cleanup runs in a `finally` block so a failing assertion cannot leak the blocked worker into same-JVM retries.

## Testing Performed

- Old worker + GC guard: fails 3/3 (identical assertion to the merge-group failure).
- New worker + GC guard: passes, 3/3 reruns after the review hardening.
- `:core:service:testAndroidHostTest` full suite: 5/5 consecutive clean reruns.
- `spotlessApply spotlessCheck detekt`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)