### PR TITLE
chore: bump VERSION_NAME_BASE to 2.8.2

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -27,7 +27,7 @@ COMPILE_SDK=37
 # Base version name for local development and fallback
 # On CI, this is overridden by the Git tag
 # Before a release, update this to the new Git tag version
-VERSION_NAME_BASE=2.8.1
+VERSION_NAME_BASE=2.8.2
 
 # Minimum firmware versions supported by this app
 MIN_FW_VERSION=2.5.14

--- a/desktopApp/packaging/linux/org.meshtastic.MeshtasticDesktop.metainfo.xml
+++ b/desktopApp/packaging/linux/org.meshtastic.MeshtasticDesktop.metainfo.xml
@@ -92,6 +92,11 @@
   </screenshots>
 
   <releases>
+    <release version="2.8.2" date="2026-08-21">
+      <description>
+        <p>Stability and reliability fixes.</p>
+      </description>
+    </release>
     <release version="2.8.1" date="2026-08-02">
       <description>
         <p>In-app update notifications, native OS notifications, deep-link handling, keyboard shortcuts, window-state persistence, and many stability fixes.</p>


### PR DESCRIPTION
Opens the 2.8.2 line.

- `config.properties` — `VERSION_NAME_BASE` 2.8.1 → 2.8.2. This is the only definition of the base version name; `resolveVersionInfo()` falls back to it for both `:androidApp` and `:desktopApp`, and CI overrides it with the release tag. `versionCode` is untouched — still git-derived (offset 29314197 + commit count).
- `desktopApp/packaging/linux/.../metainfo.xml` — matching AppStream `<release>` entry, which the **Require AppStream release entry for current version** PR check demands alongside the bump.

Two notes on the metainfo half:

1. Unlike the 2.8.1 bump (#6546), this **appends** an entry instead of rewriting the previous one in place, so 2.8.1 stays in the version history Flathub renders. (#6546 rewrote the 2.8.0 entry, which dropped 2.8.0 from the list.)
2. The description is deliberately generic — "Stability and reliability fixes." Most of what has landed since `v2.8.1` is Android-only (Legacy DFU, maintenance-UF2 manifest, accessibility shielding, `ApplicationExitInfo` reporting), and this file is the desktop listing. Happy to swap in the real 2.8.2 desktop highlights once the release notes firm up.

No Kotlin changes, so nothing for spotless (`.kt` / `.gradle.kts` only) or detekt to say. Verified locally with the gate itself:

```
VERSION=$(grep '^VERSION_NAME_BASE=' config.properties | cut -d'=' -f2)
grep -q "version=\"$VERSION\"" desktopApp/packaging/linux/org.meshtastic.MeshtasticDesktop.metainfo.xml && echo PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application version to 2.8.2.
  - Added release notes highlighting stability and reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->