### PR TITLE
fix(takserver): wire TAKPacket-SDK's logger, surface remarks-stripped

### DIFF
--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
@@ -212,7 +212,7 @@ class TAKMeshIntegration(
         val wirePayload: ByteArray =
             try {
                 val result = TakSdkCompressor.compressCoT(xml, MAX_TAK_WIRE_PAYLOAD_BYTES)
-                if (result.remarksStripped) {
+                if (result.remarksStripped && result.wirePayload != null) {
                     Logger.i { "Stripped <remarks> to fit TAK packet under MTU: type=${cotMessage.type}" }
                 }
                 result.wirePayload

--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
@@ -211,7 +211,11 @@ class TAKMeshIntegration(
         // remarks the packet exceeds the limit.
         val wirePayload: ByteArray =
             try {
-                TakSdkCompressor.compressCoT(xml, MAX_TAK_WIRE_PAYLOAD_BYTES)
+                val result = TakSdkCompressor.compressCoT(xml, MAX_TAK_WIRE_PAYLOAD_BYTES)
+                if (result.remarksStripped) {
+                    Logger.i { "Stripped <remarks> to fit TAK packet under MTU: type=${cotMessage.type}" }
+                }
+                result.wirePayload
                     ?: run {
                         Logger.w {
                             buildString {

--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TakMeshTestRunner.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TakMeshTestRunner.kt
@@ -173,7 +173,8 @@ class TakMeshTestRunner(private val commandSender: CommandSender) {
         // Parse and compress via SDK
         val wirePayload: ByteArray
         try {
-            val compressed = TakSdkCompressor.compressCoT(strippedXml, MAX_TAK_WIRE_PAYLOAD_BYTES)
+            val result = TakSdkCompressor.compressCoT(strippedXml, MAX_TAK_WIRE_PAYLOAD_BYTES)
+            val compressed = result.wirePayload
             if (compressed == null) {
                 Logger.w { "TAK Test: $name oversized even without remarks (xml=${xml.length}B)" }
                 return TakTestResult(name, xml.length, 0, false, "Oversized (>${MAX_TAK_WIRE_PAYLOAD_BYTES}B)")

--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TakSdkCompressor.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TakSdkCompressor.kt
@@ -18,6 +18,9 @@ package org.meshtastic.core.takserver
 
 import org.meshtastic.tak.CotXmlParser
 import org.meshtastic.tak.TakCompressor
+import org.meshtastic.tak.TakPacketSdk
+import co.touchlab.kermit.Logger as KermitLogger
+import org.meshtastic.tak.Logger as SdkLogger
 
 /**
  * Thin wrapper over the TAKPacket-SDK compression pipeline
@@ -28,14 +31,22 @@ import org.meshtastic.tak.TakCompressor
  */
 internal object TakSdkCompressor {
 
+    init {
+        // The SDK never logs by default (see org.meshtastic.tak.Logger's kdoc) — wire its
+        // internal diagnostics (dictionary selection, skip-compress path, etc.) into the
+        // same Kermit sink this module already uses instead of leaving them discarded.
+        TakPacketSdk.logger = SdkLogger { message -> KermitLogger.d(tag = "TakPacketSdk") { message } }
+    }
+
     /**
      * Parse CoT XML via the SDK and compress with remarks-fallback.
      *
-     * @return compressed wire payload, or `null` if the packet exceeds [maxBytes] even without remarks.
+     * @return the wire payload plus whether `<remarks>` had to be stripped to fit [maxBytes]; `wirePayload` is `null`
+     *   if the packet exceeds [maxBytes] even without remarks.
      * @throws Exception on parse or compression failure.
      */
-    fun compressCoT(xml: String, maxBytes: Int): ByteArray? {
+    fun compressCoT(xml: String, maxBytes: Int): TakCompressor.RemarksFallbackResult {
         val sdkData = CotXmlParser().parse(xml)
-        return TakCompressor().compressWithRemarksFallback(sdkData, maxBytes)
+        return TakCompressor().compressWithRemarksFallbackDetailed(sdkData, maxBytes)
     }
 }


### PR DESCRIPTION
## Summary

Two gaps found auditing this module's use of `org.meshtastic:takpacket-sdk`:
- `TakPacketSdk.logger` was never assigned despite Kermit already being used throughout this module, so the SDK's internal diagnostics (dictionary selection, skip-compress path) were silently discarded (the SDK never logs by default).
- `compressCoT()` called the plain `compressWithRemarksFallback()` and discarded the sibling `compressWithRemarksFallbackDetailed()` overload's `remarksStripped` flag, so MTU-driven truncation of chat/remarks text was invisible.

## Changes

- Wired `TakPacketSdk.logger` to the same Kermit sink this module already uses.
- Switched `compressCoT()` to the `Detailed` variant and log when remarks get stripped to fit the MTU.

## How was this verified?

Full baseline gate green.

Part of a 9-PR stack from a dependency/hygiene audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TAK message compression for payloads that exceed the available message size.
  - Automatically removes optional remarks when necessary to fit messages within transmission limits.
  - Prevents oversized or unsuccessful compressed messages from being transmitted.
- **Reliability**
  - Improved diagnostic logging for compression and transmission issues, making failures easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->