### PR TITLE
fix(tak): duplicate ATAK contacts on v1 GeoChat + surface v1-fallback notice

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1730,6 +1730,7 @@ tak_server_test_result_unknown_error
 tak_server_test_results_v2
 tak_server_test_run
 tak_server_test_running
+tak_server_v1_fallback_notice
 tak_team
 tak_team_blue
 tak_team_brown

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1781,6 +1781,7 @@
     <string name="tak_server_test_results_v2">%1$d passed, %2$d expected drop, %3$d failed of %4$d/%5$d</string>
     <string name="tak_server_test_run">Run</string>
     <string name="tak_server_test_running">Running: %1$s</string>
+    <string name="tak_server_v1_fallback_notice">Connected node firmware doesn't support full TAK integration — only location and chat messages will bridge to ATAK. Markers and other event types need firmware 2.8.0 or newer.</string>
     <string name="tak_team">Team Color</string>
     <string name="tak_team_blue">Blue</string>
     <string name="tak_team_brown">Brown</string>

--- a/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
+++ b/core/takserver/src/commonMain/kotlin/org/meshtastic/core/takserver/TAKMeshIntegration.kt
@@ -33,6 +33,7 @@ import org.meshtastic.core.repository.CommandSender
 import org.meshtastic.core.repository.MeshConfigHandler
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.ServiceRepository
+import org.meshtastic.core.takserver.TAKPacketConversion.toCoTMessage
 import org.meshtastic.core.takserver.TAKPacketConversion.toTAKPacket
 import org.meshtastic.core.takserver.TAKPacketV2Conversion.toTAKPacketV2
 import org.meshtastic.proto.MemberRole
