### PR TITLE
ci(desktop): keep the Isolated Projects escape on Windows only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,15 +314,16 @@ jobs:
         # Quote the -P flag: PowerShell on Windows interprets the dot in
         # `-PaboutLibraries.release=true` as member access on `-PaboutLibraries`,
         # splitting the token and feeding `.release=true` to Gradle as a task name.
-        # --no-isolated-projects --no-configuration-cache: CMP's Windows MSI/WiX packaging
-        # reads Project.layout on the root project, which IP and the CC each reject; both
-        # must be flags, not -D properties (inert on windows-latest), and --no-isolated-projects
-        # needs Gradle 9.7+ — full rationale on the desktop packaging step in reusable-check.yml.
+        # --no-isolated-projects --no-configuration-cache, Windows only: CMP's WiX packaging
+        # reads Project.layout on the root project, which IP rejects. configureWix only runs
+        # where MSI/EXE are target formats, so the other runners package fine with IP on.
+        # Both flags must go together and must be flags, not -D properties (inert on
+        # windows-latest) — full rationale on the desktop packaging step in reusable-check.yml.
         run: >
           ./gradlew :desktopApp:packageReleaseDistributionForCurrentOS
           ${{ contains(runner.os, 'macOS') && ':desktopApp:packageReleaseUberJarForCurrentOS' || '' }}
           '-PaboutLibraries.release=true' '-Pdesktop.release=true' --no-daemon
-          --no-isolated-projects --no-configuration-cache
+          ${{ runner.os == 'Windows' && '--no-isolated-projects --no-configuration-cache' || '' }}
 
       # Authenticode-signs the MSI/EXE installers via Azure Trusted Signing
       # (rebranded "Artifact Signing"). Skips cleanly when the secrets are

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -612,18 +612,24 @@ jobs:
         # packageDistributionForCurrentOS (debug build type, no ProGuard) produces real
         # installers (dmg/msi+exe/deb+rpm+AppImage-dir) so the snapshot release below can
         # ship something testers can actually install, not just an unpacked app dir.
-        # On Gradle 9.7.1 CMP's Windows MSI/WiX packaging reads Project.layout on the root project
-        # from ':desktopApp'. Isolated Projects and the configuration cache reject that
-        # independently, so both have to go — disabling only IP still fails as "1 problem was found
-        # storing the configuration cache", and Gradle refuses --no-configuration-cache while IP is
-        # still on. This job never persists a CC entry (cache_configuration_cache defaults to
-        # false), so dropping the cache costs nothing.
-        # Flags, not -D properties: -Dorg.gradle.isolated-projects=false took effect on macOS and
-        # both Linux runners but NOT on windows-latest, which still died on "Configuration Cache
-        # cannot be disabled when Isolated Projects is enabled". --no-isolated-projects is
-        # unambiguous; it needs 9.7+, which is exactly what this PR moves us to, so a pin-back below
-        # 9.7 has to revert this line with it.
-        run: ./gradlew :desktopApp:packageDistributionForCurrentOS :desktopApp:proguardReleaseJars -Pci=true --no-isolated-projects --no-configuration-cache
+        # Windows only: CMP's WiX packaging reads Project.layout on the root project from
+        # ':desktopApp', which Isolated Projects rejects. Stack, from a --dry-run on
+        # windows-latest against compose-multiplatform 1.12.0:
+        #     WixToolsetKt.configureWix(wixToolset.kt:43)
+        #     ConfigureJvmApplicationKt.configureJvmApplication(configureJvmApplication.kt:46)
+        #     ComposePlugin.apply$lambda$2(ComposePlugin.kt:58)
+        # configureWix only runs where MSI/EXE are target formats, which is why macOS,
+        # ubuntu-24.04 and ubuntu-24.04-arm all package fine with IP on — verified by
+        # running this exact task list unflagged on all four runners. Keep the escape
+        # pinned to the one OS that needs it, and drop it when CMP stops reaching for
+        # the root project.
+        # Both flags go together: IP implies the configuration cache, and Gradle refuses
+        # --no-configuration-cache while IP is still on. Flags, not -D properties —
+        # -Dorg.gradle.isolated-projects=false is inert on windows-latest. --no-isolated-projects
+        # needs Gradle 9.7+, so a pin-back below 9.7 has to revert this line with it.
+        run: >
+          ./gradlew :desktopApp:packageDistributionForCurrentOS :desktopApp:proguardReleaseJars -Pci=true
+          ${{ runner.os == 'Windows' && '--no-isolated-projects --no-configuration-cache' || '' }}
 
       # CMP's TargetFormat.AppImage is jpackage's "app-image" — an unpacked directory, not
       # a Linux .AppImage. Wrap it into a real AppImage, same as the release workflow.


