### PR TITLE
feat(connections): notice when transmit is disabled

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1876,6 +1876,8 @@ translation_downloading
 translation_failed
 translation_model_download_failed
 translation_not_required
+transmit_disabled
+transmit_disabled_summary
 transmit_over_lora
 ### TRANSPORT ###
 transport

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1932,6 +1932,8 @@
     <string name="translation_failed">Unable to translate message</string>
     <string name="translation_model_download_failed">Translation model download failed</string>
     <string name="translation_not_required">Message is already in your language</string>
+    <string name="transmit_disabled">Transmit is disabled</string>
+    <string name="transmit_disabled_summary">This device can receive but will not send anything over LoRa.</string>
     <string name="transmit_over_lora">Transmit over LoRa</string>
     <!-- TRANSPORT -->
     <string name="transport">Transport</string>

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModel.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModel.kt
@@ -144,6 +144,16 @@ class ConnectionsViewModel(
             .stateInWhileSubscribed(initialValue = false)
 
     /**
+     * Whether the device is configured not to transmit. Null-safe against the pre-config [LocalConfig] so the notice
+     * cannot flash before the device's config arrives.
+     */
+    val txDisabled: StateFlow<Boolean> =
+        radioConfigRepository.localConfigFlow
+            .map { it.lora?.tx_enabled == false }
+            .distinctUntilChanged()
+            .stateInWhileSubscribed(initialValue = false)
+
+    /**
      * Single source of truth for the UI's "connection status" pill/banner. Derived from [connectionState],
      * [ServiceRepository.connectionProgress], and [regionUnset]; kept here rather than in the composable so the mapping
      * is observable and testable.

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/viewmodel/ConnectionsViewModelTest.kt
@@ -53,6 +53,7 @@ import org.meshtastic.core.testing.FakeRadioPrefs
 import org.meshtastic.core.testing.FakeServiceRepository
 import org.meshtastic.core.testing.FakeUiPrefs
 import org.meshtastic.core.testing.TestDataFactory
+import org.meshtastic.proto.Config
 import org.meshtastic.proto.HardwareModel
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.User
@@ -100,19 +101,21 @@ class ConnectionsViewModelTest {
         uiPrefs.hasShownNotPairedWarning.value = false
         uiPrefs.firmwareUpdateNotificationKeys.value = emptySet()
 
-        viewModel =
-            ConnectionsViewModel(
-                radioConfigRepository = radioConfigRepository,
-                serviceRepository = serviceRepository,
-                nodeRepository = nodeRepository,
-                nodeRestartTracker = nodeRestartTracker,
-                uiPrefs = uiPrefs,
-                deviceHardwareRepository = deviceHardwareRepository,
-                firmwareReleaseRepository = firmwareReleaseRepository,
-                radioPrefs = radioPrefs,
-                notificationManager = notificationManager,
-            )
+        viewModel = newViewModel()
     }
+
+    /** Rebuilt per test so a test can stub [radioConfigRepository] differently before construction. */
+    private fun newViewModel() = ConnectionsViewModel(
+        radioConfigRepository = radioConfigRepository,
+        serviceRepository = serviceRepository,
+        nodeRepository = nodeRepository,
+        nodeRestartTracker = nodeRestartTracker,
+        uiPrefs = uiPrefs,
+        deviceHardwareRepository = deviceHardwareRepository,
+        firmwareReleaseRepository = firmwareReleaseRepository,
+        radioPrefs = radioPrefs,
+        notificationManager = notificationManager,
+    )
 
     @AfterTest
     fun tearDown() {
@@ -122,6 +125,26 @@ class ConnectionsViewModelTest {
     @Test
     fun testInitialization() {
         assertNotNull(viewModel)
+    }
+
+    @Test
+    fun `txDisabled follows the LoRa tx_enabled flag and stays false before config arrives`() = runTest {
+        val configFlow = MutableStateFlow(LocalConfig())
+        every { radioConfigRepository.localConfigFlow } returns configFlow
+        val vm = newViewModel()
+
+        vm.txDisabled.test {
+            // No lora config yet: absence of the flag is not a disabled transmitter.
+            assertEquals(false, awaitItem())
+
+            configFlow.value = LocalConfig(lora = Config.LoRaConfig(tx_enabled = false))
+            assertEquals(true, awaitItem())
+
+            configFlow.value = LocalConfig(lora = Config.LoRaConfig(tx_enabled = true))
+            assertEquals(false, awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test

--- a/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
+++ b/feature/connections/src/commonMain/kotlin/org/meshtastic/feature/connections/ui/ConnectionsScreen.kt
@@ -96,6 +96,8 @@ import org.meshtastic.core.resources.open_settings
 import org.meshtastic.core.resources.open_wifi_settings
 import org.meshtastic.core.resources.rssi
 import org.meshtastic.core.resources.set_your_region
+import org.meshtastic.core.resources.transmit_disabled
+import org.meshtastic.core.resources.transmit_disabled_summary
 import org.meshtastic.core.resources.unknown
 import org.meshtastic.core.resources.unknown_device
 import org.meshtastic.core.resources.wifi_unavailable
@@ -107,6 +109,7 @@ import org.meshtastic.core.ui.component.PermissionRecoveryCard
 import org.meshtastic.core.ui.component.RecoveryCard
 import org.meshtastic.core.ui.icon.AppSettingsAlt
 import org.meshtastic.core.ui.icon.Bluetooth
+import org.meshtastic.core.ui.icon.CellTower
 import org.meshtastic.core.ui.icon.Language
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.NoDevice
@@ -162,6 +165,7 @@ fun ConnectionsScreen(
     val ourNode by connectionsViewModel.ourNodeForDisplay.collectAsStateWithLifecycle()
     val firmwareUpdateNotice by connectionsViewModel.firmwareUpdateNotice.collectAsStateWithLifecycle()
     val regionUnset by connectionsViewModel.regionUnset.collectAsStateWithLifecycle()
+    val txDisabled by connectionsViewModel.txDisabled.collectAsStateWithLifecycle()
     val sessionAuthorized by connectionsViewModel.sessionAuthorized.collectAsStateWithLifecycle()
 
     val selectedDevice by scanModel.selectedNotNullFlow.collectAsStateWithLifecycle()
@@ -495,17 +499,14 @@ fun ConnectionsScreen(
                                 )
                             }
 
-                        // Region warning sits outside the animated card so it does not affect the
+                        // Config warnings sit outside the animated card so they do not affect the
                         // CONNECTED ↔ CONNECTING ↔ NO_DEVICE size transition.
                         val isPhysicalDevice =
                             selectedDevice != InterfaceId.MOCK.id.toString() &&
                                 selectedDevice != InterfaceId.REPLAY.id.toString()
-                        if (
-                            uiState == ConnectionUiState.CONNECTED_WITH_NODE &&
-                            regionUnset &&
-                            sessionAuthorized &&
-                            isPhysicalDevice
-                        ) {
+                        val canShowConfigWarnings =
+                            uiState == ConnectionUiState.CONNECTED_WITH_NODE && sessionAuthorized && isPhysicalDevice
+                        if (canShowConfigWarnings && regionUnset) {
                             Spacer(modifier = Modifier.height(8.dp))
                             Card(modifier = Modifier.fillMaxWidth()) {
                                 ListItem(
@@ -515,6 +516,20 @@ fun ConnectionsScreen(
                                     // renders from the connect-time snapshot meanwhile, so pre-fetching behind a
                                     // progress dialog here bought nothing and could strand the user on an empty
                                     // dialog when the read completed before the dialog observed it.
+                                    onClick = { onConfigNavigate(SettingsRoute.LoRa) },
+                                )
+                            }
+                        }
+
+                        // Transmit-disabled notice. Suppressed while the region is unset: that already disables
+                        // transmit and has its own card above, so showing both would blame one root cause twice.
+                        if (canShowConfigWarnings && txDisabled && !regionUnset) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Card(modifier = Modifier.fillMaxWidth()) {
+                                ListItem(
+                                    leadingIcon = MeshtasticIcons.CellTower,
+                                    text = stringResource(Res.string.transmit_disabled),
+                                    supportingText = stringResource(Res.string.transmit_disabled_summary),
                                     onClick = { onConfigNavigate(SettingsRoute.LoRa) },
                                 )
                             }


### PR DESCRIPTION
A device with `lora.tx_enabled` off still connects, still receives, and still looks healthy on the Connections screen — nothing there says why its messages never leave the phone. This adds a notice card next to the existing region-unset one, on the same gate (`CONNECTED_WITH_NODE` + session authorized + physical device), tapping through to LoRa settings where the toggle lives.

**Decision worth a look:** the card is suppressed while the region is `UNSET`. That state already disables transmit and already has its own card, so showing both would blame one root cause twice.

- `ConnectionsViewModel.txDisabled` mirrors `regionUnset`: `lora?.tx_enabled == false`, so it cannot flash before the device's config arrives.
- New strings in base `values/strings.xml` only, sorted with `scripts/sort-strings.py`.
- Unit test covers the pre-config → disabled → enabled transitions.

Local: `spotlessApply spotlessCheck detekt :core:ui:allTests :feature:connections:allTests assembleDebug` all green; `:screenshot-tests:validateDebugScreenshotTest` — 310 tests passed, task then failed on the pre-existing Isolated Projects / `BuildServicesRegistry.getRegistrations()` config-cache incompatibility, unrelated to this diff.

cc @vidplace7 @thebentern @Xaositek @garthvh 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a notice on the Connections screen when LoRa transmission is disabled.
  * The notice explains that the device can receive but will not transmit and links to LoRa settings.
  * Added localized text for the new transmit-disabled status.

* **Bug Fixes**
  * Improved visibility conditions for connection and configuration warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->