@@ -43,7 +44,6 @@ import org.meshtastic.proto.Team
 import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.random.Random
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 
@@ -438,63 +438,12 @@ class TAKMeshIntegration(
     private suspend fun handleV1Packet(payload: okio.ByteString) {
         try {
             val takPacket = TAKPacket.ADAPTER.decode(payload)
-            val cotMessage = convertV1ToCoT(takPacket) ?: return
+            val cotMessage = takPacket.toCoTMessage() ?: return
             takServerManager.broadcast(cotMessage)
             Logger.d { "V1 → TAK clients: ${cotMessage.type}" }
         } catch (e: Exception) {
             Logger.w(e) { "Failed to handle V1 packet: ${e.message}" }
         }
-    }
-
-    private fun convertV1ToCoT(takPacket: TAKPacket): CoTMessage? {
-        val callsign = takPacket.contact?.callsign ?: "UNKNOWN"
-        val senderUid = takPacket.contact?.device_callsign ?: "unknown"
-        val teamName = takPacket.group?.team?.toTakTeamName() ?: DEFAULT_TAK_TEAM_NAME
-        val roleName = takPacket.group?.role?.toTakRoleName() ?: DEFAULT_TAK_ROLE_NAME
-        val battery = takPacket.status?.battery ?: DEFAULT_TAK_BATTERY
-
-        val pli = takPacket.pli
-        if (pli != null) {
-            return CoTMessage.pli(
-                uid = senderUid,
-                callsign = callsign,
-                latitude = pli.latitude_i.toDouble() / TAK_COORDINATE_SCALE,
-                longitude = pli.longitude_i.toDouble() / TAK_COORDINATE_SCALE,
-                altitude = pli.altitude.toDouble(),
-                speed = pli.speed.toDouble(),
-                course = pli.course.toDouble(),
-                team = teamName,
-                role = roleName,
-                battery = battery,
-                staleMinutes = DEFAULT_TAK_STALE_MINUTES,
-            )
-        }
-
-        val chat = takPacket.chat
-        if (chat != null) {
-            val timeNow = Clock.System.now()
-            // Include chatroom in UID so ATAK routes DMs correctly — the UID format
-            // "GeoChat.<senderUid>.<chatroom>.<msgId>" is what ATAK uses to determine routing.
-            // Hardcoding "All Chat Rooms" here loses DM routing from legacy v1 nodes.
-            val chatroom = chat.to ?: "All Chat Rooms"
-            val msgId = Random.Default.nextInt().toString(TAK_HEX_RADIX)
-            return CoTMessage(
-                uid = "GeoChat.$senderUid.$chatroom.$msgId",
-                type = "b-t-f",
-                how = "h-g-i-g-o",
-                time = timeNow,
-                start = timeNow,
-                stale = timeNow + DEFAULT_TAK_STALE_MINUTES.minutes,
-                latitude = 0.0,
-                longitude = 0.0,
-                contact = CoTContact(callsign = callsign, endpoint = DEFAULT_TAK_ENDPOINT),
-                group = CoTGroup(name = teamName, role = roleName),
-                status = CoTStatus(battery = battery),
-                chat = CoTChat(chatroom = chatroom, senderCallsign = callsign, message = chat.message),
-            )
-        }
-
-        return null
     }
 
     companion object {

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TAKConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TAKConfigItemList.kt
@@ -52,8 +52,10 @@ import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.meshtastic.core.common.BuildConfigProvider
+import org.meshtastic.core.model.Capabilities
 import org.meshtastic.core.model.getColorFrom
 import org.meshtastic.core.model.getStringResFrom
+import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.TakPrefs
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.back
@@ -87,6 +89,7 @@ import org.meshtastic.core.resources.tak_server_test_result_unknown_error
 import org.meshtastic.core.resources.tak_server_test_results_v2
 import org.meshtastic.core.resources.tak_server_test_run
 import org.meshtastic.core.resources.tak_server_test_running
+import org.meshtastic.core.resources.tak_server_v1_fallback_notice
 import org.meshtastic.core.resources.tak_team
 import org.meshtastic.core.takserver.TAKDataPackageGenerator
 import org.meshtastic.core.takserver.TAKMeshIntegration
@@ -101,6 +104,7 @@ import org.meshtastic.core.ui.icon.ArrowBack
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.PlayArrow
 import org.meshtastic.core.ui.icon.Share
+import org.meshtastic.core.ui.icon.Warning
 import org.meshtastic.feature.settings.radio.RadioConfigViewModel
 import org.meshtastic.feature.settings.radio.RebootBehavior
 import org.meshtastic.feature.settings.radio.ResponseState
@@ -197,12 +201,22 @@ internal fun handleTakPermissionResult(granted: Boolean, isTakServerEnabled: Boo
 fun TakServerScreen(onBack: () -> Unit) {
     val takPrefs: TakPrefs = koinInject()
     val takServerManager: TAKServerManager = koinInject()
+    val nodeRepository: NodeRepository = koinInject()
     val isTakServerEnabled by takPrefs.isTakServerEnabled.collectAsStateWithLifecycle()
     val isMeshToCotEnabled by takPrefs.isMeshToCotEnabled.collectAsStateWithLifecycle()
     val isTakServerRunning by takServerManager.isRunning.collectAsStateWithLifecycle()
     val isTakServerStarting by takServerManager.isStarting.collectAsStateWithLifecycle()
     val takClientCount by takServerManager.connectionCount.collectAsStateWithLifecycle()
     val hasTakServerStartError by takServerManager.hasStartError.collectAsStateWithLifecycle()
+    val myNodeInfo by nodeRepository.myNodeInfo.collectAsStateWithLifecycle()
+    // The Mesh-to-CoT bridge falls back to a legacy protocol (PLI + basic chat only, no
+    // markers/POIs) when the connected node's firmware predates the v2 TAK port — see
+    // TAKMeshIntegration.useTakV2() for the same check on the actual bridging path.
+    // Defaults to true (assume supported) when firmware is unknown -- no node connected yet,
+    // or myNodeInfo hasn't arrived -- rather than treating "unknown" the same as "confirmed
+    // unsupported": Capabilities(null).supportsTakV2 is false, which would otherwise show the
+    // fallback warning even when there's no connected node to be falling back for.
+    val supportsTakV2 = myNodeInfo?.firmwareVersion?.let { Capabilities(it).supportsTakV2 } ?: true
     val takServerStatus =
         TakServerStatus.resolve(
             isSupported = takServerManager.isSupported,
@@ -253,6 +267,7 @@ fun TakServerScreen(onBack: () -> Unit) {
                 status = takServerStatus,
                 clientCount = takClientCount,
                 onExport = { exportLauncher("Meshtastic_TAK_Server.zip") },
+                supportsTakV2 = supportsTakV2,
             )
             TakMeshTestCard()
         }
@@ -269,6 +284,7 @@ internal fun TakServerSection(
     status: TakServerStatus,
     clientCount: Int,
     onExport: () -> Unit,
+    supportsTakV2: Boolean,
 ) {
     TitledCard(title = stringResource(Res.string.tak_server_section)) {
         SwitchPreference(
@@ -289,6 +305,10 @@ internal fun TakServerSection(
                 enabled = true,
                 onCheckedChange = onMeshToCotChange,
             )
+            if (isMeshToCotEnabled && !supportsTakV2) {
+                HorizontalDivider()
+                TakV1FallbackNotice()
+            }
             HorizontalDivider()
             Row(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
@@ -314,6 +334,23 @@ internal fun TakServerSection(
                 }
             }
         }
+    }
+}
+
+/** Warns that the connected node's firmware falls back to the legacy TAK bridge (PLI + chat only, no markers/POIs). */
+@Composable
+private fun TakV1FallbackNotice() {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Icon(imageVector = MeshtasticIcons.Warning, contentDescription = null, tint = MaterialTheme.colorScheme.error)
+        Text(
+            text = stringResource(Res.string.tak_server_v1_fallback_notice),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TAKConfigPreviews.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/TAKConfigPreviews.kt
@@ -51,6 +51,7 @@ fun TakServerSectionDisabledPreview() {
             status = TakServerStatus.Off,
             clientCount = 0,
             onExport = {},
+            supportsTakV2 = true,
         )
     }
 }
@@ -67,6 +68,7 @@ fun TakServerSectionEnabledPreview() {
             status = TakServerStatus.WaitingForClient,
             clientCount = 0,
             onExport = {},
+            supportsTakV2 = true,
         )
     }
 }
@@ -83,6 +85,7 @@ fun TakServerSectionConnectedPreview() {
             status = TakServerStatus.Connected,
             clientCount = 1,
             onExport = {},
+            supportsTakV2 = true,
         )
     }
 }
