### PR TITLE
fix(ci): give google-flavor debug builds the real Firebase config

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -43,6 +43,8 @@ on:
       # the two must stay separate.
       GOOGLE_MAPS_API_KEY_DEBUG:
         required: false
+      GSERVICES:
+        required: false
 
 env:
   DATADOG_APPLICATION_ID: ${{ secrets.DATADOG_APPLICATION_ID }}
@@ -471,6 +473,27 @@ jobs:
             echo "Injected debug Maps API key into secrets.properties."
           else
             echo "::warning::GOOGLE_MAPS_API_KEY_DEBUG is unset (fork PR, or the secret is not configured yet) -- the google-flavor map will be blank."
+          fi
+
+      # androidApp/google-services.json is a tracked *placeholder* (project_id "xxx"); the real
+      # config only ever landed via release.yml. AnalyticsConventionPlugin applies the
+      # google-services and crashlytics plugins for the google flavor on every build type, so
+      # snapshot and PR debug APKs initialised Firebase against a project that does not exist and
+      # reported nothing -- while docs/en/developer/test-builds.md recommends that flavor to
+      # testers precisely because "crashes and errors get reported back". Crash collection stays
+      # runtime-gated on the user's consent either way (see GooglePlatformAnalytics).
+      #
+      # Unset -- fork PRs receive no secrets -- leaves the placeholder in place.
+      - name: Load Firebase config for google-flavor debug builds
+        env:
+          GSERVICES: ${{ secrets.GSERVICES }}
+        run: |
+          if [ -n "$GSERVICES" ]; then
+            rm -f ./androidApp/google-services.json
+            echo "$GSERVICES" > ./androidApp/google-services.json
+            echo "Injected the real google-services.json."
+          else
+            echo "::warning::GSERVICES is unset (fork PR, or the secret is not configured) -- Firebase reporting will be inert in these builds."
           fi
 
       - name: Build Android APKs


### PR DESCRIPTION
Follow-up to #6886, which found the same class of gap for the Maps key. `androidApp/google-services.json` is a tracked *placeholder* — `project_id: xxx`, app id `1:xxx:android:1111` — and the real config only ever reached a build through `release.yml`'s "Load secrets" step. `AnalyticsConventionPlugin` applies the google-services and crashlytics plugins for the whole `google` flavor, every build type, so the rolling `snapshot` release and every PR-attached debug APK initialised Firebase against a project that does not exist and reported nothing at all — while `docs/en/developer/test-builds.md` recommends that flavor to testers precisely because "crashes and errors get reported back".

- `android-check` writes `androidApp/google-services.json` from the `GSERVICES` secret before assembling, mirroring `release.yml`.
- The write is guarded on a non-empty value. Fork PRs receive no secrets and keep the placeholder; that guard is load-bearing here, because the google-services plugin aborts the build on a config whose clients it cannot match rather than falling back.

Crash collection stays runtime-gated on the user's consent (`GooglePlatformAnalytics` sets `isCrashlyticsCollectionEnabled`), so this changes where a consenting tester's reports land, not whether consent is asked.

### Testing Performed

- Wrote the secret's contents into `androidApp/google-services.json` exactly as the step does (`echo "$GSERVICES" > …`), then ran `:androidApp:processGoogleDebugGoogleServices`: it executed and resolved `google_app_id` to the Google Debug app, `1:484268767777:android:cb36d568fadf4f51334160`, with `project_id` `meshutil` — not the placeholder.
- Confirmed the same export is accepted for the `com.geeksville.mesh.google.debug` client, which is the failure mode the guard protects against.
- `actionlint` with its shellcheck integration clean.
- The tracked placeholder is restored in the diff — only the workflow changes.

### Constitution Check (v1.3.3)

- **I. KMP Core** — n/a; no source-set changes.
- **II. Zero Lint Tolerance** — no Kotlin touched; `actionlint`/shellcheck clean on the workflow.
- **III. Compose Multiplatform UI** — n/a.
- **IV. Privacy First** — the config is written only inside the CI job from a repo secret and is not committed; the tracked placeholder is unchanged. Crash reporting stays consent-gated.
- **V. Design Standards** — n/a; no UI.
- **VI. Documentation Freshness** — no doc changes; this restores the accuracy of `docs/en/developer/test-builds.md`.
- **VII. Verify Before Push** — see Testing Performed; CI checked after push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Firebase configuration support for Google-flavor Android debug builds in automated checks.
  - Builds use the provided configuration when available and retain the placeholder configuration otherwise.

- **Bug Fixes**
  - Added a warning when the Firebase configuration is not provided, improving visibility into fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->