### PR TITLE
fix(map): gate the MapLibre waypoint editor on isModifiableBy

### DIFF
--- a/feature/map-maplibre/build.gradle.kts
+++ b/feature/map-maplibre/build.gradle.kts
@@ -60,6 +60,13 @@ kotlin {
             api(libs.maplibre.compose.material3)
         }
 
+        // Compose UI tests live in jvmTest, not commonTest: this module enables Android host tests, and
+        // `runComposeUiTest` has no Robolectric host there — the same tests NPE the moment they run under it.
+        jvmTest.dependencies {
+            implementation(libs.compose.multiplatform.ui.test)
+            implementation(compose.desktop.currentOs)
+        }
+
         // maplibre-compose 0.15.0 no longer brings the MapLibre Android SDK along transitively —
         // Android renders through maplibre-native FFI now, so the backend ships as its own
         // artifact. runtimeOnly because nothing compiles against it; it only has to reach the APK.

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/WaypointDialogs.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/WaypointDialogs.kt
@@ -26,7 +26,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.compose.viewmodel.koinViewModel
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Position
-import org.meshtastic.core.model.isLocked
+import org.meshtastic.core.common.util.MeasurementSystem
 import org.meshtastic.core.model.isModifiableBy
 import org.meshtastic.core.model.util.waypointIconOrDefault
 import org.meshtastic.feature.map.SharedMapViewModel
