### PR TITLE
ci: guard the root module list against drifting from settings.gradle.kts

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -140,6 +140,60 @@ jobs:
 
           print('check-changes filter is aligned with settings.gradle module roots.')
           PY
+      # Drift guard: ALL_MODULES_FULL in RootConventionPlugin.kt is a hand-maintained
+      # copy of settings.gradle.kts (subprojects {} iteration is incompatible with
+      # Isolated Projects). It has drifted before: :feature:discovery, :feature:docs
+      # and :feature:map-maplibre were never added, so they were silently absent from
+      # Dokka aggregation, Kover aggregation and kmpSmokeCompile.
+      - name: Verify the root module list matches settings.gradle.kts
+        run: |
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          settings = Path('settings.gradle.kts').read_text()
+          plugin = Path(
+              'build-logic/convention/src/main/kotlin/RootConventionPlugin.kt'
+          ).read_text()
+
+          include = settings[settings.index('include('):]
+          modules = set(re.findall(r'"(:[^"]+)"', include[: include.index('\n)')]))
+
+          # ALL_MODULES_FULL appears twice (declaration and use), so bound the slice to
+          # the declaration's own closing paren rather than searching for the name.
+          decl = plugin[plugin.index('ALL_MODULES_FULL ='):]
+          listed = set(re.findall(r'"(:[^"]+)"', decl[: decl.index('\n    )')]))
+
+          # Test harnesses and generators, deliberately kept out of root aggregation
+          # (PR #6412). Excluded here so the guard does not force them back in.
+          exempt = {
+              ':baselineprofile',
+              ':core:konsist',
+              ':docs-screenshots',
+              ':screenshot-tests',
+          }
+
+          missing = sorted(modules - listed - exempt)
+          extra = sorted(listed - modules)
+
+          problems = []
+          for m in missing:
+              problems.append(
+                  f'{m} is in settings.gradle.kts but not ALL_MODULES_FULL -- it is absent '
+                  'from Dokka/Kover aggregation and kmpSmokeCompile'
+              )
+          for m in extra:
+              problems.append(f'{m} is in ALL_MODULES_FULL but no longer in settings.gradle.kts')
+
+          if problems:
+              print('Root module list drift detected:')
+              for p in problems:
+                  print('  -', p)
+              raise SystemExit(1)
+
+          print(f'{len(listed)} modules verified against settings.gradle.kts '
+                f'({len(exempt)} exempt).')
+          PY
       # Drift guard: the shard task lists in reusable-check.yml are
       # hand-maintained and have silently dropped modules before (discovery,
       # docs, wifi-provision, car, datastore, konsist had tests that never ran

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -175,6 +175,10 @@ jobs:
 
           missing = sorted(modules - listed - exempt)
           extra = sorted(listed - modules)
+          # The exemption is bidirectional: an exempt module must also stay OUT of the
+          # list. Without this, adding one back would pass silently and quietly undo
+          # #6412 by pulling a test harness into Dokka, Kover and kmpSmokeCompile.
+          readded = sorted(listed & exempt)
 
           problems = []
           for m in missing:
@@ -184,6 +188,11 @@ jobs:
               )
           for m in extra:
               problems.append(f'{m} is in ALL_MODULES_FULL but no longer in settings.gradle.kts')
+          for m in readded:
+              problems.append(
+                  f'{m} is exempt from root aggregation (#6412) but present in '
+                  'ALL_MODULES_FULL -- remove it, or drop it from the exempt set here'
+              )
 
           if problems:
               print('Root module list drift detected:')

--- a/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
@@ -77,7 +77,15 @@ private fun Project.registerKmpSmokeCompileTask() {
 /** KMP modules that declare `withDeviceTest {}` and therefore have `compileAndroidDeviceTest` tasks. */
 private val DEVICE_TEST_MODULES = listOf(":core:database", ":core:model")
 
-/** All modules included in `settings.gradle.kts`. Update this list when adding or removing modules. */
+/**
+ * Modules that participate in root aggregation (Dokka, Kover) and `kmpSmokeCompile`.
+ *
+ * Hand-maintained rather than derived, because `subprojects {}` iteration is incompatible with Isolated Projects.
+ * The `verify-module-list` guard in `pull-request.yml` fails the build when this drifts from
+ * `settings.gradle.kts`, so a new module cannot silently fall out of the gate — which is how
+ * `:feature:discovery`, `:feature:docs` and `:feature:map-maplibre` went unaggregated and uncompiled by
+ * `kmpSmokeCompile` for several releases.
+ */
 private val ALL_MODULES_FULL =
     listOf(
         ":androidApp",
@@ -103,7 +111,10 @@ private val ALL_MODULES_FULL =
         ":feature:intro",
         ":feature:messaging",
         ":feature:connections",
+        ":feature:discovery",
+        ":feature:docs",
         ":feature:map",
+        ":feature:map-maplibre",
         ":feature:node",
         ":feature:settings",
         ":feature:firmware",


### PR DESCRIPTION
`ALL_MODULES_FULL` in `RootConventionPlugin.kt` is a hand-maintained copy of `settings.gradle.kts` — necessarily so, since `subprojects {}` iteration is incompatible with Isolated Projects. Nothing checked the copy, and it had drifted: **37 includes vs. 30 entries**.

Four of the seven gaps are deliberate (test/tooling modules dropped from aggregation in #6412). Three are not:

```
:feature:discovery   :feature:docs   :feature:map-maplibre
```

`git log -S` shows these were never added rather than removed. All three apply `meshtastic.kmp.feature` (which registers both iOS targets), two have `src/iosMain`, and they hold 32 test files between them — so all three sat outside Dokka aggregation, Kover aggregation and `kmpSmokeCompile`.

This is the same failure mode the shard guard immediately below already catches for the *other* hand-maintained list. Its comment records the history: "discovery, docs, wifi-provision, car, datastore, konsist had tests that never ran in CI."

**Not affected:** Codecov. The test shards run per-module `koverXmlReport` and upload by glob, so coverage reporting was always complete.

## What changed

- The three modules added to `ALL_MODULES_FULL` (30 → 33)
- A guard that fails on any of the three drift directions
- The four modules #6412 exempted stay exempt, so aggregation behaviour is unchanged

## Verification

- Guard passes on the fixed tree: `33 modules verified against settings.gradle.kts (4 exempt).`
- Mutation-tested — each of these fails the guard as intended:
  - a module deleted from `ALL_MODULES_FULL` (reproduces the original bug)
  - a new module added to `settings.gradle.kts` only
  - a stale entry left in `ALL_MODULES_FULL` after removal
- `kmpSmokeCompile` goes 26 → 29 modules and still passes (BUILD SUCCESSFUL, 303 tasks); confirmed by `--dry-run` that all three are now in the graph
- `actionlint` clean; `spotlessCheck detekt` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated validation to detect mismatches between declared project modules and aggregated build modules.
  * Included discovery, documentation, and MapLibre map modules in documentation, coverage, and smoke compilation checks.
* **Chores**
  * Improved build configuration guidance for maintaining the complete module list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->