### PR TITLE
ci: clear the recurring warnings and dead job the workflow logs carry

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -56,7 +56,7 @@ jobs:
           develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: '4.0.6'
           bundler-cache: true

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -86,7 +86,7 @@ jobs:
           develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: '4.0.6'
           bundler-cache: true

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -129,7 +129,7 @@ jobs:
           ref: ${{ inputs.commit_sha || inputs.tag_name }}
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: '4.0.6'
           bundler-cache: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -227,7 +227,10 @@ jobs:
           bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12 /tmp
           /tmp/actionlint -color
       - name: Lint repo shell scripts (shellcheck)
-        run: shellcheck scripts/*.sh
+        # -x so sourced libraries are followed into rather than reported as SC1091, and
+        # find rather than a glob: scripts/*.sh missed scripts/lib/, scripts/docs/ and
+        # scripts/verify-flatpak/ entirely.
+        run: find scripts -name '*.sh' -print0 | xargs -0 shellcheck -x
       - name: Validate store listing metadata lengths
         run: python3 scripts/check-metadata-length.py
       # Compose Multiplatform does not strip Android-style \" / \' escapes, so a

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -231,6 +231,13 @@ jobs:
         # find rather than a glob: scripts/*.sh missed scripts/lib/, scripts/docs/ and
         # scripts/verify-flatpak/ entirely.
         run: find scripts -name '*.sh' -print0 | xargs -0 shellcheck -x
+      # rb-check runs only in the merge queue and needs two release builds, so Step 6's
+      # classification would otherwise ship unexercised. It lives here rather than in
+      # lint-check because it needs no toolchain, and because lint-check sits behind the
+      # `android` path filter — which does not list scripts/, so a PR touching only the
+      # scanner would have skipped its own test.
+      - name: Self-test verify-rb Step 6
+        run: ./scripts/verify-rb-selftest.sh
       - name: Validate store listing metadata lengths
         run: python3 scripts/check-metadata-length.py
       # Compose Multiplatform does not strip Android-style \" / \' escapes, so a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
           echo "$GOOGLE_PLAY_JSON_KEY" > ./fastlane/play-store-credentials.json
 
       - name: Setup Fastlane
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: '4.0.6'
           bundler-cache: true
@@ -239,7 +239,7 @@ jobs:
           echo "$KEYSTORE_PROPERTIES" > ./keystore.properties
 
       - name: Setup Fastlane
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e5517072e87f198d9533967ae13d97c11b604005 # v1.99.0
         with:
           ruby-version: '4.0.6'
           bundler-cache: true

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -89,6 +89,11 @@ jobs:
           filter: 'blob:none'
           submodules: true
 
+      # rb-check runs only in the merge queue and needs two release builds, so its Step 6
+      # classification would otherwise ship unexercised. Needs no toolchain — runs here.
+      - name: Self-test verify-rb Step 6
+        run: ./scripts/verify-rb-selftest.sh
+
       - name: Gradle Setup
         uses: ./.github/actions/gradle-setup
         with:

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -89,11 +89,6 @@ jobs:
           filter: 'blob:none'
           submodules: true
 
-      # rb-check runs only in the merge queue and needs two release builds, so its Step 6
-      # classification would otherwise ship unexercised. Needs no toolchain — runs here.
-      - name: Self-test verify-rb Step 6
-        run: ./scripts/verify-rb-selftest.sh
-
       - name: Gradle Setup
         uses: ./.github/actions/gradle-setup
         with:

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -21,9 +21,6 @@ on:
       run_desktop_builds:
         type: boolean
         default: false
-      run_desktop_flatpak_src:
-        type: boolean
-        default: false
       upload_artifacts:
         type: boolean
         default: true
@@ -427,7 +424,9 @@ jobs:
           files: "desktopApp/build/reports/kover/report*.xml"
 
       - name: Upload shard reports
-        if: ${{ always() && inputs.upload_artifacts }}
+        # !cancelled(), not always(): a shard cancelled before Gradle ran has no
+        # reports, and the upload warns "No files were found" on the way out.
+        if: ${{ !cancelled() && inputs.upload_artifacts }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports-${{ matrix.shard.name }}
@@ -649,56 +648,3 @@ jobs:
             desktopApp/build/compose/binaries/main/*/*.AppImage
           retention-days: 7
           if-no-files-found: error
