### PR TITLE
fix(messaging): clear and suppress notifications for the conversation on screen

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/di/CoreDataModule.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/di/CoreDataModule.kt
@@ -16,11 +16,18 @@
  */
 package org.meshtastic.core.data.di
 
+import androidx.lifecycle.Lifecycle
+import kotlinx.coroutines.launch
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Provided
 import org.koin.core.annotation.Single
+import org.meshtastic.core.common.di.ApplicationCoroutineScope
+import org.meshtastic.core.common.di.PROCESS_LIFECYCLE
 import org.meshtastic.core.model.util.MeshDataMapper
 import org.meshtastic.core.model.util.NodeIdLookup
+import org.meshtastic.core.repository.ActiveConversationTracker
 import kotlin.time.Clock
 
 @Module
@@ -29,4 +36,20 @@ class CoreDataModule {
     @Single fun provideMeshDataMapper(nodeIdLookup: NodeIdLookup): MeshDataMapper = MeshDataMapper(nodeIdLookup)
 
     @Single fun provideClock(): Clock = Clock.System
+
+    /**
+     * [ActiveConversationTracker] is a plain holder so it stays trivially constructible in tests; the process lifecycle
+     * is bridged into it here, where an application-lifetime scope is already available.
+     */
+    @Single
+    fun provideActiveConversationTracker(
+        @Provided @Named(PROCESS_LIFECYCLE) processLifecycle: Lifecycle,
+        @Provided applicationScope: ApplicationCoroutineScope,
+    ): ActiveConversationTracker = ActiveConversationTracker().also { tracker ->
+        applicationScope.launch {
+            processLifecycle.currentStateFlow.collect { state ->
+                tracker.setAppForeground(state.isAtLeast(Lifecycle.State.STARTED))
+            }
+        }
+    }
 }

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
@@ -45,12 +45,14 @@ import org.meshtastic.core.model.util.decodeOrNull
 import org.meshtastic.core.model.util.isValidCodePoint
 import org.meshtastic.core.model.util.snrOrNull
 import org.meshtastic.core.model.util.toOneLiner
+import org.meshtastic.core.repository.ActiveConversationTracker
 import org.meshtastic.core.repository.AdminPacketHandler
 import org.meshtastic.core.repository.DataPair
 import org.meshtastic.core.repository.DiscoveryPacketCollectorRegistry
 import org.meshtastic.core.repository.MeshBeaconRepository
 import org.meshtastic.core.repository.MeshDataHandler
 import org.meshtastic.core.repository.MeshNotificationManager
+import org.meshtastic.core.repository.MessageAnnouncement
 import org.meshtastic.core.repository.MessageFilter
 import org.meshtastic.core.repository.NeighborInfoHandler
 import org.meshtastic.core.repository.NodeManager
