### PR TITLE
fix(node): confirm before clearing a node's position track

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -210,7 +210,10 @@ clean_node_database_title
 clean_nodes_older_than
 clean_now
 clean_unknown_nodes
+### CLEAR ###
 clear
+clear_position_track_message
+clear_position_track_title
 clear_selection
 clear_time_zone
 client_notification

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -231,7 +231,10 @@
     <string name="clean_nodes_older_than">Clean up nodes last seen older than %1$d days</string>
     <string name="clean_now">Clean Now</string>
     <string name="clean_unknown_nodes">Clean up only unknown nodes</string>
+    <!-- CLEAR -->
     <string name="clear">Clear</string>
+    <string name="clear_position_track_message">This permanently deletes this node's recorded GPS track. This cannot be undone.</string>
+    <string name="clear_position_track_title">Clear position track?</string>
     <string name="clear_selection">Clear selection</string>
     <string name="clear_time_zone">Clear time zone</string>
     <string name="client_notification">Client Notification</string>

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogScreens.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogScreens.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.resources.stringResource
@@ -105,7 +105,7 @@ fun PositionLogScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
 /** Trash-can action that asks for confirmation before invoking [onConfirm] to delete the position track. */
 @Composable
 private fun ClearPositionTrackButton(onConfirm: () -> Unit) {
-    var showDialog by remember { mutableStateOf(false) }
+    var showDialog by rememberSaveable { mutableStateOf(false) }
     IconButton(onClick = { showDialog = true }) {
         Icon(imageVector = MeshtasticIcons.Delete, contentDescription = stringResource(Res.string.clear))
     }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogScreens.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PositionLogScreens.kt
@@ -23,12 +23,19 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.clear
+import org.meshtastic.core.resources.clear_position_track_message
+import org.meshtastic.core.resources.clear_position_track_title
+import org.meshtastic.core.resources.delete
 import org.meshtastic.core.resources.export_gpx
 import org.meshtastic.core.resources.position_log
+import org.meshtastic.core.ui.component.MeshtasticResourceDialog
 import org.meshtastic.core.ui.icon.Delete
 import org.meshtastic.core.ui.icon.FileDownload
 import org.meshtastic.core.ui.icon.MeshtasticIcons
@@ -64,9 +71,7 @@ fun PositionLogScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
                         contentDescription = stringResource(Res.string.export_gpx),
                     )
                 }
-                IconButton(onClick = { viewModel.clearPosition() }) {
-                    Icon(imageVector = MeshtasticIcons.Delete, contentDescription = stringResource(Res.string.clear))
-                }
+                ClearPositionTrackButton(onConfirm = { viewModel.clearPosition() })
             }
             if (!state.isLocal) {
                 IconButton(onClick = { viewModel.requestPosition() }) {
@@ -95,4 +100,25 @@ fun PositionLogScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
             }
         },
     )
+}
+
+/** Trash-can action that asks for confirmation before invoking [onConfirm] to delete the position track. */
+@Composable
+private fun ClearPositionTrackButton(onConfirm: () -> Unit) {
+    var showDialog by remember { mutableStateOf(false) }
+    IconButton(onClick = { showDialog = true }) {
+        Icon(imageVector = MeshtasticIcons.Delete, contentDescription = stringResource(Res.string.clear))
+    }
+    if (showDialog) {
+        MeshtasticResourceDialog(
+            titleRes = Res.string.clear_position_track_title,
+            messageRes = Res.string.clear_position_track_message,
+            confirmTextRes = Res.string.delete,
+            onConfirm = {
+                showDialog = false
+                onConfirm()
+            },
+            onDismiss = { showDialog = false },
+        )
+    }
 }


### PR DESCRIPTION
Fixes #6741

The trash-can button on the Position Log screen deleted a node's entire recorded GPS track immediately, with no confirmation — and it sits directly next to the GPX export button, making accidental taps easy and irreversible.

This change gates the delete behind a confirmation dialog using the existing `MeshtasticResourceDialog` component: "Clear position track?" with an explicit warning that the deletion is permanent, plus Cancel/Delete actions. `viewModel.clearPosition()` only runs on explicit confirmation.

- New `ClearPositionTrackButton` composable in `PositionLogScreens.kt` owning the dialog-visible state
- Two new string resources (`clear_position_track_title`, `clear_position_track_message`); `scripts/sort-strings.py` run

Validated with the full baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests` — BUILD SUCCESSFUL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog before permanently deleting a node’s recorded GPS position track.
  * The dialog includes localized title, message, and confirmation text.

* **Bug Fixes**
  * Prevented accidental deletion by replacing immediate track removal with an explicit confirmation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->