### PR TITLE
chore(deps): update compose.screenshot to v0.0.1-alpha16

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     compileOnly(libs.android.tools.common)
     compileOnly(libs.compose.gradlePlugin)
     compileOnly(libs.compose.multiplatform.gradlePlugin)
+    compileOnly(libs.compose.screenshot.gradlePlugin)
     compileOnly(libs.datadog.gradlePlugin)
     compileOnly(libs.detekt.gradlePlugin)
     compileOnly(libs.dokka.gradlePlugin)

--- a/build-logic/convention/src/main/kotlin/AndroidScreenshotConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidScreenshotConventionPlugin.kt
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import com.android.build.api.dsl.LibraryExtension
+import com.android.compose.screenshot.tasks.PreviewScreenshotValidationTask
 import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -30,8 +31,10 @@ import org.meshtastic.buildlogic.libs
  * Owns the shared CST configuration: the `enableScreenshotTest` experimental flag, the test-retry opt-out (CST's custom
  * runner is incompatible with test retry), and the Compose Multiplatform + screenshot-validation dependencies.
  * Configuration-only: apply it ALONGSIDE `meshtastic.android.library[.compose]` and `com.android.compose.screenshot`,
- * which the module declares itself. The `screenshotTests { imageDifferenceThreshold }` block stays in the module
- * scripts — it is a DSL extension of the screenshot plugin, reachable there via generated accessors only.
+ * which the module declares itself. It also owns the image-difference tolerance, which used to live in the module
+ * scripts as `testOptions { screenshotTests { imageDifferenceThreshold } }` — alpha16 deleted that DSL and
+ * conventions the engine threshold to 0f (pixel-exact), which fails 33 of our references. The task property the
+ * DSL used to feed is still public, so the same tolerance is set directly on it here.
  */
 class AndroidScreenshotConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -39,6 +42,10 @@ class AndroidScreenshotConventionPlugin : Plugin<Project> {
             pluginManager.withPlugin("com.android.compose.screenshot") {
                 extensions.configure<LibraryExtension> {
                     experimentalProperties["android.experimental.enableScreenshotTest"] = true
+                }
+
+                tasks.withType<PreviewScreenshotValidationTask>().configureEach {
+                    testEngineInput.threshold.set(IMAGE_DIFFERENCE_THRESHOLD)
                 }
 
                 // CST screenshot tests use a custom runner incompatible with test retry
@@ -61,5 +68,9 @@ class AndroidScreenshotConventionPlugin : Plugin<Project> {
                     .configureEach { project.dependencies.add(name, libs.library("screenshot-validation-api")) }
             }
         }
+    }
+
+    private companion object {
+        const val IMAGE_DIFFERENCE_THRESHOLD = 0.0005f
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,9 @@ plugins {
     alias(libs.plugins.android.kotlin.multiplatform.library) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.compose.multiplatform) apply false
+    // On the root classpath (never applied here) so AndroidScreenshotConventionPlugin can
+    // reference PreviewScreenshotValidationTask — build-logic's compileOnly is not enough.
+    alias(libs.plugins.compose.screenshot) apply false
     alias(libs.plugins.datadog) apply false
     alias(libs.plugins.devtools.ksp) apply false
     alias(libs.plugins.koin.compiler) apply false

--- a/docs-screenshots/build.gradle.kts
+++ b/docs-screenshots/build.gradle.kts
@@ -30,11 +30,7 @@ plugins {
     alias(libs.plugins.meshtastic.android.screenshot)
 }
 
-configure<LibraryExtension> {
-    namespace = "org.meshtastic.screenshot.docs"
-
-    testOptions { screenshotTests { imageDifferenceThreshold = 0.0005f } }
-}
+configure<LibraryExtension> { namespace = "org.meshtastic.screenshot.docs" }
 
 dependencies {
     implementation(projects.core.ui)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ konsist = "0.17.3"
 turbine = "1.2.1"
 
 # Compose Screenshot Testing
-compose-screenshot = "0.0.1-alpha15"
+compose-screenshot = "0.0.1-alpha16"
 
 # Baseline Profiles / Macrobenchmark
 # `benchmark` drives both the androidx.benchmark macro lib AND the androidx.baselineprofile
@@ -313,6 +313,7 @@ androidx-room-gradlePlugin = { module = "androidx.room3:room3-gradle-plugin", ve
 compose-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 compose-multiplatform-gradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
 datadog-gradlePlugin = { module = "com.datadoghq.dd-sdk-android-gradle-plugin:com.datadoghq.dd-sdk-android-gradle-plugin.gradle.plugin", version.ref = "datadog-gradle" }
+compose-screenshot-gradlePlugin = { module = "com.android.compose.screenshot:screenshot-test-gradle-plugin", version.ref = "compose-screenshot" }
 detekt-compose = { module = "io.nlopez.compose.rules:detekt", version = "0.6.4" }
 detekt-formatting = { module = "dev.detekt:detekt-rules-ktlint-wrapper", version.ref = "detekt" }
 detekt-gradlePlugin = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt" }

--- a/screenshot-tests/build.gradle.kts
+++ b/screenshot-tests/build.gradle.kts
@@ -23,11 +23,7 @@ plugins {
     alias(libs.plugins.meshtastic.android.screenshot)
 }
 
-configure<LibraryExtension> {
-    namespace = "org.meshtastic.screenshot.tests"
-
-    testOptions { screenshotTests { imageDifferenceThreshold = 0.0005f } }
-}
+configure<LibraryExtension> { namespace = "org.meshtastic.screenshot.tests" }
 
 dependencies {
     implementation(projects.core.ui)


### PR DESCRIPTION
Supersedes #6905, which is red on 5 of 6 jobs.

### Why #6905 fails

Not the comparison — script compilation. alpha16 deletes the
`screenshotTests { imageDifferenceThreshold }` DSL, so both module scripts stop
compiling with `Unresolved reference 'screenshotTests'` and every job that
configures the build dies before it runs anything.

Confirmed against the jars rather than the release notes (there are none):

| | alpha15 | alpha16 |
|---|---|---|
| `com/android/compose/screenshot/gradle/ScreenshotTestOptions{,Impl}.class` | present | **gone** |
| `configureTestEngineInput$1` | reads `ScreenshotTestOptionsImpl.getImageDifferenceThreshold()` | `threshold.convention(0f)` |

The engine (`screenshot-validation-junit-engine`) still reads the threshold, defaulting
to `0f`. So alpha16 is pixel-exact with no DSL and no Gradle property.

### Why dropping the block is not enough

Pixel-exact fails **33 of our 324** references — the `0.0005f` tolerance was load-bearing.
Regenerating 33 goldens to match would bury real diffs, so the tolerance stays.

`PreviewScreenshotValidationTask.testEngineInput.threshold` is still a public
`Property<Float>`, so the value moves into `AndroidScreenshotConventionPlugin` alongside
the rest of the shared CST config — one place instead of two module scripts.

Reaching that type needs the plugin on the **root** buildscript classpath; build-logic's
`compileOnly` alone gives `NoClassDefFoundError:
com/android/compose/screenshot/tasks/PreviewScreenshotValidationTask` at configuration
time. Hence the `apply false` alias, same as `datadog` for `AnalyticsConventionPlugin`.

### Verified

`:screenshot-tests:validateDebugScreenshotTest` + `:docs-screenshots:validateDebugScreenshotTest`
— **324 passed, 0 failed**. `spotlessCheck` and `detekt` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Compose screenshot testing to the latest alpha16 release.
  * Preserved consistent screenshot validation by applying the configured image-difference tolerance across screenshot validation tasks.
  * Simplified screenshot test module configuration while maintaining existing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->