### PR TITLE
chore(deps): remove unused osmdroid-geopackage dependency

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -324,7 +324,6 @@ dependencies {
     add("kspGoogle", libs.androidx.appfunctions.compiler)
 
     fdroidImplementation(libs.osmdroid.android)
-    fdroidImplementation(libs.osmdroid.geopackage) { exclude(group = "com.j256.ormlite") }
     fdroidImplementation(libs.geopackage.android) {
         because("6.7.5 depends on 16 KB page-size compatible SQLite Android Bindings")
         exclude(group = "com.j256.ormlite")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -290,7 +290,6 @@ okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 uri-kmp = { module = "com.eygraber:uri-kmp", version.ref = "uri-kmp" }
 osmbonuspack = { module = "com.github.MKergall:osmbonuspack", version = "6.9.0" }
 osmdroid-android = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroid-android" }
-osmdroid-geopackage = { module = "org.osmdroid:osmdroid-geopackage", version.ref = "osmdroid-android" }
 geopackage-android = { module = "mil.nga.geopackage:geopackage-android", version.ref = "geopackage-android" }
 kermit = { module = "co.touchlab:kermit", version = "2.1.0" }
 # Debug-only leak/GC-thrash detector -- see feature/settings/.../debugging/DebugViewModel.kt and


### PR DESCRIPTION
## Summary

Confirmed zero call sites for `org.osmdroid:osmdroid-geopackage`'s API anywhere in the tree (`grep` across the codebase) before removing it as a dead dependency.

## Changes

Drops the `osmdroid-geopackage` catalog entry and its `fdroidImplementation` declaration. The separately-pinned `geopackage-android` dependency (a deliberate 16KB-page-size-compatible native SQLite binding override) is untouched.

## How was this verified?

Full baseline gate green (fdroid flavor assemble).

Part of a 9-PR stack from a dependency/hygiene audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GeoPackage dependency to support devices using 16 KB memory page sizes.
  * Preserved compatibility by continuing to exclude the ORMLite component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->