### PR TITLE
fix(firmware): hide USB maintenance where the platform cannot run it

### DIFF
--- a/docs/en/user/desktop.md
+++ b/docs/en/user/desktop.md
@@ -141,8 +141,8 @@ Requirements:
   in the browser and use the planner's GeoJSON export, then add the file as a layer — not the KML
   export, which is a ground-overlay image this map cannot draw. Custom network tile sources work
   too — see [Map & Waypoints](map-and-waypoints#adding-your-own-tile-source)
-- The USB maintenance flow — nRF52/RP2040 factory erase and bootloader upgrade — is Android-only. The
-  desktop app still shows the option, but it cannot complete there
+- The USB maintenance flow — nRF52/RP2040 factory erase and bootloader upgrade — is Android-only, and the
+  desktop app does not offer it. Use the [Web Flasher](https://flasher.meshtastic.org) instead
 - Some Android-specific features (widgets, specific notification channels) are unavailable
 - Performance may vary on low-spec hardware running Compose Desktop
 - BLE bonding is not yet supported on desktop (pairing works without bonding)

--- a/docs/en/user/firmware.md
+++ b/docs/en/user/firmware.md
@@ -46,7 +46,7 @@ Where the app offers it, an **Erase device during update** checkbox appears next
 | BLE / Wi-Fi OTA | Factory-resets the device once the update is verified. All settings and Bluetooth pairing are removed. |
 | USB | Wipes the device's flash completely, then installs the selected firmware from scratch. |
 
-It is not offered for a local firmware file, during a recovery update, or on USB devices whose board does not support the erase step. Afterwards the device needs setting up — and pairing — again.
+It is not offered for a local firmware file, during a recovery update, on USB devices whose board does not support the erase step, or over USB in the desktop app — the USB erase runs the Android-only maintenance sequence below. Afterwards the device needs setting up — and pairing — again.
 
 ### OTA via Wi-Fi (network-connected ESP32)
 
@@ -67,6 +67,8 @@ When your radio is connected over **USB/serial** (rather than Bluetooth), the Fi
 ### Factory Erase and Bootloader Upgrade
 
 On a **USB/serial** connection, nRF52 and RP2040 devices can be wiped as part of an update — that is the **Erase device during update** opt-in described earlier on this page. nRF52 devices additionally offer **Upgrade bootloader** where an upgraded bootloader is published for the board; RP2040 devices run no Adafruit bootloader, so they never see it.
+
+Both are Android-only. They depend on Android's update-drive checks, so the desktop app does not show them — use the [Web Flasher](https://flasher.meshtastic.org) there instead.
 
 Select a firmware version before either one: the app hides both until a release is chosen, because the firmware is reinstalled after the device is wiped or the new bootloader is written.
 

--- a/feature/firmware/src/androidMain/kotlin/org/meshtastic/feature/firmware/AndroidFirmwareUsbManager.kt
+++ b/feature/firmware/src/androidMain/kotlin/org/meshtastic/feature/firmware/AndroidFirmwareUsbManager.kt
@@ -39,6 +39,8 @@ import org.meshtastic.core.network.repository.UsbRepository
 class AndroidFirmwareUsbManager(private val context: Context, private val usbRepository: UsbRepository) :
     FirmwareUsbManager {
 
+    override val supportsUf2Maintenance: Boolean = true
+
     override suspend fun serialPortKeys(): Set<String> = usbRepository.serialDevices.value.keys
 
     @Suppress("ReturnCount") // each failed precondition must abort without poking an arbitrary port

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -306,6 +306,7 @@ class FirmwareUpdateViewModel(
                                     hardware = deviceHardware,
                                     updateMethod = firmwareUpdateMethod,
                                     hasRelease = release != null,
+                                    platformSupportsMaintenance = usbManager.supportsUf2Maintenance,
                                 ),
                             )
                     }

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUsbManager.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUsbManager.kt
@@ -19,6 +19,17 @@ package org.meshtastic.feature.firmware
 import kotlinx.coroutines.flow.Flow
 
 interface FirmwareUsbManager {
+    /**
+     * Whether this platform can run the multi-pass UF2 maintenance sequence (factory erase, OTAFIX bootloader upgrade)
+     * at all.
+     *
+     * Android only today: the sequence needs a mounted bootloader volume the platform can classify as removable
+     * (`FirmwareFileHandler.isRemovableDestination`) and a CDC port it can unblock ([unblockCdcPort]) to start the
+     * erase, and desktop has neither. Carried here rather than as an `expect val` so the capability stays injectable —
+     * the JVM target is both the desktop platform and the host these ViewModel tests run on.
+     */
+    val supportsUf2Maintenance: Boolean
+
     fun deviceDetachFlow(): Flow<Unit>
 
     /**

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/UsbMaintenance.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/UsbMaintenance.kt
@@ -159,15 +159,19 @@ data class UsbMaintenanceGate(
  *
  * @param hasRelease Whether a firmware release is selected. Erasing without one would strand the device with no
  *   application, so the whole section is hidden.
+ * @param platformSupportsMaintenance Whether this platform can run the sequence at all
+ *   ([FirmwareUsbManager.supportsUf2Maintenance]). Hidden rather than refused: a platform with no UF2 maintenance flow
+ *   is shaped like the wrong transport, not like data the user could go and fix.
  */
 internal fun usbMaintenanceGate(
     manifest: MaintenanceUf2Manifest,
     hardware: DeviceHardware,
     updateMethod: FirmwareUpdateMethod,
     hasRelease: Boolean,
+    platformSupportsMaintenance: Boolean,
 ): UsbMaintenanceGate {
     val uf2Architecture = hardware.isNrf52Arc || hardware.isRp2040Arc
-    if (updateMethod !is FirmwareUpdateMethod.Usb || !uf2Architecture || !hasRelease) {
+    if (!platformSupportsMaintenance || updateMethod !is FirmwareUpdateMethod.Usb || !uf2Architecture || !hasRelease) {
         return UsbMaintenanceGate(show = false)
     }
 

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/UsbMaintenanceGateTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/UsbMaintenanceGateTest.kt
@@ -165,11 +165,24 @@ class UsbMaintenanceGateTest {
     private fun esp32() =
         DeviceHardware(hwModelSlug = "HELTEC_V3", platformioTarget = "heltec-v3", architecture = "esp32-s3")
 
+    /**
+     * Calls the gate on a platform that can run the sequence, which is what every scenario below is about.
+     * [supportsMaintenance] is spelled out only where the platform itself is the subject — the real function takes it
+     * undefaulted so no production call site can forget it.
+     */
+    private fun maintenanceGate(
+        manifest: MaintenanceUf2Manifest,
+        hardware: DeviceHardware,
+        updateMethod: FirmwareUpdateMethod,
+        hasRelease: Boolean,
+        supportsMaintenance: Boolean = true,
+    ) = usbMaintenanceGate(manifest, hardware, updateMethod, hasRelease, supportsMaintenance)
+
     // ── Architecture and transport gating (R11) ──────────────────────────────
 
     @Test
     fun `gate is shown for nrf52840 over usb with a release`() {
-        val gate = usbMaintenanceGate(testManifest, nrf(), FirmwareUpdateMethod.Usb, hasRelease = true)
+        val gate = maintenanceGate(testManifest, nrf(), FirmwareUpdateMethod.Usb, hasRelease = true)
 
         assertTrue(gate.show, "nRF52840 over USB should offer maintenance")
         assertNull(gate.eraseRefusal, "A resolved SoftDevice must not refuse")
@@ -177,7 +190,7 @@ class UsbMaintenanceGateTest {
 
     @Test
     fun `gate is shown for rp2040 over usb and never refuses on softdevice`() {
-        val gate = usbMaintenanceGate(testManifest, rp2040(), FirmwareUpdateMethod.Usb, hasRelease = true)
+        val gate = maintenanceGate(testManifest, rp2040(), FirmwareUpdateMethod.Usb, hasRelease = true)
 
         assertTrue(gate.show, "RP2040 over USB should offer maintenance")
         assertNull(gate.eraseRefusal, "RP2040 has no SoftDevice to resolve")
@@ -211,7 +224,7 @@ class UsbMaintenanceGateTest {
         assertNull(eraseUf2For(hostile, nrf()), "A traversal fileName must resolve to null, not throw")
         assertNull(eraseUf2For(hostile, rp2040()), "A separator in fileName must resolve to null, not throw")
 
-        val gate = usbMaintenanceGate(hostile, rp2040(), FirmwareUpdateMethod.Usb, hasRelease = true)
+        val gate = maintenanceGate(hostile, rp2040(), FirmwareUpdateMethod.Usb, hasRelease = true)
         assertEquals(UsbMaintenanceRefusal.MaintenanceDataUnavailable, gate.eraseRefusal)
     }
 
@@ -244,21 +257,21 @@ class UsbMaintenanceGateTest {
     fun `rp2040 with no erase data reports missing data rather than unsupported architecture`() {
         val empty = MaintenanceUf2Manifest()
 
-        val gate = usbMaintenanceGate(empty, rp2040(), FirmwareUpdateMethod.Usb, hasRelease = true)
+        val gate = maintenanceGate(empty, rp2040(), FirmwareUpdateMethod.Usb, hasRelease = true)
 
         assertEquals(UsbMaintenanceRefusal.MaintenanceDataUnavailable, gate.eraseRefusal)
     }
 
     @Test
     fun `gate is hidden for esp32 even over usb`() {
-        assertFalse(usbMaintenanceGate(testManifest, esp32(), FirmwareUpdateMethod.Usb, hasRelease = true).show)
+        assertFalse(maintenanceGate(testManifest, esp32(), FirmwareUpdateMethod.Usb, hasRelease = true).show)
     }
 
     @Test
     fun `gate is hidden for every non-usb transport`() {
         listOf(FirmwareUpdateMethod.Ble, FirmwareUpdateMethod.Wifi, FirmwareUpdateMethod.Unknown).forEach { method ->
             assertFalse(
-                usbMaintenanceGate(testManifest, nrf(), method, hasRelease = true).show,
+                maintenanceGate(testManifest, nrf(), method, hasRelease = true).show,
                 "Maintenance must not be offered over $method — the flow needs the UF2 mass-storage drive",
             )
         }
@@ -266,14 +279,35 @@ class UsbMaintenanceGateTest {
 
     @Test
     fun `gate is hidden without a release because there would be nothing to reflash`() {
-        assertFalse(usbMaintenanceGate(testManifest, nrf(), FirmwareUpdateMethod.Usb, hasRelease = false).show)
+        assertFalse(maintenanceGate(testManifest, nrf(), FirmwareUpdateMethod.Usb, hasRelease = false).show)
+    }
+
+    /**
+     * Desktop has no UF2 maintenance flow: it cannot classify a bootloader volume and cannot unblock the CDC port the
+     * erase image waits on. Offering the section there ends in a refusal the user can do nothing about, so an otherwise
+     * fully eligible device must still hide it.
+     */
+    @Test
+    fun `gate is hidden on a platform that cannot run the sequence`() {
+        val gate =
+            maintenanceGate(
+                testManifest,
+                nrf(),
+                FirmwareUpdateMethod.Usb,
+                hasRelease = true,
+                supportsMaintenance = false,
+            )
+
+        assertFalse(gate.show, "A platform with no maintenance flow must hide the section rather than refuse it")
+        assertNull(gate.eraseRefusal, "Platform incapability is not a refusal the user can act on")
+        assertFalse(gate.showBootloaderUpgrade, "OTAFIX needs the same sequence")
     }
 
     // ── Fail-closed SoftDevice refusal (R4) ──────────────────────────────────
 
     @Test
     fun `unresolved softdevice shows the action but refuses it`() {
-        val gate = usbMaintenanceGate(testManifest, nrf(variant = null), FirmwareUpdateMethod.Usb, hasRelease = true)
+        val gate = maintenanceGate(testManifest, nrf(variant = null), FirmwareUpdateMethod.Usb, hasRelease = true)
 
         assertTrue(gate.show, "The action stays visible so the refusal can be explained")
         assertEquals(UsbMaintenanceRefusal.UnknownSoftDevice, gate.eraseRefusal)
@@ -320,11 +354,11 @@ class UsbMaintenanceGateTest {
     @Test
     fun `otafix is offered only for supported targets`() {
         assertTrue(
-            usbMaintenanceGate(testManifest, nrf(target = "rak4631"), FirmwareUpdateMethod.Usb, hasRelease = true)
+            maintenanceGate(testManifest, nrf(target = "rak4631"), FirmwareUpdateMethod.Usb, hasRelease = true)
                 .showBootloaderUpgrade,
         )
         assertTrue(
-            usbMaintenanceGate(
+            maintenanceGate(
                 testManifest,
                 nrf(target = "heltec-mesh-node-t114"),
                 FirmwareUpdateMethod.Usb,
@@ -349,7 +383,7 @@ class UsbMaintenanceGateTest {
         )
             .forEach { target ->
                 assertFalse(
-                    usbMaintenanceGate(testManifest, nrf(target = target), FirmwareUpdateMethod.Usb, hasRelease = true)
+                    maintenanceGate(testManifest, nrf(target = target), FirmwareUpdateMethod.Usb, hasRelease = true)
                         .showBootloaderUpgrade,
                     "$target is not an OTAFIX-supported product",
                 )

--- a/feature/firmware/src/jvmMain/kotlin/org/meshtastic/feature/firmware/DesktopFirmwareUsbManager.kt
+++ b/feature/firmware/src/jvmMain/kotlin/org/meshtastic/feature/firmware/DesktopFirmwareUsbManager.kt
@@ -24,7 +24,9 @@ import org.koin.core.annotation.Single
 class DesktopFirmwareUsbManager : FirmwareUsbManager {
     /**
      * Desktop offers no maintenance affordance at all: with no way to vet a bootloader volume and no CDC unblock, every
-     * path below refuses, so the section is hidden rather than shown and then dead-ended.
+     * maintenance operation below is a no-op, so the section is hidden rather than shown and then dead-ended.
+     * [ensureSerialPermission] is the exception — desktop serial access has no permission model, so preflighting it
+     * succeeds trivially.
      */
     override val supportsUf2Maintenance: Boolean = false
 

--- a/feature/firmware/src/jvmMain/kotlin/org/meshtastic/feature/firmware/DesktopFirmwareUsbManager.kt
+++ b/feature/firmware/src/jvmMain/kotlin/org/meshtastic/feature/firmware/DesktopFirmwareUsbManager.kt
@@ -22,6 +22,12 @@ import org.koin.core.annotation.Single
 
 @Single
 class DesktopFirmwareUsbManager : FirmwareUsbManager {
+    /**
+     * Desktop offers no maintenance affordance at all: with no way to vet a bootloader volume and no CDC unblock, every
+     * path below refuses, so the section is hidden rather than shown and then dead-ended.
+     */
+    override val supportsUf2Maintenance: Boolean = false
+
     override fun deviceDetachFlow(): Flow<Unit> = emptyFlow()
 
     /**

--- a/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
+++ b/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModelFileTest.kt
@@ -146,6 +146,10 @@ class FirmwareUpdateViewModelFileTest {
             )
         nodeRepository.setOurNode(node)
 
+        // These run on the JVM host but describe the Android platform, the only one with a UF2 maintenance flow;
+        // the desktop answer is pinned by its own test below rather than inherited from the host.
+        every { usbManager.supportsUf2Maintenance } returns true
+
         every { fileHandler.cleanupAllTemporaryFiles() } returns Unit
         everySuspend { fileHandler.deleteFile(any()) } returns Unit
         everySuspend { fileHandler.getDisplayName(any()) } calls { (it.args[0] as CommonUri).pathSegments.lastOrNull() }
@@ -820,6 +824,23 @@ class FirmwareUpdateViewModelFileTest {
         val ready = assertIs<FirmwareUpdateState.Ready>(viewModel.state.value)
         assertTrue(ready.maintenance.show, "the action stays visible so the refusal can be explained")
         assertEquals(UsbMaintenanceRefusal.UnknownSoftDevice, ready.maintenance.eraseRefusal)
+    }
+
+    @Test
+    fun `maintenance is hidden on a platform with no maintenance flow`() = runTest {
+        // Desktop: serial connects and reports USB, but nothing downstream can vet a bootloader volume, so the
+        // section must never compose there.
+        every { usbManager.supportsUf2Maintenance } returns false
+        every { radioPrefs.devAddr } returns MutableStateFlow("s/dev/ttyUSB0")
+        everySuspend { deviceHardwareRepository.getDeviceHardwareByModel(any(), any(), any()) } returns
+            Result.success(nrfHardware(SoftDeviceVariant.S140_6_1_1))
+
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val ready = assertIs<FirmwareUpdateState.Ready>(viewModel.state.value)
+        assertFalse(ready.maintenance.show, "the ViewModel must consult the platform, not just the manifest")
+        assertFalse(ready.maintenance.showBootloaderUpgrade)
     }
 
     @Test


### PR DESCRIPTION
Desktop has a real serial transport, so `radioPrefs.isSerial()` gave `FirmwareUpdateMethod.Usb` and `usbMaintenanceGate` returned `show = true` on JVM. Every route out is stubbed: `JvmFirmwareFileHandler.isRemovableDestination` returns `false` unconditionally, and `DesktopFirmwareUsbManager` returns `emptySet()` / `false` for port enumeration and CDC unblock. A desktop user got the maintenance section, picked a drive, and was refused with `DestinationNotRemovable` every time.

`FirmwareUsbManager` gains `supportsUf2Maintenance` — `true` on Android, `false` on Desktop — threaded into the gate as an **undefaulted** parameter so no future call site can inherit the bug. Platform incapability folds into the existing early `return UsbMaintenanceGate(show = false)`: hidden like the wrong transport, not refused like missing data.

Chosen over the repo's other idiom (`internal expect val` + defaulted parameter, as in `KablePlatformSetup.supportsNativeAddressScanFilter`) for two reasons. The jvm target is both the desktop platform *and* the test host, so `FirmwareUpdateViewModelFileTest` asserts `maintenance.show == true` for nRF-over-USB on the JVM — a compile-time constant makes that untestable. And `feature/firmware` has no `iosMain`, so an `expect val` would force one onto a module with zero iOS presence.

`FirmwareUsbManager` already is this module's platform boundary; its desktop impl and `JvmFirmwareFileHandler` both document "maintenance is Android-only". This makes that decidable instead of discoverable-by-failure.

**Collateral, intended:** `wipeOffer` keys the USB "Erase device during update" checkbox on `maintenance.show`, so it also disappears on desktop — correct, because over USB that toggle *is* the maintenance erase sequence. BLE/Wi-Fi wipe, the plain USB `.uf2` update, and the whole Android flow are untouched.

Constitution VI: `firmware.md` and `desktop.md` updated. `desktop.md` previously said the desktop app "still shows the option, but it cannot complete there" — true before this PR, false after.

Tests: `UsbMaintenanceGateTest` gains the platform case; the 11 existing call sites go through a test-local helper defaulting the capability to `true`. `FirmwareUpdateViewModelFileTest` pins that the ViewModel actually consults the manager. `spotlessCheck detekt :feature:firmware:jvmTest :feature:firmware:testAndroidHostTest` pass on the rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - USB maintenance options are now hidden on desktop when the Android-only factory erase and bootloader upgrade flow is unavailable.
  - Desktop users are directed to the Web Flasher for these maintenance operations.
  - Android continues to support the USB maintenance sequence.

- **Documentation**
  - Updated firmware and desktop guidance to clarify platform availability and erase-during-update limitations.

- **Tests**
  - Added coverage confirming maintenance options remain hidden when unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->