### PR TITLE
ci(flatpak): run the offline verify on version-catalog changes

### DIFF
--- a/.github/workflows/verify-flatpak.yml
+++ b/.github/workflows/verify-flatpak.yml
@@ -13,6 +13,12 @@ on:
       # The offline manifest pins the Gradle distribution independently of the wrapper —
       # a wrapper bump without a manifest update breaks the offline build silently.
       - 'gradle/wrapper/**'
+      # build.gradle.kts reads compose-multiplatform from the catalog (#6911), so a
+      # catalog-only bump changes the manifest's platform URLs. Deliberately the whole
+      # file and not a key filter: nearly every Renovate PR lands here so this over-runs,
+      # but a filter naming today's keys goes stale silently the moment the manifest
+      # reads another one — which is the failure #6911 existed to remove.
+      - 'gradle/libs.versions.toml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
#6911 moved the manifest's `compose-multiplatform` version out of a literal in
`build.gradle.kts` and into a catalog read. That closed the drift-by-forgetting
trap, but it also moved the value out from under this workflow's path filter:
a catalog-only bump now changes the platform URLs the offline build resolves,
and nothing runs.

#6904 (`1.12.0-rc01` → `1.12.0`) is the first PR in that blind spot — its
`Generate Flatpak Sources` and `build-flatpak` jobs are skipped, so I had to
dispatch the workflow by hand to check it.

### Why the whole file and not a key filter

Nearly every Renovate PR touches `gradle/libs.versions.toml`, so this
over-runs, and that is not free — `generate-sources` is ~10 min and each
`build-flatpak` arch ~12 min.

A filter naming `compose-multiplatform` would avoid that, and I decided
against it: it is correct only for as long as that is the only catalog key the
manifest reads, and it fails **silently** when that stops being true. That is
the same shape as the bug #6911 existed to remove. Over-running is visible in
the Actions tab; under-running is not.

Worth revisiting if the cost bites — but then as an explicit gate job with its
own guard, not a path glob that quietly stops matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Flatpak offline-build verification to run when the Gradle version catalog changes.
  * Improved workflow documentation explaining why catalog updates require validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->