### PR TITLE
ci(docs): gate frontmatter aliases against DocBundleLoader, map wifi-provision

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - "docs/en/**"
       - "feature/docs/src/commonMain/kotlin/org/meshtastic/feature/docs/data/DocBundleLoader.kt"
+      - "scripts/check-doc-aliases.js"
       - "scripts/check-doc-coverage.js"
       - "scripts/check-doc-freshness.js"
       - "scripts/validate-doc-links.js"
@@ -94,6 +95,13 @@ jobs:
             exit 1
           fi
           echo "DocBundleLoader and docs/en/ agree in both directions."
+
+      - name: Check alias registration
+        # The registry check above proves a page is reachable; this proves it is findable.
+        # Only DocBundleLoader's alias list reaches the app — the frontmatter one is stripped
+        # before render and stripped again by sync-android-docs.js — so an alias authored in
+        # frontmatter and never registered is a search term no consumer ever sees.
+        run: node scripts/check-doc-aliases.js .
 
       - name: Check doc freshness
         # Advisory, as it always was: a page being old is a prompt to look, not a defect.

--- a/.skills/speckit/SKILL.md
+++ b/.skills/speckit/SKILL.md
@@ -108,7 +108,7 @@ specs/
 The project constitution at `.specify/memory/constitution.md` defines non-negotiable principles.
 All specs, plans, and tasks are validated against it during `/speckit.analyze`.
 
-Current constitution (v1.3.5) enforces 7 principles:
+Current constitution (v1.3.6) enforces 7 principles:
 
 1. **KMP Core** — Business logic in `commonMain` only
 2. **Zero Lint Tolerance** — `spotlessCheck` + `detekt` must pass

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,20 @@
 <!--
 SYNC IMPACT REPORT
 ==================
+Version change: 1.3.5 → 1.3.6
+Modified principles:
+  - VI. Documentation Freshness: the verification-tooling block gains
+    scripts/check-doc-aliases.js, a fourth check and the third blocking one. Every page
+    carries an `aliases:` frontmatter list and DocBundleLoader.kt carries its own alias
+    list per page; only the loader's copy reaches a running app (the in-app renderer
+    strips frontmatter before render, and sync-android-docs.js discards aliases for
+    Docusaurus), so a frontmatter-only alias is a search term no consumer ever sees.
+    Nothing compared the two and six pages had silently drifted. The check requires the
+    loader to be a superset of the frontmatter, not equal to it: loader-only aliases are
+    deliberate extra search vocabulary and are reported as non-fatal notes.
+Modified sections: None.
+Added sections: None.
+
 Version change: 1.3.4 → 1.3.5
 Modified principles:
   - VI. Documentation Freshness: (1) image references — the rule said root-relative
