### PR TITLE
feat: report Android 17 memory-limiter kills via ApplicationExitInfo

### DIFF
--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -202,9 +202,14 @@ open class MeshUtilApplication :
         val kill =
             getSystemService(ActivityManager::class.java)
                 ?.getHistoricalProcessExitReasons(null, 0, MEMORY_LIMITER_SCAN_DEPTH)
-                ?.firstOrNull { it.description == MEMORY_LIMITER_ANON_SWAP_REASON && it.timestamp > watermark }
-                ?: return
-        prefs.edit().putLong(KEY_LAST_REPORTED_EXIT_TIMESTAMP, kill.timestamp).apply()
+                ?.firstOrNull {
+                    // contains(), not equality: OEMs may decorate the description as the rollout expands.
+                    it.description?.contains(MEMORY_LIMITER_ANON_SWAP_REASON) == true && it.timestamp > watermark
+                } ?: return
+
+        // Synchronous commit() before telemetry: this path runs precisely when the OS has been killing this
+        // process, and an apply() lost to another death would re-report the same kill. Background thread.
+        if (!prefs.edit().putLong(KEY_LAST_REPORTED_EXIT_TIMESTAMP, kill.timestamp).commit()) return
 
         // Force PlatformAnalytics construction so its Kermit log writers (Crashlytics/Datadog) are
         // registered before we log, even though nothing else has injected it yet this early in startup.
@@ -214,7 +219,12 @@ open class MeshUtilApplication :
         // a denied permission), a memory-ceiling kill means this process's own footprint was too large —
         // an actionable engineering signal, so it is deliberately reported as a non-fatal (Error), not a
         // rate-only breadcrumb.
