### PR TITLE
build(desktop): enable Compose hot reload for the desktop app

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -25,6 +25,13 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.compose.multiplatform)
+    // Adds `:desktopApp:hotRun` — the app relaunched with live recomposition on source edits.
+    // Needs the JetBrains Runtime for enhanced class redefinition, which the jvmToolchain block
+    // below already pins (vendor JETBRAINS, resolved by the foojay resolver in settings.gradle.kts).
+    // Version-less because the Compose Multiplatform plugin already carries hot-reload on the
+    // build classpath; requesting a version fails resolution ("already on the classpath with an
+    // unknown version"), the same reason Mokkery is applied bare below.
+    id("org.jetbrains.compose.hot-reload")
     alias(libs.plugins.meshtastic.detekt)
     alias(libs.plugins.meshtastic.spotless)
     alias(libs.plugins.meshtastic.koin)


### PR DESCRIPTION
## What

Applies `org.jetbrains.compose.hot-reload` to `:desktopApp`, adding:

```
Compose Hot Reload: Run tasks
hotRun     - Compose Application Run (Hot Reload enabled) | --mainClass=...
hotDev     - Compose Application Dev Run (Hot Reload enabled)
Compose Hot Reload: Other tasks
reload         - Hot Reloads code for all running applications
hotMcpServer   - Start MCP server for AI agent integration with the running Compose application
```

Desktop UI work currently costs a full `run` (or `runDistributable`, ~1–2 min) per edit. `hotRun` recomposes in place instead.

## Two notes on the implementation

**Applied version-less.** A version-pinned `alias(...)` fails resolution:

> Error resolving plugin [id: 'org.jetbrains.compose.hot-reload', version: '1.2.0'] > The request for this plugin could not be satisfied because the plugin is already on the classpath with an unknown version, so compatibility cannot be checked.

The Compose Multiplatform 1.12 plugin already carries hot-reload on the build classpath, so it is applied bare — the same reason Mokkery is applied bare a few lines below. No `libs.versions.toml` change, and nothing for Renovate to track separately.

**No toolchain work.** Hot reload needs the JetBrains Runtime for enhanced class redefinition, and `desktopApp`'s existing `jvmToolchain` block already pins `vendor.set(JvmVendorSpec.JETBRAINS)`, resolved by the foojay resolver in `settings.gradle.kts`.

## Depends on

`hotRun` launches an **unbundled** JVM, so on macOS it hits the `UNUserNotificationCenter` abort fixed in #6876. Without that fix, `hotRun` with a radio connected dies with SIGABRT on the first incoming message. Merge #6876 first, or `hotRun` is unusable on macOS.

## Testing

- `./gradlew :desktopApp:spotlessApply spotlessCheck detekt test` — green.
- `./gradlew :desktopApp:tasks --all` lists the hot-reload task groups above.
- One-line build change; no production code touched.

## Constitution Check (v1.3.3)

| Principle | Status |
|---|---|
| I. KMP Core | N/A — build-script only, no source sets touched |
| II. Zero Lint Tolerance | `spotlessCheck` (incl. `spotlessKotlinGradle`) + `detekt` pass |
| III. Compose Multiplatform UI | N/A — no UI change |
| IV. Privacy First | N/A — no data paths touched |
| V. Design Standards | N/A — no user-facing UI |
| VI. Documentation Freshness | N/A — dev tooling, no user-facing UI source touched |
| VII. Verify Before Push | Local verification run before push; CI to be confirmed via `gh pr checks` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for live UI updates during desktop development through the `:desktopApp:hotRun` task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->