### PR TITLE
fix(navigation): never let the active backstack empty under NavDisplay

### DIFF
--- a/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/MultiBackstack.kt
+++ b/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/MultiBackstack.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.setValue
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
+import co.touchlab.kermit.Logger
 
 /** Manages independent backstacks for multiple tabs. */
 class MultiBackstack(val startTab: NavKey, private val currentTabState: MutableState<NavKey>) {
@@ -37,7 +38,15 @@ class MultiBackstack(val startTab: NavKey, private val currentTabState: MutableS
         private set
 
     val activeBackStack: NavBackStack<NavKey>
-        get() = backStacks[currentTabRoute] ?: error("Stack for $currentTabRoute not found")
+        get() {
+            val stack = backStacks[currentTabRoute] ?: error("Stack for $currentTabRoute not found")
+            // A drained stack crashes NavDisplay ("backstack cannot be empty"), so restore the tab root.
+            if (stack.isEmpty()) {
+                Logger.e { "Backstack self-healed to root (MultiBackstack): tab=${currentTabRoute::class.simpleName}" }
+                stack.add(currentTabRoute)
+            }
+            return stack
+        }
 
     /** Switches to a new top-level tab route. */
     fun navigateTopLevel(route: NavKey) {

--- a/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/NavBackStackExt.kt
+++ b/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/NavBackStackExt.kt
@@ -32,6 +32,16 @@ fun MutableList<NavKey>.replaceLast(route: NavKey) {
 }
 
 /**
+ * Pops the top entry unless it is the root, so a displayed back stack can never be drained empty. Returns true when an
+ * entry was removed.
+ */
+fun MutableList<NavKey>.popUnlessRoot(): Boolean {
+    if (size <= 1) return false
+    removeAt(lastIndex)
+    return true
+}
+
+/**
  * Replaces the entire back stack with the given routes in a way that minimizes structural changes and prevents the back
  * stack from temporarily becoming empty.
  */

--- a/core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/MultiBackstackTest.kt
+++ b/core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/MultiBackstackTest.kt
@@ -180,4 +180,81 @@ class MultiBackstackTest {
         assertEquals(NodesRoute.Nodes, multiBackstack.activeBackStack.first())
         assertEquals(tracerouteMap, multiBackstack.activeBackStack.last())
     }
+
+    @Test
+    fun `goBack at root of start tab keeps the root entry`() {
+        val startTab = TopLevelDestination.Connect.route
+        val multiBackstack = createMultiBackstack(startTab)
+
+        val connectStack = NavBackStack<NavKey>().apply { addAll(listOf(TopLevelDestination.Connect.route)) }
+        multiBackstack.backStacks = mapOf(TopLevelDestination.Connect.route to connectStack)
+
+        multiBackstack.goBack()
+
+        assertEquals(1, multiBackstack.activeBackStack.size)
+        assertEquals(TopLevelDestination.Connect.route, multiBackstack.activeBackStack.first())
+    }
+
+    @Test
+    fun `rapid double goBack from depth two never empties the stack`() {
+        val startTab = TopLevelDestination.Nodes.route
+        val multiBackstack = createMultiBackstack(startTab)
+
+        val nodesStack =
+            NavBackStack<NavKey>().apply { addAll(listOf(TopLevelDestination.Nodes.route, NodesRoute.Nodes)) }
+        multiBackstack.backStacks = mapOf(TopLevelDestination.Nodes.route to nodesStack)
+
+        multiBackstack.goBack()
+        multiBackstack.goBack()
+
+        assertEquals(1, multiBackstack.activeBackStack.size)
+        assertEquals(TopLevelDestination.Nodes.route, multiBackstack.activeBackStack.first())
+    }
+
+    @Test
+    fun `activeBackStack self-heals a stack drained by a stale back handler`() {
+        // Regression for the field fatal "NavDisplay backstack cannot be empty": an always-enabled entry
+        // back handler kept firing during its exit crossfade and drained the stack past its root.
+        val startTab = TopLevelDestination.Settings.route
+        val multiBackstack = createMultiBackstack(startTab)
+
+        val settingsStack =
+            NavBackStack<NavKey>().apply { addAll(listOf(TopLevelDestination.Settings.route, SettingsRoute.HelpDocs)) }
+        multiBackstack.backStacks = mapOf(TopLevelDestination.Settings.route to settingsStack)
+
+        settingsStack.removeLastOrNull()
+        settingsStack.removeLastOrNull()
+        assertEquals(0, settingsStack.size)
+
+        val healed = multiBackstack.activeBackStack
+        assertEquals(1, healed.size)
+        assertEquals(TopLevelDestination.Settings.route, healed.first())
+    }
+
+    @Test
+    fun `navigateTopLevel to a tab with an empty stack self-heals to that tab root`() {
+        val startTab = TopLevelDestination.Connect.route
+        val multiBackstack = createMultiBackstack(startTab)
+
+        val connectStack = NavBackStack<NavKey>().apply { addAll(listOf(TopLevelDestination.Connect.route)) }
+        multiBackstack.backStacks =
+            mapOf(TopLevelDestination.Connect.route to connectStack, TopLevelDestination.Map.route to NavBackStack())
+
+        multiBackstack.navigateTopLevel(TopLevelDestination.Map.route)
+
+        assertEquals(TopLevelDestination.Map.route, multiBackstack.currentTabRoute)
+        assertEquals(1, multiBackstack.activeBackStack.size)
+        assertEquals(TopLevelDestination.Map.route, multiBackstack.activeBackStack.first())
+    }
+
+    @Test
+    fun `activeBackStack self-heals a stack restored empty from saved state`() {
+        val startTab = TopLevelDestination.Nodes.route
+        val multiBackstack = createMultiBackstack(startTab)
+        multiBackstack.backStacks = mapOf(TopLevelDestination.Nodes.route to NavBackStack())
+
+        val healed = multiBackstack.activeBackStack
+        assertEquals(1, healed.size)
+        assertEquals(TopLevelDestination.Nodes.route, healed.first())
+    }
 }

--- a/core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/NavBackStackExtTest.kt
+++ b/core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/NavBackStackExtTest.kt
@@ -19,8 +19,52 @@ package org.meshtastic.core.navigation
 import androidx.navigation3.runtime.NavKey
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class NavBackStackExtTest {
+
+    // region popUnlessRoot
+
+    @Test
+    fun `popUnlessRoot pops the top entry above the root`() {
+        val stack = mutableListOf<NavKey>(SettingsRoute.Settings(), SettingsRoute.HelpDocs)
+
+        assertTrue(stack.popUnlessRoot())
+
+        assertEquals(listOf<NavKey>(SettingsRoute.Settings()), stack.toList())
+    }
+
+    @Test
+    fun `popUnlessRoot refuses to pop the root entry`() {
+        val stack = mutableListOf<NavKey>(SettingsRoute.Settings())
+
+        assertFalse(stack.popUnlessRoot())
+
+        assertEquals(1, stack.size)
+    }
+
+    @Test
+    fun `popUnlessRoot on an empty stack is a no-op`() {
+        val stack = mutableListOf<NavKey>()
+
+        assertFalse(stack.popUnlessRoot())
+
+        assertTrue(stack.isEmpty())
+    }
+
+    @Test
+    fun `rapid double popUnlessRoot stops at the root`() {
+        val stack = mutableListOf<NavKey>(SettingsRoute.Settings(), SettingsRoute.HelpDocs)
+
+        stack.popUnlessRoot()
+        stack.popUnlessRoot()
+
+        assertEquals(1, stack.size)
+        assertEquals(SettingsRoute.Settings(), stack.first())
+    }
+
+    // endregion
 
     // region replaceLast
 

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
@@ -42,6 +42,7 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.scene.DialogSceneStrategy
 import androidx.navigation3.scene.Scene
 import androidx.navigation3.ui.NavDisplay
+import co.touchlab.kermit.Logger
 import org.meshtastic.core.navigation.MultiBackstack
 import org.meshtastic.core.navigation.rumViewName
 import org.meshtastic.core.repository.PlatformAnalytics
@@ -83,6 +84,14 @@ fun MeshtasticNavDisplay(
     onBack: (() -> Unit)? = null,
     analytics: PlatformAnalytics? = null,
 ) {
+    // Root captured at first composition; a stale entry back handler can drain the stack mid-transition
+    // and NavDisplay rejects an empty backstack (fatal in the field), so self-heal back to the root.
+    val fallbackRoot = remember(backStack) { backStack.firstOrNull() }
+    if (backStack.isEmpty() && fallbackRoot != null) {
+        Logger.e { "Backstack self-healed to root (NavDisplay): root=${fallbackRoot::class.simpleName}" }
+        backStack.add(fallbackRoot)
+    }
+
     // Track the top-of-backstack destination as a RUM view. Datadog's dd-sdk-android-compose
     // NavigationViewTrackingEffect only supports Jetpack Navigation, so Nav3 is wired manually here.
     // No-op when [analytics] is null (fdroid/desktop hosts and the intro flow pass nothing).

--- a/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/navigation/DocsNavigation.kt
+++ b/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/navigation/DocsNavigation.kt
@@ -36,6 +36,7 @@ import org.koin.compose.koinInject
 import org.meshtastic.core.common.util.currentLocaleCode
 import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.core.navigation.SettingsRoute
+import org.meshtastic.core.navigation.popUnlessRoot
 import org.meshtastic.feature.docs.ai.AIDocAssistant
 import org.meshtastic.feature.docs.ai.ChirpySessionHolder
 import org.meshtastic.feature.docs.data.DefaultDocBundleLoader
@@ -156,7 +157,13 @@ private fun DocsHelpScreen(backStack: NavBackStack<NavKey>, chirpy: ChirpyUiStat
     }
 
     val backHandlerState = rememberNavigationEventState(NavigationEventInfo.None)
-    NavigationBackHandler(state = backHandlerState, onBackCompleted = { backStack.removeLastOrNull() })
+    // Outranks NavDisplay's own handler and stays alive during the exit crossfade; gate and guard it so
+    // a rapid second back press cannot pop the tab root and hand NavDisplay an empty backstack.
+    NavigationBackHandler(
+        state = backHandlerState,
+        isBackEnabled = backStack.size > 1,
+        onBackCompleted = { backStack.popUnlessRoot() },
+    )
 
     DocsBrowserScreen(
         pages = pages,
@@ -164,7 +171,7 @@ private fun DocsHelpScreen(backStack: NavBackStack<NavKey>, chirpy: ChirpyUiStat
         searchQuery = searchQuery,
         onSearchQueryChange = { searchQuery = it },
         onSelectPage = { pageId -> backStack.add(SettingsRoute.HelpDocPage(pageId)) },
-        onBack = { backStack.removeLastOrNull() },
+        onBack = { backStack.popUnlessRoot() },
         isAiSupported = chirpy.isSupported,
         modelReadiness = chirpy.modelReadiness,
         showFab = chirpy.showFab,
@@ -243,7 +250,13 @@ private fun DocsPageScreen(pageId: String, backStack: NavBackStack<NavKey>, chir
     }
 
     val backHandlerState = rememberNavigationEventState(NavigationEventInfo.None)
-    NavigationBackHandler(state = backHandlerState, onBackCompleted = { backStack.removeLastOrNull() })
+    // Outranks NavDisplay's own handler and stays alive during the exit crossfade; gate and guard it so
+    // a rapid second back press cannot pop the tab root and hand NavDisplay an empty backstack.
+    NavigationBackHandler(
+        state = backHandlerState,
+        isBackEnabled = backStack.size > 1,
+        onBackCompleted = { backStack.popUnlessRoot() },
+    )
 
     DocsPageRouteScreen(
         pageId = pageId,
@@ -260,7 +273,7 @@ private fun DocsPageScreen(pageId: String, backStack: NavBackStack<NavKey>, chir
         onChirpyDraftChange = chirpy.onDraftChange,
         onChirpySubmit = chirpy.onSubmit,
         onChirpyNavigateToPage = chirpy.onNavigateToPage,
-        onBack = { backStack.removeLastOrNull() },
+        onBack = { backStack.popUnlessRoot() },
         onNavigateToPage = { targetPageId -> backStack.add(SettingsRoute.HelpDocPage(targetPageId)) },
     )
 }


### PR DESCRIPTION
## Why

Crashlytics `113670c3bd77018f67e6f4030246cc49` (fatal, 36 users / 42 events in the 2.8.1 window, firing since 2.7.14; Datadog `404a8928`): `IllegalArgumentException: NavDisplay backstack cannot be empty`. Root cause, verified against the nav3 1.1.1 sources: the two docs screens registered `NavigationBackHandler` pops with no `isBackEnabled` gate. Entry-level handlers register after NavDisplay's own handler and win LIFO priority, and the outgoing entry's handler stays enabled for the whole 350ms exit crossfade, so a second back press during the animation pops the tab root and leaves the stack empty; a tab-switch variant drains the now-inactive tab's stack and crashes on the next switch to it. The docs handlers were the only ungated pop handlers in the codebase (the ~56 toolbar `removeLastOrNull` callbacks are all `dropUnlessResumed`-wrapped and lifecycle-capped by nav3's decorator).

## What

Two layers, both needed:

- Root cause: `popUnlessRoot()` added to `NavBackStackExt`; the docs handlers now gate with `isBackEnabled = backStack.size > 1` and pop via `popUnlessRoot()` (the gate can be stale within a frame, hence both), and the docs toolbar back pops are guarded the same way.
- Defense for the latent class: `MultiBackstack.activeBackStack` self-heals an empty stack to its tab root, and `MeshtasticNavDisplay` re-adds the remembered first-composition root if a displayed stack empties. Both heals log a greppable `Backstack self-healed to root` non-fatal (via throwable-less `Logger.e`) so any future regression of this class is visible in Crashlytics instead of silently snapping to the root.

Reviewer note: the heals write to snapshot state during composition deliberately; a `SideEffect` would run after NavDisplay's `require` already threw. Single-tap back behavior is unchanged everywhere (docs screens always sit at depth 2 or more in healthy states). Public contracts of `MeshtasticNavDisplay` and `MultiBackstack` are unchanged; `popUnlessRoot()` is a new additive public extension in core/navigation (relevant to the SDK cutover inventory).

Follow-up (out of scope here): a konsist/lint rule requiring `isBackEnabled` on every `NavigationBackHandler`, which would close this defect class permanently.

## Testing Performed

- 9 new commonTest cases across `MultiBackstackTest` (root retention, rapid double-back, stale-handler drain heal, empty-restored-stack heal, tab-switch heal) and `NavBackStackExtTest` (`popUnlessRoot` matrix incl. rapid double-pop); suites now 13 and 15 tests, all green on fresh JUnit XML (cache replay ruled out).
- Full local baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` green (2,677 tests), clean tree.
- Two independent adversarial reviews returned APPROVE; the correctness pass verified the crash mechanism against the extracted nav3 1.1.1 / navigationevent 1.1.1 sources (the `require` at NavDisplay.kt:360, LIFO dispatcher precedence, and the library's own stale-enabled race comment).

## Constitution Check

All seven principles evaluated: I KMP purity (all commonMain, no framework bleed); II zero lint (spotless + detekt clean); III CMP UI (`MeshtasticNavDisplay`/`NavigationBackHandler` remain the mandated surface, contracts unchanged); IV privacy (heal logs carry class simple names only); V design standards (no visual change); VI documentation freshness (no doc-page content affected; `skip-docs-check` applied: crash fix to back-press plumbing with no documented user-visible behavior change); VII verify before push (full baseline run locally; CI confirmed on this PR after push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved back navigation to preserve the root screen and prevent empty navigation stacks.
  - Added recovery when navigation state is unexpectedly empty or restored without a valid root.
  - Improved handling of rapid repeated back presses and screen exit transitions.
  - Updated documentation navigation to safely stop at its root screen.

- **Tests**
  - Added coverage for root preservation, repeated back presses, empty-stack recovery, and saved-state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->