### PR TITLE
fix(metrics): eliminate the Vico canvas restore underflow crash

### DIFF
--- a/feature/node/src/androidMain/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuard.android.kt
+++ b/feature/node/src/androidMain/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuard.android.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.metrics
+
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.nativeCanvas
+
+internal actual fun Canvas.platformSaveCount(): Int = nativeCanvas.saveCount
+
+internal actual fun Canvas.platformRestoreToCount(count: Int) {
+    nativeCanvas.restoreToCount(count)
+}

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/BaseMetricChart.kt
@@ -143,7 +143,8 @@ fun GenericMetricChart(
                 getXStep = { model, _, _ -> maxOf(model.getXDeltaGcd(), MIN_X_STEP_SECONDS) },
             ),
             modelProducer = modelProducer,
-            modifier = modifier,
+            // Guard against Vico's canvas restore underflow (see chartRestoreUnderflowGuard).
+            modifier = modifier.chartRestoreUnderflowGuard(),
             scrollState = vicoScrollState,
             zoomState = zoomState,
         )

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuard.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuard.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.metrics
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import co.touchlab.kermit.Logger
+
+/**
+ * Message prefix of Android's Canvas.restore() IllegalStateException; other platforms never throw it. Deliberately also
+ * matches the "Underflow in restoreToCount" message variant.
+ */
+private const val RESTORE_UNDERFLOW_MESSAGE = "Underflow in restore"
+
+/** Reads the native canvas save count. Compose's common Canvas API does not expose it. */
+internal expect fun Canvas.platformSaveCount(): Int
+
+/** Pops saves above [count]; a no-op when the stack is already at or below [count]. */
+internal expect fun Canvas.platformRestoreToCount(count: Int)
+
+/**
+ * Runs [block] with the canvas save stack snapshotted, swallowing only Android's restore-underflow
+ * IllegalStateException and rebalancing to the entry depth so a corrupted frame is dropped, not fatal.
+ */
+internal fun Canvas.withRestoreUnderflowGuard(block: () -> Unit) {
+    val saveCount = platformSaveCount()
+    try {
+        block()
+    } catch (e: IllegalStateException) {
+        // JVM CancellationException subclasses IllegalStateException; the message filter is what rethrows it.
+        if (e.message?.contains(RESTORE_UNDERFLOW_MESSAGE) != true) throw e
+        // Error severity so analytics records a Crashlytics non-fatal; downgrade once the upstream fix is verified.
+        Logger.e(e) { "Dropped a chart frame: Vico unbalanced the canvas save stack" }
+    } finally {
+        platformRestoreToCount(saveCount)
+    }
+}
+
+/**
+ * Guards the chart subtree against Vico 3.3.0's canvas restore underflow inside BaseCartesianLayer.draw (Crashlytics
+ * issue 7744c73d302c0af1676f31f80802d59f, fatal since 2.8.0). Remove once fixed upstream.
+ *
+ * After a swallow, Vico's cached offscreen layer canvas may stay corrupted indefinitely (a frozen, blank, or partially
+ * clipped chart until the canvas size changes or the screen is recreated); the node-canvas rebalance here cannot reach
+ * it. Degraded visuals in that rare case beat the fatal crash.
+ */
+internal fun Modifier.chartRestoreUnderflowGuard(): Modifier = drawWithContent {
+    drawIntoCanvas { canvas -> canvas.withRestoreUnderflowGuard { drawContent() } }
+}

--- a/feature/node/src/iosMain/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuard.ios.kt
+++ b/feature/node/src/iosMain/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuard.ios.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.metrics
+
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.skiaCanvas
+
+internal actual fun Canvas.platformSaveCount(): Int = skiaCanvas.saveCount
+
+internal actual fun Canvas.platformRestoreToCount(count: Int) {
+    skiaCanvas.restoreToCount(count)
+}

--- a/feature/node/src/jvmMain/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuard.jvm.kt
+++ b/feature/node/src/jvmMain/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuard.jvm.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.metrics
+
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.skiaCanvas
+
+internal actual fun Canvas.platformSaveCount(): Int = skiaCanvas.saveCount
+
+internal actual fun Canvas.platformRestoreToCount(count: Int) {
+    skiaCanvas.restoreToCount(count)
+}

