### PR TITLE
feat(messaging): close the quick reaction bar on a tap outside it

### DIFF
--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageListPaged.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/MessageListPaged.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.feature.messaging
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -41,9 +42,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemContentType
@@ -221,7 +226,26 @@ private fun MessageListPagedContent(
     // Disable animations during scroll to prevent jank/stutter
     val enableAnimations by remember { derivedStateOf { !listState.isScrollInProgress } }
 
-    Box(modifier = modifier.fillMaxSize()) {
+    // One bar at a time, owned above the rows: a row cannot see a tap that lands on another row or on the space
+    // between them, and two rows owning their own state could both be open at once.
+    var openReactionBarFor by remember { mutableStateOf<Long?>(null) }
+
+    // Back closes it too: it is transient UI, and leaving it open would make Back look unresponsive.
+    val reactionBarBackState = rememberNavigationEventState(NavigationEventInfo.None)
+    NavigationBackHandler(
+        state = reactionBarBackState,
+        isBackEnabled = openReactionBarFor != null,
+        onBackCompleted = { openReactionBarFor = null },
+    )
+
+    Box(
+        modifier =
+        modifier.fillMaxSize().pointerInput(Unit) {
+            // Only taps no row consumed reach here, so this closes on the background without stealing a tap meant
+            // for a bubble or an emoji.
+            detectTapGestures { openReactionBarFor = null }
+        },
+    ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             state = listState,
@@ -278,6 +302,8 @@ private fun MessageListPagedContent(
                                 hasSamePrev = hasSamePrev,
                                 hasSameNext = hasSameNext,
                                 quickEmojis = quickEmojis,
+                                openReactionBarFor = openReactionBarFor,
+                                onOpenReactionBarChange = { openReactionBarFor = it },
                             )
                         }
                     } else {
@@ -298,6 +324,8 @@ private fun MessageListPagedContent(
                             hasSamePrev = hasSamePrev,
                             hasSameNext = hasSameNext,
                             quickEmojis = quickEmojis,
+                            openReactionBarFor = openReactionBarFor,
+                            onOpenReactionBarChange = { openReactionBarFor = it },
                         )
                     }
                 }
