### PR TITLE
fix(ai): read the real inference source instead of hardcoding it

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/ai/GeminiNanoDocAssistant.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/ai/GeminiNanoDocAssistant.kt
@@ -20,6 +20,7 @@ import co.touchlab.kermit.Logger
 import com.google.firebase.Firebase
 import com.google.firebase.ai.DownloadStatus
 import com.google.firebase.ai.InferenceMode
+import com.google.firebase.ai.InferenceSource
 import com.google.firebase.ai.OnDeviceConfig
 import com.google.firebase.ai.OnDeviceModelOption
 import com.google.firebase.ai.OnDeviceModelStatus
@@ -218,7 +219,9 @@ class GeminiNanoDocAssistant(
             try {
                 val accumulatedText = StringBuilder()
                 var lastEmitTime = 0L
+                var lastInferenceSource: InferenceSource? = null
                 onDeviceModel.generateContentStream(prompt).collect { chunk ->
+                    lastInferenceSource = chunk.inferenceSource
                     val text = chunk.text
                     if (!text.isNullOrEmpty()) {
                         accumulatedText.append(text)
@@ -230,24 +233,27 @@ class GeminiNanoDocAssistant(
                                 AIDocAssistantResult.Partial(
                                     answer = cleanResponse(accumulatedText.toString()),
                                     sourcePages = contextPages,
-                                    usedOnDeviceModel = true,
+                                    usedOnDeviceModel = chunk.inferenceSource == InferenceSource.ON_DEVICE,
                                 ),
                             )
                         }
                     }
-                    // Log token usage from last chunk
+                    // Log token usage and model version from the last chunk
                     chunk.usageMetadata?.let { meta ->
                         Logger.d(tag = TAG) {
-                            "Tokens — prompt: ${meta.promptTokenCount}, response: ${meta.candidatesTokenCount}, total: ${meta.totalTokenCount}"
+                            "Tokens — prompt: ${meta.promptTokenCount}, response: ${meta.candidatesTokenCount}, " +
+                                "total: ${meta.totalTokenCount}, source: ${chunk.inferenceSource}, " +
+                                "model: ${chunk.modelVersion}"
                         }
                     }
                 }
+                val usedOnDeviceModel = lastInferenceSource == InferenceSource.ON_DEVICE
                 // Emit final partial to ensure UI has the complete text before Success
                 emit(
                     AIDocAssistantResult.Partial(
                         answer = cleanResponse(accumulatedText.toString()),
                         sourcePages = contextPages,
-                        usedOnDeviceModel = true,
+                        usedOnDeviceModel = usedOnDeviceModel,
                     ),
                 )
                 val onDeviceAnswer = cleanResponse(accumulatedText.toString().trimEnd())
@@ -265,7 +271,7 @@ class GeminiNanoDocAssistant(
                     AIDocAssistantResult.Success(
                         answer = onDeviceAnswer,
                         sourcePages = allSourcePages,
-                        usedOnDeviceModel = true,
+                        usedOnDeviceModel = usedOnDeviceModel,
                     ),
                 )
                 return@flow // Success — exit retry loop


### PR DESCRIPTION
## Summary

`usedOnDeviceModel` was hardcoded `true` at all three emit sites in the Gemini Nano doc assistant, regardless of which model actually served the request -- so hybrid-inference telemetry would silently go wrong the moment inference mode ever leaves `ONLY_ON_DEVICE` (`PREFER_ON_DEVICE`/`PREFER_IN_CLOUD` can fall back to the other side).

## Changes

- Reads `chunk.inferenceSource` off each streamed chunk and uses the last one for the final `Partial`/`Success` emissions.
- Logs `chunk.modelVersion` alongside the existing token-usage log, so a user report can be correlated with which on-device model actually served it.

## How was this verified?

Verified the `InferenceSource`/`modelVersion` API shape against Firebase's hybrid-inference docs (couldn't read the closed-source SDK directly) -- confirmed compiling clean in the google-flavor build. Full baseline gate green (both flavors).

Part of a 9-PR stack from a dependency/hygiene audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI assistant responses now indicate whether they were generated on-device.
  * Partial and completed responses include inference source details.
  * Inference source and model version are included alongside token usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->