### PR TITLE
fix(firmware): map SoftDevice variants for the new nrf52840 boards

### DIFF
--- a/androidApp/src/main/assets/device_bootloader_ota_quirks.json
+++ b/androidApp/src/main/assets/device_bootloader_ota_quirks.json
@@ -32,7 +32,9 @@
       "hwModel": 9,
       "hwModelSlug": "RAK4631",
       "platformioTargets": [
-        "rak4631"
+        "rak4631",
+        "rak_wismesh_pocket",
+        "rak_wismesh_repeater_mini"
       ],
       "softDevice": "6.1.1"
     },
@@ -217,7 +219,8 @@
       "hwModel": 117,
       "hwModelSlug": "RAK3401",
       "platformioTargets": [
-        "rak3401-1watt"
+        "rak3401-1watt",
+        "rak_wismesh_repeater_mini_hp"
       ],
       "softDevice": "6.1.1"
     },
@@ -275,6 +278,22 @@
         "t-echo-card"
       ],
       "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 139,
+      "hwModelSlug": "HELTEC_MESH_TOWER_V2",
+      "platformioTargets": [
+        "heltec-mesh-tower-v2"
+      ],
+      "softDevice": "6.1.1"
+    },
+    {
+      "hwModel": 144,
+      "hwModelSlug": "SEEED_WIO_TRACKER_L1_PRO_1W",
+      "platformioTargets": [
+        "seeed_wio_tracker_L1_Pro_1W"
+      ],
+      "softDevice": "7.3.0"
     }
   ]
 }


### PR DESCRIPTION
## Why

The #6822 scheduled hardware-catalog refresh added new nrf52840 boards to `device_hardware.json` without the matching rows in `device_bootloader_ota_quirks.json`, so `SoftDeviceQuirkCoverageTest` now fails in the shard-app test shard for every PR that merges current main (first observed on #6839's checks). The test is doing exactly what it was built for: an unmapped board silently loses factory erase at runtime, so CI has to be what notices.

## What

Data-only, one file. Derived from `meshtastic/firmware` board definitions (`build.arduino.ldscript`: `nrf52840_s140_v6.ld` = 6.1.1, `_v7.ld` = 7.3.0):

- New row: hwModel 139 HELTEC_MESH_TOWER_V2, target `heltec-mesh-tower-v2`, SoftDevice 6.1.1 (board `heltec_mesh_tower_v2.json`, v6 ldscript).
- New row: hwModel 144 SEEED_WIO_TRACKER_L1_PRO_1W, target `seeed_wio_tracker_L1_Pro_1W`, SoftDevice 7.3.0 (board `seeed_wio_tracker_L1_Pro_1W.json`, v7 ldscript).
- Row 9 RAK4631: targets extended with `rak_wismesh_pocket` and `rak_wismesh_repeater_mini` (both `env:rak4631` extensions on `wiscore_rak4631`, v6).
- Row 117 RAK3401: targets extended with `rak_wismesh_repeater_mini_hp` (extends `env:rak3401-1watt`, same board, v6).

hwModel 140 MESHNOLOGY_W10 is esp32-s3 and out of scope.

**Durability**: this asset is a seed refreshed from api.meshtastic.org, so `data/bootloaderOtaQuirks.json` in `meshtastic/api` needs the same four changes or the next scheduled refresh reverts this. That mirror is a separate api-repo change.

## Testing Performed

- Pre-fix run reproduced exactly the two CI failures; post-fix all 6 `SoftDeviceQuirkCoverageTest` tests pass.
- `spotlessApply spotlessCheck detekt :androidApp:testFdroidDebugUnitTest` green locally.

## Constitution Check

All seven principles evaluated: I KMP (asset only); II zero lint (clean); III CMP UI (none); IV privacy (no data beyond board metadata); V design standards (N/A); VI docs (no user-facing docs affected); VII verify before push (gate run locally; CI confirmed on this PR after push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OTA bootloader support for two new RAK platform targets.
  * Added support for the high-power RAK repeater.
  * Added compatibility for the HELTEC Mesh Tower V2 and Seeed Wio Tracker L1 Pro 1W devices.
  * Updated supported software versions to improve firmware update compatibility across these devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->