### PR TITLE
fix(ci): give google-flavor debug builds a working Maps API key

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -38,13 +38,15 @@ on:
         required: false
       DATADOG_CLIENT_TOKEN:
         required: false
-      GOOGLE_MAPS_API_KEY:
+      # Debug-only Maps key -- deliberately not the release GOOGLE_MAPS_API_KEY that
+      # release.yml uses. See the "Load Maps API key" step in android-check for why
+      # the two must stay separate.
+      GOOGLE_MAPS_API_KEY_DEBUG:
         required: false
 
 env:
   DATADOG_APPLICATION_ID: ${{ secrets.DATADOG_APPLICATION_ID }}
   DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
-  MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
   GITHUB_TOKEN: ${{ github.token }}
   # Only main writes the Gradle caches. merge_group scopes are throwaway branches
   # (per gradle/actions docs) — writes there had no reader.
@@ -446,6 +448,30 @@ jobs:
         run: |
           BASE=$(grep '^VERSION_NAME_BASE=' config.properties | cut -d'=' -f2)
           echo "VERSION_NAME=${BASE}-SNAPSHOT" >> "$GITHUB_ENV"
+
+      # androidApp/src/google/AndroidManifest.xml resolves ${MAPS_API_KEY} from
+      # secrets.properties (the secrets plugin injects it at variant level). With no
+      # such file the build falls back to secrets.defaults.properties' placeholder
+      # DEFAULT_API_KEY, so every snapshot/PR google-flavor APK shipped a blank map
+      # (#6883) -- the very flavor docs/en/developer/test-builds.md tells testers to use.
+      #
+      # A debug-only key, never the release one: config/debug.keystore is checked in
+      # (#6615), so the debug applicationId + SHA-1 pair every debug APK presents is
+      # forgeable by anyone who clones this repo. Pointing it at the production key
+      # would hand production Maps quota to the world; the debug key is restricted to
+      # those debug coordinates and quota-capped on its own.
+      #
+      # Unset -- fork PRs receive no secrets -- leaves today's placeholder behaviour.
+      - name: Load Maps API key for google-flavor debug builds
+        env:
+          GOOGLE_MAPS_API_KEY_DEBUG: ${{ secrets.GOOGLE_MAPS_API_KEY_DEBUG }}
+        run: |
+          if [ -n "$GOOGLE_MAPS_API_KEY_DEBUG" ]; then
+            echo "MAPS_API_KEY=$GOOGLE_MAPS_API_KEY_DEBUG" >> ./secrets.properties
+            echo "Injected debug Maps API key into secrets.properties."
+          else
+            echo "::warning::GOOGLE_MAPS_API_KEY_DEBUG is unset (fork PR, or the secret is not configured yet) -- the google-flavor map will be blank."
+          fi
 
       - name: Build Android APKs
         # -Dorg.gradle.isolated-projects=false: the dependency-graph plugin injected by setup-gradle force-resolves

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -165,6 +165,13 @@ configure<ApplicationExtension> {
         configureEach {
             versionName = "${defaultConfig.versionName} (${defaultConfig.versionCode}) $name"
             if (name == "google") {
+                // Only the unit-test manifest merge needs this. The secrets plugin injects
+                // MAPS_API_KEY at *variant* level (from secrets.properties, else
+                // secrets.defaults.properties), which overrides this for the app manifest -- but
+                // variant-level placeholders do not reach the unit-test component, so with no
+                // flavor-level value mergeGoogleDebugUnitTestManifest fails on the unsubstituted
+                // ${MAPS_API_KEY} in src/google/AndroidManifest.xml. This value is never shipped;
+                // what a real build carries comes from the plugin. See #6883.
                 manifestPlaceholders["MAPS_API_KEY"] = "dummy"
             }
         }


### PR DESCRIPTION
The rolling `snapshot` release and every PR-attached debug APK ship a blank map on the `google` flavor — the flavor `docs/en/developer/test-builds.md` recommends to testers. `reusable-check.yml` set `MAPS_API_KEY` as a workflow-level env var, but nothing reads it from the environment: the build resolves `${MAPS_API_KEY}` in `androidApp/src/google/AndroidManifest.xml` through the secrets plugin, which reads `secrets.properties`. Only `release.yml` ever wrote that file, so CI debug builds fell back to the `DEFAULT_API_KEY` placeholder in `secrets.defaults.properties`.

Fixes #6883.

- `android-check` now writes `secrets.properties` from a new `GOOGLE_MAPS_API_KEY_DEBUG` secret before assembling. The write is guarded on a non-empty value, so fork PRs — which receive no secrets — keep today's placeholder behaviour instead of failing.
- Dropped the inert workflow-level `MAPS_API_KEY` env var and the now-orphaned `GOOGLE_MAPS_API_KEY` secret declaration. All three callers use `secrets: inherit`, so nothing else changes.
- Documented what the `"dummy"` `manifestPlaceholder` in `androidApp/build.gradle.kts` is really for. It never reaches a shipped manifest — the secrets plugin injects `MAPS_API_KEY` at *variant* level, which overrides it — and that is exactly why it read as though `google`-flavor builds deliberately shipped a fake key, which is where the issue's investigation started. But variant-level placeholders do not reach the unit-test component, so removing it fails `mergeGoogleDebugUnitTestManifest` on the unsubstituted placeholder. It stays, with a comment saying so.

**Why a separate key.** The project already has a debug-scoped "Maps Dev Key", restricted to `com.geeksville.mesh.google.debug` and the Maps SDK for Android alone — but its allowlisted SHA-1 was a developer's personal `~/.android/debug.keystore`, which #6615 orphaned when it moved debug signing to the shared checked-in `config/debug.keystore`. That is why local `googleDebug` builds lost their map too, not just CI. The shared keystore's fingerprint is now registered on the dev key only: the keystore is public, so anyone who clones this repo can present that applicationId + SHA-1 pair, and the release key gates `com.geeksville.mesh`.

### Testing Performed

- Built `:androidApp:assembleGoogleDebug` with a sentinel value in `secrets.properties`; the merged manifest carries it as `com.google.android.geo.API_KEY`. Without that file it carries `DEFAULT_API_KEY`, confirming the plugin's variant-level injection outranks the flavor placeholder.
- End to end on an Android 16 emulator with Play services: a debug-signed `googleDebug` APK carrying the real dev key renders map tiles, with no `Authorization failure` in logcat. This was the open question in the issue — whether the key would authenticate against the debug certificate at all.
- `spotlessCheck detekt :androidApp:testGoogleDebugUnitTest :androidApp:testFdroidDebugUnitTest :androidApp:assembleGoogleDebug` all pass locally.
- `actionlint` with its shellcheck integration clean on the touched workflows.
- `scripts/verify-rb.sh` covers the `fdroid` flavor only, so the new write cannot perturb the reproducible-build gate.

### Constitution Check (v1.3.3)

- **I. KMP Core** — n/a; no `commonMain` or source-set changes.
- **II. Zero Lint Tolerance** — `spotlessCheck` and `detekt` pass locally.
- **III. Compose Multiplatform UI** — n/a; no UI changes.
- **IV. Privacy First** — the key is written only into git-ignored `secrets.properties` inside the CI job and is never logged or committed; the release key is untouched.
- **V. Design Standards** — n/a; no user-facing UI.
- **VI. Documentation Freshness** — no doc page changes; this restores the accuracy of `docs/en/developer/test-builds.md` rather than altering it.
- **VII. Verify Before Push** — see Testing Performed; CI confirmed on the PR.
