### PR TITLE
fix(ci): bump verify-flatpak's vendored Gradle dist to 9.7.1 to match the wrapper

### DIFF
--- a/scripts/verify-flatpak/desktop-offline.yaml
+++ b/scripts/verify-flatpak/desktop-offline.yaml
@@ -99,8 +99,8 @@ modules:
       - type: file
         # Must be the EXACT distribution from gradle-wrapper.properties (version AND
         # -bin flavor) — distributionSha256Sum verifies this file. Update together.
-        url: https://services.gradle.org/distributions/gradle-9.6.1-bin.zip
-        sha256: 9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+        url: https://services.gradle.org/distributions/gradle-9.7.1-bin.zip
+        sha256: acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
         dest: "gradle/wrapper"
         dest-filename: "gradle-bin.zip"
       - flatpak-sources.json


### PR DESCRIPTION
## Why

[#6777](https://github.com/meshtastic/Meshtastic-Android/pull/6777) bumped `gradle-wrapper.properties` to Gradle 9.7.1, but `scripts/verify-flatpak/desktop-offline.yaml` vendors the distribution zip for the offline flatpak build and stayed at 9.6.1 — its own comment says "Update together." The wrapper now verifies the vendored zip against 9.7.1's checksum and fails: every PR since the bump fails both `build-flatpak` arches with `Expected acd53f… / Actual 9c0f7f…` (observed on #6779 and `renovate/gradle-9.x`).

## 🛠️ Change

One coupled pin: `url` → `gradle-9.7.1-bin.zip`, `sha256` → `acd53f1e…` (the same value `distributionSha256Sum` on main verifies every wrapper download against).

Renovate has no manager for this yaml — follow-up candidate: a `customManagers` regex entry so the next wrapper bump updates both sides atomically.

## Testing Performed

Pin now matches main's `gradle-wrapper.properties` exactly (version, `-bin` flavor, sha). Verification is this PR's own `build-flatpak` checks, which exercise the changed path directly — they fail on main's tip without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Gradle version to 9.7.1.
  * Refreshed the associated integrity checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->