### PR TITLE
fix(service): explain, don't hang, when a TCP reconnect lacks local-network access

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -932,6 +932,7 @@ load_indexed
 loading
 ### LOCAL ###
 local_mbtiles_file
+local_network_permission_required
 local_stats_bad
 local_stats_battery
 local_stats_diagnostics_prefix

--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -932,7 +932,7 @@ load_indexed
 loading
 ### LOCAL ###
 local_mbtiles_file
-local_network_permission_required
+local_network_permission_denied_hint
 local_stats_bad
 local_stats_battery
 local_stats_diagnostics_prefix

--- a/core/common/src/androidMain/kotlin/org/meshtastic/core/common/ContextServices.kt
+++ b/core/common/src/androidMain/kotlin/org/meshtastic/core/common/ContextServices.kt
@@ -73,6 +73,18 @@ private fun Context.getBluetoothPermissions(): Array<String> {
 /** Checks if all necessary Bluetooth permissions have been granted. */
 fun Context.hasBluetoothPermission(): Boolean = getBluetoothPermissions().isEmpty()
 
+/** API level at which ACCESS_LOCAL_NETWORK became a real runtime permission (Android 17 / API 37). */
+private const val LOCAL_NETWORK_PERMISSION_API = 37
+
+/**
+ * @return true if opening a socket to a local-network address is currently permitted. Below API 37 local-network access
+ *   is implicit via INTERNET; from 37 it is gated by the ACCESS_LOCAL_NETWORK runtime permission, whose grant is keyed
+ *   on targetSdk rather than install history.
+ */
+fun Context.hasLocalNetworkPermission(): Boolean = Build.VERSION.SDK_INT < LOCAL_NETWORK_PERMISSION_API ||
+    ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_LOCAL_NETWORK) ==
+    PackageManager.PERMISSION_GRANTED
+
 /** @return true if the user already has location permission (ACCESS_FINE_LOCATION). */
 fun Context.hasLocationPermission(): Boolean {
     val perms = listOf(Manifest.permission.ACCESS_FINE_LOCATION)

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -962,6 +962,7 @@
     <string name="loading">Loading</string>
     <!-- LOCAL -->
     <string name="local_mbtiles_file">Local MBTiles File</string>
+    <string name="local_network_permission_required">Meshtastic needs local network access to reach a radio over Wi-Fi. Open Connections and grant the permission to reconnect.</string>
     <string name="local_stats_bad">Bad %1$d</string>
     <string name="local_stats_battery">Battery: %1$d%</string>
     <string name="local_stats_diagnostics_prefix">Diagnostics: %1$s</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -962,7 +962,7 @@
     <string name="loading">Loading</string>
     <!-- LOCAL -->
     <string name="local_mbtiles_file">Local MBTiles File</string>
-    <string name="local_network_permission_required">Meshtastic needs local network access to reach a radio over Wi-Fi. Open Connections and grant the permission to reconnect.</string>
+    <string name="local_network_permission_denied_hint">Local network access is turned off for Meshtastic. If this radio is on your local network, the connection will fail until you allow local network access in system settings.</string>
     <string name="local_stats_bad">Bad %1$d</string>
     <string name="local_stats_battery">Battery: %1$d%</string>
     <string name="local_stats_diagnostics_prefix">Diagnostics: %1$s</string>

--- a/core/service/build.gradle.kts
+++ b/core/service/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
             implementation(projects.core.network)
             implementation(projects.core.ble)
             implementation(projects.core.prefs)
+            implementation(projects.core.resources)
             implementation(libs.meshtastic.protobufs)
             implementation(projects.core.takserver)
 

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidLocalNetworkAccess.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidLocalNetworkAccess.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.service
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import org.koin.core.annotation.Single
+
+/** API level at which ACCESS_LOCAL_NETWORK became a real runtime permission (Android 17 / API 37). */
+private const val LOCAL_NETWORK_PERMISSION_API = 37
+
+@Single
+class AndroidLocalNetworkAccess(private val context: Context) : LocalNetworkAccess {
+    override fun isGranted(): Boolean =
+        // Below API 37 local-network access is implicit via INTERNET. The grant is keyed on targetSdk rather than on
+        // install history, so an existing install loses it as soon as it takes an update built against 37.
+        Build.VERSION.SDK_INT < LOCAL_NETWORK_PERMISSION_API ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_LOCAL_NETWORK) ==
+            PackageManager.PERMISSION_GRANTED
+}

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidLocalNetworkAccess.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/AndroidLocalNetworkAccess.kt
@@ -16,22 +16,11 @@
  */
 package org.meshtastic.core.service
 
