### PR TITLE
fix(map): survive the WebView provider update race in Site Planner

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1670,6 +1670,7 @@ site_planner_tx_power_watts
 site_planner_use_current_location
 site_planner_use_map_center
 site_planner_use_node_location
+site_planner_webview_updating
 skip
 slot
 smart_position

--- a/androidApp/src/main/kotlin/org/meshtastic/app/map/SitePlannerRunner.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/map/SitePlannerRunner.kt
@@ -17,13 +17,17 @@
 package org.meshtastic.app.map
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.res.Resources
 import android.os.Handler
 import android.os.Looper
+import android.util.AndroidRuntimeException
 import android.webkit.JavascriptInterface
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -60,6 +64,7 @@ import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.cancel
 import org.meshtastic.core.resources.site_planner_estimating
 import org.meshtastic.core.resources.site_planner_failed
+import org.meshtastic.core.resources.site_planner_webview_updating
 import org.meshtastic.feature.map.component.SitePlannerParams
 import org.meshtastic.feature.map.component.SitePlannerSheet
 
@@ -92,6 +97,7 @@ fun SitePlannerHost(
     val context = LocalContext.current
     val failedText = stringResource(Res.string.site_planner_failed)
     val estimatingText = stringResource(Res.string.site_planner_estimating)
+    val webViewUpdatingText = stringResource(Res.string.site_planner_webview_updating)
 
     val current = running
     if (current == null) {
@@ -139,6 +145,10 @@ fun SitePlannerHost(
                         Toast.makeText(context, failedText, Toast.LENGTH_SHORT).show()
                         onDismiss()
                     },
+                    onWebViewUnavailable = {
+                        Toast.makeText(context, webViewUpdatingText, Toast.LENGTH_LONG).show()
+                        onDismiss()
+                    },
                     // Headless: fully transparent so the WebGL first-paint frame never flashes through, but still
                     // attached + sized (280dp) so the sim gets a WebGL context. alpha(0) is a compositor property —
                     // the view stays VISIBLE, so the page's requestAnimationFrame/autorun keep running.
@@ -173,59 +183,137 @@ fun SitePlannerHost(
 /**
  * Headless WebView that loads [url] (the planner with `run=1&bridge=1`), exposes a `window.__meshtasticNative` bridge,
  * and reports the coverage GeoJSON via [onResult] once the planner posts it. Main-frame load failures go to [onError].
+ * Construction rides out the system WebView provider-update race with one deferred retry, then [onWebViewUnavailable].
  */
-@SuppressLint("SetJavaScriptEnabled")
 @Composable
 private fun SitePlannerRunner(
     url: String,
     onResult: (String) -> Unit,
     onError: (String) -> Unit,
+    onWebViewUnavailable: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val onResultState by rememberUpdatedState(onResult)
     val onErrorState by rememberUpdatedState(onError)
+    val onWebViewUnavailableState by rememberUpdatedState(onWebViewUnavailable)
     AndroidView(
         modifier = modifier,
         factory = { context ->
-            val main = Handler(Looper.getMainLooper())
-            WebView(context).apply {
-                setBackgroundColor(android.graphics.Color.TRANSPARENT) // no opaque black backing before first paint
-                settings.javaScriptEnabled = true
-                settings.domStorageEnabled = true
-                addJavascriptInterface(
-                    object {
-                        // Called from the planner's JS thread — hop to main before touching Compose state.
-                        @JavascriptInterface fun onCoverage(geoJson: String) = main.post { onResultState(geoJson) }
-                    },
-                    "__meshtasticNative",
+            SitePlannerWebViewContainer(context).apply {
+                attachPlannerWebView(
+                    url = url,
+                    retriesLeft = 1,
+                    onResult = { onResultState(it) },
+                    onError = { onErrorState(it) },
+                    onUnavailable = { onWebViewUnavailableState() },
                 )
-                webViewClient =
-                    object : WebViewClient() {
-                        // Keep the __meshtasticNative bridge exclusive to the planner's own origin: block any
-                        // navigation
-                        // elsewhere (redirect/compromise/open-redirect) so foreign content can never reach
-                        // onCoverage().
-                        // Sub-resource fetches (tiles, XHR) aren't navigations, so this doesn't affect the sim itself.
-                        override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-                            val target = request?.url ?: return false
-                            val trusted = SITE_PLANNER_BASE_URL.toUri()
-                            return target.scheme != trusted.scheme || target.host != trusted.host
-                        }
-
-                        override fun onReceivedError(
-                            view: WebView?,
-                            request: WebResourceRequest?,
-                            error: WebResourceError?,
-                        ) {
-                            // Only a failed main-frame load is fatal; a stray tile/asset 404 is not.
-                            if (request?.isForMainFrame == true) {
-                                main.post { onErrorState("${error?.errorCode} ${error?.description}") }
-                            }
-                        }
-                    }
-                loadUrl(url)
             }
         },
-        onRelease = WebView::destroy,
+        onRelease = SitePlannerWebViewContainer::release,
     )
+}
+
+// One deferred retry bridges the moment the system WebView provider package finishes updating.
+private const val WEBVIEW_RETRY_DELAY_MS = 250L
+
+/**
+ * True for the exceptions WebView construction throws while the system WebView provider package updates underneath a
+ * running app: the AOSP ResourcesImpl redirect race and the AndroidRuntimeException wrapper around provider failures.
+ */
+internal fun isWebViewProviderUpdateException(throwable: Throwable): Boolean =
+    throwable is Resources.NotFoundException ||
+        (throwable is AndroidRuntimeException && throwable.message?.contains("WebView", ignoreCase = true) == true)
+
+/** Hosts the planner WebView; owns the retry/bridge handler so [release] cancels anything still pending. */
+private class SitePlannerWebViewContainer(context: Context) : FrameLayout(context) {
+    val main = Handler(Looper.getMainLooper())
+
+    fun release() {
+        main.removeCallbacksAndMessages(null)
+        val webView = getChildAt(0) as? WebView
+        removeAllViews() // detach from the view system before destroy(), per the WebView docs
+        webView?.destroy()
+    }
+}
+
+/** Builds and attaches the planner WebView, absorbing the provider-update race with a single deferred retry. */
+private fun SitePlannerWebViewContainer.attachPlannerWebView(
+    url: String,
+    retriesLeft: Int,
+    onResult: (String) -> Unit,
+    onError: (String) -> Unit,
+    onUnavailable: () -> Unit,
+) {
+    // Only bare construction races the provider update; configure outside the try so no half-built view leaks.
+    val webView =
+        try {
+            WebView(context)
+        } catch (e: Resources.NotFoundException) {
+            if (!isWebViewProviderUpdateException(e)) throw e
+            retryOrFailSoft(e, retriesLeft, onUnavailable) {
+                attachPlannerWebView(url, retriesLeft - 1, onResult, onError, onUnavailable)
+            }
+            return
+        } catch (e: AndroidRuntimeException) {
+            if (!isWebViewProviderUpdateException(e)) throw e
+            retryOrFailSoft(e, retriesLeft, onUnavailable) {
+                attachPlannerWebView(url, retriesLeft - 1, onResult, onError, onUnavailable)
+            }
+            return
+        }
+    addView(configurePlannerWebView(webView, main, url, onResult, onError))
+}
+
+private fun SitePlannerWebViewContainer.retryOrFailSoft(
+    cause: Throwable,
+    retriesLeft: Int,
+    onUnavailable: () -> Unit,
+    retry: () -> Unit,
+) {
+    if (retriesLeft > 0) {
+        Logger.withTag("SitePlanner").w(cause) { "WebView provider is updating; retrying construction once" }
+        main.postDelayed({ retry() }, WEBVIEW_RETRY_DELAY_MS)
+    } else {
+        Logger.withTag("SitePlanner").e(cause) { "WebView unavailable after retry; failing soft" }
+        onUnavailable()
+    }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+private fun configurePlannerWebView(
+    webView: WebView,
+    main: Handler,
+    url: String,
+    onResult: (String) -> Unit,
+    onError: (String) -> Unit,
+): WebView = webView.apply {
+    setBackgroundColor(android.graphics.Color.TRANSPARENT) // no opaque black backing before first paint
+    settings.javaScriptEnabled = true
+    settings.domStorageEnabled = true
+    addJavascriptInterface(
+        object {
+            // Called from the planner's JS thread; hop to main before touching Compose state.
+            @JavascriptInterface fun onCoverage(geoJson: String) = main.post { onResult(geoJson) }
+        },
+        "__meshtasticNative",
+    )
+    webViewClient =
+        object : WebViewClient() {
+            // Keep the __meshtasticNative bridge exclusive to the planner's own origin: block any navigation
+            // elsewhere (redirect/compromise/open-redirect) so foreign content can never reach onCoverage().
+            // Sub-resource fetches (tiles, XHR) aren't navigations, so this doesn't affect the sim itself.
+            override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                val target = request?.url ?: return false
+                val trusted = SITE_PLANNER_BASE_URL.toUri()
+                return target.scheme != trusted.scheme || target.host != trusted.host
+            }
+
+            override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {
+                // Only a failed main-frame load is fatal; a stray tile/asset 404 is not.
+                if (request?.isForMainFrame == true) {
+                    main.post { onError("${error?.errorCode} ${error?.description}") }
+                }
+            }
+        }
+    loadUrl(url)
 }

--- a/androidApp/src/test/kotlin/org/meshtastic/app/map/SitePlannerWebViewRecoveryTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/map/SitePlannerWebViewRecoveryTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app.map
+
+import android.app.Application
+import android.content.res.Resources
+import android.util.AndroidRuntimeException
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Classifier guard for the Site Planner WebView provider-update mitigation: only the two exception shapes the AOSP
+ * provider-update race produces may be absorbed and retried; anything else must keep propagating.
+ */
+@RunWith(RobolectricTestRunner::class)
+// Bare Application: booting the real MeshUtilApplication leaks its scopes across tests (#6644).
+@Config(application = Application::class, sdk = [34])
+class SitePlannerWebViewRecoveryTest {
+
+    @Test
+    fun `resources redirect race is recoverable`() {
+        val race = Resources.NotFoundException("failed to redirect ResourcesImpl")
+        assertTrue(isWebViewProviderUpdateException(race))
+    }
+
+    @Test
+    fun `webview provider load failure wrapper is recoverable`() {
+        val wrapper =
+            AndroidRuntimeException(
+                "android.webkit.WebViewFactory\$MissingWebViewPackageException: Failed to load WebView provider: No WebView installed",
+            )
+        assertTrue(isWebViewProviderUpdateException(wrapper))
+    }
+
+    @Test
+    fun `unrelated AndroidRuntimeException is not swallowed`() {
+        val unrelated = AndroidRuntimeException("Calling startActivity() from outside of an Activity context")
+        assertFalse(isWebViewProviderUpdateException(unrelated))
+    }
+
+    @Test
+    fun `unrelated RuntimeException is not swallowed`() {
+        assertFalse(isWebViewProviderUpdateException(IllegalStateException("boom")))
+    }
+}

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1718,6 +1718,7 @@
     <string name="site_planner_use_current_location">Use current location</string>
     <string name="site_planner_use_map_center">Use map center</string>
     <string name="site_planner_use_node_location">Use current node location</string>
+    <string name="site_planner_webview_updating">The system WebView is updating. Please try again in a moment.</string>
     <string name="skip">Skip</string>
     <string name="slot">Slot</string>
     <string name="smart_position">Smart Position</string>


### PR DESCRIPTION
## Why

Crashlytics `7b41bd386280b17278b8f6d0450dd0dc` (fatal, 30 users / 30 events, new in the 2.8.1 line, one event per user, never a loop): `Resources$NotFoundException: failed to redirect ResourcesImpl` thrown inside `WebView.<init>` at `SitePlannerRunner`. This is the well-known AOSP race where the system WebView provider package updates while the app is running; the first WebView constructed afterwards throws. Site Planner (#6136) is our only WebView, so the crash arrived with it.

## What

- WebView construction in the Site Planner's headless runner is wrapped in a recovery seam: a classifier (`isWebViewProviderUpdateException`) recognizes exactly the two shapes this race produces (`Resources.NotFoundException`, and `AndroidRuntimeException` mentioning WebView, e.g. `MissingWebViewPackageException`); both catch arms route through it so tests and production cannot drift. The try wraps only the bare `WebView(context)` constructor, so no partially configured instance can be orphaned.
- On a classified failure the attach retries once on a later main-looper dispatch (250ms); a second failure fails soft: a toast (`site_planner_webview_updating`, new string resource, sorted) plus dialog dismissal, matching the file's existing soft-fail style. Everything else rethrows unchanged.
- The WebView now lives in a container that owns the retry `Handler`: release cancels pending retries and bridge posts, detaches the child, then destroys it. Happy-path setup is byte-identical, moved verbatim into a configure function.

## Testing Performed

- 4 new Robolectric tests over the production classifier (both recoverable shapes recognized; unrelated `AndroidRuntimeException` and `IllegalStateException` propagate). The retry path itself requires a real WebView provider and is not unit-testable; the seam was kept minimal. Test pins `@Config(application = Application::class)` per repo precedent to avoid the real-Application scope leak (#6644).
- Full local baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` green (1,789 tests), clean tree.
- Two independent adversarial reviews (correctness APPROVE, conventions APPROVE); review hardening applied: constructor-only try scope, detach-before-destroy teardown, classifier-routed catches.

## Constitution Check

All seven principles evaluated: I KMP purity (Android-only file in androidApp; android.* imports appropriate there); II zero lint (clean; catches are type-specific, delay is a named constant); III CMP UI (string surfaced via Compose resource accessor); IV privacy (no data logged); V design standards (soft-fail matches existing pattern in the same flow); VI documentation freshness (`skip-docs-check` applied: crash fix, no documented behavior change); VII verify before push (full baseline run locally; CI confirmed on this PR after push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
