### PR TITLE
chore: give each display unit symbol one definition, and pin action digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,8 @@
     ":ignoreModulesAndTests",
     "group:recommended",
     "replacements:all",
-    "workarounds:all"
+    "workarounds:all",
+    "helpers:pinGitHubActionDigests"
   ],
   "commitMessageTopic": "{{depName}}",
   "osvVulnerabilityAlerts": true,

--- a/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/MetricFormatter.kt
+++ b/core/common/src/commonMain/kotlin/org/meshtastic/core/common/util/MetricFormatter.kt
@@ -31,13 +31,20 @@ package org.meshtastic.core.common.util
 @Suppress("TooManyFunctions")
 object MetricFormatter {
 
+    /**
+     * The degree symbol for the display unit, for callers that already hold a converted value and only need to label it
+     * — chart axes, and the telemetry rows fed by an upstream conversion. Defined here so a symbol has one definition:
+     * wind drifted between screens precisely because its unit was written out twice.
+     */
+    fun degreeSymbol(isFahrenheit: Boolean): String = if (isFahrenheit) FAHRENHEIT_SYMBOL else CELSIUS_SYMBOL
+
     fun temperature(celsius: Float, isFahrenheit: Boolean): String {
         val value = if (isFahrenheit) celsius * FAHRENHEIT_SCALE + FAHRENHEIT_OFFSET else celsius
-        val unit = if (isFahrenheit) "°F" else "°C"
-        return "${NumberFormatter.format(value, 1)}$unit"
+        return "${NumberFormatter.format(value, 1)}${degreeSymbol(isFahrenheit)}"
     }
 
-    fun voltage(volts: Float, decimalPlaces: Int = 2): String = "${NumberFormatter.format(volts, decimalPlaces)} V"
+    fun voltage(volts: Float, decimalPlaces: Int = 2): String =
+        "${NumberFormatter.format(volts, decimalPlaces)} $VOLT_SYMBOL"
 
     fun current(milliAmps: Float, decimalPlaces: Int = 1): String =
         "${NumberFormatter.format(milliAmps, decimalPlaces)} mA"
@@ -90,6 +97,11 @@ object MetricFormatter {
 
 /** Shown in place of a metric the radio did not report. A symbol, so it needs no translation. */
 private const val UNKNOWN_VALUE = "—"
+
+/** Display symbols. Fixed rather than translated — see the note on [MetricFormatter]. */
+const val CELSIUS_SYMBOL = "°C"
+const val FAHRENHEIT_SYMBOL = "°F"
+const val VOLT_SYMBOL = "V"
 
 private const val FAHRENHEIT_SCALE = 1.8f
 private const val FAHRENHEIT_OFFSET = 32

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentCharts.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentCharts.kt
@@ -36,6 +36,9 @@ import com.patrykandpatrick.vico.compose.cartesian.data.lineModel
 import com.patrykandpatrick.vico.compose.cartesian.layer.LineCartesianLayer
 import com.patrykandpatrick.vico.compose.cartesian.layer.rememberLineCartesianLayer
 import com.patrykandpatrick.vico.compose.common.data.ExtraStore
+import org.meshtastic.core.common.util.MeasureUnitKind
+import org.meshtastic.core.common.util.MetricFormatter
+import org.meshtastic.core.common.util.VOLT_SYMBOL
 import org.meshtastic.core.common.util.formatString
 import org.meshtastic.core.model.util.UnitConversions
 import org.meshtastic.core.resources.Res
@@ -178,11 +181,14 @@ internal fun chartValue(metric: Environment, telemetry: Telemetry, isImperial: B
 internal fun unitSuffix(metric: Environment, isFahrenheit: Boolean, isImperial: Boolean): String = when {
     metric == Environment.TEMPERATURE ||
         metric == Environment.SOIL_TEMPERATURE ||
-        metric in Environment.oneWireTemperatures -> if (isFahrenheit) "°F" else "°C"
+        metric in Environment.oneWireTemperatures -> MetricFormatter.degreeSymbol(isFahrenheit)
 
-    metric in Environment.adcVoltages -> " V"
+    metric in Environment.adcVoltages -> " $VOLT_SYMBOL"
 
-    metric == Environment.WIND_SPEED -> if (isImperial) " mph" else " km/h"
+    // Taken from the same source the cards format with, so an axis and its readings cannot drift apart —
+    // which is exactly how the chart kept m/s while the cards moved to km/h.
+    metric == Environment.WIND_SPEED ->
+        " " + (if (isImperial) MeasureUnitKind.MILE_PER_HOUR else MeasureUnitKind.KILOMETER_PER_HOUR).symbol
 
     else -> ""
 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/EnvironmentMetrics.kt
@@ -91,7 +91,7 @@ private const val LABELLED_VALUE = "%s %s"
  * only labels them — converting again here would double-count, exactly as the 1-Wire rows warn. That is why these rows
  * cannot use `MetricFormatter.temperature`, which converts.
  */
-private fun degreeUnit(isFahrenheit: Boolean) = if (isFahrenheit) "°F" else "°C"
+private fun degreeUnit(isFahrenheit: Boolean) = MetricFormatter.degreeSymbol(isFahrenheit)
 
 @Composable
 fun EnvironmentMetricsScreen(viewModel: MetricsViewModel, onNavigateUp: () -> Unit) {
@@ -515,7 +515,7 @@ private fun OneWireTemperatureDisplay(
     envMetrics: org.meshtastic.proto.EnvironmentMetrics,
     environmentDisplayFahrenheit: Boolean,
 ) {
-    val unit = if (environmentDisplayFahrenheit) "°F" else "°C"
+    val unit = MetricFormatter.degreeSymbol(environmentDisplayFahrenheit)
     Environment.oneWireTemperatures.forEachIndexed { idx, entry ->
         val temp = envMetrics.oneWireTemperature(idx)?.takeIf { !it.isNaN() } ?: return@forEachIndexed
         ChannelMetricRow(


### PR DESCRIPTION
Closes the two items deferred during review of #6925 and #6928.

## 🛠️ Unit symbols: one definition each

The review asked for the chart's unit suffixes to move to string resources so they stay localizable. **That would be wrong here**, and I want to be explicit about why rather than quietly not doing it:

- `MetricFormatter`'s own KDoc: *"Every number here reads in the user's locale; **the unit symbols are fixed**."*
- `MeasureFormatting` records that ICU's symbol translation was dropped deliberately: *"Symbols were fixed English before this function existed, so nothing regressed — only the translation improvement was given up."*
- `strings.xml` contains **zero** unit symbols today.

Localizing only the chart labels would make them the single exception in the app.

The real defect the finding pointed at is **duplication**. `unitSuffix` wrote out `°C`/`°F`, ` V` and the wind unit as literals, independently of `MetricFormatter` and `MeasureUnitKind`, which already define them. That is exactly how the chart kept `m/s` while the cards moved to `km/h` — two definitions of one symbol with nothing tying them together.

Each symbol now has one home:

| Symbol | Defined in | Used by |
|---|---|---|
| `°C` / `°F` | `CELSIUS_SYMBOL` / `FAHRENHEIT_SYMBOL`, plus `MetricFormatter.degreeSymbol()` | `MetricFormatter.temperature`, chart axes, telemetry rows |
| `V` | `VOLT_SYMBOL` | `MetricFormatter.voltage`, ADC chart axes |
| `km/h` / `mph` | `MeasureUnitKind` | `MetricFormatter.windSpeed`, wind chart axis |

`degreeSymbol()` exists for callers that hold an **already-converted** value and only need to label it — the chart axes, and the telemetry rows fed by `MetricsViewModel`'s upstream conversion. Those must not call `temperature()`, which converts; that distinction is what caused the double-conversion bug fixed in #6925, so it is now expressed in the API rather than left to a comment.

No rendered output changes. The screenshot gate confirms it.

## 🧹 Action digest pinning

Rather than SHA-pin one new workflow and leave the other twenty on tags — the inconsistency I raised when declining this on #6928 — this enables Renovate's `helpers:pinGitHubActionDigests` preset. Every workflow gets pinned to a digest and kept current automatically, which is the route both the review and I preferred.

Expect Renovate to open a follow-up PR converting the existing tag pins.

## Testing Performed

`spotlessCheck`, `detekt`, `:core:common:allTests`, `:feature:node:allTests`, `:core:konsist:allTests`, and `:screenshot-tests:validateDebugScreenshotTest` — the last being the meaningful one here, since it proves the symbols render identically after the refactor.

## Related

- #6925 — the wind/temperature fixes whose drift this makes structurally harder to repeat
- #6928 — where the pinning discussion happened

<!--
If you have screenshots or recordings to display your change, please include them!
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fEY2bsn6qQppwhFZA8p2v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized temperature, voltage, and wind-speed unit labels across metric displays and environmental charts.
  * Improved consistency of Celsius, Fahrenheit, volt, and speed symbols throughout the app.
  * Existing measurement values and unit behavior remain unchanged, with clearer and more uniform formatting across screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->