### PR TITLE
docs(discovery): name the page Local Mesh Discovery, as the app does

### DIFF
--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -570,7 +570,7 @@
     <string name="doc_title_connections">Connections</string>
     <string name="doc_title_debug_logs">Debug Logs</string>
     <string name="doc_title_desktop">Desktop App</string>
-    <string name="doc_title_discovery">Discovery</string>
+    <string name="doc_title_discovery">Local Mesh Discovery</string>
     <string name="doc_title_firmware">Firmware Updates</string>
     <string name="doc_title_help">Help &amp; In-App Docs</string>
     <string name="doc_title_map">Map &amp; Waypoints</string>

--- a/docs/en/user.md
+++ b/docs/en/user.md
@@ -27,7 +27,7 @@ Keep the last 5–8 entries and archive older ones by removing them.
 
 **August 2026** — Android Auto support was removed from every build variant, and its page with it.
 
-**July 2026** — [Discovery](user/discovery) — New Mesh Beacon: broadcast invitations to your mesh and receive Mesh invitations from others, with one-tap join or a preset-seeded Discovery scan.
+**July 2026** — [Local Mesh Discovery](user/discovery) — New Mesh Beacon: broadcast invitations to your mesh and receive Mesh invitations from others, with one-tap join or a preset-seeded Discovery scan.
 
 **July 2026** — [Settings — Radio & User](user/settings-radio-user) — Security config now offers encrypted on-device key backup/restore and a packet-authenticity Protection Level (Strict / Balanced / Compatible).
 

--- a/docs/en/user/discovery.md
+++ b/docs/en/user/discovery.md
@@ -1,10 +1,12 @@
 ---
-title: Discovery
+title: Local Mesh Discovery
 parent: User Guide
 nav_order: 12
-last_updated: 2026-08-27
+last_updated: 2026-08-28
 description: Explore your mesh network — the Local Mesh Discovery scanner, traceroute paths, neighbor maps, and node discovery tools.
 aliases:
+  - discovery
+  - local-mesh-discovery
   - mesh-discovery
   - local-discovery
   - network-scan
@@ -12,7 +14,7 @@ aliases:
   - neighbor-info
 ---
 
-# Discovery
+# Local Mesh Discovery
 
 Discovery tools help you understand **how** your mesh network is connected — which nodes can hear each other, what paths messages take, and where bottlenecks or weak links exist.
 

--- a/docs/en/user/map-and-waypoints.md
+++ b/docs/en/user/map-and-waypoints.md
@@ -124,7 +124,7 @@ The base map depends on your app flavor: **Google Play** builds use Google Maps,
 
 - [Nodes](nodes) — view and filter your node list
 - [Node Metrics](node-metrics) — signal quality and position history for individual nodes
-- [Discovery](discovery) — traceroute and neighbor info for understanding mesh topology
+- [Local Mesh Discovery](discovery) — traceroute and neighbor info for understanding mesh topology
 - [Units & Locale](units-and-locale) — distance and coordinate display formats
 
 ---

--- a/docs/en/user/node-metrics.md
+++ b/docs/en/user/node-metrics.md
@@ -171,7 +171,7 @@ The position tab shows location data for nodes that share GPS:
 - [Nodes](nodes) — node list, filtering, and sorting
 - [Telemetry & Sensors](telemetry-and-sensors) — supported sensors and configuration
 - [Signal Meter](signal-meter) — how signal quality is calculated from SNR and RSSI
-- [Discovery](discovery) — traceroute details and neighbor info
+- [Local Mesh Discovery](discovery) — traceroute details and neighbor info
 - [Units & Locale](units-and-locale) — temperature, distance, and speed display formats
 
 ---

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -157,7 +157,7 @@ A full, browsable directory of every link is also available under **Settings →
 - [Node Metrics](node-metrics) — detailed telemetry dashboards for each node
 - [Messages & Channels](messages-and-channels) — send a direct message to a node
 - [Map & Waypoints](map-and-waypoints) — view node positions geographically
