### PR TITLE
ci(rb-check): run verify-rb.sh under Isolated Projects again

### DIFF
--- a/scripts/verify-rb.sh
+++ b/scripts/verify-rb.sh
@@ -12,11 +12,11 @@ trap 'rm -rf "$WORKDIR"' EXIT
 
 echo "── Step 1: Verify aboutlibraries.json determinism ──"
 rm -f androidApp/src/main/resources/aboutlibraries.json
-./gradlew :androidApp:exportLibraryDefinitions -Pci=true -Dorg.gradle.isolated-projects=false --no-configuration-cache
+./gradlew :androidApp:exportLibraryDefinitions -Pci=true
 cp androidApp/src/main/resources/aboutlibraries.json "$WORKDIR/aboutlibraries-run1.json"
 
 rm -f androidApp/src/main/resources/aboutlibraries.json
-./gradlew :androidApp:exportLibraryDefinitions -Pci=true -Dorg.gradle.isolated-projects=false --no-configuration-cache --rerun-tasks
+./gradlew :androidApp:exportLibraryDefinitions -Pci=true --rerun-tasks
 cp androidApp/src/main/resources/aboutlibraries.json "$WORKDIR/aboutlibraries-run2.json"
 
 if ! diff -q "$WORKDIR/aboutlibraries-run1.json" "$WORKDIR/aboutlibraries-run2.json"; then
@@ -27,7 +27,7 @@ fi
 echo "✅ aboutlibraries.json is deterministic"
 
 echo "── Step 2: Build fdroid release APK ──"
-./gradlew :androidApp:assembleFdroidRelease -Pci=true -Pmeshtastic.disableAbiSplits=true -Dorg.gradle.isolated-projects=false --no-configuration-cache
+./gradlew :androidApp:assembleFdroidRelease -Pci=true -Pmeshtastic.disableAbiSplits=true
 
 APK=$(find androidApp/build/outputs/apk/fdroid/release -name "*.apk" | head -1)
 if [ -z "$APK" ]; then


### PR DESCRIPTION
All three `gradlew` calls in `scripts/verify-rb.sh` opted out of the repo-wide Isolated Projects default:

```diff
-./gradlew :androidApp:exportLibraryDefinitions -Pci=true -Dorg.gradle.isolated-projects=false --no-configuration-cache
+./gradlew :androidApp:exportLibraryDefinitions -Pci=true
-./gradlew :androidApp:exportLibraryDefinitions -Pci=true -Dorg.gradle.isolated-projects=false --no-configuration-cache --rerun-tasks
+./gradlew :androidApp:exportLibraryDefinitions -Pci=true --rerun-tasks
-./gradlew :androidApp:assembleFdroidRelease -Pci=true -Pmeshtastic.disableAbiSplits=true -Dorg.gradle.isolated-projects=false --no-configuration-cache
+./gradlew :androidApp:assembleFdroidRelease -Pci=true -Pmeshtastic.disableAbiSplits=true
```

Unlike the other IP escapes in this repo, this one carried **no stated cause** — every other one documents what breaks. Nothing had re-tested it since it was added.

## Verification

Not just the two commands in isolation — **the whole script, end to end, locally**, with `VERSION_CODE` set the way `rb-check` sets it:

```
── Step 1: Verify aboutlibraries.json determinism ──
✅ aboutlibraries.json is deterministic
...
── Step 8: Verify build from clean tree (version-control-info) ──
✅ Built from clean tree

🎉 All RB checks passed        (exit 0)
```

Step 1 is the one that mattered here: it diffs `aboutlibraries.json` across two runs to prove determinism, and enabling the configuration cache changes what gets reused between them. The log shows `Configuration cache entry reused` between the two runs — so the reuse path was actually taken rather than quietly skipped, and the determinism check still passed. Probing the two commands separately would not have exercised that.

`shellcheck -x scripts/verify-rb.sh` clean.

`rb-check` runs only in the merge queue, so the queue re-runs this for real before it lands.

## Context

Found by probing every remaining Isolated Projects escape with IP left on. Results:

| escape | verdict |
| --- | --- |
| `verify-rb.sh` (this PR) | retirable — both command shapes and the full script pass |
| `reusable-check.yml:616` desktop packaging | passes on Linux, but the comment calls out `windows-latest` behaving differently — needs a Windows check before touching |
| `reusable-check.yml:145` screenshot | **still needed** — `Cannot call 'iterator()' on BuildServicesRegistry.getRegistrations() when Isolated Projects is enabled` |
| `reusable-check.yml:549` dependency graph | **still needed** — `Project ':build-logic' cannot access 'Project.tasks' functionality on subprojects via 'allprojects'` |
| `scheduled-baseline.yml:76` baseline profile | not probed — needs a connected emulator, and its stated cause is config-cache serializability rather than IP |

Two of those four documented causes reproduce verbatim today, so those comments are accurate and current.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release verification workflow.
  * Verification checks remain unchanged, preserving existing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->