### PR TITLE
chore(discovery): remove the scan state nothing ever enters

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -442,7 +442,6 @@ discovery_lora_presets_description
 discovery_map
 discovery_not_connected
 discovery_not_connected_description
-discovery_paused
 discovery_preparing
 discovery_preset_home_label
 discovery_reconnecting

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -472,7 +472,6 @@
     <string name="discovery_map">Discovery Map</string>
     <string name="discovery_not_connected">Not Connected</string>
     <string name="discovery_not_connected_description">Connect to a Meshtastic device to start scanning.</string>
-    <string name="discovery_paused">Paused: %1$s</string>
     <string name="discovery_preparing">Preparing scan</string>
     <string name="discovery_preset_home_label">%1$s (Home)</string>
     <string name="discovery_reconnecting">Reconnecting on %1$s</string>

--- a/feature/discovery/README.md
+++ b/feature/discovery/README.md
@@ -9,7 +9,7 @@ The `:feature:discovery` module implements **Local Mesh Discovery**: the app cyc
 ## Scan Workflow
 
 - `DiscoveryScanEngine` — core scan engine. Cycles through a queue of `ScanTarget`s, dwells on each while collecting packets, and persists aggregated results via `DiscoveryDao`.
-- `DiscoveryScanState` — state machine for the scan lifecycle: `Idle → Preparing → Shifting → [Reconnecting] → Dwell → … → Analysis → Complete`, with `Cancelling`/`Restoring`/`Failed`/`Paused` side paths.
+- `DiscoveryScanState` — state machine for the scan lifecycle: `Idle → Preparing → Shifting → [Reconnecting] → Dwell → … → Analysis → Complete`, with `Cancelling`/`Restoring`/`Failed` side paths.
 - `ScanTarget` — one queue entry. `channel == null` is a public-preset target; a non-null channel is a beacon-advertised custom channel: the engine tunes the radio's primary channel to that name+PSK (and region) for the dwell, then restores it.
 - `DiscoveryRankingEngine` (`scan/`) — ranks preset results by unique node count, neighbor diversity, non-duplicate packet count, and SNR.
 - `Check24GhzCapability` (`scan/`) — layered heuristic that determines whether the connected radio supports 2.4 GHz LoRa (SX1280), returning `Supported` / `Unsupported` / `Unknown`.

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryScanState.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/DiscoveryScanState.kt
@@ -20,10 +20,10 @@ package org.meshtastic.feature.discovery
  * State machine for a discovery scan lifecycle.
  *
  * ```
- * Idle → Preparing → Shifting → [Reconnecting] → Dwell → Shifting (loop) → Analysis → Complete(Success)
- * Any scanning → Cancelling → Restoring → Complete(Cancelled)
- * Any scanning → Failed(reason) → Restoring → Complete(Failed)
- * Reconnecting timeout → Paused
+ * Idle → Preparing → Shifting → Reconnecting → Dwell → Shifting (loop) → Analysis → Complete(Success)
+ * Refused at start → Failed(reason)
+ * Shift error, reconnect timeout, or aborted dwell → Analysis → Complete(Failed)
+ * Any scanning → Cancelling → Complete(Cancelled)
  * ```
  */
 sealed interface DiscoveryScanState {
@@ -47,9 +47,6 @@ sealed interface DiscoveryScanState {
 
     /** Scan finished and results are persisted. */
     data class Complete(val outcome: CompletionOutcome = CompletionOutcome.Success) : DiscoveryScanState
-
-    /** Scan paused due to an unrecoverable transient condition (e.g. reconnect timeout). */
-    data class Paused(val reason: String) : DiscoveryScanState
 
     /** User-initiated cancellation in progress; persisting partial results before restoring home preset. */
     data object Cancelling : DiscoveryScanState

--- a/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/DiscoveryScanScreen.kt
+++ b/feature/discovery/src/commonMain/kotlin/org/meshtastic/feature/discovery/ui/DiscoveryScanScreen.kt
@@ -75,7 +75,6 @@ import org.meshtastic.core.resources.discovery_keep_screen_awake_description
 import org.meshtastic.core.resources.discovery_local_mesh
 import org.meshtastic.core.resources.discovery_not_connected
 import org.meshtastic.core.resources.discovery_not_connected_description
-import org.meshtastic.core.resources.discovery_paused
 import org.meshtastic.core.resources.discovery_preparing
 import org.meshtastic.core.resources.discovery_reconnecting
 import org.meshtastic.core.resources.discovery_restoring_preset
@@ -493,14 +492,6 @@ private fun ScanProgressSection(scanState: DiscoveryScanState, modifier: Modifie
                     Text(
                         text = stringResource(Res.string.discovery_cancelling_scan),
                         style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-
-                is DiscoveryScanState.Paused -> {
-                    Text(
-                        text = stringResource(Res.string.discovery_paused, scanState.reason),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.error,
                     )
                 }
 

--- a/specs/20260507-161658-local-mesh-discovery/spec.md
+++ b/specs/20260507-161658-local-mesh-discovery/spec.md
@@ -423,7 +423,6 @@ These features were added during implementation for safety, reliability, and cro
 | Feature | Description | File(s) |
 |---|---|---|
 | Interrupted session recovery | `markInterruptedSessions()` DAO query on ViewModel init marks any lingering `in_progress` sessions as `interrupted`. Handles app process death mid-scan. | `DiscoveryDao.kt`, `DiscoveryViewModel.kt` |
-| Paused scan state | `DiscoveryScanState.Paused` provides a recoverable grace period during BLE reconnect before transitioning to `Failed`. Original spec only had direct `WaitingForReconnect → Failed`. | `DiscoveryScanState.kt` |
 | Infrastructure node classification | Nodes with `ROUTER`, `ROUTER_LATE`, or `CLIENT_BASE` roles flagged via `isInfrastructure` on entity. `infrastructureNodeCount` aggregated per preset result. Aligns with Apple's relay/infrastructure tracking. | `DiscoveryScanEngine.kt`, `DiscoveredNodeEntity.kt`, `DiscoveryPresetResultEntity.kt` |
 | Active NeighborInfo request | Engine actively requests `NeighborInfo` at dwell start and mid-dwell via `radioController.requestNeighborInfo()`. Original spec mentioned only passive collection. | `DiscoveryScanEngine.kt` |
 | Deprecated preset filtering | `VERY_LONG_SLOW` and `LONG_SLOW` presets hidden from picker per meshtastic/design standards deprecation. | `PresetPickerCard.kt` |


### PR DESCRIPTION
`DiscoveryScanState.Paused` was declared, rendered, and given a string — and never constructed. `git log --follow` on the file returns exactly one commit, `76847dd63` (#5275), which added all three in one go. It was born dead, not orphaned by a later removal.

The spec row that justified it was false the day it shipped. `specs/20260507-161658-local-mesh-discovery/spec.md:426` claimed Paused "provides a recoverable grace period during BLE reconnect before transitioning to Failed". The same commit implemented `Reconnecting` as that grace period — `RECONNECT_TIMEOUT_MS = 60_000`, then `pauseAndAbort(persistPartialDwell = true)` → `Analysis` → `Complete(Failed)`, persisting the partial dwell and restoring the home preset. `DiscoveryScanEngineTest.reconnectTimeoutAbortsRestoresHomePresetAndFinalizesSession` already pins that path, so nothing here hides a gap.

A reachable Paused would have been worse than none: no resume entry point exists anywhere in the module, so it would have been an inescapable dead end.

Removed the variant, its render branch, the `discovery_paused` string, the README side-path mention, and the false spec row. Rewrote the state-diagram KDoc to the transitions the engine actually publishes. `DiscoveryScanState` is confined to `feature/discovery`, is not `@Serializable`, and is not persisted; its one exhaustive `when` is the renderer, so the compiler pins the removal.

Crowdin prunes the locale copies of `discovery_paused` on its next sync, matching `657592ebe`, `431f78c4e` and `37e8649ae`.

**Follow-up, not fixed here:** `DiscoveryScanState.Restoring` is a second born-dead variant, rendered at `DiscoveryScanScreen.kt:485` and never constructed — the home-preset restore happens inside `DiscoveryTerminalCoordinator` without publishing a state. The corrected diagram therefore no longer mentions it even though the variant remains declared.

`spotlessCheck detekt :feature:discovery:jvmTest` pass, 155 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the paused state from discovery scan progress.
  * Discovery failures now proceed through analysis to a failed result, while cancellations complete as cancelled.
  * Updated the discovery documentation and implementation status to reflect the revised scan lifecycle.
  * Removed the paused-status message from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->