### PR TITLE
fix(connection): extend BLE handshake deadlines while config progress flows

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImpl.kt
@@ -128,6 +128,18 @@ class MeshConnectionManagerImpl(
     private val handshakeCompleteLatch = atomic(false)
     private val locationRejectionLogged = atomic(false)
 
+    /** Armed stage guard: stage, budget, and a generation so a stale re-arm racing a stage change always loses. */
+    private data class StageGuardSpec(val stage: Int, val timeout: Duration, val generation: Long)
+
+    private val armedStageGuard = atomic<StageGuardSpec?>(null)
+    private val stageGuardGeneration = atomic(0L)
+
+    /** Clears [armedStageGuard] once a stage has run for 10x its budget, ending re-arms from trickle progress. */
+    private val stageCapJob = atomic<Job?>(null)
+
+    /** Progress signals seen since the current stage was armed; 0 in a stall report means total silence. */
+    private val stageProgressSignals = atomic(0)
+
     /**
      * Consecutive handshake-recovery failure count for [runSiblingHandshakeRecovery].
      *
@@ -264,6 +276,7 @@ class MeshConnectionManagerImpl(
             // Collapse cancel+clear into one atomic swap so a concurrent re-arm cannot
             // orphan a job in the gap between cancel and reassign.
             handshakeTimeout.getAndSet(null)?.cancel()
+            stageCapJob.getAndSet(null)?.cancel()
 
             when (c) {
                 is ConnectionState.Connecting -> serviceRepository.setConnectionState(ConnectionState.Connecting)
@@ -290,6 +303,8 @@ class MeshConnectionManagerImpl(
         // signals ignored (latch left set from the prior failed cycle). This covers both initial
         // user-initiated connects and transport-restart recovery siblings.
         handshakeCompleteLatch.value = false
+        // Fresh handshake: drop the stale stage-guard spec so early progress cannot re-arm the old stage.
+        armedStageGuard.value = null
         lockdownCoordinator.onConnect()
         // Send a wake-up heartbeat before the config request. The firmware may be in a
         // power-saving state where the NimBLE callback context needs warming up. The 100ms
@@ -304,13 +319,39 @@ class MeshConnectionManagerImpl(
             }
     }
 
-    private fun startHandshakeStallGuard(stage: Int, timeout: Duration) {
+    private fun armStageGuard(stage: Int, timeout: Duration) {
+        val spec = StageGuardSpec(stage, timeout, stageGuardGeneration.incrementAndGet())
+        armedStageGuard.value = spec
+        // Hard ceiling: after 10x the budget of continuous re-arms, clear the spec so trickle
+        // progress can no longer extend this stage; the pending guard then expires on schedule.
+        stageCapJob
+            .getAndSet(
+                scope.handledLaunch {
+                    delay(timeout * STAGE_GUARD_TOTAL_CAP_FACTOR)
+                    armedStageGuard.compareAndSet(spec, null)
+                },
+            )
+            ?.cancel()
+        scheduleStallGuard(spec)
+    }
+
+    private fun rearmStageGuardOnProgress() {
+        while (true) {
+            val spec = armedStageGuard.value ?: return
+            scheduleStallGuard(spec)
+            // A newer stage can arm mid-swap; loop so the newest spec owns the pending guard job.
+            if (armedStageGuard.value === spec) return
+        }
+    }
+
+    private fun scheduleStallGuard(spec: StageGuardSpec) {
+        val stage = spec.stage
         val fastTransport = isFastRecoveryTransport()
         // On TCP/USB the firmware handshake completes in roughly 1s when healthy (logs show),
         // while a wedged socket takes the full ~30s transport read timeout without any further
         // progress. The aggressive 12s fast timeout recovers a stuck session quickly; BLE keeps
         // the original generous budget because its GATT latency is high and variable.
-        val effectiveTimeout = if (fastTransport) FAST_HANDSHAKE_TIMEOUT else timeout
+        val effectiveTimeout = if (fastTransport) FAST_HANDSHAKE_TIMEOUT else spec.timeout
         val transportLabel = if (fastTransport) "fast transport" else "BLE"
         // Collapse cancel+reassign into one atomic swap so a concurrent re-arm cannot orphan a
         // job in the gap between cancel and reassign.
@@ -332,8 +373,12 @@ class MeshConnectionManagerImpl(
                     // re-enters handleStartConfig(). A clean transport restart creates a fresh
                     // session and re-enters the handshake naturally, which is both safer and more
                     // deterministic than a same-session retry.
+                    // connectTimeMsec is 0 until the first transport Connected (e.g. reboot re-handshake).
+                    val sinceConnectMs = connectTimeMsec.takeIf { it > 0 }?.let { nowMillis - it } ?: -1
                     Logger.e {
-                        "Handshake stall detected at Stage $stage on $transportLabel — " +
+                        "Handshake stall detected at Stage $stage on $transportLabel after " +
+                            "${effectiveTimeout.inWholeSeconds}s without progress " +
+                            "(progressSignals=${stageProgressSignals.value}, sinceConnectMs=$sinceConnectMs); " +
                             "requesting forced transport restart"
                     }
                     runSiblingHandshakeRecovery()
@@ -343,8 +388,7 @@ class MeshConnectionManagerImpl(
     }
 
     /**
-     * Launches the deterministic two-phase stall-recovery sibling used by [startHandshakeStallGuard] on every
-     * transport.
+     * Launches the deterministic two-phase stall-recovery sibling used by [scheduleStallGuard] on every transport.
      *
      * Phase 1 flips the app-level state from Connecting to Disconnected first, guarded by the connection mutex so a
      * just-completed handshake cannot be torn down after winning the race. Phase 2 then calls
@@ -511,7 +555,8 @@ class MeshConnectionManagerImpl(
     }
 
     override fun startConfigOnly() {
-        startHandshakeStallGuard(1, HANDSHAKE_TIMEOUT_STAGE1)
+        stageProgressSignals.value = 0
+        armStageGuard(1, HANDSHAKE_TIMEOUT_STAGE1)
         packetHandler.sendToRadio(ToRadio(want_config_id = HandshakeConstants.CONFIG_NONCE))
     }
 
@@ -524,7 +569,8 @@ class MeshConnectionManagerImpl(
     }
 
     override fun startNodeInfoOnly() {
-        startHandshakeStallGuard(2, HANDSHAKE_TIMEOUT_STAGE2)
+        stageProgressSignals.value = 0
+        armStageGuard(2, HANDSHAKE_TIMEOUT_STAGE2)
         packetHandler.sendToRadio(ToRadio(want_config_id = HandshakeConstants.NODE_INFO_NONCE))
     }
 
@@ -556,6 +602,7 @@ class MeshConnectionManagerImpl(
         // Collapse cancel+clear into one atomic swap so a concurrent re-arm cannot
         // orphan a job in the gap between cancel and reassign.
         handshakeTimeout.getAndSet(null)?.cancel()
+        stageCapJob.getAndSet(null)?.cancel()
 
         schedulePostHandshakeRequests()
 
@@ -698,6 +745,7 @@ class MeshConnectionManagerImpl(
         // Collapse cancel+clear into one atomic swap so a concurrent re-arm cannot orphan a
         // job in the gap between cancel and reassign.
         handshakeTimeout.getAndSet(null)?.cancel()
+        stageCapJob.getAndSet(null)?.cancel()
         // Set the completion latch so late-arriving progress packets (e.g. FileInfo that lands
         // between NODE_INFO_NONCE and the async Room DB install completion) cannot re-arm the
         // fast watchdog we just cancelled. Without this latch, those late packets would
@@ -748,13 +796,17 @@ class MeshConnectionManagerImpl(
         radioInterfaceService.getDeviceAddress()?.let { DeviceType.fromAddress(it) } in FAST_RECOVERY_TYPES
 
     override fun onHandshakeProgress() {
-        // Arm only inside the fast-recovery envelope, while Connecting, before the completion latch
-        // has fired. BLE retains the long stall-guard budget because its GATT latency is variable.
-        val shouldArmFastWatchdog =
-            isFastRecoveryTransport() &&
-                serviceRepository.connectionState.value is ConnectionState.Connecting &&
-                !handshakeCompleteLatch.value
-        if (!shouldArmFastWatchdog) return
+        // Progress only matters while a handshake is live, before the completion latch has fired.
+        if (serviceRepository.connectionState.value !is ConnectionState.Connecting || handshakeCompleteLatch.value) {
+            return
+        }
+        stageProgressSignals.incrementAndGet()
+        if (!isFastRecoveryTransport()) {
+            // BLE: re-arm the stage guard with its full budget so it acts as an inactivity window.
+            // Fixes false stalls on big meshes that drain past the fixed budget (Crashlytics e61fc83f).
+            rearmStageGuardOnProgress()
+            return
+        }
         // Atomic swap: cancel any in-flight fast watchdog and re-arm it with the full fast
         // timeout in a single operation. This keeps the watchdog quiet as long as meaningful
         // progress keeps arriving within the window, while a true stall still fires on
@@ -824,12 +876,17 @@ class MeshConnectionManagerImpl(
             return POST_HANDSHAKE_ADMISSION_INITIAL_RETRY_DELAY * (1 shl exponent)
         }
 
+        /** Total-cap multiple: a stage may re-arm for at most this many budgets before the guard must fire. */
+        private const val STAGE_GUARD_TOTAL_CAP_FACTOR = 10
+
+        /** Stage 1 budget. On BLE it is an inactivity window: each progress packet re-arms the full budget. */
         private val HANDSHAKE_TIMEOUT_STAGE1 = 30.seconds
 
         /**
          * Stage 2 drains the full node database, which can be significantly larger than Stage 1 config on big meshes.
          * 60 s matches the meshtastic-client SDK timeout and avoids premature stall-guard triggers on meshes with 50+
-         * nodes.
+         * nodes. On BLE it is an inactivity window: each progress packet re-arms the full budget, so a large nodeDB
+         * that streams for longer than the budget is never misread as a stall.
          */
         private val HANDSHAKE_TIMEOUT_STAGE2 = 60.seconds
 
@@ -846,7 +903,7 @@ class MeshConnectionManagerImpl(
          * BLE is intentionally excluded — its GATT latency budget is variable enough that the existing
          * [HANDSHAKE_TIMEOUT_STAGE1] (30s) and [HANDSHAKE_TIMEOUT_STAGE2] (60s) budgets remain the right trade-off.
          * Both transports now recover exclusively via [runSiblingHandshakeRecovery] (transport restart); the previous
-         * BLE mid-session want_config retry has been removed (see [startHandshakeStallGuard] for the firmware crash
+         * BLE mid-session want_config retry has been removed (see [scheduleStallGuard] for the firmware crash
          * rationale).
          */
         private val FAST_HANDSHAKE_TIMEOUT = 12.seconds

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshConnectionManagerImplTest.kt
@@ -1047,35 +1047,96 @@ class MeshConnectionManagerImplTest {
     }
 
     @Test
-    fun `BLE transport unaffected by onHandshakeProgress regression`() = runTest(testDispatcher) {
-        // Explicit BLE address (starts with 'x') — must NOT engage the fast path.
+    fun `BLE Stage 1 progress re-arms the stall guard as an inactivity window`() = runTest(testDispatcher) {
+        // Explicit BLE address (starts with 'x'): must NOT engage the 12s fast path.
         every { radioInterfaceService.getDeviceAddress() } returns "xAA:BB:CC:DD:EE:FF"
         manager = createManager(backgroundScope)
         radioConnectionState.value = ConnectionState.Connected
         advanceTimeBy(200)
         advanceUntilIdle()
 
-        // Spam progress signals — BLE must ignore them, so the 30s Stage 1 budget is unchanged.
-        repeat(10) {
+        // Trickle progress every 20s. Total elapsed crosses the 30s Stage 1 budget several
+        // times over, but each progress signal re-arms the full budget, so no restart may
+        // fire while progress continues. The 20s gaps also prove BLE never armed the 12s
+        // fast watchdog (it would have fired inside each gap).
+        repeat(4) {
+            advanceTimeBy(20_000L)
+            advanceUntilIdle()
             manager.onHandshakeProgress()
             advanceUntilIdle()
         }
-
-        // Advance to 13s — would fire a fast watchdog if BLE were incorrectly included.
-        advanceTimeBy(13_000L)
-        advanceUntilIdle()
 
         verifySuspend(exactly(0)) { radioInterfaceService.restartTransport() }
         assertEquals(
             ConnectionState.Connecting,
             serviceRepository.connectionState.value,
-            "BLE must ignore onHandshakeProgress and stay Connecting through 13s",
+            "BLE must stay Connecting while progress keeps arriving past the fixed budget",
         )
 
-        // Now advance past the full BLE Stage 1 budget (30s). We already advanced 13s, so 33s
-        // more crosses the 30s Stage 1 stall threshold the recovery sibling fires at. (Extra
-        // slack is harmless — the BLE stage has no retry delay before recovery.)
-        advanceTimeBy(33_000L)
+        // Silence after the last progress: the guard fires once the full 30s budget elapses.
+        advanceTimeBy(31_000L)
+        advanceUntilIdle()
+
+        verifySuspend(exactly(1)) { radioInterfaceService.restartTransport() }
+    }
+
+    @Test
+    fun `BLE total cap fires the stall guard despite continuous trickle progress`() = runTest(testDispatcher) {
+        // Explicit BLE address (starts with 'x'): must NOT engage the 12s fast path.
+        every { radioInterfaceService.getDeviceAddress() } returns "xAA:BB:CC:DD:EE:FF"
+        manager = createManager(backgroundScope)
+        radioConnectionState.value = ConnectionState.Connected
+        advanceTimeBy(200)
+        advanceUntilIdle()
+
+        // Trickle progress every 20s, which would extend the inactivity window forever. The
+        // 300s total cap (10x the 30s Stage 1 budget) stops re-arms, so the pending guard
+        // fires at most one budget later. 20 iterations = 400s, comfortably past cap + budget.
+        repeat(20) {
+            advanceTimeBy(20_000L)
+            advanceUntilIdle()
+            manager.onHandshakeProgress()
+            advanceUntilIdle()
+        }
+
+        verifySuspend(exactly(1)) { radioInterfaceService.restartTransport() }
+        assertEquals(
+            ConnectionState.Disconnected,
+            serviceRepository.connectionState.value,
+            "The total cap must end the handshake despite continuous trickle progress",
+        )
+    }
+
+    @Test
+    fun `BLE Stage 2 progress re-arms the 60s stall guard as an inactivity window`() = runTest(testDispatcher) {
+        // Default mock address is not a fast transport, so the BLE stage-guard path applies.
+        manager = createManager(backgroundScope)
+        radioConnectionState.value = ConnectionState.Connected
+        advanceTimeBy(200)
+        advanceUntilIdle()
+
+        // Enter Stage 2 directly, as the config-flow manager does once Stage 1 completes.
+        manager.startNodeInfoOnly()
+        advanceUntilIdle()
+
+        // A big node database streaming for 90s (past the fixed 60s budget) must not be
+        // misread as a stall while NodeInfo progress keeps re-arming the window.
+        repeat(2) {
+            advanceTimeBy(45_000L)
+            advanceUntilIdle()
+            manager.onHandshakeProgress()
+            advanceUntilIdle()
+        }
+
+        verifySuspend(exactly(0)) { radioInterfaceService.restartTransport() }
+        assertEquals(
+            ConnectionState.Connecting,
+            serviceRepository.connectionState.value,
+            "BLE must stay Connecting while Stage 2 progress keeps arriving past the fixed budget",
+        )
+
+        // Silence after the last progress: the guard fires once the full 60s budget elapses.
+        advanceTimeBy(61_000L)
         advanceUntilIdle()
 
         verifySuspend(exactly(1)) { radioInterfaceService.restartTransport() }

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshConnectionManager.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/MeshConnectionManager.kt
@@ -66,8 +66,9 @@ interface MeshConnectionManager {
      *
      * On fast transports (TCP, USB serial) this re-arms the transport-aware handshake watchdog so a steady trickle of
      * progress does not trip the aggressive fast-recovery timeout while a true stall still fires on schedule. On BLE
-     * this is a no-op: BLE keeps the original long-and-retry stall-guard budget because GATT latency is high and
-     * variable.
+     * this re-arms the current stage's stall guard with its full budget, turning the fixed stage deadline into an
+     * inactivity window: a large node database that streams for longer than the budget is not misread as a stall, while
+     * a silent link still fires on schedule because nothing re-arms.
      */
     fun onHandshakeProgress()
 


### PR DESCRIPTION
## Why

Crashlytics `e61fc83f4f8155d35b6c0271a1871010` is the highest-volume non-fatal on 2.8.1: 2,159 users / 9,430 events of "handshake stall" reports (the title is frozen from 2.7-era wording; the bucket groups every throwable-less `Logger.e` from the stall guard). Sampled 2.8.1 events split into two populations:

- ~50% are BLE Stage 1/2 stalls that show REAL config-stream progress right up to the deadline, firing at exactly the 30s/60s budget on large meshes (one sampled mesh: 471 nodes). The budgets were fixed totals that never extended on progress (`onHandshakeProgress()` was a deliberate no-op on BLE), and each recovery restart re-drains the nodeDB from scratch into the same wall, looping to "recovery exhausted": these users cannot connect at all. That is the bug this PR fixes.
- ~50% are fast-transport total-silence stalls: a genuinely unresponsive device or session, where the restart is the recovery mechanism working. Environmental, not addressed here.

(The sibling "forcing reconnect" variant vanished after 2.8.0 because #6470 downgraded the fast watchdog to Warn, not because the underlying stall stopped.)

## What

- On BLE, `onHandshakeProgress()` now re-arms the current stage's guard with its full budget, converting 30s/60s into inactivity windows. Only the connected device's own session-admitted config-stream frames re-arm (my_info, config, module_config, channel, node_info, metadata, fileInfo); ambient mesh traffic cannot. A silent link fires the guard exactly as before. TCP/USB fast path unchanged.
- A per-stage total cap bounds the new behavior: a cap job on the same virtual clock de-arms the spec at 10x budget, so even pathological trickle-forever firmware hits a hard ceiling (330s Stage 1 / 660s Stage 2) instead of connecting forever. The stage spec is generation-guarded so a progress signal racing the Stage 1 to Stage 2 transition cannot resurrect a stale spec.
- Stall diagnostics enriched with `progressSignals` (count since stage arm) and `sinceConnectMs`: states, counters, and timings only, no PII. Crashlytics grouping is stack-based via the synthesized exception, so the enriched message keeps the existing bucket, letting the next release discriminate silent stalls (0 signals) from any residual false positives.
- Severity deliberately stays at `Logger.e` for one release so the fix's field effect is verifiable; recommend the #6470-style Warn downgrade afterward, keeping "recovery exhausted" as the actionable non-fatal. Also flagged for later: fast-transport Stage 2 arms at 12s of inter-stage silence (12% of sampled events), worth revisiting if it persists post-fix.

## Testing Performed

- 3 new virtual-time tests in `MeshConnectionManagerImplTest`: Stage 1 trickle (20s intervals past the 30s budget; the gaps also prove the 12s fast watchdog never engages on BLE), Stage 2 trickle (45s intervals past 60s), and total-cap (continuous 20s trickle for 400s virtual asserts exactly one restart). Both trickle tests then verify a single restart after full-budget silence. The old test pinning the BLE no-op was replaced, not ignored; the surviving silence-only stall tests remain valid.
- Full local baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` green (6,700 tests), clean tree.
- Two independent adversarial reviews; the correctness pass exhaustively verified that only session-admitted config-stream frames re-arm the guard, that restart hygiene leaves no stale spec or leaked timers, and required the total cap this PR includes.

## Constitution Check

All seven principles evaluated: I KMP purity (commonMain, coroutines + atomicfu, virtual-clock timers); II zero lint (clean); III CMP UI (no UI change); IV privacy (diagnostics are counters and timings only); V design standards (N/A); VI documentation freshness (no user-facing docs affected); VII verify before push (full baseline run locally; CI confirmed on this PR after push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
