### PR TITLE
chore(deps): update flatpak-sources plugin to v0.2.1

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,7 +39,7 @@ plugins {
     // 0.1.7 fixed the Isolated Projects incompatibility (shares state via a BuildService instead of
     // gradle.extensions) that previously required gating this behind an opt-in property.
     // 0.2.0 resolves platformDependencies transitively — see the collapsed list in build.gradle.kts.
-    id("org.meshtastic.flatpak.sources.settings") version "0.2.0"
+    id("org.meshtastic.flatpak.sources.settings") version "0.2.1"
 }
 
 @Suppress("UnstableApiUsage")


### PR DESCRIPTION
Picks up two configuration-cache fixes in `captureFlatpakSources` — meshtastic/gradle-flatpak-sources#45, released as [v0.2.1](https://github.com/meshtastic/gradle-flatpak-sources/releases).

**The task action closed over a live, concurrently-written URL set.** The plugin captured the `ConcurrentHashMap.newKeySet()` its `BuildOperationListener` writes to as downloads land, so Gradle serialized a collection another thread was still mutating. That capture was never legal under the configuration cache — 9.6.1 just wins the race consistently. On 9.7.1 it does not, and `generate-sources` dies:

```
Configuration cache state could not be cached: field `map` of
`ConcurrentHashMap$KeySetView` ... The map size() is 2852, but 2853 entries
were available when iterating over it.
> Collection corrupted or changed while iterating
```

Found while retesting the Gradle 9.7.1 bump in #6917. Latent on our pinned 9.6.1, so this is not fixing a break we have today — it is removing one we would hit the moment the wrapper moves, and one that has been a coin flip rather than a guarantee all along.

**URL capture was dead on any configuration-cache hit.** `capturedUrls` was assigned into the BuildService by the settings plugin's `apply()`, which does not run on a reused entry — the recreated service held `null` and discarded every URL, emitting an empty manifest. We don't hit this: `verify-flatpak` runs on a fresh Gradle home under `RUNNER_TEMP` and never reuses an entry. It removes a trap for anyone who later enables reuse there, where the failure would surface late and confusingly — in Flathub's offline sandbox, not at generation time.

Upstream CI also went from a 9.5.1-only matrix to 9.5.1 / 9.6.1 / 9.7.1, which is what let both bugs ship past a green build.

## Verification

No API change and no expected manifest difference on 9.6.1 — `verify-flatpak` passing on both arches is the check that matters here.

The fix is already proven end-to-end on #6917, which runs 9.7.1: 3083 URLs captured and emitted, both arches' offline sandbox builds green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Flatpak sources configuration plugin to a newer patch version for improved build and packaging reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->