### PR TITLE
ci(docs): restore the docs quality gates removed with docs-governance.yml

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -1,0 +1,97 @@
+name: Docs Quality Gates
+
+# Restores the enforcing half of the old docs-governance.yml, which was removed in #6000
+# ("prune dead workflows") along with four genuinely dead workflows. Its two advisory jobs —
+# docs staleness and preview staleness — only ever posted PR comments and are not restored;
+# this is the job that actually failed a build.
+#
+# Path-filtered so it runs only when something it checks can break: the docs themselves, the
+# in-app index that must list them, or the scripts doing the checking.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/en/**"
+      - "feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/data/DocBundleLoader.kt"
+      - "scripts/check-doc-coverage.js"
+      - "scripts/check-doc-freshness.js"
+      - "scripts/validate-doc-links.js"
+      - "scripts/lib/frontmatter.js"
+      - ".github/workflows/docs-quality.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Docs quality gates
+    # Lightweight, but it fetches a Node toolchain, so it takes the ARM tier rather than
+    # ubuntu-slim. No workflow currently runs Node; ubuntu-slim's suitability for setup-node
+    # is untested and this is not the place to find out.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+
+    steps:
+      # `pull_request`, never `pull_request_target`: this checks out and executes
+      # fork-supplied code (node scripts/*.js), so it must run with the read-only token and
+      # no secrets. The original carried this same warning; keep it.
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Validate internal links
+        run: node scripts/validate-doc-links.js docs/en
+
+      - name: Check doc coverage
+        run: node scripts/check-doc-coverage.js .
+
+      - name: Validate DocBundleLoader registry
+        # Both directions matter, and they fail differently:
+        #   page with no entry   -> the page ships in the bundle but is unreachable in-app
+        #   entry with no page   -> the in-app index offers a link that resolves to nothing
+        run: |
+          loader="feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/data/DocBundleLoader.kt"
+          status=0
+
+          for f in docs/en/user/*.md docs/en/developer/*.md; do
+            [ -e "$f" ] || continue
+            slug=$(basename "$f" .md)
+            if ! grep -q "\"$slug\"" "$loader"; then
+              echo "::error file=$f::'$slug' has no UserPageDef/DeveloperPageDef in DocBundleLoader.kt, so it is unreachable in the in-app docs browser."
+              status=1
+            fi
+          done
+
+          grep -oE '"en/(user|developer)/[a-z0-9-]+\.html"' "$loader" \
+            | tr -d '"' \
+            | while read -r page; do
+                md="docs/${page%.html}.md"
+                if [ ! -f "$md" ]; then
+                  echo "::error file=$loader::DocBundleLoader references '$page' but $md does not exist."
+                  exit 1
+                fi
+              done || status=1
+
+          if [ "$status" -ne 0 ]; then
+            echo "FAILED: the in-app doc index and docs/en/ are out of sync."
+            exit 1
+          fi
+          echo "DocBundleLoader and docs/en/ agree in both directions."
+
+      - name: Check doc freshness
+        # Advisory, as it always was: a page being old is a prompt to look, not a defect.
+        continue-on-error: true
+        run: node scripts/check-doc-freshness.js docs/en --max-age-days=180

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -66,11 +66,15 @@ jobs:
           loader="feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/data/DocBundleLoader.kt"
           status=0
 
+          # Match the page's own resourcePath, not the bare slug: every page also carries an
+          # alias list, so a loose slug search passes when some *other* page happens to alias
+          # this one's name (docs/en/user/measurement.md would match units-and-locale's alias).
           for f in docs/en/user/*.md docs/en/developer/*.md; do
             [ -e "$f" ] || continue
-            slug=$(basename "$f" .md)
-            if ! grep -q "\"$slug\"" "$loader"; then
-              echo "::error file=$f::'$slug' has no UserPageDef/DeveloperPageDef in DocBundleLoader.kt, so it is unreachable in the in-app docs browser."
+            resource="en/${f#docs/en/}"
+            resource="${resource%.md}.html"
+            if ! grep -qF "\"$resource\"" "$loader"; then
+              echo "::error file=$f::no page definition in DocBundleLoader.kt references \"$resource\", so this page is unreachable in the in-app docs browser."
               status=1
             fi
           done


### PR DESCRIPTION
Restores the enforcing half of `docs-governance.yml`, which #6000 removed on 2026-06-28 alongside four genuinely dead workflows.

## Why

That workflow had three jobs. Two were advisory comment-posters. The third — **Docs quality gates** — actually failed builds, and it went out with the others. Losing it was invisible because the constitution kept describing gates that had stopped running (see #6927), so nothing pointed at the gap.

The documentation audit in #6926 then found exactly what this job existed to catch: link rot, pages missing from the in-app index, and a page still registered after its feature had been deleted.

## 🌟 What this adds

`.github/workflows/docs-quality.yml`, path-filtered so it runs when the docs, the in-app index, or the checking scripts change — not on every PR:

| Check | Enforcement |
|---|---|
| `validate-doc-links.js` — internal cross-references and image paths resolve | **blocking** |
| `check-doc-coverage.js` — every user-facing feature module has a page | **blocking** |
| `DocBundleLoader` registry — the in-app index and `docs/en/` agree | **blocking** |
| `check-doc-freshness.js` — pages older than 180 days | advisory, as before |

All four scripts already exist in `scripts/` and pass on `main` today. Nothing new to maintain.

## 🛠️ One improvement over the original

The registry check now runs **both directions**. The original only caught a page with no entry. The reverse — an entry pointing at a page that no longer exists — is the one that reaches users, because the in-app browser then offers a link that resolves to nothing.

Both directions were exercised against a deliberately broken tree before this was committed:

```
### case A: a page with no loader entry (new page, forgot to register)
  MISSING ENTRY: zz-brand-new          -> exit 1
### case B: a loader entry with no page (deleted page, forgot to unregister)
  DANGLING ENTRY: en/user/widget.html  -> exit 1
### case C: clean tree
  -> exit 0
```

Failures are emitted as `::error file=…::` annotations so they land on the offending line in the PR diff.

## 🧹 Deliberately not restored

The **docs-staleness** and **preview-staleness** jobs. Both needed `pull_request_target` and a write token to post PR comments, and neither ever blocked anything — docs-staleness carried a literal `# To upgrade to blocking, change this step to 'exit 1'` that was never taken up. If they're wanted, that should be a deliberate decision rather than a side effect of this PR.

Worth correcting a related misreading: the constitution called the staleness check a *blocking* gate. It never was, even while the workflow existed. #6927 fixes that claim.

## Security note carried over from the original

This runs on `pull_request`, **never** `pull_request_target`, because it checks out and executes fork-supplied code (`node scripts/*.js`). The read-only token and absent secrets are what make that safe. The original carried the same reasoning in a comment and it is preserved verbatim — please keep it if this file is edited.

## Testing Performed

- All three blocking checks run against `main`'s tree: pass.
- Registry check exercised against both failure modes and a clean tree (output above).
- Workflow file checked for tabs and structural sanity.

CI on this PR is itself the end-to-end test: the workflow's own path filter includes `.github/workflows/docs-quality.yml`, so it runs on this PR.

## Related

- #6926 — the documentation audit that surfaced the gap
- #6927 — the constitution amendment that stops claiming these gates exist

<!--
If you have screenshots or recordings to display your change, please include them!
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fEY2bsn6qQppwhFZA8p2v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added automated checks to validate documentation links and coverage.
  * Added consistency checks to ensure documented features stay aligned with the product’s available capabilities.
  * Added advisory freshness checks to help identify outdated documentation.

* **Chores**
  * Documentation quality checks now run automatically for relevant pull requests and can also be triggered manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->