### PR TITLE
fix(firmware): point OTAFIX bootloader self-update at meshtastic's own fork

### DIFF
--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateScreen.kt
@@ -180,7 +180,7 @@ private const val CYCLE_DELAY_MS = 4500L
  * app could drop the DFU link and brick the device.
  */
 private const val OTAFIX_BOOTLOADER_URL =
-    "https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX#changes-in-otafix-21"
+    "https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/blob/master/changelog.md#otafix-21"
 
 @Composable
 @Suppress("LongMethod")

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/MaintenanceUf2.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/MaintenanceUf2.kt
@@ -56,11 +56,11 @@ internal data class MaintenanceUf2(
 private const val ERASE_UF2_BASE =
     "https://raw.githubusercontent.com/meshtastic/web-flasher/0e353b5d0756c9a1b76f53be78e948fafc1ebd8a/public/uf2"
 
-/** Release-pinned base for the OTAFIX bootloader self-update images (`oltaco/…_OTAFIX`, MIT). */
-private const val OTAFIX_RELEASE_TAG = "0.9.2-OTAFIX2.2-BP1.3"
+/** Release-pinned base for the OTAFIX bootloader self-update images (`meshtastic/…_OTAFIX`, MIT). */
+private const val OTAFIX_RELEASE_TAG = "0.9.2-OTAFIX2.2-BP1.4"
 
 private const val OTAFIX_BASE =
-    "https://github.com/oltaco/Adafruit_nRF52_Bootloader_OTAFIX/releases/download/$OTAFIX_RELEASE_TAG"
+    "https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/releases/download/$OTAFIX_RELEASE_TAG"
 
 /** S140 6.1.1 application start — the address `nrf_erase2.uf2` is linked for. */
 internal const val APP_START_S140_6_1_1 = 0x26000L
@@ -115,69 +115,69 @@ private val OTAFIX_BY_BOARD_ID: Map<String, MaintenanceUf2> =
         "HT-n5262" to
             otafixAsset(
                 board = "heltec_t114",
-                sha256 = "d7a51ef7e41e7ba3b5906c162e8926ca0bc88a5010436a3589991d5a99741220",
+                sha256 = "c1ce07c1e66dbf42faea03df88f1e4bac6d66f1177600f41c280059e1653cba2",
             ),
         "MinewSemi-MX25LE01" to
             otafixAsset(
                 board = "minewsemi_mx25le01",
-                sha256 = "3d2039b3e22e0b350b49a8456e30709d2f8be440a239d2ed864091b1c4abc3ae",
+                sha256 = "b50a9bd0381155074ccc0a211942365ebd9cd108697c8f2e9d9da947e10265a1",
             ),
         "TRACKER L1" to
             otafixAsset(
                 board = "wio_tracker_l1",
-                sha256 = "efe1fc16f64f04deb26d171b9a3f6d81b32767ff01c40fe894924b8c682a2964",
+                sha256 = "29e11b45d43d0d2ffc49a780c6299bbef86992465a568d74c533d0d0dd5d5e30",
             ),
         "WisBlock-RAK4631-Board" to
             otafixAsset(
                 board = "wiscore_rak4631_board",
-                sha256 = "3509c8b01296bc6473acf5a9422f9aec857a5bbb47e80000f9b98e15b046e46a",
+                sha256 = "910806d0aedfcacf317fc4b9f2469593d6ec0d855568ff69c70faec3a4b06c4a",
             ),
         "WisMesh-Tag" to
             otafixAsset(
                 board = "wismesh_tag",
-                sha256 = "e1701badf22d9684d953cb5274d5d9241c3bf776c2524b935ef21a607c0bca4a",
+                sha256 = "b9e92b4ec1a74d176f75473be00804ee9902a4816bd94e098ad153ecd60a34c1",
             ),
         "nRF52840-SeeedSenseCAPSolarP1-v1" to
             otafixAsset(
                 board = "sensecap_solar_p1",
-                sha256 = "efe28af706a4a3e5604390d3bf5bcbeb7470aadc957e191c7e26e8fadc2ed4e5",
+                sha256 = "f0fad2cfa98867504085fe524a0af65916aa13c781cc5e1ff3025f04cea5db0b",
             ),
         "nRF52840-SeeedXiao-v1" to
             otafixAsset(
                 board = "xiao_nrf52840_ble",
-                sha256 = "49364762fb9992334fe55b3bea7f2d30e14dce4433de6c31e90036f6ec95d2a4",
+                sha256 = "6c7d6c6226c4b425a473f689bb25687baa9cdc79d9a350fd5201762bf7819cba",
             ),
         "nRF52840-SeeedXiaoSense-v1" to
             otafixAsset(
                 board = "xiao_nrf52840_ble_sense",
-                sha256 = "fc492fc2e30f2f75789217c0ead68ad64917de0844e6011269755fddfe532c36",
+                sha256 = "4857ae18d2f3145534515da3c6e6e2a813722069f0bc415a7fe43d9de8a0be62",
             ),
         "nRF52840-T1000-E-v1" to
-            otafixAsset(board = "t1000_e", sha256 = "c1dd30cce0f250eb7ad21e8c065cef6692b53e7efcba0578371bedcfd2493cc9"),
+            otafixAsset(board = "t1000_e", sha256 = "1b02fb4e8083a85930f615d95adcc29e983f2795a9c7755674d6a380b00410e5"),
         "nRF52840-TEcho-v1" to
             otafixAsset(
                 board = "lilygo_techo",
-                sha256 = "244c3ea9a783dbcfd9fabfa95d5f8bae3a52246bbe41c5414b2b6657683025c9",
+                sha256 = "b254aa092b312238a857e68db5beffda922410092e63044410e4c25f25498b2e",
             ),
         "nRF52840-ThinkNode-M3-v1" to
             otafixAsset(
                 board = "thinknode_m3",
-                sha256 = "073a6b6acf1bb0ca9ea4e8f7ca3c8df1cf3992aced06650b85c00aba5fa3ff13",
+                sha256 = "b04f020c7f4f0b7bd99548efbd5db33ebc9e09ef42e5dd874ef69433c363798d",
             ),
         "nRF52840-ThinkNodeM1-v1" to
             otafixAsset(
                 board = "thinknode_m1",
-                sha256 = "315d36a189b30bbc09c7846031483caea669b1d0c7237da9221ab2794757498f",
+                sha256 = "991114392f6b731860f05a932e1c6529f0c97a5e4c054ff51e081d81f2e7d3f1",
             ),
         "nRF52840-ThinkNodeM6-v1" to
             otafixAsset(
                 board = "thinknode_m6",
-                sha256 = "a7e977a8af02946559a8c703f1d2f27e22fd1cbedf61a9bc7af3472eb86fe99f",
+                sha256 = "aea8e4ce5d9f9ff7adc68e794ff735fe94bace7a6d391c3606df4c0ae6f45547",
             ),
         "nRF52840-promicro" to
             otafixAsset(
                 board = "promicro_nrf52840",
-                sha256 = "5ceb9ad4a8092f1319fc5371649eeae55b47c5ff2acd647972558017ba51dccb",
+                sha256 = "bd9cc4de26fd162b6600eafc2634a1e8c6e81ade84c141f8eb44350506321e8b",
             ),
     )
 

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/UsbMaintenanceGateTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/UsbMaintenanceGateTest.kt
@@ -182,6 +182,100 @@ class UsbMaintenanceGateTest {
         assertEquals(images.size, images.map { it.fileName }.toSet().size, "No two boards may share a filename")
     }
 
