### PR TITLE
fix: derive temperature unit from locale temperature preference, not distance system

### DIFF
--- a/core/common/src/androidHostTest/kotlin/org/meshtastic/core/common/util/TemperatureUnitTest.kt
+++ b/core/common/src/androidHostTest/kotlin/org/meshtastic/core/common/util/TemperatureUnitTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.common.util
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Locale
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class TemperatureUnitTest {
+
+    private lateinit var originalLocale: Locale
+
+    @Before
+    fun setUp() {
+        originalLocale = Locale.getDefault()
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(originalLocale)
+    }
+
+    @Test
+    fun `US locale prefers Fahrenheit`() {
+        Locale.setDefault(Locale.US)
+        assertEquals(TemperatureUnit.FAHRENHEIT, getSystemTemperatureUnit())
+    }
+
+    // The UK mixes systems: miles for distance, Celsius for temperature. Temperature must not
+    // follow the (imperial) measurement system here.
+    @Test
+    fun `UK locale prefers Celsius despite imperial distances`() {
+        Locale.setDefault(Locale.UK)
+        assertEquals(TemperatureUnit.CELSIUS, getSystemTemperatureUnit())
+        assertEquals(MeasurementSystem.IMPERIAL, getSystemMeasurementSystem())
+    }
+
+    @Test
+    fun `German locale prefers Celsius`() {
+        Locale.setDefault(Locale.GERMANY)
+        assertEquals(TemperatureUnit.CELSIUS, getSystemTemperatureUnit())
+    }
+
+    // Android 14 regional preferences surface as the locale's "mu" Unicode extension.
+    @Test
+    fun `regional preference override wins over region default`() {
+        Locale.setDefault(Locale.forLanguageTag("en-US-u-mu-celsius"))
+        assertEquals(TemperatureUnit.CELSIUS, getSystemTemperatureUnit())
+    }
+}

--- a/core/common/src/androidMain/kotlin/org/meshtastic/core/common/util/LocaleUtils.android.kt
+++ b/core/common/src/androidMain/kotlin/org/meshtastic/core/common/util/LocaleUtils.android.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.common.util
 import android.icu.util.LocaleData
 import android.icu.util.ULocale
 import android.os.Build
+import androidx.core.text.util.LocalePreferences
 import java.util.Locale
 
 actual fun currentLocaleCode(): String = Locale.getDefault().language
@@ -51,4 +52,11 @@ actual fun getSystemMeasurementSystem(): MeasurementSystem {
             else -> MeasurementSystem.METRIC
         }
     }
+}
+
+// LocalePreferences resolves from CLDR data and, on Android 14+, the user's Regional preferences
+// override. Kelvin (a valid regional preference) falls back to Celsius, which the app can display.
+actual fun getSystemTemperatureUnit(): TemperatureUnit = when (LocalePreferences.getTemperatureUnit()) {
+    LocalePreferences.TemperatureUnit.FAHRENHEIT -> TemperatureUnit.FAHRENHEIT
+    else -> TemperatureUnit.CELSIUS
 }

