### PR TITLE
Stabilize Mid-Session Locale Unit State Test

### DIFF
--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/list/NodeListViewModelTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/list/NodeListViewModelTest.kt
@@ -130,13 +130,22 @@ class NodeListViewModelTest {
     fun `nodesUiState follows a mid-session units change`() = runTest {
         val vm = createViewModel()
         vm.nodesUiState.test {
-            assertEquals(MeasurementSystem.METRIC, awaitItem().distanceUnits)
+            val initial = awaitItem()
+            assertEquals(MeasurementSystem.METRIC, initial.distanceUnits)
+            assertEquals(false, initial.tempInFahrenheit)
 
-            localeUnitsProvider.set(system = MeasurementSystem.IMPERIAL, temperature = TemperatureUnit.FAHRENHEIT)
+            // The provider exposes these as independent flows, so verify each transition without assuming atomicity.
+            localeUnitsProvider.set(system = MeasurementSystem.IMPERIAL)
 
-            val updated = awaitItem()
-            assertEquals(MeasurementSystem.IMPERIAL, updated.distanceUnits)
-            assertEquals(true, updated.tempInFahrenheit)
+            val distanceUpdated = awaitItem()
+            assertEquals(MeasurementSystem.IMPERIAL, distanceUpdated.distanceUnits)
+            assertEquals(false, distanceUpdated.tempInFahrenheit)
+
+            localeUnitsProvider.set(temperature = TemperatureUnit.FAHRENHEIT)
+
+            val temperatureUpdated = awaitItem()
+            assertEquals(MeasurementSystem.IMPERIAL, temperatureUpdated.distanceUnits)
+            assertEquals(true, temperatureUpdated.tempInFahrenheit)
 
             cancelAndIgnoreRemainingEvents()
         }


### PR DESCRIPTION
## Overview

The mid-session locale-units regression test updated measurement system and temperature back-to-back through two independent `StateFlow`s, then assumed the next `nodesUiState` emission already contained both new values.

That is not guaranteed by `combine`: either source may be observed first, producing a valid intermediate state before the second update arrives. This made the assertion scheduler-dependent across KMP targets. The same test failed in separate `shard-feature` runs on Android host and JVM while passing on the other targets.

This keeps the production behavior unchanged and makes the test exercise the actual `LocaleUnitsProvider` contract instead. Measurement-system and temperature changes are now driven and verified independently, so the test still proves that a live `NodeListViewModel` follows both locale-unit changes without relying on atomic delivery between separate flows.

## Key Changes

* Assert the complete initial metric/Celsius UI state.
* Change measurement system independently and verify the UI moves to imperial while temperature remains Celsius.
* Change temperature independently and verify the UI moves to Fahrenheit while measurement remains imperial.
* Remove the assumption that two independent flow updates appear atomically in the next `combine` emission.

## Testing

* `shard-feature` passes across the affected KMP targets.
* The stabilized test continues to cover both mid-session measurement-system and temperature updates.
* No production behavior or dependencies are changed.

## Scope

* Test-only change in `feature:node`.
* No application, persistence, protocol, or UI behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unit-change regression coverage to verify distance and temperature settings transition independently.
  * Added checks for the intermediate interface state when switching distance units before temperature units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->