### PR TITLE
feat(messaging): name the sender on the jump-to-latest control

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -879,6 +879,8 @@ ip_address
 ip_port
 ipv4_mode
 json_output_enabled
+jump_to_latest_from
+jump_to_latest_from_and_more
 ### KEY ###
 key_backup_deleted
 key_backup_not_found

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -909,6 +909,8 @@
     <string name="ip_port">Port:</string>
     <string name="ipv4_mode">IPv4 mode</string>
     <string name="json_output_enabled">JSON output enabled</string>
+    <string name="jump_to_latest_from">%1$s</string>
+    <string name="jump_to_latest_from_and_more">%1$s +%2$d</string>
     <!-- KEY -->
     <string name="key_backup_deleted">Key backup deleted</string>
     <string name="key_backup_not_found">No key backup found for this node</string>

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -305,6 +305,24 @@ fun MessageScreen(
         }
     }
 
+    // Who sent the newest unread message, for the jump-to-latest pill. Own messages are never unread, so this is
+    // simply the newest loaded message that did not come from this device.
+    val newestUnreadSender by
+        remember(pagedMessages.itemCount, unreadCount) {
+            derivedStateOf {
+                if (unreadCount == 0) {
+                    null
+                } else {
+                    pagedMessages.itemSnapshotList
+                        .firstOrNull { it != null && !it.fromLocal && !it.read }
+                        ?.node
+                        ?.user
+                        ?.let { user -> user.long_name.ifEmpty { user.short_name } }
+                        ?.takeIf { it.isNotEmpty() }
+                }
+            }
+        }
+
     val onEvent: (MessageScreenEvent) -> Unit =
         remember(viewModel, contactKey, messageInputState, ourNode) {
             fun handle(event: MessageScreenEvent) {
@@ -516,7 +534,7 @@ fun MessageScreen(
             )
             // Show FAB if we can scroll towards the newest messages (index 0).
             if (listState.canScrollBackward) {
-                ScrollToBottomFab(coroutineScope, listState, unreadCount)
+                ScrollToBottomFab(coroutineScope, listState, unreadCount, newestUnreadSender)
             }
         }
     }

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -317,8 +317,10 @@ fun MessageScreen(
                         .firstOrNull { it != null && !it.fromLocal && !it.read }
                         ?.node
                         ?.user
-                        ?.let { user -> user.long_name.ifEmpty { user.short_name } }
-                        ?.takeIf { it.isNotEmpty() }
+                        // Blank, not just empty: a name of only spaces would render an empty pill.
+                        ?.let { user ->
+                            user.long_name.takeIf { it.isNotBlank() } ?: user.short_name.takeIf { it.isNotBlank() }
+                        }
                 }
             }
         }

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageScreenComponents.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageScreenComponents.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.DropdownMenuGroup
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -90,6 +91,8 @@ import org.meshtastic.core.resources.filter_enable_for_contact
 import org.meshtastic.core.resources.filter_hide_count
 import org.meshtastic.core.resources.filter_settings
 import org.meshtastic.core.resources.filter_show_count
+import org.meshtastic.core.resources.jump_to_latest_from
+import org.meshtastic.core.resources.jump_to_latest_from_and_more
 import org.meshtastic.core.resources.navigate_back
 import org.meshtastic.core.resources.new_messages_below
 import org.meshtastic.core.resources.overflow_menu
@@ -136,31 +139,60 @@ import org.meshtastic.proto.ChannelSet
 // region ── ScrollToBottomFab ──
 
 /**
- * A FloatingActionButton that scrolls the message list to the bottom (most recent messages).
+ * Jump-to-latest control for the message list.
+ *
+ * A bare count answers "how many" but not "from whom", which is what actually decides whether to scroll now or keep
+ * reading — so when the newest unread message has a sender, the control widens to name them and keeps the count as the
+ * overflow case.
  *
  * @param coroutineScope The coroutine scope for launching the scroll animation.
  * @param listState The [LazyListState] of the message list.
  * @param unreadCount The number of unread messages to display as a badge.
+ * @param newestUnreadSender Display name of whoever sent the newest unread message, or null when there is none.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun BoxScope.ScrollToBottomFab(coroutineScope: CoroutineScope, listState: LazyListState, unreadCount: Int) {
-    FloatingActionButton(
-        modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
-        onClick = { coroutineScope.launch { listState.animateScrollToItem(0) } },
-    ) {
-        if (unreadCount > 0) {
-            BadgedBox(badge = { Badge { Text(unreadCount.toString()) } }) {
-                Icon(
-                    imageVector = MeshtasticIcons.ArrowDownward,
-                    contentDescription = stringResource(Res.string.scroll_to_bottom),
-                )
-            }
-        } else {
+fun BoxScope.ScrollToBottomFab(
+    coroutineScope: CoroutineScope,
+    listState: LazyListState,
+    unreadCount: Int,
+    newestUnreadSender: String? = null,
+) {
+    val modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp)
+    val onClick: () -> Unit = { coroutineScope.launch { listState.animateScrollToItem(0) } }
+    val icon =
+        @Composable {
             Icon(
                 imageVector = MeshtasticIcons.ArrowDownward,
                 contentDescription = stringResource(Res.string.scroll_to_bottom),
             )
+        }
+
+    if (unreadCount > 0 && newestUnreadSender != null) {
+        ExtendedFloatingActionButton(
+            modifier = modifier,
+            onClick = onClick,
+            icon = icon,
+            text = {
+                Text(
+                    text =
+                    if (unreadCount > 1) {
+                        stringResource(Res.string.jump_to_latest_from_and_more, newestUnreadSender, unreadCount - 1)
+                    } else {
+                        stringResource(Res.string.jump_to_latest_from, newestUnreadSender)
+                    },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
+        )
+    } else {
+        FloatingActionButton(modifier = modifier, onClick = onClick) {
+            if (unreadCount > 0) {
+                BadgedBox(badge = { Badge { Text(unreadCount.toString()) } }) { icon() }
+            } else {
+                icon()
+            }
         }
     }
 }


### PR DESCRIPTION
A bare unread count answers "how many" but not "from whom" — which is what actually decides whether to scroll now or keep reading.

### 🛠️ Improvements

- **Jump-to-latest names the sender.** `ScrollToBottomFab` showed a count badge. When the newest unread message has a sender, the control now widens into a pill naming them, keeping the count as the overflow case (`Alice +3`). With nothing unread it stays exactly the plain arrow it already was.
- Own messages are never unread, so the sender resolves simply to the newest loaded message that did not come from this device. Long names fall back to short names, and a blank name falls back to the plain arrow rather than an empty pill.

### 🧹 Chores

- Added `jump_to_latest_from` / `jump_to_latest_from_and_more`; ran `scripts/sort-strings.py`.

### Testing Performed

- Full baseline green: `spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`, plus `:screenshot-tests:validateDebugScreenshotTest` — no goldens moved.
- One `:feature:node` `NodeDetailCompassLifecycleTest` failure on the first run was a flake (this PR touches only `feature/messaging`); it passed on `--rerun-tasks` and on the re-run baseline. Same shape as the `:feature:settings` flake seen earlier this week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The “jump to latest” control now identifies the sender of the newest unread message.
  * For multiple unread messages, it also displays how many additional messages are waiting.
  * The control retains its compact unread-count appearance when sender information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->