### PR TITLE
fix(dfu): back off correctly when Android throttles BLE scan-starts

### DIFF
--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/FirmwareUpdateHelpers.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/FirmwareUpdateHelpers.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.feature.firmware.ota
 
 import kotlinx.coroutines.delay
+import org.meshtastic.core.ble.BleScanStartException
 import org.meshtastic.core.common.util.NumberFormatter
 
 private const val PERCENT_MAX = 100
@@ -39,7 +40,11 @@ internal fun formatTransferProgress(progress: Float, totalBytes: Int, bytesPerSe
 
 /**
  * Runs [block] up to [attempts] times, returning the first successful [Result]. [onAttempt] fires before each attempt
- * (1-based) for progress reporting, and [retryDelayMillis] is waited between tries (never after the last). If every
+ * (1-based) for progress reporting, and [retryDelayMillis] is waited between tries (never after the last) — except when
+ * a failure is (or wraps) a [BleScanStartException] carrying a `retryAfter`, in which case the wait is extended to
+ * cover it. A flat [retryDelayMillis] is nowhere near Android's BLE scan-start quota cooldown (up to its full rolling
+ * window), so retrying on schedule after a throttled scan just re-throttles every remaining attempt — this is exactly
+ * the failure mode a DFU reconnect can hit after the couple of scans `detectBootloaderProtocol` already spent. If every
  * attempt fails, returns the last failure so the caller can surface it however it likes (rethrow as-is vs. wrap in a
  * domain exception).
  */
@@ -55,7 +60,11 @@ internal suspend fun <T> retryWithDelay(
         val result = block(attempt)
         if (result.isSuccess) return result
         lastError = result.exceptionOrNull()
-        if (attempt < attempts) delay(retryDelayMillis)
+        if (attempt < attempts) delay(maxOf(retryDelayMillis, lastError.scanStartRetryAfterMillis() ?: 0L))
     }
     return Result.failure(lastError ?: IllegalStateException("retryWithDelay: all $attempts attempts failed"))
 }
+
+/** The scan-start cooldown a [BleScanStartException] (found directly or as this error's cause) demands, if any. */
+private fun Throwable?.scanStartRetryAfterMillis(): Long? =
+    ((this as? BleScanStartException) ?: (this?.cause as? BleScanStartException))?.retryAfter?.inWholeMilliseconds

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuHandler.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/ota/dfu/SecureDfuHandler.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Single
 import org.meshtastic.core.ble.BleConnectionFactory
+import org.meshtastic.core.ble.BleDevice
+import org.meshtastic.core.ble.BleScanStartException
 import org.meshtastic.core.ble.BleScanner
 import org.meshtastic.core.common.util.CommonUri
 import org.meshtastic.core.common.util.ioDispatcher