--- a/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuardTest.kt
+++ b/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/metrics/ChartDrawGuardTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.metrics
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/** Covers the save-stack guard around chart drawing (Crashlytics 7744c73d302c0af1676f31f80802d59f). */
+class ChartDrawGuardTest {
+
+    private fun newCanvas(): Canvas = Canvas(ImageBitmap(4, 4))
+
+    @Test
+    fun guardRebalancesLeakedSavesToEntryDepth() {
+        val canvas = newCanvas()
+        val entryDepth = canvas.platformSaveCount()
+        canvas.withRestoreUnderflowGuard {
+            canvas.save()
+            canvas.saveLayer(Rect(0f, 0f, 4f, 4f), Paint())
+        }
+        assertEquals(entryDepth, canvas.platformSaveCount())
+    }
+
+    @Test
+    fun guardSwallowsRestoreUnderflowException() {
+        val canvas = newCanvas()
+        val entryDepth = canvas.platformSaveCount()
+        // Message thrown by android.graphics.Canvas.restore, the crash this guard exists for.
+        canvas.withRestoreUnderflowGuard {
+            throw IllegalStateException("Underflow in restore - more restores than saves")
+        }
+        assertEquals(entryDepth, canvas.platformSaveCount())
+    }
+
+    @Test
+    fun guardRethrowsUnrelatedIllegalStateException() {
+        val canvas = newCanvas()
+        assertFailsWith<IllegalStateException> { canvas.withRestoreUnderflowGuard { error("unrelated") } }
+    }
+
+    @Test
+    fun guardRethrowsOtherExceptionTypes() {
+        val canvas = newCanvas()
+        assertFailsWith<IllegalArgumentException> {
+            canvas.withRestoreUnderflowGuard { throw IllegalArgumentException("boom") }
+        }
+    }
+
+    @Test
+    fun guardToleratesStackDrivenBelowSnapshot() {
+        val canvas = newCanvas()
+        val base = canvas.platformSaveCount()
+        canvas.save()
+        canvas.withRestoreUnderflowGuard {
+            // Skia silently ignores restores at the stack floor, so this drives the count below the snapshot.
+            canvas.restore()
+            canvas.restore()
+        }
+        // restoreToCount cannot re-raise a popped stack; it must tolerate the deficit without throwing.
+        assertEquals(base, canvas.platformSaveCount())
+    }
+
+    @Test
+    fun guardIsNoOpForBalancedDrawing() {
+        val canvas = newCanvas()
+        val entryDepth = canvas.platformSaveCount()
+        canvas.withRestoreUnderflowGuard {
+            canvas.save()
+            canvas.restore()
+        }
+        assertEquals(entryDepth, canvas.platformSaveCount())
+    }
+}


### PR DESCRIPTION
## Why

Crashlytics `7744c73d302c0af1676f31f80802d59f` (fatal, 106 users / 177 events on 2.8.1): `IllegalStateException: Underflow in restore - more restores than saves` thrown inside Vico's own `BaseCartesianLayer.draw`. The upstream routes are closed: we ship Vico 3.3.0, which is the latest release (no post-3.3.0 drawing fixes on master, no matching upstream issue), and version correlation pins the defect to the 3.3.0 line (2.7.9 on 3.2.x was crash-free; firstSeen is 2.8.0's 3.3.0-next.1). Reading the complete 3.3.0 draw path shows every save/restore pair statically balanced, and the field stacks contain no app frames, so the imbalance is a runtime condition in Vico's animation-frame layer machinery that our stock-component configuration cannot avoid. A defensive guard at our single chart host is the remaining sound option.

## What

- `ChartDrawGuard` (feature/node, expect/actual for android/jvm/ios): snapshots the native canvas save count before the chart draws, catches only `IllegalStateException` whose message contains "Underflow in restore" (which also covers the `restoreToCount` variant), rethrows everything else, and rebalances via `restoreToCount(snapshot)` in a `finally`. The rebalance is load-bearing: our charts use fading edges, and Vico pushes a non-finally `saveLayer` on the node canvas for them, so a naive catch would leave the compose frame's save stack corrupted.
- Applied as `Modifier.chartRestoreUnderflowGuard()` at the single `CartesianChartHost` call site (`BaseMetricChart`), through which every metric chart funnels.
- Each swallow records a Crashlytics non-fatal (`Logger.e`) deliberately, so the next release can confirm the fatal population converts to guard firings and reveal when a Vico upgrade silences it; downgrade the severity once field-verified.
- Documented limitation: a swallowed frame can leave Vico's cached offscreen layer canvas corrupted until the canvas resizes or the screen recreates (frozen or partially clipped chart in that rare case), which the node-canvas rebalance cannot reach. Degraded visuals beat the fatal.

Follow-ups (out of scope here): file the field facts upstream with patrykandpatrick/vico, and consider a key()-reset that rebuilds the chart host after a swallow to also refresh the cached layer canvas.

## Testing Performed

- 6 jvmTest cases against a real Skia canvas: leaked-save rebalance, underflow swallow, rethrow of unrelated ISE and non-ISE, balanced no-op, and stack-driven-below-snapshot repair.
- Full local baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` green, clean tree.
- Two independent adversarial reviews returned APPROVE; the correctness pass verified the exception message is hardcoded English in the Android SDK Canvas source, that `restoreToCount` cannot throw from the finally on either backend, and that no graphics layer sits between the guard and Vico's canvas.

## Constitution Check

All seven principles evaluated: I KMP purity (expect/actual split; commonMain uses compose + kermit only); II zero lint (clean, no suppressions or baseline edits); III CMP UI (multiplatform accessors: nativeCanvas on Android, skiaCanvas on skiko); IV privacy (log carries the exception only); V design standards (no visual change on healthy frames); VI documentation freshness (`skip-docs-check` applied: crash fix, no documented behavior change); VII verify before push (full baseline run locally; CI confirmed on this PR after push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