-import android.Manifest
 import android.content.Context
-import android.content.pm.PackageManager
-import android.os.Build
-import androidx.core.content.ContextCompat
 import org.koin.core.annotation.Single
-
-/** API level at which ACCESS_LOCAL_NETWORK became a real runtime permission (Android 17 / API 37). */
-private const val LOCAL_NETWORK_PERMISSION_API = 37
+import org.meshtastic.core.common.hasLocalNetworkPermission
 
 @Single
 class AndroidLocalNetworkAccess(private val context: Context) : LocalNetworkAccess {
-    override fun isGranted(): Boolean =
-        // Below API 37 local-network access is implicit via INTERNET. The grant is keyed on targetSdk rather than on
-        // install history, so an existing install loses it as soon as it takes an update built against 37.
-        Build.VERSION.SDK_INT < LOCAL_NETWORK_PERMISSION_API ||
-            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_LOCAL_NETWORK) ==
-            PackageManager.PERMISSION_GRANTED
+    override fun isGranted(): Boolean = context.hasLocalNetworkPermission()
 }

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/LocalNetworkAccess.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/LocalNetworkAccess.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.service
+
+/**
+ * Whether the platform currently permits opening a socket to a local-network address.
+ *
+ * Android 17 (API 37) gates local-network traffic behind `ACCESS_LOCAL_NETWORK`, and the gate is on the socket rather
+ * than on discovery: a blocked TCP connect does not fail fast, it *times out*. The service reconnects to a persisted
+ * device address at startup with no UI in sight, so without this check a TCP user who has not granted the permission
+ * simply waits out a socket timeout with nothing to explain it.
+ *
+ * A service has no `Activity`, so it cannot request the permission — it can only decline to try and say why. The
+ * request itself belongs to `ConnectionsScreen`.
+ *
+ * Implementations are per-platform and granted-by-construction everywhere the concept does not apply.
+ */
+fun interface LocalNetworkAccess {
+    fun isGranted(): Boolean
+}

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
@@ -44,9 +44,15 @@ import org.meshtastic.core.repository.ServiceStateWriter
 import org.meshtastic.core.repository.TakPrefs
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.getStringSuspend
-import org.meshtastic.core.resources.local_network_permission_required
+import org.meshtastic.core.resources.local_network_permission_denied_hint
 import org.meshtastic.core.takserver.TAKMeshIntegration
 import org.meshtastic.core.takserver.TAKServerManager
+
+// English fallback for local_network_permission_denied_hint when resource lookup is unavailable. Kept above the
+// class KDoc so that KDoc still binds to the class. Internal so tests can assert the exact surfaced text.
+internal const val UNTRANSLATED_LOCAL_NETWORK_PERMISSION_DENIED_HINT =
+    "Local network access is turned off for Meshtastic. If this radio is on your local network, " +
+        "the connection will fail until you allow local network access in system settings."
 
 /**
  * Platform-agnostic orchestrator for the mesh service lifecycle.
@@ -56,11 +62,6 @@ import org.meshtastic.core.takserver.TAKServerManager
  *
  * All injected dependencies are `commonMain` interfaces with real implementations in `core:data`.
  */
