### PR TITLE
fix(network): handle IPv6 mDNS addresses correctly, refresh on re-announce

### DIFF
--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/NetworkRepository.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/NetworkRepository.kt
@@ -24,7 +24,13 @@ interface NetworkRepository {
 
     companion object {
         fun DiscoveredService.toAddressString() = buildString {
-            append(hostAddress)
+            // Bracket IPv6 literals (they contain ':') so appending ":$port" below stays
+            // unambiguous — "fe80::1:8080" is not parseable as host+port, "[fe80::1]:8080" is.
+            if (hostAddress.contains(':')) {
+                append('[').append(hostAddress).append(']')
+            } else {
+                append(hostAddress)
+            }
             if (port != NetworkConstants.SERVICE_PORT) {
                 append(":$port")
             }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/transport/TcpTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/transport/TcpTransport.kt
@@ -254,9 +254,7 @@ class TcpTransport(
      */
     @Suppress("NestedBlockDepth")
     private suspend fun connectAndRead(address: String): Boolean = withContext(dispatchers.io) {
-        val parts = address.split(":", limit = 2)
-        val host = parts[0]
-        val port = parts.getOrNull(1)?.toIntOrNull() ?: StreamFrameCodec.DEFAULT_TCP_PORT
+        val (host, port) = parseHostAndPort(address)
 
         Logger.i { "$logTag: [$address] Connecting to $host:$port" }
         val attemptStart = nowMillis
@@ -296,6 +294,28 @@ class TcpTransport(
         } finally {
             disconnectSocket()
         }
+    }
+
+    /**
+     * Split a discovered/entered address into host and port. Handles a bracketed IPv6 literal (`[fe80::1]:4403`,
+     * matching [org.meshtastic.core.network.repository.NetworkRepository]'s `toAddressString()`) as well as the plain
+     * `host` / `host:port` forms used for IPv4 and hostnames — a bare `address.split(":", limit = 2)` would misparse an
+     * unbracketed IPv6 literal's multiple colons.
+     */
+    private fun parseHostAndPort(address: String): Pair<String, Int> {
+        if (address.startsWith("[")) {
+            val closeBracket = address.indexOf(']')
+            if (closeBracket != -1) {
+                val host = address.substring(1, closeBracket)
+                val port =
+                    address.substring(closeBracket + 1).removePrefix(":").toIntOrNull()
+                        ?: StreamFrameCodec.DEFAULT_TCP_PORT
+                return host to port
+            }
+        }
+        val parts = address.split(":", limit = 2)
+        val port = parts.getOrNull(1)?.toIntOrNull() ?: StreamFrameCodec.DEFAULT_TCP_PORT
+        return parts[0] to port
     }
 
     /**

--- a/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmServiceDiscovery.kt
+++ b/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmServiceDiscovery.kt
@@ -80,12 +80,15 @@ class JvmServiceDiscovery(private val dispatchers: CoroutineDispatchers) : Servi
                                 name = info.name,
                                 // Prefer IPv4: jmdns's IPv6 candidates are often link-local
                                 // (fe80::/10) addresses that need a zone/scope ID to be
-                                // routable, which jmdns doesn't supply. Only fall back to
-                                // whatever hostAddresses offers (which may be IPv6) if no
-                                // IPv4 candidate resolved.
+                                // routable, which jmdns doesn't supply. Fall back to a raw
+                                // (unbracketed) IPv6 literal via inet6Addresses rather than
+                                // jmdns's own hostAddresses array, which already brackets
+                                // IPv6 strings ("[fe80::1]") -- toAddressString() below adds
+                                // its own brackets, so starting from an already-bracketed
+                                // value would double-bracket and break parsing downstream.
                                 hostAddress =
                                 info.inet4Addresses.firstOrNull()?.hostAddress
-                                    ?: info.hostAddresses.firstOrNull()
+                                    ?: info.inet6Addresses.firstOrNull()?.hostAddress
                                     ?: "",
                                 port = info.port,
                                 txt = txtMap,

--- a/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmServiceDiscovery.kt
+++ b/core/network/src/jvmMain/kotlin/org/meshtastic/core/network/repository/JvmServiceDiscovery.kt
@@ -58,7 +58,10 @@ class JvmServiceDiscovery(private val dispatchers: CoroutineDispatchers) : Servi
             val listener =
                 object : ServiceListener {
                     override fun serviceAdded(event: ServiceEvent) {
-                        jmdns?.requestServiceInfo(event.type, event.name)
+                        // persistent=true: keep calling serviceResolved as fresh records arrive (re-announcements,
+                        // IP changes) instead of only once — otherwise a resolved device's address goes stale until
+                        // it's fully removed and rediscovered from scratch.
+                        jmdns?.requestServiceInfo(event.type, event.name, true)
                     }
 
                     override fun serviceRemoved(event: ServiceEvent) {
@@ -75,7 +78,15 @@ class JvmServiceDiscovery(private val dispatchers: CoroutineDispatchers) : Servi
                         val discovered =
                             DiscoveredService(
                                 name = info.name,
-                                hostAddress = info.hostAddresses.firstOrNull() ?: "",
+                                // Prefer IPv4: jmdns's IPv6 candidates are often link-local
+                                // (fe80::/10) addresses that need a zone/scope ID to be
+                                // routable, which jmdns doesn't supply. Only fall back to
+                                // whatever hostAddresses offers (which may be IPv6) if no
+                                // IPv4 candidate resolved.
+                                hostAddress =
+                                info.inet4Addresses.firstOrNull()?.hostAddress
+                                    ?: info.hostAddresses.firstOrNull()
+                                    ?: "",
                                 port = info.port,
                                 txt = txtMap,
                             )


### PR DESCRIPTION
## Summary

jmdns's discovered host address could be an IPv6 literal (often a link-local `fe80::/10` address needing a zone/scope ID jmdns doesn't supply), which broke device discovery two ways:
- `NetworkRepository.toAddressString()` appended `:$port` with no bracketing — ambiguous for any host containing colons.
- `TcpTransport.connectAndRead()` parsed that string with `address.split(":", limit=2)`, which mis-splits on an IPv6 literal's first colon instead of recognizing `[addr]:port`.

## Changes

- `JvmServiceDiscovery` now prefers `inet4Addresses` over `hostAddresses`, sidestepping the common link-local case entirely.
- `NetworkRepository.toAddressString()` brackets IPv6 literals.
- New `TcpTransport.parseHostAndPort()` helper understands both bracketed-IPv6 and plain `host[:port]` forms.
- `requestServiceInfo(..., persistent = true)` so a discovered device's info refreshes on re-announcement/IP change instead of going stale until fully removed and rediscovered.

## How was this verified?

`JvmServiceDiscoveryTest` and `TcpTransportTest` pass; full baseline gate (`spotlessApply spotlessCheck detekt assembleDebug test allTests`) green across both flavors (6,855 tests).

First of a 9-PR stack from a dependency/hygiene audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connectivity to services using IPv6 addresses, including custom ports.
  * Added support for bracketed IPv6 host-and-port formats.
  * Service discovery now refreshes when services re-announce or change IP addresses.
  * Improved address selection by preferring IPv4 when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->