@@ -340,6 +368,8 @@ private fun RenderPagedChatMessageRow(
     showUserName: Boolean,
     hasSamePrev: Boolean,
     hasSameNext: Boolean,
+    openReactionBarFor: Long?,
+    onOpenReactionBarChange: (Long?) -> Unit,
     quickEmojis: List<String>,
 ) {
     val ourNode = state.ourNode ?: return
@@ -360,7 +390,15 @@ private fun RenderPagedChatMessageRow(
         message = message,
         selected = selected,
         inSelectionMode = inSelectionMode,
-        onClick = { if (inSelectionMode) state.selectedIds.toggle(message.uuid) },
+        quickReactionsOpen = openReactionBarFor == message.uuid,
+        onQuickReactionsOpenChange = { open -> onOpenReactionBarChange(if (open) message.uuid else null) },
+        // A tap that closes another row's bar is spent doing just that, the same way the owning row swallows it.
+        onClick = {
+            when {
+                openReactionBarFor != null -> onOpenReactionBarChange(null)
+                inSelectionMode -> state.selectedIds.toggle(message.uuid)
+            }
+        },
         onLongClick = {
             if (inSelectionMode) {
                 state.selectedIds.toggle(message.uuid)

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/component/MessageItem.kt
@@ -138,6 +138,12 @@ fun MessageItem(
     showFullMessageTimestamp: Boolean = false,
     emojis: List<Reaction> = emptyList(),
     quickEmojis: List<String> = listOf("👍", "👎", "😂", "🔥", "❤️", "😮"),
+    /**
+     * Hoisted so the list can keep at most one bar open and close it on a tap anywhere else; owning it here would leave
+     * every row's bar independent, and none of them able to see a tap outside their own bubble.
+     */
+    quickReactionsOpen: Boolean = false,
+    onQuickReactionsOpenChange: (Boolean) -> Unit = {},
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = {},
     onDoubleClick: () -> Unit = {},
@@ -319,9 +325,8 @@ fun MessageItem(
     // Reached by long press or double tap; neither sends anything on its own, because a reaction is a real packet
     // on a
     // duty-cycled radio. The overflow button keeps the full actions sheet one tap away.
-    var showQuickReactions by remember { mutableStateOf(false) }
     AnimatedVisibility(
-        visible = showQuickReactions && !inSelectionMode,
+        visible = quickReactionsOpen && !inSelectionMode,
         modifier = Modifier.align(if (message.fromLocal) Alignment.End else Alignment.Start),
     ) {
         Surface(
@@ -333,15 +338,15 @@ fun MessageItem(
             QuickEmojiRow(
                 quickEmojis = quickEmojis,
                 onReact = { emoji ->
-                    showQuickReactions = false
+                    onQuickReactionsOpenChange(false)
                     sendReaction(emoji)
                 },
                 onMoreReactions = {
-                    showQuickReactions = false
+                    onQuickReactionsOpenChange(false)
                     activeSheet = ActiveSheet.Emoji
                 },
                 onMoreActions = {
-                    showQuickReactions = false
+                    onQuickReactionsOpenChange(false)
                     activeSheet = ActiveSheet.Actions
                 },
             )
@@ -403,16 +408,16 @@ fun MessageItem(
                 )
                 .widthIn(max = 480.dp)
                 .combinedClickable(
-                    onClick = { if (showQuickReactions) showQuickReactions = false else onClick() },
+                    onClick = { if (quickReactionsOpen) onQuickReactionsOpenChange(false) else onClick() },
                     onLongClick = {
                         onLongClick()
                         if (!inSelectionMode) {
-                            showQuickReactions = true
+                            onQuickReactionsOpenChange(true)
                         }
                     },
                     onDoubleClick = {
                         onDoubleClick()
-                        if (!inSelectionMode) showQuickReactions = !showQuickReactions
+                        if (!inSelectionMode) onQuickReactionsOpenChange(!quickReactionsOpen)
                     },
                 )
                 .then(messageModifier)

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/component/QuickReactionsDismissTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/component/QuickReactionsDismissTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.messaging.component
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.doubleClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import org.meshtastic.core.model.Message
+import org.meshtastic.core.model.MessageStatus
+import org.meshtastic.core.model.Node
+import org.meshtastic.core.ui.component.preview.NodePreviewParameterProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The quick reaction bar is opened per row but owned by the list, so a tap anywhere else can close it. These pin the
+ * three ways "anywhere else" shows up — another row, the space around the rows, and the row's own bubble — without the
+ * dismissal swallowing a tap that was aimed at an emoji.
+ */
+@OptIn(ExperimentalTestApi::class)
+class QuickReactionsDismissTest {
+
+    private val node: Node = NodePreviewParameterProvider().minnieMouse
+
+    private fun message(uuid: Long, text: String) = Message(
+        text = text,
+        time = "10:00",
+        fromLocal = false,
+        status = MessageStatus.RECEIVED,
+        snr = 2.5f,
+        rssi = 90,
+        hopsAway = 0,
+        uuid = uuid,
+        receivedTime = 0L,
+        node = node,
+        read = true,
+        routingError = 0,
+        packetId = uuid.toInt(),
+        emojis = listOf(),
+        replyId = null,
+        viaMqtt = false,
+    )
+
+    @Test
+    fun tappingAnotherRowClosesTheBar() = runComposeUiTest {
+        val harness = setHarness()
+        harness.openBarOnFirst(this)
+        onNodeWithText(EMOJI).assertIsDisplayed()
+
+        onNodeWithText(SECOND_TEXT).performClick()
+        waitForIdle()
+        assertNull(harness.openFor(), "a tap on another row should close the bar")
+    }
+
+    @Test
+    fun tappingTheBackgroundClosesTheBar() = runComposeUiTest {
+        val harness = setHarness()
+        harness.openBarOnFirst(this)
+        onNodeWithText(EMOJI).assertIsDisplayed()
+
+        onNodeWithTag(BACKGROUND_TAG).performTouchInput { click(Offset(centerX, bottom - 1f)) }
+        waitForIdle()
+        assertNull(harness.openFor(), "a tap on the space around the rows should close the bar")
+    }
+
+    @Test
+    fun tappingAnEmojiStillReactsAndIsNotEatenByTheDismissal() = runComposeUiTest {
+        val harness = setHarness()
+        harness.openBarOnFirst(this)
+
+        onNodeWithText(EMOJI).performClick()
+        waitForIdle()
+        assertEquals(listOf(EMOJI), harness.reactions(), "the emoji tap must still register a reaction")
+        assertNull(harness.openFor(), "reacting closes the bar")
+    }
+
+    private class Harness(val openFor: () -> Long?, val reactions: () -> List<String>) {
+        fun openBarOnFirst(test: ComposeUiTest) {
+            test.onNodeWithText(FIRST_TEXT).performTouchInput { doubleClick() }
+            test.waitForIdle()
+        }
+    }
+
+    /** Mirrors the list's ownership: one open row for the whole column, plus the container tap that closes it. */
+    private fun ComposeUiTest.setHarness(): Harness {
+        // Held outside the composition so the harness can read it, exactly as the list holds it above its rows.
+        val openState = mutableStateOf<Long?>(null)
+        var open by openState
+        val reacted = mutableListOf<String>()
+        setContent {
+            MaterialTheme {
+                Box(
+                    modifier =
+                    Modifier.testTag(BACKGROUND_TAG).fillMaxSize().pointerInput(Unit) {
+                        detectTapGestures { open = null }
+                    },
+                ) {
+                    Column(Modifier.fillMaxWidth().height(ROW_SPACE)) {
+                        listOf(FIRST_UUID to FIRST_TEXT, SECOND_UUID to SECOND_TEXT).forEach { (uuid, text) ->
+                            MessageItem(
+                                message = message(uuid, text),
+                                node = node,
+                                ourNode = node,
+                                selected = false,
+                                onStatusClick = {},
+                                quickEmojis = listOf(EMOJI),
+                                quickReactionsOpen = open == uuid,
+                                onQuickReactionsOpenChange = { shown -> open = if (shown) uuid else null },
+                                onClick = { if (open != null) open = null },
+                                sendReaction = { reacted += it },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        return Harness(openFor = { openState.value }, reactions = { reacted.toList() })
+    }
+
+    private companion object {
+        const val FIRST_UUID = 1L
+        const val SECOND_UUID = 2L
+        const val FIRST_TEXT = "first message"
+        const val SECOND_TEXT = "second message"
+        const val EMOJI = "👍"
+        const val BACKGROUND_TAG = "listBackground"
+        val ROW_SPACE = 400.dp
+    }
+}

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/component/QuickReactionsDismissTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/component/QuickReactionsDismissTest.kt
@@ -90,6 +90,17 @@ class QuickReactionsDismissTest {
     }
 
     @Test
+    fun tappingTheOwningBubbleClosesTheBar() = runComposeUiTest {
+        val harness = setHarness()
+        harness.openBarOnFirst(this)
+        onNodeWithText(EMOJI).assertIsDisplayed()
+
+        onNodeWithText(FIRST_TEXT).performClick()
+        waitForIdle()
+        assertNull(harness.openFor(), "a tap on the row that owns the bar should close it")
+    }
+
+    @Test
     fun tappingTheBackgroundClosesTheBar() = runComposeUiTest {
         val harness = setHarness()
         harness.openBarOnFirst(this)


### PR DESCRIPTION
Long-pressing a message opens the quick reaction bar, but nothing outside that message's own bubble could close it. Tapping another message, or the space around the list, left it open. Because each row owned its own `showQuickReactions`, two bars could also be open at the same time — neither row knew about the other.

## What changed

The open row is now owned by the list (`openReactionBarFor: Long?` in `MessageListPagedContent`), and `MessageItem` takes `quickReactionsOpen` / `onQuickReactionsOpenChange` instead of holding the state itself. Both params default, so the existing preview and test call sites are untouched.

Closing now happens on:

- a tap on another row,
- a tap on the container around the rows,
- a tap on the owning row's own bubble (unchanged),
- **Back**, which is new — it is transient UI, and leaving it open made Back look unresponsive on a screen that otherwise handles it. Wired with `NavigationBackHandler`, the same way `feature/firmware` and `feature/docs` already do.

Opening a bar closes whichever one was open, so at most one exists at a time.

A dismissing tap is spent doing only that — it does not also select the row it landed on. That mirrors what the owning row already did for a tap on its own bubble.

## Testing

New `QuickReactionsDismissTest` covers the three dismissal paths and, importantly, the failure mode that is easy to ship by accident: an over-eager container handler that dismisses the bar *and* eats the tap meant for an emoji. That case asserts the reaction still registers.

Worth flagging: those tests exercise `MessageItem` against a harness that mirrors the list's ownership, not `MessageListPagedContent` itself, which needs paging state to drive. The wiring in `MessageListPaged` is plain plumbing but it is not directly covered.

Not included, deliberately: scroll-to-dismiss. Happy to add if you want it — it is arguably the fourth "somewhere else" — but the request was taps.

`./gradlew spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile :screenshot-tests:validateDebugScreenshotTest` — green, 426 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick-reaction bars now open for only one message at a time.
  * Tapping another message or the surrounding area closes the open reaction bar.
  * Pressing back dismisses the open reaction bar.
  * Selecting a reaction automatically closes the reaction bar.

* **Tests**
  * Added coverage for reaction-bar dismissal and reaction selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->