### PR TITLE
refactor(firmware): dedupe the Android/JVM download byte-copy loop

### DIFF
--- a/feature/firmware/src/androidMain/kotlin/org/meshtastic/feature/firmware/AndroidFirmwareFileHandler.kt
+++ b/feature/firmware/src/androidMain/kotlin/org/meshtastic/feature/firmware/AndroidFirmwareFileHandler.kt
@@ -23,13 +23,8 @@ import com.eygraber.uri.toAndroidUri
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.head
-import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
-import io.ktor.http.contentLength
 import io.ktor.http.isSuccess
-import io.ktor.utils.io.jvm.javaio.toInputStream
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.CommonUri
@@ -42,8 +37,6 @@ import java.io.InputStream
 import java.net.URI
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
-
-private const val DOWNLOAD_BUFFER_SIZE = 8192
 
 /**
  * Helper class to handle file operations related to firmware updates, such as downloading, copying from URI, and
@@ -98,34 +91,9 @@ class AndroidFirmwareFileHandler(private val context: Context, private val clien
                 return@withContext null
             }
 
-            val body = response.bodyAsChannel()
-            val contentLength = response.contentLength() ?: -1L
-
             if (!tempDir.exists()) tempDir.mkdirs()
-
             val targetFile = java.io.File(tempDir, fileName)
-
-            body.toInputStream().use { input ->
-                java.io.FileOutputStream(targetFile).use { output ->
-                    val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
-                    var bytesRead: Int
-                    var totalBytesRead = 0L
-
-                    while (input.read(buffer).also { bytesRead = it } != -1) {
-                        if (!isActive) throw CancellationException("Download cancelled")
-
-                        output.write(buffer, 0, bytesRead)
-                        totalBytesRead += bytesRead
-
-                        if (contentLength > 0) {
-                            onProgress(totalBytesRead.toFloat() / contentLength)
-                        }
-                    }
-                    if (contentLength != -1L && totalBytesRead != contentLength) {
-                        throw IOException("Incomplete download: expected $contentLength bytes, got $totalBytesRead")
-                    }
-                }
-            }
+            downloadResponseToFile(response, targetFile, onProgress)
             targetFile.toFirmwareArtifact()
         }
 

--- a/feature/firmware/src/jvmAndroidMain/kotlin/org/meshtastic/feature/firmware/FirmwareDownload.kt
+++ b/feature/firmware/src/jvmAndroidMain/kotlin/org/meshtastic/feature/firmware/FirmwareDownload.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.firmware
+
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.contentLength
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.ensureActive
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import kotlin.coroutines.coroutineContext
+
+private const val DOWNLOAD_BUFFER_SIZE = 8192
+
+/**
+ * Streams [response]'s body into [targetFile], reporting fractional progress via [onProgress] as bytes arrive.
+ *
+ * Shared by the Android and desktop JVM [FirmwareFileHandler] implementations so the two byte-copy loops (and their
+ * cancellation/completeness checks) cannot drift apart — see [extractZipEntriesBounded] for the same rationale on the
+ * zip-extraction side. Streams incrementally rather than buffering the whole body: ktor's built-in `onDownload`
+ * progress hook pairs naturally with `HttpResponse.body(): ByteArray`, but that holds an entire firmware image — tens
+ * of MB — in memory (twice over, briefly), which isn't worth it just to drop a manual loop on a download this size.
+ *
+ * @throws IOException if the transfer is shorter than the response's declared `Content-Length`.
+ * @throws kotlinx.coroutines.CancellationException if the calling coroutine is cancelled mid-transfer.
+ */
+internal suspend fun downloadResponseToFile(response: HttpResponse, targetFile: File, onProgress: (Float) -> Unit) {
+    val body = response.bodyAsChannel()
+    val contentLength = response.contentLength() ?: -1L
+
+    body.toInputStream().use { input ->
+        FileOutputStream(targetFile).use { output ->
+            val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
+            var bytesRead: Int
+            var totalBytesRead = 0L
+
+            while (input.read(buffer).also { bytesRead = it } != -1) {
+                coroutineContext.ensureActive()
+
+                output.write(buffer, 0, bytesRead)
+                totalBytesRead += bytesRead
+
+                if (contentLength > 0) {
+                    onProgress(totalBytesRead.toFloat() / contentLength)
+                }
+            }
+            if (contentLength != -1L && totalBytesRead != contentLength) {
+                throw IOException("Incomplete download: expected $contentLength bytes, got $totalBytesRead")
+            }
+        }
+    }
+}

--- a/feature/firmware/src/jvmMain/kotlin/org/meshtastic/feature/firmware/JvmFirmwareFileHandler.kt
+++ b/feature/firmware/src/jvmMain/kotlin/org/meshtastic/feature/firmware/JvmFirmwareFileHandler.kt
@@ -20,13 +20,8 @@ import co.touchlab.kermit.Logger
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.head
-import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
-import io.ktor.http.contentLength
 import io.ktor.http.isSuccess
-import io.ktor.utils.io.jvm.javaio.toInputStream
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import org.meshtastic.core.common.util.CommonUri
@@ -40,8 +35,6 @@ import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
-
-private const val DOWNLOAD_BUFFER_SIZE = 8192
 
 @Suppress("TooManyFunctions")
 @Single
@@ -92,33 +85,9 @@ class JvmFirmwareFileHandler(private val client: HttpClient) : FirmwareFileHandl
                 return@withContext null
             }
 
-            val body = response.bodyAsChannel()
-            val contentLength = response.contentLength() ?: -1L
-
             if (!tempDir.exists()) tempDir.mkdirs()
-
             val targetFile = File(tempDir, fileName)
-            body.toInputStream().use { input ->
-                FileOutputStream(targetFile).use { output ->
-                    val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
-                    var bytesRead: Int
-                    var totalBytesRead = 0L
-
-                    while (input.read(buffer).also { bytesRead = it } != -1) {
-                        if (!isActive) throw CancellationException("Download cancelled")
-
-                        output.write(buffer, 0, bytesRead)
-                        totalBytesRead += bytesRead
-
-                        if (contentLength > 0) {
-                            onProgress(totalBytesRead.toFloat() / contentLength)
-                        }
-                    }
-                    if (contentLength != -1L && totalBytesRead != contentLength) {
-                        throw IOException("Incomplete download: expected $contentLength bytes, got $totalBytesRead")
-                    }
-                }
-            }
+            downloadResponseToFile(response, targetFile, onProgress)
             targetFile.toFirmwareArtifact()
         }
 


### PR DESCRIPTION
## Summary

`AndroidFirmwareFileHandler` and `JvmFirmwareFileHandler` each hand-rolled an identical byte-copy-with-progress loop (including the same cancellation check and incomplete-download detection) -- a drift risk on a critical OTA path, the same rationale already documented for why `extractZipEntriesBounded` lives in the shared `jvmAndroidMain` source set.

## Changes

Extracted `downloadResponseToFile()` into that same `jvmAndroidMain` source set; both handlers now call it instead of duplicating the loop.

Deliberately kept the existing incremental-streaming approach rather than switching to ktor's `onDownload` + `.body(): ByteArray`, since that would buffer an entire firmware image (tens of MB) in memory just to drop a manual loop -- not worth it for files this size.

## How was this verified?

Full baseline gate green (both flavors, 6,855 tests).

Last of a 9-PR stack from a dependency/hygiene audit.