### PR TITLE
fix(mqtt): tolerate object-typed payload in MQTT JSON messages

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/MqttJsonPayload.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/MqttJsonPayload.kt
@@ -18,6 +18,10 @@ package org.meshtastic.core.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonTransformingSerializer
 
 @Serializable
 data class MqttJsonPayload(
@@ -25,10 +29,17 @@ data class MqttJsonPayload(
     val from: Long,
     val to: Long? = null,
     val channel: Int? = null,
-    val payload: String? = null,
+    @Serializable(with = MqttPayloadStringSerializer::class) val payload: String? = null,
     @SerialName("hop_limit") val hopLimit: Int? = null,
     val id: Long? = null,
     val time: Long? = null,
     val sender: String? = null,
     // Add other fields as needed for position/telemetry
 )
+
+// Firmware and MQTT bridges send "payload" as a string for text messages but as a nested JSON
+// object for position/telemetry/map reports; coerce non-strings to their compact JSON text.
+private object MqttPayloadStringSerializer : JsonTransformingSerializer<String>(String.serializer()) {
+    override fun transformDeserialize(element: JsonElement): JsonElement =
+        if (element is JsonPrimitive && element.isString) element else JsonPrimitive(element.toString())
+}

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/MqttJsonPayloadTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/MqttJsonPayloadTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Locks down the tolerant "payload" decoding: string, nested object, and null/absent must all parse. */
+class MqttJsonPayloadTest {
+
+    // Matches the decode-relevant MQTTRepositoryImpl config.
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun string_payload_decodes_unchanged() {
+        val jsonStr =
+            """{"type":"text","from":12345678,"to":4294967295,"payload":"Hello World","hop_limit":3,"id":123}"""
+        val decoded = json.decodeFromString<MqttJsonPayload>(jsonStr)
+
+        assertEquals("text", decoded.type)
+        assertEquals(12345678L, decoded.from)
+        assertEquals("Hello World", decoded.payload)
+    }
+
+    @Test
+    fun object_payload_decodes_to_compact_json_text() {
+        val jsonStr =
+            """{"type":"position","from":12345678,"payload":{"latitude_i":123456789,"longitude_i":-987654321,"time":1600000000}}"""
+        val decoded = json.decodeFromString<MqttJsonPayload>(jsonStr)
+
+        assertEquals("position", decoded.type)
+        assertEquals("""{"latitude_i":123456789,"longitude_i":-987654321,"time":1600000000}""", decoded.payload)
+    }
+
+    @Test
+    fun null_payload_decodes_to_null() {
+        val decoded = json.decodeFromString<MqttJsonPayload>("""{"type":"text","from":1,"payload":null}""")
+        assertNull(decoded.payload)
+    }
+
+    @Test
+    fun absent_payload_decodes_to_null() {
+        val decoded = json.decodeFromString<MqttJsonPayload>("""{"type":"text","from":1}""")
+        assertNull(decoded.payload)
+    }
+
+    @Test
+    fun array_payload_decodes_to_compact_json_text() {
+        val decoded = json.decodeFromString<MqttJsonPayload>("""{"type":"text","from":1,"payload":[1,2]}""")
+        assertEquals("[1,2]", decoded.payload)
+    }
+
+    @Test
+    fun non_string_primitive_payload_is_coerced_to_text() {
+        val decoded = json.decodeFromString<MqttJsonPayload>("""{"type":"text","from":1,"payload":42}""")
+        assertEquals("42", decoded.payload)
+    }
+
+    @Test
+    fun string_payload_round_trips_as_string() {
+        val encoded =
+            json.encodeToString(MqttJsonPayload.serializer(), MqttJsonPayload(type = "text", from = 1, payload = "hi"))
+        assertTrue(encoded.contains(""""payload":"hi""""))
+    }
+
+    @Test
+    fun garbage_input_still_fails() {
+        assertFailsWith<SerializationException> { json.decodeFromString<MqttJsonPayload>("""{"from":"not json""") }
+    }
+}


### PR DESCRIPTION
## Why

Crashlytics `31a6a0931012d08caf0c22f8505abad9` is the third-highest-volume issue on 2.8.1: 186 users / 3,763 events (and ~3.5% of Datadog RUM sessions carry the same signature). `MqttJsonPayload` declares `payload` as `String?`, but the firmware's own JSON MQTT output publishes `payload` as a nested JSON object for position, telemetry, nodeinfo, and map-report messages (only text messages use a string). Every JSON-enabled gateway therefore threw `JsonDecodingException` on most uplinks, and the message was dropped instead of proxied.

The decode at `MQTTRepositoryImpl.processMessage` is a pure validation gate: its result is discarded and the raw JSON text is forwarded verbatim, so the old strictness bought nothing and silently broke a documented firmware feature (JSON `sendposition` downlink commands, which carry object payloads, were dropped by the phone in client-proxy mode).

## What

`payload` now uses a private `JsonTransformingSerializer` that passes string primitives through unchanged and coerces objects, arrays, and non-string primitives to their compact JSON text. Null/absent stay null; genuinely malformed JSON still fails as before. No consumer change needed: the field keeps its `String?` type, and the forwarded raw text is byte-identical to today.

Behavior note for reviewers: messages that previously failed decode are now forwarded to the radio. On current firmware these are uplinks the node already receives elsewhere (it logs and drops invalid envelopes); the user-visible win is that JSON downlink commands work again. Opted-in (`json_enabled`) gateways will see somewhat more BLE proxy traffic.

## Testing Performed

- 8 new unit tests in `core/model` commonTest covering the string/object/array/primitive/null/absent/garbage matrix, executed on both `jvmTest` and `testAndroidHostTest` (JUnit XML checked for masked failures).
- Full local baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` all green in a clean worktree.
- Two independent adversarial reviews (correctness/regression and conventions/constitution) both returned APPROVE; the correctness pass verified the serializer semantics against kotlinx-serialization 1.11.0 sources and traced the forwarding path through firmware `MQTT.cpp` on both current and pre-#10152 firmware.

## Constitution Check

All seven principles evaluated: I KMP purity (commonMain, kotlinx-serialization only); II zero lint (spotless + detekt clean); III CMP UI (no UI change); IV privacy (no logging change, no proto edits); V design standards (N/A, no UI); VI documentation freshness (no user-facing docs affected); VII verify before push (full baseline run locally; CI to be confirmed on this PR after push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
