### PR TITLE
fix(desktop): test the bundle path, not the identifier, before notifying

### DIFF
--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/MacOSNotificationSender.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/notification/MacOSNotificationSender.kt
@@ -132,20 +132,34 @@ private class JnaMacNotificationBridge : MacNotificationBridge {
      * the JDK's `bin/` directory. Probing the bundle identity first turns an unbundled launch into "no notifications"
      * instead of a crash on the first incoming message.
      *
+     * Tested by bundle *path*, not by `bundleIdentifier`. The identifier is not a reliable signal: the JetBrains
+     * Runtime ships its own `Info.plist`, so a Gradle-launched process has a perfectly good identifier while
+     * `bundleProxyForCurrentProcess` is still nil, and the crash happens anyway. The path is the thing that actually
+     * differs — a packaged app sits in `Foo.app`, this sits in the JDK's `Contents/Home/bin`, which is precisely what
+     * the exception message reports.
+     *
      * Resolved once — a process cannot acquire a bundle identity while running.
      */
     private val hasBundleIdentity: Boolean by lazy {
         if (!objcLoaded) {
             false
         } else {
-            val bundleClass = classRef("NSBundle")
-            val mainBundle = bundleClass?.let { msg(it, selector("mainBundle")) }
-            val identifier = mainBundle?.let { msg(it, selector("bundleIdentifier")) }
-            if (identifier == null) {
-                Logger.w { "No application bundle identity — macOS notifications disabled for this process" }
+            val path = mainBundlePath()
+            val bundled = path != null && path.endsWith(APP_BUNDLE_SUFFIX)
+            if (!bundled) {
+                Logger.w { "Not running from an application bundle — macOS notifications disabled for this process" }
             }
-            identifier != null
+            bundled
         }
+    }
+
+    /** Filesystem path of the running process's main bundle, or null if it cannot be read. */
+    private fun mainBundlePath(): String? {
+        val bundleClass = classRef("NSBundle")
+        val mainBundle = bundleClass?.let { msg(it, selector("mainBundle")) }
+        val path = mainBundle?.let { msg(it, selector("bundlePath")) }
+        val utf8 = path?.let { msg(it, selector("UTF8String")) }
+        return utf8?.getString(0)
     }
 
     override fun requestAuthorization(options: Long): Boolean = runCatching {
@@ -227,3 +241,6 @@ private class JnaMacNotificationBridge : MacNotificationBridge {
         val objcMsgSend: Function?,
     )
 }
+
+/** macOS application bundles are directories with this suffix; a Gradle-launched JVM is not one. */
+private const val APP_BUNDLE_SUFFIX = ".app"


### PR DESCRIPTION
## Problem

#6876 (merged) does not fix the crash it was written for. `:desktopApp:run` and `hotRun` still abort on the first notification:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'bundleProxyForCurrentProcess is nil: mainBundle.bundleURL
    file:///Users/.../jbrsdk_jcef-25.0.3-osx-aarch64/Contents/Home/bin/'
```

That guard required `[[NSBundle mainBundle] bundleIdentifier]` to be non-nil. It is the wrong signal: the JetBrains Runtime ships its own `Info.plist`, so a Gradle-launched process has a perfectly good bundle identifier while `bundleProxyForCurrentProcess` is still nil. The guard passes and the process aborts anyway.

## Fix

Require the main bundle's **path** to end in `.app`. That is what actually differs between the two cases, and the exception message says so itself — a packaged app is `Foo.app`, this is the JDK's `Contents/Home/bin`.

## Testing

Verified against the failing path this time, which is what #6876 lacked. Calling the real `send()` from an unbundled `hotRun`:

```
Warn: Not running from an application bundle — macOS notifications disabled for this process
Info: NOTIFDIAG posted=false
```

No abort, and `send()` returns false. Before this change the same path terminated the process. `:desktopApp:spotlessCheck detekt test` all pass.

For the record on #6876: I confirmed the bundled path worked and that the unbundled path crashed *before* the change, then called it verified without ever testing that the guard prevented the crash afterwards. Running the app is what caught it.

## Constitution Check (v1.3.3)

| Principle | Status |
|---|---|
| I. KMP Core | N/A — `desktopApp` is JVM-only; no `commonMain` touched |
| II. Zero Lint Tolerance | `spotlessCheck` + `detekt` pass |
| III. Compose Multiplatform UI | N/A — no UI change |
| IV. Privacy First | No PII/location/keys logged; the warning names no user data |
| V. Design Standards | N/A — no user-facing UI |
| VI. Documentation Freshness | N/A — no user-facing UI source touched |
| VII. Verify Before Push | Local verification plus a runtime check of the failing path; CI to be confirmed via `gh pr checks` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS notification compatibility by ensuring notifications are enabled only when the app is running from a properly packaged `.app` application.
  - Prevented notification-related issues when launching the desktop application through unsupported or non-packaged environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->