### PR TITLE
ci: run the desktop matrix on PRs that touch desktop packaging

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,10 +60,20 @@ jobs:
             # silently the moment the build reads another one.
             desktop:
               - 'desktopApp/**'
+              - 'scripts/build-appimage.sh'
+              # Shared build machinery that shapes the packaged output.
+              - 'build-logic/**'
               - 'gradle/wrapper/**'
               - 'gradle/libs.versions.toml'
-              - 'build-logic/**'
-              - 'scripts/build-appimage.sh'
+              # Root inputs the packaging tasks actually read: config.properties supplies the
+              # version metadata baked into the installers (ProjectExtensions.kt, VersionInfo.kt),
+              # and the rest change plugin resolution, configuration, or how gradlew is invoked.
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle.properties'
+              - 'config.properties'
+              - 'gradlew'
+              - 'gradlew.bat'
               - '.github/workflows/reusable-check.yml'
               - '.github/actions/gradle-setup/**'
             android:
@@ -253,7 +263,10 @@ jobs:
   # that compilation never reaches — and only runs when the desktop filter matches.
   validate-and-build:
     needs: check-changes
-    if: needs.check-changes.outputs.android == 'true'
+    # `desktop` as well as `android`: scripts/build-appimage.sh is in the desktop filter but
+    # deliberately not the android one, so gating on android alone would skip this whole
+    # workflow for an AppImage-only change and the desktop matrix would never run.
+    if: needs.check-changes.outputs.android == 'true' || needs.check-changes.outputs.desktop == 'true'
     uses: ./.github/workflows/reusable-check.yml
     permissions:
       contents: read

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       android: ${{ steps.filter.outputs.android }}
       screenshots: ${{ steps.filter.outputs.screenshots }}
+      desktop: ${{ steps.filter.outputs.desktop }}
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: dorny/paths-filter@v4
@@ -48,6 +49,23 @@ jobs:
               - 'compose_compiler_config.conf'
               - '.github/workflows/**'
               - '.github/actions/**'
+            # Desktop packaging only runs post-merge on main, so windows-latest never saw a
+            # PR — that is how #6777's Gradle 9.7.1 bump went green here and reddened main
+            # (CMP's MSI/WiX path reads Project.layout on the root project from ':desktopApp',
+            # and only Windows trips it). Narrow gate rather than always-on: the 4-OS matrix is
+            # ~40 runner-minutes, and macOS bills at 10x.
+            # libs.versions.toml is in deliberately, whole-file: #6904 was a one-line CMP bump
+            # in the catalog, and CMP's packaging is exactly what breaks. Same over-run trade
+            # verify-flatpak already accepts (#6911) — a filter naming today's keys goes stale
+            # silently the moment the build reads another one.
+            desktop:
+              - 'desktopApp/**'
+              - 'gradle/wrapper/**'
+              - 'gradle/libs.versions.toml'
+              - 'build-logic/**'
+              - 'scripts/build-appimage.sh'
+              - '.github/workflows/reusable-check.yml'
+              - '.github/actions/gradle-setup/**'
             android:
               # CI/workflow implementation
               - '.github/workflows/**'
@@ -229,9 +247,10 @@ jobs:
           fi
 
   # 2. VALIDATION & BUILD: Delegate to reusable-check.yml
-  # We disable coverage and desktop builds for PRs to keep feedback fast
-  # (< 10 mins). Desktop compilation is already covered by the :desktopApp:test
-  # task in the shard-app test shard.
+  # Coverage stays off for PRs to keep feedback fast (< 10 mins); mainline coverage comes
+  # from main-check. Desktop *compilation* is covered on every PR by :desktopApp:test in the
+  # shard-app shard, so the desktop matrix here is about packaging — the jpackage/WiX path
+  # that compilation never reaches — and only runs when the desktop filter matches.
   validate-and-build:
     needs: check-changes
     if: needs.check-changes.outputs.android == 'true'
@@ -244,6 +263,10 @@ jobs:
       run_screenshot_tests: ${{ needs.check-changes.outputs.screenshots == 'true' }}
       run_unit_tests: true
       run_coverage: false
+      # Installers (dmg/msi+exe/deb+rpm+AppImage) upload on every run that builds them —
+      # upload_artifacts is already true here — so reviewers can install a PR's desktop build
+      # instead of waiting for the post-merge snapshot.
+      run_desktop_builds: ${{ needs.check-changes.outputs.desktop == 'true' }}
       upload_artifacts: true
     secrets: inherit
 


### PR DESCRIPTION
`run_desktop_builds` is set only in `main-check.yml`, so `Build Desktop Debug` runs on push to `main` and nowhere else — not on PRs, not in the merge queue. The Windows MSI/WiX packaging path has had **no pre-merge coverage at all**.

## Why now

That gap is exactly how #6777's Gradle 9.7.1 bump went green as a PR and reddened `main` the moment it landed. CMP's packaging reads `Project.layout` on the root project from `:desktopApp` — rejected independently by Isolated Projects *and* the configuration cache — and only Windows trips it. macOS and both Linux legs passed every single time, including on the runs where Windows failed three in a row.

It cost a revert (#6786), a renovate block on the entire 9.7 line, and a day of re-diagnosis in #6917 — where the only way to settle the blocker before merging was a throwaway commit turning this very flag on.

## Gated, not always-on

Measured on #6917's runs:

| OS | duration |
| --- | --- |
| windows-latest | ~12 min |
| macos-latest | ~12 min |
| ubuntu-24.04 | ~9 min |
| ubuntu-24.04-arm | ~8 min |
| **total** | **~40 runner-min**, ~12 min wall |

macOS bills at 10× and Windows at 2×, so this is not something every PR should pay — and runner *availability*, not billing, was the binding constraint the day #6917 landed.

Compilation is already covered on every PR by `:desktopApp:test` in `shard-app`. This matrix is about **packaging** — the jpackage/WiX path compilation never reaches.

## Filter

```yaml
desktop:
  - 'desktopApp/**'
  - 'gradle/wrapper/**'
  - 'gradle/libs.versions.toml'
  - 'build-logic/**'
  - 'scripts/build-appimage.sh'
  - '.github/workflows/reusable-check.yml'
  - '.github/actions/gradle-setup/**'
```

`libs.versions.toml` is in deliberately, as the **whole file**. #6904 was a one-line CMP bump in the catalog, and CMP's packaging is exactly what breaks — a narrower filter would have missed the real case. That is the same over-run trade-off `verify-flatpak` already accepts (#6911): a filter naming today's keys goes stale silently the moment the build reads another one.

## Side benefit

`upload_artifacts` is already `true` for PRs, and the upload step is gated only on that — so matching PRs now publish real installers (`.dmg` / `.msi` + `.exe` / `.deb` / `.rpm` / `.AppImage`, 7-day retention). Reviewers can install a PR's desktop build instead of waiting for the post-merge snapshot.

## Verification

This PR touches `.github/workflows/reusable-check.yml`… actually it doesn't — it touches `pull-request.yml`, which is **not** in the desktop filter, so the matrix will *not* run here. That is correct behaviour but means the gate itself is unproven by this PR's own CI. It was proven on #6917, where the equivalent always-on flag ran all four legs green on 9.7.1.

The `check-changes` filter-drift validator passes: the new `/**` paths resolve to `desktopApp` (a module root) plus `gradle`, `build-logic` and `.github` (already-allowed infra roots).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Validation**
  * Desktop packaging and build-related changes are now detected automatically.
  * Desktop build checks run selectively when relevant files are modified.
  * Updated validation guidance to reflect the expanded desktop build coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->