### PR TITLE
fix(map): scope Google Maps clustering to the viewport above 1000 nodes

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/NodeClusterMarkers.kt
@@ -18,7 +18,11 @@ package org.meshtastic.app.map.component
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import com.google.maps.android.clustering.Cluster
+import com.google.maps.android.clustering.algo.NonHierarchicalDistanceBasedAlgorithm
+import com.google.maps.android.clustering.algo.NonHierarchicalViewBasedAlgorithm
+import com.google.maps.android.clustering.algo.ScreenBasedAlgorithmAdapter
 import com.google.maps.android.clustering.view.DefaultClusterRenderer
 import com.google.maps.android.compose.Circle
 import com.google.maps.android.compose.MapsComposeExperimentalApi
@@ -28,6 +32,12 @@ import org.meshtastic.app.map.model.NodeClusterItem
 import org.meshtastic.feature.map.BaseMapViewModel
 
 private const val MIN_CLUSTER_SIZE = 10
+
+/**
+ * Threshold for switching to [NonHierarchicalViewBasedAlgorithm], matching that class's own KDoc describing itself as
+ * being for "large numbers of items (>1000 markers)".
+ */
+private const val VIEW_BASED_ALGORITHM_NODE_THRESHOLD = 1000
 
 /**
  * Renders node markers with clustering via the library's [Clustering] composable.
@@ -41,6 +51,12 @@ private const val MIN_CLUSTER_SIZE = 10
  * lifecycle/saved-state owners, crashing under the Navigation 3 hierarchy (fixed upstream in
  * googlemaps/android-maps-compose#930, which this file previously worked around with a custom [DefaultClusterRenderer]
  * assigning pre-baked bitmaps).
+ *
+ * Below [VIEW_BASED_ALGORITHM_NODE_THRESHOLD] nodes, clusters with the default `NonHierarchicalDistanceBasedAlgorithm`
+ * (pans smoother, and clustering the whole node set is cheap at this scale). Above it, switches to
+ * [NonHierarchicalViewBasedAlgorithm] to avoid a spread-out mesh returning nearly every node as its own unclustered
+ * result at high zoom (#4544) - at the cost of its zero-margin, camera-idle-only viewport bounds popping markers in
+ * abruptly while panning.
  */
 @OptIn(MapsComposeExperimentalApi::class)
 @Composable
