### PR TITLE
fix(map): raise android-maps-utils to 5.1.1 so KML import survives xmlutil 1.0.x

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -291,6 +291,11 @@ dependencies {
     googleImplementation(libs.maps.compose)
     googleImplementation(libs.maps.compose.utils)
     googleImplementation(libs.maps.compose.widgets)
+    // Direct declaration raises the transitive android-maps-utils 5.0.0 (via maps-utils-ktx 6.2.0)
+    // to 5.1.1, whose KmlParser is built against the xmlutil 1.0.x compat API the app actually ships
+    // — 5.0.0's is compiled against 0.91.x's removed policyBuilder(), so every KML/KMZ map import
+    // crashed with NoSuchMethodError. Drop when maps-compose's chain requires >= 5.1.1 on its own.
+    googleImplementation(libs.android.maps.utils)
     // maps-compose-widgets requests androidx.compose.material:material version-less (expects a BOM
     // we exclude). Name it with a version so the version is published in the app's graph metadata.
     googleImplementation(libs.androidx.compose.material)

--- a/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/KmlParserLinkageTest.kt
+++ b/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/KmlParserLinkageTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app.map
+
+import com.google.maps.android.data.parser.kml.KmlParser
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Canary for the android-maps-utils / xmlutil linkage behind KML map overlays.
+ *
+ * android-maps-utils' `data.parser` KmlParser and the app's CoT XML code share one resolved xmlutil, and the pairing
+ * has already broken in production once: maps-utils 5.0.0 was compiled against xmlutil 0.91.x's removed
+ * `XmlConfig.Builder.policyBuilder()`, so when the app moved to xmlutil 1.0.x (2.8.0) every KML/KMZ import crashed with
+ * a fatal `NoSuchMethodError` until the maps-utils floor was raised to 5.1.1 (built against 1.0.x's compat builder).
+ * Whichever side a future dependency bump moves first, this test fails the build on the resulting binary mismatch
+ * instead of leaving it to be discovered by users opening map overlays.
+ */
+class KmlParserLinkageTest {
+
+    @Test
+    fun kmlParserParsesAMinimalDocumentAgainstTheResolvedXmlutil() {
+        val kml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <kml xmlns="http://www.opengis.net/kml/2.2">
+              <Placemark>
+                <name>linkage-canary</name>
+                <Point><coordinates>-122.084,37.421,0</coordinates></Point>
+              </Placemark>
+            </kml>
+            """
+                .trimIndent()
+
+        assertNotNull(KmlParser().parse(kml.byteInputStream()))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,11 @@ androidx-compose-bom-aligned = "1.12.0"
 jetbrains-adaptive = "1.3.0-beta02"
 
 # Google
+# 5.1.1 floor is load-bearing: 5.0.0's data.parser KmlParser is compiled against xmlutil 0.91.x's
+# removed policyBuilder() API, and the app's xmlutil 1.0.x (CoT XML) wins conflict resolution — so
+# with 5.0.0 every KML/KMZ map import dies with NoSuchMethodError (fatal in prod, 2.8.0–2.8.1).
+# 5.1.1 is built against xmlutil 1.0.x's compat builder. Guarded by KmlParserLinkageTest.
+android-maps-utils = "5.1.1"
 maps-compose = "8.4.0"
 
 # ML Kit
@@ -204,6 +209,7 @@ koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", ver
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 koin-annotations = { module = "io.insert-koin:koin-annotations", version.ref = "koin" }
+android-maps-utils = { module = "com.google.maps.android:android-maps-utils", version.ref = "android-maps-utils" }
 maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "maps-compose" }
 maps-compose-utils = { module = "com.google.maps.android:maps-compose-utils", version.ref = "maps-compose" }
 maps-compose-widgets = { module = "com.google.maps.android:maps-compose-widgets", version.ref = "maps-compose" }


### PR DESCRIPTION
Every KML/KMZ custom-overlay import on the google flavor has crashed with a fatal `NoSuchMethodError` since 2.8.0 (Crashlytics issue ac7ca3a7da92ca90d730d96f17b8148b — the app's **#1 FATAL by event count** on 2.8.1, and repetitive: users retry the import ~5x each). This fixes it while keeping the app on the latest xmlutil.

**Root cause.** The transitive `android-maps-utils-data:5.0.0` (via maps-compose 8.4.0 → maps-utils-ktx 6.2.0) is compiled against xmlutil 0.91.x's `XmlConfig.Builder.policyBuilder()`, which xmlutil **1.0.0 removed**. The app has shipped xmlutil 1.0.x for its CoT XML since the Renovate major bump (#5998, first released in 2.8.0), and in conflict resolution the app's 1.0.x wins over data-5.0.0's 0.91.3 request — so `KmlParser`'s lazy XML-config init throws on first use, every time. Verified by inspecting the published bytecode of each artifact.

### 🐛 Bug Fixes
- Declare `com.google.maps.android:android-maps-utils:5.1.1` directly (google flavor), raising the whole 5.0.0 submodule set. Upstream fixed the parser in 5.1.1 (2026-08-11): its `KmlParser` uses xmlutil 1.0.x's `XmlConfig.CompatBuilder.policyBuilder()`, which is present in the 1.0.2 the app ships. xmlutil itself is untouched.
- Not taken: jumping to the 6.0.0-rc line — unnecessary risk when 5.1.1 carries the fix (upstream fixed the parser in googlemaps/android-maps-utils#1741, shipped in 5.1.0+; an earlier read that rc01 was still broken was wrong — it carries the same fix). The real upstream gap is maps-compose still pinning maps-utils-ktx 6.2.0 → utils 5.0.0; being fixed upstream separately. Also not taken: downgrading the app to xmlutil 0.91.3 — viable (fully verified, stashed on this branch as `downgrade-to-0.91.3 approach` for reference) but it would hold the whole app and TAKPacket-SDK back on a pre-1.0 line.
- The direct declaration is droppable once maps-compose's own chain requires ≥ 5.1.1.

### Testing Performed
- New `KmlParserLinkageTest` (google unit tests): parses a minimal KML document through `KmlParser` on the real resolved classpath. This is a linkage canary — it failed correctly against the broken pairing during development, and will fail CI if a future Renovate bump moves either side of the maps-utils/xmlutil pairing out of step, instead of leaving the mismatch to be discovered by users opening map overlays.
- `dependencyInsight` confirms `android-maps-utils-data` resolves to 5.1.1 on `googleDebugRuntimeClasspath` (no residual 5.0.0), xmlutil stays 1.0.2.
- Full baseline green: `spotlessApply spotlessCheck detekt assembleDebug test allTests`.

### Notes for reviewers
- 5.0.0 → 5.1.1 also picks up upstream's 5.1.0/5.1.1 changes across the data/clustering/heatmaps submodules; nothing in the app's map code needed adapting and the existing map unit tests pass.
- Companion 2.8.1-triage PRs: #6808 (FTS index rebuild) and #6809 (SQLite busy timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KML/KMZ map import reliability by upgrading the underlying maps utility dependency.
  * Prevented failures caused by incompatibility with the app’s XML processing library.

* **Tests**
  * Added coverage to verify that KML documents parse successfully and detect future compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
