### PR TITLE
fix(database): give every SQLite connection a busy timeout

### DIFF
--- a/core/database/src/androidMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
+++ b/core/database/src/androidMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
@@ -42,14 +42,14 @@ actual fun getDatabaseBuilder(dbName: String): RoomDatabase.Builder<MeshtasticDa
         factory = { MeshtasticDatabaseConstructor.initialize() },
     )
         .configureCommon()
-        .setDriver(BundledSQLiteDriver())
+        .setDriver(BusyTimeoutSQLiteDriver(BundledSQLiteDriver()))
 }
 
 /** Returns a [RoomDatabase.Builder] configured for an in-memory Android database. */
 actual fun getInMemoryDatabaseBuilder(): RoomDatabase.Builder<MeshtasticDatabase> =
     Room.inMemoryDatabaseBuilder<MeshtasticDatabase>(factory = { MeshtasticDatabaseConstructor.initialize() })
         .configureCommon()
-        .setDriver(BundledSQLiteDriver())
+        .setDriver(BusyTimeoutSQLiteDriver(BundledSQLiteDriver()))
 
 /** Returns the Android directory where database files are stored. */
 actual fun getDatabaseDirectory(): Path {

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/BusyTimeoutSQLiteDriver.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/BusyTimeoutSQLiteDriver.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.SQLiteDriver
+import androidx.sqlite.execSQL
+
+/**
+ * Wraps a [SQLiteDriver] so every connection it opens waits up to [busyTimeoutMs] for a competing connection's lock
+ * instead of failing immediately with SQLITE_BUSY ("Error code: 5, message: database is locked").
+ *
+ * Each database normally holds a single connection (see `configureCommon`), but [DatabaseManager]'s wedge recovery
+ * deliberately abandons a stalled connection and opens a replacement pool against the same file (see
+ * `abandonWedgedDbBlock`). Until the abandoned callback finishes, both connections are live — and the bundled driver's
+ * default busy timeout is zero, so any write on the replacement fails the moment the abandoned connection holds the
+ * write lock. In the field (2.8.1, build 29321949) that surfaced as a fatal uncaught SQLITE_BUSY from Room's own
+ * invalidation-tracker housekeeping (`TriggerBasedInvalidationTracker.syncTriggers`), which the app cannot catch. A
+ * busy timeout makes the replacement connection wait out the overlap instead.
+ */
+class BusyTimeoutSQLiteDriver(
+    private val delegate: SQLiteDriver,
+    private val busyTimeoutMs: Long = DEFAULT_BUSY_TIMEOUT_MS,
+) : SQLiteDriver {
+    override fun open(fileName: String): SQLiteConnection =
+        delegate.open(fileName).also { connection -> connection.execSQL("PRAGMA busy_timeout = $busyTimeoutMs") }
+
+    companion object {
+        /**
+         * Long enough to ride out the typical abandoned-writer overlap (slow MeshLog cleanups and node-heavy packet
+         * transactions observed in the field run 1-30s), short enough that a truly stuck holder still surfaces as an
+         * error rather than an ANR-adjacent stall. Waiting happens on Room's I/O dispatcher, never the main thread.
+         */
+        const val DEFAULT_BUSY_TIMEOUT_MS = 10_000L
+    }
+}

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/BusyTimeoutSQLiteDriver.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/BusyTimeoutSQLiteDriver.kt
@@ -36,8 +36,25 @@ class BusyTimeoutSQLiteDriver(
     private val delegate: SQLiteDriver,
     private val busyTimeoutMs: Long = DEFAULT_BUSY_TIMEOUT_MS,
 ) : SQLiteDriver {
-    override fun open(fileName: String): SQLiteConnection =
-        delegate.open(fileName).also { connection -> connection.execSQL("PRAGMA busy_timeout = $busyTimeoutMs") }
+    init {
+        // SQLite disables the busy handler entirely for zero or negative values, which would silently
+        // defeat this wrapper's whole purpose.
+        require(busyTimeoutMs > 0) { "busyTimeoutMs must be positive, was $busyTimeoutMs" }
+    }
+
+    override fun open(fileName: String): SQLiteConnection {
+        val connection = delegate.open(fileName)
+        try {
+            connection.execSQL("PRAGMA busy_timeout = $busyTimeoutMs")
+        } catch (@Suppress("TooGenericExceptionCaught") setupFailure: Throwable) {
+            // The platforms throw different exception types here (android.database.SQLException on
+            // Android, androidx.sqlite.SQLiteException elsewhere); close the live native connection
+            // before rethrowing so a failed setup never leaks it.
+            connection.close()
+            throw setupFailure
+        }
+        return connection
+    }
 
     companion object {
         /**

--- a/core/database/src/iosMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
+++ b/core/database/src/iosMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
@@ -45,14 +45,14 @@ actual fun getDatabaseBuilder(dbName: String): RoomDatabase.Builder<MeshtasticDa
         factory = { MeshtasticDatabaseConstructor.initialize() },
     )
         .configureCommon()
-        .setDriver(BundledSQLiteDriver())
+        .setDriver(BusyTimeoutSQLiteDriver(BundledSQLiteDriver()))
 }
 
 /** Returns a [RoomDatabase.Builder] configured for an in-memory iOS database. */
 actual fun getInMemoryDatabaseBuilder(): RoomDatabase.Builder<MeshtasticDatabase> =
     Room.inMemoryDatabaseBuilder<MeshtasticDatabase>(factory = { MeshtasticDatabaseConstructor.initialize() })
         .configureCommon()
-        .setDriver(BundledSQLiteDriver())
+        .setDriver(BusyTimeoutSQLiteDriver(BundledSQLiteDriver()))
 
 /** Returns the iOS directory where database files are stored. */
 actual fun getDatabaseDirectory(): Path = documentDirectory().toPath()

--- a/core/database/src/jvmMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
+++ b/core/database/src/jvmMain/kotlin/org/meshtastic/core/database/DatabaseBuilder.kt
@@ -51,14 +51,14 @@ actual fun getDatabaseBuilder(dbName: String): RoomDatabase.Builder<MeshtasticDa
         factory = { MeshtasticDatabaseConstructor.initialize() },
     )
         .configureCommon()
-        .setDriver(BundledSQLiteDriver())
+        .setDriver(BusyTimeoutSQLiteDriver(BundledSQLiteDriver()))
 }
 
 /** Returns a [RoomDatabase.Builder] configured for an in-memory JVM database. */
 actual fun getInMemoryDatabaseBuilder(): RoomDatabase.Builder<MeshtasticDatabase> =
     Room.inMemoryDatabaseBuilder<MeshtasticDatabase>(factory = { MeshtasticDatabaseConstructor.initialize() })
         .configureCommon()
-        .setDriver(BundledSQLiteDriver())
+        .setDriver(BusyTimeoutSQLiteDriver(BundledSQLiteDriver()))
 
 /** Returns the JVM/Desktop directory where database files are stored. */
 actual fun getDatabaseDirectory(): Path = desktopDataDir().toPath()

--- a/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/BusyTimeoutSQLiteDriverTest.kt
+++ b/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/BusyTimeoutSQLiteDriverTest.kt
@@ -37,12 +37,22 @@ class BusyTimeoutSQLiteDriverTest {
     @Test
     fun appliesBusyTimeoutToEveryOpenedConnection() {
         val driver = BusyTimeoutSQLiteDriver(BundledSQLiteDriver())
-        driver.open(dbFile.absolutePath).use { connection ->
-            connection.prepare("PRAGMA busy_timeout").use { statement ->
-                statement.step()
-                assertEquals(BusyTimeoutSQLiteDriver.DEFAULT_BUSY_TIMEOUT_MS, statement.getLong(0))
+        // Two successive opens, so a wrapper that only configured its first connection would fail.
+        repeat(2) {
+            driver.open(dbFile.absolutePath).use { connection ->
+                connection.prepare("PRAGMA busy_timeout").use { statement ->
+                    statement.step()
+                    assertEquals(BusyTimeoutSQLiteDriver.DEFAULT_BUSY_TIMEOUT_MS, statement.getLong(0))
+                }
             }
         }
+    }
+
+    @Test
+    fun rejectsNonPositiveTimeouts() {
+        // SQLite treats zero/negative busy_timeout as "no busy handler", silently defeating the wrapper.
+        assertFailsWith<IllegalArgumentException> { BusyTimeoutSQLiteDriver(BundledSQLiteDriver(), 0) }
+        assertFailsWith<IllegalArgumentException> { BusyTimeoutSQLiteDriver(BundledSQLiteDriver(), -1) }
     }
 
     /**

--- a/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/BusyTimeoutSQLiteDriverTest.kt
+++ b/core/database/src/jvmTest/kotlin/org/meshtastic/core/database/BusyTimeoutSQLiteDriverTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.database
+
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
+import java.io.File
+import kotlin.concurrent.thread
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class BusyTimeoutSQLiteDriverTest {
+
+    private val dbFile = File.createTempFile("busy-timeout-driver", ".db").apply { delete() }
+
+    @AfterTest
+    fun cleanUp() {
+        dbFile.delete()
+    }
+
+    @Test
+    fun appliesBusyTimeoutToEveryOpenedConnection() {
+        val driver = BusyTimeoutSQLiteDriver(BundledSQLiteDriver())
+        driver.open(dbFile.absolutePath).use { connection ->
+            connection.prepare("PRAGMA busy_timeout").use { statement ->
+                statement.step()
+                assertEquals(BusyTimeoutSQLiteDriver.DEFAULT_BUSY_TIMEOUT_MS, statement.getLong(0))
+            }
+        }
+    }
+
+    /**
+     * The field failure shape (2.8.1, 29321949): a second connection to the same file writes while the first holds the
+     * write lock. The bundled driver's zero default fails instantly with SQLITE_BUSY; the wrapped driver waits the
+     * holder out.
+     */
+    @Test
+    fun waitsOutACompetingWriteLockInsteadOfFailingInstantly() {
+        val bare = BundledSQLiteDriver()
+        val holder = bare.open(dbFile.absolutePath)
+        holder.execSQL("CREATE TABLE t (x INTEGER)")
+
+        // Baseline: with the driver unwrapped (busy_timeout = 0), the competing write fails immediately.
+        holder.execSQL("BEGIN IMMEDIATE")
+        bare.open(dbFile.absolutePath).use { competitor ->
+            assertFailsWith<Exception> { competitor.execSQL("INSERT INTO t VALUES (1)") }
+        }
+
+        // Wrapped: the same competing write outlasts a lock held for 200ms.
+        val releaser = thread {
+            Thread.sleep(200)
+            holder.execSQL("COMMIT")
+        }
+        try {
+            BusyTimeoutSQLiteDriver(bare).open(dbFile.absolutePath).use { competitor ->
+                competitor.execSQL("INSERT INTO t VALUES (2)")
+                competitor.prepare("SELECT COUNT(*) FROM t").use { statement ->
+                    statement.step()
+                    assertEquals(1L, statement.getLong(0))
+                }
+            }
+        } finally {
+            releaser.join()
+            holder.close()
+        }
+    }
+}


### PR DESCRIPTION
Hardens against the new-in-2.8.1 fatal `android.database.SQLException — Error code: 5, message: database is locked` (Crashlytics issue f07b68017560d861acf3a2ce72909c69, first seen on build 29321949).

**Root cause, from field event logs.** The crash timeline in the Crashlytics samples reads: `withDb callback exceeded 30000ms; abandoned it and reopened the active DB` → the abandoned connection (a slow MeshLog cleanup on a 1,600-node database) stays alive holding the write lock → the **replacement** pool's very next write — Room's own `TriggerBasedInvalidationTracker.syncTriggers` `BEGIN` — hits SQLITE_BUSY. The bundled driver's default busy timeout is zero, so the overlap fails instantly, and because it happens inside Room's internal coroutine there is nothing the app can catch: it's fatal.

### 🐛 Bug Fixes
- New `BusyTimeoutSQLiteDriver` (commonMain) wraps the bundled driver so every opened connection runs `PRAGMA busy_timeout = 10000`. Applied in all three platform `DatabaseBuilder`s (Android, desktop/JVM, iOS) for both named and in-memory databases.
- 10s rationale: long enough to ride out the observed abandoned-writer overlap (slow cleanups and node-heavy transactions run 1–30s in the field), short enough that a truly stuck holder still surfaces as an error rather than an unbounded stall. Waiting happens on Room's I/O dispatcher, never the main thread.

### Testing Performed
- `appliesBusyTimeoutToEveryOpenedConnection`: PRAGMA readback on a wrapped connection.
- `waitsOutACompetingWriteLockInsteadOfFailingInstantly`: reproduces the field failure shape — an unwrapped competitor fails instantly against a held `BEGIN IMMEDIATE`; the wrapped competitor outlasts a 200ms hold and commits.
- Full baseline green: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` (1,789 tests).

### Notes for reviewers
- This is harm reduction for the overlap window, not a redesign of the wedge-recovery path. The stronger follow-ups — closing/interrupting the abandoned connection once its callback returns, and reducing wedges at the source — are tracked separately; the FTS desync fix (#6808) removes what was likely the biggest wedge driver on 29321949 (poisoned statements retrying against a corrupt index).
- A >10s holder will still BUSY-crash via the invalidation tracker; the timeout narrows the window rather than closing it. If Room ever exposes a way to supervise tracker errors, that's the complete fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database reliability when multiple operations compete for access.
  * Database writes now wait briefly for temporary locks instead of failing immediately.
  * Applied consistent lock handling across Android, iOS, and desktop platforms.

* **Tests**
  * Added coverage for connection timeout behavior and competing database writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->