@@ -50,6 +66,7 @@ fun NodeClusterMarkers(
     navigateToNodeDetails: (Int) -> Unit,
     onClusterClick: (Cluster<NodeClusterItem>) -> Boolean,
 ) {
+    val configuration = LocalConfiguration.current
     Clustering(
         items = nodeClusterItems,
         onClusterClick = onClusterClick,
@@ -80,6 +97,25 @@ fun NodeClusterMarkers(
             if (renderer != null && renderer.minClusterSize != MIN_CLUSTER_SIZE) {
                 renderer.minClusterSize = MIN_CLUSTER_SIZE
                 clusterManager.cluster()
+            }
+            // Only swap on a threshold crossing; otherwise just resize in place - replacing re-migrates every item.
+            val algorithm = clusterManager.algorithm
+            val needsViewBasedAlgorithm = nodeClusterItems.size > VIEW_BASED_ALGORITHM_NODE_THRESHOLD
+            when {
+                needsViewBasedAlgorithm && algorithm is NonHierarchicalViewBasedAlgorithm<*> ->
+                    algorithm.updateViewSize(configuration.screenWidthDp, configuration.screenHeightDp)
+
+                needsViewBasedAlgorithm ->
+                    clusterManager.setAlgorithm(
+                        NonHierarchicalViewBasedAlgorithm(configuration.screenWidthDp, configuration.screenHeightDp),
+                    )
+
+                algorithm is NonHierarchicalViewBasedAlgorithm<*> ->
+                    // Kotlin won't resolve setAlgorithm's Algorithm<T> overload for a plain
+                    // NonHierarchicalDistanceBasedAlgorithm; wrap it to force the ScreenBasedAlgorithm<T> overload.
+                    clusterManager.setAlgorithm(
+                        ScreenBasedAlgorithmAdapter(NonHierarchicalDistanceBasedAlgorithm<NodeClusterItem>()),
+                    )
             }
         },
     )


### PR DESCRIPTION
## Why

Fixes #4544 (google flavor only - see scope note below).

`NonHierarchicalDistanceBasedAlgorithm`, the default the `Clustering` composable uses via maps-compose-utils, always clusters over the entire node set rather than what's actually on screen. At high zoom over a geographically spread-out mesh, the on-screen clustering radius shrinks to nearly nothing, so the algorithm hands back almost every node as its own individual unclustered result even when almost none of them are visible - choking rendering exactly as reported in the issue.

## What changed

- `NodeClusterMarkers.kt` now switches to `NonHierarchicalViewBasedAlgorithm` (already a maps-compose-utils dependency, no new library) once the node count exceeds 1000, scoping clustering to the current viewport instead of the whole dataset. Below 1000 nodes, it stays on the default algorithm.
- The threshold isn't arbitrary: `NonHierarchicalViewBasedAlgorithm`'s own KDoc describes itself as being for "large numbers of items (>1000 markers)", so this matches the library author's own intent rather than a number we invented.
- The default algorithm is kept below the threshold deliberately, not just left alone incidentally: it pans more smoothly (see trade-off below), and clustering the whole node set is cheap at typical mesh sizes, so most users get the nicer experience unchanged and only pay the view-based algorithm's cost where its fix is actually needed.
- Google flavor only. fdroid's map renders through osmdroid's `RadiusMarkerClusterer` on a completely separate path (`FdroidMapOverlayRenderer.kt`), so this PR doesn't affect or claim to fix that side.

## Trade-offs

`NonHierarchicalViewBasedAlgorithm`'s viewport bounds have no margin, and it only reclusters on camera-idle (recomputing every drag frame would defeat the point of a viewport-scoped algorithm). Above the threshold, this means panning can pop markers in abruptly once the gesture stops, rather than sliding them in smoothly.

I tried padding the viewport dimensions handed to the algorithm (2x screen width/height) as a mitigation, hoping it would pre-include a ring of off-screen markers. Tested on a physical device (Samsung Galaxy S24+) and it made no measurable difference to the pop-in at any drag distance, so I dropped it rather than keep unproven complexity in the code. This is a real, accepted trade-off of viewport-scoped clustering, not something this PR claims to eliminate - it's documented in the code comment so nobody re-attempts the same padding idea without knowing it didn't work.

## Test plan

- **Benchmark** (posted on the issue before this PR): `NonHierarchicalDistanceBasedAlgorithm` vs `NonHierarchicalViewBasedAlgorithm` with 2,000 synthetic scattered nodes. Both land around 2.5-3ms either way - the real win isn't speed, it's `resultCount` going from 2000 individually-rendered markers to 0 when zoomed into an empty area, i.e. markers that never have to be rendered at all.
- **Hardware, below-threshold path** (Samsung Galaxy S24+, `google` debug build, real mesh, ~28 nodes, well under the threshold): confirmed the map renders correctly and node markers display and pan exactly as before this change - the default algorithm path is unconditionally exercised at this scale, so this is a direct regression check, not an inference.
- **Hardware, above-threshold trade-off**: confirmed the pop-in-while-panning trade-off is real by temporarily forcing the view-based algorithm on the same real mesh, and confirmed the viewport-padding mitigation attempt didn't help (see above). I did **not** have a real >1000-node mesh available to test the above-threshold path's steady-state behavior end-to-end on hardware; that path is covered by the JVM benchmark and by direct reasoning about the library's documented behavior instead.
- Local baseline green: `spotlessApply spotlessCheck detekt` for both `google` and `fdroid` flavors, `compileGoogleDebugKotlin`, `compileFdroidDebugKotlin`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved map marker clustering for areas with many nodes.
  * Enhanced responsiveness when viewing maps with more than 1,000 nodes.
  * Clustering now adapts more effectively to screen size changes, providing clearer marker groupings across different displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->