### PR TITLE
feat(discovery): suppress beacon invitations for channels the radio already has

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerImpl.kt
@@ -42,6 +42,7 @@ import org.meshtastic.core.model.source
 import org.meshtastic.core.model.textMentionsNode
 import org.meshtastic.core.model.util.MeshDataMapper
 import org.meshtastic.core.model.util.decodeOrNull
+import org.meshtastic.core.model.util.isAlreadyJoined
 import org.meshtastic.core.model.util.isValidCodePoint
 import org.meshtastic.core.model.util.snrOrNull
 import org.meshtastic.core.model.util.toOneLiner
@@ -252,8 +253,13 @@ class MeshDataHandlerImpl(
                 snr = packet.snrOrNull() ?: 0f,
                 rssi = packet.rx_rssi,
             )
-        if (meshBeaconRepository.add(offer)) {
+        val isNew = meshBeaconRepository.add(offer)
+        if (isNew) {
             radioInterfaceService.launchSessionWork(scope, session) {
+                // design#140 behavior 10: still stored for the invitations list, but a mesh the radio is already on
+                // does not warrant a notification.
+                val channelSet = radioConfigRepository.channelSetFlow.first()
+                if (beacon.isAlreadyJoined(channelSet.lora_config, channelSet.settings)) return@launchSessionWork
                 notificationManager.dispatch(
                     Notification(
                         title = getStringSuspend(Res.string.mesh_beacon_notification_title),

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/MeshDataHandlerTest.kt
@@ -68,6 +68,8 @@ import org.meshtastic.core.repository.TracerouteHandler
 import org.meshtastic.core.testing.FakeNotificationPrefs
 import org.meshtastic.proto.ChannelSet
 import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config
+import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
 import org.meshtastic.proto.Data
 import org.meshtastic.proto.MeshBeacon
 import org.meshtastic.proto.MeshPacket
@@ -487,6 +489,42 @@ class MeshDataHandlerTest {
         handler.handleReceivedData(packet, 123)
 
         assertEquals(0, meshBeaconRepository.offers.value.size)
+    }
+
+    @Test
+    fun `mesh beacon offering an already-configured channel is stored but does not notify`() = testScope.runTest {
+        // design#140 behavior 10: the radio already has "PartyNet" configured, so this offer is redundant.
+        every { radioConfigRepository.channelSetFlow } returns
+            MutableStateFlow(
+                ChannelSet(
+                    settings = listOf(ChannelSettings(name = "PartyNet")),
+                    lora_config = Config.LoRaConfig(use_preset = true, modem_preset = ModemPreset.LONG_FAST),
+                ),
+            )
+        val beacon =
+            MeshBeacon(
+                message = "Join us",
+                offer_channel = ChannelSettings(name = "PartyNet"),
+                offer_preset = ModemPreset.LONG_FAST,
+            )
+        val packet =
+            MeshPacket(
+                from = 456,
+                decoded = Data(portnum = PortNum.MESH_BEACON_APP, payload = beacon.encode().toByteString()),
+            )
+        every { dataMapper.toDataPacket(packet) } returns
+            DataPacket(
+                from = "!remote",
+                bytes = beacon.encode().toByteString(),
+                dataType = PortNum.MESH_BEACON_APP.value,
+            )
+
+        handler.handleReceivedData(packet, 123)
+        advanceUntilIdle()
+
+        // Still stored, so it can reappear in the invitations list if the user later deletes the channel.
+        assertEquals(1, meshBeaconRepository.offers.value.size)
+        verifySuspend(mode = dev.mokkery.verify.VerifyMode.not) { notificationManager.dispatch(any()) }
     }
 
     // --- Store-and-Forward handling ---

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
@@ -93,6 +93,34 @@ val ChannelSet.primaryChannel: Channel?
 
 fun ChannelSet.hasLoraConfig(): Boolean = lora_config != null
 
+/**
+ * True when [this] is a channel the radio already has configured (design#140 behavior 10). Null [currentLora] or an
+ * empty [currentChannels] means "can't tell" and returns false, never hiding a still-relevant invitation on missing
+ * data. Comparison uses resolved [ChannelIdentity] (effective name plus expanded PSK) so a blank-name primary or a
+ * short-code PSK still matches; differing PSK under an identical name is deliberately not a match, since same name with
+ * a different key is a different mesh.
+ */
+@Suppress("ReturnCount")
+fun ChannelSettings.isAlreadyJoined(
+    offerPreset: LoRaConfig.ModemPreset?,
+    currentLora: LoRaConfig?,
+    currentChannels: List<ChannelSettings>,
+): Boolean {
+    val lora = currentLora ?: return false
+    if (currentChannels.isEmpty()) return false
+    val offerLora = lora.copy(use_preset = true, modem_preset = offerPreset ?: lora.modem_preset)
+    val offerIdentity = channelIdentity(offerLora)
+    return currentChannels.any { it.channelIdentity(lora) == offerIdentity }
+}
+
+/**
+ * True when [this] beacon's offered channel is already configured on the radio; see [ChannelSettings.isAlreadyJoined].
+ */
+fun MeshBeacon.isAlreadyJoined(currentLora: LoRaConfig?, currentChannels: List<ChannelSettings>): Boolean {
+    val offer = offer_channel ?: return false
+    return offer.isAlreadyJoined(offer_preset, currentLora, currentChannels)
+}
+
 /** How a received Mesh Beacon invitation can be joined, given the connected radio's current settings. */
 enum class BeaconJoinOption {
     /** Add the offered channel to a free secondary slot with no retune/reboot (mesh shares the radio's frequency). */

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/ChannelSet.kt
@@ -98,7 +98,11 @@ fun ChannelSet.hasLoraConfig(): Boolean = lora_config != null
  * empty [currentChannels] means "can't tell" and returns false, never hiding a still-relevant invitation on missing
  * data. Comparison uses resolved [ChannelIdentity] (effective name plus expanded PSK) so a blank-name primary or a
  * short-code PSK still matches; differing PSK under an identical name is deliberately not a match, since same name with
- * a different key is a different mesh.
+ * a different key is a different mesh. Secondary slots are skipped when [isChannelPlaceholder] (blank name, no PSK):
+ * [SwitchingChannelSetDataSource] pads a gap left by a removed channel with a bare [ChannelSettings], and those
+ * placeholders are read back unfiltered here, so without this exclusion a beacon offering a genuinely blank/cleartext
+ * channel would misclassify a padding slot as a real match. The primary slot (index 0) is never skipped: it always
+ * represents a real channel, matching the same convention in [normalizeReplacementSettings].
  */
 @Suppress("ReturnCount")
 fun ChannelSettings.isAlreadyJoined(
@@ -110,7 +114,9 @@ fun ChannelSettings.isAlreadyJoined(
     if (currentChannels.isEmpty()) return false
     val offerLora = lora.copy(use_preset = true, modem_preset = offerPreset ?: lora.modem_preset)
     val offerIdentity = channelIdentity(offerLora)
-    return currentChannels.any { it.channelIdentity(lora) == offerIdentity }
+    return currentChannels.withIndex().any { (index, settings) ->
+        (index == 0 || !settings.isChannelPlaceholder()) && settings.channelIdentity(lora) == offerIdentity
+    }
 }
 
 /**

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/MeshBeaconOfferTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/MeshBeaconOfferTest.kt
@@ -287,4 +287,13 @@ class MeshBeaconOfferTest {
         val beacon = MeshBeacon(message = "hi")
         assertEquals(false, beacon.isAlreadyJoined(radioLora, radioChannels))
     }
+
+    @Test
+    fun `blank-name no-psk secondary placeholder slot is not mistaken for an already-joined channel`() {
+        // SwitchingChannelSetDataSource pads a gap left by a removed channel with a bare ChannelSettings(); a beacon
+        // offering a genuinely blank cleartext channel on the same preset must not match that padding.
+        val configured = listOf(ChannelSettings(name = "HomeMesh"), ChannelSettings())
+        val beacon = MeshBeacon(offer_channel = ChannelSettings(), offer_preset = ModemPreset.LONG_FAST)
+        assertEquals(false, beacon.isAlreadyJoined(radioLora, configured))
+    }
 }

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/MeshBeaconOfferTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/MeshBeaconOfferTest.kt
@@ -17,6 +17,8 @@
 package org.meshtastic.core.model.util
 
 import okio.ByteString.Companion.encodeUtf8
+import okio.ByteString.Companion.toByteString
+import org.meshtastic.core.model.Channel
 import org.meshtastic.core.model.MeshBeaconOffer
 import org.meshtastic.proto.ChannelSettings
 import org.meshtastic.proto.Config.LoRaConfig
@@ -210,5 +212,79 @@ class MeshBeaconOfferTest {
     @Test
     fun `decode returns null for a malformed record`() {
         assertNull(MeshBeaconOffer.decode("not-a-valid-record"))
+    }
+
+    @Test
+    fun `offer matching a configured channel by name and psk is already joined`() {
+        val configured = listOf(ChannelSettings(name = "PartyNet", psk = "secret".encodeUtf8()))
+        val beacon =
+            MeshBeacon(
+                offer_channel = ChannelSettings(name = "PartyNet", psk = "secret".encodeUtf8()),
+                offer_preset = ModemPreset.LONG_FAST,
+            )
+        assertEquals(true, beacon.isAlreadyJoined(radioLora, configured))
+    }
+
+    @Test
+    fun `offer for a channel not configured on the radio is not already joined`() {
+        val configured = listOf(ChannelSettings(name = "HomeMesh"))
+        val beacon =
+            MeshBeacon(offer_channel = ChannelSettings(name = "PartyNet"), offer_preset = ModemPreset.LONG_FAST)
+        assertEquals(false, beacon.isAlreadyJoined(radioLora, configured))
+    }
+
+    @Test
+    fun `same name but different psk is a different mesh and is not already joined`() {
+        // Same name under a different key is deliberately NOT a match.
+        val configured = listOf(ChannelSettings(name = "PartyNet", psk = "secret".encodeUtf8()))
+        val beacon =
+            MeshBeacon(
+                offer_channel = ChannelSettings(name = "PartyNet", psk = "different".encodeUtf8()),
+                offer_preset = ModemPreset.LONG_FAST,
+            )
+        assertEquals(false, beacon.isAlreadyJoined(radioLora, configured))
+    }
+
+    @Test
+    fun `empty-name primary channel matches an offer naming the preset display name`() {
+        // The radio's primary has a blank name, which resolves to the preset display name for identity purposes.
+        val configured = listOf(ChannelSettings(name = ""))
+        val beacon =
+            MeshBeacon(offer_channel = ChannelSettings(name = "LongFast"), offer_preset = ModemPreset.LONG_FAST)
+        assertEquals(true, beacon.isAlreadyJoined(radioLora, configured))
+    }
+
+    @Test
+    fun `default 1-byte psk shorthand matches its expanded full-length equivalent`() {
+        // Both sides resolve to the same expanded default key bytes even though one is the 1-byte shorthand.
+        val expandedDefaultKey =
+            ChannelSettings(name = "HomeMesh", psk = byteArrayOf(1).toByteString()).let {
+                it.copy(psk = Channel(it, radioLora).psk)
+            }
+        val configured = listOf(expandedDefaultKey)
+        val beacon =
+            MeshBeacon(
+                offer_channel = ChannelSettings(name = "HomeMesh", psk = byteArrayOf(1).toByteString()),
+                offer_preset = ModemPreset.LONG_FAST,
+            )
+        assertEquals(true, beacon.isAlreadyJoined(radioLora, configured))
+    }
+
+    @Test
+    fun `isAlreadyJoined returns false when lora config is unknown so a real invitation is never hidden`() {
+        val beacon = MeshBeacon(offer_channel = ChannelSettings(name = "HomeMesh"))
+        assertEquals(false, beacon.isAlreadyJoined(currentLora = null, currentChannels = radioChannels))
+    }
+
+    @Test
+    fun `isAlreadyJoined returns false when no channels are configured`() {
+        val beacon = MeshBeacon(offer_channel = ChannelSettings(name = "HomeMesh"))
+        assertEquals(false, beacon.isAlreadyJoined(currentLora = radioLora, currentChannels = emptyList()))
+    }
+
+    @Test
+    fun `isAlreadyJoined returns false for a beacon with no offer channel`() {
+        val beacon = MeshBeacon(message = "hi")
+        assertEquals(false, beacon.isAlreadyJoined(radioLora, radioChannels))
     }
 }

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryViewModel.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import org.koin.core.annotation.KoinViewModel
@@ -28,6 +29,7 @@ import org.meshtastic.core.database.entity.DiscoverySessionEntity
 import org.meshtastic.core.model.ChannelOption
 import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.MeshBeaconOffer
+import org.meshtastic.core.model.util.isAlreadyJoined
 import org.meshtastic.core.repository.DiscoveryPrefs
 import org.meshtastic.core.repository.MeshBeaconRepository
 import org.meshtastic.core.repository.RadioConfigRepository
@@ -55,40 +57,6 @@ class DiscoveryViewModel(
     val currentSession: StateFlow<DiscoverySessionEntity?> = scanEngine.currentSession
     val connectionState: StateFlow<ConnectionState> = serviceRepository.connectionState
 
-    /** Mesh Beacon invitations received from other meshes, newest first. */
-    val beaconOffers: StateFlow<List<MeshBeaconOffer>> = meshBeaconRepository.offers
-
-    /** Modem presets advertised by any received beacon — flagged in the scan-setup picker (FR-004). */
-    val beaconPresets: StateFlow<Set<ChannelOption>> =
-        meshBeaconRepository.offers
-            .map { offers -> offers.mapNotNull { ChannelOption.from(it.beacon.offer_preset) }.toSet() }
-            .stateInWhileSubscribed(initialValue = emptySet())
-
-    /** Distinct custom channels advertised by beacons — offered as selectable scan targets (FR-007). */
-    val beaconChannels: StateFlow<List<BeaconChannel>> =
-        meshBeaconRepository.offers
-            .map { offers ->
-                offers
-                    .mapNotNull { offer ->
-                        val ch = offer.beacon.offer_channel ?: return@mapNotNull null
-                        val name =
-                            ch.name.ifBlank {
-                                return@mapNotNull null
-                            }
-                        BeaconChannel(
-                            name = name,
-                            psk = ch.psk,
-                            preset = ChannelOption.from(offer.beacon.offer_preset),
-                            region = offer.beacon.offer_region,
-                        )
-                    }
-                    .distinctBy { it.id }
-            }
-            .stateInWhileSubscribed(initialValue = emptyList())
-
-    private val _selectedBeaconChannels = MutableStateFlow<Set<String>>(emptySet())
-    val selectedBeaconChannels: StateFlow<Set<String>> = _selectedBeaconChannels.asStateFlow()
-
     /** The radio's current LoRa config — drives the add-vs-switch decision for a beacon join. */
     val currentLora: StateFlow<LoRaConfig?> =
         radioConfigRepository.localConfigFlow.map { it.lora }.stateInWhileSubscribed(initialValue = null)
@@ -96,6 +64,33 @@ class DiscoveryViewModel(
     /** The radio's current channel settings (index 0 = primary) — drives the add-vs-switch decision. */
     val currentChannels: StateFlow<List<ChannelSettings>> =
         radioConfigRepository.channelSetFlow.map { it.settings }.stateInWhileSubscribed(initialValue = emptyList())
+
+    /**
+     * Mesh Beacon invitations received from other meshes, newest first, minus offers for a channel the radio already
+     * has configured (design#140 behavior 10). Filtered reactively at presentation time, not at ingest, so a later
+     * channel deletion brings a still-stored invitation back and joining removes it, without ever mutating
+     * [MeshBeaconRepository].
+     */
+    val beaconOffers: StateFlow<List<MeshBeaconOffer>> =
+        combine(meshBeaconRepository.offers, currentLora, currentChannels, ::filterAlreadyJoinedOffers)
+            .stateInWhileSubscribed(initialValue = emptyList())
+
+    /** Modem presets advertised by any received beacon — flagged in the scan-setup picker (FR-004). */
+    val beaconPresets: StateFlow<Set<ChannelOption>> =
+        meshBeaconRepository.offers
+            .map { offers -> offers.mapNotNull { ChannelOption.from(it.beacon.offer_preset) }.toSet() }
+            .stateInWhileSubscribed(initialValue = emptySet())
+
+    /**
+     * Distinct custom channels advertised by beacons — offered as selectable scan targets (FR-007), minus a channel the
+     * radio already has configured (design#140 behavior 10).
+     */
+    val beaconChannels: StateFlow<List<BeaconChannel>> =
+        combine(meshBeaconRepository.offers, currentLora, currentChannels, ::filterAlreadyJoinedBeaconChannels)
+            .stateInWhileSubscribed(initialValue = emptyList())
+
+    private val _selectedBeaconChannels = MutableStateFlow<Set<String>>(emptySet())
+    val selectedBeaconChannels: StateFlow<Set<String>> = _selectedBeaconChannels.asStateFlow()
 
     val homePreset: StateFlow<ChannelOption> =
         radioConfigRepository.localConfigFlow
@@ -242,3 +237,39 @@ class DiscoveryViewModel(
         private const val SECONDS_PER_MINUTE = 60L
     }
 }
+
+/**
+ * Drops beacon offers whose channel the radio already has configured (design#140 behavior 10). Extracted as a plain
+ * function so the filtering logic is unit-testable without constructing [DiscoveryViewModel] or its Flow wiring.
+ */
+internal fun filterAlreadyJoinedOffers(
+    offers: List<MeshBeaconOffer>,
+    lora: LoRaConfig?,
+    channels: List<ChannelSettings>,
+): List<MeshBeaconOffer> = offers.filterNot { it.beacon.isAlreadyJoined(lora, channels) }
+
+/**
+ * Builds the distinct, selectable beacon-channel scan targets, dropping any channel the radio already has configured
+ * (design#140 behavior 10). Extracted as a plain function for the same testability reason as
+ * [filterAlreadyJoinedOffers].
+ */
+internal fun filterAlreadyJoinedBeaconChannels(
+    offers: List<MeshBeaconOffer>,
+    lora: LoRaConfig?,
+    channels: List<ChannelSettings>,
+): List<BeaconChannel> = offers
+    .mapNotNull { offer ->
+        val ch = offer.beacon.offer_channel ?: return@mapNotNull null
+        val name =
+            ch.name.ifBlank {
+                return@mapNotNull null
+            }
+        if (ch.isAlreadyJoined(offer.beacon.offer_preset, lora, channels)) return@mapNotNull null
+        BeaconChannel(
+            name = name,
+            psk = ch.psk,
+            preset = ChannelOption.from(offer.beacon.offer_preset),
+            region = offer.beacon.offer_region,
+        )
+    }
+    .distinctBy { it.id }

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryViewModel.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryViewModel.kt
@@ -57,11 +57,11 @@ class DiscoveryViewModel(
     val currentSession: StateFlow<DiscoverySessionEntity?> = scanEngine.currentSession
     val connectionState: StateFlow<ConnectionState> = serviceRepository.connectionState
 
-    /** The radio's current LoRa config — drives the add-vs-switch decision for a beacon join. */
+    /** The radio's current LoRa config, which drives the add-vs-switch decision for a beacon join. */
     val currentLora: StateFlow<LoRaConfig?> =
         radioConfigRepository.localConfigFlow.map { it.lora }.stateInWhileSubscribed(initialValue = null)
 
-    /** The radio's current channel settings (index 0 = primary) — drives the add-vs-switch decision. */
+    /** The radio's current channel settings (index 0 = primary), which drives the add-vs-switch decision. */
     val currentChannels: StateFlow<List<ChannelSettings>> =
         radioConfigRepository.channelSetFlow.map { it.settings }.stateInWhileSubscribed(initialValue = emptyList())
 
@@ -82,7 +82,7 @@ class DiscoveryViewModel(
             .stateInWhileSubscribed(initialValue = emptySet())
 
     /**
-     * Distinct custom channels advertised by beacons — offered as selectable scan targets (FR-007), minus a channel the
+     * Distinct custom channels advertised by beacons, offered as selectable scan targets (FR-007), minus a channel the
      * radio already has configured (design#140 behavior 10).
      */
     val beaconChannels: StateFlow<List<BeaconChannel>> =

--- a/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryViewModelTest.kt
+++ b/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryViewModelTest.kt
@@ -82,7 +82,7 @@ class DiscoveryViewModelTest {
 
     @Test
     fun `beacon channels filter still deduplicates by id once already-joined entries are removed`() {
-        val duplicate = partyNetOffer.copy(fromNodeNum = 789) // Same channel from a second node — one row, not two.
+        val duplicate = partyNetOffer.copy(fromNodeNum = 789) // Same channel from a second node: one row, not two.
         val beaconChannels =
             filterAlreadyJoinedBeaconChannels(
                 listOf(partyNetOffer, duplicate),
@@ -108,13 +108,13 @@ class DiscoveryViewModelTest {
 
         assertTrue(results.last().isEmpty(), "already configured, so the invitation starts out hidden")
 
-        // The user deletes the "PartyNet" channel — the still-stored offer must reappear without dismiss()/repository
+        // The user deletes the "PartyNet" channel; the still-stored offer must reappear without dismiss()/repository
         // mutation, since MeshBeaconRepository is never touched by this filter.
         channelsFlow.value = emptyList()
         runCurrent()
         assertEquals(listOf(partyNetOffer), results.last())
 
-        // The user re-adds an unrelated channel — still not a match, offer stays visible.
+        // The user re-adds an unrelated channel; still not a match, offer stays visible.
         channelsFlow.value = listOf(ChannelSettings(name = "HomeMesh"))
         runCurrent()
         assertEquals(listOf(partyNetOffer), results.last())

--- a/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryViewModelTest.kt
+++ b/feature/discovery/src/commonTest/kotlin/org/meshtastic/feature/discovery/DiscoveryViewModelTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.discovery
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.meshtastic.core.model.MeshBeaconOffer
+import org.meshtastic.proto.ChannelSettings
+import org.meshtastic.proto.Config.LoRaConfig
+import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
+import org.meshtastic.proto.MeshBeacon
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers design#140 behavior 10's presentation-time filtering exactly as [DiscoveryViewModel] wires it: these tests
+ * call the same [filterAlreadyJoinedOffers]/[filterAlreadyJoinedBeaconChannels] functions the view model's
+ * `beaconOffers`/`beaconChannels` combine over, so the wiring itself is exercised without constructing the full view
+ * model and its dependency graph (matcher edge cases already have direct coverage in `MeshBeaconOfferTest`).
+ */
+class DiscoveryViewModelTest {
+
+    private val radioLora = LoRaConfig(use_preset = true, modem_preset = ModemPreset.LONG_FAST)
+    private val partyNetOffer =
+        MeshBeaconOffer(
+            fromNodeNum = 456,
+            beacon =
+            MeshBeacon(
+                message = "Join us",
+                offer_channel = ChannelSettings(name = "PartyNet"),
+                offer_preset = ModemPreset.LONG_FAST,
+            ),
+        )
+
+    @Test
+    fun `offer for an unconfigured channel passes through both filters`() {
+        val channels = listOf(ChannelSettings(name = "HomeMesh"))
+
+        val offers = filterAlreadyJoinedOffers(listOf(partyNetOffer), radioLora, channels)
+        val beaconChannels = filterAlreadyJoinedBeaconChannels(listOf(partyNetOffer), radioLora, channels)
+
+        assertEquals(listOf(partyNetOffer), offers)
+        assertEquals(listOf("PartyNet"), beaconChannels.map { it.name })
+    }
+
+    @Test
+    fun `offer matching a configured channel is dropped from both filters`() {
+        val channels = listOf(ChannelSettings(name = "PartyNet"))
+
+        val offers = filterAlreadyJoinedOffers(listOf(partyNetOffer), radioLora, channels)
+        val beaconChannels = filterAlreadyJoinedBeaconChannels(listOf(partyNetOffer), radioLora, channels)
+
+        assertTrue(offers.isEmpty(), "an already-joined offer must not appear in the invitations list")
+        assertTrue(beaconChannels.isEmpty(), "an already-joined channel must not appear as a scan target")
+    }
+
+    @Test
+    fun `filtering never mutates the offers list it is given`() {
+        // The repository itself must never be touched by presentation-time filtering (spec: reactive, not destructive).
+        val original = listOf(partyNetOffer)
+        filterAlreadyJoinedOffers(original, LoRaConfig(use_preset = true), listOf(ChannelSettings(name = "PartyNet")))
+        assertEquals(1, original.size)
+    }
+
+    @Test
+    fun `beacon channels filter still deduplicates by id once already-joined entries are removed`() {
+        val duplicate = partyNetOffer.copy(fromNodeNum = 789) // Same channel from a second node — one row, not two.
+        val beaconChannels =
+            filterAlreadyJoinedBeaconChannels(
+                listOf(partyNetOffer, duplicate),
+                radioLora,
+                listOf(ChannelSettings(name = "HomeMesh")),
+            )
+        assertEquals(1, beaconChannels.size)
+    }
+
+    @Test
+    fun `reactively combining offers with a later-changing channel set brings a filtered invitation back`() = runTest {
+        // Mirrors DiscoveryViewModel's own combine(offers, currentLora, currentChannels) wiring: proves the filter is
+        // reactive at presentation time, not a one-shot decision baked in when the offer arrived.
+        val offersFlow = MutableStateFlow(listOf(partyNetOffer))
+        val loraFlow = MutableStateFlow<LoRaConfig?>(radioLora)
+        val channelsFlow = MutableStateFlow(listOf(ChannelSettings(name = "PartyNet")))
+
+        val results = mutableListOf<List<MeshBeaconOffer>>()
+        val job = launch {
+            combine(offersFlow, loraFlow, channelsFlow, ::filterAlreadyJoinedOffers).collect { results += it }
+        }
+        runCurrent()
+
+        assertTrue(results.last().isEmpty(), "already configured, so the invitation starts out hidden")
+
+        // The user deletes the "PartyNet" channel — the still-stored offer must reappear without dismiss()/repository
+        // mutation, since MeshBeaconRepository is never touched by this filter.
+        channelsFlow.value = emptyList()
+        runCurrent()
+        assertEquals(listOf(partyNetOffer), results.last())
+
+        // The user re-adds an unrelated channel — still not a match, offer stays visible.
+        channelsFlow.value = listOf(ChannelSettings(name = "HomeMesh"))
+        runCurrent()
+        assertEquals(listOf(partyNetOffer), results.last())
+
+        job.cancel()
+    }
+}


### PR DESCRIPTION
### Why

A beacon inviting you to a mesh you are already on is not an invitation ([design#140](https://github.com/meshtastic/design/issues/140) behavior 10, from meshtastic/firmware#11645). The firmware cannot know an offer is redundant; the client can. iOS shipped this in 2.7.20 (Meshtastic-Apple#2371's sibling, commit f6b2e293).

Part of #6931 (behavior 10).

### What

- New pure matcher in `core/model`: an offer matches a configured channel when the name and PSK are both equal (same name with a different key is a different mesh and still shows). Placeholder secondary slots are excluded from matching.
- `DiscoveryViewModel` filters reactively by combining the stored offers with the live channel set: joining a mesh hides its standing invitations from the Discovery invitations section and the beacon scan-target list, and deleting the channel later makes the still-stored invitation reappear. Nothing is deleted from `MeshBeaconRepository`.
- `MeshDataHandlerImpl` no longer posts the first-sight notification for an already-joined offer (the offer is still stored).

### Testing Performed

- Matcher edge cases in `MeshBeaconOfferTest` (empty-name primary, default PSK, same-name/different-key, placeholder slots).
- Reactive filtering in new `DiscoveryViewModelTest` cases (join hides, delete reappears, unrelated channel changes leave offers alone, re-broadcast dedup unaffected).
- Notification suppression covered in `MeshDataHandlerTest`.
- Full local baseline green: `spotlessApply spotlessCheck detekt assembleDebug test allTests`.