### PR TITLE
chore(detekt): scan flavor, iosMain and jvmAndroidMain sources

### DIFF
--- a/androidApp/detekt-baseline.xml
+++ b/androidApp/detekt-baseline.xml
@@ -2,6 +2,63 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>ComplexCondition:MapViewModel.kt:MapViewModel$name.isBlank() || (urlTemplate.isBlank() &amp;&amp; localUri == null) || (localUri == null &amp;&amp; !isValidTileUrlTemplate(urlTemplate))</ID>
+    <ID>ComplexCondition:MapViewModel.kt:MapViewModel$normalized.name.isBlank() || (normalized.urlTemplate.isBlank() &amp;&amp; normalized.localUri == null) || (normalized.localUri == null &amp;&amp; !isValidTileUrlTemplate(normalized.urlTemplate))</ID>
+    <ID>ComposableParamOrder:MapView.kt:@OptIn(ExperimentalMaterial3Api::class) @Composable private fun MapsDialog</ID>
+    <ID>CyclomaticComplexMethod:DiscoveryGoogleMap.kt:@OptIn(MapsComposeExperimentalApi::class) @Composable fun DiscoveryGoogleMap</ID>
+    <ID>CyclomaticComplexMethod:DiscoveryOsmMap.kt:@Composable fun DiscoveryOsmMap</ID>
+    <ID>CyclomaticComplexMethod:GeminiNanoDocAssistant.kt:GeminiNanoDocAssistant$override fun answerStream: kotlinx.coroutines.flow.Flow&lt;AIDocAssistantResult></ID>
+    <ID>CyclomaticComplexMethod:GeminiNanoDocAssistant.kt:GeminiNanoDocAssistant$private fun buildContext: ContextResult</ID>
+    <ID>CyclomaticComplexMethod:TracerouteOsmMap.kt:@Composable fun TracerouteOsmMap</ID>
+    <ID>LambdaParameterInRestartableEffect:LocationHandler.kt:onPermissionResult: (Boolean) -> Unit</ID>
+    <ID>LambdaParameterInRestartableEffect:TracerouteOsmMap.kt:onMappableCountChange: (shown: Int, total: Int) -> Unit</ID>
+    <ID>LongMethod:DiscoveryGoogleMap.kt:@OptIn(MapsComposeExperimentalApi::class) @Composable fun DiscoveryGoogleMap</ID>
+    <ID>LongMethod:DiscoveryOsmMap.kt:@Composable fun DiscoveryOsmMap</ID>
+    <ID>LongMethod:GeminiNanoDocAssistant.kt:GeminiNanoDocAssistant$override fun answerStream: kotlinx.coroutines.flow.Flow&lt;AIDocAssistantResult></ID>
+    <ID>LongMethod:GeminiNanoDocAssistant.kt:GeminiNanoDocAssistant$override suspend fun isSupported: Boolean</ID>
+    <ID>LongMethod:GeminiNanoDocAssistant.kt:GeminiNanoDocAssistant$private fun buildPrompt: String</ID>
+    <ID>LongMethod:MapFilterDropdown.kt:@Composable internal fun MapFilterDropdown</ID>
+    <ID>LongMethod:MapView.kt:@Composable private fun FdroidMainMapFilterDropdown</ID>
+    <ID>LongMethod:NodeTrackOsmMap.kt:@Composable fun NodeTrackOsmMap</ID>
+    <ID>LongMethod:TracerouteOsmMap.kt:@Composable fun TracerouteOsmMap</ID>
+    <ID>LoopWithTooManyJumpStatements:FdroidMapOverlayRenderer.kt:FdroidMapOverlayRenderer$for</ID>
+    <ID>LoopWithTooManyJumpStatements:GeminiNanoDocAssistant.kt:GeminiNanoDocAssistant$for</ID>
+    <ID>MatchingDeclarationName:MapView.kt:GoogleMapMode</ID>
+    <ID>ModifierMissing:DownloadButton.kt:@Composable fun DownloadButton</ID>
     <ID>ModifierMissing:Main.kt:@Composable fun MainScreen</ID>
