### PR TITLE
chore(deps): update flatpak-sources plugin to v0.2.0, drop hand-tracked skiko entry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,10 @@ plugins.withId("org.meshtastic.flatpak.sources") {
         // Force-resolve platform-specific native artifacts not resolved on the generation host (the
         // manifest is generated on an x86_64 runner, but the offline build also needs to run on arm64).
         //
+        // Since plugin 0.2.0 each coordinate resolves TRANSITIVELY, so only direct dependencies belong
+        // here — desktop-jvm-{platform} brings org.jetbrains.skiko:skiko-awt-runtime-{platform} along
+        // by itself (its version previously had to be tracked by hand against desktop-jvm's POM).
+        //
         // KEEP desktop-jvm's version IN SYNC with the compose-multiplatform entry in
         // gradle/libs.versions.toml — that's exactly the maintenance trap that caused this to break once
         // already: this block was pinned to 1.11.1 and never updated when the catalog moved to
@@ -53,13 +57,8 @@ plugins.withId("org.meshtastic.flatpak.sources") {
         // would auto-track it, but that accessor isn't resolvable in this project's script — tried and
         // confirmed via a direct `./gradlew help` failure — so it has to stay a literal that a human/agent
         // updates by hand alongside any compose-multiplatform bump.)
-        //
-        // skiko isn't in this catalog at all — its version must track whatever desktop-jvm-<platform>'s
-        // own POM declares for org.jetbrains.skiko:skiko-awt-runtime-<platform> (0.150.1 for
-        // compose-multiplatform 1.12.0-rc01); check that POM again if this version is bumped.
         targetPlatforms.set(setOf("linux-x64", "linux-arm64"))
         platformDependencies.set(setOf(
-            "org.jetbrains.skiko:skiko-awt-runtime-{platform}:0.150.1",
             "org.jetbrains.compose.desktop:desktop-jvm-{platform}:1.12.0-rc01",
         ))
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,16 @@ plugins {
 }
 
 plugins.withId("org.meshtastic.flatpak.sources") {
+    // The generated `libs` accessor isn't resolvable in this script, but the runtime catalog API is —
+    // reading the version here (instead of a hand-maintained literal) closes the trap that already bit
+    // once: the block was pinned to 1.11.1 long after the catalog moved on, so the arm64 offline flatpak
+    // build kept resolving (and shipping) URLs for a version nothing in the project used anymore.
+    val composeMultiplatformVersion =
+        extensions.getByType<org.gradle.api.artifacts.VersionCatalogsExtension>()
+            .named("libs")
+            .findVersion("compose-multiplatform")
+            .get()
+            .requiredVersion
     extensions.configure<org.meshtastic.flatpak.sources.FlatpakSourcesExtension> {
         outputFile.set(layout.buildDirectory.file("flatpak-sources.json"))
         mustRunAfterTasks.set(listOf(":desktopApp:assemble", ":desktopApp:packageUberJarForCurrentOS"))
@@ -48,18 +58,9 @@ plugins.withId("org.meshtastic.flatpak.sources") {
         // Since plugin 0.2.0 each coordinate resolves TRANSITIVELY, so only direct dependencies belong
         // here — desktop-jvm-{platform} brings org.jetbrains.skiko:skiko-awt-runtime-{platform} along
         // by itself (its version previously had to be tracked by hand against desktop-jvm's POM).
-        //
-        // KEEP desktop-jvm's version IN SYNC with the compose-multiplatform entry in
-        // gradle/libs.versions.toml — that's exactly the maintenance trap that caused this to break once
-        // already: this block was pinned to 1.11.1 and never updated when the catalog moved to
-        // 1.12.0-rc01, so the arm64 offline flatpak build kept resolving (and shipping) URLs for a version
-        // nothing in the project used anymore. (A `libs.versions.composeMultiplatform` reference here
-        // would auto-track it, but that accessor isn't resolvable in this project's script — tried and
-        // confirmed via a direct `./gradlew help` failure — so it has to stay a literal that a human/agent
-        // updates by hand alongside any compose-multiplatform bump.)
         targetPlatforms.set(setOf("linux-x64", "linux-arm64"))
         platformDependencies.set(setOf(
-            "org.jetbrains.compose.desktop:desktop-jvm-{platform}:1.12.0-rc01",
+            "org.jetbrains.compose.desktop:desktop-jvm-{platform}:$composeMultiplatformVersion",
         ))
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,7 +38,8 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver") version "1.0.0"
     // 0.1.7 fixed the Isolated Projects incompatibility (shares state via a BuildService instead of
     // gradle.extensions) that previously required gating this behind an opt-in property.
-    id("org.meshtastic.flatpak.sources.settings") version "0.1.7"
+    // 0.2.0 resolves platformDependencies transitively — see the collapsed list in build.gradle.kts.
+    id("org.meshtastic.flatpak.sources.settings") version "0.2.0"
 }
 
 @Suppress("UnstableApiUsage")


### PR DESCRIPTION
Adopts gradle-flatpak-sources 0.2.0 (released today), whose headline change — transitive `platformDependencies` resolution (meshtastic/gradle-flatpak-sources#43) — exists because of the maintenance trap this repo hit in #6901.

## What changes

- **`settings.gradle.kts`**: plugin `org.meshtastic.flatpak.sources.settings` 0.1.7 → 0.2.0.
- **`build.gradle.kts`**: `platformDependencies` names only the direct dependency. `desktop-jvm-{platform}` brings `org.jetbrains.skiko:skiko-awt-runtime-{platform}` transitively, so the explicit skiko entry — and the version we had to track by hand against desktop-jvm's POM — is deleted.
- **`build.gradle.kts`**: desktop-jvm's own version is now read from `gradle/libs.versions.toml` via the runtime `VersionCatalogsExtension` API instead of a hand-maintained literal. The old KEEP-IN-SYNC comment claimed the catalog wasn't reachable from this script; the generated `libs` accessor indeed doesn't resolve here, but the runtime API does (disproven on the #6901 branch, re-verified on this one). That closes the trap that already bit once at 1.11.1 — this block no longer contains any version to keep in sync.

Also in 0.2.0: each coordinate resolves in its own configuration, so one unresolvable entry no longer silently drops every other platform URL from the manifest, and the resolution warning names the coordinate that failed.

## Verification

- Local: the Gradle `help` task configures the whole build cleanly with 0.2.0 resolved from the Plugin Portal and the version read from the catalog (a wrong catalog key would throw at configuration time).
- CI: this PR touches both build scripts, so the **Verify Flatpak Offline Build** workflow runs the real gate — generate the manifest, then offline flatpak builds on x64 and arm64. The manifest should gain nothing and lose nothing versus main: the skiko URLs previously contributed by the explicit entry now arrive transitively from desktop-jvm.

## Notes

- Supersedes #6910 (Renovate's version-only bump — it can't collapse the dependency list).
- #6901 carries a `check-platform-deps.py` guard whose transitive-completeness half is *inverted* by 0.2.0; that branch will handle the guard change together with its own collapse when it rebases onto this. Main has no guard, so this PR is unaffected.
