### PR TITLE
fix(ui): request HIGH error correction for generated QR codes

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/QrUtils.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/QrUtils.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import qrcode.QRCode
+import qrcode.raw.ErrorCorrectionLevel
 
 /**
  * Generates a QR code painter directly using the Skia/Compose canvas API in pure Kotlin.
@@ -37,7 +38,10 @@ import qrcode.QRCode
 @Suppress("MagicNumber")
 @Composable
 fun rememberQrCodePainter(text: String, size: Int = 512): Painter {
-    val qrCode = androidx.compose.runtime.remember(text) { QRCode.ofSquares().build(text) }
+    val qrCode =
+        androidx.compose.runtime.remember(text) {
+            QRCode.ofSquares().withErrorCorrectionLevel(ErrorCorrectionLevel.HIGH).build(text)
+        }
     val rawMatrix = androidx.compose.runtime.remember(qrCode) { qrCode.rawData }
     val matrixSize = androidx.compose.runtime.remember(qrCode) { rawMatrix.size }
     val quietZone = 4 // QR standard quiet zone is 4 modules on all sides


### PR DESCRIPTION
## Summary

qrcode-kotlin's builder silently defaults to `ErrorCorrectionLevel.LOW` (confirmed directly in its source) when not explicitly set, and this call site never set one — so channel/contact-share QR codes shipped with the weakest damage tolerance available.

## Changes

Explicitly request `ErrorCorrectionLevel.HIGH` in `rememberQrCodePainter()`.

## How was this verified?

Confirmed the default via qrcode-kotlin's actual `QRCodeBuilder.kt` source. Full baseline gate green.

Part of a 9-PR stack from a dependency/hygiene audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * QR codes are now generated with high error correction, improving readability when partially obscured or damaged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->