--- a/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/MeasurementSystem.kt
+++ b/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/MeasurementSystem.kt
@@ -25,6 +25,22 @@ enum class MeasurementSystem {
 /** returns the system's preferred measurement system. */
 expect fun getSystemMeasurementSystem(): MeasurementSystem
 
+/**
+ * The system's preferred temperature unit. Deliberately decoupled from [MeasurementSystem]: some locales mix systems
+ * (the UK measures road distance in miles but temperature in Celsius), so temperature must never be derived from the
+ * distance unit.
+ */
+enum class TemperatureUnit {
+    CELSIUS,
+    FAHRENHEIT,
+}
+
+/**
+ * Returns the temperature unit preferred by the OS locale, honoring the user's regional-preference override where the
+ * platform supports one (Android 14+ Settings > System > Languages > Regional preferences).
+ */
+expect fun getSystemTemperatureUnit(): TemperatureUnit
+
 /** Returns the device's current locale as a 2-letter ISO 639-1 language code (e.g. "en", "es", "fr"). */
 expect fun currentLocaleCode(): String
 

--- a/core/common/src/iosMain/kotlin/org/meshtastic/core/common/util/NoopStubs.kt
+++ b/core/common/src/iosMain/kotlin/org/meshtastic/core/common/util/NoopStubs.kt
@@ -40,6 +40,8 @@ actual object DateFormatter {
 
 actual fun getSystemMeasurementSystem(): MeasurementSystem = MeasurementSystem.METRIC
 
+actual fun getSystemTemperatureUnit(): TemperatureUnit = TemperatureUnit.CELSIUS
+
 actual fun currentLocaleCode(): String = "en"
 
 actual fun currentRegionCode(): String = ""

--- a/core/common/src/jvmMain/kotlin/org/meshtastic/core/common/util/JvmPlatformUtils.kt
+++ b/core/common/src/jvmMain/kotlin/org/meshtastic/core/common/util/JvmPlatformUtils.kt
@@ -88,6 +88,20 @@ actual fun getSystemMeasurementSystem(): MeasurementSystem =
         else -> MeasurementSystem.METRIC
     }
 
+// CLDR unitPreferenceData lists these regions as defaulting to Fahrenheit; everywhere else is Celsius.
+actual fun getSystemTemperatureUnit(): TemperatureUnit =
+    when (Locale.getDefault().country.uppercase(Locale.getDefault())) {
+        "US",
+        "BS",
+        "BZ",
+        "KY",
+        "PR",
+        "PW",
+        -> TemperatureUnit.FAHRENHEIT
+
+        else -> TemperatureUnit.CELSIUS
+    }
+
 actual fun currentLocaleCode(): String = Locale.getDefault().language
 
 actual fun currentRegionCode(): String = Locale.getDefault().country

--- a/docs/en/developer/measurement.md
+++ b/docs/en/developer/measurement.md
@@ -2,7 +2,7 @@
 title: Measurement & Formatting
 parent: Developer Guide
 nav_order: 9
-last_updated: 2026-07-07
+last_updated: 2026-08-19
 aliases:
   - measurement
   - metric-formatter
@@ -92,11 +92,13 @@ object NumberFormatter {
 
 Three measurements convert away from metric for display, each gated by a boolean flag sourced from the user's device locale or preferences:
 
-| Measurement | Flag | Conversion |
-|---|---|---|
-| `temperature` | `isFahrenheit` | `°F = °C × 1.8 + 32` |
-| `windSpeed` | `isImperial` | m/s × 2.23694 → mph |
-| `rainfall` | `isImperial` | mm ÷ 25.4 → in |
+| Measurement | Flag | Source | Conversion |
+|---|---|---|---|
+| `temperature` | `isFahrenheit` | `getSystemTemperatureUnit()` | `°F = °C × 1.8 + 32` |
+| `windSpeed` | `isImperial` | `getSystemMeasurementSystem()` | m/s × 2.23694 → mph |
+| `rainfall` | `isImperial` | `getSystemMeasurementSystem()` | mm ÷ 25.4 → in |
+
+The two source functions (in `core/common/.../util/MeasurementSystem.kt`) are deliberately separate: some locales mix systems (the UK uses miles for distance but Celsius for temperature), so temperature must never be derived from the distance unit. On Android, `getSystemTemperatureUnit()` delegates to `androidx.core.text.util.LocalePreferences`, which resolves CLDR locale data and honors the Android 14+ Regional preferences temperature override.
 
 Everything else (voltage, current, pressure, SNR, RSSI, humidity, percent) displays in its native metric units. The user-facing [Units & Locale](../user/units-and-locale) page explains what end users see.
 

--- a/docs/en/user/units-and-locale.md
+++ b/docs/en/user/units-and-locale.md
@@ -2,7 +2,7 @@
 title: Units, Measurement & Locale
 parent: User Guide
 nav_order: 16
-last_updated: 2026-07-08
+last_updated: 2026-08-19
 description: How the app formats temperature, distance, speed, and other measurements based on your device locale.
 ---
 
@@ -34,6 +34,8 @@ Temperature values from environment sensors are transmitted as **°C** and displ
 | Fahrenheit | 72°F |
 
 This affects all temperature displays throughout the app: node environment telemetry, soil temperature, dew point, and telemetry chart axes.
+
+Temperature follows your locale's **temperature preference**, independent of the distance system. Locales that mix systems work correctly — a UK phone shows miles for distance but **°C** for temperature. On Android 14+, the **Temperature** regional preference (Settings → System → Languages → Regional preferences) overrides the locale default.
 
 ## Distance & Altitude
 
@@ -113,7 +115,8 @@ On Android, your measurement system (metric vs imperial) is tied to your region 
 
 1. Open **Android Settings → System → Language & Region**
 2. Change your **Region** or **Measurement units** preference
-3. Return to Meshtastic — values update immediately
+3. On Android 14+, temperature can be overridden on its own under **Regional preferences → Temperature**
+4. Return to Meshtastic — values update immediately
 
 > 💡 **Tip:** All measurement formatting is handled centrally and respects your platform's locale, so units stay consistent everywhere in the app.
 

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/domain/usecase/CommonGetNodeDetailsUseCase.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import org.koin.core.annotation.Single
+import org.meshtastic.core.common.util.TemperatureUnit
+import org.meshtastic.core.common.util.getSystemTemperatureUnit
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.model.DeviceHardware
 import org.meshtastic.core.model.DeviceLink
@@ -49,7 +51,6 @@ import org.meshtastic.feature.node.detail.NodeRequestActions
 import org.meshtastic.feature.node.metrics.EnvironmentMetricsState
 import org.meshtastic.feature.node.model.LogsType
 import org.meshtastic.feature.node.model.MetricsState
-import org.meshtastic.proto.Config.DisplayConfig.DisplayUnits
 import org.meshtastic.proto.DeviceProfile
 import org.meshtastic.proto.FirmwareEdition
 import org.meshtastic.proto.MeshPacket
@@ -200,7 +201,7 @@ constructor(
                     deviceLinks = deviceLinks,
                     reportedTarget = pioEnv,
                     isManaged = identity.profile.config?.security?.is_managed ?: false,
-                    isFahrenheit = displayUnits == DisplayUnits.IMPERIAL,
+                    isFahrenheit = getSystemTemperatureUnit() == TemperatureUnit.FAHRENHEIT,
                     displayUnits = displayUnits,
                     deviceMetrics = logs.telemetry.filter { it.device_metrics != null },
                     localStats = logs.telemetry.filter { it.local_stats != null },

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
@@ -28,8 +28,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.core.annotation.KoinViewModel
-import org.meshtastic.core.common.util.MeasurementSystem
-import org.meshtastic.core.common.util.getSystemMeasurementSystem
+import org.meshtastic.core.common.util.TemperatureUnit
+import org.meshtastic.core.common.util.getSystemTemperatureUnit
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
@@ -134,7 +134,7 @@ class NodeListViewModel(
 
     // OS locale rarely changes mid-session; snapshot once instead of per filter/sort emission.
     private val distanceUnits = DistanceUnit.getFromLocale().value
-    private val tempInFahrenheit = getSystemMeasurementSystem() == MeasurementSystem.IMPERIAL
+    private val tempInFahrenheit = getSystemTemperatureUnit() == TemperatureUnit.FAHRENHEIT
     val nodesUiState: StateFlow<NodesUiState> =
         combine(nodeSortOption, nodeFilter) { sort, nodeFilter ->
             NodesUiState(


### PR DESCRIPTION
## What

Temperature display units were inferred from the distance measurement system (`isFahrenheit = displayUnits == IMPERIAL`). That is wrong for mixed-unit locales: ICU defines `LocaleData.MeasurementSystem.UK` as distinct from `US` precisely because the UK uses miles for road distance but Celsius for temperature. An `en-GB` phone correctly showed miles — and incorrectly showed °F.

## How

- New `TemperatureUnit` expect/actual in `core/common`, deliberately decoupled from `MeasurementSystem`.
- Android actual delegates to `androidx.core.text.util.LocalePreferences.getTemperatureUnit()`, which resolves CLDR locale data **and honors the Android 14+ Regional preferences temperature override** (Settings → System → Languages → Regional preferences → Temperature), which was previously ignored.
- JVM (desktop) actual uses CLDR's Fahrenheit-default region list (US, BS, BZ, KY, PR, PW); the iOS stub returns Celsius like its existing measurement-system stub.
- Both derivation sites switched: `CommonGetNodeDetailsUseCase` and `NodeListViewModel`. Distance/speed continue to follow `getSystemMeasurementSystem()` unchanged.
- New Robolectric host test `TemperatureUnitTest` covers US (°F), UK (°C + imperial distance), Germany (°C), and the `-u-mu-celsius` regional-preference override.
- Updated `docs/en/user/units-and-locale.md` and `docs/en/developer/measurement.md` (with `last_updated` bumps) to document the decoupling.

## Constitution Check (v1.3.3)

- **I. KMP Core** — new API is `expect`/`actual`; no `java.*`/`android.*` in `commonMain`. ✅
- **II. Zero Lint Tolerance** — `spotlessApply spotlessCheck detekt` pass locally. ✅
- **III. Compose Multiplatform UI** — no UI changes; composables consume the same booleans. ✅
- **IV. Privacy First** — no logging, no PII. ✅
- **V. Design Standards** — no visual changes. N/A
- **VI. Documentation Freshness** — both affected doc pages updated with `last_updated: 2026-08-19`. ✅
- **VII. Verify Before Push** — `spotlessApply spotlessCheck detekt :core:common:testAndroidHostTest :core:common:jvmTest :feature:node:testAndroidHostTest :feature:node:jvmTest` all pass locally; CI checked after push. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Temperature displays now follow the system’s dedicated temperature preference, independently of distance units.
  * Supports Fahrenheit and Celsius preferences across locales and platforms.
  * Android regional temperature overrides are supported.

* **Documentation**
  * Updated user and developer guidance for temperature preferences, locale behavior, and mixed measurement systems.

* **Tests**
  * Added coverage for regional, locale-based, and Android temperature preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->