-
-  # ── Flatpak Sources ───────────────────────────────────────────────────
-  build-flatpak-src:
-    name: Generate Flatpak Sources (${{ matrix.os }})
-    if: inputs.run_desktop_flatpak_src == true
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-      pull-requests: write
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          filter: 'blob:none'
-          submodules: true
-
-      - name: Gradle Setup
-        uses: ./.github/actions/gradle-setup
-        with:
-          gradle_encryption_key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          develocity_access_key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
-          job_summary_pr_comment: ${{ env.GRADLE_PR_COMMENT }}
-          cache_read_only: true
-          install_jetbrains_jdk: 'true'
-
-      # Isolated Gradle user home — see explanation in release.yml.
-      # packageUberJarForCurrentOS is what the in-flatpak build invokes; it resolves the FULL
-      # runtime classpath. :assemble alone would miss runtime-only deps (skiko, ktor-cio, …).
-      - name: Generate Flatpak Sources
-        run: >
-          ./gradlew --no-build-cache
-          -Dgradle.user.home=${{ runner.temp }}/flatpak-gradle-home
-          :desktopApp:packageUberJarForCurrentOS :captureFlatpakSources
-
-      - name: Stage manifest
-        run: cp build/flatpak-sources.json flatpak-sources.json
-
-      - run: ls -lah flatpak-sources.json
-
-      - name: Upload Flatpak Sources
-        if: ${{ inputs.upload_artifacts }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: flatpak-sources-${{ runner.arch }}
-          path: flatpak-sources.json
-          retention-days: 7

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/NodeManagerImplTest.kt
@@ -1010,7 +1010,7 @@ class NodeManagerImplTest {
         assertNull(nodeManager.nodeDBbyNodeNum[oldNum])
         val canonical = nodeManager.nodeDBbyNodeNum[newNum]
         assertNotNull(canonical)
-        assertEquals("Migrated", canonical!!.user.long_name)
+        assertEquals("Migrated", canonical.user.long_name)
         assertEquals(validPk, canonical.publicKey)
         verifyNoRepositoryDeletion()
         verifySuspend(mode = VerifyMode.not) { nodeRepository.upsert(any()) }
@@ -1063,7 +1063,7 @@ class NodeManagerImplTest {
         assertEquals(7, placeholder.channel)
         val canonical = nodeManager.nodeDBbyNodeNum[newNum]
         assertNotNull(canonical)
-        assertEquals("Migrated", canonical!!.user.long_name)
+        assertEquals("Migrated", canonical.user.long_name)
         verifyNoRepositoryDeletion()
         verifySuspend(mode = VerifyMode.not) { nodeRepository.upsert(any()) }
         verifySuspend(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
@@ -1093,11 +1093,11 @@ class NodeManagerImplTest {
 
         val fromNode = nodeManager.nodeDBbyNodeNum[fromNum]
         assertNotNull(fromNode)
-        assertEquals("Established", fromNode!!.user.long_name)
+        assertEquals("Established", fromNode.user.long_name)
         assertEquals(differentPk, fromNode.publicKey)
         val otherNode = nodeManager.nodeDBbyNodeNum[otherNum]
         assertNotNull(otherNode)
-        assertEquals("Other", otherNode!!.user.long_name)
+        assertEquals("Other", otherNode.user.long_name)
         verifyNoRepositoryDeletion()
         verifySuspend(mode = VerifyMode.not) { nodeRepository.upsert(any()) }
         verifySuspend(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
@@ -1233,7 +1233,7 @@ class NodeManagerImplTest {
         assertNull(nodeManager.nodeDBbyNodeNum[otherNum])
         val localNode = nodeManager.nodeDBbyNodeNum[localNum]
         assertNotNull(localNode)
-        assertEquals("Local Node", localNode!!.user.long_name)
+        assertEquals("Local Node", localNode.user.long_name)
         assertEquals(validPk, localNode.publicKey)
         verifyNoRepositoryDeletion()
         verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.upsert(any()) }
@@ -1317,7 +1317,7 @@ class NodeManagerImplTest {
 
         val result = nodeManager.nodeDBbyNodeNum[newNodeNum]
         assertNotNull(result)
-        assertEquals("New Node", result!!.user.long_name)
+        assertEquals("New Node", result.user.long_name)
         assertEquals(newPk, result.publicKey)
         verifyNoRepositoryDeletion()
         verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.upsert(any()) }
@@ -1401,7 +1401,7 @@ class NodeManagerImplTest {
 
         val result = nodeManager.nodeDBbyNodeNum[nodeNum]
         assertNotNull(result)
-        assertEquals("Updated", result!!.user.long_name)
+        assertEquals("Updated", result.user.long_name)
         assertEquals(validPk, result.publicKey)
         verifyNoRepositoryDeletion()
         verifySuspend(mode = VerifyMode.exactly(1)) { nodeRepository.upsert(any()) }
@@ -1526,7 +1526,7 @@ class NodeManagerImplTest {
         assertNull(nodeManager.nodeDBbyNodeNum[oldNum])
         val survivor = nodeManager.getNodeById(sharedUserId)
         assertNotNull(survivor)
-        assertEquals(newNum, survivor!!.num)
+        assertEquals(newNum, survivor.num)
     }
 
     // ── Additional identity reconciliation tests ────────────────────────────────
@@ -1716,7 +1716,7 @@ class NodeManagerImplTest {
         // byId should point to node2 (non-placeholder, lowest among non-placeholders)
         val representative = nodeManager.getNodeById(userId)
         assertNotNull(representative)
-        assertEquals(node2, representative!!.num)
+        assertEquals(node2, representative.num)
     }
 
     // 17. Old-ID survivor restoration after put
@@ -1751,12 +1751,12 @@ class NodeManagerImplTest {
         // byId for oldUserId should now point to survivorNum
         val survivor = nodeManager.getNodeById(oldUserId)
         assertNotNull(survivor)
-        assertEquals(survivorNum, survivor!!.num)
+        assertEquals(survivorNum, survivor.num)
 
         // byId for newUserId should point to nodeNum
         val newNode = nodeManager.getNodeById(newUserId)
         assertNotNull(newNode)
-        assertEquals(nodeNum, newNode!!.num)
+        assertEquals(nodeNum, newNode.num)
     }
 
     // 18. fromByNum insertion-order independence
@@ -1882,7 +1882,7 @@ class NodeManagerImplTest {
         assertNotNull(nodeManager.nodeDBbyNodeNum[preferredNum])
         val representative = nodeManager.getNodeById(userId)
         assertNotNull(representative)
-        assertEquals(preferredNum, representative!!.num)
+        assertEquals(preferredNum, representative.num)
     }
 
     // 20. Accepted local node remains the byId representative
@@ -1916,7 +1916,7 @@ class NodeManagerImplTest {
         assertNotNull(nodeManager.nodeDBbyNodeNum[remoteNum])
         val representative = nodeManager.getNodeById(userId)
         assertNotNull(representative)
-        assertEquals(localNum, representative!!.num)
+        assertEquals(localNum, representative.num)
     }
 
     // 21. Exact notification title, message, ID, category, and deep link
@@ -1986,7 +1986,7 @@ class NodeManagerImplTest {
         assertNull(nodeManager.nodeDBbyNodeNum[staleNum])
         val canonical = nodeManager.nodeDBbyNodeNum[canonicalNum]
         assertNotNull(canonical)
-        assertEquals("Canonical", canonical!!.user.long_name)
+        assertEquals("Canonical", canonical.user.long_name)
         assertEquals(canonicalKey, canonical.publicKey)
         assertEquals(111, canonical.position.latitude_i)
         assertEquals(222, canonical.position.longitude_i)
@@ -2021,7 +2021,7 @@ class NodeManagerImplTest {
         assertNull(nodeManager.nodeDBbyNodeNum[staleNum])
         val canonical = nodeManager.nodeDBbyNodeNum[canonicalNum]
         assertNotNull(canonical)
-        assertEquals("Fresh Canonical", canonical!!.user.long_name)
+        assertEquals("Fresh Canonical", canonical.user.long_name)
         assertEquals(canonicalKey, canonical.publicKey)
         verifyNoRepositoryDeletion()
         verifySuspend(mode = VerifyMode.not) { nodeRepository.upsert(any()) }
@@ -2059,8 +2059,8 @@ class NodeManagerImplTest {
         val bravo = nodeManager.nodeDBbyNodeNum[b]
         assertNotNull(alpha)
         assertNotNull(bravo)
-        assertEquals("Alpha Packet", alpha!!.user.long_name)
-        assertEquals("Bravo", bravo!!.user.long_name)
+        assertEquals("Alpha Packet", alpha.user.long_name)
+        assertEquals("Bravo", bravo.user.long_name)
         verifyNoRepositoryDeletion()
         verifySuspend(mode = VerifyMode.not) { nodeRepository.upsert(any()) }
         verifySuspend(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
@@ -2096,9 +2096,9 @@ class NodeManagerImplTest {
         val atNoncanonical = nodeManager.nodeDBbyNodeNum[noncanonicalNum]
         assertNotNull(atCanonical)
         assertNotNull(atNoncanonical)
-        assertEquals(establishedKey, atCanonical!!.publicKey)
+        assertEquals(establishedKey, atCanonical.publicKey)
         assertEquals("Established", atCanonical.user.long_name)
-        assertEquals(canonicalKey, atNoncanonical!!.publicKey)
+        assertEquals(canonicalKey, atNoncanonical.publicKey)
         verifyNoRepositoryDeletion()
         verifySuspend(mode = VerifyMode.not) { nodeRepository.upsert(any()) }
         verifySuspend(mode = VerifyMode.not) { notificationManager.dispatch(any()) }
@@ -2482,7 +2482,7 @@ class NodeManagerImplTest {
         assertNull(nodeManager.nodeDBbyNodeNum[staleNum], "stale-DB row must not leak into the live index")
         val loaded = nodeManager.nodeDBbyNodeNum[freshNum]
         assertNotNull(loaded)
-        assertEquals("New DB", loaded!!.user.long_name)
+        assertEquals("New DB", loaded.user.long_name)
     }
 
     @Test
@@ -2518,7 +2518,7 @@ class NodeManagerImplTest {
         )
         val live = nodeManager.nodeDBbyNodeNum[liveNum]
         assertNotNull(live)
-        assertEquals("Live After Clear", live!!.user.long_name)
+        assertEquals("Live After Clear", live.user.long_name)
     }
 
     @Test
@@ -2547,7 +2547,7 @@ class NodeManagerImplTest {
 
         val result = nodeManager.nodeDBbyNodeNum[num]
         assertNotNull(result)
-        assertEquals("Live Updated", result!!.user.long_name)
+        assertEquals("Live Updated", result.user.long_name)
         assertEquals(200, result.lastHeard, "live mutation field must not be overwritten by the snapshot")
     }
 
@@ -2722,7 +2722,7 @@ class NodeManagerImplTest {
 
             val reused = nodeManager.nodeDBbyNodeNum[num]
             assertNotNull(reused)
-            assertEquals("Replacement", reused!!.user.long_name)
+            assertEquals("Replacement", reused.user.long_name)
             assertEquals(reuseKey, reused.publicKey)
             assertEquals(1, reuseDispatches.count { it.id == num && it.message == "Replacement" })
         }

--- a/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ExportNodeDatabaseUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/org/meshtastic/core/domain/usecase/settings/ExportNodeDatabaseUseCase.kt
@@ -175,6 +175,10 @@ private fun EnvironmentMetrics.toExport(): EnvironmentMetricsExport? = Environme
 )
     .takeUnless { it == EnvironmentMetricsExport() }
 
+// ch4-ch8 are deprecated in the proto (protobufs#877 moved ADC readings to
+// EnvironmentMetrics.adc_voltage_ch0-7). Exports must still carry them: they are the only record of what
+// firmware predating that move reported, and an export that silently dropped them would lose stored history.
+@Suppress("DEPRECATION")
 private fun PowerMetrics.toExport(): PowerMetricsExport? = PowerMetricsExport(
     ch1Voltage = ch1_voltage,
     ch1Current = ch1_current,

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/InlineMarkdown.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/InlineMarkdown.kt
@@ -22,6 +22,7 @@ import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
+import org.intellij.markdown.parser.CancellationToken
 import org.intellij.markdown.parser.MarkdownParser
 
 /**
@@ -39,13 +40,20 @@ import org.intellij.markdown.parser.MarkdownParser
  */
 fun parseInlineMarkdown(source: String): InlineMarkdownResult {
     // Empty input or a parser failure (assertions are disabled, but stay total regardless) → literal text, no spans.
-    val tree = if (source.isEmpty()) null else runCatching { parser.buildMarkdownTreeFromString(source) }.getOrNull()
+    val tree = if (source.isEmpty()) null else parseOrNull(source)
     return tree?.let { InlineMarkdownVisitor(source).build(it) }
         ?: InlineMarkdownResult(source, emptyList(), emptyList())
 }
 
 // assertionsEnabled = false → the parser recovers to a flat tree instead of throwing on malformed input.
-private val parser = MarkdownParser(GFMFlavourDescriptor(), false)
+// cancellationToken is passed explicitly to select the current constructor: omitting it resolves to the
+// deprecated two-argument overload.
+private val parser = MarkdownParser(GFMFlavourDescriptor(), false, CancellationToken.NonCancellable)
+
+// The String overload of buildMarkdownTreeFromString is deprecated in favour of the CharSequence one, and
+// Kotlin picks the more specific String overload unless the argument is widened here.
+private fun parseOrNull(source: String): ASTNode? =
+    runCatching { parser.buildMarkdownTreeFromString(source as CharSequence) }.getOrNull()
 
 /**
  * Style spans over the RAW [source] (delimiters kept in place) for live in-field styling. Unlike [parseInlineMarkdown]
@@ -54,9 +62,7 @@ private val parser = MarkdownParser(GFMFlavourDescriptor(), false)
  */
 fun inlineMarkdownStyleRanges(source: String): List<StyleSpan> {
     val hasDelimiter = source.any { it == '*' || it == '~' || it == '`' }
-    val tree =
-        (if (hasDelimiter) runCatching { parser.buildMarkdownTreeFromString(source) }.getOrNull() else null)
-            ?: return emptyList()
+    val tree = (if (hasDelimiter) parseOrNull(source) else null) ?: return emptyList()
     val spans = mutableListOf<StyleSpan>()
     collectStyleRanges(tree, spans)
     return spans

--- a/feature/node/detekt-baseline.xml
+++ b/feature/node/detekt-baseline.xml
@@ -51,7 +51,7 @@
     <ID>MultipleEmitters:AdministrationSection.kt:@Composable private fun FirmwareVersionItems</ID>
     <ID>MultipleEmitters:HostMetricsLog.kt:@Composable private fun LoadRow</ID>
     <ID>MultipleEmitters:PositionSection.kt:@Composable internal fun PositionInlineContent</ID>
-    <ID>MultipleEmitters:PowerMetrics.kt:@Composable @Suppress("CyclomaticComplexMethod") private fun PowerChannelsExtraRows</ID>
+    <ID>MultipleEmitters:PowerMetrics.kt:@Composable @Suppress("CyclomaticComplexMethod", "DEPRECATION") private fun PowerChannelsExtraRows</ID>
     <ID>MultipleEmitters:TracerouteLog.kt:@Composable private fun TracerouteCardMetrics</ID>
     <ID>MutableStateAutoboxing:CooldownOutlinedIconButton.kt:mutableStateOf(0f)</ID>
     <ID>MutableStateAutoboxing:TracerouteMapScreen.kt:mutableStateOf(0)</ID>

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/PowerMetrics.kt
@@ -403,8 +403,13 @@ private fun PowerChannelsRow1(pm: org.meshtastic.proto.PowerMetrics, channelLabe
     }
 }
 
+// PowerMetrics.ch4-ch8 are deprecated in the proto: protobufs#877 moved multi-channel ADC readings to
+// EnvironmentMetrics.adc_voltage_ch0-7, which this app already reads and graphs. These reads stay because
+// firmware predating that move still reports on ch4-ch8, and dropping them would blank the channels those
+// devices show today. Delete them, and PowerChannel.FOUR..EIGHT, once the proto removes the fields.
+// Note the migration covers voltage only - ch4-ch8 *current* has no successor field at all.
 @Composable
-@Suppress("CyclomaticComplexMethod")
+@Suppress("CyclomaticComplexMethod", "DEPRECATION")
 private fun PowerChannelsExtraRows(pm: org.meshtastic.proto.PowerMetrics, channelLabels: List<String>) {
     val hasCh456 =
         hasChannelData(pm.ch4_voltage, pm.ch4_current) ||
@@ -480,27 +485,29 @@ private fun PowerChannelColumn(titleRes: StringResource, customLabel: String?, v
 }
 
 /** Retrieves the appropriate voltage depending on `channelSelected`. */
-@Suppress("CyclomaticComplexMethod")
-private fun retrieveVoltage(channelSelected: PowerChannel, telemetry: Telemetry): Float = when (channelSelected) {
-    PowerChannel.ONE -> telemetry.power_metrics?.ch1_voltage ?: Float.NaN
-    PowerChannel.TWO -> telemetry.power_metrics?.ch2_voltage ?: Float.NaN
-    PowerChannel.THREE -> telemetry.power_metrics?.ch3_voltage ?: Float.NaN
-    PowerChannel.FOUR -> telemetry.power_metrics?.ch4_voltage ?: Float.NaN
-    PowerChannel.FIVE -> telemetry.power_metrics?.ch5_voltage ?: Float.NaN
-    PowerChannel.SIX -> telemetry.power_metrics?.ch6_voltage ?: Float.NaN
-    PowerChannel.SEVEN -> telemetry.power_metrics?.ch7_voltage ?: Float.NaN
-    PowerChannel.EIGHT -> telemetry.power_metrics?.ch8_voltage ?: Float.NaN
-}
+@Suppress("CyclomaticComplexMethod", "DEPRECATION") // ch4-ch8: see PowerChannelsExtraRows
+private fun retrieveVoltage(channelSelected: PowerChannel, telemetry: Telemetry): Float =
+    when (channelSelected) {
+        PowerChannel.ONE -> telemetry.power_metrics?.ch1_voltage ?: Float.NaN
+        PowerChannel.TWO -> telemetry.power_metrics?.ch2_voltage ?: Float.NaN
+        PowerChannel.THREE -> telemetry.power_metrics?.ch3_voltage ?: Float.NaN
+        PowerChannel.FOUR -> telemetry.power_metrics?.ch4_voltage ?: Float.NaN
+        PowerChannel.FIVE -> telemetry.power_metrics?.ch5_voltage ?: Float.NaN
+        PowerChannel.SIX -> telemetry.power_metrics?.ch6_voltage ?: Float.NaN
+        PowerChannel.SEVEN -> telemetry.power_metrics?.ch7_voltage ?: Float.NaN
+        PowerChannel.EIGHT -> telemetry.power_metrics?.ch8_voltage ?: Float.NaN
+    }
 
 /** Retrieves the appropriate current depending on `channelSelected`. */
-@Suppress("CyclomaticComplexMethod")
-private fun retrieveCurrent(channelSelected: PowerChannel, telemetry: Telemetry): Float = when (channelSelected) {
-    PowerChannel.ONE -> telemetry.power_metrics?.ch1_current ?: Float.NaN
-    PowerChannel.TWO -> telemetry.power_metrics?.ch2_current ?: Float.NaN
-    PowerChannel.THREE -> telemetry.power_metrics?.ch3_current ?: Float.NaN
-    PowerChannel.FOUR -> telemetry.power_metrics?.ch4_current ?: Float.NaN
-    PowerChannel.FIVE -> telemetry.power_metrics?.ch5_current ?: Float.NaN
-    PowerChannel.SIX -> telemetry.power_metrics?.ch6_current ?: Float.NaN
-    PowerChannel.SEVEN -> telemetry.power_metrics?.ch7_current ?: Float.NaN
-    PowerChannel.EIGHT -> telemetry.power_metrics?.ch8_current ?: Float.NaN
-}
+@Suppress("CyclomaticComplexMethod", "DEPRECATION") // ch4-ch8: see PowerChannelsExtraRows
+private fun retrieveCurrent(channelSelected: PowerChannel, telemetry: Telemetry): Float =
+    when (channelSelected) {
+        PowerChannel.ONE -> telemetry.power_metrics?.ch1_current ?: Float.NaN
+        PowerChannel.TWO -> telemetry.power_metrics?.ch2_current ?: Float.NaN
+        PowerChannel.THREE -> telemetry.power_metrics?.ch3_current ?: Float.NaN
+        PowerChannel.FOUR -> telemetry.power_metrics?.ch4_current ?: Float.NaN
+        PowerChannel.FIVE -> telemetry.power_metrics?.ch5_current ?: Float.NaN
+        PowerChannel.SIX -> telemetry.power_metrics?.ch6_current ?: Float.NaN
+        PowerChannel.SEVEN -> telemetry.power_metrics?.ch7_current ?: Float.NaN
+        PowerChannel.EIGHT -> telemetry.power_metrics?.ch8_current ?: Float.NaN
+    }

--- a/scripts/lib/stripped-libs.sh
+++ b/scripts/lib/stripped-libs.sh
@@ -1,0 +1,42 @@
+# shellcheck shell=bash
+# Classifies the native libraries in an unpacked APK as known-pre-stripped or unexpected.
+# Sourced by verify-rb.sh (Step 6); exercised directly by verify-rb-selftest.sh.
+
+# These arrive pre-stripped from their upstream AARs and always will. Listing them every run
+# made the warning 100% noise, so it never read as a signal; only a .so outside this set is
+# worth a warning. Add an entry when a new dependency's prebuilt lib shows up — never to
+# silence one we build ourselves.
+KNOWN_PRESTRIPPED_LIBS="
+libandroidx.graphics.path.so
+libimage_processing_util_jni.so
+libjniMaplibreNativeC.so
+libmaplibre-native-c.so
+libsurface_util_jni.so
+"
+
+# scan_stripped_libs <unpacked-apk-dir>
+# Sets STRIPPED_UNEXPECTED (space-prefixed basenames) and STRIPPED_KNOWN_COUNT.
+#
+# Matching is by basename: inside one APK every library lives at lib/<abi>/<name>.so, so a
+# basename is unique per ABI by construction and the same basename across ABIs is the same
+# library — which is the duplication `sort -u` collapses.
+scan_stripped_libs() {
+  local dir=$1 lib
+  STRIPPED_UNEXPECTED=""
+  STRIPPED_KNOWN_COUNT=0
+  while IFS= read -r lib; do
+    [ -n "$lib" ] || continue
+    if printf '%s\n' "$KNOWN_PRESTRIPPED_LIBS" | grep -qxF "$lib"; then
+      STRIPPED_KNOWN_COUNT=$((STRIPPED_KNOWN_COUNT + 1))
+    else
+      STRIPPED_UNEXPECTED="${STRIPPED_UNEXPECTED} ${lib}"
+    fi
+  done < <(
+    while IFS= read -r -d '' so; do
+      # no .symtab = stripped
+      if ! readelf -S "$so" 2>/dev/null | grep -q "\.symtab"; then
+        basename "$so"
+      fi
+    done < <(find "$dir" -name "*.so" -print0 2>/dev/null) | sort -u
+  )
+}

--- a/scripts/verify-rb-selftest.sh
+++ b/scripts/verify-rb-selftest.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Self-test for scripts/lib/stripped-libs.sh — verify-rb.sh Step 6.
+#
+# Step 6 itself only runs in the merge queue and needs two full release builds, so the
+# classification it depends on would otherwise ship unexercised: a typo in the allowlist
+# silently brings the noise back, and a broken dedup silently restores per-ABI repeats.
+# This runs in lint-check on every PR instead.
+#
+# readelf is stubbed: the fixture writes the literal STRIPPED into a lib to mean "no
+# .symtab", anything else means the symbol table survived.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+# shellcheck source=scripts/lib/stripped-libs.sh
+. scripts/lib/stripped-libs.sh
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/bin"
+cat > "$WORKDIR/bin/readelf" <<'STUB'
+#!/usr/bin/env bash
+# Stub: report a .symtab section unless the fixture marked the file STRIPPED.
+for arg in "$@"; do :; done
+if [ -f "$arg" ] && [ "$(cat "$arg")" = "STRIPPED" ]; then
+  echo "  [ 1] .text             PROGBITS"
+else
+  echo "  [ 1] .text             PROGBITS"
+  echo "  [ 2] .symtab           SYMTAB"
+fi
+STUB
+chmod +x "$WORKDIR/bin/readelf"
+PATH="$WORKDIR/bin:$PATH"
+
+FAILURES=0
+
+# lib <apk-dir> <name> <STRIPPED|SYMBOLS> — writes the lib into both ABI directories,
+# mirroring how an APK ships one library per supported ABI.
+lib() {
+  local dir=$1 name=$2 state=$3 abi
+  for abi in arm64-v8a armeabi-v7a; do
+    mkdir -p "$dir/lib/$abi"
+    printf '%s' "$state" > "$dir/lib/$abi/$name"
+  done
+}
+
+check() {
+  local name=$1 want_known=$2 want_unexpected=$3
+  local got_unexpected="${STRIPPED_UNEXPECTED# }"
+  if [ "$STRIPPED_KNOWN_COUNT" = "$want_known" ] && [ "$got_unexpected" = "$want_unexpected" ]; then
+    echo "✅ $name"
+  else
+    echo "❌ $name"
+    echo "     known:      want '$want_known' got '$STRIPPED_KNOWN_COUNT'"
+    echo "     unexpected: want '$want_unexpected' got '$got_unexpected'"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# 1. The regression that motivated the allowlist: known libs shipped for two ABIs collapse to
+#    one entry each and stay silent, while a genuinely unexpected stripped lib still warns.
+A="$WORKDIR/case-mixed"
+lib "$A" libmaplibre-native-c.so STRIPPED
+lib "$A" libandroidx.graphics.path.so STRIPPED
+lib "$A" libmine.so STRIPPED
+scan_stripped_libs "$A"
+check "two-ABI known libs dedupe; unexpected lib still warns" 2 "libmine.so"
+
+# 2. Every allowlist entry must actually match a file of that name — a typo or stray
+#    whitespace in the list would surface here as an unexpected lib rather than in CI logs
+#    six months from now.
+B="$WORKDIR/case-allowlist"
+COUNT=0
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  lib "$B" "$name" STRIPPED
+  COUNT=$((COUNT + 1))
+done <<< "$KNOWN_PRESTRIPPED_LIBS"
+scan_stripped_libs "$B"
+check "every allowlist entry matches its own name" "$COUNT" ""
+
+# 3. Unstripped libraries are not classified at all, allowlisted or not.
+C="$WORKDIR/case-symbols"
+lib "$C" libmaplibre-native-c.so SYMBOLS
+lib "$C" libmine.so SYMBOLS
+scan_stripped_libs "$C"
+check "libraries retaining .symtab are ignored" 0 ""
+
+# 4. An APK with no native libraries at all is silent, not an empty-string warning.
+D="$WORKDIR/case-empty"
+mkdir -p "$D"
+scan_stripped_libs "$D"
+check "no native libraries" 0 ""
+
+# 5. An allowlisted name that is NOT stripped does not inflate the known count — the count
+#    reports what was actually skipped, so a shrinking set stays visible.
+E="$WORKDIR/case-partial"
+lib "$E" libmaplibre-native-c.so STRIPPED
+lib "$E" libsurface_util_jni.so SYMBOLS
+scan_stripped_libs "$E"
+check "known count reflects libs actually skipped" 1 ""
+
+# 6. Allowlist matching is against the whole entry, not a substring of one. Dropping the -x
+#    from the grep would let any name contained in an entry — here the entry minus its "lib"
+#    prefix — be silently accepted as known.
+F="$WORKDIR/case-substring"
+lib "$F" maplibre-native-c.so STRIPPED
+scan_stripped_libs "$F"
+check "allowlist matches whole entries, not substrings" 0 "maplibre-native-c.so"
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo "::error::verify-rb Step 6 self-test failed ($FAILURES case(s))"
+  exit 1
+fi
+echo "✅ verify-rb Step 6 self-test passed (6 cases)"

--- a/scripts/verify-rb.sh
+++ b/scripts/verify-rb.sh
@@ -103,8 +103,8 @@ fi
 echo "✅ No DEPENDENCY_INFO_BLOCK in signing block"
 
 echo "── Step 6: Check native libraries have debug symbols (not stripped) ──"
-# shellcheck source=lib/stripped-libs.sh
-. "$(dirname "$0")/lib/stripped-libs.sh"
+# Run from repo root (see header), so this is a static path shellcheck -x can follow.
+. scripts/lib/stripped-libs.sh
 scan_stripped_libs "$APK_DIR"
 if [ -n "$STRIPPED_UNEXPECTED" ]; then
   echo "::warning::Unexpected stripped native libraries (may cause NDK-version-dependent RB failures):${STRIPPED_UNEXPECTED}"

--- a/scripts/verify-rb.sh
+++ b/scripts/verify-rb.sh
@@ -103,37 +103,13 @@ fi
 echo "✅ No DEPENDENCY_INFO_BLOCK in signing block"
 
 echo "── Step 6: Check native libraries have debug symbols (not stripped) ──"
-# These arrive pre-stripped from their upstream AARs and always will. Listing them
-# every run made the warning 100% noise, so it never read as a signal; only a .so
-# outside this set is worth a warning. Add an entry here when a new dependency's
-# prebuilt lib shows up — never to silence one we build ourselves.
-KNOWN_PRESTRIPPED="
-libandroidx.graphics.path.so
-libimage_processing_util_jni.so
-libjniMaplibreNativeC.so
-libmaplibre-native-c.so
-libsurface_util_jni.so
-"
-STRIPPED_LIBS=""
-KNOWN_COUNT=0
-while IFS= read -r lib; do
-  if printf '%s\n' "$KNOWN_PRESTRIPPED" | grep -qxF "$lib"; then
-    KNOWN_COUNT=$((KNOWN_COUNT + 1))
-  else
-    STRIPPED_LIBS="${STRIPPED_LIBS} ${lib}"
-  fi
-done < <(
-  while IFS= read -r -d '' so; do
-    # no .symtab = stripped
-    if ! readelf -S "$so" 2>/dev/null | grep -q "\.symtab"; then
-      basename "$so"
-    fi
-  done < <(find "$APK_DIR" -name "*.so" -print0 2>/dev/null) | sort -u
-)
-if [ -n "$STRIPPED_LIBS" ]; then
-  echo "::warning::Unexpected stripped native libraries (may cause NDK-version-dependent RB failures):${STRIPPED_LIBS}"
+# shellcheck source=lib/stripped-libs.sh
+. "$(dirname "$0")/lib/stripped-libs.sh"
+scan_stripped_libs "$APK_DIR"
+if [ -n "$STRIPPED_UNEXPECTED" ]; then
+  echo "::warning::Unexpected stripped native libraries (may cause NDK-version-dependent RB failures):${STRIPPED_UNEXPECTED}"
 else
-  echo "✅ Native libraries retain debug symbols (${KNOWN_COUNT} known pre-stripped third-party lib(s) ignored)"
+  echo "✅ Native libraries retain debug symbols (${STRIPPED_KNOWN_COUNT} known pre-stripped third-party lib(s) ignored)"
 fi
 
 echo "── Step 7: Check aboutlibraries 'generated' timestamp not in APK ──"

--- a/scripts/verify-rb.sh
+++ b/scripts/verify-rb.sh
@@ -103,18 +103,37 @@ fi
 echo "✅ No DEPENDENCY_INFO_BLOCK in signing block"
 
 echo "── Step 6: Check native libraries have debug symbols (not stripped) ──"
+# These arrive pre-stripped from their upstream AARs and always will. Listing them
+# every run made the warning 100% noise, so it never read as a signal; only a .so
+# outside this set is worth a warning. Add an entry here when a new dependency's
+# prebuilt lib shows up — never to silence one we build ourselves.
+KNOWN_PRESTRIPPED="
+libandroidx.graphics.path.so
+libimage_processing_util_jni.so
+libjniMaplibreNativeC.so
+libmaplibre-native-c.so
+libsurface_util_jni.so
+"
 STRIPPED_LIBS=""
-while IFS= read -r -d '' so; do
-  # no .symtab = stripped
-  if ! readelf -S "$so" 2>/dev/null | grep -q "\.symtab"; then
-    STRIPPED_LIBS="${STRIPPED_LIBS} $(basename "$so")"
+KNOWN_COUNT=0
+while IFS= read -r lib; do
+  if printf '%s\n' "$KNOWN_PRESTRIPPED" | grep -qxF "$lib"; then
+    KNOWN_COUNT=$((KNOWN_COUNT + 1))
+  else
+    STRIPPED_LIBS="${STRIPPED_LIBS} ${lib}"
   fi
-done < <(find "$APK_DIR" -name "*.so" -print0 2>/dev/null)
-# some third-party .so arrive pre-stripped — warn only
+done < <(
+  while IFS= read -r -d '' so; do
+    # no .symtab = stripped
+    if ! readelf -S "$so" 2>/dev/null | grep -q "\.symtab"; then
+      basename "$so"
+    fi
+  done < <(find "$APK_DIR" -name "*.so" -print0 2>/dev/null) | sort -u
+)
 if [ -n "$STRIPPED_LIBS" ]; then
-  echo "::warning::Some native libraries appear stripped (may cause NDK-version-dependent RB failures):${STRIPPED_LIBS}"
+  echo "::warning::Unexpected stripped native libraries (may cause NDK-version-dependent RB failures):${STRIPPED_LIBS}"
 else
-  echo "✅ Native libraries retain debug symbols"
+  echo "✅ Native libraries retain debug symbols (${KNOWN_COUNT} known pre-stripped third-party lib(s) ignored)"
 fi
 
 echo "── Step 7: Check aboutlibraries 'generated' timestamp not in APK ──"


### PR DESCRIPTION
An audit of the last ~60 workflow runs for warnings, deprecations and cruft. Four things showed up on every run and none of them meant anything; this clears them so the next real warning is visible.

**`build-flatpak-src` never runs.** It is gated on `run_desktop_flatpak_src`, which defaults to `false` and is passed by none of the three callers of `reusable-check.yml`. The work it does now lives in `verify-flatpak.yml` (PRs) and `release.yml` (releases), both of which call `:captureFlatpakSources` per-arch themselves. 53 lines and an input removed.

**"No files were found with the provided path: `**/build/reports`".** The shard-report upload ran under `always()`, so a shard cancelled before Gradle started still tried to upload and warned on the way out — three per cancelled run. Now `!cancelled()`, matching the Codecov steps beside it.

**`ruby/setup-ruby@v1`.** The only third-party `uses:` on a floating tag; the other 40-odd are SHA-pinned with a version comment. Pinned to `v1.99.0`.

**"Some native libraries appear stripped".** Every `.so` this check has ever named comes pre-stripped from an upstream AAR (androidx.graphics.path, maplibre, camerax), so it fired on every build and never meant anything — and listed each lib once per ABI, so five names appeared eight times. Allowlisted those five and deduped by basename; the warning now fires only on something unexpected.

Plus the two largest sources of Kotlin warning noise in the logs:

- `InlineMarkdown.kt` used the deprecated `MarkdownParser(flavour, assertionsEnabled)` constructor and the deprecated `String` overload of `buildMarkdownTreeFromString` — 18 warnings per compile, on every target.
- `NodeManagerImplTest.kt` applied `!!` to 23 receivers `assertNotNull` had already smart-cast; the next line in each case already used the value without it. 69 warnings a run across three targets.

- `PowerMetrics.kt` / `ExportNodeDatabaseUseCase.kt` read the `ch4`–`ch8` fields [protobufs#877](https://github.com/meshtastic/protobufs/pull/877) deprecated when it moved multi-channel ADC readings to `EnvironmentMetrics.adc_voltage_ch0-7`. The app already reads and graphs the new fields, so these are compatibility reads for firmware predating the move — deleting them would blank channels those devices still populate and drop stored history from the node-database export. Suppressed at the four call sites with the reason and the condition for removal. 19 warnings per compile.

Together that is ~110 of the 477 `w:` lines a `main-check` run emits.

## Test coverage

`rb-check` runs only in the merge queue and needs two full release builds, so the Step 6 classification this PR changes would have shipped unexercised. The scan is now extracted to `scripts/lib/stripped-libs.sh` and covered by `scripts/verify-rb-selftest.sh`, which stubs `readelf` and builds two-ABI fixture trees — six cases: ABI dedup, an unexpected lib still warning, every allowlist entry matching its own name, unstripped libs ignored, an empty APK staying silent, and whole-entry rather than substring matching.

Each case was checked against a mutation that should break it: dropping `sort -u`, dropping `grep`'s `-x`, inverting the `readelf` test, and misspelling an allowlist entry each fail the suite.

It runs in `lint-check`, before Gradle setup — no toolchain needed, and unlike `rb-check` it runs on every PR.

## Verification

- `actionlint .github/workflows/*.yml` — clean
- `shellcheck -x scripts/verify-rb.sh scripts/verify-rb-selftest.sh scripts/lib/stripped-libs.sh` — clean
- `./scripts/verify-rb-selftest.sh` — 6/6 pass
- `./gradlew spotlessCheck detekt :core:ui:jvmTest :core:data:jvmTest` — BUILD SUCCESSFUL
- `:core:ui`, `:core:data`, `:feature:node` and `:core:domain` now compile with none of the removed warnings
- `detekt` baseline entry for `PowerChannelsExtraRows` re-keyed: its ID embeds the annotated signature, so adding `"DEPRECATION"` to the existing `@Suppress` moved it. Underlying `MultipleEmitters` finding unchanged.

## Found but not changed

- `A terminally deprecated method in sun.misc.Unsafe has been called` (23/run) comes from the toolchain, not our code.
- The `main-check` cancellations are `cancel-in-progress` working as designed on a day with eight merges.
- Six `action_required` PR runs are fork-approval gating, an org setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline markdown parsing reliability and cancellation handling.
  * Reduced false warnings during native library verification by recognizing known pre-stripped libraries.
  * Ensured test reports are uploaded only for completed workflow runs.

* **Chores**
  * Improved release workflow security and reproducibility by pinning Ruby setup tooling.
  * Removed the unused Flatpak source manifest build step.
  * Expanded shell script checks to cover nested script directories and sourced files.
  * Documented continued compatibility handling for legacy power metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

