### PR TITLE
fix(ui): give feedback when a contact or channel import arrives while disconnected

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -849,6 +849,8 @@ import_configuration
 import_export_label
 import_known_shared_contact_text
 import_label
+import_pending_channels_connect
+import_pending_contact_connect
 import_shared_contact
 incoming_messages
 indoor_air_quality_iaq

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -879,6 +879,8 @@
     <string name="import_export_label">Import/Export</string>
     <string name="import_known_shared_contact_text">Warning: This contact is known, importing will overwrite the previous contact information.</string>
     <string name="import_label">Import</string>
+    <string name="import_pending_channels_connect">Channel settings received. Connect to a device to import them.</string>
+    <string name="import_pending_contact_connect">Contact received. Connect to a device to import it.</string>
     <string name="import_shared_contact">Import Shared Contact?</string>
     <string name="incoming_messages">Incoming Messages</string>
     <string name="indoor_air_quality_iaq">Indoor Air Quality (IAQ)</string>

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
@@ -71,6 +71,8 @@ import org.meshtastic.core.repository.notificationId
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.client_notification
 import org.meshtastic.core.resources.compromised_keys
+import org.meshtastic.core.resources.import_pending_channels_connect
+import org.meshtastic.core.resources.import_pending_contact_connect
 import org.meshtastic.core.ui.component.ScrollToTopEvent
 import org.meshtastic.core.ui.util.AlertManager
 import org.meshtastic.core.ui.util.ComposableContent
@@ -318,6 +320,16 @@ class UIViewModel(
 
     fun setSharedContactRequested(contact: SharedContact?) {
         _sharedContactRequested.value = contact
+        if (contact != null) notifyImportPendingIfNotConnected(Res.string.import_pending_contact_connect)
+    }
+
+    /**
+     * The import dialogs in `SharedDialogs` only render while [ConnectionState.Connected], so a QR scanned while
+     * disconnected would otherwise queue silently with no feedback.
+     */
+    private fun notifyImportPendingIfNotConnected(messageRes: StringResource) {
+        if (connectionState.value is ConnectionState.Connected) return
+        safeLaunch(tag = "notifyImportPending") { snackbarManager.showSnackbar(message = getString(messageRes)) }
     }
 
     /** Clears the pending shared contact request. */
@@ -335,6 +347,7 @@ class UIViewModel(
 
     fun setRequestChannelSet(channelSet: ChannelSet?) {
         _requestChannelSet.value = channelSet
+        if (channelSet != null) notifyImportPendingIfNotConnected(Res.string.import_pending_channels_connect)
     }
 
     val latestStableFirmwareRelease = firmwareReleaseRepository.stableRelease.mapNotNull { it?.asDeviceVersion() }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/UIViewModel.kt
@@ -71,6 +71,7 @@ import org.meshtastic.core.repository.notificationId
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.client_notification
 import org.meshtastic.core.resources.compromised_keys
+import org.meshtastic.core.resources.getStringSuspend
 import org.meshtastic.core.resources.import_pending_channels_connect
 import org.meshtastic.core.resources.import_pending_contact_connect
 import org.meshtastic.core.ui.component.ScrollToTopEvent
@@ -329,7 +330,7 @@ class UIViewModel(
      */
     private fun notifyImportPendingIfNotConnected(messageRes: StringResource) {
         if (connectionState.value is ConnectionState.Connected) return
-        safeLaunch(tag = "notifyImportPending") { snackbarManager.showSnackbar(message = getString(messageRes)) }
+        safeLaunch(tag = "notifyImportPending") { snackbarManager.showSnackbar(message = getStringSuspend(messageRes)) }
     }
 
     /** Clears the pending shared contact request. */


### PR DESCRIPTION
Scanning a shared-contact QR (`meshtastic.org/v/#…`) or channel-set QR (`meshtastic.org/e/#…`) while no device is connected gave zero feedback: the import request was parked in `UIViewModel` state, but the consuming dialogs in `SharedDialogs` only render while `ConnectionState.Connected`, so from the user's perspective the scan silently did nothing. This adds minimal snackbar feedback so the user knows the import was received and what to do next.

### 🐛 Bug Fixes
- `UIViewModel.setSharedContactRequested` / `setRequestChannelSet` now enqueue a snackbar via the existing `SnackbarManager` when an import arrives while the device is not connected: "Contact received. Connect to a device to import it." / "Channel settings received. Connect to a device to import them."
- Hooking the setters (rather than `handleDeepLink`) also covers the Discovery screen's join-offer path, which feeds the same gated dialogs.
- Import semantics are unchanged: the pending request still sits in state and the import dialog still appears automatically once the device connects. The URL format is untouched.

### Notes
- `SnackbarManager` buffers events in a `Channel(BUFFERED)` consumed only when a host collects, so a message enqueued before `MainScreen` composes (e.g. during app intro, or a cold-start deep link) is queued, not dropped.
- The snackbar can also fire while `Connecting`/`DeviceSleep`, where the dialog may pop moments later anyway; suppressing it there would reintroduce silence if the connection attempt fails, so it is deliberately kept simple.

### Testing Performed
- Full local baseline in this worktree: `spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green.
- Verified `SnackbarManager`'s buffered-channel behavior covers the no-host-composed edge case (app intro screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications for pending contact and channel imports when the device is disconnected.
  * Users are prompted to connect their device before importing shared contact or channel settings.
  * Imports continue automatically through the existing flow once connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->