### PR TITLE
ci: run Dokka under Isolated Projects again

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -110,7 +110,7 @@ jobs:
             --baseurl /${{ github.event.repository.name }}/main &
           jekyll_pid=$!
           if [ "$BUILD_DOKKA" = "true" ]; then
-            ./gradlew dokkaGeneratePublicationHtml -Dorg.gradle.isolated-projects=false --no-configuration-cache
+            ./gradlew dokkaGeneratePublicationHtml
           else
             echo "No Dokka-relevant changes — skipping API reference rebuild."
           fi

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -104,7 +104,7 @@ jobs:
       # Dokka API reference (/api/) — production releases only.
       - name: Build Dokka HTML documentation
         if: steps.version.outputs.is_production == 'true'
-        run: ./gradlew dokkaGeneratePublicationHtml -Dorg.gradle.isolated-projects=false --no-configuration-cache
+        run: ./gradlew dokkaGeneratePublicationHtml
 
       - name: Compile Jekyll Sites
         env:


### PR DESCRIPTION
`dokkaGeneratePublicationHtml` was the only Gradle invocation in the docs workflows still opting out of the repo-wide Isolated Projects default:

```diff
- ./gradlew dokkaGeneratePublicationHtml -Dorg.gradle.isolated-projects=false --no-configuration-cache
+ ./gradlew dokkaGeneratePublicationHtml
```

`docs-deploy.yml:113` and `docs-release.yml:107`.

## Why it can go

The flags were never a Dokka-specific decision. `git log -S` puts their origin in the **Gradle 9.7.0 bump (#6589)**, with #6613 later reworking `--no-isolated-projects` into the property form because the flag was 9.7-only. Nothing has re-tested the underlying problem since, so the escape outlived whatever broke.

Dokka 2.2.0 configures and runs clean with IP on. Verified on a tree at `origin/main`: **BUILD SUCCESSFUL**, and the run reports `Configuration cache entry stored` — *stored*, not *reused*, so configuration genuinely executed under Isolated Projects rather than being skipped by a warm entry. Confirmed twice, on two separate worktrees, including one cold run that executed 534 tasks.

## What this is and isn't worth

The gain is Isolated Projects' parallel configuration, plus one less divergence from the repo-wide default. It is **not** configuration-cache reuse — `gradle-setup` sets `cache_configuration_cache: 'false'`, so entries aren't shared across runners and every CI run configures fresh either way.

## Verification

- `./gradlew dokkaGeneratePublicationHtml` (no overrides, IP on from `gradle.properties`) — BUILD SUCCESSFUL
- `actionlint` clean

The `docs-deploy` path also runs Dokka concurrently with a backgrounded Jekyll build; that interaction is unchanged by this diff, but this PR's own Deploy Documentation run is what exercises it end to end.

## Context

Found while auditing the Isolated Projects escape hatches: IP is on globally but disabled at 9 sites for 6 distinct upstream causes, each documented but none with any mechanism that ever re-tests whether the cause still holds. This is the first one retested. The remaining five — AGP screenshot plugin, dependency-graph plugin, CMP WiX packaging, aboutlibraries, baseline profile — are untested and may or may not still be needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the API documentation build process for both deployment and production releases.
  * Documentation generation now uses Gradle’s default build optimization settings for more efficient builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->