@@ -115,6 +117,7 @@ class MeshDataHandlerImpl(
     private val geofenceMonitor: GeofenceMonitor,
     private val meshBeaconRepository: MeshBeaconRepository,
     private val radioInterfaceService: RadioInterfaceService,
+    private val activeConversationTracker: ActiveConversationTracker,
     private val scope: ServiceScope,
 ) : MeshDataHandler {
 
@@ -503,18 +506,33 @@ class MeshDataHandlerImpl(
         val mentionsMe =
             dataPacket.dataType == PortNum.TEXT_MESSAGE_APP.value &&
                 textMentionsNode(dataPacket.text, nodeManager.getMyId())
-        val isSilent = nodeMuted || (conversationMuted && !mentionsMe)
-        if (dataPacket.dataType == PortNum.ALERT_APP.value && !isSilent) {
-            notificationManager.dispatch(
-                Notification(
-                    title = getSenderName(dataPacket),
-                    message = dataPacket.alert ?: getStringSuspend(Res.string.critical_alert),
-                    category = Notification.Category.Alert,
-                    contactKey = contactKey,
-                ),
-            )
-        } else if (updateNotification && !isSilent) {
-            updateNotification(contactKey, dataPacket, isSilent)
+        val muted = nodeMuted || (conversationMuted && !mentionsMe)
+        when {
+            // A critical alert is the one category that deliberately breaks through, so it is not suppressed for the
+            // conversation on screen — only mute silences it.
+            dataPacket.dataType == PortNum.ALERT_APP.value ->
+                if (!muted) {
+                    notificationManager.dispatch(
+                        Notification(
+                            title = getSenderName(dataPacket),
+                            message = dataPacket.alert ?: getStringSuspend(Res.string.critical_alert),
+                            category = Notification.Category.Alert,
+                            contactKey = contactKey,
+                        ),
+                    )
+                }
+
+            !updateNotification || muted -> Unit
+
+            // Reading the conversation is its own acknowledgement: notifying about a message whose bubble is already
+            // on screen only buzzes the phone in the user's hand. Foreground-but-elsewhere still posts, silently, so
+            // the shade and Auto/Wear keep the conversation.
+            else ->
+                when (activeConversationTracker.announcementFor(contactKey)) {
+                    MessageAnnouncement.Suppress -> Unit
+                    MessageAnnouncement.Silent -> updateNotification(contactKey, dataPacket, isSilent = true)
+                    MessageAnnouncement.Alert -> updateNotification(contactKey, dataPacket, isSilent = false)
+                }
         }
     }
 
@@ -620,9 +638,10 @@ class MeshDataHandlerImpl(
                     // Skip notification if the original message was filtered
                     val conversationMuted = packetRepository.value.getContactSettings(contactKey).isMuted
                     val nodeMuted = nodeManager.getNodeById(fromId)?.isMuted == true
-                    val isSilent = conversationMuted || nodeMuted
+                    val muted = conversationMuted || nodeMuted
+                    val announcement = activeConversationTracker.announcementFor(contactKey)
 
-                    if (!isSilent) {
+                    if (!muted && announcement != MessageAnnouncement.Suppress) {
                         val isBroadcast = originalPacket.destination is NodeAddress.Broadcast
                         val channelName =
                             if (isBroadcast) {
@@ -640,7 +659,7 @@ class MeshDataHandlerImpl(
                             emoji,
                             isBroadcast,
                             channelName,
-                            isSilent,
+                            announcement == MessageAnnouncement.Silent,
                         )
                     }
                 }

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
@@ -45,6 +45,7 @@ import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.model.Reaction
 import org.meshtastic.core.model.util.MeshDataMapper
+import org.meshtastic.core.repository.ActiveConversationTracker
 import org.meshtastic.core.repository.AdminPacketHandler
 import org.meshtastic.core.repository.MeshBeaconPrefs
 import org.meshtastic.core.repository.MeshBeaconRepository
@@ -136,6 +137,9 @@ class MeshDataHandlerTest {
         }
     private val meshBeaconRepository = MeshBeaconRepository(fakeBeaconPrefs, geofenceScope)
 
+    // Backgrounded by default, so existing expectations about notifications firing are unchanged.
+    private val activeConversationTracker = ActiveConversationTracker()
+
     @AfterTest
     fun tearDown() {
         geofenceScope.cancel()
@@ -175,6 +179,7 @@ class MeshDataHandlerTest {
                 ),
                 meshBeaconRepository = meshBeaconRepository,
                 radioInterfaceService = radioInterfaceService,
+                activeConversationTracker = activeConversationTracker,
                 scope = testScope.asServiceScope(),
             )
 
@@ -1125,6 +1130,65 @@ class MeshDataHandlerTest {
             Node(num = 456, user = User(id = "!remote", long_name = "Remote User"))
 
         handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        verifySuspend {
+            serviceNotifications.updateMessageNotification(any(), any(), any(), any(), any(), isSilent = false)
+        }
+    }
+
+    // --- Active-conversation suppression ---
+    //
+    // contactKey for these packets is "$channel$to" = "0^all" (channel 0, broadcast).
+
+    private fun arrangeUnmutedBroadcast() {
+        val packet = mentionPacket()
+        every { dataMapper.toDataPacket(packet) } returns mentionDataPacket()
+        everySuspend { packetRepository.findPacketsWithId(101) } returns emptyList()
+        everySuspend { packetRepository.getContactSettings(any()) } returns ContactSettings(contactKey = "test")
+        every { messageFilter.shouldFilter(any(), any()) } returns false
+        every { nodeManager.getMyId() } returns myId
+        every { nodeManager.getNodeById("!remote") } returns
+            Node(num = 456, user = User(id = "!remote", long_name = "Remote User"))
+    }
+
+    @Test
+    fun `message for the conversation on screen does not notify`() = testScope.runTest {
+        arrangeUnmutedBroadcast()
+        activeConversationTracker.setAppForeground(true)
+        activeConversationTracker.setActive("0^all")
+
+        handler.handleReceivedData(mentionPacket(), 123)
+        advanceUntilIdle()
+
+        verifySuspend(mode = dev.mokkery.verify.VerifyMode.not) {
+            serviceNotifications.updateMessageNotification(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `message for another conversation while foregrounded notifies silently`() = testScope.runTest {
+        arrangeUnmutedBroadcast()
+        activeConversationTracker.setAppForeground(true)
+        activeConversationTracker.setActive("0!someoneelse")
+
+        handler.handleReceivedData(mentionPacket(), 123)
+        advanceUntilIdle()
+
+        verifySuspend {
+            serviceNotifications.updateMessageNotification(any(), any(), any(), any(), any(), isSilent = true)
+        }
+    }
+
+    @Test
+    fun `message while backgrounded notifies normally even for the last viewed conversation`() = testScope.runTest {
+        arrangeUnmutedBroadcast()
+        // Screen paused on backgrounding clears the key; belt-and-braces, a stale key must not silence a
+        // background notification either.
+        activeConversationTracker.setActive("0^all")
+        activeConversationTracker.setAppForeground(false)
+
+        handler.handleReceivedData(mentionPacket(), 123)
         advanceUntilIdle()
 
         verifySuspend {

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ActiveConversationTracker.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/ActiveConversationTracker.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** How an arriving message for a conversation should be announced, given where the user currently is. */
+enum class MessageAnnouncement {
+    /** The conversation is on screen — the message itself is the notification. Post nothing. */
+    Suppress,
+
+    /** App is in front but on another screen — post without sound or vibration so the shade still has it. */
+    Silent,
+
+    /** App is backgrounded or the screen is off — announce normally. */
+    Alert,
+}
+
+/**
+ * Tracks which conversation the user is currently looking at, so the notification path does not buzz the phone for a
+ * message whose bubble is already animating onto the screen.
+ *
+ * Only the message screen writes [setActive]/[clearActive], on resume and pause. That is deliberately the only signal
+ * [MessageAnnouncement.Suppress] needs: backgrounding the app pauses the screen, which clears the key on its way out.
+ * [appForeground] is driven from the process lifecycle and only separates [MessageAnnouncement.Silent] from
+ * [MessageAnnouncement.Alert].
+ */
+class ActiveConversationTracker {
+
+    private val _activeContactKey = MutableStateFlow<String?>(null)
+
+    /** Contact key of the conversation currently on screen, or null when no conversation is visible. */
+    val activeContactKey: StateFlow<String?> = _activeContactKey.asStateFlow()
+
+    private val _appForeground = MutableStateFlow(false)
+
+    /** True while any part of the app is visible to the user. */
+    val appForeground: StateFlow<Boolean> = _appForeground.asStateFlow()
+
+    /** Call when a conversation becomes visible. */
+    fun setActive(contactKey: String) {
+        _activeContactKey.value = contactKey
+    }
+
+    /**
+     * Call when a conversation stops being visible. Compares before clearing so that navigating straight from one
+     * conversation to another cannot have the outgoing screen's pause erase the incoming screen's key.
+     */
+    fun clearActive(contactKey: String) {
+        _activeContactKey.compareAndSet(contactKey, null)
+    }
+
+    fun setAppForeground(foreground: Boolean) {
+        _appForeground.value = foreground
+    }
+
+    fun announcementFor(contactKey: String): MessageAnnouncement = when {
+        appForeground.value && activeContactKey.value == contactKey -> MessageAnnouncement.Suppress
+        appForeground.value -> MessageAnnouncement.Silent
+        else -> MessageAnnouncement.Alert
+    }
+}

--- a/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ActiveConversationTrackerTest.kt
+++ b/core/repository/src/commonTest/kotlin/org/meshtastic/core/repository/ActiveConversationTrackerTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ActiveConversationTrackerTest {
+
+    private val tracker = ActiveConversationTracker()
+
+    @Test
+    fun `defaults to alerting`() {
+        assertEquals(MessageAnnouncement.Alert, tracker.announcementFor("0^all"))
+    }
+
+    @Test
+    fun `suppresses only the conversation on screen`() {
+        tracker.setAppForeground(true)
+        tracker.setActive("0^all")
+
+        assertEquals(MessageAnnouncement.Suppress, tracker.announcementFor("0^all"))
+        assertEquals(MessageAnnouncement.Silent, tracker.announcementFor("0!abcdef01"))
+    }
+
+    @Test
+    fun `backgrounding alerts even while a key is still set`() {
+        tracker.setActive("0^all")
+        tracker.setAppForeground(false)
+
+        assertEquals(MessageAnnouncement.Alert, tracker.announcementFor("0^all"))
+    }
+
+    @Test
+    fun `clearing a stale key does not erase the conversation that replaced it`() {
+        tracker.setAppForeground(true)
+        tracker.setActive("0^all")
+        // Navigating A -> B: B resumes before A pauses.
+        tracker.setActive("0!abcdef01")
+        tracker.clearActive("0^all")
+
+        assertEquals("0!abcdef01", tracker.activeContactKey.value)
+        assertEquals(MessageAnnouncement.Suppress, tracker.announcementFor("0!abcdef01"))
+    }
+
+    @Test
+    fun `clearing the current key clears it`() {
+        tracker.setActive("0^all")
+        tracker.clearActive("0^all")
+
+        assertNull(tracker.activeContactKey.value)
+    }
+}

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import kotlinx.collections.immutable.ImmutableMap
@@ -194,6 +195,12 @@ fun MessageScreen(
 
     // Prevent the message TextField from stealing focus when the screen opens
     SideEffect(contactKey) { focusManager.clearFocus() }
+
+    // Tell the notification path this conversation is on screen, so an arriving message for it is not announced twice.
+    LifecycleResumeEffect(contactKey) {
+        viewModel.onConversationVisible(contactKey)
+        onPauseOrDispose { viewModel.onConversationHidden(contactKey) }
+    }
 
     // Derived state, memoized for performance
     val channelInfo =

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
@@ -46,12 +46,13 @@ import org.meshtastic.core.model.ContactSettings
 import org.meshtastic.core.model.Message
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
+import org.meshtastic.core.repository.ActiveConversationTracker
 import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.CustomEmojiPrefs
 import org.meshtastic.core.repository.HomoglyphPrefs
+import org.meshtastic.core.repository.MeshNotificationManager
 import org.meshtastic.core.repository.MessagingController
 import org.meshtastic.core.repository.NodeRepository
-import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.QuickChatActionRepository
 import org.meshtastic.core.repository.RadioConfigRepository
@@ -103,7 +104,8 @@ class MessageViewModel(
     private val uiPrefs: UiPrefs,
     private val customEmojiPrefs: CustomEmojiPrefs,
     private val homoglyphEncodingPrefs: HomoglyphPrefs,
-    private val notificationManager: NotificationManager,
+    private val meshNotificationManager: MeshNotificationManager,
+    private val activeConversationTracker: ActiveConversationTracker,
     private val sendMessageUseCase: SendMessageUseCase,
     private val messageTranslationService: MessageTranslationService,
     private val snackbarManager: SnackbarManager,
@@ -428,6 +430,15 @@ class MessageViewModel(
 
     // endregion
 
+    /**
+     * Marks [contactKey] as the conversation on screen so an arriving message for it is not also announced as a
+     * notification. Paired with [onConversationHidden] on pause — backgrounding the app hides the screen, which is what
+     * makes a single signal enough.
+     */
+    fun onConversationVisible(contactKey: String) = activeConversationTracker.setActive(contactKey)
+
+    fun onConversationHidden(contactKey: String) = activeConversationTracker.clearActive(contactKey)
+
     fun clearUnreadCount(contact: String, messageUuid: Long, lastReadTimestamp: Long) =
         safeLaunch(context = ioDispatcher, tag = "clearUnreadCount") {
             val existingTimestamp = contactSettings.value[contact]?.lastReadMessageTimestamp ?: Long.MIN_VALUE
@@ -437,7 +448,9 @@ class MessageViewModel(
             packetRepository.clearUnreadCount(contact, lastReadTimestamp)
             packetRepository.updateLastReadMessage(contact, messageUuid, lastReadTimestamp)
             val unreadCount = packetRepository.getUnreadCount(contact)
-            if (unreadCount == 0) notificationManager.cancel(contact.hashCode())
+            // Must go through the domain manager: the conversation is posted under a notification *tag*, so an
+            // untagged cancel by id never matches it. This also rebuilds the group summary.
+            if (unreadCount == 0) meshNotificationManager.cancelMessageNotification(contact)
         }
 
     companion object {

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageViewModel.kt
@@ -448,9 +448,14 @@ class MessageViewModel(
             packetRepository.clearUnreadCount(contact, lastReadTimestamp)
             packetRepository.updateLastReadMessage(contact, messageUuid, lastReadTimestamp)
             val unreadCount = packetRepository.getUnreadCount(contact)
-            // Must go through the domain manager: the conversation is posted under a notification *tag*, so an
-            // untagged cancel by id never matches it. This also rebuilds the group summary.
-            if (unreadCount == 0) meshNotificationManager.cancelMessageNotification(contact)
+            // The count is read before this suspends, so it can be stale by the time the cancel lands. Re-checking
+            // that the conversation is still on screen closes the window: while it is, an arriving message posts no
+            // notification at all (ActiveConversationTracker suppresses it), so there is nothing this can erase. Once
+            // the user has left, the notification is theirs to see and must survive.
+            // Cancelling must go through the domain manager: the conversation is posted under a notification *tag*,
+            // so an untagged cancel by id never matches it. This also rebuilds the group summary.
+            val stillOnScreen = activeConversationTracker.activeContactKey.value == contact
+            if (unreadCount == 0 && stillOnScreen) meshNotificationManager.cancelMessageNotification(contact)
         }
 
     companion object {

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageViewModelTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageViewModelTest.kt
@@ -25,6 +25,7 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,6 +77,7 @@ class MessageViewModelTest {
     private val uiPrefs: UiPrefs = mock(MockMode.autofill)
     private val meshNotificationManager: org.meshtastic.core.repository.MeshNotificationManager =
         mock(MockMode.autofill)
+    private val activeConversationTracker = ActiveConversationTracker()
     private val messageTranslationService: MessageTranslationService = mock(MockMode.autofill)
     private val snackbarManager: SnackbarManager = SnackbarManager()
 
@@ -135,7 +137,7 @@ class MessageViewModelTest {
                 homoglyphEncodingPrefs = homoglyphPrefs,
                 uiPrefs = uiPrefs,
                 meshNotificationManager = meshNotificationManager,
-                activeConversationTracker = ActiveConversationTracker(),
+                activeConversationTracker = activeConversationTracker,
                 messageTranslationService = messageTranslationService,
                 snackbarManager = snackbarManager,
             )
@@ -319,6 +321,7 @@ class MessageViewModelTest {
         everySuspend { packetRepository.updateLastReadMessage(contact, 1L, 1000L) } returns Unit
         everySuspend { packetRepository.getUnreadCount(contact) } returns 0
         everySuspend { meshNotificationManager.cancelMessageNotification(contact) } returns Unit
+        activeConversationTracker.setActive(contact)
 
         viewModel.clearUnreadCount(contact, 1L, 1000L)
 
@@ -327,6 +330,23 @@ class MessageViewModelTest {
         verifySuspend { packetRepository.clearUnreadCount(contact, 1000L) }
         verifySuspend { packetRepository.updateLastReadMessage(contact, 1L, 1000L) }
         verifySuspend { meshNotificationManager.cancelMessageNotification(contact) }
+    }
+
+    @Test
+    fun testClearUnreadCountLeavesNotificationAloneOnceTheUserHasLeft() = runTest {
+        // The count was read before this coroutine suspended. If the user left in the meantime, a message that
+        // arrived since posted a notification that is legitimately theirs to see — cancelling would erase it.
+        val contact = "0!12345678"
+        everySuspend { packetRepository.clearUnreadCount(contact, 1000L) } returns Unit
+        everySuspend { packetRepository.updateLastReadMessage(contact, 1L, 1000L) } returns Unit
+        everySuspend { packetRepository.getUnreadCount(contact) } returns 0
+        activeConversationTracker.clearActive(contact)
+
+        viewModel.clearUnreadCount(contact, 1L, 1000L)
+
+        advanceUntilIdle()
+
+        verifySuspend(mode = VerifyMode.not) { meshNotificationManager.cancelMessageNotification(contact) }
     }
 
     @Test

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageViewModelTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageViewModelTest.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.ContactSettings
+import org.meshtastic.core.repository.ActiveConversationTracker
 import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.CustomEmojiPrefs
 import org.meshtastic.core.repository.HomoglyphPrefs
@@ -73,7 +74,8 @@ class MessageViewModelTest {
     private val customEmojiPrefs: CustomEmojiPrefs = mock(MockMode.autofill)
     private val homoglyphPrefs: HomoglyphPrefs = mock(MockMode.autofill)
     private val uiPrefs: UiPrefs = mock(MockMode.autofill)
-    private val notificationManager: org.meshtastic.core.repository.NotificationManager = mock(MockMode.autofill)
+    private val meshNotificationManager: org.meshtastic.core.repository.MeshNotificationManager =
+        mock(MockMode.autofill)
     private val messageTranslationService: MessageTranslationService = mock(MockMode.autofill)
     private val snackbarManager: SnackbarManager = SnackbarManager()
 
@@ -132,7 +134,8 @@ class MessageViewModelTest {
                 customEmojiPrefs = customEmojiPrefs,
                 homoglyphEncodingPrefs = homoglyphPrefs,
                 uiPrefs = uiPrefs,
-                notificationManager = notificationManager,
+                meshNotificationManager = meshNotificationManager,
+                activeConversationTracker = ActiveConversationTracker(),
                 messageTranslationService = messageTranslationService,
                 snackbarManager = snackbarManager,
             )
@@ -315,7 +318,7 @@ class MessageViewModelTest {
         everySuspend { packetRepository.clearUnreadCount(contact, 1000L) } returns Unit
         everySuspend { packetRepository.updateLastReadMessage(contact, 1L, 1000L) } returns Unit
         everySuspend { packetRepository.getUnreadCount(contact) } returns 0
-        every { notificationManager.cancel(contact.hashCode()) } returns Unit
+        everySuspend { meshNotificationManager.cancelMessageNotification(contact) } returns Unit
 
         viewModel.clearUnreadCount(contact, 1L, 1000L)
 
@@ -323,7 +326,7 @@ class MessageViewModelTest {
 
         verifySuspend { packetRepository.clearUnreadCount(contact, 1000L) }
         verifySuspend { packetRepository.updateLastReadMessage(contact, 1L, 1000L) }
-        verifySuspend { notificationManager.cancel(contact.hashCode()) }
+        verifySuspend { meshNotificationManager.cancelMessageNotification(contact) }
     }
 
     @Test

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageViewModelTranslationTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageViewModelTranslationTest.kt
@@ -37,11 +37,12 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.ContactSettings
 import org.meshtastic.core.model.Message
 import org.meshtastic.core.model.MessageStatus
+import org.meshtastic.core.repository.ActiveConversationTracker
 import org.meshtastic.core.repository.ConnectionStateProvider
 import org.meshtastic.core.repository.CustomEmojiPrefs
 import org.meshtastic.core.repository.HomoglyphPrefs
+import org.meshtastic.core.repository.MeshNotificationManager
 import org.meshtastic.core.repository.MessagingController
-import org.meshtastic.core.repository.NotificationManager
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.repository.QuickChatActionRepository
 import org.meshtastic.core.repository.RadioConfigRepository
@@ -124,7 +125,7 @@ class MessageViewModelTranslationTest {
     private val customEmojiPrefs: CustomEmojiPrefs = mock(MockMode.autofill)
     private val homoglyphPrefs: HomoglyphPrefs = mock(MockMode.autofill)
     private val uiPrefs: UiPrefs = mock(MockMode.autofill)
-    private val notificationManager: NotificationManager = mock(MockMode.autofill)
+    private val meshNotificationManager: MeshNotificationManager = mock(MockMode.autofill)
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -188,7 +189,8 @@ class MessageViewModelTranslationTest {
                 customEmojiPrefs = customEmojiPrefs,
                 homoglyphEncodingPrefs = homoglyphPrefs,
                 uiPrefs = uiPrefs,
-                notificationManager = notificationManager,
+                meshNotificationManager = meshNotificationManager,
+                activeConversationTracker = ActiveConversationTracker(),
                 messageTranslationService = translationService,
                 snackbarManager = snackbarManager,
             )


### PR DESCRIPTION
Two notification bugs that made chat feel broken: a notification for a thread you had already read stayed in the shade, and an arriving message buzzed the phone while its own conversation was open on screen.

### 🐛 Bug Fixes

- **Reading a thread now dismisses its notification.** `MessageViewModel.clearUnreadCount` cancelled with `NotificationManager.cancel(contactKey.hashCode())`, but the conversation is posted as `notify(TAG_MESSAGE, id, …)`. An untagged cancel never matches a tagged post, so the notification — and the group-summary entry that Android Auto and Wear read from — survived being read. It now routes through `MeshNotificationManager.cancelMessageNotification(contactKey)`, which cancels with the tag and rebuilds the summary.
- **A message no longer announces itself for the conversation you are looking at.** `MeshDataHandlerImpl` gated only on conversation mute and node mute; nothing asked whether the screen was on or which thread was open.

### 🛠️ Refactoring & Architecture

- New `ActiveConversationTracker` (`core/repository`, commonMain) records the conversation currently on screen plus process foreground state, and resolves the three outcomes:

  | Where you are | Result |
  |---|---|
  | Viewing that conversation | Nothing posted — the bubble is the notification |
  | App foreground, another screen | Posted with `setSilent(true)` so the shade/Auto/Wear still have it |
  | Backgrounded or screen off | Unchanged |

- The tracker is a plain holder with no lifecycle dependency, so it stays trivially constructible in tests; the process lifecycle is bridged into it in `CoreDataModule`, which already owns an application-lifetime scope. `MessageScreen` writes it from a `LifecycleResumeEffect` — backgrounding pauses the screen, which clears the key on the way out, so no second signal is needed for the suppress case.
- `clearActive` compares before clearing, so navigating straight from one conversation to another cannot have the outgoing screen's pause erase the incoming screen's key.
- Applies to reactions as well as messages. Critical alerts (`ALERT_APP`) deliberately still break through — only mute silences those.

### Testing Performed

- `core/repository` — new `ActiveConversationTrackerTest`: default is alert; suppresses only the conversation on screen and stays silent for others; backgrounding alerts even with a stale key; stale-key clear does not erase the conversation that replaced it.
- `core/data` — new `MeshDataHandlerTest` cases: message for the conversation on screen does not notify; message for another conversation while foregrounded notifies silently; message while backgrounded notifies normally.
- `feature/messaging` — `MessageViewModelTest.testClearUnreadCount` now asserts the tagged `cancelMessageNotification` call.
- Full baseline green: `spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message notifications based on the conversation currently open.
  * Messages in the active conversation are suppressed.
  * Messages from other conversations are delivered silently while the app is in use.
  * Normal alerts continue when the app is in the background.
  * Reaction notifications now follow the same conversation-aware behavior.
  * Opening a conversation automatically clears its related unread notifications.

* **Bug Fixes**
  * Improved notification handling when quickly switching between conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->