### PR TITLE
feat(privacy): shield sensitive UI content from non-tool accessibility services

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditBase64Preference.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditBase64Preference.kt
@@ -35,6 +35,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.semantics.isSensitiveData
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -94,7 +96,10 @@ fun EditBase64Preference(
                 valueState = it
                 runCatching { it.base64ToByteString() }.onSuccess(onValueChange)
             },
-            modifier = Modifier.fillMaxWidth().onFocusChanged { focusState -> isFocused = focusState.isFocused },
+            modifier =
+            Modifier.fillMaxWidth()
+                .onFocusChanged { focusState -> isFocused = focusState.isFocused }
+                .semantics { isSensitiveData = true },
             enabled = enabled,
             readOnly = readOnly,
             label = { Text(text = title) },

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/QrDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/QrDialog.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.isSensitiveData
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
@@ -136,7 +138,7 @@ fun QrDialog(title: String, uriString: String, onDismiss: () -> Unit) {
                 ) {
                     Text(
                         text = uriString,
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier.weight(1f).semantics { isSensitiveData = true },
                         style = MaterialTheme.typography.bodySmall,
                         overflow = TextOverflow.Visible,
                         softWrap = true,

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isSensitiveData
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
@@ -323,6 +324,7 @@ fun MessageItem(
             .semantics(mergeDescendants = true) {
                 contentDescription = messageA11yText
                 role = Role.Button
+                isSensitiveData = true
             },
         color = containerColor,
         contentColor = contentColor,
@@ -537,7 +539,12 @@ private fun OriginalMessageSnippet(
         // rounded corners, so the reply header inherits the correct top radii
         // automatically and stays square on the bottom where body text follows.
         Surface(
-            modifier = modifier.fillMaxWidth().clickable { onNavigateToOriginalMessage(originalMessage.packetId) },
+            modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable { onNavigateToOriginalMessage(originalMessage.packetId) }
+                // clickable makes this its own a11y node, so the bubble's isSensitiveData doesn't reach it
+                .semantics { isSensitiveData = true },
             contentColor = replyContentColor,
             color = replyContainerColor,
             shape = RectangleShape,

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageScreenComponents.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageScreenComponents.kt
@@ -62,6 +62,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.isSensitiveData
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
@@ -201,7 +203,7 @@ fun ReplySnippet(originalMessage: Message?, onClearReply: () -> Unit, ourNode: N
                     style = MaterialTheme.typography.labelMedium,
                 )
                 Text(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).semantics { isSensitiveData = true },
                     text = message.text.ellipsize(SNIPPET_CHARACTER_LIMIT),
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 1,

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactItem.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/ContactItem.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isSensitiveData
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -172,7 +173,7 @@ private fun ChatMetadata(contact: Contact, modifier: Modifier = Modifier) {
     ) {
         Text(
             text = contact.lastMessageText.orEmpty(),
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.weight(1f).semantics { isSensitiveData = true },
             style = MaterialTheme.typography.bodyMedium,
             overflow = TextOverflow.Ellipsis,
             maxLines = 2,

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeDetailsSection.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeDetailsSection.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isSensitiveData
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -406,7 +407,10 @@ private fun PublicKeyItem(publicKeyBytes: ByteArray) {
                 role = Role.Button,
             )
             .padding(horizontal = 20.dp, vertical = 8.dp)
-            .semantics(mergeDescendants = true) { contentDescription = contentDescriptionText },
+            .semantics(mergeDescendants = true) {
+                contentDescription = contentDescriptionText
+                isSensitiveData = true
+            },
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(


### PR DESCRIPTION
Hardens the app against accessibility-service snooping: Android 16 lets apps mark UI nodes so that only accessibility services declaring `isAccessibilityTool` (TalkBack, Switch Access) can read them, hiding the content from malware-style services that abuse the accessibility API to scrape screens. This applies that protection, via Compose's `isSensitiveData` semantics property, to everything covered by our "never expose PII, location, or cryptographic keys" rule: message content, PSK and private-key material, and channel share URLs (which embed PSKs). Background: [Android Developers Blog, "Stop malware from snooping on your app data"](https://android-developers.googleblog.com/2025/12/enhancing-android-security-stop-malware.html).

### 🌟 New Features

- **Crypto material**: `EditBase64Preference` (the shared field behind the channel PSK, security public key, and private key editors, plus admin-key lists via `EditListPreference`) and `PublicKeyItem` on the node detail screen now carry `isSensitiveData`.
- **Channel share URL**: the URL text in `QrDialog` is flagged; the clipboard copy there was already marked sensitive, this closes the on-screen read path. The QR `Image` itself needs no flag, since its only a11y payload is the literal label "QR code".
- **Message content**: the `MessageItem` bubble (covers body text and the a11y `contentDescription`), the quoted-reply `OriginalMessageSnippet`, the compose-bar `ReplySnippet`, and the conversation list's last-message preview in `ContactItem`.

### Implementation notes for reviewers

- `isSensitiveData` is commonMain in Compose UI 1.9+ (we pin CMP 1.12.0-rc01), so no expect/actual: it compiles on all targets and is a no-op off Android.
- Compose's a11y delegate filters **per node** with no parent-to-child inheritance, unlike the View system's `accessibilityDataSensitive="auto"`. Any clickable descendant forms its own a11y node and escapes a parent's flag; that is why `OriginalMessageSnippet` is flagged separately from its parent bubble (commented at the site).
- Known upstream gap: links and @mentions inside `AutoLinkText` surface as their own virtual nodes, so those fragments (not the message body) remain readable by non-tool services until Compose adds subtree inheritance.
- Tradeoff worth an explicit ack: non-tool-declared accessibility services (some password managers, automation tools) lose read access to message content. For keys/PSKs/URLs this is unambiguous; for messages it mirrors what messaging apps do with the View-system attribute.

### Testing Performed

No test files changed. Full baseline run is green: `spotlessApply spotlessCheck detekt assembleDebug test allTests` (2588 tests) plus `kmpSmokeCompile` confirming the new semantics property resolves on Android, JVM, iOS arm64, and iOS simulator targets.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>


And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Sensitive information is now better protected from accessibility services and screen-sharing features across message content, contact previews, QR dialogs, Base64 fields, and node public keys.
  * Message replies, quoted text, and copied QR data are also identified as sensitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->