@@ -99,6 +102,24 @@ fun TakServerSectionFailedPreview() {
             status = TakServerStatus.Failed,
             clientCount = 0,
             onExport = {},
+            supportsTakV2 = true,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+fun TakServerSectionV1FallbackPreview() {
+    AppTheme {
+        TakServerSection(
+            isTakServerEnabled = true,
+            onEnabledChange = {},
+            isMeshToCotEnabled = true,
+            onMeshToCotChange = {},
+            status = TakServerStatus.Connected,
+            clientCount = 1,
+            onExport = {},
+            supportsTakV2 = false,
         )
     }
 }


### PR DESCRIPTION
Two fixes for #6583, addressing the two distinct problems reported in that thread.

## Duplicate ATAK contacts on legacy GeoChat (real regression)

`TAKMeshIntegration.convertV1ToCoT()` built a v1 GeoChat's sender UID from the raw `device_callsign` wire string — but that string is actually a smuggled `"<senderUid>|<messageId>"` pair (see `TAKPacketConversion.createChatPacket`). Since `messageId` is random per message, every incoming chat from the same device got a different `senderUid`, so ATAK treated each one as a brand-new contact with an empty history (@Guylby's report).

The correct parsing already existed — `TAKPacketConversion.toCoTMessage()`, using `TakConversionHelpers.parseDeviceCallsign()` — but was dead code, only referenced from a test. A refactor in #5434 swapped its call site for the new (buggy) private `convertV1ToCoT()` and never wired the correct implementation back in. Fixed by pointing `handleV1Packet()` at the existing correct implementation and deleting the duplicate. Verified team/role mapping is unaffected: `TakConversionHelpers.teamToColorName()`/`roleToName()` are thin wrappers around the exact same extension functions `convertV1ToCoT()` called directly.

## Silent v1 fallback (UX gap)

@jamesarich's diagnosis in the thread: real ATAK traffic gates on the connected node's firmware (`Capabilities.supportsTakV2`, firmware ≥ 2.8.0) and silently falls back to a legacy path (PLI + one chat type only — no markers, POIs) on older firmware, with zero user-facing signal, only a log line. Since 2.8.0 is currently nightly-only, this affects most real users today.

Added a warning row in TAK Server settings (`TakV1FallbackNotice`), shown when Mesh-to-CoT is enabled but the connected node doesn't support v2, explaining what still works (location, chat) vs. what needs a firmware update (markers, other event types).

## Testing

- `:core:takserver:allTests` (253 tests), `:feature:settings:allTests` — pass
- `detekt`, `spotlessCheck` (both modules) — pass
- `assembleDebug` — full clean build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warning in TAK server settings when connected firmware supports only legacy TAK integration.
  - The notice explains available functionality and the firmware version needed for full integration.
  - Added preview support for both full-integration and legacy-fallback states.

- **Bug Fixes**
  - Improved TAK v1 packet conversion by using the standard conversion process, helping maintain consistent message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->