-- [Discovery](discovery) — traceroute and neighbor info for topology exploration
+- [Local Mesh Discovery](discovery) — traceroute and neighbor info for topology exploration
 - [Signal Meter](signal-meter) — understand what the signal bars mean
 
 ---

--- a/docs/en/user/settings-module-admin.md
+++ b/docs/en/user/settings-module-admin.md
@@ -198,7 +198,7 @@ Broadcasts information about directly heard neighbors, enabling mesh topology ma
 | Update Interval (s) | How often to broadcast neighbor list |
 | Transmit Over LoRa | Also broadcast neighbor info over LoRa, not just MQTT/phone. Unavailable on a channel using the default key and name |
 
-See [Discovery](discovery) for how to use neighbor data for mesh topology exploration.
+See [Local Mesh Discovery](discovery) for how to use neighbor data for mesh topology exploration.
 
 ### Ambient Lighting Module
 
@@ -255,7 +255,7 @@ node to reboot.
 ### Mesh Beacon Module
 
 Broadcasts an invitation to your mesh, and receives invitations from others. See
-[Discovery](discovery) for the full walkthrough.
+[Local Mesh Discovery](discovery) for the full walkthrough.
 
 ### TAK Module
 

--- a/docs/en/user/widget.md
+++ b/docs/en/user/widget.md
@@ -45,6 +45,6 @@ Tap the widget to open the app, or use its refresh control to request fresh stat
 
 - [Node Metrics](node-metrics) — the full Signal Quality and Local Stats history inside the app
 - [Connections](connections) — connect to a radio so the widget has stats to show
-- [Discovery](discovery) — channel and airtime utilization across the mesh
+- [Local Mesh Discovery](discovery) — channel and airtime utilization across the mesh
 
 ---

--- a/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/data/DocBundleLoader.kt
+++ b/feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/data/DocBundleLoader.kt
@@ -361,7 +361,7 @@ class DefaultDocBundleLoader : DocBundleLoader {
                 CoreRes.string.doc_keywords_discovery,
                 "en/user/discovery.html",
                 12,
-                listOf("mesh-discovery", "local-discovery", "network-scan"),
+                listOf("discovery", "local-mesh-discovery", "mesh-discovery", "local-discovery", "network-scan"),
                 2800,
                 "discovery",
             ),


### PR DESCRIPTION
The app has called this feature **Local Mesh Discovery** for a while; the documentation still called it plain "Discovery". A user following the settings entry landed on a page with a different name.

## 🧹 Chores

The app side is already consistent — `discovery_local_mesh` is the settings entry on Android (`RadioConfig.kt`) and Desktop (`DesktopSettingsScreen.kt`), and the scan screen's own title (`DiscoveryScanScreen.kt`). Only the docs lagged.

- page **title** and **H1**, and the in-app docs browser's title for it (`doc_title_discovery`)
- cross-page **link text** in `nodes`, `widget`, `node-metrics`, `map-and-waypoints` and `settings-module-admin`, plus the What's New entry in `user.md`
- `discovery` and `local-mesh-discovery` added to the page's **aliases**, in both the frontmatter and `DocBundleLoader`, so searching the old name still finds it

**The slug stays `discovery`.** It is the resource path in `DocBundleLoader`, the `/discovery` deep-link segment declared in `DeepLinkRouter.topLevelPathSegments` and the manifest's `pathPrefix`, and the anchor every existing link uses. Renaming it would break in-app navigation and any external link for a cosmetic gain. Only what the reader sees changes.

## Testing Performed

- `spotlessCheck`, `detekt`, `:feature:docs:allTests`, `:core:resources:allTests`
- The docs quality gates added in #6928: internal links, coverage, and the registry check in both directions — the last being the relevant one here, since the page keeps its resource path while changing its title.
- `scripts/sort-strings.py` run after the string change, per repo convention.

<!--
If you have screenshots or recordings to display your change, please include them!
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fEY2bsn6qQppwhFZA8p2v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Renamed the “Discovery” documentation topic to **“Local Mesh Discovery”** across the user guide and related links.
  - Updated the page title, heading, date, and aliases for improved navigation.
  - Expanded search keywords so the topic is easier to find using related terms.
  - Updated the corresponding in-app label across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->