+    <ID>ModifierMissing:NodeMapScreen.kt:@Composable fun NodeMapScreen</ID>
+    <ID>ModifierMissing:WaypointMarkers.kt:@OptIn(MapsComposeExperimentalApi::class) @Composable fun WaypointMarkers</ID>
+    <ID>ReturnCount:GooglePlatformAnalytics.kt:GooglePlatformAnalytics.CrashlyticsLogWriter$override fun log</ID>
+    <ID>ReturnCount:MapViewModel.kt:MapViewModel$fun getTileProvider: TileProvider?</ID>
+    <ID>ReturnCount:MlKitDocTranslator.kt:MlKitDocTranslator$override suspend fun translatePage: TranslationResult</ID>
+    <ID>ReturnCount:MlKitMessageTranslator.kt:MlKitMessageTranslator$override suspend fun downloadLanguageModels: DownloadResult</ID>
+    <ID>ReturnCount:MlKitMessageTranslator.kt:MlKitMessageTranslator$override suspend fun translate: TranslationResult</ID>
+    <ID>SwallowedException:MapViewModel.kt:MapViewModel$e: Exception</ID>
+    <ID>ThrowsCount:MeshtasticAppFunctions.kt:MeshtasticAppFunctions$@AppFunction(isDescribedByKDoc = true) suspend fun getChannelInfo: GetChannelInfoResponse</ID>
+    <ID>ThrowsCount:MeshtasticAppFunctions.kt:MeshtasticAppFunctions$@AppFunction(isDescribedByKDoc = true) suspend fun getDeviceStatus: GetDeviceStatusResponse</ID>
+    <ID>ThrowsCount:MeshtasticAppFunctions.kt:MeshtasticAppFunctions$@AppFunction(isDescribedByKDoc = true) suspend fun getMeshMetrics: GetMeshMetricsResponse</ID>
+    <ID>ThrowsCount:MeshtasticAppFunctions.kt:MeshtasticAppFunctions$@AppFunction(isDescribedByKDoc = true) suspend fun getNodeDetails: GetNodeDetailsResponse</ID>
+    <ID>ThrowsCount:MeshtasticAppFunctions.kt:MeshtasticAppFunctions$@AppFunction(isDescribedByKDoc = true) suspend fun getNodeList: GetNodeListResponse</ID>
+    <ID>ThrowsCount:MeshtasticAppFunctions.kt:MeshtasticAppFunctions$@AppFunction(isDescribedByKDoc = true) suspend fun getRecentMessages: GetRecentMessagesResponse</ID>
+    <ID>ThrowsCount:MeshtasticAppFunctions.kt:MeshtasticAppFunctions$@AppFunction(isDescribedByKDoc = true) suspend fun sendMessage: SendMessageResponse</ID>
+    <ID>TooGenericExceptionCaught:FdroidMapOverlayRenderer.kt:FdroidMapOverlayRenderer$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:GeminiNanoDocAssistant.kt:GeminiNanoDocAssistant$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MapView.kt:e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MapView.kt:ex: Exception</ID>
+    <ID>TooGenericExceptionCaught:MapViewModel.kt:MapViewModel$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MlKitDocTranslator.kt:MlKitDocTranslator$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MlKitMessageTranslator.kt:MlKitMessageTranslator$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SqlTileWriterExt.kt:SqlTileWriterExt$e: Exception</ID>
+    <ID>TooManyFunctions:GeminiNanoDocAssistant.kt:GeminiNanoDocAssistant : AIDocAssistant</ID>
+    <ID>TooManyFunctions:MapView.kt:org.meshtastic.app.map.MapView.kt</ID>
+    <ID>TooManyFunctions:MapViewModel.kt:MapViewModel : BaseMapViewModel</ID>
+    <ID>UtilityClassWithPublicConstructor:CustomTileSource.kt:CustomTileSource</ID>
+    <ID>ViewModelForwarding:MapView.kt:CustomTileProviderManagerSheet(mapViewModel = mapViewModel)</ID>
+    <ID>ViewModelForwarding:MapView.kt:FdroidMainMapFilterDropdown( expanded = mapFilterExpanded, onDismissRequest = { mapFilterExpanded = false }, mapFilterState = mapFilterState, mapViewModel = mapViewModel, )</ID>
+    <ID>ViewModelForwarding:MapView.kt:MainMapContent( nodeClusterItems = nodeClusterItems, mapFilterState = mapFilterState, navigateToNodeDetails = navigateToNodeDetails, displayableWaypoints = displayableWaypoints, myNodeNum = myNodeNum, onEditWaypointRequest = { editingWaypoint = it }, onDeleteWaypointRequest = { deletingWaypoint = it }, onShowGeofenceInfo = { geofenceInfoWaypoint = it }, selectedWaypointId = selectedWaypointId, mapLayers = mapLayers, mapViewModel = mapViewModel, cameraPositionState = cameraPositionState, coroutineScope = coroutineScope, onShowClusterItemsDialog = { showClusterItemsDialog = it }, )</ID>
+    <ID>ViewModelForwarding:MapView.kt:MapFilterDropdown( expanded = mapFilterMenuExpanded, onDismissRequest = { mapFilterMenuExpanded = false }, mapViewModel = mapViewModel, )</ID>
+    <ID>ViewModelForwarding:MapView.kt:MapLayerOverlay(layerItem, mapViewModel)</ID>
+    <ID>ViewModelForwarding:MapView.kt:MapTypeDropdown( expanded = mapTypeMenuExpanded, onDismissRequest = { mapTypeMenuExpanded = false }, mapViewModel = mapViewModel, onManageCustomTileProvidersClick = { mapTypeMenuExpanded = false showCustomTileManagerSheet = true }, )</ID>
+    <ID>ViewModelForwarding:MapView.kt:NodeMapFilterDropdown( expanded = mapFilterMenuExpanded, onDismissRequest = { mapFilterMenuExpanded = false }, mapViewModel = mapViewModel, )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FlavorModule.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/di/FlavorModule.kt
@@ -24,6 +24,7 @@ import org.meshtastic.core.ui.theme.EventFontResolver
 
 @Module(includes = [FdroidAiModule::class])
 class FlavorModule {
+    @Suppress("FunctionOnlyReturningConstant") // Flavor-dispatched: the google flavor returns a different value.
     @Single
     @Named(GOOGLE_SERVICES_AVAILABLE)
     fun googleServicesAvailable(): Boolean = false

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapOverlayRenderer.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/FdroidMapOverlayRenderer.kt
@@ -44,6 +44,11 @@ private const val DEFAULT_GEOJSON_FILL_OPACITY = 0.35f
 private const val DEFAULT_GEOJSON_STROKE_WIDTH = 2f
 private const val OPAQUE = 255
 
+// rgb()/rgba() component-list layout for parseCssColor().
+private const val RGB_PARTS = 3
+private const val RGBA_PARTS = 4
+private const val ALPHA_INDEX = 3
+
 /**
  * F-Droid flavor's map-overlay renderer: turns the shared [MapLayerItem] list into OSMdroid overlays via osmbonuspack's
  * [KmlDocument], honoring per-feature mapbox **simplestyle** (`fill`/`stroke`/`fill-opacity`/`stroke-width`) so
@@ -209,8 +214,8 @@ private fun parseCssColor(raw: String): Int? {
     return try {
         if (value.startsWith("rgb", ignoreCase = true)) {
             val parts = value.substringAfter('(').substringBefore(')').split(',').map { it.trim() }
-            if (parts.size < 3) return null
-            val alpha = if (parts.size >= 4) (parts[3].toFloat() * OPAQUE).roundToInt() else OPAQUE
+            if (parts.size < RGB_PARTS) return null
+            val alpha = if (parts.size >= RGBA_PARTS) (parts[ALPHA_INDEX].toFloat() * OPAQUE).roundToInt() else OPAQUE
             Color.argb(alpha, parts[0].toInt(), parts[1].toInt(), parts[2].toInt())
         } else {
             value.toColorInt() // #hex or named color

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/GetMapViewProvider.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/GetMapViewProvider.kt
@@ -21,4 +21,5 @@ import org.meshtastic.core.ui.util.MapViewProvider
 fun getMapViewProvider(): MapViewProvider = FdroidMapViewProvider()
 
 /** Site Planner (coverage-estimate) — the F-Droid map renders imported coverage as OSMdroid overlays (see #6138). */
+@Suppress("FunctionOnlyReturningConstant") // Flavor-dispatched: the google flavor returns a different value.
 fun sitePlannerAvailable(): Boolean = true

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapView.kt
@@ -102,6 +102,7 @@ import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.geofence.toGeofence
 import org.meshtastic.core.model.isLocked
 import org.meshtastic.core.model.isModifiableBy
+import org.meshtastic.core.model.util.GeoConstants.DEG_D
 import org.meshtastic.core.model.util.toCodePointString
 import org.meshtastic.core.model.util.waypointIconOrDefault
 import org.meshtastic.core.resources.Res
@@ -384,11 +385,11 @@ fun MapView(
                     enableFollowLocation()
                     getBitmapFromVectorDrawable(context, R.drawable.ic_map_location_dot)?.let {
                         setPersonIcon(it)
-                        setPersonAnchor(0.5f, 0.5f)
+                        setPersonAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
                     }
                     getBitmapFromVectorDrawable(context, R.drawable.ic_map_navigation)?.let {
                         setDirectionIcon(it)
-                        setDirectionAnchor(0.5f, 0.5f)
+                        setDirectionAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
                     }
                 }
             overlays.add(myLocationOverlay)
@@ -420,7 +421,7 @@ fun MapView(
     LaunchedEffect(selectedWaypointId, waypoints) {
         if (selectedWaypointId != null && waypoints.containsKey(selectedWaypointId)) {
             waypoints[selectedWaypointId]?.waypoint?.let { pt ->
-                val geoPoint = GeoPoint((pt.latitude_i ?: 0) * 1e-7, (pt.longitude_i ?: 0) * 1e-7)
+                val geoPoint = GeoPoint((pt.latitude_i ?: 0) * DEG_D, (pt.longitude_i ?: 0) * DEG_D)
                 map.controller.setCenter(geoPoint)
                 map.controller.setZoom(WAYPOINT_ZOOM)
             }
@@ -620,9 +621,8 @@ fun MapView(
 
     fun MapView.generateBoxOverlay() {
         overlays.removeAll { it is Polygon && it !is GeofenceOverlayPolygon }
-        val zoomFactor = 1.3
         zoomLevelMin = minOf(zoomLevelDouble, zoomLevelMax)
-        downloadRegionBoundingBox = boundingBox.zoomIn(zoomFactor)
+        downloadRegionBoundingBox = boundingBox.zoomIn(DOWNLOAD_BOX_ZOOM_FACTOR)
         val polygon =
             Polygon().apply {
                 points = Polygon.pointsAsRect(downloadRegionBoundingBox).map { GeoPoint(it.latitude, it.longitude) }
@@ -1198,8 +1198,8 @@ private fun CacheInfoDialog(mapView: MapView, onDismiss: () -> Unit) {
         onDismiss = onDismiss,
         negativeButton = { TextButton(onClick = { onDismiss() }) { Text(text = stringResource(Res.string.close)) } },
     ) {
-        val capacityMb = cacheCapacity / (1024 * 1024)
-        val usageMb = currentCacheUsage / (1024 * 1024)
+        val capacityMb = cacheCapacity / BYTES_PER_MB
+        val usageMb = currentCacheUsage / BYTES_PER_MB
         Text(modifier = Modifier.padding(16.dp), text = stringResource(Res.string.map_cache_info, capacityMb, usageMb))
     }
 }
@@ -1289,6 +1289,8 @@ private const val GEOFENCE_OVERLAY_COLOR = 0xFFFF9800.toInt()
 private const val GEOFENCE_FILL_COLOR = 0x1FFF9800 // ~12% alpha orange
 private const val GEOFENCE_STROKE_WIDTH_PX = 4f
 private const val GEOFENCE_BOX_ZOOM_FACTOR = 1.3
+private const val DOWNLOAD_BOX_ZOOM_FACTOR = 1.3
+private const val BYTES_PER_MB = 1024 * 1024
 
 /** Converts an OSMDroid [BoundingBox] (decimal degrees) to a proto [ProtoBoundingBox] (degrees ×1e7). */
 @Suppress("MagicNumber")

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewExtensions.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/MapViewExtensions.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import org.meshtastic.app.R
+import org.meshtastic.core.model.util.GeoConstants.DEG_D
+import org.meshtastic.core.model.util.GeoConstants.HEADING_DEG
 import org.meshtastic.proto.Position
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
@@ -34,6 +36,13 @@ import org.osmdroid.views.overlay.Polyline
 import org.osmdroid.views.overlay.ScaleBarOverlay
 import org.osmdroid.views.overlay.advancedpolyline.MonochromaticPaintList
 import org.osmdroid.views.overlay.gridlines.LatLonGridlineOverlay2
+
+private const val GRID_LABEL_TEXT_SIZE_PX = 40f
+private const val GRID_LINE_WIDTH_PX = 3.0f
+
+// Track polyline dash pattern (on/off lengths in px), shared by the border and fill paints.
+private const val TRACK_DASH_ON_PX = 80f
+private const val TRACK_DASH_OFF_PX = 60f
 
 /** Adds copyright to map depending on what source is showing */
 fun MapView.addCopyright() {
@@ -56,7 +65,7 @@ fun MapView.createLatLongGrid(enabled: Boolean) {
     if (latLongGridOverlay.isEnabled) {
         val textPaint =
             Paint().apply {
-                textSize = 40f
+                textSize = GRID_LABEL_TEXT_SIZE_PX
                 color = Color.GRAY
                 isAntiAlias = true
                 isFakeBoldText = true
@@ -64,7 +73,7 @@ fun MapView.createLatLongGrid(enabled: Boolean) {
             }
         latLongGridOverlay.textPaint = textPaint
         latLongGridOverlay.setBackgroundColor(Color.TRANSPARENT)
-        latLongGridOverlay.setLineWidth(3.0f)
+        latLongGridOverlay.setLineWidth(GRID_LINE_WIDTH_PX)
         latLongGridOverlay.setLineColor(Color.GRAY)
         overlays.add(latLongGridOverlay)
     }
@@ -99,7 +108,7 @@ fun MapView.addPolyline(density: Density, geoPoints: List<GeoPoint>, onClick: ()
                     style = Paint.Style.STROKE
                     strokeJoin = Paint.Join.ROUND
                     strokeCap = Paint.Cap.ROUND
-                    pathEffect = DashPathEffect(floatArrayOf(80f, 60f), 0f)
+                    pathEffect = DashPathEffect(floatArrayOf(TRACK_DASH_ON_PX, TRACK_DASH_OFF_PX), 0f)
                 }
             outlinePaintLists.add(MonochromaticPaintList(borderPaint))
             val fillPaint =
@@ -110,7 +119,7 @@ fun MapView.addPolyline(density: Density, geoPoints: List<GeoPoint>, onClick: ()
                     style = Paint.Style.FILL_AND_STROKE
                     strokeJoin = Paint.Join.ROUND
                     strokeCap = Paint.Cap.ROUND
-                    pathEffect = DashPathEffect(floatArrayOf(80f, 60f), 0f)
+                    pathEffect = DashPathEffect(floatArrayOf(TRACK_DASH_ON_PX, TRACK_DASH_OFF_PX), 0f)
                 }
             outlinePaintLists.add(MonochromaticPaintList(fillPaint))
             setPoints(geoPoints)
@@ -130,9 +139,9 @@ fun MapView.addPositionMarkers(positions: List<Position>, onClick: (Int) -> Unit
         positions.map { pos ->
             Marker(this).apply {
                 icon = navIcon
-                rotation = ((pos.ground_track ?: 0) * 1e-5).toFloat()
+                rotation = ((pos.ground_track ?: 0) * HEADING_DEG).toFloat()
                 setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
-                position = GeoPoint((pos.latitude_i ?: 0) * 1e-7, (pos.longitude_i ?: 0) * 1e-7)
+                position = GeoPoint((pos.latitude_i ?: 0) * DEG_D, (pos.longitude_i ?: 0) * DEG_D)
                 setOnMarkerClickListener { _, _ ->
                     onClick(pos.time)
                     true

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/component/DownloadButton.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/component/DownloadButton.kt
@@ -33,6 +33,8 @@ import org.meshtastic.core.resources.map_download_region
 import org.meshtastic.core.ui.icon.Download
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 
+private const val DOWNLOAD_ICON_SCALE = 1.25f
+
 @Composable
 fun DownloadButton(enabled: Boolean, onClick: () -> Unit) {
     AnimatedVisibility(
@@ -52,7 +54,7 @@ fun DownloadButton(enabled: Boolean, onClick: () -> Unit) {
             Icon(
                 imageVector = MeshtasticIcons.Download,
                 contentDescription = stringResource(Res.string.map_download_region),
-                modifier = Modifier.scale(1.25f),
+                modifier = Modifier.scale(DOWNLOAD_ICON_SCALE),
             )
         }
     }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/model/MarkerWithLabel.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/model/MarkerWithLabel.kt
@@ -34,6 +34,7 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
         private const val LABEL_Y_OFFSET_DP = 34f
         private const val FONT_SIZE_SP = 14f
         private const val EMOJI_FONT_SIZE_SP = 20f
+        private const val LABEL_BG_HALF_WIDTH_PADDING_PX = 3
     }
 
     private val labelYOffsetPx by lazy { mapView?.context?.dpToPx(LABEL_Y_OFFSET_DP) ?: 100 }
@@ -94,7 +95,7 @@ class MarkerWithLabel(mapView: MapView?, label: String, emoji: String? = null) :
 
     private fun getTextBackgroundSize(text: String, x: Float, y: Float): RectF {
         val fontMetrics = textPaint.fontMetrics
-        val halfTextLength = textPaint.measureText(text) / 2 + 3
+        val halfTextLength = textPaint.measureText(text) / 2 + LABEL_BG_HALF_WIDTH_PADDING_PX
         return RectF((x - halfTextLength), (y + fontMetrics.top), (x + halfTextLength), (y + fontMetrics.bottom))
     }
 

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/model/NOAAWmsTileSource.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/model/NOAAWmsTileSource.kt
@@ -26,6 +26,14 @@ import kotlin.math.atan
 import kotlin.math.pow
 import kotlin.math.sinh
 
+private const val MAX_ZOOM_LEVEL = 5
+private const val TILE_SIZE_PX = 256
+private const val FULL_CIRCLE_DEGREES = 360.0
+private const val MAX_LONGITUDE_DEGREES = 180
+
+// A web Mercator bounding box holds four coordinates: minX, minY, maxX, maxY.
+private const val BBOX_SIZE = 4
+
 open class NOAAWmsTileSource(
     aName: String,
     aBaseUrl: Array<String>,
@@ -38,8 +46,8 @@ open class NOAAWmsTileSource(
 ) : OnlineTileSourceBase(
     aName,
     0,
-    5,
-    256,
+    MAX_ZOOM_LEVEL,
+    TILE_SIZE_PX,
     "png",
     aBaseUrl,
     "",
@@ -86,7 +94,8 @@ open class NOAAWmsTileSource(
         if (time != null) this.time = time
     }
 
-    private fun tile2lon(x: Int, z: Int): Double = x / 2.0.pow(z.toDouble()) * 360.0 - 180
+    private fun tile2lon(x: Int, z: Int): Double =
+        x / 2.0.pow(z.toDouble()) * FULL_CIRCLE_DEGREES - MAX_LONGITUDE_DEGREES
 
     private fun tile2lat(y: Int, z: Int): Double {
         val n = Math.PI - 2.0 * Math.PI * y / 2.0.pow(z.toDouble())
@@ -101,7 +110,7 @@ open class NOAAWmsTileSource(
         val maxx = tileOrigin[origX] + (x + 1) * tileSize
         val miny = tileOrigin[origY] - (y + 1) * tileSize
         val maxy = tileOrigin[origY] - y * tileSize
-        val bbox = DoubleArray(4)
+        val bbox = DoubleArray(BBOX_SIZE)
         bbox[minX] = minx
         bbox[minY] = miny
         bbox[maxX] = maxx

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeTrackMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeTrackMap.kt
@@ -26,7 +26,7 @@ import org.meshtastic.proto.Position
  * Flavor-unified entry point for the embeddable node-track map. Resolves [destNum] to obtain
  * [NodeMapViewModel.mapStyleId], then delegates to the OSMDroid implementation ([NodeTrackOsmMap]).
  *
- * Supports optional synchronized selection via [selectedPositionTime] and [onPositionSelected].
+ * Supports optional synchronized selection via [selectedPositionTime] and [onPositionSelect].
  */
 @Composable
 fun NodeTrackMap(
@@ -34,7 +34,7 @@ fun NodeTrackMap(
     positions: List<Position>,
     modifier: Modifier = Modifier,
     selectedPositionTime: Int? = null,
-    onPositionSelected: ((Int) -> Unit)? = null,
+    onPositionSelect: ((Int) -> Unit)? = null,
 ) {
     val vm = koinViewModel<NodeMapViewModel>()
     vm.setDestNum(destNum)
@@ -43,6 +43,6 @@ fun NodeTrackMap(
         mapStyleId = vm.mapStyleId,
         modifier = modifier,
         selectedPositionTime = selectedPositionTime,
-        onPositionSelected = onPositionSelected,
+        onPositionSelect = onPositionSelect,
     )
 }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeTrackOsmMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/node/NodeTrackOsmMap.kt
@@ -64,7 +64,7 @@ import kotlin.math.roundToInt
  * minimal [MapControlsOverlay][org.meshtastic.feature.map.component.MapControlsOverlay] with a track time filter slider
  * so users can adjust the time range directly from the map.
  *
- * Supports optional synchronized selection via [selectedPositionTime] and [onPositionSelected].
+ * Supports optional synchronized selection via [selectedPositionTime] and [onPositionSelect].
  *
  * Unlike the main [org.meshtastic.app.map.MapView], this composable does **not** include node clusters, waypoints, or
  * location tracking. It is designed to be embedded inside the position-log adaptive layout.
@@ -75,7 +75,7 @@ fun NodeTrackOsmMap(
     mapStyleId: Int,
     modifier: Modifier = Modifier,
     selectedPositionTime: Int? = null,
-    onPositionSelected: ((Int) -> Unit)? = null,
+    onPositionSelect: ((Int) -> Unit)? = null,
     mapViewModel: MapViewModel = koinViewModel(),
 ) {
     val density = LocalDensity.current
@@ -108,7 +108,7 @@ fun NodeTrackOsmMap(
                 map.addCopyright()
                 map.addScaleBarOverlay(density)
                 map.addPolyline(density, geoPoints) {}
-                map.addPositionMarkers(filteredPositions) { time -> onPositionSelected?.invoke(time) }
+                map.addPositionMarkers(filteredPositions) { time -> onPositionSelect?.invoke(time) }
                 // Center on selected position
                 if (selectedPositionTime != null) {
                     val selected = filteredPositions.find { it.time == selectedPositionTime }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/traceroute/TracerouteMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/traceroute/TracerouteMap.kt
@@ -29,13 +29,13 @@ import org.meshtastic.proto.Position
 fun TracerouteMap(
     tracerouteOverlay: TracerouteOverlay?,
     tracerouteNodePositions: Map<Int, Position>,
-    onMappableCountChanged: (shown: Int, total: Int) -> Unit,
+    onMappableCountChange: (shown: Int, total: Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     TracerouteOsmMap(
         tracerouteOverlay = tracerouteOverlay,
         tracerouteNodePositions = tracerouteNodePositions,
-        onMappableCountChanged = onMappableCountChanged,
+        onMappableCountChange = onMappableCountChange,
         modifier = modifier,
     )
 }

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/traceroute/TracerouteOsmMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/map/traceroute/TracerouteOsmMap.kt
@@ -78,7 +78,7 @@ private const val TRACEROUTE_ZOOM_OUT_LEVELS = 0.5
 fun TracerouteOsmMap(
     tracerouteOverlay: TracerouteOverlay?,
     tracerouteNodePositions: Map<Int, Position>,
-    onMappableCountChanged: (shown: Int, total: Int) -> Unit,
+    onMappableCountChange: (shown: Int, total: Int) -> Unit,
     modifier: Modifier = Modifier,
     mapViewModel: MapViewModel = koinViewModel(),
 ) {
@@ -105,7 +105,7 @@ fun TracerouteOsmMap(
     // Report mappable count
     LaunchedEffect(tracerouteOverlay, displayNodes) {
         if (tracerouteOverlay != null) {
-            onMappableCountChanged(displayNodes.size, tracerouteOverlay.relatedNodeNums.size)
+            onMappableCountChange(displayNodes.size, tracerouteOverlay.relatedNodeNums.size)
         }
     }
 

--- a/androidApp/src/fdroid/kotlin/org/meshtastic/app/node/component/InlineMap.kt
+++ b/androidApp/src/fdroid/kotlin/org/meshtastic/app/node/component/InlineMap.kt
@@ -28,6 +28,8 @@ import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 
+private const val INLINE_MAP_ZOOM = 15.0
+
 @Composable
 fun InlineMap(node: Node, modifier: Modifier = Modifier) {
     val context = androidx.compose.ui.platform.LocalContext.current
@@ -42,7 +44,7 @@ fun InlineMap(node: Node, modifier: Modifier = Modifier) {
             setMultiTouchControls(false)
             isTilesScaledToDpi = true
 
-            controller.setZoom(15.0)
+            controller.setZoom(INLINE_MAP_ZOOM)
         }
     }
 

--- a/androidApp/src/google/kotlin/org/meshtastic/app/ai/GeminiNanoDocAssistant.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/ai/GeminiNanoDocAssistant.kt
@@ -194,12 +194,15 @@ class GeminiNanoDocAssistant(
 
             // Rank pages by relevance: full-text content search + keyword/title matching.
             val rankedPages = rankPagesByRelevance(queryTerms, bundle.pages, allContent)
-            Logger.d(tag = TAG) { "Ranked pages: ${rankedPages.take(5).map { "${it.first.id}(${it.second})" }}" }
+            Logger.d(tag = TAG) {
+                "Ranked pages: ${rankedPages.take(RANKED_PAGES_LOG_COUNT).map { "${it.first.id}(${it.second})" }}"
+            }
 
             // Build compact context by extracting only relevant paragraphs.
             val contextResult = buildContext(currentPageId, queryTerms, rankedPages, allContent, MAX_CONTEXT_CHARS)
             Logger.d(tag = TAG) {
-                "Context: ${contextResult.parts.size} pages, ${contextResult.totalChars} chars (budget $MAX_CONTEXT_CHARS)"
+                "Context: ${contextResult.parts.size} pages, " +
+                    "${contextResult.totalChars} chars (budget $MAX_CONTEXT_CHARS)"
             }
 
             prompt = buildPrompt(question, contextResult.parts)
@@ -226,7 +229,7 @@ class GeminiNanoDocAssistant(
                     if (!text.isNullOrEmpty()) {
                         accumulatedText.append(text)
                         val now = System.nanoTime()
-                        val elapsedMs = (now - lastEmitTime) / 1_000_000
+                        val elapsedMs = (now - lastEmitTime) / NANOS_PER_MILLI
                         if (elapsedMs >= STREAM_THROTTLE_MS) {
                             lastEmitTime = now
                             emit(
@@ -483,7 +486,8 @@ class GeminiNanoDocAssistant(
         val metricsInfo =
             if (ourNode != null) {
                 val battery = ourNode.batteryLevel
-                val batteryStr = if (battery != null && battery in 1..100) "$battery%" else "Unknown (External Power)"
+                val batteryStr =
+                    if (battery != null && battery in VALID_BATTERY_RANGE) "$battery%" else "Unknown (External Power)"
                 val voltage = ourNode.voltage
                 val voltStr = if (voltage != null && voltage > 0f) "${voltage}V" else "Unknown"
 
@@ -610,6 +614,15 @@ Guidelines:
 
         /** Minimum interval between partial stream emissions to avoid UI jank. */
         private const val STREAM_THROTTLE_MS = 80L
+
+        /** Nanoseconds per millisecond, for stream-throttle elapsed-time math. */
+        private const val NANOS_PER_MILLI = 1_000_000
+
+        /** Number of top-ranked pages to include in debug logging. */
+        private const val RANKED_PAGES_LOG_COUNT = 5
+
+        /** Battery percentages treated as a real reading; anything else means external power. */
+        private val VALID_BATTERY_RANGE = 1..100
 
         // Scoring weights for page ranking
         private const val CONTENT_MATCH_SCORE = 3

--- a/androidApp/src/google/kotlin/org/meshtastic/app/ai/appfunctions/MeshtasticAppFunctions.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/ai/appfunctions/MeshtasticAppFunctions.kt
@@ -30,6 +30,9 @@ import org.meshtastic.core.data.ai.SendMessageResult
  * Exposes Meshtastic mesh networking capabilities to system AI assistants via the Android App Functions API. Functions
  * declared here are discoverable by the system and can be invoked by AI agents such as Gemini.
  */
+// The AppFunctions calling convention requires every @AppFunction to take AppFunctionContext as
+// its first parameter, even when the implementation never reads it.
+@Suppress("UnusedParameter")
 class MeshtasticAppFunctions(private val provider: AiFunctionProvider) {
 
     /**

--- a/androidApp/src/google/kotlin/org/meshtastic/app/di/AppFunctionsModule.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/di/AppFunctionsModule.kt
@@ -46,5 +46,7 @@ class AppFunctionsModule {
 
     @Single
     @Named(GOOGLE_SERVICES_AVAILABLE)
+    // Flavor-dispatched: the fdroid flavor returns a different value.
+    @Suppress("FunctionOnlyReturningConstant")
     fun googleServicesAvailable(): Boolean = true
 }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/GetMapViewProvider.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/GetMapViewProvider.kt
@@ -21,4 +21,6 @@ import org.meshtastic.core.ui.util.MapViewProvider
 fun getMapViewProvider(): MapViewProvider = GoogleMapViewProvider()
 
 /** Site Planner (coverage-estimate) availability — Google flavor only (the flavor that renders map overlays). */
+// Flavor-dispatched: the fdroid flavor returns a different value.
+@Suppress("FunctionOnlyReturningConstant")
 fun sitePlannerAvailable(): Boolean = true

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MBTilesProvider.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MBTilesProvider.kt
@@ -21,6 +21,9 @@ import com.google.android.gms.maps.model.Tile
 import com.google.android.gms.maps.model.TileProvider
 import java.io.File
 
+/** MBTiles raster tiles are 256x256 pixels. */
+private const val TILE_SIZE_PX = 256
+
 class MBTilesProvider(private val file: File) :
     TileProvider,
     AutoCloseable {
@@ -51,7 +54,7 @@ class MBTilesProvider(private val file: File) :
 
         if (cursor.moveToFirst()) {
             val tileData = cursor.getBlob(0)
-            tile = Tile(256, 256, tileData)
+            tile = Tile(TILE_SIZE_PX, TILE_SIZE_PX, tileData)
         }
         cursor.close()
 

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -694,7 +694,7 @@ fun MapView(
                             displayUnits = displayUnits,
                             myNodeNum = myNodeNum,
                             selectedPositionTime = mode.selectedPositionTime,
-                            onPositionSelected = mode.onPositionSelected,
+                            onPositionSelect = mode.onPositionSelected,
                         )
                     }
                 }
@@ -880,7 +880,7 @@ fun MapView(
                         expanded = mapTypeMenuExpanded,
                         onDismissRequest = { mapTypeMenuExpanded = false },
                         mapViewModel = mapViewModel,
-                        onManageCustomTileProvidersClicked = {
+                        onManageCustomTileProvidersClick = {
                             mapTypeMenuExpanded = false
                             showCustomTileManagerSheet = true
                         },
@@ -1172,7 +1172,7 @@ private fun WaypointGeofenceOverlay(waypoint: Waypoint) {
  * [TripOrigin] dot with an info-window on tap.
  *
  * When [selectedPositionTime] matches a marker's `Position.time`, that marker is highlighted with the primary color and
- * elevated z-index. Tapping a marker invokes [onPositionSelected] for list synchronization.
+ * elevated z-index. Tapping a marker invokes [onPositionSelect] for list synchronization.
  */
 @OptIn(MapsComposeExperimentalApi::class)
 @Composable
@@ -1183,7 +1183,7 @@ private fun NodeTrackOverlay(
     displayUnits: DisplayUnits,
     myNodeNum: Int?,
     selectedPositionTime: Int? = null,
-    onPositionSelected: ((Int) -> Unit)? = null,
+    onPositionSelect: ((Int) -> Unit)? = null,
 ) {
     val isHighPriority = focusedNode.num == myNodeNum || focusedNode.isFavorite
     val activeNodeZIndex = if (isHighPriority) 5f else 4f
@@ -1212,7 +1212,7 @@ private fun NodeTrackOverlay(
                     zIndex = activeNodeZIndex,
                     alpha = if (isHighPriority) 1.0f else 0.9f,
                     onClick = {
-                        onPositionSelected?.invoke(position.time)
+                        onPositionSelect?.invoke(position.time)
                         false // Allow default info window behavior
                     },
                 ) {
@@ -1225,7 +1225,7 @@ private fun NodeTrackOverlay(
                     snippet = formatAgo(position.time),
                     zIndex = if (isSelected) activeNodeZIndex - 0.5f else 1f + alpha,
                     onClick = {
-                        onPositionSelected?.invoke(position.time)
+                        onPositionSelect?.invoke(position.time)
                         false // Allow default info window behavior
                     },
                     infoContent = { PositionInfoWindowContent(position = position, displayUnits = displayUnits) },

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -137,8 +137,7 @@ class MapViewModel(
                                 (waypoint.latitude_i ?: 0) / WAYPOINT_COORD_SCALE,
                                 (waypoint.longitude_i ?: 0) / WAYPOINT_COORD_SCALE,
                             )
-                        cameraPositionState.position =
-                            CameraPosition.fromLatLngZoom(latLng, WAYPOINT_FOCUS_ZOOM)
+                        cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, WAYPOINT_FOCUS_ZOOM)
                     }
                 }
             }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapViewModel.kt
@@ -70,6 +70,12 @@ import kotlin.uuid.Uuid
 
 private const val TILE_SIZE = 256
 
+/** Waypoint coordinates arrive as integer degrees scaled by 1e7. */
+private const val WAYPOINT_COORD_SCALE = 1e7
+
+/** Camera zoom applied when centering on a selected waypoint. */
+private const val WAYPOINT_FOCUS_ZOOM = 15f
+
 enum class CameraInitialization {
     Loading,
     FitNodes,
@@ -126,8 +132,13 @@ class MapViewModel(
                     val wpMap = waypoints.first { it.containsKey(id) }
                     wpMap[id]?.let { packet ->
                         val waypoint = packet.waypoint!!
-                        val latLng = LatLng((waypoint.latitude_i ?: 0) / 1e7, (waypoint.longitude_i ?: 0) / 1e7)
-                        cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 15f)
+                        val latLng =
+                            LatLng(
+                                (waypoint.latitude_i ?: 0) / WAYPOINT_COORD_SCALE,
+                                (waypoint.longitude_i ?: 0) / WAYPOINT_COORD_SCALE,
+                            )
+                        cameraPositionState.position =
+                            CameraPosition.fromLatLngZoom(latLng, WAYPOINT_FOCUS_ZOOM)
                     }
                 }
             }
@@ -405,8 +416,12 @@ class MapViewModel(
                 val wpMap = waypoints.first { it.containsKey(wpId) }
                 wpMap[wpId]?.let { packet ->
                     val waypoint = packet.waypoint!!
-                    val latLng = LatLng((waypoint.latitude_i ?: 0) / 1e7, (waypoint.longitude_i ?: 0) / 1e7)
-                    cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 15f)
+                    val latLng =
+                        LatLng(
+                            (waypoint.latitude_i ?: 0) / WAYPOINT_COORD_SCALE,
+                            (waypoint.longitude_i ?: 0) / WAYPOINT_COORD_SCALE,
+                        )
+                    cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, WAYPOINT_FOCUS_ZOOM)
                 }
             }
         }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/MapTypeDropdown.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/MapTypeDropdown.kt
@@ -47,7 +47,7 @@ internal fun MapTypeDropdown(
     expanded: Boolean,
     onDismissRequest: () -> Unit,
     mapViewModel: MapViewModel,
-    onManageCustomTileProvidersClicked: () -> Unit,
+    onManageCustomTileProvidersClick: () -> Unit,
 ) {
     val customTileProviders by mapViewModel.customTileProviderConfigs.collectAsStateWithLifecycle()
     val selectedCustomProviderId by mapViewModel.selectedCustomTileProviderId.collectAsStateWithLifecycle()
@@ -112,7 +112,7 @@ internal fun MapTypeDropdown(
         DropdownMenuItem(
             text = { Text(stringResource(Res.string.manage_custom_tile_sources)) },
             onClick = {
-                onManageCustomTileProvidersClicked()
+                onManageCustomTileProvidersClick()
                 onDismissRequest()
             },
         )

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/component/PulsingNodeChip.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/component/PulsingNodeChip.kt
@@ -33,12 +33,18 @@ import org.meshtastic.core.common.util.nowSeconds
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.ui.component.NodeChip
 
+/** Pulse only for nodes heard within this many seconds. */
+private const val RECENTLY_HEARD_SECONDS = 5
+
+/** Peak alpha of the pulse highlight before it fades out. */
+private const val PULSE_MAX_ALPHA = 0.3f
+
 @Composable
 fun PulsingNodeChip(node: Node, modifier: Modifier = Modifier) {
     val animatedProgress = remember { Animatable(0f) }
 
     LaunchedEffect(node) {
-        if ((nowSeconds - node.lastHeard) <= 5) {
+        if ((nowSeconds - node.lastHeard) <= RECENTLY_HEARD_SECONDS) {
             launch {
                 animatedProgress.snapTo(0f)
                 animatedProgress.animateTo(
@@ -54,7 +60,7 @@ fun PulsingNodeChip(node: Node, modifier: Modifier = Modifier) {
         modifier.drawWithContent {
             drawContent()
             if (animatedProgress.value > 0 && animatedProgress.value < 1f) {
-                val alpha = (1f - animatedProgress.value) * 0.3f
+                val alpha = (1f - animatedProgress.value) * PULSE_MAX_ALPHA
                 drawRoundRect(
                     size = size,
                     cornerRadius = CornerRadius(8.dp.toPx()),

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/model/CustomTileSource.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/model/CustomTileSource.kt
@@ -19,7 +19,10 @@ package org.meshtastic.app.map.model
 class CustomTileSource {
 
     companion object {
-        // No-op stub for the Google flavor (osmdroid tile sources are fdroid-only).
-        fun getTileSource(index: Int) {}
+        // Signature mirrors the fdroid flavor's osmdroid-backed implementation.
+        @Suppress("UnusedParameter")
+        fun getTileSource(index: Int) {
+            // No-op stub for the Google flavor (osmdroid tile sources are fdroid-only).
+        }
     }
 }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/node/NodeTrackMap.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/node/NodeTrackMap.kt
@@ -32,7 +32,7 @@ import org.meshtastic.proto.Position
  * which provides the full shared map infrastructure (location tracking, tile providers, controls overlay with track
  * filter).
  *
- * Supports optional synchronized selection via [selectedPositionTime] and [onPositionSelected].
+ * Supports optional synchronized selection via [selectedPositionTime] and [onPositionSelect].
  */
 @Composable
 fun NodeTrackMap(
@@ -40,7 +40,7 @@ fun NodeTrackMap(
     positions: List<Position>,
     modifier: Modifier = Modifier,
     selectedPositionTime: Int? = null,
-    onPositionSelected: ((Int) -> Unit)? = null,
+    onPositionSelect: ((Int) -> Unit)? = null,
 ) {
     val vm = koinViewModel<NodeMapViewModel>()
     vm.setDestNum(destNum)
@@ -52,7 +52,7 @@ fun NodeTrackMap(
             focusedNode = focusedNode,
             positions = positions,
             selectedPositionTime = selectedPositionTime,
-            onPositionSelected = onPositionSelected,
+            onPositionSelected = onPositionSelect,
         ),
     )
 }

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/traceroute/TracerouteMap.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/traceroute/TracerouteMap.kt
@@ -31,7 +31,7 @@ import org.meshtastic.proto.Position
 fun TracerouteMap(
     tracerouteOverlay: TracerouteOverlay?,
     tracerouteNodePositions: Map<Int, Position>,
-    onMappableCountChanged: (shown: Int, total: Int) -> Unit,
+    onMappableCountChange: (shown: Int, total: Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     MapView(
@@ -40,7 +40,7 @@ fun TracerouteMap(
         GoogleMapMode.Traceroute(
             overlay = tracerouteOverlay,
             nodePositions = tracerouteNodePositions,
-            onMappableCountChanged = onMappableCountChanged,
+            onMappableCountChanged = onMappableCountChange,
         ),
     )
 }

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
@@ -242,7 +242,7 @@ class MainActivity : AppCompatActivity() {
                     org.meshtastic.app.map.traceroute.TracerouteMap(
                         tracerouteOverlay = overlay,
                         tracerouteNodePositions = nodePositions,
-                        onMappableCountChanged = onMappableCountChanged,
+                        onMappableCountChange = onMappableCountChanged,
                         modifier = modifier,
                     )
                 },

--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Detekt.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/Detekt.kt
@@ -40,7 +40,10 @@ internal fun Project.configureDetekt(extension: DetektExtension) = extension.app
         baseline.set(baselineFile)
     }
 
-    // Default sources
+    // Default sources. Every production source set that ships code must be listed explicitly — detekt silently
+    // skips anything not named here, which is how src/fdroid, src/google, src/iosMain, and src/jvmAndroidMain
+    // went unanalyzed for as long as only the main/common sets were listed. (Test source sets are deliberately
+    // not scanned, matching the original list.)
     source.setFrom(
         files(
             "src/main/java",
@@ -48,6 +51,12 @@ internal fun Project.configureDetekt(extension: DetektExtension) = extension.app
             "src/commonMain/kotlin",
             "src/androidMain/kotlin",
             "src/jvmMain/kotlin",
+            "src/jvmAndroidMain/kotlin",
+            "src/iosMain/kotlin",
+            "src/fdroid/java",
+            "src/fdroid/kotlin",
+            "src/google/java",
+            "src/google/kotlin",
         ),
     )
 

--- a/core/takserver/detekt-baseline.xml
+++ b/core/takserver/detekt-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:ZipArchiver.kt:ZipArchiver$actual fun createZip: ByteArray</ID>
+    <ID>ReturnCount:TAKServerJvm.kt:TAKServerJvm$override suspend fun start: Result&lt;Unit></ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/core/takserver/src/jvmAndroidMain/kotlin/org/meshtastic/core/takserver/TAKServerJvm.kt
+++ b/core/takserver/src/jvmAndroidMain/kotlin/org/meshtastic/core/takserver/TAKServerJvm.kt
@@ -39,6 +39,9 @@ import kotlin.concurrent.withLock
 import kotlin.random.Random
 import kotlinx.coroutines.isActive as coroutineIsActive
 
+/** Listen-socket backlog; a handful of pending connections is plenty for local TAK clients. */
+private const val SERVER_SOCKET_BACKLOG = 4
+
 /**
  * JSSE-backed TLS TAK server. Matches the Meshtastic-Apple (iOS) implementation:
  * - Binds `127.0.0.1:8089` (loopback only — no remote device can reach the server)
@@ -92,8 +95,7 @@ internal class TAKServerJvm(private val dispatchers: CoroutineDispatchers, priva
                     val factory = sslContext.serverSocketFactory
                     // Use the address-specific overload so we bind to loopback only.
                     val loopback = InetAddress.getByName("127.0.0.1")
-                    // backlog of 4 is plenty for local TAK clients
-                    val tls = factory.createServerSocket(port, 4, loopback) as SSLServerSocket
+                    val tls = factory.createServerSocket(port, SERVER_SOCKET_BACKLOG, loopback) as SSLServerSocket
                     configureTlsServerSocket(tls)
                     tls
                 }

--- a/core/testing/src/iosMain/kotlin/org/meshtastic/core/testing/TestUtils.ios.kt
+++ b/core/testing/src/iosMain/kotlin/org/meshtastic/core/testing/TestUtils.ios.kt
@@ -16,4 +16,6 @@
  */
 package org.meshtastic.core.testing
 
-actual fun setupTestContext() {}
+actual fun setupTestContext() {
+    // No-op: iOS tests need no context setup.
+}

--- a/core/ui/detekt-baseline.xml
+++ b/core/ui/detekt-baseline.xml
@@ -71,6 +71,8 @@
     <ID>ParameterNaming:EmojiPickerDialog.kt:onCategoryChanged: (Int) -> Unit</ID>
     <ID>ParameterNaming:EmojiPickerDialog.kt:onCategorySelected: (Int) -> Unit</ID>
     <ID>ParameterNaming:EmojiPickerDialog.kt:onEmojiSelected: (String) -> Unit</ID>
+    <ID>ParameterNaming:NoopStubs.kt:onUriReceived: (CommonUri) -> Unit</ID>
+    <ID>ParameterNaming:NoopStubs.kt:onUriReceived: (CommonUri?) -> Unit</ID>
     <ID>ParameterNaming:PlatformUtils.kt:onUriReceived: (CommonUri) -> Unit</ID>
     <ID>ParameterNaming:PlatformUtils.kt:onUriReceived: (CommonUri?) -> Unit</ID>
     <ID>ParameterNaming:PlatformUtils.kt:onUriReceived: (org.meshtastic.core.common.util.CommonUri) -> Unit</ID>
@@ -115,6 +117,7 @@
     <ID>PreviewPublic:SwitchPreference.kt:@Preview(showBackground = true) @Composable fun SwitchPreferencePreview</ID>
     <ID>PreviewPublic:TextDividerPreference.kt:@Preview(showBackground = true) @Composable fun TextDividerPreferencePreview</ID>
     <ID>PreviewPublic:TitledCard.kt:@PreviewLightDark @Composable fun TitledCardPreview</ID>
+    <ID>TooManyFunctions:NoopStubs.kt:org.meshtastic.core.ui.util.NoopStubs.kt</ID>
     <ID>ViewModelForwarding:MeshtasticAppShell.kt:MeshtasticCommonAppSetup( uiViewModel = uiViewModel, onNavigateToTracerouteMap = { destNum, requestId, logUuid -> multiBackstack.handleDeepLink( listOf( NodesRoute.Nodes, NodeDetailRoute.TracerouteMap(destNum = destNum, requestId = requestId, logUuid = logUuid), ), ) }, )</ID>
     <ID>ViewModelForwarding:MeshtasticCommonAppSetup.kt:FirmwareVersionCheck(viewModel = uiViewModel)</ID>
     <ID>ViewModelForwarding:MeshtasticCommonAppSetup.kt:SharedDialogs(uiViewModel = uiViewModel)</ID>

--- a/core/ui/src/iosMain/kotlin/org/meshtastic/core/ui/util/NoopStubs.kt
+++ b/core/ui/src/iosMain/kotlin/org/meshtastic/core/ui/util/NoopStubs.kt
@@ -50,7 +50,10 @@ actual fun rememberOpenFileLauncher(onUriReceived: (CommonUri?) -> Unit): (mimeT
 
 @Composable actual fun rememberReadTextFromUri(): suspend (uri: CommonUri, maxChars: Int) -> String? = { _, _ -> null }
 
-@Composable actual fun KeepScreenOn(enabled: Boolean) {}
+@Composable
+actual fun KeepScreenOn(enabled: Boolean) {
+    // No-op iOS stub.
+}
 
 @Composable actual fun rememberOpenLocationSettings(): () -> Unit = {}
 
@@ -64,7 +67,10 @@ actual fun rememberOpenFileLauncher(onUriReceived: (CommonUri?) -> Unit): (mimeT
 
 @Composable actual fun isWifiUnavailable(): Boolean = false
 
-@Composable actual fun SetScreenBrightness(brightness: Float) {}
+@Composable
+actual fun SetScreenBrightness(brightness: Float) {
+    // No-op iOS stub.
+}
 
 @Composable actual fun rememberOpenAppSettings(): () -> Unit = {}
 

--- a/feature/settings/detekt-baseline.xml
+++ b/feature/settings/detekt-baseline.xml
@@ -21,7 +21,6 @@
     <ID>LongMethod:DetectionSensorConfigItemList.kt:@Composable fun DetectionSensorConfigScreen</ID>
     <ID>LongMethod:LoRaConfigItemList.kt:@Composable fun LoRaConfigScreen</ID>
     <ID>LongMethod:PowerConfigItemList.kt:@Composable fun PowerConfigScreen</ID>
-    <ID>LongMethod:RadioConfigViewModel.kt:RadioConfigViewModel$fun setResponseStateLoading</ID>
     <ID>LongMethod:RadioConfigViewModel.kt:RadioConfigViewModel$private fun processPacketResponse</ID>
     <ID>LongMethod:SecurityConfigScreen.android.kt:@Composable actual fun SecurityKeyBackupActions</ID>
     <ID>LongMethod:SerialConfigItemList.kt:@Composable fun SerialConfigScreen</ID>
@@ -38,17 +37,16 @@
     <ID>MagicNumber:EditDeviceProfileDialog.kt:ProfileField.FIXED_POSITION$6</ID>
     <ID>MagicNumber:EditDeviceProfileDialog.kt:ProfileField.MODULE_CONFIG$5</ID>
     <ID>ModifierClickableOrder:ChannelScreen.kt:clickable(onClick = onClick)</ID>
+    <ID>ModifierMissing:AcknowledgementsScreen.kt:@Composable fun AcknowledgementsScreen</ID>
     <ID>ModifierMissing:AdministrationScreen.kt:@Composable fun AdministrationScreen</ID>
     <ID>ModifierMissing:AmbientLightingConfigItemList.kt:@Composable fun AmbientLightingConfigScreen</ID>
     <ID>ModifierMissing:AppInfoSection.kt:@Composable fun AppInfoSection</ID>
-    <ID>ModifierMissing:AcknowledgementsScreen.kt:@Composable fun AcknowledgementsScreen</ID>
     <ID>ModifierMissing:AudioConfigItemList.kt:@Composable fun AudioConfigScreen</ID>
     <ID>ModifierMissing:BluetoothConfigItemList.kt:@Composable fun BluetoothConfigScreen</ID>
     <ID>ModifierMissing:CannedMessageConfigItemList.kt:@Suppress("DEPRECATION", "LongMethod") @Composable fun CannedMessageConfigScreen</ID>
     <ID>ModifierMissing:ChannelConfigScreen.kt:@Composable fun ChannelConfigScreen</ID>
     <ID>ModifierMissing:ChannelScreen.kt:@Composable @Suppress("LongMethod") fun ChannelScreen</ID>
     <ID>ModifierMissing:CleanNodeDatabaseScreen.kt:@Composable fun CleanNodeDatabaseScreen</ID>
-    <ID>ModifierMissing:Debug.kt:@Suppress("LongMethod") @Composable fun DebugScreen</ID>
     <ID>ModifierMissing:DesktopSettingsScreen.kt:@Suppress("LongMethod") @Composable fun DesktopSettingsScreen</ID>
     <ID>ModifierMissing:DetectionSensorConfigItemList.kt:@Composable fun DetectionSensorConfigScreen</ID>
     <ID>ModifierMissing:DeviceConfigScreen.kt:@Suppress("DEPRECATION", "LongMethod") @Composable fun DeviceConfigScreenCommon</ID>
@@ -76,10 +74,8 @@
     <ID>ModifierMissing:SettingsScreen.kt:@Suppress("LongMethod", "CyclomaticComplexMethod") @Composable fun SettingsScreen</ID>
     <ID>ModifierMissing:StatusMessageConfigItemList.kt:@Composable fun StatusMessageConfigScreen</ID>
     <ID>ModifierMissing:StoreForwardConfigItemList.kt:@Composable fun StoreForwardConfigScreen</ID>
-    <ID>ModifierMissing:TAKConfigItemList.kt:@Composable fun TAKConfigScreen</ID>
     <ID>ModifierMissing:TelemetryConfigItemList.kt:@Composable fun TelemetryConfigScreen</ID>
     <ID>ModifierMissing:ThemePickerDialog.kt:@Composable fun ThemePickerDialog</ID>
-    <ID>ModifierMissing:TrafficManagementConfigItemList.kt:@Suppress("LongMethod") @Composable fun TrafficManagementConfigScreen</ID>
     <ID>ModifierMissing:UserConfigItemList.kt:@Composable fun UserConfigScreen</ID>
     <ID>MultipleEmitters:MQTTConfigItemList.kt:@Composable private fun MqttAddressAndProbe</ID>
     <ID>MultipleEmitters:PacketResponseStateDialog.kt:@Composable private fun ErrorContent</ID>
@@ -90,6 +86,7 @@
     <ID>ParameterNaming:CleanNodeDatabaseScreen.kt:onCheckedChanged: (Boolean) -> Unit</ID>
     <ID>ParameterNaming:CleanNodeDatabaseScreen.kt:onDaysChanged: (Float) -> Unit</ID>
     <ID>ParameterNaming:ExternalNotificationConfigScreen.android.kt:onRingtoneImported: (String) -> Unit</ID>
+    <ID>ParameterNaming:ExternalNotificationConfigScreen.ios.kt:onRingtoneImported: (String) -> Unit</ID>
     <ID>ParameterNaming:ExternalNotificationConfigScreen.jvm.kt:onRingtoneImported: (String) -> Unit</ID>
     <ID>ParameterNaming:ExternalNotificationConfigScreen.kt:onRingtoneImported: (String) -> Unit</ID>
     <ID>ParameterNaming:MapReportingPreference.kt:onMapReportingEnabledChanged: (Boolean) -> Unit = {}</ID>
@@ -97,6 +94,7 @@
     <ID>ParameterNaming:MapReportingPreference.kt:onPublishIntervalSecsChanged: (Int) -> Unit = {}</ID>
     <ID>ParameterNaming:MapReportingPreference.kt:onShouldReportLocationChanged: (Boolean) -> Unit = {}</ID>
     <ID>ParameterNaming:PositionConfigScreen.android.kt:onLocationReceived: (Position) -> Unit</ID>
+    <ID>ParameterNaming:PositionConfigScreen.ios.kt:onLocationReceived: (Position) -> Unit</ID>
     <ID>ParameterNaming:PositionConfigScreen.jvm.kt:onLocationReceived: (Position) -> Unit</ID>
     <ID>ParameterNaming:PositionConfigScreen.kt:onLocationReceived: (Position) -> Unit</ID>
     <ID>PreviewPublic:AppInfoSection.kt:@Preview(showBackground = true) @Composable fun AppInfoSectionPreview</ID>
@@ -108,8 +106,6 @@
     <ID>TooGenericExceptionCaught:DebugViewModel.kt:DebugViewModel$e: Exception</ID>
     <ID>TooManyFunctions:RadioConfigViewModel.kt:RadioConfigViewModel : ViewModel</ID>
     <ID>ViewModelForwarding:AdministrationScreen.kt:AdminRouteItems(viewModel = viewModel, enabled = enabled, state = state, destNode = destNode)</ID>
-    <ID>ViewModelForwarding:Debug.kt:DebugLogSettings(viewModel = viewModel)</ID>
-    <ID>ViewModelForwarding:Debug.kt:DebugSearchStateWithViewModel( viewModel = viewModel, modifier = Modifier.graphicsLayer(alpha = animatedAlpha), searchState = searchState, filterTexts = filterTexts, presetFilters = viewModel.presetFilters, logs = logs, filterMode = filterMode, onFilterModeChange = { filterMode = it }, onExportLogs = { val format = LocalDateTime.Format { year() monthNumber() day() char('_') hour() minute() second() } val timestamp = fromEpochMilliseconds(nowMillis).toLocalDateTime(TimeZone.UTC).format(format) val fileName = "meshtastic_debug_$timestamp.txt" exportLogsLauncher(fileName) }, )</ID>
     <ID>ViewModelForwarding:PositionConfigScreen.kt:DeviceLocationButton( viewModel = viewModel, enabled = state.connected, onLocationReceived = { locationInput = it }, )</ID>
     <ID>ViewModelForwarding:SecurityConfigScreen.kt:SecurityKeyBackupActions( viewModel = viewModel, enabled = state.connected, securityConfig = securityConfig, )</ID>
   </CurrentIssues>


### PR DESCRIPTION
detekt's source list in the convention plugin only named `src/main`, `src/commonMain`, `src/androidMain`, and `src/jvmMain` — so despite the zero-lint gate, four production source sets were never analyzed at all:

| Source set | Files never scanned |
|---|---|
| `src/fdroid` + `src/google` | 75 (androidApp, core:barcode) |
| `src/iosMain` | 29 (12 KMP modules) |
| `src/jvmAndroidMain` | 14 |

Turning them on surfaced ~150 accumulated violations. This PR fixes the mechanical ones and baselines the structural rest, per the existing per-module-baseline convention (`Detekt.kt`'s own comment: remove baselines incrementally as modules are cleaned up). Test source sets remain unscanned, matching the original list's policy.

(Found while working on #6834 — an adversarial review of that branch noticed its new fdroid-flavor code was never being linted.)

### 🧹 Chores
- **`Detekt.kt`**: list every production source set that ships code, with a comment explaining why explicitness matters here.
- **Fixed (~66 violations, no behavior change):**
  - `MagicNumber` (~45): named constants across both flavors' map/AI code and `core:takserver`, reusing canonical values where they exist (`Marker.ANCHOR_CENTER`, `GeoConstants.DEG_D`/`HEADING_DEG`).
  - `ParameterNaming` (3 renames): `onPositionSelect`, `onMappableCountChange`, `onManageCustomTileProvidersClick` — kept identical across the fdroid/google flavor pairs, all named-argument call sites updated (incl. `MainActivity`).
  - `FunctionOnlyReturningConstant` (4): suppressed with rationale — flavor-dispatch functions whose counterpart returns a different constant, so the function-ness is load-bearing.
  - `UnusedParameter` in `MeshtasticAppFunctions`: class-level suppress — the androidx AppFunctions calling convention requires the `AppFunctionContext` parameter.
  - `EmptyFunctionBlock` (3) in iOS no-op stubs, one `MaxLineLength` wrap.
- **Baselined (structural refactors, not drive-by material):** androidApp's 58 remaining flavor findings (`LongMethod`, complexity, `ViewModelForwarding`, `TooGenericExceptionCaught`, `ThrowsCount`, …) plus small counts in `core:ui`, `core:takserver`, `feature:settings`. The `ParameterNaming` hits on iosMain `actual` functions stay baselined deliberately: renaming an `actual`'s parameters desyncs the commonMain `expect` declaration, and renaming both sides is a public-API refactor. `core:testing`'s baseline held exactly one now-fixed entry, so it's deleted.

### Testing Performed
- `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — fully green (`kmpSmokeCompile` included because iosMain files changed and must still compile for the iOS targets).
- From here on, any new violation in the 118 newly covered files fails the build like everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized map-related callback names and configuration labels.
  - Replaced scattered numeric values with descriptive shared constants, preserving existing map, routing, and visualization behavior.
  - Clarified platform-specific no-op implementations and service availability handling.

- **Chores**
  - Expanded static-analysis coverage and updated baselines across Android, iOS, and shared modules.
  - Improved inline documentation and lint-warning handling.
  - No functional changes or visible interface changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->