### PR TITLE
fix(desktop): disable macOS notifications when the process has no app bundle

### DIFF
--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/MacOSNotificationSender.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/MacOSNotificationSender.kt
@@ -117,7 +117,36 @@ private class JnaMacNotificationBridge : MacNotificationBridge {
     }
 
     override val isAvailable: Boolean
+        get() = objcLoaded && hasBundleIdentity
+
+    private val objcLoaded: Boolean
         get() = objc != null && objcGetClass != null && selRegisterName != null && objcMsgSend != null
+
+    /**
+     * Whether the running process has an application bundle.
+     *
+     * `+[UNUserNotificationCenter currentNotificationCenter]` raises `NSInternalInconsistencyException`
+     * ("bundleProxyForCurrentProcess is nil") when it does not, which aborts the process with SIGABRT — an Objective-C
+     * exception unwinds through the JNA frame into `libc++abi`, so the `runCatching` below never sees it and cannot
+     * degrade gracefully. Running from Gradle (`:desktopApp:run`, or `hotRun`) is exactly that case: the main bundle is
+     * the JDK's `bin/` directory. Probing the bundle identity first turns an unbundled launch into "no notifications"
+     * instead of a crash on the first incoming message.
+     *
+     * Resolved once — a process cannot acquire a bundle identity while running.
+     */
+    private val hasBundleIdentity: Boolean by lazy {
+        if (!objcLoaded) {
+            false
+        } else {
+            val bundleClass = classRef("NSBundle")
+            val mainBundle = bundleClass?.let { msg(it, selector("mainBundle")) }
+            val identifier = mainBundle?.let { msg(it, selector("bundleIdentifier")) }
+            if (identifier == null) {
+                Logger.w { "No application bundle identity — macOS notifications disabled for this process" }
+            }
+            identifier != null
+        }
+    }
 
     override fun requestAuthorization(options: Long): Boolean = runCatching {
         val centerClass = classRef("UNUserNotificationCenter") ?: return false


### PR DESCRIPTION
## Problem

With a radio connected, `./gradlew :desktopApp:run` on macOS dies on the first incoming message:

```
Debug: DesktopNotificationManager dispatch: category=Message, enabled=true
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'bundleProxyForCurrentProcess is nil: mainBundle.bundleURL
    file:///Users/.../jbrsdk_jcef-25.0.3-osx-aarch64/Contents/Home/bin/'
  3  UserNotifications  __53+[UNUserNotificationCenter currentNotificationCenter]_block_invoke.cold.2
  7  UserNotifications  +[UNUserNotificationCenter currentNotificationCenter] + 176
  8  jna...  ffi_call
 10  jna...  Java_com_sun_jna_Native_invokePointer
libc++abi: terminating due to uncaught exception of type NSException
```

Process exits 134 (SIGABRT).

`+[UNUserNotificationCenter currentNotificationCenter]` raises `NSInternalInconsistencyException` when the running process has no application bundle. Under Gradle that is always true — the main bundle is the JDK's `bin/` directory.

The `runCatching` already wrapping the bridge cannot help: an Objective-C exception unwinds through the JNA frame straight into `libc++abi`, so it never becomes a Kotlin throwable. `isAvailable` only checked that `objc`/`UserNotifications` had loaded, which they had.

## Fix

Probe `[[NSBundle mainBundle] bundleIdentifier]` once, through the JNA machinery already in the file, and fold it into `isAvailable`. An unbundled launch now degrades to "no notifications" rather than aborting.

`runDistributable` and shipped builds were never affected — they have a real bundle and `bundleID = "org.meshtastic.MeshtasticDesktop"`.

This is also what makes `:desktopApp:hotRun` viable (#6877), since hot reload likewise runs unbundled.

## Testing

- `./gradlew :desktopApp:spotlessApply spotlessCheck detekt test` — green.
- The observable contract (`isAvailable == false` ⇒ no authorization request, no post) is already covered by `MacOSNotificationSenderTest.returns false when bridge unavailable`.
- The ObjC probe itself is not unit-testable — it needs a real process bundle. Verified empirically: `runDistributable` renders and survives incoming messages; `run` aborted as above before this change.

## Constitution Check (v1.3.3)

| Principle | Status |
|---|---|
| I. KMP Core | N/A — `desktopApp` is a JVM-only module; no `commonMain` touched, no new `java.*`/`android.*` in shared code |
| II. Zero Lint Tolerance | `spotlessCheck` + `detekt` pass |
| III. Compose Multiplatform UI | N/A — no UI change |
| IV. Privacy First | No PII/location/keys logged; the added warning names no user data |
| V. Design Standards | N/A — no user-facing UI |
| VI. Documentation Freshness | N/A — no user-facing UI source touched, so no doc page corresponds |
| VII. Verify Before Push | Local verification run before push; CI to be confirmed via `gh pr checks` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS notification handling by validating application bundle availability before requesting notification access.
  * Unbundled app launches now disable notifications gracefully and provide a warning instead of triggering failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->