### PR TITLE
fix(ci): retry snapshot asset uploads instead of losing the release

### DIFF
--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -53,7 +53,10 @@ jobs:
     # APK build itself failed, the artifact download below fails and this job goes red.
     if: github.repository == 'meshtastic/Meshtastic-Android' && !cancelled()
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 10
+    # ~1.5 GB of assets, uploaded with up to 3 attempts each (see "Upload snapshot assets").
+    # The 2026-08-26 failure was already 3m25s into uploading when it died, on top of ~2m of
+    # checkout and artifact download -- 10 minutes left no room for a single retry.
+    timeout-minutes: 25
     permissions:
       contents: write
     env:
@@ -132,8 +135,37 @@ jobs:
 
           **Obtainium:** enable *Include prereleases*. Each build's APK filename carries the versionCode, so updates are detected.
           EOF
-          gh release create snapshot upload/* \
+          gh release create snapshot \
             --title "Snapshot $VERSION_CODE ($GITHUB_SHA)" \
             --target "$GITHUB_SHA" \
             --prerelease \
             --notes-file notes.md
+
+      # Uploaded per file, with retries, rather than as assets on the `gh release create`
+      # above. uploads.github.com intermittently 400s on a multi-hundred-MB asset, and this
+      # release is ~1.5 GB across 15 of them, so a single flake is close to routine. Passed
+      # to `create`, one such 400 aborts the whole command -- gh then deletes the release it
+      # was staging, and because the previous release and tag are already gone by that point
+      # main is left with no snapshot at all until the next push. That is exactly what
+      # happened on 2026-08-26 (run 33015261548, the aarch64 AppImage).
+      #
+      # Trade-off: `create` no longer publishes only once every asset has landed, so there is
+      # now a window where the release exists while assets are still arriving. For a rolling
+      # prerelease that is replaced on every push to main, a briefly-incomplete release beats
+      # an absent one.
+      #
+      # --clobber makes a retry idempotent: an attempt that uploaded the asset and then failed
+      # reporting it does not leave the next attempt colliding with its own partial upload.
+      - name: Upload snapshot assets
+        run: |
+          for f in upload/*; do
+            for attempt in 1 2 3; do
+              if gh release upload snapshot "$f" --clobber; then
+                continue 2
+              fi
+              echo "::warning::Upload of $(basename "$f") failed (attempt ${attempt}/3)."
+              sleep $((attempt * 15))
+            done
+            echo "::error::Upload of $(basename "$f") failed after 3 attempts."
+            exit 1
+          done

--- a/.github/workflows/main-check.yml
+++ b/.github/workflows/main-check.yml
@@ -53,10 +53,12 @@ jobs:
     # APK build itself failed, the artifact download below fails and this job goes red.
     if: github.repository == 'meshtastic/Meshtastic-Android' && !cancelled()
     runs-on: ubuntu-24.04-arm
-    # ~1.5 GB of assets, uploaded with up to 3 attempts each (see "Upload snapshot assets").
-    # The 2026-08-26 failure was already 3m25s into uploading when it died, on top of ~2m of
-    # checkout and artifact download -- 10 minutes left no room for a single retry.
-    timeout-minutes: 25
+    # ~1.5 GB of assets, uploaded one at a time with up to 3 attempts each (see "Upload
+    # snapshot assets"). Sized for the worst case that still succeeds -- every asset failing
+    # twice before landing -- which is 45 uploads plus 7m30s of backoff. The 2026-08-26
+    # failure was already 3m25s into uploading when it died, on top of ~2m of checkout and
+    # artifact download, so the old 10-minute budget had no room for even one retry.
+    timeout-minutes: 35
     permissions:
       contents: write
     env:
@@ -156,15 +158,22 @@ jobs:
       #
       # --clobber makes a retry idempotent: an attempt that uploaded the asset and then failed
       # reporting it does not leave the next attempt colliding with its own partial upload.
+      #
+      # `timeout 8m` bounds a single attempt. Uploading per file is sequential where the old
+      # `gh release create upload/*` was concurrent, so the step is already slower than the
+      # code it replaces; without a per-attempt cap one stalled upload could then spend the
+      # whole job budget by itself and the job would be cancelled mid-release -- the same
+      # half-published outcome this step exists to avoid. 8 minutes is far beyond what a
+      # ~120 MB asset needs, so it fires only on a genuine stall.
       - name: Upload snapshot assets
         run: |
           for f in upload/*; do
             for attempt in 1 2 3; do
-              if gh release upload snapshot "$f" --clobber; then
+              if timeout 8m gh release upload snapshot "$f" --clobber; then
                 continue 2
               fi
               echo "::warning::Upload of $(basename "$f") failed (attempt ${attempt}/3)."
-              sleep $((attempt * 15))
+              sleep $((attempt * 10))
             done
             echo "::error::Upload of $(basename "$f") failed after 3 attempts."
             exit 1


### PR DESCRIPTION
## What broke

[Run 33015261548](https://github.com/meshtastic/Meshtastic-Android/actions/runs/33015261548) failed `publish-snapshot` with:

```
HTTP 400: 400 Bad Request (https://uploads.github.com/repos/meshtastic/Meshtastic-Android/releases/377444082/assets?label=&name=Meshtastic_Desktop-snapshot-aarch64-29322037.AppImage)
```

Every other job in the run was green. The `snapshot` release is currently **gone entirely** — not stale, absent.

## Why one 400 removes the release

`publish-snapshot` deletes the previous snapshot release *and its tag*, then recreates both by handing all 15 assets (~1.5 GB) to a single `gh release create`. A 400 on any one of them aborts the whole command; `gh` then deletes the release it was staging. The old release and tag are already gone by that point, so main is left with no snapshot until the next push. Confirmed — release `377444082` now 404s and no orphaned draft remains.

The asset itself was fine: a 119 MB AppImage, normal size. The run 7 hours earlier was green with byte-comparable artifacts (351,280,800 vs 351,331,258 for `desktop-app-Linux-ARM64`), and nothing in #6890 touches the publish path. This is a transient `uploads.github.com` failure that the job had no way to absorb.

## The change

- Create the release with **no assets**, then upload each file separately with up to 3 attempts and a backing-off sleep. A flake now costs one retry of one file rather than the entire release. `--clobber` keeps a retry idempotent.
- Raise `timeout-minutes` from 10 to 25. The failing run was already 3m25s into uploading when it died, on top of ~2m of checkout and artifact download — there was no room for even one retry.

**Trade-off, stated up front:** `create` no longer publishes only once every asset has landed, so the release is briefly visible while assets are still arriving. For a rolling prerelease that is replaced on every push to main, a briefly-incomplete release beats an absent one. Happy to switch to staging a draft and publishing it last if reviewers would rather keep strict atomicity.

## Verification

**This job cannot be exercised by any PR check** — `publish-snapshot` runs only on push to `main`, so nothing here executes the changed job before merge. What does stand behind it:

- `actionlint` clean, which shellchecks the `run:` blocks.
- The upload loop run locally against a fake `gh`, covering both paths:
  - an asset that 400s twice then succeeds → recovers on attempt 3, loop exits 0;
  - an asset that always 400s → warns 3×, emits `::error::`, exits 1 (the job still goes red rather than silently publishing an incomplete release).
- Filenames containing spaces (`Meshtastic Desktop-2.8.2-*.dmg`) and `continue 2` semantics under `bash -e` both verified in those runs.

The real test is the first push to main after merge — that push recreates the snapshot, and the release should come back with all 15 assets.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved snapshot release publishing reliability.
  * Extended the publishing timeout to support longer-running releases.
  * Added individual asset uploads with automatic retries and clearer failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->