### PR TITLE
build(docs): raise the bundle size gate above one translation cycle

### DIFF
--- a/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/DocsTasks.kt
+++ b/build-logic/convention/src/main/kotlin/org/meshtastic/buildlogic/DocsTasks.kt
@@ -35,8 +35,10 @@ private const val DEFAULT_NAV_ORDER = 999
 private const val MIN_KEYWORD_LENGTH = 3
 private const val MAX_KEYWORDS = 30
 private const val BYTES_PER_MB = 1024.0 * 1024.0
-private const val BUNDLE_SIZE_HARD_LIMIT_MB = 10.0
-private const val BUNDLE_SIZE_WARN_THRESHOLD_MB = 8.0
+// Catches accidental bloat, not real content — the bundle only feeds Pages. One corpus-wide
+// English audit adds ~1.9 MB once Crowdin fans it across 42 locales; the gap clears one cycle.
+private const val BUNDLE_SIZE_HARD_LIMIT_MB = 20.0
+private const val BUNDLE_SIZE_WARN_THRESHOLD_MB = 16.0
 private val LOCALE_PATTERN = Regex("^[a-z]{2,3}(-r[A-Z]{2})?$")
 
 /**


### PR DESCRIPTION
The docs deploy has failed on `main` since #6976 — [run 33397000789](https://github.com/meshtastic/Meshtastic-Android/actions/runs/33397000789) and every run after it:

```
Execution failed for task ':validateDocsBundle'.
> Bundle size 10.61 MB exceeds 10.0 MB hard limit
```

## What happened

Not a bad commit. #6976 is the routine Crowdin sync, and it propagated the English user-guide audit (#6968) into all 41 non-English locales — about 45 KB each. Markdown under `docs/` went 8.67 MB → 10.52 MB across that one sync, and the generated bundle went with it.

Last green was 5d5061fc, first red e58bbb46 — the two sides of that sync.

## Why raise it rather than shrink

The gated bundle (`build/generated/docs/common`) only feeds the GitHub Pages site, which has a 1 GB budget. It is not what ships in the APK. So there is no size problem to solve; the tripwire was just set below where normal content growth reaches.

The gate is still worth having — it catches a stray binary or a generator bug duplicating output — and a flat number does that fine. But the old thresholds left 2 MB between warn and hard, and one corpus-wide English change lands ~1.9 MB once Crowdin fans it across 42 locales. The warning could never fire early enough to be a warning. Warn now sits at 16 MB and hard at 20 MB, so a full audit cycle fits between them.

## Verification

```
> Task :validateDocsBundle
Docs bundle validation PASSED: 851 pages, 10.62 MB
```

## Separately

The same sync also grew `feature/docs/src/commonMain/composeResources` to 11 MB. That copy *does* ship in the APK, and it has no size gate at all. Worth a follow-up issue; out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased documentation bundle size limits to support expected growth across locales.
  * Updated warning and hard-limit thresholds for documentation bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->