@@ -249,4 +263,4 @@ summary derived from this constitution. The files `.github/copilot-instructions.
 Constitution Check confirming all seven principles were evaluated. Complexity violations
 require explicit justification in the Complexity Tracking table of the plan document.
 
-**Version**: 1.3.5 | **Ratified**: 2026-05-07 | **Last Amended**: 2026-08-29
+**Version**: 1.3.6 | **Ratified**: 2026-05-07 | **Last Amended**: 2026-08-30

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -158,13 +158,14 @@ Governance rules:
   means deleting its locale copies in the same commit.
 
 Verification tooling — also enforced in CI: `.github/workflows/docs-quality.yml` runs the
-link check, the coverage check, and a two-way `DocBundleLoader.kt` registry check as a
-**blocking** gate on PRs touching `docs/en/**` (freshness stays advisory). Run locally
-before pushing docs changes:
+link check, the coverage check, a two-way `DocBundleLoader.kt` registry check, and the alias
+registration check as a **blocking** gate on PRs touching `docs/en/**` (freshness stays
+advisory). Run locally before pushing docs changes:
 
 ```bash
 node scripts/check-doc-coverage.js    # every user-facing feature module has a page
 node scripts/validate-doc-links.js    # internal cross-references and image paths resolve
+node scripts/check-doc-aliases.js     # frontmatter aliases are registered in DocBundleLoader.kt
 node scripts/check-doc-freshness.js   # advisory: pages >180 days old, or missing last_updated
 ```
 <!-- Rationale: Documentation drift misleads users and increases support burden. Three distinct consumers means changes must be verified across all delivery channels. -->

--- a/docs/en/developer/documentation-style.md
+++ b/docs/en/developer/documentation-style.md
@@ -2,7 +2,7 @@
 title: Documentation Style
 parent: Developer Guide
 nav_order: 11
-last_updated: 2026-08-29
+last_updated: 2026-08-30
 description: House style for the user and developer docs — voice, wording, formatting, page structure, and the decisions behind them.
 aliases:
   - style
@@ -152,7 +152,7 @@ Where this guide deviates from the external guides it synthesizes, the deviation
 2. Register the page in `feature/docs/.../data/DocBundleLoader.kt` with keywords and aliases.
 3. Put screenshots in `docs/assets/screenshots/`, referenced per IMG-1.
 4. Add a *What's New* entry (STRUCT-6).
-5. Validate locally: `node scripts/validate-doc-links.js docs/en`, `node scripts/check-doc-coverage.js .`, and the docs bundle Gradle checks in [Contributing](contributing).
+5. Validate locally: `node scripts/validate-doc-links.js docs/en`, `node scripts/check-doc-coverage.js .`, `node scripts/check-doc-aliases.js .` (every alias in step 1's frontmatter must also be in step 2's loader entry — only the loader's list reaches in-app search), and the docs bundle Gradle checks in [Contributing](contributing).
 
 ## Related Topics
 

--- a/scripts/check-doc-aliases.js
+++ b/scripts/check-doc-aliases.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// scripts/check-doc-aliases.js
+// Checks that every alias a page declares in frontmatter is also carried by that page's
+// entry in DocBundleLoader.kt, the in-app docs index.
+// Exit 0 = every authored alias is registered, Exit 1 = drift found.
+//
+// Contract: the loader MUST be a superset of the frontmatter, not identical to it.
+// Only the loader's list reaches the running app — DefaultDocBundleLoader.stripFrontmatter()
+// discards the frontmatter before the markdown is rendered, and KeywordSearchEngine scores
+// against DocPage.aliases, which comes from the loader. sync-android-docs.js strips aliases
+// for Docusaurus too, so an alias that exists only in frontmatter is a search term the author
+// wrote and no consumer ever sees — the drift this check exists to catch. The reverse is
+// harmless: an extra loader alias is extra search vocabulary for a page that already owns it,
+// and several are deliberate (signal-meter keeps "signal-quality"/"signal-strength", translate
+// keeps "language"/"i18n"/"contribute"). Demanding equality would make those permanently red.
+//
+// Usage: node scripts/check-doc-aliases.js [repo-root]
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { parseFrontmatter, parseListField, forEachDocPage } = require("./lib/frontmatter");
+
+const REPO_ROOT = path.resolve(process.argv[2] || ".");
+const DOCS_DIR = path.join(REPO_ROOT, "docs", "en");
+const LOADER_REL = path.join(
+    "feature", "docs", "src", "commonMain", "kotlin", "org", "meshtastic", "feature", "docs", "data",
+    "DocBundleLoader.kt",
+);
+const LOADER_PATH = path.join(REPO_ROOT, LOADER_REL);
+
+// A page entry in the loader is anchored on its resourcePath literal. User entries
+// (UserPageDef) carry one list — the aliases; their keywords come from a string resource.
+// Developer entries (KeywordIndexEntry) carry two — keywords first, then aliases.
+const ALIAS_LIST_INDEX = { user: 0, developer: 1 };
+const EXPECTED_LISTS = { user: 1, developer: 2 };
+
+/** Extract the string literals of each listOf(...)/emptyList() group in a slice of Kotlin. */
+function parseListGroups(source) {
+    const groups = [];
+    const openRe = /\b(listOf|emptyList)\s*\(/g;
+    let match;
+
+    while ((match = openRe.exec(source)) !== null) {
+        if (match[1] === "emptyList") {
+            groups.push([]);
+            continue;
+        }
+
+        // Walk forward from the opening paren, string-aware, to find its partner.
+        let depth = 1;
+        let i = openRe.lastIndex;
+        let inString = false;
+        while (i < source.length && depth > 0) {
+            const ch = source[i];
+            if (inString) {
+                if (ch === "\\") i++;
+                else if (ch === '"') inString = false;
+            } else if (ch === '"') {
+                inString = true;
+            } else if (ch === "(") {
+                depth++;
+            } else if (ch === ")") {
+                depth--;
+            }
+            i++;
+        }
+
+        const inner = source.slice(openRe.lastIndex, i - 1);
+        groups.push([...inner.matchAll(/"([^"\\]*)"/g)].map(m => m[1]));
+        openRe.lastIndex = i;
+    }
+
+    return groups;
+}
+
+/** Slice out the constructor call that encloses `index`, parens balanced. */
+function enclosingEntry(source, index) {
+    const ctorRe = /\b(UserPageDef|KeywordIndexEntry)\s*\(/g;
+    let open = -1;
+    let match;
+    while ((match = ctorRe.exec(source)) !== null && match.index < index) {
+        open = ctorRe.lastIndex;
+    }
+    if (open < 0) return null;
+
+    let depth = 1;
+    let i = open;
+    let inString = false;
+    while (i < source.length && depth > 0) {
+        const ch = source[i];
+        if (inString) {
+            if (ch === "\\") i++;
+            else if (ch === '"') inString = false;
+        } else if (ch === '"') {
+            inString = true;
+        } else if (ch === "(") {
+            depth++;
+        } else if (ch === ")") {
+            depth--;
+        }
+        i++;
+    }
+    return i > index ? source.slice(open, i - 1) : null;
+}
+
+/** Map "user/nodes" -> { section, slug, lists } for every page registered in DocBundleLoader.kt. */
+function parseLoaderEntries(source) {
+    const anchorRe = /"en\/(user|developer)\/([a-z0-9-]+)\.html"/g;
+    const entries = new Map();
+
+    for (const anchor of source.matchAll(anchorRe)) {
+        const [, section, slug] = anchor;
+        const body = enclosingEntry(source, anchor.index);
+        entries.set(`${section}/${slug}`, { section, slug, lists: body ? parseListGroups(body) : [] });
+    }
+
+    return entries;
+}
+
+if (!fs.existsSync(LOADER_PATH)) {
+    console.log(`ERROR: ${LOADER_REL} not found under ${REPO_ROOT}.`);
+    process.exit(1);
+}
+
+const loaderEntries = parseLoaderEntries(fs.readFileSync(LOADER_PATH, "utf-8"));
+
+console.log(`Checking frontmatter aliases against ${loaderEntries.size} DocBundleLoader entries...`);
+console.log("");
+
+let errors = 0;
+let extras = 0;
+let checked = 0;
+
+forEachDocPage(DOCS_DIR, (filePath, slug, section) => {
+    const relPath = path.relative(REPO_ROOT, filePath);
+    const { raw } = parseFrontmatter(fs.readFileSync(filePath, "utf-8"));
+    const declared = parseListField(raw, "aliases");
+
+    const entry = loaderEntries.get(`${section}/${slug}`);
+    if (!entry) {
+        console.log(
+            `::error file=${relPath}::no DocBundleLoader.kt entry for '${section}/${slug}', ` +
+            `so its ${declared.length} frontmatter alias(es) are not searchable in the app.`,
+        );
+        errors++;
+        return;
+    }
+
+    // Guard the shape rather than silently comparing the wrong list: a UserPageDef that grew a
+    // keyword list, or a KeywordIndexEntry that lost one, would otherwise pass while checking
+    // keywords against aliases.
+    if (entry.lists.length !== EXPECTED_LISTS[section]) {
+        console.log(
+            `::error file=${LOADER_REL}::entry '${section}/${slug}' has ${entry.lists.length} ` +
+            `list(s); expected ${EXPECTED_LISTS[section]}. Update check-doc-aliases.js if the ` +
+            `loader's entry shape changed.`,
+        );
+        errors++;
+        return;
+    }
+
+    checked++;
+    const registered = new Set(entry.lists[ALIAS_LIST_INDEX[section]].map(a => a.toLowerCase()));
+    const missing = declared.filter(a => !registered.has(a.toLowerCase()));
+
+    if (missing.length > 0) {
+        console.log(
+            `::error file=${relPath}::aliases ${missing.map(a => `'${a}'`).join(", ")} are declared ` +
+            `in frontmatter but missing from the DocBundleLoader.kt entry for '${section}/${slug}', ` +
+            `so in-app search will not match them.`,
+        );
+        errors++;
+    }
+
+    const declaredSet = new Set(declared.map(a => a.toLowerCase()));
+    const loaderOnly = [...registered].filter(a => !declaredSet.has(a));
+    if (loaderOnly.length > 0) {
+        console.log(`  note: ${section}/${slug} — loader-only alias(es): ${loaderOnly.join(", ")}`);
+        extras++;
+    }
+});
+
+console.log("");
+console.log(`Compared ${checked} page(s); ${extras} carry loader-only aliases (allowed).`);
+
+if (errors > 0) {
+    console.log(`\nFAILED: ${errors} page(s) whose frontmatter aliases are not registered in DocBundleLoader.kt.`);
+    process.exit(1);
+} else {
+    console.log("PASSED: every frontmatter alias is registered in DocBundleLoader.kt.");
+    process.exit(0);
+}

--- a/scripts/check-doc-coverage.js
+++ b/scripts/check-doc-coverage.js
@@ -17,16 +17,19 @@ const DOCS_DIR = path.join(REPO_ROOT, "docs", "en");
 // Map of feature module directory names to expected doc page slugs.
 // Modules not listed here are considered internal (no user-facing docs required).
 const MODULE_TO_DOCS = {
-    "feature/connections":  { pages: ["connections"], section: "user" },
-    "feature/discovery":    { pages: ["discovery"], section: "user" },
-    "feature/docs":         { pages: [], section: "user", internal: true },
-    "feature/firmware":     { pages: ["firmware"], section: "user" },
-    "feature/intro":        { pages: ["onboarding"], section: "user" },
-    "feature/map":          { pages: ["map-and-waypoints"], section: "user" },
-    "feature/messaging":    { pages: ["messages-and-channels"], section: "user" },
-    "feature/node":         { pages: ["nodes", "node-metrics"], section: "user" },
-    "feature/settings":     { pages: ["settings-radio-user", "settings-module-admin"], section: "user" },
-    "feature/telemetry":    { pages: ["telemetry-and-sensors"], section: "user" },
+    "feature/connections":    { pages: ["connections"], section: "user" },
+    "feature/discovery":      { pages: ["discovery"], section: "user" },
+    "feature/docs":           { pages: [], section: "user", internal: true },
+    "feature/firmware":       { pages: ["firmware"], section: "user" },
+    "feature/intro":          { pages: ["onboarding"], section: "user" },
+    "feature/map":            { pages: ["map-and-waypoints"], section: "user" },
+    "feature/messaging":      { pages: ["messages-and-channels"], section: "user" },
+    "feature/node":           { pages: ["nodes", "node-metrics"], section: "user" },
+    "feature/settings":       { pages: ["settings-radio-user", "settings-module-admin"], section: "user" },
+    "feature/telemetry":      { pages: ["telemetry-and-sensors"], section: "user" },
+    // Wi-Fi Provisioning for mPWRD-OS is a Settings entry point, documented in the
+    // "Wi-Fi provisioning" note of the TCP/IP section of connections.md.
+    "feature/wifi-provision": { pages: ["connections"], section: "user" },
 };
 
 // Collect existing doc pages

--- a/scripts/lib/frontmatter.js
+++ b/scripts/lib/frontmatter.js
@@ -26,6 +26,50 @@ function parseFrontmatter(content) {
     return { fields, body, raw };
 }
 
+/**
+ * Read a YAML list field out of a raw frontmatter block (the `raw` from parseFrontmatter).
+ * `fields` cannot carry these: a block list leaves the key's own line empty.
+ * Handles both the block form used by every page —
+ *     aliases:
+ *       - bluetooth
+ *       - usb
+ * — and the inline form `aliases: [bluetooth, usb]`. Returns [] when the key is absent.
+ */
+function parseListField(rawFrontmatter, key) {
+    const lines = rawFrontmatter.split("\n");
+    const values = [];
+    let inList = false;
+
+    for (const line of lines) {
+        if (!inList) {
+            const head = line.match(new RegExp(`^${key}:\\s*(.*)$`));
+            if (!head) continue;
+
+            const inline = head[1].trim();
+            if (inline.startsWith("[")) {
+                return inline
+                    .replace(/^\[|\]$/g, "")
+                    .split(",")
+                    .map(v => v.trim().replace(/^["']|["']$/g, ""))
+                    .filter(v => v.length > 0);
+            }
+            if (inline.length > 0) return [inline.replace(/^["']|["']$/g, "")];
+            inList = true;
+            continue;
+        }
+
+        const item = line.match(/^\s+-\s+(.*)$/);
+        if (item) {
+            values.push(item[1].trim().replace(/^["']|["']$/g, ""));
+            continue;
+        }
+        // Any non-item line at this point ends the list.
+        if (line.trim().length > 0) break;
+    }
+
+    return values;
+}
+
 /** Discover all .md page slugs under docs/{section}/ */
 function discoverSlugs(docsDir, section) {
     const dir = path.join(docsDir, section);
@@ -48,4 +92,4 @@ function forEachDocPage(docsDir, fn) {
     }
 }
 
-module.exports = { parseFrontmatter, discoverSlugs, forEachDocPage };
+module.exports = { parseFrontmatter, parseListField, discoverSlugs, forEachDocPage };

--- a/scripts/lib/frontmatter.js
+++ b/scripts/lib/frontmatter.js
@@ -47,11 +47,10 @@ function parseListField(rawFrontmatter, key) {
 
             const inline = head[1].trim();
             if (inline.startsWith("[")) {
-                return inline
-                    .replace(/^\[|\]$/g, "")
-                    .split(",")
-                    .map(v => v.trim().replace(/^["']|["']$/g, ""))
-                    .filter(v => v.length > 0);
+                // Split on commas that sit outside quotes: a quoted scalar may legally contain one
+                // (aliases: ["serial, USB"]), and a naive split would report it as two aliases and
+                // then flag phantom drift against DocBundleLoader.
+                return splitInlineList(inline.replace(/^\[|\]$/g, ""));
             }
             if (inline.length > 0) return [inline.replace(/^["']|["']$/g, "")];
             inList = true;
@@ -93,3 +92,28 @@ function forEachDocPage(docsDir, fn) {
 }
 
 module.exports = { parseFrontmatter, parseListField, discoverSlugs, forEachDocPage };
+
+/**
+ * Split the body of an inline YAML flow sequence on top-level commas only, honouring single and
+ * double quotes. Returns trimmed, unquoted, non-empty values.
+ */
+function splitInlineList(body) {
+    const out = [];
+    let cur = "";
+    let quote = null;
+    for (const ch of body) {
+        if (quote) {
+            if (ch === quote) quote = null;
+            else cur += ch;
+        } else if (ch === '"' || ch === "'") {
+            quote = ch;
+        } else if (ch === ",") {
+            out.push(cur);
+            cur = "";
+        } else {
+            cur += ch;
+        }
+    }
+    out.push(cur);
+    return out.map(v => v.trim()).filter(v => v.length > 0);
+}


### PR DESCRIPTION
Every page carries an `aliases:` frontmatter list, and `DocBundleLoader.kt` carries its own alias list per page. Nothing compared them, and six pages had silently drifted — five user pages plus `developer/architecture`, all resynced in #6968.

Only the loader's copy reaches a running app: the in-app renderer strips frontmatter before render, and `sync-android-docs.js` discards aliases for Docusaurus. So a frontmatter-only alias is a search term the author wrote that no consumer ever sees, and the reader searching for it finds nothing.

**Contract: loader ⊇ frontmatter, not equality.** Loader-only aliases are deliberate extra search vocabulary — `signal-meter` carries `signal-quality` and `signal-strength`, `translate` carries `language`, `i18n`, `contribute` — and are reported as non-fatal notes. Requiring equality would hold those permanently red.

`scripts/check-doc-aliases.js` follows the conventions of its three siblings: same CLI shape, same exit codes, `::error file=…::` annotations matching the workflow's inline registry check. The parser is whole-file and paren-balanced, so it handles both single-line and multi-line `listOf(` forms, and it asserts entry shape (user: one list = aliases; developer: two = keywords then aliases) so a reshaped entry fails loudly rather than silently comparing keywords against aliases.

Wired into `docs-quality.yml` as a blocking step. **Passes against current main**, verified after #6968 merged — which is why this PR was held until then.

Also: `feature/wifi-provision` was absent from `check-doc-coverage.js`'s `MODULE_TO_DOCS` map, so the script reported 100% coverage without ever checking it. Added, pointing at `connections`.

Reported, not fixed — same blind-spot class, left for a judgment call: `feature/widget` is unmapped despite `widget.md` existing; `feature/map-maplibre` is unmapped; and a `feature/telemetry` key names a module that does not exist, which `fs.existsSync` skips silently, hiding that `telemetry-and-sensors.md` has no owning module.

Second commit amends the constitution to 1.3.6 per its own amendment procedure — Principle VI enumerates the verification tooling, so a new blocking check makes it stale otherwise. SYNC IMPACT REPORT entry and `.skills/speckit/SKILL.md` updated atomically, following `e3557db16`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation guidance and metadata, including the referenced Constitution version.
  * Added Wi-Fi Provisioning to documentation coverage checks.
  * Clarified alias requirements for in-app search.

* **Quality Checks**
  * Added automated validation to ensure documentation aliases are registered correctly.
  * Improved frontmatter list parsing to support multiple YAML formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->