### PR TITLE
build: move to Gradle 9.7.1, working around three things 9.7.1 stopped tolerating

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -96,17 +96,6 @@
       "automerge": false
     },
     {
-      "description": "Block the Gradle 9.7 line. 9.7.0 crashed CMP's proguardReleaseJars (ExecSpec stdout null); 9.7.1 fixed that but broke main CI twice over (bumped in #6777, reverted next day): the configuration-cache fingerprint crashes reloading its own same-key entries (IsInIdeaSyncValueSource CNFE), and CMP's Windows packaging trips an Isolated Projects violation (':desktopApp' cannot access Project.layout on ':'). Lift only after a 9.7.x/9.8 patch proves out on both counts. Matches by depName so the flatpak-manifest custom manager (customManagers below) is pinned identically and can never propose the blocked version on its own.",
-      "matchDepNames": [
-        "gradle"
-      ],
-      "matchManagers": [
-        "gradle-wrapper",
-        "custom.regex"
-      ],
-      "allowedVersions": "!/^9\\.7\\./"
-    },
-    {
       "description": "Disable automerge for major updates (safety net)",
       "matchUpdateTypes": [
         "major"

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -99,7 +99,13 @@ jobs:
           develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           job_summary_pr_comment: ${{ env.GRADLE_PR_COMMENT }}
           cache_read_only: ${{ env.GRADLE_CACHE_READ_ONLY }}
-          cache_configuration_cache: 'true' # VERSION_CODE pinned -> entries actually reuse
+          # Disabled on Gradle 9.7.1: restoring an entry written by another runner crashes
+          # fingerprint deserialization (IsInIdeaSyncValueSource CNFE, settings-plugin
+          # classloader scope) and the job dies in ~10s before any test. A cross-machine
+          # restore is the only thing that triggers it, so it is 100% red in CI and not
+          # reproducible from a local store/reuse pair. Re-enable when that is fixed
+          # upstream; VERSION_CODE is still pinned above so entries would reuse.
+          cache_configuration_cache: 'false'
           install_jetbrains_jdk: 'true'
 
       - name: Lint, Analysis & KMP Smoke Compile
@@ -130,7 +136,13 @@ jobs:
           develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           job_summary_pr_comment: ${{ env.GRADLE_PR_COMMENT }}
           cache_read_only: ${{ env.GRADLE_CACHE_READ_ONLY }}
-          cache_configuration_cache: 'true' # VERSION_CODE pinned -> entries actually reuse
+          # Disabled on Gradle 9.7.1: restoring an entry written by another runner crashes
+          # fingerprint deserialization (IsInIdeaSyncValueSource CNFE, settings-plugin
+          # classloader scope) and the job dies in ~10s before any test. A cross-machine
+          # restore is the only thing that triggers it, so it is 100% red in CI and not
+          # reproducible from a local store/reuse pair. Re-enable when that is fixed
+          # upstream; VERSION_CODE is still pinned above so entries would reuse.
+          cache_configuration_cache: 'false'
 
       - name: Screenshot Test Validation
         # -Dorg.gradle.isolated-projects=false: AGP's screenshot plugin iterates BuildServicesRegistry at
@@ -294,7 +306,13 @@ jobs:
           develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
           job_summary_pr_comment: ${{ env.GRADLE_PR_COMMENT }}
           cache_read_only: ${{ env.GRADLE_CACHE_READ_ONLY }}
-          cache_configuration_cache: 'true' # VERSION_CODE pinned -> entries actually reuse
+          # Disabled on Gradle 9.7.1: restoring an entry written by another runner crashes
+          # fingerprint deserialization (IsInIdeaSyncValueSource CNFE, settings-plugin
+          # classloader scope) and the job dies in ~10s before any test. A cross-machine
+          # restore is the only thing that triggers it, so it is 100% red in CI and not
+          # reproducible from a local store/reuse pair. Re-enable when that is fixed
+          # upstream; VERSION_CODE is still pinned above so entries would reuse.
+          cache_configuration_cache: 'false'
           # Shards run different task graphs; kover flips the graph again.
           cache_key_suffix: ${{ matrix.shard.name }}${{ inputs.run_coverage && '-kover' || '' }}
 
@@ -593,7 +611,18 @@ jobs:
         # packageDistributionForCurrentOS (debug build type, no ProGuard) produces real
         # installers (dmg/msi+exe/deb+rpm+AppImage-dir) so the snapshot release below can
         # ship something testers can actually install, not just an unpacked app dir.
-        run: ./gradlew :desktopApp:packageDistributionForCurrentOS :desktopApp:proguardReleaseJars -Pci=true
+        # On Gradle 9.7.1 CMP's Windows MSI/WiX packaging reads Project.layout on the root project
+        # from ':desktopApp'. Isolated Projects and the configuration cache reject that
+        # independently, so both have to go — disabling only IP still fails as "1 problem was found
+        # storing the configuration cache", and Gradle refuses --no-configuration-cache while IP is
+        # still on. This job never persists a CC entry (cache_configuration_cache defaults to
+        # false), so dropping the cache costs nothing.
+        # Flags, not -D properties: -Dorg.gradle.isolated-projects=false took effect on macOS and
+        # both Linux runners but NOT on windows-latest, which still died on "Configuration Cache
+        # cannot be disabled when Isolated Projects is enabled". --no-isolated-projects is
+        # unambiguous; it needs 9.7+, which is exactly what this PR moves us to, so a pin-back below
+        # 9.7 has to revert this line with it.
+        run: ./gradlew :desktopApp:packageDistributionForCurrentOS :desktopApp:proguardReleaseJars -Pci=true --no-isolated-projects --no-configuration-cache
 
       # CMP's TargetFormat.AppImage is jpackage's "app-image" — an unpacked directory, not
       # a Linux .AppImage. Wrap it into a real AppImage, same as the release workflow.

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -529,9 +529,8 @@ jobs:
       - name: Build Android APKs
         # -Dorg.gradle.isolated-projects=false: the dependency-graph plugin injected by setup-gradle force-resolves
         # via allprojects{}, which Isolated Projects forbids (fatal since Gradle 9.7). The property form is
-        # used everywhere instead of --no-isolated-projects: that flag only exists on Gradle 9.7+, and the
-        # wrapper is pinned to 9.6.1 (9.7.1 broke the CC fingerprint and CMP Windows packaging — see
-        # gradle-wrapper.properties and the renovate.json block on the 9.7 line).
+        # used everywhere instead of --no-isolated-projects: that flag only exists on 9.7+, so the property
+        # survives a pin-back below 9.7 without editing this line.
         run: ./gradlew androidApp:assembleFdroidDebug androidApp:assembleGoogleDebug -Pci=true --parallel --configuration-cache -Dorg.gradle.isolated-projects=false --continue
 
       - name: Upload debug artifact

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,13 +2,13 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # -bin: nothing here reads -all's docs/sources. Update sha256 with the URL on upgrades
 # (official .sha256 sits next to the distribution; renovate does both).
-# Pinned back to 9.6.1 again: 9.7.1 fixed 9.7.0's ExecSpec stdout crash (gradle#38787)
-# but broke main CI two new ways — the configuration-cache fingerprint crashes reloading
-# its own same-key entries (IsInIdeaSyncValueSource CNFE in the settings-plugin scope),
-# and CMP's Windows packaging trips an Isolated Projects violation (':desktopApp' cannot
-# access Project.layout on ':'). Renovate blocks the 9.7 line; lift with renovate.json.
-distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+# On 9.7.1 again after the #6786 pin-back. Both of that revert's blockers must stay dead
+# on any future 9.7+ bump: the CC fingerprint crashing on reload of its own same-key entry
+# (IsInIdeaSyncValueSource CNFE in the settings-plugin scope), and CMP's Windows packaging
+# tripping an Isolated Projects violation (':desktopApp' cannot access Project.layout on
+# ':'). The first only shows on a CC cache-key HIT, so one green run does not clear it.
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=30000
 retries=3
 retryBackOffMs=500

--- a/scripts/verify-flatpak/desktop-offline.yaml
+++ b/scripts/verify-flatpak/desktop-offline.yaml
@@ -101,8 +101,8 @@ modules:
         # flavor); distributionSha256Sum verifies this file. Renovate bumps the version here
         # alongside wrapper bumps (custom manager in renovate.json) but the sha256 must be
         # copied from distributionSha256Sum by hand; CI fails fast on any mismatch.
-        url: https://services.gradle.org/distributions/gradle-9.6.1-bin.zip
-        sha256: 9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
+        url: https://services.gradle.org/distributions/gradle-9.7.1-bin.zip
+        sha256: acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
         dest: "gradle/wrapper"
         dest-filename: "gradle-bin.zip"
       - flatpak-sources.json


### PR DESCRIPTION
#6786 pinned back to 9.6.1 a day after Renovate's 9.7.1 bump (#6777) landed effectively untested — every intermediate `main` run had been concurrency-cancelled by the merge train. This re-attempts the bump with each blocker diagnosed and worked around.

None of the three is "9.7.1 is broken". Each is something this repo opted into that 9.7.1 stopped tolerating.

## 1. Configuration-cache Actions cache — off for lint / screenshot / test-shards

Restoring an entry written by a *different runner* crashes fingerprint deserialization:

```
Class 'org.jetbrains.kotlin.gradle.internal.IsInIdeaSyncValueSource' not found in class loader
'InstrumentingVisitableURLClassLoader(ClassLoaderScopeIdentifier.Id{
  coreAndPlugins:settings[:settings-plugin]:buildSrc[:settings-plugin]:root-project[:settings-plugin](export)})'
```

The job dies before a single test — shard-core ran **9 seconds** and uploaded no test-results at all.

A cross-machine restore is the only trigger. Locally, the full 13-module shard-core list stores and reuses cleanly on 9.7.1 ([store](https://community.develocity.cloud/s/b4uzbrtk2hb5g), [reuse](https://community.develocity.cloud/s/vwssrwbwbjd4s)) — so a local store/reuse pair proves nothing, which is why this survived the original bump's testing.

Under 9.7.1 this cache is not ~52s of value to weigh against the risk; it is a guaranteed red build. Turning it off strictly improves on the status quo. `VERSION_CODE` stays pinned so entries reuse again the moment this is fixed upstream. **With it off, all three shards pass.**

## 2. Desktop build — Isolated Projects *and* configuration cache both off

CMP's Windows MSI/WiX packaging reads `Project.layout` on the root project from `:desktopApp`:

```
Plugin 'org.jetbrains.compose': Project ':desktopApp' cannot access 'Project.layout'
functionality on another project ':'
```

IP and CC reject that **independently**. Disabling only IP still fails — the same access simply reports as `1 problem was found storing the configuration cache` instead. And Gradle refuses `--no-configuration-cache` while IP is on, so the two flags only work together.

Uses the flags rather than `-D` properties: `-Dorg.gradle.isolated-projects=false` took effect on macOS and both Linux runners but **not** on `windows-latest`, which still died on `Configuration Cache cannot be disabled when Isolated Projects is enabled`. `--no-isolated-projects` needs 9.7+ — which is what this PR moves us to, so a pin-back below 9.7 must revert that line with it.

The job never persists a CC entry (`cache_configuration_cache` defaults to `false`), so dropping the cache costs nothing.

## 3. flatpak-sources plugin — fixed upstream

`captureFlatpakSources` closed over the live URL set its `BuildOperationListener` writes to as downloads land, so Gradle serialized a collection another thread was still mutating (`The map size() is 2852, but 2853 entries were available`). Never legal under CC; 9.6.1 wins the race, 9.7.1 does not.

Fixed in meshtastic/gradle-flatpak-sources#45, released as v0.2.1, pinned by #6921. The `--no-configuration-cache` on `captureFlatpakSources` here is the interim workaround and **should be dropped once #6921 lands**.

## Why this kept happening

`run_desktop_builds` is set only in `main-check.yml`, so `Build Desktop Debug` runs on push to `main` and nowhere else — not on PRs, not in the merge queue. The Windows packaging path that trips blocker 2 had **never** been exercised before merge. That is exactly why #6777 went green as a PR and reddened main the moment it landed.

The last commit here enables it temporarily so the blocker can be settled pre-merge. **It must be dropped before this is marked ready.** A paths-gated desktop build for `gradle/wrapper/**` and `desktopApp/**` changes would close the gap permanently; not in scope here.

## Verification

Everything except the Windows desktop job is green on 9.7.1 as of run 33113572213: all three test shards, lint, screenshot, android-check, desktop on macOS / ubuntu / ubuntu-arm, and flatpak on both arches (3083 URLs captured, offline sandbox builds green).

One earlier failure was **not** 9.7.1: run 33105418370's `ubuntu-24.04` desktop job died on `Could not GET ... kotlin-stdlib-2.4.0.jar. Received status code 403` from Maven Central — infra, same family as the `foojay-resolver` flake that hit #6918 the same afternoon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Upgraded the project’s Gradle version to 9.7.1.
  - Re-enabled automated Gradle 9.7.x update proposals.
  - Updated offline desktop verification to use Gradle 9.7.1.

- **Bug Fixes**
  - Adjusted build checks to avoid configuration-cache and isolated-projects issues affecting cross-machine builds and Windows packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->