### PR TITLE
ci: keep verify-flatpak's vendored Gradle dist in lockstep with the wrapper

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -96,9 +96,13 @@
       "automerge": false
     },
     {
-      "description": "Block Gradle 9.7.0: its ExecOperations.exec spec defaults standardOutput to null, crashing the Compose Multiplatform proguardReleaseJars task (ExternalToolRunner reads the stream back). Lift once a fixed Gradle patch or a CMP release that stops reading spec.standardOutput is out.",
+      "description": "Block Gradle 9.7.0: its ExecOperations.exec spec defaults standardOutput to null, crashing the Compose Multiplatform proguardReleaseJars task (ExternalToolRunner reads the stream back). Lift once a fixed Gradle patch or a CMP release that stops reading spec.standardOutput is out. Matches by depName so the flatpak-manifest custom manager (customManagers below) is pinned identically and can never propose the blocked version on its own.",
+      "matchDepNames": [
+        "gradle"
+      ],
       "matchManagers": [
-        "gradle-wrapper"
+        "gradle-wrapper",
+        "custom.regex"
       ],
       "allowedVersions": "!/^9\\.7\\.0$/"
     },
@@ -122,6 +126,21 @@
         "/^io\\.insert-koin\\.compiler\\.plugin/"
       ],
       "automerge": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Mirror gradle-wrapper.properties bumps into the vendored Gradle distribution URL in the verify-flatpak offline manifest (see PRs #6777/#6782, where a wrapper bump without this file broke both build-flatpak arches). Shares depName 'gradle' with the gradle-wrapper manager so both files update in the same Renovate branch/PR. The sha256 line below the URL cannot be auto-updated (the gradle-version datasource has no digest support and the hosted app disallows postUpgradeTasks); the fail-fast guard in verify-flatpak.yml's generate-sources job holds that PR red until the sha256 is copied from distributionSha256Sum.",
+      "managerFilePatterns": [
+        "/^scripts/verify-flatpak/desktop-offline\\.yaml$/"
+      ],
+      "matchStrings": [
+        "services\\.gradle\\.org/distributions/gradle-(?<currentValue>\\d+(?:\\.\\d+)*)-bin\\.zip"
+      ],
+      "depNameTemplate": "gradle",
+      "datasourceTemplate": "gradle-version",
+      "versioningTemplate": "gradle"
     }
   ]
 }

--- a/.github/workflows/verify-flatpak.yml
+++ b/.github/workflows/verify-flatpak.yml
@@ -31,6 +31,28 @@ jobs:
         with:
           submodules: recursive
 
+      # Renovate mirrors wrapper bumps into the manifest's distribution URL but cannot
+      # rewrite its sha256, so on a wrapper bump this drift is expected: fail here in
+      # seconds instead of ~15 minutes into both build-flatpak arches ("Verification of
+      # Gradle distribution failed!", see #6777/#6782).
+      - name: Check vendored Gradle dist matches the wrapper
+        run: |
+          props=gradle/wrapper/gradle-wrapper.properties
+          manifest=scripts/verify-flatpak/desktop-offline.yaml
+          wrapper_dist=$(grep '^distributionUrl=' "$props" | sed 's|.*/||' || true)
+          wrapper_sha=$(grep '^distributionSha256Sum=' "$props" | cut -d= -f2 || true)
+          manifest_dist=$(grep -o 'gradle-[0-9][^/]*\.zip' "$manifest" || true)
+          manifest_sha=$(awk '/url:.*services\.gradle\.org\/distributions\//{getline; sub(/^[[:space:]]*sha256:[[:space:]]*/, ""); print}' "$manifest")
+          if [ -z "$wrapper_dist" ] || [ -z "$wrapper_sha" ]; then
+            echo "::error file=$props::Could not parse distributionUrl/distributionSha256Sum from $props; the guard in verify-flatpak.yml needs updating."
+            exit 1
+          fi
+          if [ "$wrapper_dist" != "$manifest_dist" ] || [ "$wrapper_sha" != "$manifest_sha" ]; then
+            echo "::error file=$manifest::Vendored Gradle dist is out of sync: $manifest pins '$manifest_dist' (sha256 '$manifest_sha') but $props pins '$wrapper_dist' (sha256 '$wrapper_sha'). Update the url and sha256 in $manifest; the correct sha256 is distributionSha256Sum in $props."
+            exit 1
+          fi
+          echo "OK: $manifest vendors $wrapper_dist, matching $props"
+
       - uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/scripts/verify-flatpak/desktop-offline.yaml
