### PR TITLE
fix(settings): drop the beacon single-target scalars protobufs reserved

### DIFF
--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1136,7 +1136,6 @@
     <string name="mesh_beacon_on_region">Transmit region</string>
     <string name="mesh_beacon_preset_indicator">Advertised by a nearby beacon</string>
     <string name="mesh_beacon_preset_none">None</string>
-    <string name="mesh_beacon_send_as_node">Broadcast as node number (0 = this node)</string>
     <string name="mesh_beacon_target">Target %1$d</string>
     <string name="mesh_beacon_target_add">Add target</string>
     <string name="mesh_beacon_target_channel_index">Channel index</string>

--- a/feature/settings/settings-validation.md
+++ b/feature/settings/settings-validation.md
@@ -394,11 +394,7 @@ refresh) and writes via `AdminMessage.setModuleConfig`. Flag edits are read-modi
 | `broadcast_offer_channel.psk` | Base64 | Must decode as Base64 | Field shows an error while invalid; the value is only committed once it decodes (confirming while invalid reverts to the last valid value) |
 | `broadcast_offer_region` | Enum | Dropdown: `RegionCode` entries | — |
 | `broadcast_offer_preset` | Enum | Dropdown: `ModemPreset` entries | Defaults to `LONG_FAST` |
-| `broadcast_targets` | Target list | Rows added/removed via buttons | Per row: `region` dropdown, `preset` dropdown, `channel_index` signed integer input. Non-empty list supersedes the `broadcast_on_*` scalars |
-| `broadcast_on_region` | Enum | Dropdown: `RegionCode` entries | Visible only when `broadcast_targets` is empty |
-| `broadcast_on_preset` | Enum | Dropdown: `ModemPreset` entries | Visible only when `broadcast_targets` is empty; defaults to `LONG_FAST` |
-| `broadcast_send_as_node` | Integer | Signed integer input | Node number to send as; always visible |
-| `broadcast_on_channel` | — | Not editable | Preserved verbatim through the save round-trip; superseded by the targets list |
+| `broadcast_targets` | Target list | Rows added/removed via buttons | Per row: `region` dropdown, `preset` dropdown, `channel_index` signed integer input. Empty list = one beacon on the running preset/region over the primary channel |
 
 ---
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MeshBeaconConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MeshBeaconConfigItemList.kt
@@ -43,7 +43,6 @@ import org.meshtastic.core.resources.mesh_beacon_offer_preset_setting
 import org.meshtastic.core.resources.mesh_beacon_offer_region_setting
 import org.meshtastic.core.resources.mesh_beacon_on_preset
 import org.meshtastic.core.resources.mesh_beacon_on_region
-import org.meshtastic.core.resources.mesh_beacon_send_as_node
 import org.meshtastic.core.resources.mesh_beacon_target_add
 import org.meshtastic.core.resources.mesh_beacon_target_channel_index
 import org.meshtastic.core.resources.mesh_beacon_target_remove
@@ -72,9 +71,8 @@ private fun Int.hasFlag(flag: Int): Boolean = (this and flag) != 0
  * config sync (there is no `ModuleConfigType` beacon value to request per-module) and writes via
  * `AdminMessage.setModuleConfig`. Flag edits are read-modify-write so `FLAG_LEGACY_SPLIT` and any unknown bits survive.
  *
- * The repeated `broadcast_targets` list is editable ([BroadcastTargetsCard]); the single-target `broadcast_on_*`
- * scalars are shown only as the fallback when no targets are set (Apple parity). `broadcast_on_channel` is preserved
- * verbatim through the Wire `copy()` round-trip (no scalar editor — the targets list supersedes it).
+ * The repeated `broadcast_targets` list ([BroadcastTargetsCard]) is the only way to name a beacon destination. An empty
+ * list means one beacon on the node's running preset and region over the primary channel.
  */
 @Suppress("LongMethod")
 @Composable
@@ -209,42 +207,12 @@ fun MeshBeaconConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit, 
                 onChange = { formState.value = formState.value.copy(broadcast_targets = it) },
             )
         }
