### PR TITLE
chore(r8): drop keepclassmembers rule subsumed by bundled-driver keep

### DIFF
--- a/config/proguard/shared-rules.pro
+++ b/config/proguard/shared-rules.pro
@@ -126,7 +126,6 @@
 # bundled JNI library calls back into JVM methods on the driver class
 # (e.g. `nativeThreadSafeMode`). Keep the whole driver package.
 -keep class androidx.sqlite.driver.bundled.** { *; }
--keepclassmembers class androidx.sqlite.driver.bundled.** { native <methods>; *; }
 
 # ---- Room KMP (room3) -------------------------------------------------------
 -keep class * extends androidx.room3.RoomDatabase { <init>(); }


### PR DESCRIPTION
### Why

The AGP 9.3 R8 Configuration Analyzer's "Subsumed" view flags one of our own rules in `config/proguard/shared-rules.pro` as fully redundant: the `-keepclassmembers class androidx.sqlite.driver.bundled.** { native <methods>; *; }` line is a strict subset of the `-keep class androidx.sqlite.driver.bundled.** { *; }` directly above it, which already retains those classes and every member — native methods included. The subsumption holds identically under desktop ProGuard, the other consumer of this file, so the line does nothing on either platform. Removing it keeps the rule set honest: every remaining line is load-bearing.

Beyond this one line, the analyzer run was a clean bill of health — 96.2% shrinking / 96.0% optimization coverage, no broad wildcard keeps, obfuscation intentionally 0% (`-dontobfuscate`, readable stack traces for an open-source app). Everything else in the Subsumed view was either mutual pairings of equivalent rule forms or library-shipped consumer rules that are not ours to edit.

### What changed

- Removed the redundant `-keepclassmembers` line for `androidx.sqlite.driver.bundled.**` from `config/proguard/shared-rules.pro`. The broader `-keep` above it and its explanatory comment are unchanged.

### Testing Performed

- `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — green
- `./gradlew :androidApp:assembleFdroidRelease` — green (exercises R8, the Android consumer of shared-rules.pro)
- `./gradlew :desktopApp:proguardReleaseJars` — green (exercises ProGuard 7.7, the desktop consumer)
- `./gradlew :androidApp:analyzeFdroidReleaseR8Config` — report inspected interactively; this rule was the only actionable finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android release builds by ensuring all bundled SQLite driver classes and members are retained during optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->