### PR TITLE
fix(map): pin the maplibre native ffi snapshot so 32-bit F-Droid gets a map engine

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -343,3 +343,19 @@ dependencies {
     // plugin merges the generated rules into src/<variant>/generated/baselineProfiles at build time.
     baselineProfile(projects.baselineprofile)
 }
+
+// DO NOT MERGE AS-IS — pinned to an unreleased snapshot.
+//
+// #6901 moved F-Droid from OSMdroid to maplibre-compose, whose 0.15.0 native stack
+// (maplibre-native-ffi 0.202608.3) publishes arm64-v8a and x86_64 only. Our abiFilters above
+// still list armeabi-v7a, so the 32-bit split installs with no map engine and the map tab dies
+// with UnsatisfiedLinkError on libjniMaplibreNativeC.so — meshtastic/Meshtastic-Android#7001.
+//
+// Upstream merged ARM32 on 2026-08-24 (maplibre-native-ffi#658, #659, #660) but has not cut a
+// release carrying it. The 0.1.0-SNAPSHOT publication does carry it, which is what this pin is
+// for. Replace with a maplibre-compose version whose ffi pin is >= the first release containing
+// those PRs, then delete this block.
+configurations.configureEach {
+    resolutionStrategy.eachDependency { if (requested.group == "org.maplibre.nativeffi") useVersion("0.1.0-SNAPSHOT") }
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
+}


### PR DESCRIPTION
## Why

`#6901` moved the F-Droid flavor from OSMdroid to maplibre-compose. maplibre-compose 0.15.0's native stack — `maplibre-native-ffi 0.202608.3` — publishes **arm64-v8a and x86_64 only**, but `androidApp/build.gradle.kts` still lists `armeabi-v7a` in both `abiFilters` and the ABI `splits`. The 32-bit split builds and installs happily with no map engine in it, and opening the map tab dies:

```
FATAL EXCEPTION: main
java.lang.UnsatisfiedLinkError: dlopen failed: library "libjniMaplibreNativeC.so" not found
  at org.maplibre.nativeffi.internal.javacpp.MaplibreNativeC.<clinit>(MaplibreNativeC.java:10)
  at org.maplibre.compose.mlnffi.EnsureMlnFfiConfigured(EnsureMlnFfiConfigured.android.kt:12)
  at org.meshtastic.feature.map.maplibre.MeshMapKt.MeshMap(MeshMap.kt:139)
  at org.meshtastic.feature.map.maplibre.MapLibreMapViewProvider.MapView(MapLibreMapViewProvider.kt:150)
```

Every armeabi-v7a install of 29322131 and later has no map, by construction. Shipped artifacts from `v2.8.2-closed.1`:

| release APK | size | MapLibre `.so` |
| --- | --- | --- |
| `androidApp-fdroid-arm64-v8a-release.apk` | 32.5 MB | present |
| `androidApp-fdroid-armeabi-v7a-release.apk` | 18.2 MB | **absent** |

Relates to #7001.

## 🐛 Bug Fixes

- Pin the `org.maplibre.nativeffi` group to `0.1.0-SNAPSHOT`, the rolling publication that carries armeabi-v7a, so the 32-bit split ships a map engine again.
- Set `cacheChangingModulesFor(0, "seconds")` so a snapshot pin is not served stale from the dependency cache.

## Not for merge in this form

A snapshot pin is not shippable. Upstream merged Android ARM32 on 2026-08-24 — maplibre-native-ffi [#658](https://github.com/maplibre/maplibre-native-ffi/pull/658) (ARMv7 OpenGL), [#659](https://github.com/maplibre/maplibre-native-ffi/pull/659) (Kotlin/Native `androidNativeArm32`), [#660](https://github.com/maplibre/maplibre-native-ffi/pull/660) (ARMv7 Vulkan) — but the newest release, `0.202608.3` (2026-08-20), predates them, and maplibre-compose `main` still pins that version.

The shipping fix is a two-step upstream wait:

1. maplibre-native-ffi cuts a release containing #658/#659/#660.
2. maplibre-compose bumps its `maplibre-nativeFfi` pin to it and publishes.

Then this becomes a one-line `maplibre-compose` bump in `gradle/libs.versions.toml` and this block gets deleted.

This PR exists to prove the fix works and to produce a 32-bit APK affected users can test.

## Testing Performed

Verified against the artifacts, not just the build:

- `:androidApp:assembleFdroidDebug` — the armeabi-v7a split grows 60 MB → 70 MB and now contains `lib/armeabi-v7a/libmaplibre-native-c.so` (8.8 MB) and `lib/armeabi-v7a/libjniMaplibreNativeC.so` (908 KB).
- Both are genuine 32-bit binaries: `ELF 32-bit LSB shared object, ARM, EABI5 version 1`, `Tag_CPU_arch: v7`, NDK r28c, built for Android 24.
- The snapshot FFI is drop-in compatible with maplibre-compose 0.15.0 — the arm64 build from this branch installs and renders on a Pixel 6a: `maplibre-compose: Rendered the first map frame with OPENGL`. This also clears the concern that #660's Vulkan handle ABI break would affect our OpenGL path. It does not.
- Reproduced the original failure first, to confirm the diagnosis: stripping the two MapLibre `.so` files from the arm64 APK (leaving exactly the lib set the v7a split ships), re-signing and installing gives the identical `UnsatisfiedLinkError` above.
- `spotlessApply spotlessCheck detekt` green.

Not verified: the ARM32 code path actually executing. armeabi-v7a emulator system images stop at API 25 and `minSdk` is 26, so no emulator can run it, and the only physical device here is arm64-only. That rests on upstream's CI until a 32-bit phone runs the artifact from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
