### PR TITLE
fix(build): carry the Gradle 9.7.1 desktop packaging flags into the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,10 +314,15 @@ jobs:
         # Quote the -P flag: PowerShell on Windows interprets the dot in
         # `-PaboutLibraries.release=true` as member access on `-PaboutLibraries`,
         # splitting the token and feeding `.release=true` to Gradle as a task name.
+        # --no-isolated-projects --no-configuration-cache: CMP's Windows MSI/WiX packaging
+        # reads Project.layout on the root project, which IP and the CC each reject; both
+        # must be flags, not -D properties (inert on windows-latest), and --no-isolated-projects
+        # needs Gradle 9.7+ — full rationale on the desktop packaging step in reusable-check.yml.
         run: >
           ./gradlew :desktopApp:packageReleaseDistributionForCurrentOS
           ${{ contains(runner.os, 'macOS') && ':desktopApp:packageReleaseUberJarForCurrentOS' || '' }}
           '-PaboutLibraries.release=true' '-Pdesktop.release=true' --no-daemon
+          --no-isolated-projects --no-configuration-cache
 
       # Authenticode-signs the MSI/EXE installers via Azure Trusted Signing
       # (rebranded "Artifact Signing"). Skips cleanly when the secrets are


### PR DESCRIPTION
The 2.8.2 internal release (run 33327874249) failed on the `release-desktop (windows-latest)` job with the known Gradle 9.7.1 Isolated Projects violation in CMP's Windows MSI/WiX packaging path: `Plugin 'org.jetbrains.compose': Project ':desktopApp' cannot access 'Project.layout' functionality on another project ':'` ([build scan](https://community.develocity.cloud/s/3hpnmzpqgogzq)). #6917 re-adopted Gradle 9.7.1 and worked around exactly this in Main CI's desktop packaging step, but the release workflow's `Package Native Distributions` step was missed — and PR CI never exercises the release desktop jobs, so the gap only surfaced at release time.

### 🐛 Bug Fixes

- Append `--no-isolated-projects --no-configuration-cache` to `:desktopApp:packageReleaseDistributionForCurrentOS` in `release.yml`, unconditionally across OSes, mirroring the Main CI step in `reusable-check.yml`. Flags rather than `-D` properties: the property form is inert on windows-latest, and Gradle refuses `--no-configuration-cache` while Isolated Projects is still on (full rationale on the Main CI step's comment block). No configuration-cache value is lost — this job never persists a CC entry.
- Note for any future pin-back below Gradle 9.7: `--no-isolated-projects` only parses on 9.7+, so this line has to be reverted together with the Main CI one.

### Testing Performed

- `actionlint` passes on the edited workflow.
- The failure is not reproducible in PR CI (release desktop jobs only run from the release workflow — the same blind spot that let #6917 miss this). Verification is the next internal release dispatch; per the tag rollback in `cleanup-on-failure`, that should be a fresh `workflow_dispatch` after this merges, not a rerun of the failed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)