+    /**
+     * Board-ID -> (release filename, sha256), transcribed from the actual `0.9.2-OTAFIX2.2-BP1.4` release assets
+     * (downloaded and hashed, not carried over from BP1.3), so a future edit that pairs the right hash with the wrong
+     * board — or vice versa — fails here even though it would still pass the uniqueness-only checks above.
+     */
+    private val expectedOtafixAssetsByBoardId =
+        mapOf(
+            "HT-n5262" to
+                (
+                    "update-heltec_t114_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "c1ce07c1e66dbf42faea03df88f1e4bac6d66f1177600f41c280059e1653cba2"
+                    ),
+            "MinewSemi-MX25LE01" to
+                (
+                    "update-minewsemi_mx25le01_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "b50a9bd0381155074ccc0a211942365ebd9cd108697c8f2e9d9da947e10265a1"
+                    ),
+            "TRACKER L1" to
+                (
+                    "update-wio_tracker_l1_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "29e11b45d43d0d2ffc49a780c6299bbef86992465a568d74c533d0d0dd5d5e30"
+                    ),
+            "WisBlock-RAK4631-Board" to
+                (
+                    "update-wiscore_rak4631_board_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "910806d0aedfcacf317fc4b9f2469593d6ec0d855568ff69c70faec3a4b06c4a"
+                    ),
+            "WisMesh-Tag" to
+                (
+                    "update-wismesh_tag_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "b9e92b4ec1a74d176f75473be00804ee9902a4816bd94e098ad153ecd60a34c1"
+                    ),
+            "nRF52840-SeeedSenseCAPSolarP1-v1" to
+                (
+                    "update-sensecap_solar_p1_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "f0fad2cfa98867504085fe524a0af65916aa13c781cc5e1ff3025f04cea5db0b"
+                    ),
+            "nRF52840-SeeedXiao-v1" to
+                (
+                    "update-xiao_nrf52840_ble_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "6c7d6c6226c4b425a473f689bb25687baa9cdc79d9a350fd5201762bf7819cba"
+                    ),
+            "nRF52840-SeeedXiaoSense-v1" to
+                (
+                    "update-xiao_nrf52840_ble_sense_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "4857ae18d2f3145534515da3c6e6e2a813722069f0bc415a7fe43d9de8a0be62"
+                    ),
+            "nRF52840-T1000-E-v1" to
+                (
+                    "update-t1000_e_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "1b02fb4e8083a85930f615d95adcc29e983f2795a9c7755674d6a380b00410e5"
+                    ),
+            "nRF52840-TEcho-v1" to
+                (
+                    "update-lilygo_techo_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "b254aa092b312238a857e68db5beffda922410092e63044410e4c25f25498b2e"
+                    ),
+            "nRF52840-ThinkNode-M3-v1" to
+                (
+                    "update-thinknode_m3_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "b04f020c7f4f0b7bd99548efbd5db33ebc9e09ef42e5dd874ef69433c363798d"
+                    ),
+            "nRF52840-ThinkNodeM1-v1" to
+                (
+                    "update-thinknode_m1_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "991114392f6b731860f05a932e1c6529f0c97a5e4c054ff51e081d81f2e7d3f1"
+                    ),
+            "nRF52840-ThinkNodeM6-v1" to
+                (
+                    "update-thinknode_m6_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "aea8e4ce5d9f9ff7adc68e794ff735fe94bace7a6d391c3606df4c0ae6f45547"
+                    ),
+            "nRF52840-promicro" to
+                (
+                    "update-promicro_nrf52840_bootloader-0.9.2-OTAFIX2.2-BP1.4_nosd.uf2" to
+                        "bd9cc4de26fd162b6600eafc2634a1e8c6e81ade84c141f8eb44350506321e8b"
+                    ),
+        )
+
+    @Test
+    fun `every otafix board id maps to its exact expected release filename and digest`() {
+        assertEquals(
+            expectedOtafixAssetsByBoardId.keys,
+            otafixBoardIds,
+            "This test's expectation table and the shipped board-id map have drifted apart",
+        )
+        expectedOtafixAssetsByBoardId.forEach { (boardId, expected) ->
+            val (expectedFileName, expectedSha256) = expected
+            val image = assertNotNull(otafixUf2ForBoardId(boardId), "no image for $boardId")
+            assertEquals(expectedFileName, image.fileName, "$boardId: wrong release filename")
+            assertEquals(expectedSha256, image.sha256, "$boardId: wrong digest")
+        }
+    }
+
     @Test
     fun `board id selects the image rather than the build target`() {
         val rak = otafixUf2ForBoardId("WisBlock-RAK4631-Board")

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/UsbMaintenanceGateTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/UsbMaintenanceGateTest.kt
@@ -176,7 +176,7 @@ class UsbMaintenanceGateTest {
 
     @Test
     fun `every shipped otafix image resolves and no two boards share a digest or filename`() {
-        assertEquals(14, otafixBoardIds.size, "OTAFIX 2.2-BP1.3 ships 14 update images")
+        assertEquals(14, otafixBoardIds.size, "OTAFIX 2.2-BP1.4 ships 14 update images")
         val images = otafixBoardIds.map { assertNotNull(otafixUf2ForBoardId(it), "no image for $it") }
         assertEquals(images.size, images.map { it.sha256 }.toSet().size, "No two boards may share a digest")
         assertEquals(images.size, images.map { it.fileName }.toSet().size, "No two boards may share a filename")


### PR DESCRIPTION
## Summary

`oltaco/Adafruit_nRF52_Bootloader_OTAFIX` is now org-owned as [`meshtastic/Adafruit_nRF52_Bootloader_OTAFIX`](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX). It just cut its first release under the fork, [`0.9.2-OTAFIX2.2-BP1.4`](https://github.com/meshtastic/Adafruit_nRF52_Bootloader_OTAFIX/releases/tag/0.9.2-OTAFIX2.2-BP1.4) — built from the same source lineage as `BP1.3` plus a `lib/nrfx`/`lib/tinyusb` bump (real-hardware tested on RAK4631) and a `CURRENT.UF2` dump-and-restore hang fix (also real-hardware tested).

This repoints the in-app bootloader self-update flow (`MaintenanceUf2.kt`) at the new fork and release:

- `OTAFIX_BASE` now builds download URLs against `meshtastic/...` instead of `oltaco/...`
- `OTAFIX_RELEASE_TAG` bumped `0.9.2-OTAFIX2.2-BP1.3` → `0.9.2-OTAFIX2.2-BP1.4`
- All 14 per-board `sha256` pins recomputed against the new release's actual `update-*_nosd.uf2` assets — downloaded each one from the release and hashed it, not carried over or guessed
- The "what's new in OTAFIX 2.1" learn-more link (`FirmwareUpdateScreen.kt`) now points at the fork's `changelog.md#otafix-21` instead of oltaco's README anchor, which this fork's docs restructure (meshtastic/Adafruit_nRF52_Bootloader_OTAFIX#21) removed

Two other files (`SecureDfuProtocol.kt`, `LegacyDfuTransport.kt`) mention "oltaco" only in historical-attribution prose ("the Adafruit/oltaco OTAFIX bootloader") describing the bootloader's lineage, not as a live link — left as-is.

Board coverage is unchanged (still 14 boards). `NANO_G2_ULTRA` and `NOMADSTAR_METEOR_PRO` bootloader support is tracked upstream (meshtastic/Adafruit_nRF52_Bootloader_OTAFIX#4, #5) and out of scope here.

## Test plan

- [x] `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green, including all 36 `UsbMaintenanceGateTest` cases (board-id/digest/filename uniqueness, board-id resolution, real-device `INFO_UF2.TXT` parsing fixtures — left untouched since they're verbatim captures, not tied to the download source)
- [x] Every new sha256 verified against a freshly downloaded copy of each of the 14 release assets, not transcribed by hand
- [ ] Not tested against a physical device performing the in-app bootloader upgrade end-to-end — the parsing/gating logic is unchanged, only the pinned constants moved; flagging in case a maintainer wants to do one real-device upgrade before merge given this path writes directly to the bootloader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OTAFIX bootloader downloads to use the latest release and verified image checksums.
  * Updated the firmware maintenance information link to the current bootloader documentation.
  * Updated release validation to recognize OTAFIX version 2.2-BP1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->