### PR TITLE
feat(notifications): offer conversations as bubbles

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -197,6 +197,15 @@
         </service>
 
         <activity
+            android:name="org.meshtastic.app.BubbleActivity"
+            android:allowEmbedded="true"
+            android:documentLaunchMode="always"
+            android:resizeableActivity="true"
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
+            android:exported="false" />
+
+        <activity
             android:name="org.meshtastic.app.MainActivity"
             android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize"

--- a/androidApp/src/main/kotlin/org/meshtastic/app/BubbleActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/BubbleActivity.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.compose.viewmodel.koinViewModel
+import org.meshtastic.core.ui.theme.AppTheme
+import org.meshtastic.core.ui.theme.MODE_DYNAMIC
+import org.meshtastic.core.ui.viewmodel.UIViewModel
+import org.meshtastic.feature.messaging.MessageScreen
+import org.meshtastic.feature.messaging.MessageViewModel
+
+/**
+ * Hosts a single conversation inside a notification bubble.
+ *
+ * Bubbles require their activity to be resizeable, embeddable and document-launched, which the launcher activity cannot
+ * be without changing how the whole app behaves in recents — so this is a separate, deliberately small host. It renders
+ * only [MessageScreen]: a bubble is a conversation, and every route out of one (node details, quick chat, filter
+ * settings) belongs in the full app, so those simply collapse the bubble instead.
+ */
+class BubbleActivity : AppCompatActivity() {
+
+    private val model: UIViewModel by viewModel()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val contactKey = intent?.data?.lastPathSegment
+        if (contactKey.isNullOrEmpty()) {
+            finish()
+            return
+        }
+
+        setContent {
+            val theme by model.theme.collectAsStateWithLifecycle()
+            val dark =
+                when (theme) {
+                    AppCompatDelegate.MODE_NIGHT_YES -> true
+                    AppCompatDelegate.MODE_NIGHT_NO -> false
+                    else -> isSystemInDarkTheme()
+                }
+            AppTheme(dynamicColor = theme == MODE_DYNAMIC, darkTheme = dark) {
+                val messageViewModel: MessageViewModel = koinViewModel(key = "bubble-messages-$contactKey")
+                messageViewModel.setContactKey(contactKey)
+                MessageScreen(
+                    contactKey = contactKey,
+                    message = "",
+                    viewModel = messageViewModel,
+                    navigateToNodeDetails = { finish() },
+                    navigateToQuickChatOptions = { finish() },
+                    navigateToFilterSettings = { finish() },
+                    onNavigateBack = { finish() },
+                )
+            }
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/org/meshtastic/app/BubbleActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/BubbleActivity.kt
@@ -16,15 +16,17 @@
  */
 package org.meshtastic.app
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.getValue
+import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import org.koin.compose.viewmodel.koinViewModel
+import org.meshtastic.core.navigation.DEEP_LINK_BASE_URI
 import org.meshtastic.core.ui.theme.AppTheme
 import org.meshtastic.core.ui.theme.MODE_DYNAMIC
 import org.meshtastic.core.ui.viewmodel.UIViewModel
@@ -35,13 +37,17 @@ import org.meshtastic.feature.messaging.MessageViewModel
  * Hosts a single conversation inside a notification bubble.
  *
  * Bubbles require their activity to be resizeable, embeddable and document-launched, which the launcher activity cannot
- * be without changing how the whole app behaves in recents — so this is a separate, deliberately small host. It renders
- * only [MessageScreen]: a bubble is a conversation, and every route out of one (node details, quick chat, filter
- * settings) belongs in the full app, so those simply collapse the bubble instead.
+ * be without changing how the whole app behaves in recents — so this is a separate, deliberately small host rendering
+ * only [MessageScreen].
+ *
+ * Anything that navigates out of the conversation hands off to the full app rather than just closing: a bubble that
+ * vanished when you asked for node details would look like a crash. Only back — which for a bubble means "collapse me"
+ * — finishes on its own.
  */
 class BubbleActivity : AppCompatActivity() {
 
     private val model: UIViewModel by viewModel()
+    private val messageViewModel: MessageViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,6 +57,7 @@ class BubbleActivity : AppCompatActivity() {
             finish()
             return
         }
+        messageViewModel.setContactKey(contactKey)
 
         setContent {
             val theme by model.theme.collectAsStateWithLifecycle()
@@ -61,18 +68,28 @@ class BubbleActivity : AppCompatActivity() {
                     else -> isSystemInDarkTheme()
                 }
             AppTheme(dynamicColor = theme == MODE_DYNAMIC, darkTheme = dark) {
-                val messageViewModel: MessageViewModel = koinViewModel(key = "bubble-messages-$contactKey")
-                messageViewModel.setContactKey(contactKey)
                 MessageScreen(
                     contactKey = contactKey,
                     message = "",
                     viewModel = messageViewModel,
-                    navigateToNodeDetails = { finish() },
-                    navigateToQuickChatOptions = { finish() },
-                    navigateToFilterSettings = { finish() },
+                    navigateToNodeDetails = { nodeNum -> openInApp("nodes/$nodeNum") },
+                    // Quick chat and message filters have no deep link of their own, so the full app opens on this
+                    // conversation — the screen those menu items live on.
+                    navigateToQuickChatOptions = { openInApp("messages/$contactKey") },
+                    navigateToFilterSettings = { openInApp("messages/$contactKey") },
                     onNavigateBack = { finish() },
                 )
             }
         }
+    }
+
+    /** Opens [path] in the full app and collapses this bubble behind it. */
+    private fun openInApp(path: String) {
+        startActivity(
+            Intent(Intent.ACTION_VIEW, "$DEEP_LINK_BASE_URI/$path".toUri(), this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+        )
+        finish()
     }
 }

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/app/BubbleActivity.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/app/BubbleActivity.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app
+
+import android.app.Activity
+
+/**
+ * Test-only stub for the real `BubbleActivity` in the `:androidApp` module, mirroring the [MainActivity] stub next to
+ * it. `MeshNotificationManagerImpl` resolves the bubble host by FQN via `Class.forName(...)` so `:core:service` does
+ * not depend on `:androidApp`; this lets unit tests build the bubble `PendingIntent` without that dependency.
+ */
+class BubbleActivity : Activity()

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
@@ -196,6 +196,15 @@ class MeshNotificationManagerImplConversationTest {
                 (android.content.Intent.FLAG_ACTIVITY_NEW_TASK or android.content.Intent.FLAG_ACTIVITY_NEW_DOCUMENT),
             "a NEW_TASK-style flag launches outside the bubble and collapses it",
         )
+        // The other half of that rule: the platform can only add those flags itself if the PendingIntent is mutable.
+        assertTrue(
+            shadowIntent.flags and android.app.PendingIntent.FLAG_IMMUTABLE == 0,
+            "an immutable PendingIntent stops the platform applying the bubble's own launch flags",
+        )
+        assertTrue(
+            shadowIntent.flags and android.app.PendingIntent.FLAG_MUTABLE != 0,
+            "bubble PendingIntents are the documented exception to preferring FLAG_IMMUTABLE",
+        )
     }
 
     @Test

--- a/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
+++ b/core/service/src/androidHostTest/kotlin/org/meshtastic/core/service/MeshNotificationManagerImplConversationTest.kt
@@ -144,7 +144,13 @@ class MeshNotificationManagerImplConversationTest {
      * `:androidApp` and is intentionally not on this module's test classpath.
      */
     private fun registerStubMainActivity() {
-        val componentName = android.content.ComponentName(context, "org.meshtastic.app.MainActivity")
+        registerStubActivity("org.meshtastic.app.MainActivity")
+        // The conversation notification also builds bubble metadata pointing at the bubble host.
+        registerStubActivity("org.meshtastic.app.BubbleActivity")
+    }
+
+    private fun registerStubActivity(className: String) {
+        val componentName = android.content.ComponentName(context, className)
         val activityInfo =
             android.content.pm.ActivityInfo().apply {
                 name = componentName.className
@@ -152,6 +158,44 @@ class MeshNotificationManagerImplConversationTest {
                 exported = true
             }
         org.robolectric.Shadows.shadowOf(context.packageManager).addOrUpdateActivity(activityInfo)
+    }
+
+    /**
+     * Bubble eligibility is a checklist the platform silently fails: it needs a long-lived conversation shortcut, a
+     * Person on the notification itself, and an activity target that is not launched with a NEW_TASK-style flag —
+     * `FLAG_ACTIVITY_NEW_DOCUMENT` included, which launches outside the bubble and collapses it.
+     */
+    @Test
+    fun `conversation notifications carry bubble metadata the platform will accept`() = runWithRenderScope { scope ->
+        val manager = createManager(scope).also { it.initChannels() }
+        mockHistory(message("hello", read = false, receivedTime = 1_000))
+
+        manager.updateMessageNotification("0^all", "Hawk Ridge", "hello", isBroadcast = true, channelName = "LongFast")
+        advanceUntilIdle()
+
+        val posted = activeByTag("message").single().notification
+        val bubble = posted.bubbleMetadata
+        assertNotNull(bubble, "conversation notifications must offer a bubble")
+        assertNotNull(bubble.icon, "a bubble without an icon is rejected")
+        assertEquals("0^all", posted.shortcutId, "the bubble needs its long-lived conversation shortcut")
+        assertTrue(
+            posted.extras.containsKey(Notification.EXTRA_PEOPLE_LIST),
+            "eligibility is judged on the notification's own person list, not MessagingStyle's",
+        )
+
+        val shadowIntent = org.robolectric.Shadows.shadowOf(bubble.intent)
+        val savedIntent = shadowIntent.savedIntent
+        assertEquals(
+            "org.meshtastic.app.BubbleActivity",
+            savedIntent.component?.className,
+            "bubbles must target the embeddable host, not the launcher activity",
+        )
+        assertEquals(
+            0,
+            savedIntent.flags and
+                (android.content.Intent.FLAG_ACTIVITY_NEW_TASK or android.content.Intent.FLAG_ACTIVITY_NEW_DOCUMENT),
+            "a NEW_TASK-style flag launches outside the bubble and collapses it",
+        )
     }
 
     @Test

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
@@ -985,15 +985,17 @@ class MeshNotificationManagerImpl(
      */
     private fun createBubbleMetadata(contactKey: String, icon: IconCompat): NotificationCompat.BubbleMetadata {
         val deepLinkUri = "$DEEP_LINK_BASE_URI/messages/$contactKey".toUri()
-        // No task flags: the platform launches this into the bubble's own task, and a NEW_TASK-style flag
-        // (including NEW_DOCUMENT) makes it launch outside and collapse the bubble instead.
+        // Two halves of one rule. The intent carries no task flags, because the platform is the thing that applies
+        // FLAG_ACTIVITY_NEW_DOCUMENT and FLAG_ACTIVITY_MULTIPLE_TASK for a bubble — setting them here instead
+        // launches outside the bubble and collapses it. And the PendingIntent must be MUTABLE precisely so the
+        // platform can add them; this is the documented exception to preferring FLAG_IMMUTABLE everywhere else.
         val intent = Intent(Intent.ACTION_VIEW, deepLinkUri, context, Class.forName(BUBBLE_ACTIVITY_CLASS))
         val pendingIntent =
             PendingIntent.getActivity(
                 context,
                 contactKey.hashCode(),
                 intent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
             )
         return NotificationCompat.BubbleMetadata.Builder(pendingIntent, icon)
             .setDesiredHeight(BUBBLE_DESIRED_HEIGHT_DP)

--- a/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
+++ b/core/service/src/androidMain/kotlin/org/meshtastic/core/service/MeshNotificationManagerImpl.kt
@@ -148,6 +148,14 @@ class MeshNotificationManagerImpl(
         // overwrite the foreground-service notification, or num == 1 the group summary). notify()/cancel() must use
         // the same (tag, id) pair.
         private const val TAG_MESSAGE = "message"
+
+        /**
+         * Fully-qualified name of the bubble host, as a string to avoid a module dependency back onto `:androidApp`.
+         */
+        private const val BUBBLE_ACTIVITY_CLASS = "org.meshtastic.app.BubbleActivity"
+
+        /** Roughly a phone's lower half — enough conversation to reply in without covering what is underneath. */
+        private const val BUBBLE_DESIRED_HEIGHT_DP = 600
         private const val TAG_MESSAGE_SUMMARY = "message_summary"
         private const val TAG_WAYPOINT = "waypoint"
         private const val TAG_ALERT = "alert"
@@ -172,6 +180,12 @@ class MeshNotificationManagerImpl(
      * entries are cheap and colors/names rarely change.
      */
     private val personIconCache = ConcurrentHashMap<String, IconCompat>()
+
+    /** Rounded variant, for surfaces that mask the icon into a circle (notification bubbles). */
+    private fun cachedRoundedPersonIcon(key: String, shortName: String, backgroundColor: Int, foregroundColor: Int) =
+        personIconCache.getOrPut("rounded|$key|$shortName|$backgroundColor|$foregroundColor") {
+            PersonIconFactory.createLabel(shortName, backgroundColor, foregroundColor, rounded = true)
+        }
 
     /** Circular, node-colored avatar holding the sender's full short name (e.g. "2c3d"), not just its first letter. */
     private fun cachedPersonIcon(key: String, shortName: String, backgroundColor: Int, foregroundColor: Int) =
@@ -811,12 +825,31 @@ class MeshNotificationManagerImpl(
             }
         }
         val lastMessage = history.last()
+        // The bubble wears the other party's avatar, not ours — a bubble is recognised by who is in it.
+        val bubbleNode = lastMessage.node
+        val bubbleIcon =
+            cachedRoundedPersonIcon(
+                bubbleNode.user.id,
+                bubbleNode.user.short_name,
+                bubbleNode.colors.second,
+                bubbleNode.colors.first,
+            )
 
         builder
             .setCategory(Notification.CATEGORY_MESSAGE)
             // Link to the conversation shortcut so this is treated as a Conversation notification (Android 11+).
             .setShortcutId(contactKey)
             .setLocusId(LocusIdCompat(contactKey))
+            // MessagingStyle carries per-message Persons, but conversation and bubble eligibility is judged on the
+            // notification's own person list, so the counterpart is added here too.
+            .addPerson(
+                Person.Builder()
+                    .setName(bubbleNode.user.long_name.ifEmpty { bubbleNode.user.short_name })
+                    .setKey(bubbleNode.user.id)
+                    .setIcon(bubbleIcon)
+                    .build(),
+            )
+            .setBubbleMetadata(createBubbleMetadata(contactKey, bubbleIcon))
             .setAutoCancel(true)
             .setStyle(style)
             .setGroup(GROUP_KEY_MESSAGES)
@@ -940,6 +973,35 @@ class MeshNotificationManagerImpl(
             addNextIntentWithParentStack(deepLinkIntent)
             getPendingIntent(contactKey.hashCode(), PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
         }
+    }
+
+    /**
+     * Bubble target: [org.meshtastic.app.BubbleActivity], not the launcher activity. A bubble's activity must be
+     * resizeable, embeddable and document-launched, and making the launcher activity document-launched would change how
+     * the whole app behaves in recents.
+     *
+     * The icon is the same per-node avatar the conversation notification already builds, so a bubble is recognisable as
+     * that conversation rather than as the app.
+     */
+    private fun createBubbleMetadata(contactKey: String, icon: IconCompat): NotificationCompat.BubbleMetadata {
+        val deepLinkUri = "$DEEP_LINK_BASE_URI/messages/$contactKey".toUri()
+        // No task flags: the platform launches this into the bubble's own task, and a NEW_TASK-style flag
+        // (including NEW_DOCUMENT) makes it launch outside and collapse the bubble instead.
+        val intent = Intent(Intent.ACTION_VIEW, deepLinkUri, context, Class.forName(BUBBLE_ACTIVITY_CLASS))
+        val pendingIntent =
+            PendingIntent.getActivity(
+                context,
+                contactKey.hashCode(),
+                intent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+        return NotificationCompat.BubbleMetadata.Builder(pendingIntent, icon)
+            .setDesiredHeight(BUBBLE_DESIRED_HEIGHT_DP)
+            // Never auto-expand or suppress the shade entry: the user opts a conversation into bubbling, the app does
+            // not decide to take over their screen because a packet arrived.
+            .setAutoExpandBubble(false)
+            .setSuppressNotification(false)
+            .build()
     }
 
     private fun createOpenWaypointIntent(waypointId: Int): PendingIntent {


### PR DESCRIPTION
The app had already paid for bubbles without offering them: long-lived conversation shortcuts with `Person` data and a `LocusId`, published through `pushDynamicShortcut` on every message, are the hard prerequisite — and they have been in place since conversation notifications landed.

### 🌟 New Features

- **Conversations can be bubbled.** `setBubbleMetadata` on the conversation notification, with the other party's avatar and a desired height of 600 dp. It never auto-expands and never suppresses the shade entry: the user opts a conversation into bubbling, the app does not take over their screen because a packet arrived.

### 🛠️ Refactoring & Architecture

- **`BubbleActivity`, not `MainActivity`.** A bubble's host must be `resizeableActivity` + `allowEmbedded` + `documentLaunchMode="always"`, and making the launcher activity document-launched would change how the whole app behaves in recents. `BubbleActivity` is a separate, deliberately small host rendering only `MessageScreen`; every route out of a conversation (node details, quick chat, filter settings) belongs in the full app, so those collapse the bubble instead.
- Resolved by FQN via `Class.forName`, matching the existing `MainActivity` pattern, so `:core:service` still does not depend on `:androidApp`. A test-only stub mirrors the existing `MainActivity` one.

### 🐛 Three things the first cut had wrong

Checked against the platform's [bubbles](https://developer.android.com/develop/ui/views/notifications/bubbles) and [conversations](https://developer.android.com/develop/ui/views/notifications/conversations) guidance, each of which fails **silently** — you get an ordinary notification and no explanation:

1. **`FLAG_ACTIVITY_NEW_DOCUMENT` on the bubble intent.** Documented as launching *outside* the bubble and collapsing it. The intent now carries no task flags at all; the platform launches it into the bubble's own task.
2. **Persons only inside `MessagingStyle`.** Bubble eligibility is judged on the notification's own person list, so the counterpart is now added with `addPerson` as well.
3. **Square avatar.** A bubble masks its icon into a circle, so it now uses the rounded variant of the same per-node avatar.

The conversation-notification side needed no changes — `MessagingStyle`, `setShortcutId`, `LocusIdCompat`, long-lived shortcut with `Person`, `pushDynamicShortcut` were all already correct.

### Testing Performed

- `core/service` — new `conversation notifications carry bubble metadata the platform will accept`: asserts bubble metadata and icon exist, the shortcut id is set, the notification's own person list is populated, the intent targets `BubbleActivity`, and **no NEW_TASK-style flag is set** (guarding regression 1 above).
- **Verified on an emulator**, which caught a crash no unit test would have: `BubbleActivity` extends `AppCompatActivity` but does not call `installSplashScreen()`, so it never left the launcher's `SplashTheme` and died with *"You need to use a Theme.AppCompat theme (or descendant) with this activity"*. Fixed by declaring the theme on the manifest entry; re-verified after the compliance fixes — launches clean, `MessageScreen` renders, no crash.
- Full baseline green: `spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`.

### Not verified here

An end-to-end bubble (tapping the bubble button in the shade and expanding it) needs a real conversation notification from a connected radio. The metadata, target, flags and host activity are all covered above; the last mile is worth a manual check on a real device before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added notification bubbles for conversations, enabling quick access to message threads.
  - Conversation bubbles now display the correspondent’s avatar and open in a resizable message view.
  - Bubble behavior supports manual expansion and preserves conversations for easier return access.

- **Bug Fixes**
  - Improved notification bubble metadata to ensure compatibility with supported Android behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->