### PR TITLE
fix(network): point the API base URL at the R2-backed apiv2 host

### DIFF
--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
@@ -29,17 +29,23 @@ object HttpClientDefaults {
     const val TIMEOUT_MS = 30_000L
 
     /**
-     * Timeout in milliseconds for a whole request. Deliberately generous: api.meshtastic.org has been measured taking
-     * 20-60s to serve `github/firmware/list` and `resource/deviceHardware`, and callers use stale-while-revalidate
-     * caching so nothing user-facing waits on this deadline.
+     * Timeout in milliseconds for a whole request. Deliberately generous: the API has been measured taking 20-60s to
+     * serve `github/firmware/list` and `resource/deviceHardware`, and callers use stale-while-revalidate caching so
+     * nothing user-facing waits on this deadline.
      */
     const val REQUEST_TIMEOUT_MS = 90_000L
 
     /** Maximum number of automatic retries on server errors (5xx) and transient connection/IO failures. */
     const val MAX_RETRIES = 3
 
-    /** Base URL for the Meshtastic public API. Installed via the `DefaultRequest` plugin. */
-    const val API_BASE_URL = "https://api.meshtastic.org/"
+    /**
+     * Base URL for the Meshtastic public API, installed via the `DefaultRequest` plugin.
+     *
+     * The Cloudflare R2-backed v2 host, not `api.meshtastic.org`. v2 is CDN-cached with `stale-if-error`, and it
+     * answers cross-origin requests: v1 replies HTTP 500 to any `Origin` outside a hardcoded allowlist, so it cannot be
+     * reached from a browser at all (meshtastic/api#134).
+     */
+    const val API_BASE_URL = "https://apiv2.meshtastic.org/"
 }
 
 /**


### PR DESCRIPTION
## Why

`api.meshtastic.org` is the host this repo keeps working around.

It routinely takes 20 to 60 seconds to serve `github/firmware/list` and `resource/deviceHardware`, which is why `REQUEST_TIMEOUT_MS` is 90s. It went down in July 2026, which is why `FirmwareReleaseRepositoryImpl` carries a regression test for keeping cached data flowing through an outage, and why `SingleFlightRefresher` exists at all.

`apiv2.meshtastic.org` is the new Cloudflare R2 backed host. It serves `ETag` and `cache-control: public, max-age=300, s-maxage=86400, stale-if-error=86400`, so the CDN keeps answering for a day after the origin stops. That is the resilience we have been hand-rolling, for free, one constant away.

It also answers cross-origin requests, which v1 does not. v1 replies **HTTP 500** with body `Origin not allowed by CORS` to any `Origin` outside a hardcoded allowlist, preflight included, so it is unreachable from a browser unless the origin happens to be on that list. Fix proposed upstream in meshtastic/api#134. That is what forces the switch for the web target being built now, but as above it is not the only reason to make it here.

This is one constant. On `main` it is picked up by three call sites: `NetworkModule` (Android), `DesktopKoinModule` (desktop), and the maintenance UF2 asset URL in `MaintenanceUf2.kt`.

## Testing Performed

`./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` green on this branch.

Parity was checked endpoint by endpoint before switching, not assumed. All six endpoints `ApiService` consumes return 200 `application/json` on both hosts:

| endpoint | result |
| --- | --- |
| `resource/deviceHardware` | byte-identical |
| `resource/deviceLinks` | identical but for the `generatedAt` stamp; all 213 links identical |
| `github/firmware/list` | differs by one transient pull-request entry |
| `resource/eventFirmware` | byte-identical |
| `resource/bootloaderOtaQuirks` | byte-identical |
| `resource/maintenanceUf2` | byte-identical |

Both diffs are CDN freshness, not shape.

The three maintenance UF2 binaries under `resource/maintenanceUf2/asset/` (`nrf_erase2.uf2`, `nrf_erase_sd7_3.uf2`, `pico_erase.uf2`) are byte-identical on both hosts and match the `sha256` digests the manifest declares, so the digest-verified flash path is unaffected.

CORS behaviour, measured:

```
$ curl -o /dev/null -w '%{http_code}' -H 'Origin: https://client.meshtastic.org' \
    https://api.meshtastic.org/resource/deviceHardware
500                     # body: Origin not allowed by CORS

$ curl -o /dev/null -w '%{http_code}' -H 'Origin: https://client.meshtastic.org' \
    https://apiv2.meshtastic.org/resource/deviceHardware
200                     # access-control-allow-origin: *
```

## Deliberately not changed

- **Timeout and retry constants.** v2 answered every probe in roughly 0.2s, but those were all Cloudflare cache hits and say nothing about a cold miss. The generous deadline costs nothing given callers use stale-while-revalidate.
- **`.github/workflows/scheduled-updates.yml`.** Those curls populate the seed assets shipped in the APK. CI has no CORS problem, and apiv2's R2 snapshot was measured about 1.4 days behind v1 while the CDN `age` was only about 3.9 hours, so the lag is in the object rather than the cache. Pointing a daily seed refresh at it would bake stale data in for no gain.

## Known gap this does not close

`resource/eventFirmware` on apiv2 still serves `iconUrl` values pointing at `api.meshtastic.org`. `api/src/routes/eventFirmware.ts` re-origins hosted icon URLs off `X-Forwarded-Host` correctly, but apiv2 serves R2 objects and never runs that route, so the v1 URLs pass through. On Android and desktop this is harmless, since neither sends an `Origin` header. It will matter for the web target, and it belongs to the apiv2 Worker/R2 sync rather than to this repo or to the `api` repo. Flagged to @thebentern on meshtastic/api#134.

## Risk

`apiv2.meshtastic.org` was announced as live for people to poke rather than as a declared-stable replacement, so this points production at a host without a published stability guarantee. v1 remains up. Reverting is the same one constant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s network API endpoint to the newer v2 service for improved reliability and browser compatibility.
  * Enabled CDN-backed responses with stale content available during service interruptions.

* **Documentation**
  * Clarified API endpoint behavior, caching, and timeout details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->