### PR TITLE
fix(firmware): add fallback painter to device hardware image

### DIFF
--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
@@ -139,6 +139,7 @@ import org.meshtastic.core.resources.firmware_update_verifying
 import org.meshtastic.core.resources.firmware_update_waiting_reconnect
 import org.meshtastic.core.resources.i_know_what_i_m_doing
 import org.meshtastic.core.resources.img_chirpy
+import org.meshtastic.core.resources.img_hw_unknown
 import org.meshtastic.core.resources.learn_more
 import org.meshtastic.core.resources.okay
 import org.meshtastic.core.resources.save
@@ -633,11 +634,15 @@ private fun ChirpyCard() {
 private fun DeviceHardwareImage(deviceHardware: DeviceHardware, modifier: Modifier = Modifier) {
     val hwImg = deviceHardware.images?.getOrNull(1) ?: deviceHardware.images?.getOrNull(0) ?: "unknown.svg"
     val imageUrl = "https://flasher.meshtastic.org/img/devices/$hwImg"
+    val fallbackPainter = painterResource(Res.drawable.img_hw_unknown)
 
     AsyncImage(
         model = ImageRequest.Builder(LocalPlatformContext.current).data(imageUrl).crossfade(true).build(),
         contentScale = ContentScale.Fit,
         contentDescription = deviceHardware.displayName,
+        placeholder = fallbackPainter,
+        error = fallbackPainter,
+        fallback = fallbackPainter,
         modifier = modifier,
     )
 }


### PR DESCRIPTION
## Summary

`FirmwareUpdateScreen`'s `DeviceHardwareImage` was the only device-hardware `AsyncImage` call site with no placeholder/error/fallback painter, unlike the equivalent composable in `feature/node`'s `DeviceDetailsSection` -- a network failure loading the device image left a blank space instead of the shared `img_hw_unknown` fallback the rest of the app uses.

## Changes

Added the same `placeholder`/`error`/`fallback` painter pattern already used elsewhere.

## How was this verified?

Full baseline gate green.

Part of a 9-PR stack from a dependency/hygiene audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware image loading by displaying a consistent fallback image when the device hardware is unknown or an image cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->