### PR TITLE
fix(barcode): narrow the F-Droid scanner to QR-only

### DIFF
--- a/core/barcode/src/fdroid/kotlin/org/meshtastic/core/barcode/BarcodeAnalyzerFactory.kt
+++ b/core/barcode/src/fdroid/kotlin/org/meshtastic/core/barcode/BarcodeAnalyzerFactory.kt
@@ -17,7 +17,9 @@
 package org.meshtastic.core.barcode
 
 import androidx.camera.core.ImageAnalysis
+import com.google.zxing.BarcodeFormat
 import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
 import com.google.zxing.MultiFormatReader
 import com.google.zxing.PlanarYUVLuminanceSource
 import com.google.zxing.common.HybridBinarizer
@@ -29,7 +31,14 @@ import java.nio.ByteBuffer
  * This is the F-Droid flavor implementation; the Google flavor uses ML Kit instead.
  */
 internal fun createBarcodeAnalyzer(onResult: (String) -> Unit): ImageAnalysis.Analyzer {
-    val reader = MultiFormatReader()
+    val reader =
+        MultiFormatReader().apply {
+            // Without this, MultiFormatReader tries every supported format (DataMatrix,
+            // PDF417, Aztec, Code128/39, EAN/UPC, ...) on every camera frame even though
+            // this analyzer only ever wants QR codes — narrowing it is a meaningful
+            // per-frame CPU/battery win during an active scan session.
+            setHints(mapOf(DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE)))
+        }
 
     return ImageAnalysis.Analyzer { imageProxy ->
         try {


### PR DESCRIPTION
## Summary

The F-Droid scanner's `MultiFormatReader` had no `DecodeHintType.POSSIBLE_FORMATS` hint, so it ran every supported decoder (DataMatrix, PDF417, Aztec, Code128/39, EAN/UPC, ...) against every camera frame even though this analyzer only ever wants QR codes -- a meaningful per-frame CPU/battery cost during an active scan session. The Google flavor's ML Kit scanner already narrows to QR-only.

## Changes

Set `POSSIBLE_FORMATS = [QR_CODE]` once on the reader.

## How was this verified?

Full baseline gate green (fdroid flavor assemble + tests).

Part of a 9-PR stack from a dependency/hygiene audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved barcode scanning reliability by focusing detection on QR codes.
  * Preserved existing frame processing and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->