@@ -559,13 +561,9 @@ class SecureDfuHandler(
 
         Logger.i { "DFU: detect — scanning for Legacy DFU service (${LegacyDfuUuids.SERVICE})" }
         val legacyHit =
-            scanForBleDevice(
-                scanner = bleScanner,
+            scanForBleDeviceTolerant(
                 tag = "DFU detect (legacy)",
                 serviceUuid = LegacyDfuUuids.SERVICE,
-                retryCount = 1,
-                retryDelay = 0.seconds,
-                scanTimeout = DETECT_SCAN_TIMEOUT,
                 predicate = { it.address in targetAddresses },
             )
 
@@ -578,19 +576,48 @@ class SecureDfuHandler(
 
         Logger.i { "DFU: detect — scanning for Secure DFU service (${SecureDfuUuids.SERVICE})" }
         val secureHit =
-            scanForBleDevice(
-                scanner = bleScanner,
+            scanForBleDeviceTolerant(
                 tag = "DFU detect (secure)",
                 serviceUuid = SecureDfuUuids.SERVICE,
-                retryCount = 1,
-                retryDelay = 0.seconds,
-                scanTimeout = DETECT_SCAN_TIMEOUT,
                 predicate = { it.address in targetAddresses },
             )
 
         val detection = if (secureHit != null) BootloaderDetection.SecureObserved else BootloaderDetection.Unknown
         Logger.i { "DFU: detect — secureHit=${secureHit != null}, result=$detection" }
         return detection
+    }
+
+    /**
+     * [scanForBleDevice] with `retryCount = 1`, `scanTimeout = DETECT_SCAN_TIMEOUT` — detection's fixed shape — but
+     * tolerant of Android's BLE scan-start quota: with no internal retry budget of its own, a throttled scan here would
+     * otherwise propagate straight out of [detectBootloaderProtocol] and abort the whole DFU attempt before a single
+     * reconnect attempt ran. Waits the reported cooldown (or the same detect timeout, if the failure carried none) and
+     * tries once more; if that also can't start a scan, returns null so detection degrades to
+     * [BootloaderDetection.Unknown] rather than crashing — the fallback coordinator still tries both protocols from
+     * there, now via [retryWithDelay]'s own scan-start-aware backoff.
+     */
+    private suspend fun scanForBleDeviceTolerant(
+        tag: String,
+        serviceUuid: Uuid,
+        predicate: (BleDevice) -> Boolean,
+    ): BleDevice? {
+        repeat(2) { pass ->
+            try {
+                return scanForBleDevice(
+                    scanner = bleScanner,
+                    tag = tag,
+                    serviceUuid = serviceUuid,
+                    retryCount = 1,
+                    retryDelay = 0.seconds,
+                    scanTimeout = DETECT_SCAN_TIMEOUT,
+                    predicate = predicate,
+                )
+            } catch (e: BleScanStartException) {
+                Logger.w(e) { "$tag: scan could not start (${e.reason}), pass ${pass + 1}/2" }
+                if (pass == 0) delay(e.retryAfter ?: DETECT_SCAN_TIMEOUT)
+            }
+        }
+        return null
     }
 
     /**


### PR DESCRIPTION
## Summary

Root cause of a real reconnect-after-DFU-mode-entry failure reported in testing on a Nano G2 Ultra (with our OTAFIX bootloader): the device's BLE MAC shifts by +1 on entering DFU mode (`B6:FA`→`B6:FB`, confirmed expected/known behavior), and the app failed to reconnect — while a third-party DFU app (MBEtools) also showed the same symptom, pointing at Android BLE scan behavior rather than app logic.

Traced it precisely rather than guessing:
- `calculateMacPlusOne` (and the retry-with-address-set logic built on it across `SecureDfuTransport`/`LegacyDfuTransport`/`SecureDfuHandler`) was already correct — confirmed by reading it, not assumed.
- The build this was tested on (`2.8.1 (29321920) google`, commit `f0f2e4449`, merged 2026-08-18) is *after* all three recent DFU fix PRs (#6041, #6079, #6201), ruling out a stale-build explanation.
- A full DFU attempt can burn through **10+ BLE scan-starts**: 2 in `detectBootloaderProtocol` (Legacy + Secure), up to 4 per `connectWithRetry` call, times up to two protocols if both Legacy and Secure get tried via `DfuFallbackCoordinator`. That's easily enough to trip Android's 5-scans-per-30s quota mid-flow.
- `AndroidBleScanStartLimiter` already detects this and throws `BleScanStartException` with a `retryAfter` cooldown — but nothing in the DFU path looked at it. `safeCatching` wraps it into a plain `Result.failure`, and `retryWithDelay` waited its flat 2s `RETRY_DELAY_MS` regardless of *why* the previous attempt failed — nowhere near long enough to clear a quota that can take up its full 30s window. Every remaining retry hit the same throttle, and the whole flow failed with a generic "connection failed / Forget+Re-pair" error indistinguishable from a genuinely absent device.
- `feature/connections/ScannerViewModel` already has the correct handling for this exact exception (`effectiveBleScanRetryCooldown`) — it just was never wired into the DFU retry path.

## Changes

- `retryWithDelay` (`FirmwareUpdateHelpers.kt`) now waits `max(retryDelayMillis, the failure's BleScanStartException.retryAfter)` instead of always the flat default. Also benefits the ESP32 OTA handler, which shares this helper.
- `detectBootloaderProtocol`'s two scans (`SecureDfuHandler.kt`) have no internal retry budget of their own (`retryCount=1`), so a throttled scan there used to propagate straight out and abort the whole DFU attempt before a single reconnect was even tried. They now go through a new `scanForBleDeviceTolerant()` that waits the cooldown and retries once, degrading to `BootloaderDetection.Unknown` (not a crash) if a second scan-start also can't be granted.

## Test plan

- [x] `./gradlew :feature:firmware:spotlessApply :feature:firmware:spotlessCheck :feature:firmware:detekt :feature:firmware:allTests` — all green, 139 tests passed
- [ ] Not tested against a physical device hitting the actual scan-throttle mid-DFU — the failure mode is timing/OS-dependent and hard to reproduce on demand; flagging in case a maintainer with the affected hardware wants to confirm before merge