### PR TITLE
fix(map): parse KMZ archives in the F-Droid map overlay renderer

### DIFF
--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapOverlayRenderer.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapOverlayRenderer.kt
@@ -19,6 +19,7 @@ package org.meshtastic.app.map
 import android.graphics.Color
 import androidx.core.graphics.toColorInt
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.meshtastic.app.map.cluster.RadiusMarkerClusterer
@@ -37,9 +38,16 @@ import org.osmdroid.views.overlay.Polyline
 import java.io.BufferedInputStream
 import java.io.File
 import java.io.InputStream
+import java.io.OutputStream
 import kotlin.math.roundToInt
 
 private const val TAG = "MapOverlayRenderer"
+
+/**
+ * Cap on a spooled KMZ's size: `openStream` can be an unbounded network fetch, and osmbonuspack's KMZ path needs the
+ * whole archive on disk before it can parse it. 50 MB comfortably covers a legitimate overlay plus embedded icons.
+ */
+private const val MAX_KMZ_BYTES = 50L * 1024 * 1024
 
 // simplestyle-spec fallbacks, mirroring the Google flavor's applySimpleStyleSpec(); tune here.
 private const val DEFAULT_GEOJSON_FILL_OPACITY = 0.35f
@@ -129,7 +137,7 @@ class FdroidMapOverlayRenderer {
                             LayerType.KML -> {
                                 val buffered = BufferedInputStream(input)
                                 if (buffered.isKmzArchive()) {
-                                    parseKmz(buffered, doc, cacheDir)
+                                    parseKmz(buffered, doc, cacheDir, layer.name)
                                 } else {
                                     doc.parseKMLStream(buffered, null)
                                 }
@@ -139,9 +147,13 @@ class FdroidMapOverlayRenderer {
                 if (ok) {
                     doc
                 } else {
-                    Logger.withTag(TAG).e { "Failed to parse map layer (malformed KML/KMZ/GeoJSON?): ${layer.name}" }
+                    Logger.withTag(TAG).w { "Failed to parse map layer (malformed KML/KMZ/GeoJSON?): ${layer.name}" }
                     null
                 }
+            } catch (e: CancellationException) {
+                // reconcile() is re-invoked on every layer-list change, cancelling an in-flight parse routinely —
+                // not a load failure. Matches the Google flavor's MapLayerOverlay handling of the same pattern.
+                throw e
             } catch (e: Exception) {
                 Logger.withTag(TAG).e(e) { "Error parsing map layer: ${layer.name}" }
                 null
@@ -155,13 +167,35 @@ class FdroidMapOverlayRenderer {
      * temp file — matching how the Google flavor treats KMZ uniformly regardless of whether the layer's source is a
      * local file or a network fetch — rather than reimplementing the unzip here.
      */
-    private fun parseKmz(stream: InputStream, doc: KmlDocument, cacheDir: File): Boolean {
+    private fun parseKmz(stream: InputStream, doc: KmlDocument, cacheDir: File, layerName: String): Boolean {
         val temp = File.createTempFile("layer", ".kmz", cacheDir)
         return try {
-            temp.outputStream().use { stream.copyTo(it) }
-            doc.parseKMZFile(temp)
+            val bytesCopied = temp.outputStream().use { stream.copyToBounded(it, MAX_KMZ_BYTES) }
+            if (bytesCopied > MAX_KMZ_BYTES) {
+                // Oversized input, not an app defect — warn (matching the malformed-input path), don't error.
+                Logger.withTag(TAG).w { "KMZ layer exceeds $MAX_KMZ_BYTES byte limit, skipping: $layerName" }
+                false
+            } else {
+                doc.parseKMZFile(temp)
+            }
         } finally {
             temp.delete()
+        }
+    }
+
+    /**
+     * Like [InputStream.copyTo], but stops as soon as more than [limit] bytes have been read, returning the count read
+     * so far (which will exceed [limit]) instead of continuing to buffer an unbounded stream to disk.
+     */
+    private fun InputStream.copyToBounded(out: OutputStream, limit: Long): Long {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var total = 0L
+        while (true) {
+            val read = read(buffer)
+            if (read == -1) return total
+            total += read
+            if (total > limit) return total
+            out.write(buffer, 0, read)
         }
     }
 

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapOverlayRenderer.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapOverlayRenderer.kt
@@ -34,6 +34,8 @@ import org.osmdroid.views.overlay.Marker
 import org.osmdroid.views.overlay.Overlay
 import org.osmdroid.views.overlay.Polygon
 import org.osmdroid.views.overlay.Polyline
+import java.io.BufferedInputStream
+import java.io.File
 import java.io.InputStream
 import kotlin.math.roundToInt
 
@@ -83,7 +85,7 @@ class FdroidMapOverlayRenderer {
         // Build overlays for visible layers not already drawn.
         for (layer in visible) {
             if (rendered.containsKey(layer.id)) continue
-            val doc = parse(layer, openStream) ?: continue
+            val doc = parse(layer, openStream, map.context.cacheDir) ?: continue
             val overlay =
                 withContext(Dispatchers.Main.immediate) {
                     // Build on the main thread: overlay markers reference the MapView (info windows, defaults).
@@ -108,7 +110,11 @@ class FdroidMapOverlayRenderer {
         map.invalidate()
     }
 
-    private suspend fun parse(layer: MapLayerItem, openStream: suspend (MapLayerItem) -> InputStream?): KmlDocument? {
+    private suspend fun parse(
+        layer: MapLayerItem,
+        openStream: suspend (MapLayerItem) -> InputStream?,
+        cacheDir: File,
+    ): KmlDocument? {
         val stream = openStream(layer) ?: return null
         return withContext(Dispatchers.IO) {
             try {
@@ -120,14 +126,42 @@ class FdroidMapOverlayRenderer {
                             LayerType.COVERAGE,
                             -> doc.parseGeoJSON(input.bufferedReader().readText())
 
-                            LayerType.KML -> doc.parseKMLStream(input, null)
+                            LayerType.KML -> {
+                                val buffered = BufferedInputStream(input)
+                                if (buffered.isKmzArchive()) {
+                                    parseKmz(buffered, doc, cacheDir)
+                                } else {
+                                    doc.parseKMLStream(buffered, null)
+                                }
+                            }
                         }
                     }
-                if (ok) doc else null
+                if (ok) {
+                    doc
+                } else {
+                    Logger.withTag(TAG).e { "Failed to parse map layer (malformed KML/KMZ/GeoJSON?): ${layer.name}" }
+                    null
+                }
             } catch (e: Exception) {
                 Logger.withTag(TAG).e(e) { "Error parsing map layer: ${layer.name}" }
                 null
             }
+        }
+    }
+
+    /**
+     * osmbonuspack only exposes KMZ parsing via [KmlDocument.parseKMZFile], which needs random-access zip seeking (to
+     * resolve embedded images) that a sequential [InputStream] can't do. So spool the already-sniffed KMZ stream to a
+     * temp file — matching how the Google flavor treats KMZ uniformly regardless of whether the layer's source is a
+     * local file or a network fetch — rather than reimplementing the unzip here.
+     */
+    private fun parseKmz(stream: InputStream, doc: KmlDocument, cacheDir: File): Boolean {
+        val temp = File.createTempFile("layer", ".kmz", cacheDir)
+        return try {
+            temp.outputStream().use { stream.copyTo(it) }
+            doc.parseKMZFile(temp)
+        } finally {
+            temp.delete()
         }
     }
 

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -1438,25 +1438,13 @@ private fun MapLayerOverlay(layerItem: MapLayerItem, mapViewModel: MapViewModel)
     }
 }
 
-/** Zip magic bytes; a [LayerType.KML] source starting with these is a KMZ archive rather than bare KML. */
-private val KMZ_MAGIC = byteArrayOf('P'.code.toByte(), 'K'.code.toByte())
-
 /**
  * Parse a custom overlay into the maps-utils platform-agnostic [DataLayer] model; null if the format is unrecognized.
  */
 private fun parseMapLayer(layerType: LayerType, stream: InputStream): DataLayer? = when (layerType) {
     LayerType.KML -> {
         val buffered = BufferedInputStream(stream)
-        buffered.mark(KMZ_MAGIC.size)
-        val magic = ByteArray(KMZ_MAGIC.size)
-        val read = buffered.read(magic)
-        buffered.reset()
-        val kml =
-            if (read == KMZ_MAGIC.size && magic.contentEquals(KMZ_MAGIC)) {
-                KmzParser().parse(buffered)
-            } else {
-                KmlParser().parse(buffered)
-            }
+        val kml = if (buffered.isKmzArchive()) KmzParser().parse(buffered) else KmlParser().parse(buffered)
         kml.toLayer()
     }
 

--- a/androidApp/src/main/kotlin/org/meshtastic/app/map/MapLayer.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/map/MapLayer.kt
@@ -74,9 +74,16 @@ private val KMZ_MAGIC = byteArrayOf('P'.code.toByte(), 'K'.code.toByte())
 fun InputStream.isKmzArchive(): Boolean {
     mark(KMZ_MAGIC.size)
     val magic = ByteArray(KMZ_MAGIC.size)
-    val read = read(magic)
+    // read(ByteArray) is only guaranteed to return at least 1 byte before EOF, not to fill the buffer — loop rather
+    // than trust a single call, or a short read could misclassify a real KMZ as bare KML.
+    var totalRead = 0
+    while (totalRead < magic.size) {
+        val read = read(magic, totalRead, magic.size - totalRead)
+        if (read == -1) break
+        totalRead += read
+    }
     reset()
-    return read == KMZ_MAGIC.size && magic.contentEquals(KMZ_MAGIC)
+    return totalRead == KMZ_MAGIC.size && magic.contentEquals(KMZ_MAGIC)
 }
 
 /** On-disk extension marking a saved coverage estimate, so [LayerType.COVERAGE] survives a restart. */

--- a/androidApp/src/main/kotlin/org/meshtastic/app/map/MapLayer.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/map/MapLayer.kt
@@ -21,6 +21,7 @@ import android.net.Uri
 import android.provider.OpenableColumns
 import co.touchlab.kermit.Logger
 import org.meshtastic.core.common.util.nowMillis
+import java.io.InputStream
 import kotlin.uuid.Uuid
 
 /**
@@ -58,6 +59,25 @@ data class MapLayerItem(
 
 private val KML_EXTENSIONS = listOf("kml", "kmz", "vnd.google-earth.kml+xml", "vnd.google-earth.kmz")
 private val GEOJSON_EXTENSIONS = listOf("geojson", "json")
+
+/** Zip magic bytes; a [LayerType.KML] source starting with these is a KMZ archive rather than bare KML. */
+private val KMZ_MAGIC = byteArrayOf('P'.code.toByte(), 'K'.code.toByte())
+
+/**
+ * True if [this] starts with the zip magic bytes, meaning a nominally-[LayerType.KML] source (`.kml` and `.kmz` both
+ * resolve to that one type — see [KML_EXTENSIONS]) is actually a KMZ archive. Shared by both flavors' parsers so
+ * neither has to duplicate the sniff or trust the file extension, which the content resolver can get wrong.
+ *
+ * Requires a mark-capable stream (wrap with [java.io.BufferedInputStream] first if unsure); leaves the stream position
+ * unchanged either way.
+ */
+fun InputStream.isKmzArchive(): Boolean {
+    mark(KMZ_MAGIC.size)
+    val magic = ByteArray(KMZ_MAGIC.size)
+    val read = read(magic)
+    reset()
+    return read == KMZ_MAGIC.size && magic.contentEquals(KMZ_MAGIC)
+}
 
 /** On-disk extension marking a saved coverage estimate, so [LayerType.COVERAGE] survives a restart. */
 const val COVERAGE_EXTENSION = "coverage"


### PR DESCRIPTION
Fixes #6833.

`.kml` and `.kmz` both resolve to `LayerType.KML` with no extension-level way to tell them apart, and `FdroidMapOverlayRenderer` fed a KMZ's raw zip bytes straight to osmbonuspack's `parseKMLStream()`, which expects KML XML. The SAX parse just failed and returned `false` with no exception thrown, so `reconcile()`'s `parse(...) ?: continue` silently dropped the layer — no crash, no log, nothing on screen.

PR #6811 (merged 2026-08-21) separately fixed a real crash on the `google` flavor (`NoSuchMethodError` from an xmlutil/maps-utils version mismatch). That fix doesn't touch `fdroid` at all, and a collaborator confirmed on #6833 that the latest `fdroid` snapshot still doesn't crash but the KMZ layer "does not load/display" — this PR is that remaining gap.

### 🐛 Bug Fixes
- The `google` flavor already sniffs the zip magic bytes (`PK`) before choosing `KmlParser` vs `KmzParser`; that sniff was flavor-agnostic, so it's now a shared `InputStream.isKmzArchive()` extension in `MapLayer.kt` (the doc-designated flavor-neutral file) instead of a private duplicate.
- osmbonuspack (the `fdroid` KML library) has no stream-native KMZ parser — only `KmlDocument.parseKMZFile(File)`, which needs random-access zip seeking to resolve embedded images. `FdroidMapOverlayRenderer` now spools a detected KMZ stream to a temp file in `cacheDir` (deleted immediately after parsing) and calls that, mirroring how the `google` flavor treats KMZ uniformly regardless of whether the layer's source is a local file or a network fetch.
- `parse()`'s previously-silent `ok == false` path (malformed KML/KMZ/GeoJSON) now logs via Kermit instead of vanishing.

### Testing Performed
- `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests` — all green, both `google` and `fdroid` flavors.
- No new test added (no local fixture KMZ available in this pass); manual verification would be importing a `.kmz` on an `fdroid` build and confirming the overlay renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map overlay support for KML and KMZ files.
  * KMZ archives are now identified and processed correctly, while standard KML files continue to load normally.
  * Improved handling of larger map files during import.
  * Malformed or unreadable documents now fail gracefully with clearer error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->