### PR TITLE
ci(l10n): drop the --preserve-hierarchy args crowdin CLI 5 removed

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -269,10 +269,8 @@ jobs:
           config: 'crowdin.yml'
           crowdin_branch_name: 'main'
           upload_sources: true
-          upload_sources_args: '--preserve-hierarchy'
           upload_translations: false
           download_translations: true
-          download_translations_args: '--preserve-hierarchy'
           create_pull_request: false
           commit_message: 'chore(l10n): New Crowdin Translations from scheduled update'
           push_translations: false

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,7 @@
+# Explicit because CLI 5 removed --preserve-hierarchy (it is now the default);
+# pinning it here keeps the layout independent of that default.
+preserve_hierarchy: true
+
 files:
   - source: /**/composeResources/values/strings.xml
     translation: /%original_path%-%two_letters_code%/strings.xml


### PR DESCRIPTION
`crowdin/github-action@v3` (#6900) runs Crowdin CLI 5, which removed the positive
`--preserve-hierarchy` flag and made preserving the hierarchy the default.

The hourly sync is not broken — CLI 5 ignores the flag rather than erroring. Run
[33066727951](https://github.com/meshtastic/Meshtastic-Android/actions/runs/33066727951)
(11:17Z, first full pass after #6900) uploaded and downloaded normally, with the layout
intact: `docs/sq-rAL/user/…`, `core/resources/src/commonMain/composeResources/values-sq/strings.xml`.

So this is hygiene, not a fix: the two `*_args` inputs now point at an argument that no
longer exists, and a later CLI turning that into a hard error would take the l10n sync down.
`preserve_hierarchy: true` in `crowdin.yml` is the documented replacement, and pinning it
there keeps the layout off a default that could change again.

Also removed in CLI 5, none of which this workflow passes: `pre-translate` → `auto-translate`,
`--plain` → `--output plain`, `--translate-untranslated-only` → `--scope`.

Not exercised by PR CI — the workflow is cron + `workflow_dispatch` only. A manual dispatch
after merge is the check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated translation synchronization settings to preserve the project’s file structure.
  * Simplified automated translation downloads while keeping translation uploads disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->