### PR DESCRIPTION
The desktop packaging escape was applied to all four runners, but only one needs it.

```diff
-          ./gradlew :desktopApp:packageDistributionForCurrentOS :desktopApp:proguardReleaseJars -Pci=true --no-isolated-projects --no-configuration-cache
+          ./gradlew :desktopApp:packageDistributionForCurrentOS :desktopApp:proguardReleaseJars -Pci=true
+          ${{ runner.os == 'Windows' && '--no-isolated-projects --no-configuration-cache' || '' }}
```

Same change in `release.yml` for `packageReleaseDistributionForCurrentOS`.

## Evidence

I ran the exact task list, unflagged, on all four runners the real job uses:

| runner | result |
| --- | --- |
| `macos-latest` | packages clean with IP on — 169 tasks executed, `packageDmg` ran |
| `ubuntu-24.04` | packages clean — 170 executed, `packageDeb` ran |
| `ubuntu-24.04-arm` | packages clean — 170 executed |
| `windows-latest` | **fails to configure** |

Task execution was confirmed from the logs, not inferred from a green step — a cached task would have passed without exercising anything.

## Root cause is upstream, not this build

Stack from a `--dry-run` on `windows-latest` against `compose-multiplatform 1.12.0`:

```
Project ':desktopApp' cannot access 'Project.layout' functionality on another project ':'
  at org.jetbrains.compose.desktop.application.internal.WixToolsetKt.configureWix(wixToolset.kt:43)
  at org.jetbrains.compose.desktop.application.internal.ConfigureJvmApplicationKt.configureJvmApplication(configureJvmApplication.kt:46)
  at org.jetbrains.compose.ComposePlugin.apply$lambda$2(ComposePlugin.kt:58)
```

`configureWix` only runs where `TargetFormat.Msi`/`Exe` are configured, which is precisely why the failure is Windows-only. Every root-project access this repo owns already goes through `isolated.rootProject` — `desktopApp/build.gradle.kts:166`, `feature/docs/build.gradle.kts:65`, and the vendored secrets plugin — so there is nothing to fix on our side.

The `release.yml` comment already named this cause correctly; `reusable-check.yml` documented the workaround's symptom ("Configuration Cache cannot be disabled when Isolated Projects is enabled") rather than the violation. Both comments now carry the stack.

## Effect

Three of four desktop legs get Isolated Projects' parallel configuration back. Reverting is a one-line change if CMP regresses somewhere else.

This PR's own `Build Desktop Debug` matrix runs all four runners, so it verifies itself.

## Context

Found by probing every remaining IP escape with IP left on. Of the five, two reproduce their documented failure verbatim and must stay (screenshot plugin's `BuildServicesRegistry` iteration; the dependency-graph plugin's `allprojects{}`), one is retirable outright (#6988, `verify-rb.sh`), this one narrows to a single OS, and the baseline-profile escape was not probed — it needs a connected emulator and its cause is config-cache serializability rather than IP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop packaging reliability across operating systems.
  * Windows builds now apply the required Gradle compatibility settings, while other platforms retain optimized build configuration.
  * Updated build workflow guidance to better reflect platform-specific packaging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->