+++ b/scripts/verify-flatpak/desktop-offline.yaml
@@ -97,8 +97,10 @@ modules:
       - type: dir
         path: meshtastic-android
       - type: file
-        # Must be the EXACT distribution from gradle-wrapper.properties (version AND
-        # -bin flavor) — distributionSha256Sum verifies this file. Update together.
+        # Must be the EXACT distribution from gradle-wrapper.properties (version AND -bin
+        # flavor); distributionSha256Sum verifies this file. Renovate bumps the version here
+        # alongside wrapper bumps (custom manager in renovate.json) but the sha256 must be
+        # copied from distributionSha256Sum by hand; CI fails fast on any mismatch.
         url: https://services.gradle.org/distributions/gradle-9.7.1-bin.zip
         sha256: acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
         dest: "gradle/wrapper"


### PR DESCRIPTION
Renovate wrapper bumps kept breaking the offline flatpak build silently: #6777 bumped the wrapper to 9.7.1 without touching the vendored distribution pin in `scripts/verify-flatpak/desktop-offline.yaml`, and every PR that triggered verify-flatpak then failed both build-flatpak arches 15+ minutes in with "Verification of Gradle distribution failed!" (hand-fixed by #6782). This wires the two files together so they cannot drift silently again. Rebased on #6782, so the manifest change here is only the pin-comment update.

### 🧹 Chores

- **Renovate custom manager** (`.github/renovate.json`): mirrors `gradle-wrapper.properties` bumps into the manifest's distribution URL. It shares depName `gradle` and the `gradle-version` datasource with the built-in `gradle-wrapper` manager, so both files update in the same Renovate branch/PR. The `sha256:` line cannot be auto-updated: the `gradle-version` datasource has no digest support and the hosted Mend app disallows `postUpgradeTasks`, so the sha still needs a one-line hand copy from `distributionSha256Sum`.
- **9.7.0 block rule** now matches by depName across both managers, so the new custom manager can never propose a wrapper-blocked version on its own.
- **Fail-fast guard** at the top of `generate-sources` in `verify-flatpak.yml`: compares the manifest's dist filename (version AND flavor) and sha256 against `gradle-wrapper.properties`, failing in seconds with an error that names both files and where the correct sha lives. A wrapper-bump PR now goes red at the guard instead of after two full flatpak builds.
- **Manifest pin comment** updated to document the coupling (Renovate bumps the URL, the sha is copied by hand, CI guards the pair).

Note: the guard makes drift loud and early, but it only hard-blocks automerge if verify-flatpak is enforced; #6777 landed with the workflow red.

### Testing Performed

- `renovate-config-validator` on Renovate 44.35.2 (current hosted line): config validates clean. An older cached 37.x rejects `managerFilePatterns`, so the validation was rerun against latest deliberately.
- The custom manager's `matchStrings` regex tested against the manifest: extracts exactly `9.7.1` and does not match `dest-filename: "gradle-bin.zip"`.
- Guard script extracted verbatim from the workflow YAML and exercised in three states: in-sync (passes), the 9.6.1 vs 9.7.1 drift that was on main before #6782 (fails with the full message), and the future Renovate case of URL bumped with a stale sha (fails).
- Guard step passed on the PR's own verify-flatpak run (run 32317760527) before the rebase.
- `actionlint` and `shellcheck` clean.
- No Kotlin or build files touched, so no Gradle verification needed (Spotless targets only Kotlin sources).

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)