### PR TITLE
fix(messaging): fire swipe row actions once per swipe, and let the snackbar go

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/SnackbarManager.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/SnackbarManager.kt
@@ -28,6 +28,10 @@ import org.koin.core.annotation.Single
  *
  * Events are buffered in a [Channel] and consumed exactly once by the host composable via `MeshtasticSnackbarHost`.
  *
+ * `MeshtasticSnackbarHost` consumes events from a single `collect`, and `showSnackbar` suspends until the snackbar goes
+ * away — so an [SnackbarDuration.Indefinite] event with no dismiss affordance stalls that collector and every later
+ * snackbar queues behind it. Action snackbars therefore default to [SnackbarDuration.Long], not indefinite.
+ *
  * @see AlertManager for the modal dialog equivalent.
  */
 @Single
@@ -47,7 +51,7 @@ open class SnackbarManager {
         message: String,
         actionLabel: String? = null,
         withDismissAction: Boolean = false,
-        duration: SnackbarDuration = if (actionLabel != null) SnackbarDuration.Indefinite else SnackbarDuration.Short,
+        duration: SnackbarDuration = if (actionLabel != null) SnackbarDuration.Long else SnackbarDuration.Short,
         onAction: (() -> Unit)? = null,
     ) {
         _events.trySend(

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/SnackbarManager.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/SnackbarManager.kt
@@ -28,9 +28,10 @@ import org.koin.core.annotation.Single
  *
  * Events are buffered in a [Channel] and consumed exactly once by the host composable via `MeshtasticSnackbarHost`.
  *
- * `MeshtasticSnackbarHost` consumes events from a single `collect`, and `showSnackbar` suspends until the snackbar goes
- * away — so an [SnackbarDuration.Indefinite] event with no dismiss affordance stalls that collector and every later
- * snackbar queues behind it. Action snackbars therefore default to [SnackbarDuration.Long], not indefinite.
+ * [showSnackbar] here only buffers and returns. It is the host that waits: `MeshtasticSnackbarHost` consumes events
+ * from a single `collect`, and its `SnackbarHostState.showSnackbar` call suspends for as long as that snackbar is on
+ * screen — so an [SnackbarDuration.Indefinite] event with no dismiss affordance stalls the collector and leaves every
+ * later snackbar queued behind it. Action snackbars therefore default to [SnackbarDuration.Long], not indefinite.
  *
  * @see AlertManager for the modal dialog equivalent.
  */

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/SnackbarManagerTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/SnackbarManagerTest.kt
@@ -41,14 +41,16 @@ class SnackbarManagerTest {
     }
 
     @Test
-    fun showSnackbar_with_action_defaults_to_indefinite_duration() = runTest {
+    fun showSnackbar_with_action_defaults_to_long_duration() = runTest {
         snackbarManager.events.test {
             snackbarManager.showSnackbar(message = "Deleted", actionLabel = "Undo")
 
             val event = awaitItem()
             assertEquals("Deleted", event.message)
             assertEquals("Undo", event.actionLabel)
-            assertEquals(SnackbarDuration.Indefinite, event.duration)
+            // Not Indefinite: the host collects events one at a time and suspends for the snackbar's lifetime, so an
+            // action snackbar that never times out would hold every later snackbar behind it.
+            assertEquals(SnackbarDuration.Long, event.duration)
         }
     }
 

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
@@ -53,8 +53,10 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -67,8 +69,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
@@ -664,35 +669,64 @@ private fun LazyListScope.contactSection(
 /**
  * One-handed row actions: swipe toward the reading direction to mute, away from it to delete.
  *
- * `confirmValueChange` always returns false, so the row never actually dismisses — it fires the action and springs
- * back. Mute is instant and undoable from a snackbar; delete is not, because [ContactsViewModel.deleteContacts] hard
- * deletes the conversation's packets with nothing to restore from, so it routes into the same confirmation dialog the
- * selection toolbar uses.
+ * The action fires from `onDismiss`, which the box raises once per settle. It must not fire from `confirmValueChange`:
+ * that runs from the fling's `calculateSnapOffset`, so it is called once per frame — a single swipe fired mute nine
+ * times, leaving the result decided by frame-count parity and stacking a snackbar per call. It is also deprecated in
+ * `AnchoredDraggable`, which directs callers at the anchor set instead.
+ *
+ * `SwipeToDismissBox` disables its own gestures while the row is settled in a dismissed direction, so animating home is
+ * what re-arms the next swipe rather than mere decoration.
+ *
+ * Mute is instant and undoable from a snackbar; delete is not, because [ContactsViewModel.deleteContacts] hard deletes
+ * the conversation's packets with nothing to restore from, so it routes into the same confirmation dialog the selection
+ * toolbar uses.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SwipeableContactRow(
+internal fun SwipeableContactRow(
     contact: Contact,
     enabled: Boolean,
     onMute: () -> Unit,
     onDelete: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    val dismissState =
-        rememberSwipeToDismissBoxState(
-            confirmValueChange = { value ->
-                when (value) {
-                    SwipeToDismissBoxValue.StartToEnd -> onMute()
-                    SwipeToDismissBoxValue.EndToStart -> onDelete()
-                    SwipeToDismissBoxValue.Settled -> Unit
+    // These outlive a recomposition, so without them the callbacks would stay the ones captured the first time — and
+    // they read the contact's mute state, which is exactly what a swipe changes.
+    val currentOnMute by rememberUpdatedState(onMute)
+    val currentOnDelete by rememberUpdatedState(onDelete)
+    val dismissState = rememberSwipeToDismissBoxState()
+    // Kept stable on purpose: the box raises `onDismiss` from a `LaunchedEffect` keyed on the lambda, so a fresh one
+    // each recomposition would re-fire the action for a row that is still settled open.
+    val onDismiss = remember {
+        { direction: SwipeToDismissBoxValue ->
+            when (direction) {
+                SwipeToDismissBoxValue.StartToEnd -> currentOnMute()
+                SwipeToDismissBoxValue.EndToStart -> currentOnDelete()
+                SwipeToDismissBoxValue.Settled -> Unit
+            }
+        }
+    }
+    LaunchedEffect(dismissState) {
+        snapshotFlow { dismissState.settledValue }
+            .collect { settled ->
+                if (settled == SwipeToDismissBoxValue.Settled) return@collect
+                // `AnchoredDraggableState` serialises mutations, so the first attempt can lose to the gesture's own
+                // settle still holding the mutex; retrying wins uncontended rather than leaving the row stranded.
+                while (dismissState.currentValue != SwipeToDismissBoxValue.Settled) {
+                    try {
+                        dismissState.reset()
+                    } catch (interrupted: CancellationException) {
+                        // Ours to retry unless the effect itself is going away.
+                        if (!currentCoroutineContext().isActive) throw interrupted
+                    }
                 }
-                false
-            },
-        )
+            }
+    }
     SwipeToDismissBox(
         state = dismissState,
         backgroundContent = { SwipeBackground(dismissState.dismissDirection, contact.isMuted) },
         gesturesEnabled = enabled,
+        onDismiss = onDismiss,
         content = { content() },
     )
 }

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/ui/contact/Contacts.kt
@@ -63,7 +63,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
@@ -695,6 +697,17 @@ internal fun SwipeableContactRow(
     val currentOnMute by rememberUpdatedState(onMute)
     val currentOnDelete by rememberUpdatedState(onDelete)
     val dismissState = rememberSwipeToDismissBoxState()
+    val haptics = LocalHapticFeedback.current
+    LaunchedEffect(dismissState) {
+        // A tick the moment the swipe becomes eligible, so the row can be committed or dragged back without
+        // watching it. `snapshotFlow` is distinct-until-changed, so re-crossing the threshold ticks again.
+        snapshotFlow { dismissState.targetValue }
+            .collect { target ->
+                if (target != SwipeToDismissBoxValue.Settled) {
+                    haptics.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
+                }
+            }
+    }
     // Kept stable on purpose: the box raises `onDismiss` from a `LaunchedEffect` keyed on the lambda, so a fresh one
     // each recomposition would re-fire the action for a row that is still settled open.
     val onDismiss = remember {
@@ -722,9 +735,28 @@ internal fun SwipeableContactRow(
                 }
             }
     }
+    // The same two actions without the gesture: a swipe is unusable under a screen reader, and Material asks for a
+    // non-swipe route to anything a swipe can reach.
+    val muteLabel =
+        stringResource(if (contact.isMuted) Res.string.swipe_action_unmute else Res.string.swipe_action_mute)
+    val deleteLabel = stringResource(Res.string.swipe_action_delete)
+    val rowActions =
+        remember(muteLabel, deleteLabel) {
+            listOf(
+                CustomAccessibilityAction(muteLabel) {
+                    currentOnMute()
+                    true
+                },
+                CustomAccessibilityAction(deleteLabel) {
+                    currentOnDelete()
+                    true
+                },
+            )
+        }
     SwipeToDismissBox(
         state = dismissState,
         backgroundContent = { SwipeBackground(dismissState.dismissDirection, contact.isMuted) },
+        modifier = Modifier.semantics { customActions = rowActions },
         gesturesEnabled = enabled,
         onDismiss = onDismiss,
         content = { content() },

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/ui/contact/SwipeableContactRowTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/ui/contact/SwipeableContactRowTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.messaging.ui.contact
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import org.meshtastic.core.model.Contact
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * `rememberSwipeToDismissBoxState` keeps `confirmValueChange` in a keyless `rememberSaveable`, so the lambda it holds
+ * is the one from the row's first composition. Muting a row therefore used to leave the gesture calling a closure that
+ * still saw the contact as unmuted, and the next swipe re-muted it instead of unmuting.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SwipeableContactRowTest {
+
+    private fun contact(isMuted: Boolean) = Contact(
+        contactKey = "0!abcd1234",
+        shortName = "ABCD",
+        longName = "Longfellow",
+        lastMessageTime = null,
+        lastMessageText = "hi",
+        unreadCount = 0,
+        messageCount = 1,
+        isMuted = isMuted,
+        isUnmessageable = false,
+    )
+
+    @Test
+    fun swipingAMutedRowUnmutesItRatherThanRemutingIt() = runComposeUiTest {
+        var muted by mutableStateOf(false)
+        var muteCalls = 0
+
+        setContent {
+            MaterialTheme {
+                val current = contact(isMuted = muted)
+                SwipeableContactRow(
+                    contact = current,
+                    enabled = true,
+                    // Mirrors the production call site, which decides the direction from the contact it captured.
+                    onMute = {
+                        muteCalls++
+                        muted = !current.isMuted
+                    },
+                    onDelete = {},
+                ) {
+                    Box(Modifier.testTag(ROW_TAG).fillMaxWidth().height(64.dp)) { Text(current.longName) }
+                }
+            }
+        }
+
+        onNodeWithTag(ROW_TAG).performTouchInput { swipeRight() }
+        waitForIdle()
+        assertTrue(muted, "first swipe should mute")
+        assertEquals(1, muteCalls, "a swipe is one action, not one per animation frame")
+        // The box turns its own gestures off while the row is settled open, so a row that does not come home is a row
+        // that can never be swiped again.
+        assertEquals(0f, onNodeWithTag(ROW_TAG).getBoundsInRoot().left.value, "row should animate home")
+
+        onNodeWithTag(ROW_TAG).performTouchInput { swipeRight() }
+        waitForIdle()
+        assertEquals(2, muteCalls, "the row must stay swipeable after it settles back")
+        assertFalse(muted, "second swipe should unmute, not re-mute")
+    }
+
+    private companion object {
+        const val ROW_TAG = "swipeableContactRow"
+    }
+}

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/ui/contact/SwipeableContactRowTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/ui/contact/SwipeableContactRowTest.kt
@@ -26,7 +26,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
@@ -94,6 +96,41 @@ class SwipeableContactRowTest {
         waitForIdle()
         assertEquals(2, muteCalls, "the row must stay swipeable after it settles back")
         assertFalse(muted, "second swipe should unmute, not re-mute")
+    }
+
+    @Test
+    fun exposesMuteAndDeleteWithoutTheSwipeGesture() = runComposeUiTest {
+        var muted by mutableStateOf(false)
+        var deleted = false
+
+        setContent {
+            MaterialTheme {
+                val current = contact(isMuted = muted)
+                SwipeableContactRow(
+                    contact = current,
+                    enabled = true,
+                    onMute = { muted = !current.isMuted },
+                    onDelete = { deleted = true },
+                ) {
+                    Box(Modifier.testTag(ROW_TAG).fillMaxWidth().height(64.dp)) { Text(current.longName) }
+                }
+            }
+        }
+
+        // A screen reader cannot swipe, so both actions have to be reachable from the row's semantics.
+        val actions =
+            onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.CustomActions))
+                .fetchSemanticsNode()
+                .config[SemanticsActions.CustomActions]
+        assertEquals(2, actions.size, "the row should offer both swipe actions to accessibility services")
+
+        actions[0].action()
+        waitForIdle()
+        assertTrue(muted, "the first action should mute")
+
+        actions[1].action()
+        waitForIdle()
+        assertTrue(deleted, "the second action should delete")
     }
 
     private companion object {


### PR DESCRIPTION
Two reported symptoms in the conversation list — the mute snackbar never went away, and swiping an already-muted row didn't unmute it — turned out to be one bug plus one aggravating default.

## Swipe actions fired once per animation frame

`SwipeableContactRow` fired mute/delete from `confirmValueChange`. `AnchoredDraggable` invokes that from the fling's `calculateSnapOffset`, so it runs **once per frame**, not once per swipe. A regression test measured **nine calls for a single swipe**.

Consequences:

- Mute is a toggle, so the conversation's final state was decided by frame-count parity. Swiping an already-muted row usually left it muted.
- Every call queued its own "muted" snackbar, so one swipe stacked up nine of them.

`confirmValueChange` is also deprecated in `AnchoredDraggable` ("Rather than relying on a callback to veto state changes, the anchor set should not include disallowed anchors"), so the fix moves to `SwipeToDismissBox`'s own `onDismiss`, which is raised once per settle.

Two things that fall out of that and are easy to get wrong, both now covered by comments and the test:

- The box disables its own gestures while a row is settled in a dismissed direction (`enabled = gesturesEnabled && state.settledValue == Settled`). Animating the row home is therefore what re-arms the next swipe, not decoration — without it the row strands off-screen and can never be swiped again.
- That reset has to retry. `AnchoredDraggableState` serialises mutations, and the first attempt can lose the mutex to the gesture's own settle. A `CancellationException` from losing the race is retried; one from the effect being torn down is rethrown.

## Action snackbars defaulted to `Indefinite`

`SnackbarManager` defaulted `duration` to `Indefinite` whenever an `actionLabel` was present, and set no dismiss action — so tapping the action was the only exit. Worse, `MeshtasticSnackbarProvider` consumes events from a single `collect` and `showSnackbar` suspends for the snackbar's lifetime, so one stuck action snackbar holds **every later snackbar in the app** behind it.

Action snackbars now default to `Long`. The mute-undo snackbar was the only production caller passing `actionLabel`.

## Behaviour change worth a look

The row now sweeps fully across and animates back, where before it sprang back from partway. I think this reads better — the old spring-back was indistinguishable from a cancelled swipe — but it is a visible change and easy to cap if you'd rather.

## Testing

New `SwipeableContactRowTest` pins all three failure modes: one action per swipe (not one per frame), the row returns to x=0 so it stays swipeable, and a second swipe unmutes rather than re-muting. It was written to fail first and did, on every iteration — including catching a stranded-row regression introduced partway through this fix.

`./gradlew spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed contact swipe actions so muted contacts can be unmuted correctly after repeated swipes.
  * Improved swipe behavior after canceled or completed dismissals.

* **User Experience**
  * Action snackbars now remain visible for a long duration instead of requiring indefinite dismissal, allowing subsequent notifications to appear normally.

* **Tests**
  * Added coverage for repeated contact swipe interactions and updated snackbar duration expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->