### PR TITLE
chore(mcp): register the Compose Hot Reload MCP server for :desktopApp

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,13 @@
 {
-  "$comment": "Team-shared MCP servers (auth-free only — anything needing tokens stays in user-level config). context7 = live library docs lookup; used constantly for Kotlin/Compose/AGP version questions.",
+  "$comment": "Team-shared MCP servers (auth-free only — anything needing tokens stays in user-level config). context7 = live library docs lookup; used constantly for Kotlin/Compose/AGP version questions. compose-hot-reload = drive the running :desktopApp (screenshot, semantic tree, click/type/scroll, logs, reload) instead of rebuilding a distributable to eyeball a change; needs `:desktopApp:hotRun` alive in another terminal, and CMP 1.12+ for the server to exist.",
   "mcpServers": {
     "context7": {
       "type": "http",
       "url": "https://mcp.context7.com/mcp"
+    },
+    "compose-hot-reload": {
+      "command": "./gradlew",
+      "args": ["--no-daemon", "--quiet", "--console=plain", ":desktopApp:hotMcpServer"]
     }
   }
 }

--- a/.skills/compose-ui/SKILL.md
+++ b/.skills/compose-ui/SKILL.md
@@ -56,6 +56,13 @@ Choose the right tool for the job:
 ## 5. Dialog & State Patterns
 - **Dialog State Preservation:** Use `rememberSaveable` for dialog state (search queries, selected tabs, expanded flags) to preserve across configuration changes. Boolean and String types are auto-saveable — no custom `Saver` needed.
 
+## 6. Driving the running desktop app
+CMP 1.12+ ships an MCP server inside Compose Hot Reload; `.mcp.json` registers it as `compose-hot-reload` (`:desktopApp:hotMcpServer`). With `./gradlew :desktopApp:hotRun` running, it drives the **live** app — inspect, input and reload without a rebuild.
+- **Tools:** `status`, `reload`, `await_reload`, `get_semantic_tree`, `click`, `type_text`, `scroll`, `get_logs`, `get_ui_error`, `take_screenshot`.
+- **Poll `status` until `connected: true`** before anything else — the server accepts requests before the app has connected to it.
+- **`get_semantic_tree` is the assertion surface:** roles, text, `selected`/`focused`, available actions and bounds. `click` addresses nodes by `nodeId` taken from that tree. Prefer it over `take_screenshot`, whose output depends on the host renderer.
+- **`reload` after editing sources** applies the change into the running app; use `await_reload` instead when the app was started with `--auto`.
+
 ## Reference Anchors
 - **Shared Strings:** `core/resources/src/commonMain/composeResources/values/strings.xml`
 - **Platform abstraction contract:** `core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/MapViewProvider.kt`


### PR DESCRIPTION
CMP 1.12.0 (already on main, #6904) ships an MCP server inside Compose Hot Reload. Registering it here means an agent can drive the running desktop app — inspect the semantic tree, click/type/scroll, read logs, trigger a reload — instead of rebuilding a distributable to eyeball a change. Auth-free and repo-local, which is what `.mcp.json` says it is for.

`:desktopApp:hotMcpServer` comes from the `org.jetbrains.compose.hot-reload` plugin already applied in `desktopApp/build.gradle.kts`, so this is config only — no build change. Second commit documents it in `.skills/compose-ui`.

Verified against a running `:desktopApp:hotRun`:

- handshake: `compose-hot-reload` 1.2.0, MCP `2024-11-05`
- `status` → `{"connected": true, "reloadState": "ok"}`
- `get_semantic_tree` → full tree, nav rail addressable with roles/bounds/selection
- `click {"nodeId": ...}` → `{"success": true}`, tree confirms the selection moved

Two things worth knowing when using it:

- poll `status` until `connected` before calling anything else — the server accepts requests before the app has connected to it
- the semantic tree is the reliable assertion surface; `take_screenshot` output depends on the host renderer (it came back blank on my Linux/XWayland setup)