### PR TITLE
ci: stop the windows desktop job failing in setup-gradle's post step

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -19,7 +19,7 @@ inputs:
   job_summary_pr_comment:
     description: |
       Job summary as a PR comment: never | always | on-failure. Needs `pull-requests: write`;
-      no-ops on fork PRs (read-only token).
+      no-ops on fork PRs (read-only token). Forced to `never` on Windows — see below.
     default: 'never'
   dependency_graph:
     description: |
@@ -120,7 +120,12 @@ runs:
         # Skip cleanup there — a slightly larger cache beats no cache at all.
         cache-cleanup: ${{ runner.os == 'Windows' && 'never' || 'on-success' }}
         add-job-summary: always
-        add-job-summary-as-pr-comment: ${{ inputs.job_summary_pr_comment }}
+        # Windows-only: the post step exits while the octokit sockets from comment
+        # minimization are still live, and Node 24.18.0 aborts in libuv teardown
+        # there (nodejs/node#56645), failing jobs whose build already passed.
+        # Nothing else in this post step does HTTP on a PR — the cache is
+        # read-only off main and dependency-graph defaults to disabled.
+        add-job-summary-as-pr-comment: ${{ runner.os == 'Windows' && 'never' || inputs.job_summary_pr_comment }}
         dependency-graph: ${{ inputs.dependency_graph }}
         gradle-home-cache-includes: |
           caches


### PR DESCRIPTION
`Build Desktop Debug (windows-latest)` has been failing on PRs while the build itself succeeds — the job dies in `Post Gradle Setup`, after the artifact has already uploaded. Four hits today across three PRs (#6901, #6933 twice, #6934) — 4 of 12 Windows desktop jobs. Re-running does not reliably clear it: #6933 failed the same way on the retry.

The cause is not Gradle. `setup-gradle`'s post step exits while the octokit sockets from "Minimizing obsolete Job Summary comments on PR #NNNN" are still live, and the runner's bundled Node 24.18.0 aborts in libuv teardown on Windows:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
```

That is nodejs/node#56645 — a Windows-only race between `DefaultProcessExitHandler` and a V8 worker, reproduced by `fetch()` followed by `process.exit()`. Linux and macOS tolerate it silently. Runner 2.336.0 bundles exactly the affected Node (24.18.0); it does not reproduce on Node 22 or on Node 26, so this resolves itself when the runner image moves on.

Nothing consumer-side fixes it properly — the offending code is inside `gradle/actions`' bundled `dist`, the action declares `using: node24` so `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` cannot downgrade it, and nodejs/corepack's answer was to drop `windows-latest` from its matrix entirely. What we *can* do is remove the HTTP work that is in flight when the post step exits.

### 🐛 Bug Fixes

- `add-job-summary-as-pr-comment` is now forced to `never` on Windows in `.github/actions/gradle-setup`, mirroring the existing `cache-cleanup` guard directly above it.
- With the comment gone, the Windows post step performs no HTTP on a PR at all: the cache is read-only off `main` (`Entry not saved: cache is read-only`) and `dependency_graph` defaults to `disabled` for the desktop job. That removes the handle class the race needs rather than just narrowing the window.

Cost is one Windows-only convenience: the job summary still renders in the Actions UI (`add-job-summary: always` is untouched), it just no longer mirrors itself into a PR comment from Windows jobs. Linux and macOS behaviour is unchanged.

### Testing Performed

No Kotlin changed, so the Kotlin baseline does not apply. Verified with `actionlint` (clean) and by parsing the action manifest to confirm the expression resolves as intended. Real verification is this PR's own `windows-latest` desktop job — it is a race, so a green run is evidence, not proof; the honest measure is whether the ~3-in-11 failure rate goes away over the next few days.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows build stability by disabling pull request job-summary comments on Windows runners.
  * Preserved job-summary comment behavior on other supported platforms.
  * Updated configuration guidance to clarify the Windows-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->