@@ -59,30 +59,21 @@ internal fun WaypointDialogs(
 
     selectedId?.let { id ->
         waypoints[id]?.waypoint?.let { waypoint ->
-            WaypointInfoDialog(
+            WaypointInfoSlot(
                 waypoint = waypoint,
+                myNodeNum = viewModel.myNodeNum,
+                isConnected = isConnected,
                 displayUnits = displayUnits,
                 alertsEnabled = waypoint.id in alertOptIns,
                 onToggleAlerts = { viewModel.setGeofenceAlertOptIn(waypoint.id, it) },
-                onDismissRequest = { onSelectedIdChange(null) },
-                // Editing re-broadcasts, so it needs a connection — and a locked foreign geofence stays read-only.
-                onEdit =
-                if (!waypoint.isLocked && isConnected) {
-                    {
-                        onSelectedIdChange(null)
-                        editing.onEdit(waypoint)
-                    }
-                } else {
-                    null
+                onDismiss = { onSelectedIdChange(null) },
+                onEdit = {
+                    onSelectedIdChange(null)
+                    editing.onEdit(waypoint)
                 },
-                onDeleteForMe =
-                if (!waypoint.isLocked) {
-                    {
-                        onSelectedIdChange(null)
-                        deletingId = waypoint.id
-                    }
-                } else {
-                    null
+                onDeleteForMe = {
+                    onSelectedIdChange(null)
+                    deletingId = waypoint.id
                 },
             )
         }
@@ -114,6 +105,37 @@ internal fun WaypointDialogs(
             )
         }
     }
+}
+
+/**
+ * The tapped waypoint's details, offering only the actions the current state allows.
+ *
+ * Stateless so both gates can be exercised without a view model.
+ */
+@Composable
+internal fun WaypointInfoSlot(
+    waypoint: Waypoint,
+    myNodeNum: Int?,
+    isConnected: Boolean,
+    displayUnits: MeasurementSystem,
+    alertsEnabled: Boolean,
+    onToggleAlerts: (Boolean) -> Unit,
+    onDismiss: () -> Unit,
+    onEdit: () -> Unit,
+    onDeleteForMe: () -> Unit,
+) {
+    WaypointInfoDialog(
+        waypoint = waypoint,
+        displayUnits = displayUnits,
+        alertsEnabled = alertsEnabled,
+        onToggleAlerts = onToggleAlerts,
+        onDismissRequest = onDismiss,
+        // Editing re-broadcasts, so it needs a connection and mesh-wide permission: unlocked, or locked to us.
+        // `isLocked` alone made our own locked waypoint read-only, with no other route to the editor.
+        onEdit = if (waypoint.isModifiableBy(myNodeNum) && isConnected) onEdit else null,
+        // Dropping our local copy is not a mesh operation, so a foreign lock does not withhold it.
+        onDeleteForMe = onDeleteForMe,
+    )
 }
 
 /** Delete confirmation, wrapped so dismissing and acting both clear the pending waypoint. */

--- a/feature/map-maplibre/src/jvmTest/kotlin/org/meshtastic/feature/map/maplibre/component/WaypointInfoSlotTest.kt
+++ b/feature/map-maplibre/src/jvmTest/kotlin/org/meshtastic/feature/map/maplibre/component/WaypointInfoSlotTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.meshtastic.core.common.util.MeasurementSystem
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.delete_for_me
+import org.meshtastic.core.resources.edit
+import org.meshtastic.core.resources.getString
+import org.meshtastic.proto.Waypoint
+import kotlin.test.Test
+
+/**
+ * The info dialog is the only route to the editor on this map — a long press always creates a new waypoint — so
+ * anything it withholds is unreachable. The gates must match the Google flavor's, which dispatches on `isModifiableBy`.
+ */
+@OptIn(ExperimentalTestApi::class)
+class WaypointInfoSlotTest {
+
+    private val myNodeNum = 0x433D0D3C
+    private val otherNodeNum = 0x1A2B3C4D
+
+    @Composable
+    private fun InfoSlot(waypoint: Waypoint, isConnected: Boolean) = WaypointInfoSlot(
+        waypoint = waypoint,
+        myNodeNum = myNodeNum,
+        isConnected = isConnected,
+        displayUnits = MeasurementSystem.METRIC,
+        alertsEnabled = false,
+        onToggleAlerts = {},
+        onDismiss = {},
+        onEdit = {},
+        onDeleteForMe = {},
+    )
+
+    @Test
+    fun `a waypoint locked to our own node is still editable`() = runComposeUiTest {
+        setContent { InfoSlot(waypoint = Waypoint(id = 1, locked_to = myNodeNum), isConnected = true) }
+
+        onNodeWithText(getString(Res.string.edit)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `an unlocked waypoint is editable while connected`() = runComposeUiTest {
+        setContent { InfoSlot(waypoint = Waypoint(id = 1, locked_to = 0), isConnected = true) }
+
+        onNodeWithText(getString(Res.string.edit)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `editing is withheld while disconnected because saving re-broadcasts`() = runComposeUiTest {
+        setContent { InfoSlot(waypoint = Waypoint(id = 1, locked_to = 0), isConnected = false) }
+
+        onNodeWithText(getString(Res.string.edit)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a waypoint locked to another node offers no editor`() = runComposeUiTest {
+        setContent { InfoSlot(waypoint = Waypoint(id = 1, locked_to = otherNodeNum), isConnected = true) }
+
+        onNodeWithText(getString(Res.string.edit)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a waypoint locked to another node can still be dropped locally`() = runComposeUiTest {
+        // Dropping our own copy is not a mesh operation, so a foreign lock does not withhold it.
+        setContent { InfoSlot(waypoint = Waypoint(id = 1, locked_to = otherNodeNum), isConnected = false) }
+
+        onNodeWithText(getString(Res.string.delete_for_me)).assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
On F-Droid and Desktop, a waypoint locked to your own node had no **Edit** and no **Delete for me**. A long press only ever creates a new waypoint, so its creator had no route to the editor at all.

`WaypointDialogs.kt` gated both actions on `!waypoint.isLocked`. The predicate is `isModifiableBy(myNodeNum)` — `locked_to == 0 || locked_to == myNodeNum` — which is what the Google flavor already uses at `WaypointMarkers.kt:102`. `isConnected` stays on edit, because saving re-broadcasts.

`onDeleteForMe` is now ungated. It drops only the local copy, and three places already say that is unconditional: `DeleteWaypointDialog`'s KDoc ("needs no mesh-wide permission, so it stays available for a waypoint locked to another node"), `WaypointInfoDialog`'s KDoc, and Google's call site. The mesh-wide delete inside it is still gated by the untouched `removableForEveryone(myNodeNum, isConnected)`.

Not touched: `MapView.kt:815`'s `!isLocked` gate. That path is only reached for foreign geofences, where the two predicates coincide.

Constitution VI: no page changed. `docs/en/user/map-and-waypoints.md:64` already says "if locked, only the creator can edit or delete" — the app was contradicting its own docs, so this brings code to docs.

Tests: `WaypointInfoSlotTest`, five cases covering locked-to-me, unlocked, disconnected, and locked-to-other. `spotlessCheck detekt :feature:map-maplibre:jvmTest :core:model:jvmTest` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved waypoint actions based on ownership and connection status.
  * Users can edit waypoints they control when connected.
  * Users can delete waypoints locally regardless of lock ownership or connection status.

* **Tests**
  * Added coverage for waypoint editing and deletion scenarios, including locked and disconnected states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->