### PR TITLE
fix(map): restore osmbonuspack native styling, fix tile-scaling gap

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapOverlayRenderer.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapOverlayRenderer.kt
@@ -87,7 +87,9 @@ class FdroidMapOverlayRenderer {
             val overlay =
                 withContext(Dispatchers.Main.immediate) {
                     // Build on the main thread: overlay markers reference the MapView (info windows, defaults).
-                    doc.mKmlRoot.buildOverlay(map, null, SimpleStyleStyler, doc).also { insertBelowMarkers(map, it) }
+                    doc.mKmlRoot.buildOverlay(map, null, SimpleStyleStyler(map, doc), doc).also {
+                        insertBelowMarkers(map, it)
+                    }
                 }
             rendered[layer.id] = Rendered(signatureOf(layer), overlay)
             dirty = true
@@ -138,16 +140,29 @@ class FdroidMapOverlayRenderer {
 
 /**
  * osmbonuspack styler that maps mapbox simplestyle properties (read from a GeoJSON feature's `properties`, which
- * osmbonuspack stores as KML ExtendedData) onto the built osmdroid geometry. Only overrides when a property is present,
- * so KML files keep their own `<Style>`.
+ * osmbonuspack stores as KML ExtendedData) onto the built osmdroid geometry, layered on top of osmbonuspack's own
+ * native KML `<Style>` resolution.
+ *
+ * osmbonuspack's `buildOverlay()` is an either/or branch: passing a non-null [KmlFeature.Styler] (as [reconcile] does,
+ * for both KML and GeoJSON) makes it skip `applyDefaultStyling()` entirely and call this styler instead — it is NOT an
+ * addition on top of the default. So every `on*` override here calls the matching `applyDefaultStyling()` itself first
+ * (resolving the placemark's real KML `<Style>`/`<IconStyle>`, and — for polygons — the tap info-window bubble), then
+ * applies simplestyle overrides only when the corresponding GeoJSON property is actually present.
  */
-private object SimpleStyleStyler : KmlFeature.Styler {
+private class SimpleStyleStyler(private val map: MapView, private val kmlDocument: KmlDocument) : KmlFeature.Styler {
     override fun onFeature(overlay: Overlay?, kmlFeature: KmlFeature?) = Unit
 
-    override fun onPoint(marker: Marker?, kmlPlacemark: KmlPlacemark?, kmlPoint: KmlPoint?) = Unit
+    override fun onPoint(marker: Marker?, kmlPlacemark: KmlPlacemark?, kmlPoint: KmlPoint?) {
+        marker ?: return
+        kmlPoint?.applyDefaultStyling(marker, null, kmlPlacemark, kmlDocument, map)
+        // simplestyle's marker-color/marker-symbol aren't modeled here (they'd need Maki icon
+        // sprites or manual icon tinting) — KML's own <IconStyle>, applied above, is what this
+        // fixes; GeoJSON points still fall back to osmdroid's default marker icon.
+    }
 
     override fun onLineString(polyline: Polyline?, kmlPlacemark: KmlPlacemark?, kmlLineString: KmlLineString?) {
         polyline ?: return
+        kmlLineString?.applyDefaultStyling(polyline, null, kmlPlacemark, kmlDocument, map)
         val stroke = kmlPlacemark?.cssColor("stroke") ?: kmlPlacemark?.cssColor("color")
         stroke?.let { polyline.color = it }
         kmlPlacemark?.getExtendedData("stroke-width")?.toFloatOrNull()?.let { polyline.width = it }
@@ -155,16 +170,25 @@ private object SimpleStyleStyler : KmlFeature.Styler {
 
     override fun onPolygon(polygon: Polygon?, kmlPlacemark: KmlPlacemark?, kmlPolygon: KmlPolygon?) {
         polygon ?: return
+        kmlPolygon?.applyDefaultStyling(polygon, null, kmlPlacemark, kmlDocument, map)
+        val hasNativeKmlStyle = kmlDocument.getStyle(kmlPlacemark?.mStyle) != null
         val fill = kmlPlacemark?.cssColor("fill") ?: kmlPlacemark?.cssColor("color")
         val stroke = kmlPlacemark?.cssColor("stroke") ?: kmlPlacemark?.cssColor("color")
         val fillOpacity = kmlPlacemark?.getExtendedData("fill-opacity")?.toFloatOrNull()
-        val strokeWidth = kmlPlacemark?.getExtendedData("stroke-width")?.toFloatOrNull() ?: DEFAULT_GEOJSON_STROKE_WIDTH
+        val strokeWidth = kmlPlacemark?.getExtendedData("stroke-width")?.toFloatOrNull()
         fill?.let { polygon.fillColor = it.resolveFillAlpha(fillOpacity) }
         stroke?.let { polygon.strokeColor = it }
-        polygon.strokeWidth = strokeWidth
+        // Only fall back to the GeoJSON default when neither a real KML <Style> nor an explicit
+        // simplestyle stroke-width applied above — otherwise this would overwrite a native KML
+        // polygon's own stroke width every time (KML files don't carry a stroke-width ExtendedData).
+        polygon.strokeWidth =
+            strokeWidth ?: if (hasNativeKmlStyle) polygon.strokeWidth else DEFAULT_GEOJSON_STROKE_WIDTH
     }
 
-    override fun onTrack(polyline: Polyline?, kmlPlacemark: KmlPlacemark?, kmlTrack: KmlTrack?) = Unit
+    override fun onTrack(polyline: Polyline?, kmlPlacemark: KmlPlacemark?, kmlTrack: KmlTrack?) {
+        polyline ?: return
+        kmlTrack?.applyDefaultStyling(polyline, null, kmlPlacemark, kmlDocument, map)
+    }
 }
 
 private fun KmlPlacemark.cssColor(key: String): Int? = getExtendedData(key)?.let { parseCssColor(it) }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/node/component/InlineMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/node/component/InlineMap.kt
@@ -40,6 +40,7 @@ fun InlineMap(node: Node, modifier: Modifier = Modifier) {
             // Default osmdroid tile source.
             setTileSource(TileSourceFactory.MAPNIK)
             setMultiTouchControls(false)
+            isTilesScaledToDpi = true
 
             controller.setZoom(15.0)
         }


### PR DESCRIPTION
## Summary

osmbonuspack's `buildOverlay()` is a strict either/or: passing a non-null `KmlFeature.Styler` (which this renderer always does, for both KML and GeoJSON) makes it skip `applyDefaultStyling()` entirely rather than layer on top of it (verified directly against osmbonuspack's own `KmlPoint.java`/`KmlPolygon.java` source). That meant:
- Every imported point rendered with a bare default marker (`onPoint` was a literal no-op, discarding KML's own `<IconStyle>`).
- Polygons lost both their native `<Style>` color/stroke *and* the tap-to-show-info-window bubble that `applyDefaultStyling` wires up.

## Changes

Each `Styler` callback now calls the matching `applyDefaultStyling()` itself first, then layers the existing simplestyle GeoJSON overrides on top only when that property is actually present. The polygon stroke-width fallback is now conditioned on whether a real KML `<Style>` resolved, so it no longer overwrites a native KML polygon's own stroke width.

Also added `isTilesScaledToDpi = true` to `InlineMap`'s `MapView`, matching the app's main `MapViewWithLifecycle` (previously inconsistent, giving the node-detail inline map slightly fuzzier tile labels than the main map view).

## How was this verified?

Read osmbonuspack's actual GitHub source (`KmlPoint.java`, `KmlPolygon.java`) to confirm the either/or branch before fixing. Full baseline gate green (fdroid flavor).

Part of a 9-PR stack from a dependency/hygiene audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map overlay styling for KML and GeoJSON content, including points, tracks, polygons, and stroke widths.
  * Preserved native KML styling unless an explicit override is provided.
  * Enabled DPI-scaled map tiles for clearer rendering on high-density displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->