### PR TITLE
perf(ui): render QR codes at display density instead of fixed 960px

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/QrDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/QrDialog.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
@@ -63,13 +64,14 @@ import org.meshtastic.core.ui.util.createClipEntry
 import org.meshtastic.core.ui.util.rememberQrCodePainter
 
 private const val QR_DISPLAY_SIZE = 320
-private const val QR_RENDER_SIZE = 960
 
 @Composable
 fun QrDialog(title: String, uriString: String, onDismiss: () -> Unit) {
     val clipboardManager = LocalClipboard.current
     val coroutineScope = rememberCoroutineScope()
-    val qrPainter = rememberQrCodePainter(uriString, QR_RENDER_SIZE)
+    // Render at the actual on-screen pixel size so low-density devices don't over-allocate bitmap memory.
+    val qrRenderSizePx = with(LocalDensity.current) { QR_DISPLAY_SIZE.dp.roundToPx() }
+    val qrPainter = rememberQrCodePainter(uriString, qrRenderSizePx)
 
     val nfcSupported = LocalNfcScannerSupported.current
     val nfcWriter = LocalNfcWriterProvider.current


### PR DESCRIPTION
## Why

A bitmap memory audit (ahead of Android 17 per-app memory ceilings) found the QR dialog over-renders on most devices: it generates its bitmap at a hardcoded 960px while displaying at 320.dp. 960px only matches actual on-screen pixels on 3x-density (xxhdpi) devices. mdpi/hdpi/xhdpi allocate up to ~9x more pixel memory than the screen can show, while xxxhdpi (4x, needs 1280px) is under-rendered and upscales with blur.

## What changed

`QrDialog` now derives the render size from `LocalDensity` at the call site (`QR_DISPLAY_SIZE.dp.roundToPx()`), so the bitmap is generated at exactly the displayed pixel size on every density: 320px on mdpi up to 1280px on xxxhdpi. The `QR_RENDER_SIZE` constant is removed.

`rememberQrCodePainter` is untouched: same signature, still pure commonMain (`LocalDensity` is available in commonMain). Its existing `remember(qrCode, size)` key means a density change (display-size setting, moving a desktop window between monitors) regenerates the bitmap correctly. `QrDialog` is the only caller.

Out of scope (evaluated and deliberately deferred): switching the `ImageBitmap` to Rgb565, which needs Skiko-target runtime verification since desktop/iOS/web have historically been unreliable with non-N32 raster configs.

## Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt assembleDebug :core:ui:allTests kmpSmokeCompile` — all passed (`:core:ui:allTests` and `kmpSmokeCompile` included since this touches a KMP commonMain module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * QR codes now render at the appropriate screen resolution.
  * Reduced unnecessary bitmap memory usage on lower-density devices.
  * Preserved the existing 320 dp on-screen QR code size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->