### PR TITLE
fix(map): resolve the persisted basemap before the map first renders

### DIFF
--- a/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/map/MapPrefsImpl.kt
+++ b/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/map/MapPrefsImpl.kt
@@ -48,6 +48,8 @@ class MapPrefsImpl(private val dataStore: MapDataStore, dispatchers: CoroutineDi
         scope.launch { dataStore.edit { it[KEY_MAP_STYLE_PREF] = style } }
     }
 
+    override suspend fun awaitMapStyle(): Int = dataStore.data.map { it[KEY_MAP_STYLE_PREF] ?: 0 }.first()
+
     override val showOnlyFavorites: StateFlow<Boolean> =
         dataStore.data.map { it[KEY_SHOW_ONLY_FAVORITES_PREF] ?: false }.stateIn(scope, SharingStarted.Eagerly, false)
 

--- a/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/map/MapPrefsImplTest.kt
+++ b/core/prefs/src/commonTest/kotlin/org/meshtastic/core/prefs/map/MapPrefsImplTest.kt
@@ -79,6 +79,13 @@ class MapPrefsImplTest {
     }
 
     @Test
+    fun `map style await sees the persisted value rather than the eager default`() = testScope.runTest {
+        prefs.setMapStyle(3)
+
+        assertEquals(3, prefs.awaitMapStyle())
+    }
+
+    @Test
     fun `layer opacity is absent until a slider is moved`() =
         testScope.runTest { assertEquals(emptySet<String>(), prefs.layerOpacity.value) }
 

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AppPreferences.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AppPreferences.kt
@@ -265,6 +265,16 @@ interface MapPrefs {
 
     fun setMapStyle(style: Int)
 
+    /**
+     * Persisted [mapStyle]; suspends for the first disk load to avoid a cold-start default.
+     *
+     * [mapStyle] is shared eagerly and starts at `0` before the first disk read completes, same as [hiddenLayerUrls]'s
+     * empty-set default. A caller that renders a basemap from the eager value before this resolves can render the wrong
+     * one and then swap moments later — which, for a MapLibre style, means tearing down and rebuilding the whole style
+     * subcomposition out from under sources still attaching to it.
+     */
+    suspend fun awaitMapStyle(): Int
+
     val showOnlyFavorites: StateFlow<Boolean>
 
     fun setShowOnlyFavorites(show: Boolean)

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeAppPreferences.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeAppPreferences.kt
@@ -274,6 +274,8 @@ class FakeMapPrefs : MapPrefs {
         mapStyle.value = style
     }
 
+    override suspend fun awaitMapStyle(): Int = mapStyle.value
+
     override val showOnlyFavorites = MutableStateFlow(false)
 
     override fun setShowOnlyFavorites(show: Boolean) {

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MapLibreMapViewProvider.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MapLibreMapViewProvider.kt
@@ -131,7 +131,8 @@ class MapLibreMapViewProvider(
         sitePlannerNodeNum: Int?,
     ) {
         val viewModel: SharedMapViewModel = koinViewModel()
-        val basemaps = rememberBasemapSelection(customBasemaps())
+        // Null for the one frame before the basemap preference has loaded from disk; see rememberBasemapSelection.
+        val basemaps = rememberBasemapSelection(customBasemaps()) ?: return
 
         val cameraState = rememberCameraState()
         val location = rememberLocationControls(cameraState)

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/NodeTrackMap.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/NodeTrackMap.kt
@@ -103,7 +103,8 @@ fun MapLibreNodeTrackMap(
 
     // The basemap is a shared preference, so a track opens on whatever the main map is set to. The OSMdroid track map
     // resolved the same preference; hardcoding the default meant picking Dark on the main map and getting Liberty here.
-    val basemaps = rememberBasemapSelection(customBasemaps())
+    // Null for the one frame before the preference has loaded from disk; see rememberBasemapSelection.
+    val basemaps = rememberBasemapSelection(customBasemaps()) ?: return
 
     val viewModel: SharedMapViewModel = koinViewModel()
     val filterState by viewModel.mapFilterStateFlow.collectAsStateWithLifecycle()

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/SecondaryMaps.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/SecondaryMaps.kt
@@ -100,7 +100,8 @@ fun MapLibreInlineMap(
     customBasemaps: @Composable () -> List<Basemap.Raster> = { customRasterBasemaps() },
 ) {
     if (node.validPosition == null) return
-    val basemaps = rememberBasemapSelection(customBasemaps())
+    // Null for the one frame before the basemap preference has loaded from disk; see rememberBasemapSelection.
+    val basemaps = rememberBasemapSelection(customBasemaps()) ?: return
     val target = GeoPosition(longitude = node.longitude, latitude = node.latitude)
     val cameraState = rememberCameraState(CameraPosition(target = target, zoom = INLINE_ZOOM))
 
@@ -149,7 +150,8 @@ fun MapLibreTracerouteMap(
     customBasemaps: @Composable () -> List<Basemap.Raster> = { customRasterBasemaps() },
 ) {
     val cameraState = rememberCameraState()
-    val basemaps = rememberBasemapSelection(customBasemaps())
+    // Null for the one frame before the basemap preference has loaded from disk; see rememberBasemapSelection.
+    val basemaps = rememberBasemapSelection(customBasemaps()) ?: return
     val hops = (forwardRoute + returnRoute).distinct().mapNotNull { nodeLookup[it] }
 
     // Keyed on the hops: the route is what this map exists to frame, so a different route should re-frame it. The
@@ -188,7 +190,8 @@ fun MapLibreDiscoveryMap(
 ) {
     val scanner = GeoPosition(longitude = userLongitude, latitude = userLatitude)
     val cameraState = rememberCameraState(CameraPosition(target = scanner, zoom = DETAIL_ZOOM))
-    val basemaps = rememberBasemapSelection(customBasemaps())
+    // Null for the one frame before the basemap preference has loaded from disk; see rememberBasemapSelection.
+    val basemaps = rememberBasemapSelection(customBasemaps()) ?: return
     // The node itself, not its index. The feature carries an index into `located`, which is only meaningful for
     // the composition that built it — a scan that reports another node afterwards renumbers the list, and a held
     // index would then describe somebody else. Resolving at tap time closes that window.

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/BasemapSelection.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/BasemapSelection.kt
@@ -18,6 +18,7 @@ package org.meshtastic.feature.map.maplibre.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -55,15 +56,37 @@ internal class BasemapSelection(
  * Two preferences back this, matching how the Google flavor stores it: an index into the built-in list, and a separate
  * id for a user-defined source. Keeping them apart means a custom source being added or removed cannot silently repoint
  * the built-in selection, which an index over a mixed list would.
+ *
+ * Returns null until both preferences have been read from disk once. [MapPrefs.mapStyle] and
+ * [MapTileProviderPrefs.selectedCustomTileProviderId] are eager StateFlows that start at a hardcoded default (`0`,
+ * `null`) and only take on the persisted value after their first disk read — so a map composed before that read
+ * resolves opens on the default basemap and swaps to the persisted one moments later. That swap is not cosmetic: every
+ * caller hands `current` to `MaplibreMap`'s `baseStyle`, and a changed `baseStyle` unloads the live style synchronously
+ * (maplibre-compose 0.15.0, `MlnFfiMapSession.setBaseStyle`), so map content still attaching its sources to that style
+ * throws "Source ... was not added: its style is no longer loaded" — an error dialog over a dead map. Fast hardware
+ * masks the race, which is why development never saw it: the preference read settles in milliseconds, long before the
+ * style's network fetch completes, so the swap lands while nothing is attached yet. On slow storage the read can land
+ * exactly in the attach window, on every open. Waiting for the persisted values means the map only ever opens with one
+ * style. (The live StateFlows can lag the awaited read by a dispatch, but that catch-up emission carries an equal value
+ * and lands before any style could finish loading and begin attaching, so the gate itself cannot reintroduce the swap.)
  */
 @Composable
-internal fun rememberBasemapSelection(customs: List<Basemap.Raster>): BasemapSelection {
+internal fun rememberBasemapSelection(customs: List<Basemap.Raster>): BasemapSelection? {
     val mapPrefs: MapPrefs = koinInject()
     val tilePrefs: MapTileProviderPrefs = koinInject()
     val scope = rememberCoroutineScope()
 
+    var hasLoaded by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        mapPrefs.awaitMapStyle()
+        tilePrefs.awaitSelectedCustomTileProviderId()
+        hasLoaded = true
+    }
+
     val styleIndex by mapPrefs.mapStyle.collectAsStateWithLifecycle()
     val selectedCustomId by tilePrefs.selectedCustomTileProviderId.collectAsStateWithLifecycle()
+
+    if (!hasLoaded) return null
 
     val current =
         customs.firstOrNull { it.id == selectedCustomId } ?: Basemaps.all.getOrElse(styleIndex) { Basemaps.default }

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/BasemapSelection.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/BasemapSelection.kt
@@ -25,7 +25,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -40,6 +40,9 @@ import org.meshtastic.feature.map.component.BasemapMenu
 import org.meshtastic.feature.map.component.MapButton
 import org.meshtastic.feature.map.maplibre.style.Basemap
 import org.meshtastic.feature.map.maplibre.style.Basemaps
+
+/** A preference value that has been read from disk; distinguishes "not read yet" from a persisted null. */
+private data class Loaded<T>(val value: T)
 
 /** The basemap in use, everything selectable, and how to change it. */
 @Stable
@@ -67,8 +70,9 @@ internal class BasemapSelection(
  * masks the race, which is why development never saw it: the preference read settles in milliseconds, long before the
  * style's network fetch completes, so the swap lands while nothing is attached yet. On slow storage the read can land
  * exactly in the attach window, on every open. Waiting for the persisted values means the map only ever opens with one
- * style. (The live StateFlows can lag the awaited read by a dispatch, but that catch-up emission carries an equal value
- * and lands before any style could finish loading and begin attaching, so the gate itself cannot reintroduce the swap.)
+ * style. (The initial values come from the awaited reads themselves — each live flow's replayed current value is
+ * dropped, since it can still be the default — so the gate cannot open on a value the renderer would immediately swap
+ * away from.)
  */
 @Composable
 internal fun rememberBasemapSelection(customs: List<Basemap.Raster>): BasemapSelection? {
@@ -76,20 +80,30 @@ internal fun rememberBasemapSelection(customs: List<Basemap.Raster>): BasemapSel
     val tilePrefs: MapTileProviderPrefs = koinInject()
     val scope = rememberCoroutineScope()
 
-    var hasLoaded by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        mapPrefs.awaitMapStyle()
-        tilePrefs.awaitSelectedCustomTileProviderId()
-        hasLoaded = true
+    var styleIndex by remember { mutableStateOf<Loaded<Int>?>(null) }
+    var selectedCustomId by remember { mutableStateOf<Loaded<String?>?>(null) }
+
+    // Subscribe before reading, and drop each flow's replayed current value: it can predate the first disk read and
+    // so may still be the eager default. The awaited reads supply the initial values — re-delivering anything a
+    // dropped replay carried — and every later emission is a genuine update that overwrites them. The reads fill only
+    // a still-null slot, so they never clobber a newer collected value. Plain collect rather than a lifecycle-aware
+    // collector: drop(1) must drop only the subscription replay, and a lifecycle restart would re-drop a real value.
+    LaunchedEffect(mapPrefs, tilePrefs) {
+        launch { mapPrefs.mapStyle.drop(1).collect { styleIndex = Loaded(it) } }
+        launch { tilePrefs.selectedCustomTileProviderId.drop(1).collect { selectedCustomId = Loaded(it) } }
+        val style = Loaded(mapPrefs.awaitMapStyle())
+        val custom = Loaded(tilePrefs.awaitSelectedCustomTileProviderId())
+        if (styleIndex == null) styleIndex = style
+        if (selectedCustomId == null) selectedCustomId = custom
     }
 
-    val styleIndex by mapPrefs.mapStyle.collectAsStateWithLifecycle()
-    val selectedCustomId by tilePrefs.selectedCustomTileProviderId.collectAsStateWithLifecycle()
-
-    if (!hasLoaded) return null
+    val loadedStyle = styleIndex
+    val loadedCustom = selectedCustomId
+    if (loadedStyle == null || loadedCustom == null) return null
 
     val current =
-        customs.firstOrNull { it.id == selectedCustomId } ?: Basemaps.all.getOrElse(styleIndex) { Basemaps.default }
+        customs.firstOrNull { it.id == loadedCustom.value }
+            ?: Basemaps.all.getOrElse(loadedStyle.value) { Basemaps.default }
 
     return BasemapSelection(
         current = current,


### PR DESCRIPTION
Testers of the 2026-08-29 snapshot hit an error dialog over a dead map the moment the MapLibre Mesh Map opened (reported on Discord against the desktop snapshot on a Clockwork uConsole, arch64):

> Source '__MAPLIBRE_COMPOSE_source_0' was not added: its style is no longer loaded. Any layer referencing it will fail to attach.

The basemap preferences (`MapPrefs.mapStyle`, `MapTileProviderPrefs.selectedCustomTileProviderId`) are eager `StateFlow`s that start at a hardcoded default and take on the persisted value only after their first disk read. A map composed before that read resolves opens on the default basemap and swaps to the persisted one moments later. That swap is not cosmetic: `MaplibreMap` reacts to a changed `baseStyle` by unloading the live style **synchronously** (maplibre-compose 0.15.0, `MlnFfiMapSession.setBaseStyle`), and map content still attaching its sources to that style throws the error above rather than no-opping.

Fast hardware masks the race, which is why development never saw it: the preference read settles milliseconds after open, long before the style's network fetch completes, so the swap lands while nothing is attached yet. On slow storage the read can land exactly in the attach window — on every open.

### 🐛 Bug Fixes

- `rememberBasemapSelection` now returns null until both basemap preferences have been read from disk once, so the map only ever opens with one style. All five call sites (main map, inline node map, traceroute map, discovery map, node track map) skip composing the map for that first moment.
- Added `MapPrefs.awaitMapStyle()`, following the same await-the-first-disk-load convention as `awaitCameraPosition()` and `awaitHiddenLayerUrls()`; `MapTileProviderPrefs.awaitSelectedCustomTileProviderId()` already existed and is now used.

### Remaining upstream

maplibre-compose 0.15.0's `Source.attach` hard-throws on an unloaded binding that its own `mutate()` documents as "normal for a frame during a style swap", so a manual basemap switch landing in the previous style's attach window can still reach the same check. That will be reported separately against maplibre/maplibre-compose; this PR removes the systematic trigger on our side.

## Testing Performed

- New unit test: `MapPrefsImplTest` — `map style await sees the persisted value rather than the eager default`.
- Full local baseline green on the rebased branch: `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map startup behavior by waiting for saved map and tile preferences to load before rendering.
  * Prevented temporary blank, incorrect, or unstable basemap states during initial map display.
  * Ensured the saved map style is restored reliably, including after cold starts.

* **Tests**
  * Added coverage verifying persisted map styles are returned correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->