### PR TITLE
Demote Repeated Offline Heartbeat Rejection Logs to Debug

### DIFF
--- a/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
+++ b/core/network/src/androidHostTest/kotlin/org/meshtastic/core/network/radio/SerialRadioTransportTest.kt
@@ -111,6 +111,26 @@ class SerialRadioTransportTest {
     }
 
     @Test
+    fun `offline heartbeat owns rejection logging while an ordinary send keeps the serial warning`() = runTest {
+        val address = "serial-device"
+        val transportRejections = mutableListOf<String>()
+        val transport = createTransport(address, backgroundScope)
+        transport.sendRejectionLogger = { transportRejections += it }
+
+        transport.keepAlive()
+        testScheduler.runCurrent()
+        assertTrue(
+            transportRejections.isEmpty(),
+            "HeartbeatSender must be the sole owner of expected offline rejection severity",
+        )
+
+        assertFalse(transport.handleSendToRadio(byteArrayOf(1)))
+        assertEquals(1, transportRejections.size)
+        assertTrue("Serial connection not available" in transportRejections.single())
+        transport.close()
+    }
+
+    @Test
     fun `send is rejected promptly while connection is still opening`() = runBlocking<Unit> {
         val address = "serial-device"
         val connectEntered = CountDownLatch(1)

--- a/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
+++ b/core/network/src/androidMain/kotlin/org/meshtastic/core/network/radio/SerialRadioTransport.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.meshtastic.core.common.util.handledLaunch
 import org.meshtastic.core.common.util.nowMillis
+import org.meshtastic.core.model.util.anonymize
 import org.meshtastic.core.network.repository.SerialConnection
 import org.meshtastic.core.network.repository.SerialConnectionListener
 import org.meshtastic.core.network.transport.HeartbeatSender
@@ -97,10 +98,18 @@ class SerialRadioTransport(
     private val lifecycle =
         TransportLifecycleGate("Android serial", teardownTimeout = SERIAL_TRANSPORT_TEARDOWN_TIMEOUT)
 
+    /** Per-instance sink keeps send-rejection routing observable without replacing Kermit's process-wide writers. */
+    internal var sendRejectionLogger: (String) -> Unit = { message -> Logger.w { message } }
+
     // Detached from the service scope so a claimed generation always publishes cleanup completion.
     private val cleanupScope = CoroutineScope(SupervisorJob() + scope.coroutineContext.minusKey(Job))
 
-    private val heartbeatSender = HeartbeatSender(sendToRadio = { handleSendToRadio(it) }, logTag = "Serial[$address]")
+    private val heartbeatSender =
+        HeartbeatSender(
+            // HeartbeatSender owns rejection severity; avoid a second warning from the generic admission path.
+            sendToRadio = { trySendToRadio(it, logUnavailable = false) },
+            logTag = "Serial[${address.anonymize()}]",
+        )
 
     override fun start() = connect()
 
@@ -463,7 +472,9 @@ class SerialRadioTransport(
         completion.complete(Unit)
     }
 
-    override fun handleSendToRadio(p: ByteArray): Boolean {
+    override fun handleSendToRadio(p: ByteArray): Boolean = trySendToRadio(p, logUnavailable = true)
+
+    private fun trySendToRadio(p: ByteArray, logUnavailable: Boolean): Boolean {
         val transportLease = lifecycle.tryAcquire()
         val operation =
             transportLease?.let {
@@ -472,7 +483,11 @@ class SerialRadioTransport(
             }
         return if (transportLease == null || operation == null) {
             transportLease?.release()
-            Logger.w { "[$address] Serial connection not available, cannot send ${p.size} bytes" }
+            if (logUnavailable) {
+                sendRejectionLogger(
+                    "[${address.anonymize()}] Serial connection not available, cannot send ${p.size} bytes",
+                )
+            }
             false
         } else {
             queueFramedSend(

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/radio/BleRadioTransport.kt
@@ -225,6 +225,9 @@ class BleRadioTransport(
 
     private val bytesSent = atomic(0L)
 
+    /** Per-instance sink keeps send-rejection routing observable without replacing Kermit's process-wide writers. */
+    internal var sendRejectionLogger: (String) -> Unit = { message -> Logger.w { message } }
+
     @Volatile private var isFullyConnected = false
     private var connectionJob: Job? = null
 
@@ -246,12 +249,14 @@ class BleRadioTransport(
 
     private val heartbeatSender =
         HeartbeatSender(
-            sendToRadio = { handleSendToRadio(it) },
+            // HeartbeatSender owns rejection severity. Suppress the generic offline-admission warning here so one
+            // rejected heartbeat cannot emit two warnings; write-backlog pressure remains warning-worthy below.
+            sendToRadio = { trySendToRadio(it, logUnavailable = false) },
             afterHeartbeat = {
                 delay(HEARTBEAT_DRAIN_DELAY)
                 activeSession.value?.profile?.requestDrain()
             },
-            logTag = address,
+            logTag = address.anonymize(),
         )
 
     override fun start() {
@@ -768,7 +773,9 @@ class BleRadioTransport(
      * @return true when the current BLE profile generation accepted responsibility for the bounded write attempt.
      *   Delivery is confirmed later by the protocol, not by this result.
      */
-    override fun handleSendToRadio(p: ByteArray): Boolean {
+    override fun handleSendToRadio(p: ByteArray): Boolean = trySendToRadio(p, logUnavailable = true)
+
+    private fun trySendToRadio(p: ByteArray, logUnavailable: Boolean): Boolean {
         val transportLease = lifecycle.tryAcquire()
         return if (transportLease == null) {
             false
@@ -780,12 +787,14 @@ class BleRadioTransport(
                 if (writePermit) writePermits.release()
                 sessionLease?.release()
                 transportLease.release()
-                Logger.w {
-                    if (!writePermit && session != null && sessionLease != null) {
-                        "[$address] BLE write backlog is full, cannot admit ${p.size} bytes"
-                    } else {
-                        "[$address] toRadio characteristic unavailable, cannot send ${p.size} bytes"
-                    }
+                if (!writePermit && session != null && sessionLease != null) {
+                    sendRejectionLogger(
+                        "[${address.anonymize()}] BLE write backlog is full, cannot admit ${p.size} bytes",
+                    )
+                } else if (logUnavailable) {
+                    sendRejectionLogger(
+                        "[${address.anonymize()}] toRadio characteristic unavailable, cannot send ${p.size} bytes",
+                    )
                 }
                 false
             } else {

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/transport/HeartbeatSender.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/transport/HeartbeatSender.kt
@@ -35,14 +35,31 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  * @param afterHeartbeat optional suspend callback invoked after sending (e.g. to schedule a drain)
  * @param logTag tag for log messages
  */
-class HeartbeatSender(
+class HeartbeatSender
+private constructor(
     private val sendToRadio: (ByteArray) -> Boolean,
-    private val afterHeartbeat: (suspend () -> Unit)? = null,
-    private val logTag: String = "HeartbeatSender",
+    private val afterHeartbeat: (suspend () -> Unit)?,
+    private val logTag: String,
+    private val rejectionLogSink: HeartbeatRejectionLogSink,
 ) {
+    constructor(
+        sendToRadio: (ByteArray) -> Boolean,
+        afterHeartbeat: (suspend () -> Unit)? = null,
+        logTag: String = "HeartbeatSender",
+    ) : this(sendToRadio, afterHeartbeat, logTag, HeartbeatRejectionLogSink(::logHeartbeatRejection))
+
+    internal constructor(
+        sendToRadio: (ByteArray) -> Boolean,
+        afterHeartbeat: (suspend () -> Unit)? = null,
+        logTag: String = "HeartbeatSender",
+        rejectionLogger: (HeartbeatRejectionLogLevel, String) -> Unit,
+    ) : this(sendToRadio, afterHeartbeat, logTag, HeartbeatRejectionLogSink(rejectionLogger))
+
     @OptIn(ExperimentalAtomicApi::class)
     private val nonce = AtomicInt(0)
     private val nonceMutex = Mutex()
+
+    private val rejectionLogPolicy = HeartbeatRejectionLogPolicy()
 
     /**
      * Sends a heartbeat to the radio.
@@ -50,23 +67,71 @@ class HeartbeatSender(
      * The firmware responds to heartbeats by queuing a `queueStatus` FromRadio packet, proving the link is alive and
      * keeping the local node's lastHeard timestamp current.
      *
+     * Repeated rejections while disconnected are expected (e.g. a radio that left BLE range), so only the first
+     * [HeartbeatRejectionLogPolicy.DEFAULT_WARN_LIMIT] consecutive rejections log at warn severity; later ones are
+     * demoted to debug until a successful send resets the streak.
+     *
      * @return `true` when the transport accepted the heartbeat handoff.
      */
     @OptIn(ExperimentalAtomicApi::class)
     suspend fun sendHeartbeat(): Boolean {
-        val accepted =
+        val (accepted, rejectionLogLevel) =
             nonceMutex.withLock {
                 val n = nonce.load()
                 Logger.v { "[$logTag] Sending ToRadio heartbeat (nonce=$n)" }
                 val admitted = sendToRadio(ToRadio(heartbeat = Heartbeat(nonce = n)).encode())
                 if (admitted) nonce.fetchAndAdd(1)
-                admitted
+                admitted to rejectionLogPolicy.record(admitted)
             }
-        if (!accepted) {
-            Logger.w { "[$logTag] Heartbeat handoff was rejected by the transport" }
-            return false
+        if (rejectionLogLevel != null) {
+            val message = "[$logTag] Heartbeat handoff was rejected by the transport"
+            rejectionLogSink.log(rejectionLogLevel, message)
         }
+        if (!accepted) return false
         afterHeartbeat?.invoke()
         return true
+    }
+}
+
+private fun interface HeartbeatRejectionLogSink {
+    fun log(level: HeartbeatRejectionLogLevel, message: String)
+}
+
+private fun logHeartbeatRejection(level: HeartbeatRejectionLogLevel, message: String) {
+    when (level) {
+        HeartbeatRejectionLogLevel.Warn -> Logger.w { message }
+        HeartbeatRejectionLogLevel.Debug -> Logger.d { message }
+    }
+}
+
+internal enum class HeartbeatRejectionLogLevel {
+    Warn,
+    Debug,
+}
+
+/**
+ * Tracks the generic heartbeat rejection-log streak without coupling tests to Kermit process-wide logger configuration.
+ * Cause-specific transport diagnostics stay independent; for example BLE backlog pressure continues to warn on every
+ * rejected admission even after this generic heartbeat line has been demoted.
+ */
+internal class HeartbeatRejectionLogPolicy {
+    private var consecutiveRejections = 0
+
+    /** Returns the severity for a rejected handoff, or null for an accepted handoff. */
+    fun record(admitted: Boolean): HeartbeatRejectionLogLevel? {
+        if (admitted) {
+            consecutiveRejections = 0
+            return null
+        }
+        consecutiveRejections++
+        return if (consecutiveRejections <= DEFAULT_WARN_LIMIT) {
+            HeartbeatRejectionLogLevel.Warn
+        } else {
+            HeartbeatRejectionLogLevel.Debug
+        }
+    }
+
+    companion object {
+        const val DEFAULT_WARN_LIMIT = 2
     }
 }

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/radio/BleRadioTransportTest.kt
@@ -131,6 +131,64 @@ class BleRadioTransportTest {
     }
 
     @Test
+    fun `offline heartbeat owns rejection logging while an ordinary send keeps the transport warning`() = runTest {
+        val transportRejections = mutableListOf<String>()
+        val bleTransport =
+            BleRadioTransport(
+                scope = backgroundScope,
+                scanner = scanner,
+                bluetoothRepository = bluetoothRepository,
+                connectionFactory = connectionFactory,
+                callback = service,
+                address = address,
+            )
+        bleTransport.sendRejectionLogger = { transportRejections += it }
+
+        try {
+            bleTransport.keepAlive()
+            runCurrent()
+            assertTrue(
+                transportRejections.isEmpty(),
+                "HeartbeatSender must be the sole owner of expected offline rejection severity",
+            )
+
+            assertFalse(bleTransport.handleSendToRadio(byteArrayOf(1, 2, 3)))
+            assertEquals(1, transportRejections.size)
+            assertTrue("toRadio characteristic unavailable" in transportRejections.single())
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    @Test
+    fun `BLE write backlog rejection retains a transport warning on every rejection`() = runTest {
+        val device = FakeBleDevice(address = address, name = "Test Device")
+        bluetoothRepository.bond(device)
+        scanner.emitDevice(device)
+        val transportRejections = mutableListOf<String>()
+        val bleTransport = bleTransportOn(this, FakeRadioInterfaceService())
+        bleTransport.sendRejectionLogger = { transportRejections += it }
+        bleTransport.start()
+
+        try {
+            advanceTimeBy(4_000L)
+            // Keep the production queue bound private. Four admitted writes fill the current bounded queue; the test
+            // then verifies the externally observable behavior rather than widening a production constant for access.
+            repeat(4) { assertTrue(bleTransport.handleSendToRadio(byteArrayOf(it.toByte()))) }
+
+            repeat(3) { attempt -> assertFalse(bleTransport.handleSendToRadio(byteArrayOf((99 + attempt).toByte()))) }
+            assertEquals(3, transportRejections.size)
+            assertTrue(
+                transportRejections.all { "BLE write backlog is full" in it },
+                "backlog pressure must stay warning-worthy on every rejected admission",
+            )
+            runCurrent()
+        } finally {
+            bleTransport.close()
+        }
+    }
+
+    @Test
     fun `close drains every write admitted by the active BLE profile generation`() = runTest {
         val device = FakeBleDevice(address = address, name = "Test Device")
         bluetoothRepository.bond(device)

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/transport/HeartbeatSenderTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/transport/HeartbeatSenderTest.kt
@@ -81,6 +81,37 @@ class HeartbeatSenderTest {
     }
 
     @Test
+    fun `sender demotes repeated rejections and an accepted handoff resets warning severity`() = runTest {
+        var admitted = false
+        val loggedRejections = mutableListOf<Pair<HeartbeatRejectionLogLevel, String>>()
+        val sender =
+            HeartbeatSender(
+                sendToRadio = { admitted },
+                logTag = "test",
+                rejectionLogger = { level, message -> loggedRejections += level to message },
+            )
+
+        repeat(HeartbeatRejectionLogPolicy.DEFAULT_WARN_LIMIT) { assertFalse(sender.sendHeartbeat()) }
+        assertFalse(sender.sendHeartbeat())
+        assertEquals(
+            listOf(HeartbeatRejectionLogLevel.Warn, HeartbeatRejectionLogLevel.Warn, HeartbeatRejectionLogLevel.Debug),
+            loggedRejections.map { it.first },
+        )
+
+        admitted = true
+        assertTrue(sender.sendHeartbeat())
+        assertEquals(3, loggedRejections.size, "an accepted handoff must not emit a rejection log")
+
+        admitted = false
+        assertFalse(sender.sendHeartbeat())
+        assertEquals(HeartbeatRejectionLogLevel.Warn, loggedRejections.last().first)
+        assertTrue(
+            loggedRejections.all { it.second == "[test] Heartbeat handoff was rejected by the transport" },
+            "the sender must dispatch the production rejection message through the severity seam",
+        )
+    }
+
+    @Test
     fun `heartbeat loop emits at the configured interval`() = runTest {
         val sentPackets = mutableListOf<ByteArray>()
         val sender = HeartbeatSender(sendToRadio = { sentPackets.add(it) })


### PR DESCRIPTION
## Overview

While a radio is unavailable, each periodic heartbeat handoff is rejected by the transport. That expected offline state could produce two warning lines for the same heartbeat: the transport's generic admission warning followed by the heartbeat sender's rejection warning. With heartbeats continuing during an extended disconnect, those duplicate warnings create substantial log noise without adding new diagnostic information.

This makes `HeartbeatSender` the owner of generic heartbeat rejection severity. The first two consecutive rejected handoffs remain warnings, while later consecutive rejections are demoted to debug. Any accepted heartbeat resets the streak, so a new failure after connectivity returns is visible at warn severity again.

BLE and Android serial transports route heartbeat sends through a quiet unavailable-admission path. That suppresses only the duplicate generic unavailable warning for heartbeat traffic. Ordinary application sends continue to warn, and cause-specific BLE write-backlog pressure remains independently visible at warning severity on every rejected admission.

## Key Changes

### Heartbeat rejection severity

* Track consecutive generic heartbeat rejection logs in `HeartbeatRejectionLogPolicy`.
* Keep the first two consecutive rejections at warn severity.
* Demote subsequent consecutive rejections to debug until a handoff succeeds.
* Reset the streak immediately after any accepted heartbeat.
* Keep rejection logging outside `nonceMutex` so logger work cannot extend the heartbeat critical section.
* Keep the policy independent from Kermit's process-wide logger configuration.

### Transport routing

* Route BLE heartbeat sends through normal admission without emitting the duplicate generic transport-unavailable warning.
* Apply the same behavior to Android serial heartbeats.
* Preserve warning behavior for ordinary application sends.
* Preserve the dedicated BLE backlog warning on every full-queue rejection, independently of the generic heartbeat rejection streak.
* Keep `BLE_MAX_PENDING_WRITES` private rather than widening a production implementation detail for tests.

### Testability and diagnostics

* Use per-instance internal logging seams to verify routing without modifying Kermit's process-wide writers.
* Keep the testing seam off the public API.
* Anonymize the touched BLE and serial transport identifiers in the affected diagnostics.
* Test BLE queue pressure behaviorally rather than exposing its private capacity constant.

## Testing

* Added sender-level coverage proving the exact warn/warn/debug rejection sequence.
* Added coverage proving a successful heartbeat resets the streak so the next rejection warns again.
* Added BLE coverage proving offline heartbeat rejection suppresses the duplicate generic admission warning while ordinary sends retain it.
* Added Android serial coverage for the same heartbeat-versus-ordinary-send distinction.
* Added repeated BLE backlog coverage proving every rejected admission from a full queue retains its dedicated transport warning, even though the generic heartbeat rejection line may be demoted.
* CI passes across the affected targets.

## Scope

* Heartbeat cadence, nonce handling, encoding, and transport admission decisions are unchanged.
* Accepted-heartbeat behavior and BLE post-heartbeat drain scheduling are unchanged.
* Cause-specific transport failures remain visible at warning severity.
* No protocol, persistence, or firmware changes are introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate offline connection warnings during heartbeat activity.
  * Heartbeat rejection messages now become less prominent after repeated failures and reset after a successful send.
  * Protected serial connection details in diagnostic logs.
  * Preserved clear warnings for ordinary send failures and full BLE write backlogs.

* **Tests**
  * Added coverage for heartbeat logging, offline sends, unavailable BLE characteristics, and write-backlog limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->