-        item {
-            TitledCard(title = stringResource(Res.string.mesh_beacon_on_region)) {
-                // Single-target transmit scalars are the fallback used only when no multi-target list is set (Apple
-                // shows these two only when broadcast_targets is empty). broadcast_send_as_node applies either way.
-                if (formState.value.broadcast_targets.isEmpty()) {
-                    DropDownPreference(
-                        title = stringResource(Res.string.mesh_beacon_on_region),
-                        selectedItem = formState.value.broadcast_on_region,
-                        enabled = state.connected,
-                        onItemSelected = { formState.value = formState.value.copy(broadcast_on_region = it) },
-                    )
-                    HorizontalDivider()
-                    DropDownPreference(
-                        title = stringResource(Res.string.mesh_beacon_on_preset),
-                        selectedItem = formState.value.broadcast_on_preset ?: ModemPreset.LONG_FAST,
-                        enabled = state.connected,
-                        onItemSelected = { formState.value = formState.value.copy(broadcast_on_preset = it) },
-                    )
-                    HorizontalDivider()
-                }
-                SignedIntegerEditTextPreference(
-                    title = stringResource(Res.string.mesh_beacon_send_as_node),
-                    value = formState.value.broadcast_send_as_node,
-                    enabled = state.connected,
-                    keyboardActions = KeyboardActions.Default,
-                    onValueChanged = { formState.value = formState.value.copy(broadcast_send_as_node = it) },
-                )
-            }
-        }
     }
 }
 
 /**
- * Editor for the repeated `broadcast_targets` list (Apple FR-014 multi-target). Each target carries its own
- * region/preset and an optional `channel_index`; rows can be added and removed. When the list is non-empty it
- * supersedes the single-target `broadcast_on_*` scalars.
+ * Editor for the repeated `broadcast_targets` list (Apple FR-014). Each target carries its own region/preset and an
+ * optional `channel_index`; rows can be added and removed. One beacon copy is sent per distinct destination.
  */
 @Composable
 private fun BroadcastTargetsCard(


### PR DESCRIPTION
Unblocks #6939.

protobufs `2.7.26.159` (meshtastic/protobufs#1047, meshtastic/protobufs#1048) reserves four `MeshBeaconConfig` fields:

- `broadcast_send_as_node` — firmware never applied it (the assignment in `MeshBeaconModule::sendBeacon()` is commented out), and rewriting `from` forges no signature, so it was a settable, persisted no-op.
- `broadcast_on_channel` / `broadcast_on_region` / `broadcast_on_preset` — a second way to describe one beacon destination, used only when `broadcast_targets` was empty. Consolidated so a destination has one representation.

The editor still referenced all four, which is every one of the 12 failing checks on #6939 — one compile error in `MeshBeaconConfigItemList.kt:219`, fanned out across lint, screenshot, both test shards, four desktop builds and the Flatpak offline verify.

## What changes

- Delete the single-target fallback card. `BroadcastTargetsCard` is now the only destination editor; an empty list means one beacon on the node's running preset and region over the primary channel.
- Drop `mesh_beacon_send_as_node` from the source strings — the scheduled translation sync prunes the locale copies (precedent: #6929).
- `settings-validation.md`: collapse the five beacon-TX rows to the one that still exists.

Removing a usage compiles against both the current `.155` pin and `.159`, so this lands on `main` ahead of the Renovate bump rather than inside it — editing `renovate/meshtastic.protobufs` directly would stop Renovate rebasing it and block its automerge. Once this merges, #6939 rebases and goes green on its own.

The proto delta is purely subtractive, so there is no new field surface to audit.

## Verification

`:feature:settings:compileKotlinJvm :feature:settings:allTests :feature:settings:detekt` — BUILD SUCCESSFUL (6m 23s) against the current `.155` pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Mesh Beacon configuration to use the `broadcast_targets` list for destination selection.
- **Bug Fixes**
  - Removed outdated single-target options for region, preset, channel, and node number.
- **Documentation**
  - Updated Mesh Beacon validation guidance to reflect the list-based configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->