### PR TITLE
fix(navigation): clear deep-link replay cache once applied to the backstack

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticAppShell.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticAppShell.kt
@@ -48,7 +48,10 @@ fun MeshtasticAppShell(
     content: @Composable () -> Unit,
 ) {
     LaunchedEffect(uiViewModel) {
-        uiViewModel.navigationDeepLink.collect { navKeys -> multiBackstack.handleDeepLink(navKeys) }
+        uiViewModel.navigationDeepLink.collect { navKeys ->
+            multiBackstack.handleDeepLink(navKeys)
+            uiViewModel.onDeepLinkHandled()
+        }
     }
 
     MeshtasticCommonAppSetup(

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
@@ -125,6 +125,18 @@ class UIViewModel(
     val navigationDeepLink = _navigationDeepLink.asSharedFlow()
 
     /**
+     * Clears the buffered deep link once its collector has applied it to the backstack.
+     *
+     * [_navigationDeepLink] replays its last value so a deep link emitted before the collector subscribes (e.g. on cold
+     * start) isn't lost. But this ViewModel is Activity-scoped and survives configuration changes, while the collecting
+     * `LaunchedEffect` does not — without this, a device rotation after a deep link re-subscribes and replays the same
+     * value, duplicate-appending it onto [MultiBackstack]'s current tab.
+     */
+    fun onDeepLinkHandled() {
+        _navigationDeepLink.resetReplayCache()
+    }
+
+    /**
      * Unified handler for all Meshtastic deep links and OS intents.
      *
      * This method orchestrates two distinct types of URI handling:


### PR DESCRIPTION
## Why

`UIViewModel` is Activity-scoped and survives configuration changes, but the `LaunchedEffect` in `MeshtasticAppShell` that collects `navigationDeepLink` does not. The flow uses `replay = 1` (so a deep link emitted before the collector subscribes — cold start, intro screen still showing — isn't lost), but the cache was never cleared after delivery. A device rotation any time after a deep link therefore tore down and rebuilt the composition, re-subscribed the collector, and replayed the stale value into `MultiBackstack.handleDeepLink`:

- **Non-tab routes** (e.g. `meshtastic://…/firmware/update`) hit the `addAll` branch and were duplicate-appended onto the current tab's stack.
- **Tab-owned routes** (e.g. `/nodes/{destNum}/device-metrics`) hit the `replaceAll` branch: rotation force-switched back to the deep-linked tab and wiped any navigation the user had done since the deep link.

## What

Adds `UIViewModel.onDeepLinkHandled()`, which calls `resetReplayCache()` on the shared flow, and invokes it from the collector immediately after `multiBackstack.handleDeepLink(navKeys)`. Two files, 16 lines. No change to `DeepLinkRouter`, the URL scheme, or any route's synthetic back-stack construction.

Found while auditing `DeepLinkRouter`/`MultiBackstack` against Google's Nav3 synthetic back-stack reference ([android/nav3-recipes](https://github.com/android/nav3-recipes) `syntheticbackstackapp` + deep-link guide). The router's root-first `List<NavKey>` construction already matches the recommended pattern; this replay leak was the one real gap.

## Reviewer notes

- `resetReplayCache()` semantics (verified against kotlinx-coroutines 1.11.0 sources): only *new* subscribers are affected — an active collector still receives values buffered after a concurrent emit, so no deep link can be dropped by the reset. Pre-subscribe buffering is preserved because the reset only runs after a successful collect.
- `resetReplayCache()` is `@ExperimentalCoroutinesApi`; `UIViewModel` already opts in at class level.
- `navigationDeepLink` has exactly one collector repo-wide (the shared shell, Android + Desktop), confirmed by search. Desktop has no config-change recreation, so the reset is a no-op there.

## Testing Performed

- Full local baseline on this exact state: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green (1776 tasks; jvmTest, androidHostTest, and KMP `allTests` across `feature:*`, `core:*`, `desktopApp`).
- No dedicated unit test added: constructing `UIViewModel` requires faking its full 15-dependency constructor and no such harness exists; the fix is two lines against a verified kotlinx-coroutines contract. Happy to add one if a `UIViewModel` test fixture lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)