-        Logger.e { "Previous process exit: $MEMORY_LIMITER_ANON_SWAP_REASON pss=${kill.pss}KB rss=${kill.rss}KB" }
+        // getPss()/getRss() return 0 when the system didn't capture them; don't report that as "0KB".
+        fun formatKb(kiloBytes: Long) = if (kiloBytes > 0) "${kiloBytes}KB" else "unreported"
+        Logger.e {
+            "Previous process exit: $MEMORY_LIMITER_ANON_SWAP_REASON " +
+                "pss=${formatKb(kill.pss)} rss=${formatKb(kill.rss)}"
+        }
     }
 
     private fun scheduleMeshLogCleanup() {

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -16,10 +16,12 @@
  */
 package org.meshtastic.app
 
+import android.app.ActivityManager
 import android.app.Application
 import android.appwidget.AppWidgetProviderInfo
 import android.content.Context
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import androidx.collection.intSetOf
 import androidx.glance.appwidget.GlanceAppWidgetManager
@@ -49,6 +51,7 @@ import org.meshtastic.app.di.AndroidKoinApp
 import org.meshtastic.core.common.ContextServices
 import org.meshtastic.core.database.DatabaseManager
 import org.meshtastic.core.repository.MeshPrefs
+import org.meshtastic.core.repository.PlatformAnalytics
 import org.meshtastic.core.repository.ServiceRepository
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.discovery_interrupted_scan_restored
@@ -59,6 +62,14 @@ import org.meshtastic.feature.widget.LocalStatsWidgetReceiver
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
+
+/**
+ * [android.app.ApplicationExitInfo.getDescription] reported by Android 17's per-app memory ceiling (zram-swap kill).
+ */
+private const val MEMORY_LIMITER_ANON_SWAP_REASON = "MemoryLimiter:AnonSwap"
+private const val MEMORY_LIMITER_PREFS_NAME = "memory_limiter_exit_check"
+private const val KEY_LAST_REPORTED_EXIT_TIMESTAMP = "last_reported_exit_timestamp"
+private const val MEMORY_LIMITER_SCAN_DEPTH = 5
 
 /**
  * The main application class for Meshtastic.
@@ -95,6 +106,12 @@ open class MeshUtilApplication :
         // Schedule periodic MeshLog cleanup. Off-main: WorkManager uses on-demand init here
         // (the startup provider is removed), so getInstance() opens WorkManager's Room DB.
         applicationScope.launch { scheduleMeshLogCleanup() }
+
+        // ApplicationExitInfo requires API 30+. A "MemoryLimiter:AnonSwap" reason means Android 17's per-app
+        // memory ceiling zram-swapped then killed the previous process — see reportMemoryLimiterExitIfPresent.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            applicationScope.launch { reportMemoryLimiterExitIfPresent() }
+        }
 
         // Generate and publish widget preview for Android 15+ widget picker
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
@@ -172,6 +189,32 @@ open class MeshUtilApplication :
             super.onTerminate()
             org.koin.core.context.stopKoin()
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun reportMemoryLimiterExitIfPresent() {
+        // getHistoricalProcessExitReasons() returns a persistent record, not a queue, so the timestamp
+        // watermark keeps a kill from being re-reported on every cold start. Scanning a few records
+        // (newest first) instead of just index 0 matters: a crash during the restart that follows a
+        // limiter kill slides the AnonSwap record down the list, and the newest entry alone would miss it.
+        val prefs = getSharedPreferences(MEMORY_LIMITER_PREFS_NAME, Context.MODE_PRIVATE)
+        val watermark = prefs.getLong(KEY_LAST_REPORTED_EXIT_TIMESTAMP, -1L)
+        val kill =
+            getSystemService(ActivityManager::class.java)
+                ?.getHistoricalProcessExitReasons(null, 0, MEMORY_LIMITER_SCAN_DEPTH)
+                ?.firstOrNull { it.description == MEMORY_LIMITER_ANON_SWAP_REASON && it.timestamp > watermark }
+                ?: return
+        prefs.edit().putLong(KEY_LAST_REPORTED_EXIT_TIMESTAMP, kill.timestamp).apply()
+
+        // Force PlatformAnalytics construction so its Kermit log writers (Crashlytics/Datadog) are
+        // registered before we log, even though nothing else has injected it yet this early in startup.
+        get<PlatformAnalytics>()
+
+        // Unlike the recoverable, environment-driven states ExpectedCondition.kt guards against (BLE off,
+        // a denied permission), a memory-ceiling kill means this process's own footprint was too large —
+        // an actionable engineering signal, so it is deliberately reported as a non-fatal (Error), not a
+        // rate-only breadcrumb.
+        Logger.e { "Previous process exit: $MEMORY_LIMITER_ANON_SWAP_REASON pss=${kill.pss}KB rss=${kill.rss}KB" }
     }
 
     private fun scheduleMeshLogCleanup() {


### PR DESCRIPTION
## Why

Android 17 enforces per-app memory ceilings, rolling out starting with Pixel and expanding across OEMs (Android Developers Blog: [Prioritizing Memory Efficiency: Essential Steps for Android 17](https://android-developers.googleblog.com/2026/06/prioritizing-memory-efficiency-steps-for-android-17.html), [Preparing your app for broader memory limits](https://android-developers.googleblog.com/2026/08/app-broader-memory-limits.html)). Apps over budget get zRAM-swapped (jank) and then killed, and the only signal is an `ApplicationExitInfo` description of `MemoryLimiter:AnonSwap`. We currently have zero visibility into whether our 24/7 foreground-service app is being hit by this.

## What

On cold start (API 30+; minSdk is 26 so this is a runtime gate), `MeshUtilApplication` scans the last 5 historical process exit records for a `MemoryLimiter:AnonSwap` kill newer than a SharedPreferences timestamp watermark, and reports the newest match as a non-fatal (`Logger.e`) through the existing Kermit -> Crashlytics/Datadog writer pipeline, including the pss/rss the OS recorded at kill time (not PII; 0 formats as "unreported" since the system returns 0 when it did not capture them).

Design notes for reviewers:

- **Watermark dedupe with durable persistence**: `getHistoricalProcessExitReasons()` returns a persistent record, not a queue, so without the timestamp watermark the same kill would re-report on every cold start. The watermark is written with a checked synchronous `commit()` before telemetry is emitted: this path runs precisely when the OS has been killing the process, and an async `apply()` lost to another death would double-report. Runs on a background dispatcher, so no main-thread jank.
- **Depth-5 scan, not index 0**: a crash during the restart that follows a limiter kill slides the AnonSwap record down the list; the newest entry alone would never report it.
- **`contains()` match on the description**: OEMs may decorate the string as the rollout expands; exact equality still matches inside `contains`, and no other exit reason plausibly embeds that token.
- **Deliberate `Error` severity**: unlike the environment-driven states `ExpectedCondition.kt` keeps out of Crashlytics/RUM (BLE off, denied permission), a memory-ceiling kill indicts the app's own footprint, so it is reported as an actionable non-fatal rather than a rate-only breadcrumb.
- **`get<PlatformAnalytics>()` before logging**: that singleton's init wires the Kermit writers; normally it is first constructed lazily from Compose, which may not have happened yet this early in startup. Consent gating is preserved by construction: with analytics consent denied both writers no-op, and the fdroid flavor logs to logcat only.
- **Follow-up if the rate is nonzero**: `ProfilingManager` (`TRIGGER_TYPE_OOM`) is the blog-recommended next step for capturing production heap dumps; deliberately out of scope here until this telemetry shows we need it.

A bitmap audit accompanying this work (map tiles, avatars, QR) found no raw `BitmapFactory`/`ARGB_8888` decode paths in our code; one QR render-size finding is tracked as a separate follow-up.

## Testing Performed

- `spotlessApply spotlessCheck detekt assembleDebug` (fdroidDebug + googleDebug): pass, re-run after each revision
- `:androidApp:testFdroidDebugUnitTest` and `:androidApp:testGoogleDebugUnitTest`: pass (115 tests each), confirmed executed fresh (not build-cache replays); Robolectric boots this Application class and the new block exercises its empty-record early-return path
- KMP `allTests` not run: the diff is confined to `androidApp/src/main`, a leaf module no KMP module depends on

🤖 Generated with [Claude Code](https://claude.com/claude-code)