### PR TITLE
fix(firmware): map T_ECHO_CARD (136) to SoftDevice 6.1.1

### DIFF
--- a/androidApp/src/main/assets/device_bootloader_ota_quirks.json
+++ b/androidApp/src/main/assets/device_bootloader_ota_quirks.json
@@ -267,6 +267,14 @@
         "heltec-mesh-node-t1"
       ],
       "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 136,
+      "hwModelSlug": "T_ECHO_CARD",
+      "platformioTargets": [
+        "t-echo-card"
+      ],
+      "softDevice": "6.1.1"
     }
   ]
 }


### PR DESCRIPTION
## What

Unblocks CI for every open PR. The scheduled hardware-catalog update (#6758) added the **LilyGo T-Echo-Card** (hwModel 136, nrf52840) with no row in `device_bootloader_ota_quirks.json`. `SoftDeviceQuirkCoverageTest` is fail-closed by design, so the `shard-app` test job now fails on every PR's merge with `main` (see #6773, #6774, #6775).

## How

One row: hwModel 136 / `T_ECHO_CARD` / target `t-echo-card` / SoftDevice `6.1.1`.

Derived per the test's own instructions from `meshtastic/firmware` (develop): `variants/nrf52840/t-echo-card/platformio.ini` extends `board = t-echo`, and `boards/t-echo.json` declares `build.arduino.ldscript = nrf52840_s140_v6.ld` → S140 **6.1.1** (`sd_fwid 0x00B6`), matching the rest of the T-Echo family (T_ECHO 7, T_ECHO_PLUS 33, T_ECHO_LITE 109).

## Verification

`:androidApp:testFdroidDebugUnitTest --tests "org.meshtastic.app.firmware.SoftDeviceQuirkCoverageTest"` — all 6 tests pass locally against the updated catalog; `spotlessCheck` passes.

## Constitution Check (v1.3.3)

I. KMP Core — N/A (asset only). II. Zero Lint — spotlessCheck passes. III. CMP UI — N/A. IV. Privacy — N/A. V. Design Standards — N/A. VI. Docs Freshness — no user-facing behavior change (restores factory-erase availability for a new board via existing documented flow). VII. Verify Before Push — test run above; CI confirmed after push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the T-ECHO Card device.
  * Enabled compatibility with its hardware model, PlatformIO target, and SoftDevice version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->