-// English fallback for local_network_permission_required when resource lookup is unavailable.
-private const val UNTRANSLATED_LOCAL_NETWORK_PERMISSION_REQUIRED =
-    "Meshtastic needs local network access to reach a radio over Wi-Fi. " +
-        "Open Connections and grant the permission to reconnect."
-
 @Suppress("LongParameterList")
 @Single
 class MeshServiceOrchestrator(
@@ -103,20 +104,24 @@ class MeshServiceOrchestrator(
         // start() and raced ahead of the DB switch, reading the default (or null) DB.
         nodeManager.loadCachedNodeDB()
         // Android 17 gates the socket, not just discovery: a TCP connect without ACCESS_LOCAL_NETWORK times out
-        // rather than failing fast. There is no Activity here to request from, so decline to try and say why —
-        // the alert is a StateFlow, so it is still waiting when the user next opens the app. Granting the
-        // permission and reselecting the device in ConnectionsScreen restarts the transport via setDeviceAddress.
+        // rather than failing fast. There is no Activity here to request from, so warn — the alert is a StateFlow,
+        // still waiting when the user next opens the app — and then connect ANYWAY, for two load-bearing reasons:
+        // the address prefix says nothing about locality (a radio reached over a public IP, a port-forward, or a
+        // VPN needs no local-network permission and must keep working), and connect() is the sole installer of the
+        // transport-recovery listeners (BLE state, network availability, USB replug) — skipping it would leave a
+        // later successful manual connect with no recovery layer for the life of the process. The OS enforces the
+        // permission at the socket, so a genuinely local connect fails exactly as it would have; the difference is
+        // the user now has an explanation and the fix in hand.
         if (address?.firstOrNull() == InterfaceId.TCP.id && !localNetworkAccess.isGranted()) {
-            Logger.w { "Local network access not granted; skipping reconnect to the persisted TCP address" }
+            Logger.w { "Local network access not granted; the persisted TCP reconnect may time out" }
             serviceStateWriter.setErrorMessage(
                 // Same shape as ScannerViewModel's scan-failure messages: resource lookup can fail outside a
                 // fully wired resource environment, and an untranslated warning beats no warning at all.
                 text =
-                safeCatchingAll { getStringSuspend(Res.string.local_network_permission_required) }
-                    .getOrDefault(UNTRANSLATED_LOCAL_NETWORK_PERMISSION_REQUIRED),
+                safeCatchingAll { getStringSuspend(Res.string.local_network_permission_denied_hint) }
+                    .getOrDefault(UNTRANSLATED_LOCAL_NETWORK_PERMISSION_DENIED_HINT),
                 severity = Severity.Warn,
             )
-            return
         }
         Logger.i { "Per-device database initialized, connecting radio" }
         radioInterfaceService.connect()

--- a/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
+++ b/core/service/src/commonMain/kotlin/org/meshtastic/core/service/MeshServiceOrchestrator.kt
@@ -32,7 +32,9 @@ import org.meshtastic.core.common.database.DatabaseManager
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.isValidDeviceAddress
 import org.meshtastic.core.common.util.safeCatching
+import org.meshtastic.core.common.util.safeCatchingAll
 import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.core.model.InterfaceId
 import org.meshtastic.core.repository.MeshConnectionManager
 import org.meshtastic.core.repository.MeshMessageProcessor
 import org.meshtastic.core.repository.MeshNotificationManager
@@ -40,6 +42,9 @@ import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.RadioInterfaceService
 import org.meshtastic.core.repository.ServiceStateWriter
 import org.meshtastic.core.repository.TakPrefs
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.getStringSuspend
+import org.meshtastic.core.resources.local_network_permission_required
 import org.meshtastic.core.takserver.TAKMeshIntegration
 import org.meshtastic.core.takserver.TAKServerManager
 
@@ -51,6 +56,11 @@ import org.meshtastic.core.takserver.TAKServerManager
  *
  * All injected dependencies are `commonMain` interfaces with real implementations in `core:data`.
  */
+// English fallback for local_network_permission_required when resource lookup is unavailable.
+private const val UNTRANSLATED_LOCAL_NETWORK_PERMISSION_REQUIRED =
+    "Meshtastic needs local network access to reach a radio over Wi-Fi. " +
+        "Open Connections and grant the permission to reconnect."
+
 @Suppress("LongParameterList")
 @Single
 class MeshServiceOrchestrator(
@@ -65,12 +75,52 @@ class MeshServiceOrchestrator(
     private val databaseManager: DatabaseManager,
     private val connectionManager: MeshConnectionManager,
     private val dispatchers: CoroutineDispatchers,
+    private val localNetworkAccess: LocalNetworkAccess,
 ) {
     // Per-start coroutine scope. A fresh scope is created on each start() and cancelled on stop(), so all collectors
     // launched from start() are torn down cleanly and do not accumulate across start/stop/start cycles.
     // Held in an atomic ref so concurrent start()/stop() callers serialize on compareAndSet rather than racing through
     // a check-then-set on a plain var.
     private val scopeRef = atomic<CoroutineScope?>(null)
+
+    // Cold-start lifecycle invariant: a transport must NOT start for a selected address until
+    // the active DB has been switched to that same address. We enforce the ordering
+    // (valid address -> DB switch -> connect) by waiting for currentDeviceAddressFlow to
+    // surface a real selected address before performing the DB switch and connecting the
+    // radio. Address sync inside SharedRadioInterfaceService now runs independently of
+    // connect() (via its init{} listener), so this wait completes as soon as prefs load —
+    // without it, connect() would race ahead of the DB switch and the firmware handshake
+    // would write into the wrong (or null) DB.
+    //
+    // If no device is ever selected this suspends indefinitely for the lifetime of newScope;
+    // by design the radio must not connect without a selected device. This mirrors
+    // MeshService's foreground-service stay-alive gate (isValidDeviceAddress).
+    private suspend fun coldStartConnect() {
+        val address = radioInterfaceService.currentDeviceAddressFlow.first(::isValidDeviceAddress)
+        databaseManager.switchActiveDatabase(address)
+        // Load cached nodes from the now-active per-device DB before connect() so the firmware
+        // handshake doesn't see a stale/empty node set. Previously this ran synchronously in
+        // start() and raced ahead of the DB switch, reading the default (or null) DB.
+        nodeManager.loadCachedNodeDB()
+        // Android 17 gates the socket, not just discovery: a TCP connect without ACCESS_LOCAL_NETWORK times out
+        // rather than failing fast. There is no Activity here to request from, so decline to try and say why —
+        // the alert is a StateFlow, so it is still waiting when the user next opens the app. Granting the
+        // permission and reselecting the device in ConnectionsScreen restarts the transport via setDeviceAddress.
+        if (address?.firstOrNull() == InterfaceId.TCP.id && !localNetworkAccess.isGranted()) {
+            Logger.w { "Local network access not granted; skipping reconnect to the persisted TCP address" }
+            serviceStateWriter.setErrorMessage(
+                // Same shape as ScannerViewModel's scan-failure messages: resource lookup can fail outside a
+                // fully wired resource environment, and an untranslated warning beats no warning at all.
+                text =
+                safeCatchingAll { getStringSuspend(Res.string.local_network_permission_required) }
+                    .getOrDefault(UNTRANSLATED_LOCAL_NETWORK_PERMISSION_REQUIRED),
+                severity = Severity.Warn,
+            )
+            return
+        }
+        Logger.i { "Per-device database initialized, connecting radio" }
+        radioInterfaceService.connect()
+    }
 
     /** Whether the orchestrator is currently running. */
     val isRunning: Boolean
@@ -122,28 +172,7 @@ class MeshServiceOrchestrator(
             }
             .launchIn(newScope)
 
-        // Cold-start lifecycle invariant: a transport must NOT start for a selected address until
-        // the active DB has been switched to that same address. We enforce the ordering
-        // (valid address -> DB switch -> connect) by waiting for currentDeviceAddressFlow to
-        // surface a real selected address before performing the DB switch and connecting the
-        // radio. Address sync inside SharedRadioInterfaceService now runs independently of
-        // connect() (via its init{} listener), so this wait completes as soon as prefs load —
-        // without it, connect() would race ahead of the DB switch and the firmware handshake
-        // would write into the wrong (or null) DB.
-        //
-        // If no device is ever selected this suspends indefinitely for the lifetime of newScope;
-        // by design the radio must not connect without a selected device. This mirrors
-        // MeshService's foreground-service stay-alive gate (isValidDeviceAddress).
-        newScope.handledLaunch {
-            val address = radioInterfaceService.currentDeviceAddressFlow.first(::isValidDeviceAddress)
-            databaseManager.switchActiveDatabase(address)
-            // Load cached nodes from the now-active per-device DB before connect() so the firmware
-            // handshake doesn't see a stale/empty node set. Previously this ran synchronously in
-            // start() and raced ahead of the DB switch, reading the default (or null) DB.
-            nodeManager.loadCachedNodeDB()
-            Logger.i { "Per-device database initialized, connecting radio" }
-            radioInterfaceService.connect()
-        }
+        newScope.handledLaunch { coldStartConnect() }
 
         // Mid-session device-address transitions (late process-lifecycle devAddr propagation,
         // user-initiated device switch, etc.): keep the active DB in sync with the selected

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
@@ -32,8 +32,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 import okio.ByteString.Companion.toByteString
 import org.meshtastic.core.common.database.DatabaseManager
+import org.meshtastic.core.common.util.safeCatchingAll
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.repository.CommandSender
@@ -48,6 +50,9 @@ import org.meshtastic.core.repository.RadioSessionContext
 import org.meshtastic.core.repository.ReceivedRadioFrame
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.core.repository.TakPrefs
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.getStringSuspend
+import org.meshtastic.core.resources.local_network_permission_denied_hint
 import org.meshtastic.core.takserver.MeshToCotBroadcaster
 import org.meshtastic.core.takserver.TAKMeshIntegration
 import org.meshtastic.core.takserver.TAKServerManager
@@ -533,10 +538,18 @@ class MeshServiceOrchestratorTest {
     }
 
     @Test
-    fun tcpReconnectIsSkippedWithAMessageWhenLocalNetworkAccessIsMissing() {
-        // Android 17 gates the socket: without ACCESS_LOCAL_NETWORK this connect would not fail, it would sit on a
-        // timeout with nothing to explain it. The service has no Activity to request from, so the contract is
-        // "decline and say why".
+    fun tcpReconnectWarnsAndStillConnectsWhenLocalNetworkAccessIsMissing() = runTest {
+        // Android 17 gates the socket: without ACCESS_LOCAL_NETWORK a local TCP connect times out silently. The
+        // service has no Activity to request from, so the contract is warn-and-proceed — proceed because the address
+        // prefix says nothing about locality (public-IP/VPN radios need no permission) and because connect() is the
+        // sole installer of the transport-recovery listeners.
+        //
+        // Pre-warm the resource: the first read completes on compose-resources' own Dispatchers.Default scope, so an
+        // un-warmed lookup lands after the assertions (see ScannerViewModelTest's warmScanFailureStrings). The same
+        // safeCatchingAll-with-fallback shape as production keeps the expected text identical either way.
+        val expectedMessage =
+            safeCatchingAll { getStringSuspend(Res.string.local_network_permission_denied_hint) }
+                .getOrDefault(UNTRANSLATED_LOCAL_NETWORK_PERMISSION_DENIED_HINT)
         val orchestrator =
             createOrchestrator(
                 currentDeviceAddressFlow = MutableStateFlow<String?>("t192.168.1.100"),
@@ -545,14 +558,14 @@ class MeshServiceOrchestratorTest {
 
         orchestrator.start()
 
-        verify(exactly(0)) { radioInterfaceService.connect() }
-        verify { serviceRepository.setErrorMessage(any(), Severity.Warn) }
+        verify { serviceRepository.setErrorMessage(expectedMessage, Severity.Warn) }
+        verify { radioInterfaceService.connect() }
 
         orchestrator.stop()
     }
 
     @Test
-    fun tcpReconnectProceedsWhenLocalNetworkAccessIsHeld() {
+    fun tcpReconnectConnectsWithoutAWarningWhenLocalNetworkAccessIsHeld() {
         val orchestrator =
             createOrchestrator(
                 currentDeviceAddressFlow = MutableStateFlow<String?>("t192.168.1.100"),
@@ -562,6 +575,7 @@ class MeshServiceOrchestratorTest {
         orchestrator.start()
 
         verify { radioInterfaceService.connect() }
+        verify(exactly(0)) { serviceRepository.setErrorMessage(any(), any()) }
 
         orchestrator.stop()
     }
@@ -569,7 +583,7 @@ class MeshServiceOrchestratorTest {
     @Test
     fun nonTcpReconnectIsUnaffectedByLocalNetworkAccess() {
         // Guards against over-gating: ACCESS_LOCAL_NETWORK has nothing to do with a BLE radio, so a denied grant
-        // must not keep a Bluetooth device from reconnecting.
+        // must neither warn nor keep a Bluetooth device from reconnecting.
         val orchestrator =
             createOrchestrator(
                 currentDeviceAddressFlow = MutableStateFlow<String?>(DEFAULT_ADDRESS),
@@ -579,6 +593,7 @@ class MeshServiceOrchestratorTest {
         orchestrator.start()
 
         verify { radioInterfaceService.connect() }
+        verify(exactly(0)) { serviceRepository.setErrorMessage(any(), any()) }
 
         orchestrator.stop()
     }

--- a/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
+++ b/core/service/src/commonTest/kotlin/org/meshtastic/core/service/MeshServiceOrchestratorTest.kt
@@ -101,6 +101,9 @@ class MeshServiceOrchestratorTest {
         isSessionActive: (RadioSessionContext) -> Boolean = { activeSession.value == it },
         takEnabledFlow: MutableStateFlow<Boolean> = MutableStateFlow(false),
         takRunningFlow: MutableStateFlow<Boolean> = MutableStateFlow(false),
+        // Granted by default so every pre-existing test keeps reaching connect(); DEFAULT_ADDRESS is BLE
+        // anyway, but the cold-start ordering test deliberately uses a TCP address.
+        localNetworkAccess: LocalNetworkAccess = LocalNetworkAccess { true },
     ): MeshServiceOrchestrator {
         every { radioInterfaceService.receivedData } returns receivedData
         every { radioInterfaceService.connectionError } returns connectionError
@@ -157,6 +160,7 @@ class MeshServiceOrchestratorTest {
             databaseManager = databaseManager,
             connectionManager = connectionManager,
             dispatchers = dispatchers,
+            localNetworkAccess = localNetworkAccess,
         )
     }
 
@@ -526,5 +530,56 @@ class MeshServiceOrchestratorTest {
         connectionState.value = ConnectionState.Disconnected
         connectionState.value = ConnectionState.Connected
         assertFalse(orchestrator.isRunning)
+    }
+
+    @Test
+    fun tcpReconnectIsSkippedWithAMessageWhenLocalNetworkAccessIsMissing() {
+        // Android 17 gates the socket: without ACCESS_LOCAL_NETWORK this connect would not fail, it would sit on a
+        // timeout with nothing to explain it. The service has no Activity to request from, so the contract is
+        // "decline and say why".
+        val orchestrator =
+            createOrchestrator(
+                currentDeviceAddressFlow = MutableStateFlow<String?>("t192.168.1.100"),
+                localNetworkAccess = LocalNetworkAccess { false },
+            )
+
+        orchestrator.start()
+
+        verify(exactly(0)) { radioInterfaceService.connect() }
+        verify { serviceRepository.setErrorMessage(any(), Severity.Warn) }
+
+        orchestrator.stop()
+    }
+
+    @Test
+    fun tcpReconnectProceedsWhenLocalNetworkAccessIsHeld() {
+        val orchestrator =
+            createOrchestrator(
+                currentDeviceAddressFlow = MutableStateFlow<String?>("t192.168.1.100"),
+                localNetworkAccess = LocalNetworkAccess { true },
+            )
+
+        orchestrator.start()
+
+        verify { radioInterfaceService.connect() }
+
+        orchestrator.stop()
+    }
+
+    @Test
+    fun nonTcpReconnectIsUnaffectedByLocalNetworkAccess() {
+        // Guards against over-gating: ACCESS_LOCAL_NETWORK has nothing to do with a BLE radio, so a denied grant
+        // must not keep a Bluetooth device from reconnecting.
+        val orchestrator =
+            createOrchestrator(
+                currentDeviceAddressFlow = MutableStateFlow<String?>(DEFAULT_ADDRESS),
+                localNetworkAccess = LocalNetworkAccess { false },
+            )
+
+        orchestrator.start()
+
+        verify { radioInterfaceService.connect() }
+
+        orchestrator.stop()
     }
 }

--- a/core/service/src/jvmMain/kotlin/org/meshtastic/core/service/DesktopLocalNetworkAccess.kt
+++ b/core/service/src/jvmMain/kotlin/org/meshtastic/core/service/DesktopLocalNetworkAccess.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.service
+
+import org.koin.core.annotation.Single
+
+/** Desktop has no local-network permission model, so a socket to a LAN address is always permitted. */
+@Single
+class DesktopLocalNetworkAccess : LocalNetworkAccess {
+    override fun isGranted(): Boolean = true
+}


### PR DESCRIPTION
Follow-up to #6766, which gates the two *user-initiated* TCP connect paths. This covers the third one, and the worst-affected user: the service reconnects to the **persisted** device address at startup, with no UI in sight.

On Android 17 (API 37) a TCP connect without `ACCESS_LOCAL_NETWORK` does not fail — per [Google's documentation](https://developer.android.com/privacy-and-security/local-network-permission) it "will typically result in a timeout error", and the only fast diagnostic is an NDK call this app has no native layer to make. The implicit legacy grant is keyed on **targetSdk, not install history**, so an existing install with a persisted TCP radio loses access the moment it takes an update built against 37. The radio just stops connecting — no prompt, no error, nothing to explain it.

## 🐛 Bug Fixes

A service has no `Activity`, so it cannot request the permission. The contract here is **warn and proceed — never block**: when the persisted address is TCP and the permission is missing, the orchestrator surfaces a persistent warning naming the fix, then connects anyway.

It connects anyway for two load-bearing reasons (both from adversarial review of the first revision, which skipped the connect):

1. **`connect()` is the sole installer of the transport-recovery listeners** (BLE adapter state, network availability, USB replug). Skipping it left a reachable state — device selected, transport later connected via `setDeviceAddress`, no recovery layer — where a Wi-Fi drop strands a dead socket nothing tears down, for the life of the process.
2. **The address prefix says nothing about locality.** A radio reached over a public IP, a port-forward, or a VPN needs no `ACCESS_LOCAL_NETWORK` at all; blocking its reconnect told the user something false. The OS enforces the permission at the socket, so proceeding costs nothing a blocked local connect wouldn't already cost — the user just has the explanation and the fix in hand.

`ServiceRepository.errorMessage` is a `StateFlow` feeding `UIViewModel`'s alert, so the warning set at boot is still waiting the next time the user opens the app.

## 🛠️ Refactoring & Architecture

- New `LocalNetworkAccess` seam in `core:service` — Android implementation delegates to a new `Context.hasLocalNetworkPermission()` in `core:common` (alongside the existing permission helpers, deduplicating the API-37 gate); desktop is always granted. Each platform's Koin component scan sees exactly one, matching the module's existing platform split.
- The cold-start block moves into its own `coldStartConnect()` — it had outgrown `start()`, and the added branch pushed it past the `LongMethod` limit. Ordering (`first(::isValidDeviceAddress)` → DB switch → cached-NodeDB load → connect) is unchanged and adversarially verified byte-identical.
- New string `local_network_permission_denied_hint` (shared verbatim with #6766, so the branches merge cleanly), with an untranslated English fallback matching `ScannerViewModel`'s scan-failure shape.

## Testing Performed

Three tests in `MeshServiceOrchestratorTest`, passing on both `jvm` and `androidHostTest`:

- TCP + access denied → the exact warning text is stored with `Severity.Warn` **and** `connect()` still runs.
- TCP + access held → `connect()` runs, no message.
- BLE + access denied → `connect()` runs, no message (guards against over-gating).

The denied-case test pre-warms the compose resource before asserting — the first read completes on a library-owned dispatcher the test scheduler cannot drain, the exact flake this repo's own test docs describe.

Full baseline green: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`. `scripts/sort-strings.py` run for the string change.

## Review provenance

First revision (skip-and-explain) was reworked after CodeRabbit (string wording, weak test assertion) and an adversarial review pass (orphaned recovery listeners, locality false-positives, KDoc rebinding to the fallback const, duplicated API-37 check, racy resource assertion) — all findings addressed in the second commit.

<!--
If you have screenshots or recordings to display your change, please include them!
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)