### PR TITLE
feat(appfunctions): reconcile system state instead of blind-writing it

### DIFF
--- a/androidApp/src/google/kotlin/org/meshtastic/app/ai/appfunctions/AppFunctionStateSync.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/ai/appfunctions/AppFunctionStateSync.kt
@@ -17,9 +17,13 @@
 package org.meshtastic.app.ai.appfunctions
 
 import android.content.Context
+import androidx.appfunctions.AppFunctionException
 import androidx.appfunctions.AppFunctionManager
+import androidx.appfunctions.metadata.AppFunctionName
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -32,6 +36,9 @@ import org.meshtastic.core.repository.AppFunctionsPrefs
  * [AppFunctionManager].
  *
  * When the master toggle is off, all functions are disabled regardless of individual toggles.
+ *
+ * Writes are driven by a read-back of the system's own state, so a pass that lands while the functions are still being
+ * indexed (first launch) converges on a retry instead of leaving the system on its defaults forever.
  */
 class AppFunctionStateSync(
     private val context: Context,
@@ -68,25 +75,53 @@ class AppFunctionStateSync(
             .launchIn(scope)
     }
 
-    private suspend fun syncStates(states: List<Pair<String, Boolean>>) {
+    private suspend fun syncStates(desired: List<Pair<String, Boolean>>) {
         val manager = AppFunctionManager.getInstance(context) ?: return
 
-        for ((functionId, enabled) in states) {
-            val state =
-                if (enabled) {
-                    AppFunctionManager.APP_FUNCTION_STATE_ENABLED
-                } else {
-                    AppFunctionManager.APP_FUNCTION_STATE_DISABLED
+        repeat(MAX_SYNC_ATTEMPTS) { attempt ->
+            val pending = pendingWrites(desired, readStates(manager, desired.map { it.first }))
+            if (pending.isEmpty()) return
+
+            for ((functionId, enabled) in pending) {
+                val state =
+                    if (enabled) {
+                        AppFunctionManager.APP_FUNCTION_STATE_ENABLED
+                    } else {
+                        AppFunctionManager.APP_FUNCTION_STATE_DISABLED
+                    }
+                try {
+                    manager.setAppFunctionEnabled(functionId, state)
+                } catch (e: AppFunctionException) {
+                    // Usually "not indexed yet" on first launch; the read-back drives the retry.
+                    Logger.d(e) { "AppFunction $functionId not writable yet" }
                 }
-            try {
-                manager.setAppFunctionEnabled(functionId, state)
-            } catch (_: Exception) {
-                // Function may not be indexed yet (first launch)
             }
+            if (attempt < MAX_SYNC_ATTEMPTS - 1) delay(RETRY_DELAY_MS)
         }
     }
 
+    /** System state per function id, or null when it cannot be read — in which case every write is attempted. */
+    private suspend fun readStates(manager: AppFunctionManager, functionIds: List<String>): Map<String, Boolean>? =
+        try {
+            manager.getAppFunctionStates(functionIds.map { AppFunctionName(context.packageName, it) }).associate {
+                it.functionName.functionIdentifier to it.isEnabled
+            }
+        } catch (e: AppFunctionException) {
+            Logger.d(e) { "AppFunction states unreadable; writing all toggles" }
+            null
+        }
+
     companion object {
+        private const val MAX_SYNC_ATTEMPTS = 3
+        private const val RETRY_DELAY_MS = 2_000L
+
+        /** Toggles whose system state does not already match what prefs ask for. */
+        internal fun pendingWrites(
+            desired: List<Pair<String, Boolean>>,
+            actual: Map<String, Boolean>?,
+        ): List<Pair<String, Boolean>> =
+            if (actual == null) desired else desired.filter { (id, enabled) -> actual[id] != enabled }
+
         private const val CLASS_PREFIX = "org.meshtastic.app.ai.appfunctions.MeshtasticAppFunctions#"
 
         const val SEND_MESSAGE_ID = "${CLASS_PREFIX}sendMessage"

--- a/androidApp/src/google/kotlin/org/meshtastic/app/ai/appfunctions/AppFunctionStateSync.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/ai/appfunctions/AppFunctionStateSync.kt
@@ -21,6 +21,7 @@ import androidx.appfunctions.AppFunctionException
 import androidx.appfunctions.AppFunctionManager
 import androidx.appfunctions.metadata.AppFunctionName
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
@@ -71,8 +72,19 @@ class AppFunctionStateSync(
         combine(prefs.masterEnabled, combine(functions.map { it.enabled }) { it.toList() }) { master, toggles ->
             functions.mapIndexed { index, fn -> fn.id to (master && toggles[index]) }
         }
-            .onEach { states -> syncStates(states) }
+            .onEach { states -> syncStatesSafely(states) }
             .launchIn(scope)
+    }
+
+    /** Anything escaping [syncStates] would cancel the collector, leaving sync dead for the process lifetime. */
+    private suspend fun syncStatesSafely(desired: List<Pair<String, Boolean>>) {
+        try {
+            syncStates(desired)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Logger.e(e) { "AppFunction sync pass failed" }
+        }
     }
 
     private suspend fun syncStates(desired: List<Pair<String, Boolean>>) {

--- a/androidApp/src/testGoogle/kotlin/org/meshtastic/app/ai/appfunctions/AppFunctionStateSyncTest.kt
+++ b/androidApp/src/testGoogle/kotlin/org/meshtastic/app/ai/appfunctions/AppFunctionStateSyncTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app.ai.appfunctions
+
+import org.meshtastic.app.ai.appfunctions.AppFunctionStateSync.Companion.pendingWrites
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppFunctionStateSyncTest {
+
+    private val desired =
+        listOf(AppFunctionStateSync.SEND_MESSAGE_ID to true, AppFunctionStateSync.GET_NODE_LIST_ID to false)
+
+    @Test
+    fun `unreadable system state writes every toggle`() {
+        assertEquals(desired, pendingWrites(desired, actual = null))
+    }
+
+    @Test
+    fun `matching system state writes nothing`() {
+        val actual = mapOf(AppFunctionStateSync.SEND_MESSAGE_ID to true, AppFunctionStateSync.GET_NODE_LIST_ID to false)
+
+        assertEquals(emptyList(), pendingWrites(desired, actual))
+    }
+
+    @Test
+    fun `only drifted toggles are written`() {
+        val actual = mapOf(AppFunctionStateSync.SEND_MESSAGE_ID to true, AppFunctionStateSync.GET_NODE_LIST_ID to true)
+
+        assertEquals(listOf(AppFunctionStateSync.GET_NODE_LIST_ID to false), pendingWrites(desired, actual))
+    }
+
+    /** A function the system has not indexed yet is absent from the read-back, so it must still be written. */
+    @Test
+    fun `unindexed toggles are written`() {
+        val actual = mapOf(AppFunctionStateSync.SEND_MESSAGE_ID to true)
+
+        assertEquals(listOf(AppFunctionStateSync.GET_NODE_LIST_ID to false), pendingWrites(desired, actual))
+    }
+}


### PR DESCRIPTION
`AppFunctionStateSync` pushed all nine toggles to `AppFunctionManager` on every prefs
emission and swallowed the result with `catch (_: Exception) { // Function may not be
indexed yet (first launch) }`.

That comment is accurate and that is the bug. On first launch the functions are not
indexed, so every write throws and disappears — and prefs do not re-emit on their own,
so a user who had disabled a function is left with the system on its defaults until they
next touch a toggle. A genuine fault looks identical.

androidx.appfunctions `1.0.0-alpha11` (#6892) added the read side. `syncStates` now:

- reads the system's own state in one call — `getAppFunctionStates(functionIds.map { AppFunctionName(context.packageName, it) })`
- writes only the toggles that actually drift
- retries up to 3× (2s apart) so a pass that lands mid-indexing converges instead of giving up
- catches `AppFunctionException` rather than bare `Exception`, so a real fault is logged

A function absent from the read-back is treated as "not indexed, write it", and an
unreadable read-back falls back to writing everything — so this is never *less* eager
than the old behaviour.

`pendingWrites` is extracted to make that decision testable; `AppFunctionStateSyncTest`
covers all four cases.

Verified: `spotlessApply`, `:androidApp:detekt`, `:androidApp:testGoogleDebugUnitTest`,
`:androidApp:testFdroidDebugUnitTest` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization of AI app-function settings with system state.
  - Prevented unnecessary updates when settings are already in sync.
  - Automatically retries synchronization when system state cannot be read.
  - Correctly updates only settings that differ, including previously unindexed options.

- **Tests**
  - Added coverage for matching, mismatched, unreadable, and unindexed settings states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->