### PR TITLE
fix(ci): accept breaking-change markers in the PR labeler title regex

### DIFF
--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -29,7 +29,7 @@ jobs:
           // Match branch prefix (e.g. feat/..., fix/..., chore-something)
           // Also parse conventional-commit-style PR titles as a fallback: type(scope): subject
           const branchPrefix = branch.split(/[\/\-_]/)[0].toLowerCase();
-          const titleMatch = title.match(/^(\w+)(?:\(([^)]+)\))?:/);
+          const titleMatch = title.match(/^(\w+)(?:\(([^)]+)\))?!?:/);
           const titlePrefix = titleMatch?.[1]?.toLowerCase();
           const titleScope = titleMatch?.[2]?.toLowerCase();
 


### PR DESCRIPTION
The PR auto-labeler's conventional-commit title regex required the type/scope to be followed immediately by `:`, so titles carrying the breaking-change marker `!` (e.g. `refactor(car)!: remove the Android Auto integration`, #6779) failed to match and the run ended with "No labels matched".

### 🐛 Bug Fixes

- Allow an optional `!` before the colon in the labeler's title regex in `.github/workflows/pull-request-target.yml` (`/^(\w+)(?:\(([^)]+)\))?:/` → `/^(\w+)(?:\(([^)]+)\))?!?:/`). Everything else in the script is unchanged.

Not changed, just noting: the branch-prefix fallback also doesn't help `claude/`-prefixed branches — `branch.split(/[\/\-_]/)[0]` yields `claude`, which maps to no label — so on such branches the title regex is the only type/scope signal. Left as-is deliberately.

### Testing Performed

Workflow-only change, no Gradle tasks run. Verified the new regex against both title shapes in a JS scratch check: `refactor(car)!: remove the Android Auto integration` now matches (type `refactor`, scope `car`); plain `fix(ci): ...` titles match exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)