### PR TITLE
feat(map-maplibre): offline terrain (hillshade + contours) for MapLibre

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -254,6 +254,7 @@ jobs:
               :feature:intro:allTests
               :feature:map:allTests
               :feature:map-maplibre:allTests
+              :feature:map-terrain:allTests
               :feature:messaging:allTests
               :feature:node:allTests
               :feature:settings:allTests
@@ -267,6 +268,7 @@ jobs:
               :feature:intro:koverXmlReport
               :feature:map:koverXmlReport
               :feature:map-maplibre:koverXmlReport
+              :feature:map-terrain:koverXmlReport
               :feature:messaging:koverXmlReport
               :feature:node:koverXmlReport
               :feature:settings:koverXmlReport

--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1336,8 +1336,12 @@ notifications_on_message_receipt
 now
 ntp_server
 number_of_records
+### OFFLINE ###
 offline_maps
 offline_maps_empty
+offline_terrain_empty
+offline_terrain_manager
+offline_terrain_regional_detail
 ok_to_mqtt
 okay
 oled_type

--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1050,6 +1050,7 @@ map_start_download
 map_style_selection
 map_subDescription
 map_tile_download_estimate
+map_tile_download_estimate_detail
 map_tile_limit_reached
 map_tile_source
 map_type_hybrid
@@ -1339,6 +1340,7 @@ number_of_records
 ### OFFLINE ###
 offline_maps
 offline_maps_empty
+offline_terrain_cache_detail
 offline_terrain_empty
 offline_terrain_manager
 offline_terrain_regional_detail

--- a/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/RootConventionPlugin.kt
@@ -115,6 +115,7 @@ private val ALL_MODULES_FULL =
         ":feature:docs",
         ":feature:map",
         ":feature:map-maplibre",
+        ":feature:map-terrain",
         ":feature:node",
         ":feature:settings",
         ":feature:firmware",

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1372,8 +1372,12 @@
     <string name="now">Now</string>
     <string name="ntp_server">NTP server</string>
     <string name="number_of_records">Number of records</string>
+    <!-- OFFLINE -->
     <string name="offline_maps">Offline maps</string>
     <string name="offline_maps_empty">No areas downloaded yet</string>
+    <string name="offline_terrain_empty">No terrain downloaded yet</string>
+    <string name="offline_terrain_manager">Offline Terrain</string>
+    <string name="offline_terrain_regional_detail">Includes high-detail regional terrain</string>
     <string name="ok_to_mqtt">Ok to MQTT</string>
     <string name="okay">OK</string>
     <string name="oled_type">OLED type</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1086,6 +1086,7 @@
     <string name="map_style_selection">Map style selection</string>
     <string name="map_subDescription">bearing: %1$d° distance: %2$s</string>
     <string name="map_tile_download_estimate">Tile download estimate:</string>
+    <string name="map_tile_download_estimate_detail">%1$s %2$s %3$s</string>
     <string name="map_tile_limit_reached">Tile limit reached (%1$d)</string>
     <string name="map_tile_source">Tile Source</string>
     <string name="map_type_hybrid">Hybrid</string>
@@ -1375,6 +1376,7 @@
     <!-- OFFLINE -->
     <string name="offline_maps">Offline maps</string>
     <string name="offline_maps_empty">No areas downloaded yet</string>
+    <string name="offline_terrain_cache_detail">%1$s: %2$s · %3$s</string>
     <string name="offline_terrain_empty">No terrain downloaded yet</string>
     <string name="offline_terrain_manager">Offline Terrain</string>
     <string name="offline_terrain_regional_detail">Includes high-detail regional terrain</string>

--- a/feature/map-maplibre/build.gradle.kts
+++ b/feature/map-maplibre/build.gradle.kts
@@ -47,6 +47,10 @@ kotlin {
             implementation(projects.core.service)
             implementation(projects.core.ui)
             implementation(projects.feature.map)
+            // Offline terrain math (elevation decode, contour generation, zoom-banded intervals) and storage
+            // (TerrainTileStore, TerrainRegionExtractor) — see feature/map-terrain's own build.gradle.kts for why the
+            // MapLibre-specific rendering wiring lives here instead.
+            implementation(projects.feature.mapTerrain)
 
             implementation(libs.kotlinx.collections.immutable)
             // The KML conversion cache lives on disk; Okio is how common code reaches it.
@@ -59,6 +63,10 @@ kotlin {
             api(libs.maplibre.compose)
             api(libs.maplibre.compose.material3)
         }
+
+        // Backs OfflineTerrainRepositoryTest's manifest/store round-trips without touching a real disk — same
+        // precedent as :feature:map-terrain's own TerrainTileStoreTest.
+        commonTest.dependencies { implementation(libs.okio.fakefilesystem) }
 
         // Compose UI tests live in jvmTest, not commonTest: this module enables Android host tests, and
         // `runComposeUiTest` has no Robolectric host there — the same tests NPE the moment they run under it.

--- a/feature/map-maplibre/src/androidMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainStorage.android.kt
+++ b/feature/map-maplibre/src/androidMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainStorage.android.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import okio.Path
+import okio.Path.Companion.toPath
+import org.meshtastic.core.common.ContextServices
+import java.io.File
+
+/** App-internal storage, so downloaded terrain is private to the app and removed with it. */
+actual fun terrainStorageDirectory(): Path = File(ContextServices.app.filesDir, TERRAIN_DIR).absolutePath.toPath()
+
+private const val TERRAIN_DIR = "terrain"

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MeshMap.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MeshMap.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
 import org.maplibre.compose.camera.CameraState
@@ -59,6 +60,7 @@ import org.meshtastic.feature.map.maplibre.layers.CustomLayers
 import org.meshtastic.feature.map.maplibre.layers.MapOverlayLayers
 import org.meshtastic.feature.map.maplibre.layers.NodeLayers
 import org.meshtastic.feature.map.maplibre.layers.RasterBasemapLayer
+import org.meshtastic.feature.map.maplibre.layers.TerrainLayers
 import org.meshtastic.feature.map.maplibre.layers.WaypointLayers
 import org.meshtastic.feature.map.maplibre.style.Basemap
 import org.meshtastic.feature.map.maplibre.style.Basemaps
@@ -116,6 +118,7 @@ fun MeshMap(
     val waypoints by viewModel.waypoints.collectAsStateWithLifecycle()
     val filterState by viewModel.mapFilterStateFlow.collectAsStateWithLifecycle()
     val myNodeInfo by viewModel.myNodeInfo.collectAsStateWithLifecycle()
+    val displayUnits by viewModel.displayUnits.collectAsStateWithLifecycle()
 
     val scope = rememberCoroutineScope()
     // This body recomposes on every camera frame (it reads the viewport below); the mesh-wide filter should not.
@@ -157,38 +160,66 @@ fun MeshMap(
             RasterBasemapLayer(basemap)
         }
         MapOverlayLayers(overlays, layerOpacity)
+        TerrainLayers(
+            viewportBounds = cameraState.viewport?.visibleBoundingBox,
+            zoom = cameraState.position.zoom,
+            displayUnits = displayUnits,
+        )
         CustomLayers(customLayers, layerOpacity)
 
         if (filterState.showWaypoints) {
             WaypointLayers(waypoints = waypoints.values, onWaypointClick = onWaypointClick)
         }
 
-        NodeLayers(
-            nodes = visibleNodes,
-            // Padded so a modest pan keeps the same nodes in view, and the chips are not redrawn for every frame of a
-            // drag. Without a viewport at all — the first composition — every node is a candidate, as before.
-            visibleBounds = cameraState.viewport?.visibleBoundingBox?.padded(CHIP_VIEW_PADDING),
-            // Floored: clustering indexes per whole zoom level, so the set only changes when the level does — and a
-            // pinch does not recompute it for every fractional step in between.
-            zoom = floor(cameraState.position.zoom).toInt(),
+        MeshMapNodeLayers(
+            visibleNodes = visibleNodes,
+            cameraState = cameraState,
+            filterState = filterState,
             myNodeNum = myNodeInfo?.myNodeNum,
-            showPrecisionCircles = filterState.showPrecisionCircle,
-            onNodeClick = navigateToNodeDetails,
+            navigateToNodeDetails = navigateToNodeDetails,
             onClusterMembers = onClusterMembers,
-            onClusterZoom = { centre, expansionZoom ->
-                scope.launch {
-                    val current = cameraState.position
-                    // A cluster that cannot report an expansion zoom answers with a sentinel (0 on
-                    // Android and desktop, -1 on iOS), so clamp — never zoom out on a tap.
-                    cameraState.animateTo(current.copy(target = centre, zoom = maxOf(expansionZoom, current.zoom)))
-                }
-            },
+            scope = scope,
         )
 
         // Declared last so the user's own position and an in-progress box corner draw above the mesh.
         UserLocationPuck(locationState = locationState, cameraState = cameraState, visible = followLocation)
         BoxCornerMarker(boxCorner)
     }
+}
+
+/** The node chips, clusters and precision circles — split out of [MeshMap] itself only to keep that function short. */
+@Composable
+@MaplibreComposable
+private fun MeshMapNodeLayers(
+    visibleNodes: List<Node>,
+    cameraState: CameraState,
+    filterState: BaseMapViewModel.MapFilterState,
+    myNodeNum: Int?,
+    navigateToNodeDetails: (Int) -> Unit,
+    onClusterMembers: (List<ClusterMember>) -> Unit,
+    scope: CoroutineScope,
+) {
+    NodeLayers(
+        nodes = visibleNodes,
+        // Padded so a modest pan keeps the same nodes in view, and the chips are not redrawn for every frame of a
+        // drag. Without a viewport at all — the first composition — every node is a candidate, as before.
+        visibleBounds = cameraState.viewport?.visibleBoundingBox?.padded(CHIP_VIEW_PADDING),
+        // Floored: clustering indexes per whole zoom level, so the set only changes when the level does — and a
+        // pinch does not recompute it for every fractional step in between.
+        zoom = floor(cameraState.position.zoom).toInt(),
+        myNodeNum = myNodeNum,
+        showPrecisionCircles = filterState.showPrecisionCircle,
+        onNodeClick = navigateToNodeDetails,
+        onClusterMembers = onClusterMembers,
+        onClusterZoom = { centre, expansionZoom ->
+            scope.launch {
+                val current = cameraState.position
+                // A cluster that cannot report an expansion zoom answers with a sentinel (0 on
+                // Android and desktop, -1 on iOS), so clamp — never zoom out on a tap.
+                cameraState.animateTo(current.copy(target = centre, zoom = maxOf(expansionZoom, current.zoom)))
+            }
+        },
+    )
 }
 
 /**

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/MapLayersButton.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/MapLayersButton.kt
@@ -132,6 +132,18 @@ private fun MapLayersSheet(
 
         HorizontalDivider()
 
+        // Not offlineMapsSupported-gated — see OfflineTerrainSection's own doc comment for why terrain downloads
+        // work on both Android and Desktop even though the base map's own offline packs don't.
+        OfflineTerrainSection(
+            target = offlineTarget,
+            onShowRegion = { bounds ->
+                onDismiss()
+                offlineTarget.showRegion(bounds)
+            },
+        )
+
+        HorizontalDivider()
+
         extra()
     }
 }

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/OfflineTerrainSection.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/OfflineTerrainSection.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.delete
+import org.meshtastic.core.resources.map_cache_megabytes
+import org.meshtastic.core.resources.map_cache_size
+import org.meshtastic.core.resources.map_cache_tiles
+import org.meshtastic.core.resources.map_select_download_region
+import org.meshtastic.core.resources.map_start_download
+import org.meshtastic.core.resources.map_tile_download_estimate
+import org.meshtastic.core.resources.map_tile_limit_reached
+import org.meshtastic.core.resources.map_zoom_levels
+import org.meshtastic.core.resources.offline_terrain_empty
+import org.meshtastic.core.resources.offline_terrain_manager
+import org.meshtastic.core.resources.offline_terrain_regional_detail
+import org.meshtastic.core.ui.icon.Delete
+import org.meshtastic.core.ui.icon.MeshtasticIcons
+import org.meshtastic.feature.map.maplibre.terrain.OfflineTerrainRegion
+import org.meshtastic.feature.map.maplibre.terrain.OfflineTerrainRepository
+import org.meshtastic.feature.map.maplibre.terrain.estimateTerrainTiles
+import org.meshtastic.feature.map.maplibre.terrain.toBoundingBox
+import org.meshtastic.feature.map.maplibre.terrain.toGeoBounds
+import org.meshtastic.feature.map.terrain.GeoBounds
+import org.meshtastic.feature.map.terrain.MapterhornEndpoints
+import org.meshtastic.feature.map.terrain.TerrainDownloadState
+import org.meshtastic.feature.map.terrain.TerrainRegionExtractor
+
+/**
+ * Offline terrain — hillshade and elevation contours for the viewport, downloaded as its own section of the layers
+ * sheet.
+ *
+ * Deliberately not gated by `offlineMapsSupported` like [OfflineMapsSection]: that flag exists because MapLibre's
+ * native `OfflinePack` API silently downloads nothing on Desktop (see this module's README), but
+ * [OfflineTerrainRepository] downloads over plain Ktor/Okio — the same reason `:feature:map-terrain`'s own
+ * build.gradle.kts says its storage "must also work on Desktop". This section works on both hosts and is shown on both.
+ */
+@Composable
+internal fun OfflineTerrainSection(target: OfflineMapTarget, onShowRegion: (BoundingBox) -> Unit) {
+    val repository = remember { OfflineTerrainRepository.default }
+    val scope = rememberCoroutineScope()
+    val region by repository.region.collectAsState()
+    // Not a local composable state: startDownload runs on the repository's own scope (see its doc comment for
+    // why), so the state it reports has to be read from there too, or progress would appear to vanish the moment
+    // this composable leaves composition and reappear wrong on the next one.
+    val downloadState by repository.downloadState.collectAsState()
+
+    LaunchedEffect(Unit) { repository.refresh() }
+
+    val bounds = target.bounds()
+    val maxZoom = target.terrainMaxZoom()
+    val estimate = bounds?.let { estimateTerrainTiles(it.toGeoBounds(), maxZoom) } ?: 0L
+    val overLimit = estimate > TerrainRegionExtractor.MAX_TILES
+    val isDownloading = downloadState is TerrainDownloadState.InProgress
+
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Text(text = stringResource(Res.string.offline_terrain_manager), style = MaterialTheme.typography.titleMedium)
+
+        val downloaded = region
+        if (downloaded == null) {
+            Text(
+                text = stringResource(Res.string.offline_terrain_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            DownloadedTerrainRow(
+                region = downloaded,
+                onShow = { onShowRegion(downloaded.bounds.toBoundingBox()) },
+                onDelete = { scope.launch { repository.delete() } },
+            )
+        }
+
+        TerrainDownloadControls(
+            bounds = bounds,
+            maxZoom = maxZoom,
+            estimate = estimate,
+            overLimit = overLimit,
+            isDownloading = isDownloading,
+            downloadState = downloadState,
+            onStartDownload = { b -> repository.startDownload(b, maxZoom) },
+        )
+    }
+}
+
+/**
+ * The estimate, the Start Download button, and its progress bar — split out only to keep [OfflineTerrainSection] short.
+ */
+@Composable
+private fun TerrainDownloadControls(
+    bounds: BoundingBox?,
+    maxZoom: Int,
+    estimate: Long,
+    overLimit: Boolean,
+    isDownloading: Boolean,
+    downloadState: TerrainDownloadState?,
+    onStartDownload: (GeoBounds) -> Unit,
+) {
+    // One outer Column, not three sibling top-level emitters: compose-rules' MultipleEmitters wants a composable to
+    // emit from a single source at its own top level, same as every other section composable in this file.
+    Column {
+        Column(modifier = Modifier.padding(top = 8.dp)) {
+            Text(
+                text = stringResource(Res.string.map_select_download_region),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                text =
+                stringResource(Res.string.map_tile_download_estimate) +
+                    " " +
+                    stringResource(Res.string.map_cache_tiles, estimate.toInt()) +
+                    "  " +
+                    stringResource(Res.string.map_zoom_levels, 0, maxZoom),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (overLimit) {
+                Text(
+                    text = stringResource(Res.string.map_tile_limit_reached, TerrainRegionExtractor.MAX_TILES),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+
+        Button(
+            onClick = { bounds?.let { onStartDownload(it.toGeoBounds()) } },
+            enabled = bounds != null && estimate in 1L..TerrainRegionExtractor.MAX_TILES.toLong() && !isDownloading,
+            modifier = Modifier.padding(vertical = 8.dp),
+        ) {
+            Text(text = stringResource(Res.string.map_start_download))
+        }
+
+        if (downloadState is TerrainDownloadState.InProgress) {
+            val fraction =
+                if (downloadState.total > 0) {
+                    downloadState.completed.toFloat() / downloadState.total.toFloat()
+                } else {
+                    0f
+                }
+            LinearProgressIndicator(
+                progress = { fraction.coerceIn(0f, 1f) },
+                modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DownloadedTerrainRow(region: OfflineTerrainRegion, onShow: () -> Unit, onDelete: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).clickable(onClick = onShow),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(modifier = Modifier.fillMaxWidth(TERRAIN_ROW_TEXT_FRACTION)) {
+            Text(
+                text =
+                stringResource(Res.string.map_cache_size) +
+                    ": " +
+                    stringResource(Res.string.map_cache_megabytes, region.byteSize.megabytes()) +
+                    " · " +
+                    stringResource(Res.string.map_cache_tiles, region.tileCount.toInt()),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (region.hasRegionalDetail) {
+                Text(
+                    text = stringResource(Res.string.offline_terrain_regional_detail),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        IconButton(onClick = onDelete) {
+            Icon(imageVector = MeshtasticIcons.Delete, contentDescription = stringResource(Res.string.delete))
+        }
+    }
+}
+
+/**
+ * The zoom levels a terrain download covers: the current level plus a couple deeper, mirroring [OfflineMapTarget]'s own
+ * private `zoomRange` convention for the base map's offline packs.
+ *
+ * Bounded by [MapterhornEndpoints.REGIONAL_MAX_ZOOM] rather than MapLibre's own 0..20, since [estimateTerrainTiles] and
+ * [TerrainRegionExtractor] never fetch anything deeper than that regardless of what is asked for.
+ */
+private fun OfflineMapTarget.terrainMaxZoom(): Int {
+    val current = zoom().toInt().coerceIn(0, MapterhornEndpoints.REGIONAL_MAX_ZOOM)
+    return (current + TERRAIN_EXTRA_ZOOM_LEVELS).coerceAtMost(MapterhornEndpoints.REGIONAL_MAX_ZOOM)
+}
+
+private const val TERRAIN_EXTRA_ZOOM_LEVELS = 2
+private const val TERRAIN_ROW_TEXT_FRACTION = 0.8f

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/OfflineTerrainSection.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/OfflineTerrainSection.kt
@@ -48,8 +48,10 @@ import org.meshtastic.core.resources.map_cache_tiles
 import org.meshtastic.core.resources.map_select_download_region
 import org.meshtastic.core.resources.map_start_download
 import org.meshtastic.core.resources.map_tile_download_estimate
+import org.meshtastic.core.resources.map_tile_download_estimate_detail
 import org.meshtastic.core.resources.map_tile_limit_reached
 import org.meshtastic.core.resources.map_zoom_levels
+import org.meshtastic.core.resources.offline_terrain_cache_detail
 import org.meshtastic.core.resources.offline_terrain_empty
 import org.meshtastic.core.resources.offline_terrain_manager
 import org.meshtastic.core.resources.offline_terrain_regional_detail
@@ -145,11 +147,12 @@ private fun TerrainDownloadControls(
             )
             Text(
                 text =
-                stringResource(Res.string.map_tile_download_estimate) +
-                    " " +
-                    stringResource(Res.string.map_cache_tiles, estimate.toInt()) +
-                    "  " +
+                stringResource(
+                    Res.string.map_tile_download_estimate_detail,
+                    stringResource(Res.string.map_tile_download_estimate),
+                    stringResource(Res.string.map_cache_tiles, estimate.toInt()),
                     stringResource(Res.string.map_zoom_levels, 0, maxZoom),
+                ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -195,11 +198,12 @@ private fun DownloadedTerrainRow(region: OfflineTerrainRegion, onShow: () -> Uni
         Column(modifier = Modifier.fillMaxWidth(TERRAIN_ROW_TEXT_FRACTION)) {
             Text(
                 text =
-                stringResource(Res.string.map_cache_size) +
-                    ": " +
-                    stringResource(Res.string.map_cache_megabytes, region.byteSize.megabytes()) +
-                    " · " +
+                stringResource(
+                    Res.string.offline_terrain_cache_detail,
+                    stringResource(Res.string.map_cache_size),
+                    stringResource(Res.string.map_cache_megabytes, region.byteSize.megabytes()),
                     stringResource(Res.string.map_cache_tiles, region.tileCount.toInt()),
+                ),
                 style = MaterialTheme.typography.bodyMedium,
             )
             if (region.hasRegionalDetail) {

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/geojson/ContourFeatureKeys.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/geojson/ContourFeatureKeys.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.geojson
+
+/**
+ * simplestyle-spec property keys carried on a contour line feature — read by
+ * [ContourLayer][org.meshtastic.feature.map.maplibre.layers.ContourLayer]'s style expressions.
+ *
+ * Its own file rather than living alongside [contourLinesToFeatures] in `ContourFeatures.kt`: detekt's
+ * `MatchingDeclarationName` requires a file with a single top-level class/object to be named after it, and
+ * `ContourFeatures.kt`'s own name describes the functions that file actually holds, not this small keys holder.
+ */
+internal object ContourFeatureKeys {
+    const val STROKE = "stroke"
+    const val STROKE_WIDTH = "stroke-width"
+    const val STROKE_OPACITY = "stroke-opacity"
+}

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/geojson/ContourFeatures.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/geojson/ContourFeatures.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.geojson
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.LineString
+import org.maplibre.spatialk.geojson.Position
+import org.meshtastic.feature.map.terrain.ContourGenerator
+import org.meshtastic.feature.map.terrain.ContourIntervals
+import org.meshtastic.feature.map.terrain.ContourLine
+import org.meshtastic.feature.map.terrain.ContourStyling
+import org.meshtastic.feature.map.terrain.ElevationTile
+import org.meshtastic.feature.map.terrain.MapterhornEndpoints
+import org.meshtastic.feature.map.terrain.TerrainSource
+import org.meshtastic.feature.map.terrain.TerrainTileMath
+import org.meshtastic.feature.map.terrain.TerrainTileStore
+import org.meshtastic.feature.map.terrain.TileIndex
+import org.meshtastic.feature.map.terrain.decodeTerrariumTile
+
+/**
+ * A decoded tile's contour lines, converted into real-world GeoJSON [Feature]s.
+ *
+ * Pure and unit-testable on its own — the impure half (reading tile bytes, decoding WebP) is
+ * [loadContourFeatureCollection], kept separate so this conversion can be tested without a [TerrainTileStore] or a real
+ * Terrarium tile.
+ *
+ * One feature per contour line, styled individually via [ContourStyling.styleFor] rather than split into two layers
+ * (index vs. minor): a single [ContourLayer] reading `stroke`/`stroke-width`/`stroke-opacity` off each feature is the
+ * same simplestyle pattern this module's imported-layer rendering (`CustomLayers.kt`) already uses, so contour lines
+ * style themselves the same way any other simplestyle-carrying import does.
+ */
+internal fun contourLinesToFeatures(
+    tile: TileIndex,
+    lines: List<ContourLine>,
+    zoom: Int,
+    metric: Boolean,
+): List<Feature<LineString, JsonObject?>> = lines.mapNotNull { line ->
+    // A contour needs at least two points to be a line; ContourGenerator.chain can in principle hand back a
+    // degenerate single-point chain at a grid's own edge.
+    if (line.points.size < 2) return@mapNotNull null
+
+    val positions =
+        line.points.map { point ->
+            val lonLat = TerrainTileMath.lonLatAt(tile, point.x, point.y)
+            Position(longitude = lonLat.longitude, latitude = lonLat.latitude)
+        }
+    val style = ContourStyling.styleFor(line, zoom, metric)
+
+    Feature(
+        geometry = LineString(positions),
+        properties =
+        buildJsonObject {
+            put(ContourFeatureKeys.STROKE, style.strokeHexColor)
+            put(ContourFeatureKeys.STROKE_WIDTH, style.strokeWidth)
+            put(ContourFeatureKeys.STROKE_OPACITY, style.strokeOpacity)
+        },
+    )
+}
+
+/**
+ * Decodes every downloaded elevation tile in [tiles] at [zoom] and turns their contours into one [FeatureCollection].
+ *
+ * Impure — reads from [store] and decodes WebP — so callers must run this off the composition thread; see
+ * [ContourLayer][org.meshtastic.feature.map.maplibre.layers.ContourLayer]'s own `produceState`/`ioDispatcher` usage,
+ * which follows the same precedent `GroundOverlayLayer` in `CustomLayers.kt` set for exactly this reason.
+ *
+ * A tile with nothing downloaded (outside the region, or above the region's own `maxZoom`) is skipped rather than
+ * treated as an error — the caller only ever asks for the tiles a viewport touches, some of which may fall outside what
+ * was actually downloaded.
+ *
+ * Per-tile [ContourIntervals.levelsForZoom]'s `maxElevationMeters` is that tile's own highest sample, not a shared
+ * constant: it keeps the level count tight for a low-lying tile instead of generating levels no cell could ever reach.
+ */
+internal fun loadContourFeatureCollection(
+    store: TerrainTileStore,
+    tiles: List<TileIndex>,
+    zoom: Int,
+    metric: Boolean,
+): FeatureCollection<LineString, JsonObject?> {
+    val features =
+        tiles.flatMap { tile ->
+            val source =
+                if (tile.zoom <= MapterhornEndpoints.GLOBAL_MAX_ZOOM) TerrainSource.GLOBAL else TerrainSource.REGIONAL
+            val bytes = store.readTile(source, tile) ?: return@flatMap emptyList()
+            val elevationTile = decodeElevationTileOrNull(bytes) ?: return@flatMap emptyList()
+
+            val maxElevation = elevationTile.elevations.maxOrNull() ?: return@flatMap emptyList()
+            val levels = ContourIntervals.levelsForZoom(zoom, metric, maxElevation)
+            val lines = ContourGenerator.generate(elevationTile, levels)
+            contourLinesToFeatures(tile, lines, zoom, metric)
+        }
+    return FeatureCollection(features)
+}
+
+/**
+ * A corrupt or unrecognized tile is skipped, matching [TerrainTileStore]'s own "absent means null" convention.
+ *
+ * Broad on purpose: [decodeTerrariumTile]'s platform actuals throw whatever their own image decoder throws for
+ * malformed bytes (`IllegalStateException` from the JVM/Android actuals' own `check()`/`error()` calls, or a
+ * decoder-specific `RuntimeException` from Skia for bytes that aren't a WebP at all) — a corrupt tile on disk should
+ * degrade to "no contours for this tile", never crash the map.
+ */
+private fun decodeElevationTileOrNull(bytes: ByteArray): ElevationTile? = try {
+    decodeTerrariumTile(bytes)
+} catch (_: RuntimeException) {
+    null
+}

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/TerrainLayers.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/TerrainLayers.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.layers
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonObject
+import org.maplibre.compose.expressions.dsl.asNumber
+import org.maplibre.compose.expressions.dsl.asString
+import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.expressions.dsl.convertToColor
+import org.maplibre.compose.expressions.dsl.dp
+import org.maplibre.compose.expressions.dsl.feature
+import org.maplibre.compose.layers.HillshadeLayer
+import org.maplibre.compose.layers.LineLayer
+import org.maplibre.compose.sources.GeoJsonData
+import org.maplibre.compose.sources.RasterDemEncoding
+import org.maplibre.compose.sources.TileSetOptions
+import org.maplibre.compose.sources.rememberGeoJsonSource
+import org.maplibre.compose.sources.rememberRasterDemSource
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.FeatureCollection
+import org.maplibre.spatialk.geojson.LineString
+import org.meshtastic.core.common.util.MeasurementSystem
+import org.meshtastic.core.common.util.ioDispatcher
+import org.meshtastic.feature.map.maplibre.geojson.ContourFeatureKeys
+import org.meshtastic.feature.map.maplibre.geojson.loadContourFeatureCollection
+import org.meshtastic.feature.map.maplibre.terrain.OfflineTerrainRegion
+import org.meshtastic.feature.map.maplibre.terrain.OfflineTerrainRepository
+import org.meshtastic.feature.map.maplibre.terrain.intersects
+import org.meshtastic.feature.map.maplibre.terrain.toGeoBounds
+import org.meshtastic.feature.map.terrain.MapterhornEndpoints
+import org.meshtastic.feature.map.terrain.TerrainSource
+import org.meshtastic.feature.map.terrain.TerrainTileMath
+
+/**
+ * Offline terrain — hillshade and elevation contours, rendered for the viewport when a downloaded region covers it.
+ *
+ * Gated on [OfflineTerrainRepository.default]'s [OfflineTerrainRegion] rather than being a togglable
+ * [org.meshtastic.feature.map.maplibre.style.MapOverlay] like the online hillshade overlay: there is nothing to toggle
+ * until something has been downloaded, and once it has, showing it automatically — the same "auto-activate once the
+ * precondition is met" shape the base offline layer's own fallback uses — beats a second switch the user has to
+ * remember to flip. If the online [org.meshtastic.feature.map.maplibre.style.MapOverlay.Hillshade] overlay is also on,
+ * the two composite on top of each other; harmless (both are legitimate shading of the same real terrain) and
+ * deliberately not deduplicated for this first version.
+ *
+ * **Not visually verified on a real device or desktop build in this session** — no display was available. The
+ * `file://` + raster-dem combination is architecturally sound (see this feature's PR description for the
+ * maplibre-native source evidence) but needs an on-device smoke test before merge, and so does the behavior of a
+ * `file://` tile source for a tile the store doesn't have on disk (a viewport that only partially overlaps the
+ * downloaded region, or a zoom level between the two tiers) — MapLibre's handling of a missing local file is unverified
+ * here.
+ */
+@Composable
+internal fun TerrainLayers(viewportBounds: BoundingBox?, zoom: Double, displayUnits: MeasurementSystem) {
+    val repository = remember { OfflineTerrainRepository.default }
+    val region by repository.region.collectAsState()
+
+    LaunchedEffect(Unit) { repository.refresh() }
+
+    // Two early returns (detekt's ReturnCount limit), kept inline rather than in a helper function: a helper
+    // returning a resolved nullable can't hand the compiler back a smart-cast on *this* function's own
+    // `viewportBounds` parameter, and ContourLayer below needs it non-null. A manifest can record `maxZoom = -1` —
+    // TerrainRegionExtractor's own "zero tiles requested" success case (see OfflineTerrainRepositoryTest) — meaning
+    // nothing was ever fetched; that and "no region at all" are treated the same way here.
+    val downloaded = region
+    if (downloaded == null || downloaded.maxZoom < 0 || viewportBounds == null) return
+    if (!downloaded.intersects(viewportBounds)) return
+
+    HillshadeTiers(repository, downloaded)
+    ContourLayer(repository, downloaded, viewportBounds, zoom, displayUnits == MeasurementSystem.METRIC)
+}
+
+/**
+ * The two hillshade tiers, as two [HillshadeLayer]s over two `file://` raster-dem sources (see
+ * [org.maplibre.compose.sources.rememberRasterDemSource]) — see this feature's PR description for why MapLibre's own
+ * internal Horn's-method shading means no decoded elevation grid or [org.meshtastic.feature.map.terrain.Hillshade] call
+ * is needed here at all, unlike the contours below.
+ *
+ * A style layer's own `minZoom`/`maxZoom` (exclusive on the max, per the style spec) is how the two tiers hand off: the
+ * global layer stops at [MapterhornEndpoints.REGIONAL_MIN_ZOOM] once regional detail exists, and the regional layer
+ * starts there — never both drawing the same pixel. Each source's own [TileSetOptions] is clamped to
+ * [OfflineTerrainRegion.maxZoom] as well as the tier's own endpoint constant, so MapLibre is never asked for a tile
+ * file this region's own download never fetched.
+ */
+@Composable
+private fun HillshadeTiers(repository: OfflineTerrainRepository, region: OfflineTerrainRegion) {
+    val globalMaxZoom = minOf(region.maxZoom, MapterhornEndpoints.GLOBAL_MAX_ZOOM)
+    val globalSource =
+        rememberRasterDemSource(
+            tiles = listOf(repository.tileUrlTemplate(TerrainSource.GLOBAL)),
+            options = TileSetOptions(minZoom = 0, maxZoom = globalMaxZoom),
+            encoding = RasterDemEncoding.Terrarium,
+        )
+
+    if (region.hasRegionalDetail) {
+        HillshadeLayer(
+            id = "offline-terrain-hillshade-global",
+            source = globalSource,
+            maxZoom = MapterhornEndpoints.REGIONAL_MIN_ZOOM.toFloat(),
+            shadowColor = const(Color.Black),
+            highlightColor = const(Color.White),
+            accentColor = const(Color.Black),
+        )
+
+        val regionalMaxZoom = minOf(region.maxZoom, MapterhornEndpoints.REGIONAL_MAX_ZOOM)
+        val regionalSource =
+            rememberRasterDemSource(
+                tiles = listOf(repository.tileUrlTemplate(TerrainSource.REGIONAL)),
+                options = TileSetOptions(minZoom = MapterhornEndpoints.REGIONAL_MIN_ZOOM, maxZoom = regionalMaxZoom),
+                encoding = RasterDemEncoding.Terrarium,
+            )
+        HillshadeLayer(
+            id = "offline-terrain-hillshade-regional",
+            source = regionalSource,
+            minZoom = MapterhornEndpoints.REGIONAL_MIN_ZOOM.toFloat(),
+            shadowColor = const(Color.Black),
+            highlightColor = const(Color.White),
+            accentColor = const(Color.Black),
+        )
+    } else {
+        HillshadeLayer(
+            id = "offline-terrain-hillshade-global",
+            source = globalSource,
+            shadowColor = const(Color.Black),
+            highlightColor = const(Color.White),
+            accentColor = const(Color.Black),
+        )
+    }
+}
+
+/**
+ * Elevation contours for the tiles [viewportBounds] touches, decoded off the composition thread — see
+ * [loadContourFeatureCollection]'s own doc comment for why, and `GroundOverlayLayer` in `CustomLayers.kt` for the
+ * precedent this follows.
+ *
+ * Styled per-feature via the simplestyle properties [loadContourFeatureCollection] already attached
+ * ([ContourFeatureKeys]), the same `stroke`/`stroke-width`/`stroke-opacity` expression pattern `CustomLayers.kt`'s
+ * `ImportedLayer` uses for imported overlays.
+ */
+@Composable
+private fun ContourLayer(
+    repository: OfflineTerrainRepository,
+    region: OfflineTerrainRegion,
+    viewportBounds: BoundingBox,
+    zoom: Double,
+    metric: Boolean,
+) {
+    // region.maxZoom.coerceAtLeast(0): a manifest can in principle round-trip a maxZoom of -1 (a real,
+    // successful "zero tiles requested" download — see OfflineTerrainRepositoryTest's own case for it), and
+    // coerceIn(0, -1) throws. Never produced by this section's own UI, but the manifest is disk state, not a
+    // value this code controls end to end.
+    val tileZoom = zoom.toInt().coerceIn(0, region.maxZoom.coerceAtLeast(0))
+    val tiles =
+        remember(viewportBounds, tileZoom) {
+            TerrainTileMath.tilesAt(tileZoom, viewportBounds.toGeoBounds()).take(MAX_CONTOUR_TILES)
+        }
+
+    val collection by
+        produceState<FeatureCollection<LineString, JsonObject?>?>(null, tiles, tileZoom, metric) {
+            value =
+                withContext(ioDispatcher) {
+                    loadContourFeatureCollection(repository.tileStore, tiles, tileZoom, metric)
+                }
+        }
+    val loaded = collection ?: return
+    if (loaded.features.isEmpty()) return
+
+    // Not rememberFeatureSource: that wrapper's own `remember` is keyed on inputs that change *before* the
+    // asynchronous produceState above finishes decoding, so it would republish the previous collection under
+    // the new keys and only catch up a recomposition later — contours would lag one tile-change behind forever.
+    // `loaded` here is already the freshly produced collection, so publishing it directly on every recomposition
+    // is the correct (and cheap — GeoJsonData.Features is a data class) case FeatureSource.kt's own doc comment
+    // describes for rememberGeoJsonSource itself.
+    val source = rememberGeoJsonSource(data = GeoJsonData.Features(loaded))
+
+    LineLayer(
+        id = "offline-terrain-contours",
+        source = source,
+        color = feature[ContourFeatureKeys.STROKE].asString().convertToColor(const(ContourFallbackColor)),
+        width = feature[ContourFeatureKeys.STROKE_WIDTH].asNumber().dp,
+        opacity = feature[ContourFeatureKeys.STROKE_OPACITY].asNumber(),
+    )
+}
+
+/**
+ * Tiles processed per contour recomposition — bounds the work `produceState`'s decode+marching-squares does on a
+ * viewport spanning many tiles at a shallow zoom. A viewport this wide already has coarser downloaded terrain (see
+ * [org.meshtastic.feature.map.maplibre.component.OfflineTerrainSection]'s own zoom-based download cap), so the tiles
+ * beyond this cap are the ones contributing the least visible contour detail anyway.
+ */
+private const val MAX_CONTOUR_TILES = 16
+
+/**
+ * Fallback only — every contour feature this module builds always carries its own `stroke` property (see
+ * [loadContourFeatureCollection]), so this is never actually drawn. Matches
+ * [org.meshtastic.feature.map.terrain.ContourStyling]'s own topo-map-conventional brown.
+ */
+private val ContourFallbackColor = Color(0xFF8B5A2B)

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/TerrainLayers.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/TerrainLayers.kt
@@ -92,6 +92,17 @@ internal fun TerrainLayers(viewportBounds: BoundingBox?, zoom: Double, displayUn
 }
 
 /**
+ * Attribution for both hillshade tiers' [TileSetOptions], picked up by
+ * [org.maplibre.compose.material3.AttributionButton]'s own per-source aggregation (deduplicated, so setting this on
+ * both tiers rather than only the always-present global one is harmless). The contour
+ * [org.maplibre.compose.sources.GeoJsonSource] below has no attribution field of its own to carry this on —
+ * [org.maplibre.compose.sources.GeoJsonOptions] doesn't have one — but contours only ever render alongside hillshade
+ * (see [TerrainLayers]'s shared gate), so this covers both.
+ */
+private const val MAPTERHORN_ATTRIBUTION_HTML =
+    "&copy; <a href=\"${MapterhornEndpoints.ATTRIBUTION_URL}\">Mapterhorn</a>"
+
+/**
  * The two hillshade tiers, as two [HillshadeLayer]s over two `file://` raster-dem sources (see
  * [org.maplibre.compose.sources.rememberRasterDemSource]) — see this feature's PR description for why MapLibre's own
  * internal Horn's-method shading means no decoded elevation grid or [org.meshtastic.feature.map.terrain.Hillshade] call
@@ -109,7 +120,8 @@ private fun HillshadeTiers(repository: OfflineTerrainRepository, region: Offline
     val globalSource =
         rememberRasterDemSource(
             tiles = listOf(repository.tileUrlTemplate(TerrainSource.GLOBAL)),
-            options = TileSetOptions(minZoom = 0, maxZoom = globalMaxZoom),
+            options =
+            TileSetOptions(minZoom = 0, maxZoom = globalMaxZoom, attributionHtml = MAPTERHORN_ATTRIBUTION_HTML),
             encoding = RasterDemEncoding.Terrarium,
         )
 
@@ -127,7 +139,12 @@ private fun HillshadeTiers(repository: OfflineTerrainRepository, region: Offline
         val regionalSource =
             rememberRasterDemSource(
                 tiles = listOf(repository.tileUrlTemplate(TerrainSource.REGIONAL)),
-                options = TileSetOptions(minZoom = MapterhornEndpoints.REGIONAL_MIN_ZOOM, maxZoom = regionalMaxZoom),
+                options =
+                TileSetOptions(
+                    minZoom = MapterhornEndpoints.REGIONAL_MIN_ZOOM,
+                    maxZoom = regionalMaxZoom,
+                    attributionHtml = MAPTERHORN_ATTRIBUTION_HTML,
+                ),
                 encoding = RasterDemEncoding.Terrarium,
             )
         HillshadeLayer(

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRegion.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRegion.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import kotlinx.serialization.Serializable
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Position
+import org.meshtastic.feature.map.terrain.GeoBounds
+
+/**
+ * What one downloaded offline-terrain region covers, persisted alongside its tiles as `manifest.json`.
+ *
+ * Deliberately singular — [OfflineTerrainRepository] tracks at most one region at a time, replaced wholesale by the
+ * next download. Unlike the base map's own offline packs (which can be stacked, one per neighborhood, and MapLibre's
+ * native `OfflineManager` already carries that bookkeeping) terrain has no equivalent native API to lean on, and
+ * nothing in the F-Droid/Desktop UX yet asks for more than "the terrain around where I am" — see
+ * [OfflineTerrainRepository]'s own doc comment for the fuller reasoning. Multi-region support, if ever needed, is an
+ * additive change: give this a generated `id` and the manifest a list.
+ */
+@Serializable
+data class OfflineTerrainRegion(
+    val south: Double,
+    val west: Double,
+    val north: Double,
+    val east: Double,
+    val maxZoom: Int,
+    val hasRegionalDetail: Boolean,
+    val tileCount: Long,
+    val byteSize: Long,
+) {
+    val bounds: GeoBounds
+        get() = GeoBounds(south = south, west = west, north = north, east = east)
+}
+
+/** [bounds] as the manifest's flat lat/lon fields — the inverse of [OfflineTerrainRegion.bounds]. */
+internal fun GeoBounds.toBoundingBox(): BoundingBox = BoundingBox(
+    southwest = Position(longitude = west, latitude = south),
+    northeast = Position(longitude = east, latitude = north),
+)
+
+/** A MapLibre viewport box as this module's own [GeoBounds] — the type `feature/map-terrain`'s math works in. */
+internal fun BoundingBox.toGeoBounds(): GeoBounds = GeoBounds(south = south, west = west, north = north, east = east)
+
+/**
+ * Whether [bounds] overlaps this region at all.
+ *
+ * Intersection, not containment: a viewport straddling the region's edge still gets partial hillshade/contours rather
+ * than none, which reads better than a hard cutoff mid-screen. The tradeoff — tiles just outside the downloaded
+ * footprint are requested and may be missing — is the same `file://`-missing-tile risk already flagged for the whole
+ * offline-terrain rendering path; see this feature's PR description.
+ */
+internal fun OfflineTerrainRegion.intersects(bounds: BoundingBox): Boolean =
+    south <= bounds.north && north >= bounds.south && west <= bounds.east && east >= bounds.west

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
@@ -30,15 +30,16 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okio.FileSystem
+import okio.IOException
 import okio.Path
 import org.meshtastic.core.common.util.ioDispatcher
 import org.meshtastic.feature.map.layers.mapLayerFileSystem
 import org.meshtastic.feature.map.terrain.GeoBounds
+import org.meshtastic.feature.map.terrain.TerrainDownloadFailure
 import org.meshtastic.feature.map.terrain.TerrainDownloadState
 import org.meshtastic.feature.map.terrain.TerrainRegionExtractor
 import org.meshtastic.feature.map.terrain.TerrainSource
@@ -120,32 +121,20 @@ class OfflineTerrainRepository(private val fileSystem: FileSystem, private val b
             _region.value = null
 
             TerrainRegionExtractor(store).download(bounds, maxZoom).collect { state ->
-                when (state) {
-                    is TerrainDownloadState.Complete -> {
-                        val downloaded =
-                            OfflineTerrainRegion(
-                                south = bounds.south,
-                                west = bounds.west,
-                                north = bounds.north,
-                                east = bounds.east,
-                                maxZoom = maxZoom,
-                                hasRegionalDetail = state.hasRegionalDetail,
-                                tileCount = state.tileCount,
-                                byteSize = state.byteSize,
-                            )
-                        writeManifest(downloaded)
-                        _region.value = downloaded
-                    }
+                val outcome =
+                    when (state) {
+                        is TerrainDownloadState.Complete -> persistCompletedDownload(bounds, maxZoom, state)
 
-                    is TerrainDownloadState.Failed -> {
-                        // Nothing partial is kept: TerrainRegionExtractor already ran store.deleteAll() itself
-                        // on both failure reasons (TILE_LIMIT_EXCEEDED never wrote a tile to begin with).
-                        Logger.withTag(LOG_TAG).w { "Offline terrain download failed: ${state.reason}" }
-                    }
+                        is TerrainDownloadState.Failed -> {
+                            // Nothing partial is kept: TerrainRegionExtractor already ran store.deleteAll() itself on
+                            // both failure reasons (TILE_LIMIT_EXCEEDED never wrote a tile to begin with).
+                            Logger.withTag(LOG_TAG).w { "Offline terrain download failed: ${state.reason}" }
+                            state
+                        }
 
-                    is TerrainDownloadState.InProgress -> Unit
-                }
-                emit(state)
+                        is TerrainDownloadState.InProgress -> state
+                    }
+                emit(outcome)
             }
         }
     }
@@ -184,9 +173,16 @@ class OfflineTerrainRepository(private val fileSystem: FileSystem, private val b
      * `baseDir` is always an absolute path (see [terrainStorageDirectory]'s platform actuals), so this yields a
      * three-slash `file:///...` URL — see `OfflineTerrainRepositoryTest`'s template test for why that is asserted
      * explicitly rather than left to be "fixed" to four slashes later.
+     *
+     * The directory portion is percent-encoded before interpolation — a Desktop/JVM user-data path can legitimately
+     * contain characters reserved in a URL (a space in a Windows/macOS username is the common case, `#`/`%` less so but
+     * just as real) — while the trailing `{z}/{x}/{y}` placeholders are appended afterwards, literally, so
+     * [rememberRasterDemSource]'s own substitution still sees them unescaped.
      */
-    fun tileUrlTemplate(source: TerrainSource): String =
-        "file://${baseDir / TILES_DIR_NAME / source.dirName}/{z}/{x}/{y}.webp"
+    fun tileUrlTemplate(source: TerrainSource): String {
+        val encodedDir = (baseDir / TILES_DIR_NAME / source.dirName).toString().percentEncodeUrlReserved()
+        return "file://$encodedDir/{z}/{x}/{y}.webp"
+    }
 
     private fun loadIfNeeded(force: Boolean = false) {
         if (loaded && !force) return
@@ -205,17 +201,62 @@ class OfflineTerrainRepository(private val fileSystem: FileSystem, private val b
         if (store.sizeBytes() > 0L) store.deleteAll()
     }
 
+    /**
+     * A manifest that fails to parse is unusable, but leaving it (and its tile directory) on disk would permanently
+     * retain that disk usage with no region shown and no delete action available to reclaim it — the next call would
+     * just hit the same corrupt file and return `null` again. Both are deleted here so the next [download] starts clean
+     * instead of layering a fresh manifest over stale, orphaned tiles.
+     *
+     * A single [IllegalArgumentException] catch, not a separate one for `SerializationException`: kotlinx.serialization
+     * throws that as a subtype of it, so one catch already covers both a malformed-JSON and a schema-mismatch manifest.
+     */
     private fun readManifest(): OfflineTerrainRegion? {
         if (!fileSystem.exists(manifestPath)) return null
         return try {
             val text = fileSystem.read(manifestPath) { readUtf8() }
             json.decodeFromString<OfflineTerrainRegion>(text)
-        } catch (error: SerializationException) {
-            Logger.withTag(LOG_TAG).w(error) { "Ignoring an unreadable offline-terrain manifest" }
-            null
         } catch (error: IllegalArgumentException) {
-            Logger.withTag(LOG_TAG).w(error) { "Ignoring an unreadable offline-terrain manifest" }
+            Logger.withTag(LOG_TAG).w(error) { "Discarding an unreadable offline-terrain manifest and its tiles" }
+            deleteManifest()
+            store.deleteAll()
             null
+        }
+    }
+
+    /**
+     * Builds the [OfflineTerrainRegion] for a [TerrainDownloadState.Complete] and persists it via [writeManifest] — the
+     * one write in [download] with no error handling of its own, so a full disk or a permission failure here would
+     * otherwise propagate as an uncaught exception instead of surfacing through [downloadState] like every other
+     * failure mode. On write failure, the tiles [TerrainRegionExtractor] just fetched are discarded too: a manifest-
+     * less tile directory is exactly what [cleanUpOrphanedTiles] treats as orphaned, so leaving them would just be
+     * deferring the same cleanup to the next [loadIfNeeded] instead of reporting the failure now.
+     */
+    private fun persistCompletedDownload(
+        bounds: GeoBounds,
+        maxZoom: Int,
+        state: TerrainDownloadState.Complete,
+    ): TerrainDownloadState {
+        val downloaded =
+            OfflineTerrainRegion(
+                south = bounds.south,
+                west = bounds.west,
+                north = bounds.north,
+                east = bounds.east,
+                maxZoom = maxZoom,
+                hasRegionalDetail = state.hasRegionalDetail,
+                tileCount = state.tileCount,
+                byteSize = state.byteSize,
+            )
+        return try {
+            writeManifest(downloaded)
+            _region.value = downloaded
+            state
+        } catch (error: IOException) {
+            Logger.withTag(LOG_TAG).w(error) { "Failed to persist the offline-terrain manifest" }
+            store.deleteAll()
+            deleteManifest()
+            _region.value = null
+            TerrainDownloadState.Failed(TerrainDownloadFailure.IO_ERROR)
         }
     }
 

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
@@ -151,7 +151,17 @@ class OfflineTerrainRepository(private val fileSystem: FileSystem, private val b
     fun startDownload(bounds: GeoBounds, maxZoom: Int) {
         if (downloadJob?.isActive == true) return
         _downloadState.value = null
-        downloadJob = scope.launch { download(bounds, maxZoom).collect { state -> _downloadState.value = state } }
+        downloadJob =
+            scope.launch {
+                try {
+                    download(bounds, maxZoom).collect { state -> _downloadState.value = state }
+                } catch (e: IOException) {
+                    // download() reports the extractor's and manifest's own failures as states; this is the
+                    // pre-extraction disk work (clearing the previous region), which otherwise leaves the state stuck.
+                    Logger.withTag(LOG_TAG).w(e) { "Offline terrain download failed before extraction" }
+                    _downloadState.value = TerrainDownloadState.Failed(TerrainDownloadFailure.IO_ERROR)
+                }
+            }
     }
 
     /** Deletes the current region's tiles and manifest, leaving nothing downloaded. A no-op if there is none. */

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
@@ -126,7 +126,8 @@ class OfflineTerrainRepository(private val fileSystem: FileSystem, private val b
                         is TerrainDownloadState.Complete -> persistCompletedDownload(bounds, maxZoom, state)
 
                         is TerrainDownloadState.Failed -> {
-                            // Nothing partial is kept: TerrainRegionExtractor already ran store.deleteAll() itself on
+                            // Nothing partial is kept: TerrainRegionExtractor already ran store.deleteAll()
+                            // itself on
                             // both failure reasons (TILE_LIMIT_EXCEEDED never wrote a tile to begin with).
                             Logger.withTag(LOG_TAG).w { "Offline terrain download failed: ${state.reason}" }
                             state

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+import org.meshtastic.core.common.util.ioDispatcher
+import org.meshtastic.feature.map.layers.mapLayerFileSystem
+import org.meshtastic.feature.map.terrain.GeoBounds
+import org.meshtastic.feature.map.terrain.TerrainDownloadState
+import org.meshtastic.feature.map.terrain.TerrainRegionExtractor
+import org.meshtastic.feature.map.terrain.TerrainSource
+import org.meshtastic.feature.map.terrain.TerrainTileStore
+
+/**
+ * Owns the one downloaded offline-terrain region: its manifest, and the [TerrainTileStore] holding its tiles.
+ *
+ * Not a Koin `@Single`. [MapLibreMapViewProvider][org.meshtastic.feature.map.maplibre.MapLibreMapViewProvider]'s own
+ * doc comment already states this module's rule — "free of any assumption about how the host app wires its graph" — and
+ * it turns out to bind harder than usual here: a `@Module @ComponentScan` in this package would only take effect once
+ * some host's Koin startup imports it, and every host that does that (`androidApp/src/main`'s `MainKoinModule`)
+ * compiles into *both* Android flavors, so registering it there would pull a MapLibre-only type into the Google
+ * flavor's dependency graph, exactly what this module's own build.gradle.kts forbids. [default] is how every caller
+ * reaches the same instance instead — a plain lazily-initialized singleton, not a DI one.
+ *
+ * Single region, not a list: see [OfflineTerrainRegion]'s own doc comment for why. A new [download] therefore replaces
+ * whatever was there before — deleting the old tiles and manifest *before* fetching the first new one, not after. This
+ * is a known, deliberate tradeoff, not an oversight: there is nowhere to stage the new region side-by-side with the old
+ * one without doubling disk usage for the download's duration, so a [download] that later fails or is cancelled leaves
+ * nothing downloaded rather than restoring what was there — [region] reports `null`, the same as if nothing had ever
+ * been fetched.
+ */
+class OfflineTerrainRepository(private val fileSystem: FileSystem, private val baseDir: Path) {
+
+    private val store = TerrainTileStore(fileSystem, baseDir / TILES_DIR_NAME)
+
+    /** For reading tile bytes directly — [org.meshtastic.feature.map.maplibre.layers.ContourLayer]'s own use. */
+    val tileStore: TerrainTileStore
+        get() = store
+
+    private val manifestPath = baseDir / MANIFEST_FILE_NAME
+    private val json = Json { ignoreUnknownKeys = true }
+    private val mutex = Mutex()
+    private var loaded = false
+
+    // Owns download execution — deliberately not the caller's CoroutineScope. A UI-scoped download (the layers
+    // sheet's own rememberCoroutineScope, say) is cancelled the instant that UI goes away — closing the sheet,
+    // rotating the device — and TerrainRegionExtractor's own broad `catch (_: Exception)` also catches the
+    // CancellationException that produces, running store.deleteAll() on a download the user never actually asked
+    // to abandon. Owning the scope here means only this repository's own lifetime (the process) can cancel one.
+    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private var downloadJob: Job? = null
+
+    private val _region = MutableStateFlow<OfflineTerrainRegion?>(null)
+
+    /** The current region, or `null` if nothing has been downloaded. Populated by [refresh]. */
+    val region: StateFlow<OfflineTerrainRegion?> = _region.asStateFlow()
+
+    private val _downloadState = MutableStateFlow<TerrainDownloadState?>(null)
+
+    /** The most recent state [startDownload] has reported, surviving a UI that goes away and comes back. */
+    val downloadState: StateFlow<TerrainDownloadState?> = _downloadState.asStateFlow()
+
+    /**
+     * Loads the manifest from disk if this is the first call. Idempotent, and cheap after the first: everything past
+     * that point reads [region]'s already-loaded value. Callers that only ever read [region] from a composable should
+     * call this once from a `LaunchedEffect`; see
+     * [TerrainLayers][org.meshtastic.feature.map.maplibre.layers.TerrainLayers].
+     */
+    suspend fun refresh() {
+        withContext(ioDispatcher) { mutex.withLock { loadIfNeeded(force = true) } }
+    }
+
+    /**
+     * Replaces whatever region was downloaded before with a fresh one covering [bounds] up to [maxZoom].
+     *
+     * Runs on [ioDispatcher] — [TerrainRegionExtractor] does blocking range-request I/O per tile (see
+     * `TerrainTileFetcher`'s own doc comment), and this flow's collector must never be left running on the caller's own
+     * dispatcher for that reason. The manifest is written only after the extractor reports
+     * [TerrainDownloadState.Complete], so a process death mid-download leaves tiles with no manifest — [loadIfNeeded]
+     * treats that combination as orphaned and clears it, rather than resurrecting a manifest-less region.
+     */
+    fun download(bounds: GeoBounds, maxZoom: Int): Flow<TerrainDownloadState> = flow {
+        mutex.withLock {
+            loadIfNeeded()
+            store.deleteAll()
+            deleteManifest()
+            _region.value = null
+
+            TerrainRegionExtractor(store).download(bounds, maxZoom).collect { state ->
+                when (state) {
+                    is TerrainDownloadState.Complete -> {
+                        val downloaded =
+                            OfflineTerrainRegion(
+                                south = bounds.south,
+                                west = bounds.west,
+                                north = bounds.north,
+                                east = bounds.east,
+                                maxZoom = maxZoom,
+                                hasRegionalDetail = state.hasRegionalDetail,
+                                tileCount = state.tileCount,
+                                byteSize = state.byteSize,
+                            )
+                        writeManifest(downloaded)
+                        _region.value = downloaded
+                    }
+
+                    is TerrainDownloadState.Failed -> {
+                        // Nothing partial is kept: TerrainRegionExtractor already ran store.deleteAll() itself
+                        // on both failure reasons (TILE_LIMIT_EXCEEDED never wrote a tile to begin with).
+                        Logger.withTag(LOG_TAG).w { "Offline terrain download failed: ${state.reason}" }
+                    }
+
+                    is TerrainDownloadState.InProgress -> Unit
+                }
+                emit(state)
+            }
+        }
+    }
+        .flowOn(ioDispatcher)
+
+    /**
+     * Starts a [download] on this repository's own [scope] and mirrors its emissions into [downloadState], so a caller
+     * observes progress instead of collecting a `Flow` tied to its own lifecycle — see [scope]'s own comment for why
+     * that distinction matters here. A no-op while a download is already running, closing the double-tap window a
+     * UI-side "is it downloading" check can't close on its own (the first [TerrainDownloadState.InProgress] only
+     * arrives after several tiles have already been fetched).
+     */
+    fun startDownload(bounds: GeoBounds, maxZoom: Int) {
+        if (downloadJob?.isActive == true) return
+        _downloadState.value = null
+        downloadJob = scope.launch { download(bounds, maxZoom).collect { state -> _downloadState.value = state } }
+    }
+
+    /** Deletes the current region's tiles and manifest, leaving nothing downloaded. A no-op if there is none. */
+    suspend fun delete() {
+        withContext(ioDispatcher) {
+            mutex.withLock {
+                store.deleteAll()
+                deleteManifest()
+                _region.value = null
+                loaded = true
+            }
+        }
+    }
+
+    /**
+     * The `file://` URL template [rememberRasterDemSource][org.maplibre.compose.sources.rememberRasterDemSource]
+     * (hillshade) can use to reach [source]'s downloaded tiles directly, matching [TerrainTileStore]'s own
+     * `<baseDir>/<source>/<zoom>/<x>/<y>.webp` layout.
+     *
+     * `baseDir` is always an absolute path (see [terrainStorageDirectory]'s platform actuals), so this yields a
+     * three-slash `file:///...` URL — see `OfflineTerrainRepositoryTest`'s template test for why that is asserted
+     * explicitly rather than left to be "fixed" to four slashes later.
+     */
+    fun tileUrlTemplate(source: TerrainSource): String =
+        "file://${baseDir / TILES_DIR_NAME / source.dirName}/{z}/{x}/{y}.webp"
+
+    private fun loadIfNeeded(force: Boolean = false) {
+        if (loaded && !force) return
+        cleanUpOrphanedTiles()
+        _region.value = readManifest()
+        loaded = true
+    }
+
+    /**
+     * A tile directory with no manifest can only be the result of a process death mid-[download] (the manifest is
+     * always the last thing written, on [TerrainDownloadState.Complete]) — there is no region to describe it, so its
+     * tiles are unreachable and just consuming disk. Cleared on the next load rather than left to accumulate.
+     */
+    private fun cleanUpOrphanedTiles() {
+        if (fileSystem.exists(manifestPath)) return
+        if (store.sizeBytes() > 0L) store.deleteAll()
+    }
+
+    private fun readManifest(): OfflineTerrainRegion? {
+        if (!fileSystem.exists(manifestPath)) return null
+        return try {
+            val text = fileSystem.read(manifestPath) { readUtf8() }
+            json.decodeFromString<OfflineTerrainRegion>(text)
+        } catch (error: SerializationException) {
+            Logger.withTag(LOG_TAG).w(error) { "Ignoring an unreadable offline-terrain manifest" }
+            null
+        } catch (error: IllegalArgumentException) {
+            Logger.withTag(LOG_TAG).w(error) { "Ignoring an unreadable offline-terrain manifest" }
+            null
+        }
+    }
+
+    private fun writeManifest(region: OfflineTerrainRegion) {
+        manifestPath.parent?.let { fileSystem.createDirectories(it) }
+        fileSystem.write(manifestPath) { writeUtf8(json.encodeToString(region)) }
+    }
+
+    private fun deleteManifest() {
+        if (fileSystem.exists(manifestPath)) fileSystem.delete(manifestPath)
+    }
+
+    companion object {
+        private const val TILES_DIR_NAME = "tiles"
+        private const val MANIFEST_FILE_NAME = "manifest.json"
+        private const val LOG_TAG = "OfflineTerrainRepository"
+
+        /**
+         * The one instance every host and composable in this module shares — see the class doc comment for why this is
+         * a plain lazy singleton rather than a Koin one. Backed by [terrainStorageDirectory] and [mapLayerFileSystem],
+         * the same storage-location split [org.meshtastic.feature.map.layers.MapLayersManager] uses.
+         */
+        val default: OfflineTerrainRepository by lazy {
+            OfflineTerrainRepository(mapLayerFileSystem(), terrainStorageDirectory())
+        }
+    }
+}

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainStorage.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainStorage.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import okio.Path
+
+/**
+ * Where this platform's offline terrain (Mapterhorn tiles plus [OfflineTerrainRegion]'s manifest) is kept.
+ *
+ * Mirrors [org.meshtastic.feature.map.layers.mapLayersDirectory]'s expect/actual shape — same reasoning: app-private
+ * storage on Android, a home-directory folder on Desktop next to the existing `~/.meshtastic` data. Declared here
+ * rather than in `:feature:map-terrain` (which owns [org.meshtastic.feature.map.terrain.TerrainTileStore] itself but
+ * deliberately knows nothing about *where* a caller puts it) or `:feature:map` (shared by both flavors, and the Google
+ * flavor's own offline-terrain storage convention is a separate piece of work, not this one's to decide).
+ *
+ * [org.meshtastic.feature.map.layers.mapLayerFileSystem] is reused for the [okio.FileSystem] — it is already
+ * `FileSystem.SYSTEM` on every platform this module targets, and redeclaring the same expect/actual here would just be
+ * a second name for it.
+ */
+expect fun terrainStorageDirectory(): Path

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/PathPercentEncoding.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/PathPercentEncoding.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+/**
+ * Percent-encodes the characters a legitimate Desktop/JVM user-data path can contain that are reserved in a URL — a
+ * space in a Windows/macOS username is the common case, `#` (fragment) and a literal `%` less so but just as real. `/`
+ * passes through untouched, since it is [OfflineTerrainRepository.tileUrlTemplate]'s own path separator, not something
+ * to escape.
+ *
+ * Deliberately narrow rather than a full RFC 3986 path encoder: the directory it is applied to is platform file-system
+ * output, not arbitrary or untrusted input, so only the characters that would otherwise break the `file://` URL need
+ * handling. Its own file, not a member of [OfflineTerrainRepository], so that class stays under detekt's
+ * `TooManyFunctions` per-class/per-file thresholds.
+ */
+internal fun String.percentEncodeUrlReserved(): String = buildString {
+    for (char in this@percentEncodeUrlReserved) {
+        when (char) {
+            ' ' -> append("%20")
+            '#' -> append("%23")
+            '%' -> append("%25")
+            else -> append(char)
+        }
+    }
+}

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/TerrainDownloadEstimate.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/TerrainDownloadEstimate.kt
@@ -25,16 +25,18 @@ import org.meshtastic.feature.map.terrain.TerrainTileMath
  * [bounds] up to [maxZoom] — the global tier always, the regional tier only where [MapterhornEndpoints.regionalUrlFor]
  * finds one.
  *
- * A separate, pure re-implementation of the extractor's own tile enumeration rather than a shared helper: the
- * extractor's `download` is a suspending [kotlinx.coroutines.flow.Flow] that fetches as it counts, which is exactly the
- * network work this estimate has to run *without* — matching [org.meshtastic.feature.map.maplibre.tileCount]'s own
- * "shown before a download starts" role for the base offline layer. If the extractor's own enumeration ever changes,
- * this must change with it — that coupling is intentional, not an oversight; a unit test pins it against
- * [MapterhornEndpoints]'s real constants rather than a copy of them.
+ * The counting itself is [TerrainTileMath.tileCountAt] — the same O(1)-per-zoom corner arithmetic the extractor uses to
+ * bound memory before it enumerates tiles, so this and the extractor can never silently disagree on *how many* a zoom
+ * level covers. What's re-derived here, network-free, is only the *which zoom levels / which tier* decision from the
+ * extractor's own suspending `download` [kotlinx.coroutines.flow.Flow] — matching
+ * [org.meshtastic.feature.map.maplibre.tileCount]'s own "shown before a download starts" role for the base offline
+ * layer. If the extractor's own tier/zoom-range logic ever changes, this must change with it — that coupling is
+ * intentional, not an oversight; a unit test pins it against [MapterhornEndpoints]'s real constants rather than a copy
+ * of them.
  */
 internal fun estimateTerrainTiles(bounds: GeoBounds, maxZoom: Int): Long {
     val globalZoomRange = 0..minOf(maxZoom, MapterhornEndpoints.GLOBAL_MAX_ZOOM)
-    val globalCount = globalZoomRange.sumOf { zoom -> countTiles(zoom, bounds) }
+    val globalCount = globalZoomRange.sumOf { zoom -> TerrainTileMath.tileCountAt(zoom, bounds) }
 
     val hasRegionalTier =
         maxZoom > MapterhornEndpoints.GLOBAL_MAX_ZOOM && MapterhornEndpoints.regionalUrlFor(bounds) != null
@@ -42,25 +44,10 @@ internal fun estimateTerrainTiles(bounds: GeoBounds, maxZoom: Int): Long {
         if (hasRegionalTier) {
             val regionalMaxZoom = minOf(maxZoom, MapterhornEndpoints.REGIONAL_MAX_ZOOM)
             val regionalZoomRange = MapterhornEndpoints.REGIONAL_MIN_ZOOM..regionalMaxZoom
-            regionalZoomRange.sumOf { zoom -> countTiles(zoom, bounds) }
+            regionalZoomRange.sumOf { zoom -> TerrainTileMath.tileCountAt(zoom, bounds) }
         } else {
             0L
         }
 
     return globalCount + regionalCount
-}
-
-/**
- * How many tiles [TerrainTileMath.tilesAt] would return for [zoom]/[bounds], computed from the two corner indices
- * rather than by materializing the list — [TerrainTileMath.tilesAt] doesn't unwrap the antimeridian (unlike
- * [org.meshtastic.feature.map.maplibre.tileCount]'s own counter), so a world-spanning [bounds] at a deep zoom is a
- * multi-million-entry list; this stays O(1) per zoom regardless of how large the count itself is. `coerceAtLeast(0)`
- * mirrors what an empty `IntRange` (start > end) already does in [TerrainTileMath.tilesAt]'s own loop.
- */
-private fun countTiles(zoom: Int, bounds: GeoBounds): Long {
-    val northwest = TerrainTileMath.tileAt(zoom, bounds.north, bounds.west)
-    val southeast = TerrainTileMath.tileAt(zoom, bounds.south, bounds.east)
-    val columns = (southeast.x - northwest.x + 1).coerceAtLeast(0)
-    val rows = (southeast.y - northwest.y + 1).coerceAtLeast(0)
-    return columns.toLong() * rows.toLong()
 }

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/TerrainDownloadEstimate.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/TerrainDownloadEstimate.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import org.meshtastic.feature.map.terrain.GeoBounds
+import org.meshtastic.feature.map.terrain.MapterhornEndpoints
+import org.meshtastic.feature.map.terrain.TerrainTileMath
+
+/**
+ * How many tiles [TerrainRegionExtractor][org.meshtastic.feature.map.terrain.TerrainRegionExtractor] would fetch for
+ * [bounds] up to [maxZoom] — the global tier always, the regional tier only where [MapterhornEndpoints.regionalUrlFor]
+ * finds one.
+ *
+ * A separate, pure re-implementation of the extractor's own tile enumeration rather than a shared helper: the
+ * extractor's `download` is a suspending [kotlinx.coroutines.flow.Flow] that fetches as it counts, which is exactly the
+ * network work this estimate has to run *without* — matching [org.meshtastic.feature.map.maplibre.tileCount]'s own
+ * "shown before a download starts" role for the base offline layer. If the extractor's own enumeration ever changes,
+ * this must change with it — that coupling is intentional, not an oversight; a unit test pins it against
+ * [MapterhornEndpoints]'s real constants rather than a copy of them.
+ */
+internal fun estimateTerrainTiles(bounds: GeoBounds, maxZoom: Int): Long {
+    val globalZoomRange = 0..minOf(maxZoom, MapterhornEndpoints.GLOBAL_MAX_ZOOM)
+    val globalCount = globalZoomRange.sumOf { zoom -> countTiles(zoom, bounds) }
+
+    val hasRegionalTier =
+        maxZoom > MapterhornEndpoints.GLOBAL_MAX_ZOOM && MapterhornEndpoints.regionalUrlFor(bounds) != null
+    val regionalCount =
+        if (hasRegionalTier) {
+            val regionalMaxZoom = minOf(maxZoom, MapterhornEndpoints.REGIONAL_MAX_ZOOM)
+            val regionalZoomRange = MapterhornEndpoints.REGIONAL_MIN_ZOOM..regionalMaxZoom
+            regionalZoomRange.sumOf { zoom -> countTiles(zoom, bounds) }
+        } else {
+            0L
+        }
+
+    return globalCount + regionalCount
+}
+
+/**
+ * How many tiles [TerrainTileMath.tilesAt] would return for [zoom]/[bounds], computed from the two corner indices
+ * rather than by materializing the list — [TerrainTileMath.tilesAt] doesn't unwrap the antimeridian (unlike
+ * [org.meshtastic.feature.map.maplibre.tileCount]'s own counter), so a world-spanning [bounds] at a deep zoom is a
+ * multi-million-entry list; this stays O(1) per zoom regardless of how large the count itself is. `coerceAtLeast(0)`
+ * mirrors what an empty `IntRange` (start > end) already does in [TerrainTileMath.tilesAt]'s own loop.
+ */
+private fun countTiles(zoom: Int, bounds: GeoBounds): Long {
+    val northwest = TerrainTileMath.tileAt(zoom, bounds.north, bounds.west)
+    val southeast = TerrainTileMath.tileAt(zoom, bounds.south, bounds.east)
+    val columns = (southeast.x - northwest.x + 1).coerceAtLeast(0)
+    val rows = (southeast.y - northwest.y + 1).coerceAtLeast(0)
+    return columns.toLong() * rows.toLong()
+}

--- a/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/geojson/ContourFeaturesTest.kt
+++ b/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/geojson/ContourFeaturesTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.geojson
+
+import kotlinx.serialization.json.float
+import kotlinx.serialization.json.jsonPrimitive
+import org.maplibre.spatialk.geojson.LineString
+import org.meshtastic.feature.map.terrain.ContourLine
+import org.meshtastic.feature.map.terrain.ContourPoint
+import org.meshtastic.feature.map.terrain.TerrainTileMath
+import org.meshtastic.feature.map.terrain.TileIndex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ContourFeaturesTest {
+
+    private val tile = TileIndex(zoom = 10, x = 163, y = 353)
+
+    @Test
+    fun `a two-point line becomes one LineString feature`() {
+        val line = ContourLine(elevationMeters = 250f, points = listOf(ContourPoint(0f, 0f), ContourPoint(1f, 1f)))
+
+        val features = contourLinesToFeatures(tile, listOf(line), zoom = 12, metric = true)
+
+        assertEquals(1, features.size)
+        assertEquals(2, (features.single().geometry as LineString).coordinates.size)
+    }
+
+    @Test
+    fun `a degenerate single-point line is dropped`() {
+        val line = ContourLine(elevationMeters = 250f, points = listOf(ContourPoint(0.5f, 0.5f)))
+        assertTrue(contourLinesToFeatures(tile, listOf(line), zoom = 12, metric = true).isEmpty())
+    }
+
+    @Test
+    fun `tile-local points convert to the same lat lon TerrainTileMath's own inverse would produce`() {
+        val line = ContourLine(elevationMeters = 100f, points = listOf(ContourPoint(0f, 0f), ContourPoint(1f, 1f)))
+        val feature = contourLinesToFeatures(tile, listOf(line), zoom = 12, metric = true).single()
+        val positions = (feature.geometry as LineString).coordinates
+
+        val expectedFirst = TerrainTileMath.lonLatAt(tile, 0f, 0f)
+        assertEquals(expectedFirst.longitude, positions.first().longitude)
+        assertEquals(expectedFirst.latitude, positions.first().latitude)
+    }
+
+    @Test
+    fun `an index-level line's properties differ from a minor-level line's`() {
+        // At zoom 8, metric, ContourIntervals bands the index level at 2500m and the minor at 500m increments —
+        // see ContourIntervalsTest for the table this pins.
+        val twoPoints = listOf(ContourPoint(0f, 0f), ContourPoint(1f, 0f))
+        val indexLine = ContourLine(elevationMeters = 2_500f, points = twoPoints)
+        val minorLine = ContourLine(elevationMeters = 500f, points = twoPoints)
+
+        val indexFeature = contourLinesToFeatures(tile, listOf(indexLine), zoom = 8, metric = true).single()
+        val minorFeature = contourLinesToFeatures(tile, listOf(minorLine), zoom = 8, metric = true).single()
+
+        val indexWidth = indexFeature.properties?.get("stroke-width")?.jsonPrimitive?.float
+        val minorWidth = minorFeature.properties?.get("stroke-width")?.jsonPrimitive?.float
+        assertTrue(requireNotNull(indexWidth) > requireNotNull(minorWidth))
+    }
+}

--- a/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRegionTest.kt
+++ b/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRegionTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import org.maplibre.spatialk.geojson.BoundingBox
+import org.maplibre.spatialk.geojson.Position
+import org.meshtastic.feature.map.terrain.GeoBounds
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OfflineTerrainRegionTest {
+
+    private fun region(south: Double, west: Double, north: Double, east: Double) = OfflineTerrainRegion(
+        south = south,
+        west = west,
+        north = north,
+        east = east,
+        maxZoom = 12,
+        hasRegionalDetail = false,
+        tileCount = 1,
+        byteSize = 1,
+    )
+
+    @Test
+    fun `bounds reflects the manifest's own flat fields`() {
+        val region = region(south = 1.0, west = 2.0, north = 3.0, east = 4.0)
+        assertEquals(GeoBounds(south = 1.0, west = 2.0, north = 3.0, east = 4.0), region.bounds)
+    }
+
+    @Test
+    fun `toBoundingBox and toGeoBounds are inverses`() {
+        val bounds = GeoBounds(south = -10.0, west = -20.0, north = 30.0, east = 40.0)
+        assertEquals(bounds, bounds.toBoundingBox().toGeoBounds())
+    }
+
+    @Test
+    fun `intersects is true for overlapping boxes and false for disjoint ones`() {
+        val region = region(south = 0.0, west = 0.0, north = 10.0, east = 10.0)
+
+        val overlapping =
+            BoundingBox(
+                southwest = Position(longitude = 5.0, latitude = 5.0),
+                northeast = Position(longitude = 15.0, latitude = 15.0),
+            )
+        assertTrue(region.intersects(overlapping))
+
+        val disjoint =
+            BoundingBox(
+                southwest = Position(longitude = 20.0, latitude = 20.0),
+                northeast = Position(longitude = 30.0, latitude = 30.0),
+            )
+        assertFalse(region.intersects(disjoint))
+    }
+
+    @Test
+    fun `intersects is true for a viewport entirely inside the region`() {
+        val region = region(south = 0.0, west = 0.0, north = 10.0, east = 10.0)
+        val inside =
+            BoundingBox(
+                southwest = Position(longitude = 4.0, latitude = 4.0),
+                northeast = Position(longitude = 6.0, latitude = 6.0),
+            )
+        assertTrue(region.intersects(inside))
+    }
+}

--- a/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepositoryTest.kt
+++ b/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepositoryTest.kt
@@ -64,6 +64,24 @@ class OfflineTerrainRepositoryTest {
     }
 
     @Test
+    fun `a corrupt manifest is deleted along with its tile directory not just ignored`() = runTest {
+        // A manifest that fails to parse must not be left on disk to permanently retain its tiles' disk usage with
+        // no region shown and no delete action available to reclaim it.
+        fileSystem.createDirectories(baseDir)
+        fileSystem.write(baseDir / "manifest.json") { writeUtf8("not valid json") }
+        val store = TerrainTileStore(fileSystem, baseDir / "tiles")
+        store.writeTile(TerrainSource.GLOBAL, TileIndex(5, 1, 1), byteArrayOf(1, 2, 3))
+        assertTrue(store.sizeBytes() > 0L)
+
+        val repository = repository()
+        repository.refresh()
+
+        assertNull(repository.region.value)
+        assertTrue(!fileSystem.exists(baseDir / "manifest.json"))
+        assertEquals(0L, store.sizeBytes())
+    }
+
+    @Test
     fun `a manifest with no tile directory still loads as a region`() = runTest {
         // The manifest and the tile directory are independent on disk; this only exercises manifest read/write, not
         // the orphan-tile cleanup above.
@@ -137,6 +155,18 @@ class OfflineTerrainRepositoryTest {
         assertEquals(
             "file:///data/terrain/tiles/regional/{z}/{x}/{y}.webp",
             repository.tileUrlTemplate(TerrainSource.REGIONAL),
+        )
+    }
+
+    @Test
+    fun `tileUrlTemplate percent-encodes reserved characters but leaves the z x y placeholders literal`() {
+        // A Windows/macOS username with a space is the common real-world case; # and % are less common but just as
+        // real (a fragment delimiter and the escape prefix itself, respectively).
+        val repository = OfflineTerrainRepository(fileSystem, "/data/My Terrain #1 100%/dir".toPath())
+
+        assertEquals(
+            "file:///data/My%20Terrain%20%231%20100%25/dir/tiles/global/{z}/{x}/{y}.webp",
+            repository.tileUrlTemplate(TerrainSource.GLOBAL),
         )
     }
 

--- a/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepositoryTest.kt
+++ b/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepositoryTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import org.meshtastic.feature.map.terrain.GeoBounds
+import org.meshtastic.feature.map.terrain.TerrainSource
+import org.meshtastic.feature.map.terrain.TerrainTileStore
+import org.meshtastic.feature.map.terrain.TileIndex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class OfflineTerrainRepositoryTest {
+
+    private val fileSystem = FakeFileSystem()
+    private val baseDir = "/terrain".toPath()
+
+    private fun repository() = OfflineTerrainRepository(fileSystem, baseDir)
+
+    @Test
+    fun `region is null before anything is downloaded`() = runTest {
+        val repository = repository()
+        repository.refresh()
+        assertNull(repository.region.value)
+    }
+
+    // A single-tile, single-zoom bounding box that fits in one z6 archive, so the fake extractor's fetch below is a
+    // network-free, single-tile round trip through TerrainTileStore rather than a real download.
+    private val tinyBounds = GeoBounds(south = 47.6, west = -122.4, north = 47.61, east = -122.39)
+
+    @Test
+    fun `an orphaned tile directory with no manifest is cleared on load`() = runTest {
+        // Simulates a process death mid-download: tiles on disk, no manifest ever written.
+        val store = TerrainTileStore(fileSystem, baseDir / "tiles")
+        store.writeTile(TerrainSource.GLOBAL, TileIndex(5, 1, 1), byteArrayOf(1, 2, 3))
+        assertTrue(store.sizeBytes() > 0L)
+
+        val repository = repository()
+        repository.refresh()
+
+        assertNull(repository.region.value)
+        assertEquals(0L, store.sizeBytes())
+    }
+
+    @Test
+    fun `a manifest with no tile directory still loads as a region`() = runTest {
+        // The manifest and the tile directory are independent on disk; this only exercises manifest read/write, not
+        // the orphan-tile cleanup above.
+        val repository = repository()
+        writeManifestDirectly(
+            OfflineTerrainRegion(
+                south = tinyBounds.south,
+                west = tinyBounds.west,
+                north = tinyBounds.north,
+                east = tinyBounds.east,
+                maxZoom = 10,
+                hasRegionalDetail = false,
+                tileCount = 3,
+                byteSize = 900,
+            ),
+        )
+
+        repository.refresh()
+
+        val region = repository.region.value
+        assertEquals(3L, region?.tileCount)
+        assertEquals(900L, region?.byteSize)
+    }
+
+    @Test
+    fun `delete clears both the manifest and the region state`() = runTest {
+        val repository = repository()
+        writeManifestDirectly(
+            OfflineTerrainRegion(
+                south = 0.0,
+                west = 0.0,
+                north = 1.0,
+                east = 1.0,
+                maxZoom = 10,
+                hasRegionalDetail = false,
+                tileCount = 1,
+                byteSize = 1,
+            ),
+        )
+        repository.refresh()
+        assertTrue(repository.region.value != null)
+
+        repository.delete()
+
+        assertNull(repository.region.value)
+        assertTrue(!fileSystem.exists(baseDir / "manifest.json"))
+    }
+
+    @Test
+    fun `download with zero tiles still emits Complete and persists an empty region`() = runTest {
+        val repository = repository()
+        // A box at maxZoom -1 requests no zoom levels at all, so TerrainRegionExtractor's own totalTiles==0 short
+        // circuit fires with no network access — the same "zero is a real, successful outcome" case its own flow
+        // documents.
+        val states = repository.download(tinyBounds, maxZoom = -1).toList()
+
+        assertEquals(1, states.size)
+        val region = repository.region.value
+        assertEquals(0L, region?.tileCount)
+        assertTrue(fileSystem.exists(baseDir / "manifest.json"))
+    }
+
+    @Test
+    fun `tileUrlTemplate is an absolute three-slash file url with z x y placeholders`() {
+        val repository = OfflineTerrainRepository(fileSystem, "/data/terrain".toPath())
+
+        assertEquals(
+            "file:///data/terrain/tiles/global/{z}/{x}/{y}.webp",
+            repository.tileUrlTemplate(TerrainSource.GLOBAL),
+        )
+        assertEquals(
+            "file:///data/terrain/tiles/regional/{z}/{x}/{y}.webp",
+            repository.tileUrlTemplate(TerrainSource.REGIONAL),
+        )
+    }
+
+    private fun writeManifestDirectly(region: OfflineTerrainRegion) {
+        val manifestPath = baseDir / "manifest.json"
+        fileSystem.createDirectories(baseDir)
+        fileSystem.write(manifestPath) { writeUtf8(Json.encodeToString(region)) }
+    }
+}

--- a/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/TerrainDownloadEstimateTest.kt
+++ b/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/TerrainDownloadEstimateTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import org.meshtastic.feature.map.terrain.GeoBounds
+import org.meshtastic.feature.map.terrain.MapterhornEndpoints
+import org.meshtastic.feature.map.terrain.TerrainTileMath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TerrainDownloadEstimateTest {
+
+    private val tinyBounds = GeoBounds(south = 47.6, west = -122.4, north = 47.61, east = -122.39)
+
+    @Test
+    fun `matches a manual sum of tilesAt across the global zoom range only`() {
+        val maxZoom = MapterhornEndpoints.GLOBAL_MAX_ZOOM
+        val expected = (0..maxZoom).sumOf { zoom -> TerrainTileMath.tilesAt(zoom, tinyBounds).size.toLong() }
+
+        assertEquals(expected, estimateTerrainTiles(tinyBounds, maxZoom))
+    }
+
+    @Test
+    fun `a maxZoom at or below the global ceiling never counts a regional tier`() {
+        val globalOnly = estimateTerrainTiles(tinyBounds, MapterhornEndpoints.GLOBAL_MAX_ZOOM)
+        val deeper = estimateTerrainTiles(tinyBounds, MapterhornEndpoints.GLOBAL_MAX_ZOOM + 1)
+
+        // The regional tier only exists past the global ceiling — one more zoom level must add regional tiles too.
+        assertTrue(deeper > globalOnly)
+    }
+
+    @Test
+    fun `a huge box that never fits a single regional archive gets no regional tier`() {
+        // Spans more than one z6 tile, so MapterhornEndpoints.regionalUrlFor returns null.
+        val huge = GeoBounds(south = -60.0, west = -170.0, north = 60.0, east = 170.0)
+
+        val atGlobalCeiling = estimateTerrainTiles(huge, MapterhornEndpoints.GLOBAL_MAX_ZOOM)
+        val past = estimateTerrainTiles(huge, MapterhornEndpoints.GLOBAL_MAX_ZOOM + 1)
+
+        // Past the global ceiling with no regional archive, nothing further is fetched — the count doesn't grow.
+        assertEquals(atGlobalCeiling, past)
+    }
+
+    @Test
+    fun `zero or negative maxZoom counts nothing`() {
+        assertEquals(0L, estimateTerrainTiles(tinyBounds, -1))
+    }
+}

--- a/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/TerrainDownloadEstimateTest.kt
+++ b/feature/map-maplibre/src/commonTest/kotlin/org/meshtastic/feature/map/maplibre/terrain/TerrainDownloadEstimateTest.kt
@@ -57,7 +57,14 @@ class TerrainDownloadEstimateTest {
     }
 
     @Test
-    fun `zero or negative maxZoom counts nothing`() {
+    fun `negative maxZoom counts nothing`() {
         assertEquals(0L, estimateTerrainTiles(tinyBounds, -1))
+    }
+
+    @Test
+    fun `maxZoom 0 counts the single world-covering z0 tile`() {
+        // Unlike a negative maxZoom, 0 is a real, valid zoom range (0..0) -- it legitimately counts the one z0 tile
+        // that covers the whole world, not nothing.
+        assertEquals(1L, estimateTerrainTiles(tinyBounds, 0))
     }
 }

--- a/feature/map-maplibre/src/iosMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainStorage.ios.kt
+++ b/feature/map-maplibre/src/iosMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainStorage.ios.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import okio.Path
+import okio.Path.Companion.toPath
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
+
+/**
+ * The app's Documents directory. Compiled for target validation only, matching every other iOS actual in this module
+ * (see `MapLibreMapViewProvider`'s own doc comment) — there is no iOS MapLibre host yet, so nothing calls this.
+ */
+actual fun terrainStorageDirectory(): Path {
+    val documents = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true).first() as String
+    return "$documents/terrain".toPath()
+}

--- a/feature/map-maplibre/src/jvmMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainStorage.jvm.kt
+++ b/feature/map-maplibre/src/jvmMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainStorage.jvm.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.maplibre.terrain
+
+import okio.Path
+import okio.Path.Companion.toPath
+
+/** Alongside the desktop database and imported map layers, which already live in `~/.meshtastic`. */
+actual fun terrainStorageDirectory(): Path = "${System.getProperty("user.home")}/.meshtastic/terrain".toPath()

--- a/feature/map-terrain/build.gradle.kts
+++ b/feature/map-terrain/build.gradle.kts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+plugins { alias(libs.plugins.meshtastic.kmp.feature) }
+
+// Offline terrain: Terrarium elevation decode, hillshade shading, and contour-line generation —
+// pure computation shared by both the Google flavor (androidApp/src/google, pre-rendered hillshade
+// PNGs + Polyline contours) and the MapLibre flavor (feature/map-maplibre, native raster-dem
+// hillshade + GeoJSON contours). No Compose UI and no rendering primitives live here; only math and
+// the platform image decode it depends on. Only jvm()+android() are declared below — nothing here
+// is consumed by a KMP-shared iOS surface — but the `meshtastic.kmp.feature` convention plugin adds
+// Kotlin/Native (iOS) targets to every KMP module regardless, so `decodeTerrariumTile`'s expect/actual
+// still needs a nativeMain actual; see its doc comment for why that one intentionally throws.
+kotlin {
+    jvm()
+
+    @Suppress("UnstableApiUsage")
+    android {
+        namespace = "org.meshtastic.feature.map.terrain"
+        androidResources.enable = false
+        withHostTest { isIncludeAndroidResources = true }
+    }
+
+    sourceSets {
+        commonMain.dependencies { implementation(projects.core.common) }
+
+        // Skia's Image decoder reaches WebP directly; brought in transitively by Compose
+        // Multiplatform's desktop UI artifact, which the `meshtastic.kmp.feature` convention plugin
+        // already applies — see feature/map-maplibre's identical jvmTest dependency for precedent.
+        jvmMain.dependencies { implementation(compose.desktop.currentOs) }
+    }
+}

--- a/feature/map-terrain/build.gradle.kts
+++ b/feature/map-terrain/build.gradle.kts
@@ -35,11 +35,28 @@ kotlin {
     }
 
     sourceSets {
-        commonMain.dependencies { implementation(projects.core.common) }
+        commonMain.dependencies {
+            implementation(projects.core.common)
+            implementation(libs.kotlinx.coroutines.core)
+            // Local terrain-tile storage is a plain file hierarchy, not SQLite: unlike the base offline layer's
+            // Google-only archive (which can assume Android's SQLite), this module's storage must also work on
+            // Desktop, and Okio's FileSystem is genuinely multiplatform where Android's SQLite APIs are not.
+            implementation(libs.okio)
+        }
 
-        // Skia's Image decoder reaches WebP directly; brought in transitively by Compose
-        // Multiplatform's desktop UI artifact, which the `meshtastic.kmp.feature` convention plugin
-        // already applies — see feature/map-maplibre's identical jvmTest dependency for precedent.
-        jvmMain.dependencies { implementation(compose.desktop.currentOs) }
+        commonTest.dependencies { implementation(libs.okio.fakefilesystem) }
+
+        // ch.poole.geo.pmtiles:Reader is a plain Java library, usable identically from both the android and
+        // jvm targets — but KMP has no built-in "android+jvm, not native" source set to put it in once, so the
+        // small amount of code wrapping it is duplicated between androidMain and jvmMain, same as
+        // ElevationTile's platform-specific decode actuals.
+        androidMain.dependencies { implementation(libs.pmtiles.reader) }
+        jvmMain.dependencies {
+            implementation(libs.pmtiles.reader)
+            // Skia's Image decoder reaches WebP directly; brought in transitively by Compose
+            // Multiplatform's desktop UI artifact, which the `meshtastic.kmp.feature` convention plugin
+            // already applies — see feature/map-maplibre's identical jvmTest dependency for precedent.
+            implementation(compose.desktop.currentOs)
+        }
     }
 }

--- a/feature/map-terrain/src/androidMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.android.kt
+++ b/feature/map-terrain/src/androidMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.android.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import android.graphics.BitmapFactory
+
+actual fun decodeTerrariumTile(webpBytes: ByteArray): ElevationTile {
+    // inPremultiplied = false: BitmapFactory premultiplies RGB by alpha by default, which would corrupt the
+    // elevation bits encoded in the RGB channels wherever a tile's alpha isn't fully opaque.
+    val options = BitmapFactory.Options().apply { inPremultiplied = false }
+    val bitmap =
+        BitmapFactory.decodeByteArray(webpBytes, 0, webpBytes.size, options)
+            ?: error("Could not decode Terrarium WebP tile (${webpBytes.size} bytes)")
+
+    val width = bitmap.width
+    val height = bitmap.height
+    val pixels = IntArray(width * height)
+    bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+    bitmap.recycle()
+
+    val elevations = FloatArray(width * height)
+    for (i in pixels.indices) {
+        val pixel = pixels[i]
+        val red = (pixel ushr RED_SHIFT) and COLOR_MASK
+        val green = (pixel ushr GREEN_SHIFT) and COLOR_MASK
+        val blue = pixel and COLOR_MASK
+        elevations[i] = terrariumElevationMeters(red, green, blue)
+    }
+    return ElevationTile(width, height, elevations)
+}
+
+private const val RED_SHIFT = 16
+private const val GREEN_SHIFT = 8
+private const val COLOR_MASK = 0xFF

--- a/feature/map-terrain/src/androidMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.android.kt
+++ b/feature/map-terrain/src/androidMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.android.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import ch.poole.geo.pmtiles.Constants
+import ch.poole.geo.pmtiles.HttpUrlConnectionChannel
+import ch.poole.geo.pmtiles.Reader
+import java.net.URL
+import java.util.zip.GZIPInputStream
+
+actual class TerrainTileFetcher actual constructor(pmtilesUrl: String) : AutoCloseable {
+
+    private val reader: Reader = Reader(HttpUrlConnectionChannel(URL(pmtilesUrl)))
+
+    actual fun fetchTile(zoom: Int, x: Int, y: Int): ByteArray? {
+        val raw = reader.getTile(zoom, x, y) ?: return null
+        return if (reader.tileCompression == Constants.COMPRESSION_GZIP) gunzip(raw) else raw
+    }
+
+    actual override fun close() {
+        reader.close()
+    }
+
+    private fun gunzip(bytes: ByteArray): ByteArray = GZIPInputStream(bytes.inputStream()).use { it.readBytes() }
+}

--- a/feature/map-terrain/src/androidMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.android.kt
+++ b/feature/map-terrain/src/androidMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.android.kt
@@ -19,6 +19,8 @@ package org.meshtastic.feature.map.terrain
 import ch.poole.geo.pmtiles.Constants
 import ch.poole.geo.pmtiles.HttpUrlConnectionChannel
 import ch.poole.geo.pmtiles.Reader
+import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.net.URL
 import java.util.zip.GZIPInputStream
 
@@ -35,5 +37,32 @@ actual class TerrainTileFetcher actual constructor(pmtilesUrl: String) : AutoClo
         reader.close()
     }
 
-    private fun gunzip(bytes: ByteArray): ByteArray = GZIPInputStream(bytes.inputStream()).use { it.readBytes() }
+    /**
+     * Bounded, not a bare `GZIPInputStream(...).readBytes()`: `download.mapterhorn.com` is a fixed first-party URL, but
+     * a compromised or MITM'd response is still a real defense-in-depth gap — an unbounded gunzip is a classic zip-bomb
+     * vector. A Terrarium tile decodes to at most 256×256×4 bytes (~256KB); [MAX_DECOMPRESSED_TILE_BYTES] is a generous
+     * multiple of that, not a tight fit.
+     */
+    private fun gunzip(bytes: ByteArray): ByteArray {
+        GZIPInputStream(bytes.inputStream()).use { gzip ->
+            val buffer = ByteArray(GUNZIP_BUFFER_BYTES)
+            val output = ByteArrayOutputStream()
+            var totalRead = 0
+            while (true) {
+                val read = gzip.read(buffer)
+                if (read == -1) break
+                totalRead += read
+                if (totalRead > MAX_DECOMPRESSED_TILE_BYTES) {
+                    throw IOException("Decompressed terrain tile exceeds $MAX_DECOMPRESSED_TILE_BYTES bytes")
+                }
+                output.write(buffer, 0, read)
+            }
+            return output.toByteArray()
+        }
+    }
+
+    private companion object {
+        private const val MAX_DECOMPRESSED_TILE_BYTES = 8 * 1024 * 1024
+        private const val GUNZIP_BUFFER_BYTES = 8192
+    }
 }

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ContourGenerator.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ContourGenerator.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlin.math.roundToLong
+
+/** A point in a tile's own `[0,1]×[0,1]` unit square — same convention as the base offline layer's tile-local math. */
+data class ContourPoint(val x: Float, val y: Float)
+
+/** One contour line at [elevationMeters], already chained into a single connected polyline. */
+data class ContourLine(val elevationMeters: Float, val points: List<ContourPoint>)
+
+/**
+ * Marching-squares contour generation, ported from the sibling iOS app's `ContourGenerator.swift`.
+ *
+ * Positive elevations only: Mapterhorn's data carries bathymetry banding, and generating contours below sea level would
+ * ring every patch of open water. One pass per grid, not one pass per level: each cell's corner elevations bound which
+ * of [levels] can possibly cross it, so a level far outside a cell's own [min,max] is skipped for that cell without a
+ * full re-scan.
+ */
+object ContourGenerator {
+
+    /**
+     * Generates every requested contour level from [tile]'s elevation grid, chained into polylines.
+     *
+     * @param tile an [ElevationTile]. Unlike [Hillshade.shade], this doesn't need cross-tile margin padding — contour
+     *   geometry only needs it if lines should visually continue past this tile's own edge, which is the caller's
+     *   choice, not a requirement here.
+     * @param levels the elevations (meters) to contour at — see [ContourIntervals] for the zoom-banded table this is
+     *   normally called with.
+     */
+    fun generate(tile: ElevationTile, levels: List<Float>): List<ContourLine> {
+        val positiveLevels = levels.filter { it > 0f }
+        if (positiveLevels.isEmpty()) return emptyList()
+
+        val segmentsByLevel = HashMap<Float, MutableList<Segment>>()
+        for (y in 0 until tile.height - 1) {
+            for (x in 0 until tile.width - 1) {
+                val tl = tile.elevationAt(x, y)
+                val tr = tile.elevationAt(x + 1, y)
+                val br = tile.elevationAt(x + 1, y + 1)
+                val bl = tile.elevationAt(x, y + 1)
+                val cellMin = minOf(tl, tr, br, bl)
+                val cellMax = maxOf(tl, tr, br, bl)
+                if (cellMax <= 0f) continue
+
+                for (level in positiveLevels) {
+                    if (level < cellMin || level > cellMax) continue
+                    val cellSegments = marchCell(x, y, tl, tr, br, bl, level, tile.width - 1, tile.height - 1)
+                    if (cellSegments.isNotEmpty()) segmentsByLevel.getOrPut(level) { mutableListOf() } += cellSegments
+                }
+            }
+        }
+
+        return segmentsByLevel.entries.flatMap { (level, segments) ->
+            chain(segments).map { points -> ContourLine(level, points) }
+        }
+    }
+
+    private data class Segment(val a: ContourPoint, val b: ContourPoint)
+
+    /**
+     * One cell's contribution to a single [level]'s contour: zero segments (level doesn't cross this cell), one (the
+     * ordinary case), or two (a saddle — the two diagonal corner pairs disagree with each other, so the level crosses
+     * all four edges and two separate line pieces pass through the cell).
+     *
+     * Coordinates are normalized by [gridWidth]/[gridHeight] — the number of *cells*, one less than the elevation
+     * grid's own sample count — so the output lands in `[0,1]` regardless of the source grid's resolution.
+     */
+    private fun marchCell(
+        x: Int,
+        y: Int,
+        tl: Float,
+        tr: Float,
+        br: Float,
+        bl: Float,
+        level: Float,
+        gridWidth: Int,
+        gridHeight: Int,
+    ): List<Segment> {
+        val top = edgeCrossing(tl, tr, level)
+        val right = edgeCrossing(tr, br, level)
+        val bottom = edgeCrossing(bl, br, level)
+        val left = edgeCrossing(tl, bl, level)
+
+        fun point(cellX: Float, cellY: Float) = ContourPoint((x + cellX) / gridWidth, (y + cellY) / gridHeight)
+
+        val topPoint = top?.let { point(it, 0f) }
+        val rightPoint = right?.let { point(1f, it) }
+        val bottomPoint = bottom?.let { point(it, 1f) }
+        val leftPoint = left?.let { point(0f, it) }
+        val crossings = listOfNotNull(topPoint, rightPoint, bottomPoint, leftPoint)
+
+        return when (crossings.size) {
+            0 -> emptyList()
+
+            2 -> listOf(Segment(crossings[0], crossings[1])).filterNot { it.a == it.b }
+
+            // Saddle: opposite corner pairs disagree with each other, so all four edges cross and there are two
+            // separate segments through the cell. Center-average decider (the standard resolution — a corner-only
+            // rule can misjudge some grid geometries): if the 4-corner average sits on the "TL/BR" side of the
+            // level, pair (top,left) with (bottom,right), isolating TL and BR as their own corners; otherwise pair
+            // (top,right) with (left,bottom), isolating TR and BL. Both segments are real and both are returned —
+            // this differs from the ordinary case, which only ever has one.
+            ALL_EDGES_CROSSING -> {
+                val centerAverage = (tl + tr + br + bl) / CORNER_COUNT
+                if (centerAverage >= level) {
+                    listOf(Segment(topPoint!!, leftPoint!!), Segment(bottomPoint!!, rightPoint!!))
+                } else {
+                    listOf(Segment(topPoint!!, rightPoint!!), Segment(leftPoint!!, bottomPoint!!))
+                }
+            }
+
+            else -> emptyList() // 1 or 3 crossings only happens when a corner sits exactly on the level; skip it.
+        }
+    }
+
+    private fun edgeCrossing(a: Float, b: Float, level: Float): Float? {
+        val aAbove = a >= level
+        val bAbove = b >= level
+        if (aAbove == bAbove) return null
+        val denominator = b - a
+        return if (denominator == 0f) DEFAULT_CROSSING_POSITION else ((level - a) / denominator).coerceIn(0f, 1f)
+    }
+
+    /**
+     * Chains segments sharing an endpoint into ordered polylines. Endpoints from adjacent cells are computed from the
+     * same two corner samples, so they're bit-identical in the overwhelming majority of cases; quantizing to
+     * [QUANTIZATION] only mops up the rare degenerate corner-touch, matching iOS's own approach. A chain that closes on
+     * itself terminates naturally: once every segment around the loop is visited, the next lookup at its own starting
+     * point finds nothing left unvisited.
+     */
+    private fun chain(segments: List<Segment>): List<List<ContourPoint>> {
+        val adjacency = HashMap<Long, MutableList<Segment>>()
+        segments.forEach { segment ->
+            adjacency.getOrPut(quantize(segment.a)) { mutableListOf() }.add(segment)
+            adjacency.getOrPut(quantize(segment.b)) { mutableListOf() }.add(segment)
+        }
+
+        val visited = HashSet<Segment>()
+        val chains = mutableListOf<List<ContourPoint>>()
+
+        for (start in segments) {
+            if (start in visited) continue
+            visited += start
+            val chainPoints = ArrayDeque<ContourPoint>()
+            chainPoints.addLast(start.a)
+            chainPoints.addLast(start.b)
+
+            extend(chainPoints, adjacency, visited, atHead = false)
+            extend(chainPoints, adjacency, visited, atHead = true)
+
+            chains += chainPoints.toList()
+        }
+        return chains
+    }
+
+    private fun extend(
+        chainPoints: ArrayDeque<ContourPoint>,
+        adjacency: Map<Long, MutableList<Segment>>,
+        visited: MutableSet<Segment>,
+        atHead: Boolean,
+    ) {
+        while (true) {
+            val tip = if (atHead) chainPoints.first() else chainPoints.last()
+            val next = adjacency[quantize(tip)].orEmpty().firstOrNull { it !in visited } ?: return
+            visited += next
+            val other = if (quantize(next.a) == quantize(tip)) next.b else next.a
+            if (atHead) chainPoints.addFirst(other) else chainPoints.addLast(other)
+        }
+    }
+
+    private const val QUANTIZATION = 1_048_576.0 // 2^20, matching iOS's endpoint-quantization precision.
+    private const val CORNER_COUNT = 4f
+    private const val ALL_EDGES_CROSSING = 4 // Saddle cell: all 4 edges of the cell cross the contour level.
+    private const val DEFAULT_CROSSING_POSITION = 0.5f // Midpoint when both corners match the level.
+
+    // Packs two quantized 32-bit coordinates into one Long key: qx in the high 32 bits, qy in the low 32.
+    private const val LOW_BITS_WIDTH = 32
+    private const val LOW_32_BITS_MASK = 0xFFFFFFFFL
+
+    private fun quantize(point: ContourPoint): Long {
+        val qx = (point.x * QUANTIZATION).roundToLong()
+        val qy = (point.y * QUANTIZATION).roundToLong()
+        return (qx shl LOW_BITS_WIDTH) or (qy and LOW_32_BITS_MASK)
+    }
+}

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ContourIntervals.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ContourIntervals.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+/**
+ * A zoom band's minor/index spacing, always in meters — [ContourIntervals.forZoom]'s `metric` flag only picks which
+ * round-number family (meters vs. feet-converted-to-meters) generated the values.
+ */
+data class ContourIntervalBand(val minorMeters: Float, val indexMeters: Float)
+
+/**
+ * The zoom-banded contour interval table, ported verbatim from the sibling iOS app's `ContourGenerator.swift:38-58`
+ * (`ContourIntervals.intervals(forZoom:metric:)`). `indexMeters` is always `5 × minorMeters` in every band; every 5th
+ * minor line is an index line.
+ */
+object ContourIntervals {
+
+    // literal here is one of the table's own values, not a computed quantity; naming each one (Z10_MINOR,
+    // Z10_INDEX, ...) would just relabel the table without adding information, the same tradeoff as the ported
+    // protobuf field numbers in VectorTile.kt.
+    @Suppress("detekt:MagicNumber") // Ported zoom-band lookup table (ContourGenerator.swift:38-58) — every
+    fun forZoom(zoom: Int, metric: Boolean): ContourIntervalBand = when {
+        zoom <= 10 -> if (metric) ContourIntervalBand(500f, 2_500f) else feetBand(minorFeet = 2_000f)
+        zoom <= 12 -> if (metric) ContourIntervalBand(100f, 500f) else feetBand(minorFeet = 500f)
+        zoom <= 14 -> if (metric) ContourIntervalBand(50f, 250f) else feetBand(minorFeet = 200f)
+        else -> if (metric) ContourIntervalBand(20f, 100f) else feetBand(minorFeet = 100f)
+    }
+
+    private fun feetBand(minorFeet: Float): ContourIntervalBand {
+        val minorMeters = minorFeet * FOOT_METERS
+        return ContourIntervalBand(minorMeters, minorMeters * INDEX_MULTIPLIER)
+    }
+
+    /** Every minor-interval level up to [maxElevationMeters], for [ContourGenerator.generate]'s `levels` param. */
+    fun levelsForZoom(zoom: Int, metric: Boolean, maxElevationMeters: Float): List<Float> {
+        val minor = forZoom(zoom, metric).minorMeters
+        if (minor <= 0f || maxElevationMeters <= 0f) return emptyList()
+        val levelCount = (maxElevationMeters / minor).toInt()
+        return (1..levelCount).map { it * minor }
+    }
+
+    /** Whether [elevationMeters] (assumed to be one of [levelsForZoom]'s own outputs) is an index line, not minor. */
+    fun isIndexLevel(elevationMeters: Float, zoom: Int, metric: Boolean): Boolean {
+        val band = forZoom(zoom, metric)
+        if (band.indexMeters <= 0f) return false
+        val steps = elevationMeters / band.indexMeters
+        return kotlin.math.abs(steps - kotlin.math.round(steps)) < INDEX_LEVEL_TOLERANCE
+    }
+
+    private const val FOOT_METERS = 0.3048f
+    private const val INDEX_MULTIPLIER = 5f
+    private const val INDEX_LEVEL_TOLERANCE = 1e-3f
+}

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ContourStyle.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ContourStyle.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+/**
+ * A contour line's style, expressed as simplestyle-spec property values (`stroke`, `stroke-width`, `stroke-opacity`)
+ * rather than a platform color type — both renderers already consume simplestyle properties for imported layers
+ * (MapLibre's `CustomLayers.kt` style expressions; Google's `applySimpleStyleSpec()`), so a contour feature carrying
+ * these properties styles itself identically on both flavors with no per-flavor color logic to keep in sync.
+ *
+ * Colors here are a placeholder, not a design-reviewed choice — a topo-map-conventional brown, distinguishable from
+ * this app's existing traceroute/geofence palette (both of which already use blue/orange). Needs a pass against the
+ * Meshtastic design standards before shipping (constitution principle V), same as any other new on-map visual element.
+ */
+data class ContourStyle(val strokeHexColor: String, val strokeWidth: Float, val strokeOpacity: Float)
+
+object ContourStyling {
+
+    fun styleFor(line: ContourLine, zoom: Int, metric: Boolean): ContourStyle {
+        val isIndex = ContourIntervals.isIndexLevel(line.elevationMeters, zoom, metric)
+        return if (isIndex) INDEX_STYLE else MINOR_STYLE
+    }
+
+    private val INDEX_STYLE = ContourStyle(strokeHexColor = TOPO_BROWN, strokeWidth = 1.5f, strokeOpacity = 0.55f)
+    private val MINOR_STYLE = ContourStyle(strokeHexColor = TOPO_BROWN, strokeWidth = 0.75f, strokeOpacity = 0.3f)
+
+    private const val TOPO_BROWN = "#8B5A2B"
+}

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.kt
@@ -35,6 +35,7 @@ fun terrariumElevationMeters(red: Int, green: Int, blue: Int): Float =
  */
 class ElevationTile(val width: Int, val height: Int, val elevations: FloatArray) {
     init {
+        require(width > 0 && height > 0) { "width ($width) and height ($height) must both be positive" }
         require(elevations.size == width * height) {
             "elevations.size (${elevations.size}) must equal width×height ($width×$height)"
         }

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.kt
@@ -36,7 +36,8 @@ fun terrariumElevationMeters(red: Int, green: Int, blue: Int): Float =
 class ElevationTile(val width: Int, val height: Int, val elevations: FloatArray) {
     init {
         require(width > 0 && height > 0) { "width ($width) and height ($height) must both be positive" }
-        require(elevations.size == width * height) {
+        // Long math: width*height can wrap in Int (65536², say) and collide with a tiny elevations.size.
+        require(elevations.size.toLong() == width.toLong() * height) {
             "elevations.size (${elevations.size}) must equal width×height ($width×$height)"
         }
     }

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+/**
+ * Mapterhorn/Mapzen's Terrarium elevation encoding: `elevation = R×256 + G + B÷256 − 32768`, spec at
+ * https://github.com/tilezen/joerd/blob/master/docs/formats.md. Ported from the sibling iOS app's
+ * `TerrariumDecoder.swift`, same formula, same 32768m offset (covers the full ±11000m range with margin).
+ */
+private const val TERRARIUM_OFFSET_METERS = 32768f
+private const val TERRARIUM_RED_SCALE = 256f
+private const val TERRARIUM_BLUE_SCALE = 256f
+
+fun terrariumElevationMeters(red: Int, green: Int, blue: Int): Float =
+    (red * TERRARIUM_RED_SCALE + green + blue / TERRARIUM_BLUE_SCALE) - TERRARIUM_OFFSET_METERS
+
+/**
+ * A decoded elevation grid in meters, row-major with (0,0) at the image's top-left — the same orientation as the source
+ * tile's own pixels, and as [org.meshtastic.app.map.offline.pmtiles.WebMercatorTileMath]'s tile-local Y (top-to-bottom,
+ * matching XYZ tile convention).
+ */
+class ElevationTile(val width: Int, val height: Int, val elevations: FloatArray) {
+    init {
+        require(elevations.size == width * height) {
+            "elevations.size (${elevations.size}) must equal width×height ($width×$height)"
+        }
+    }
+
+    /** Nearest-sample elevation at pixel [x], [y], clamped to the tile's own edge outside its bounds. */
+    fun elevationAt(x: Int, y: Int): Float {
+        val cx = x.coerceIn(0, width - 1)
+        val cy = y.coerceIn(0, height - 1)
+        return elevations[cy * width + cx]
+    }
+}
+
+/**
+ * Decodes a Terrarium-encoded WebP tile (Mapterhorn's format) into meters-above-sea-level.
+ *
+ * Every platform actual must decode with straight, not premultiplied, alpha: elevation lives entirely in the RGB
+ * channels, and both Android's [android.graphics.BitmapFactory] and Skia default to alpha-premultiplied output, which
+ * would silently scale RGB by alpha and corrupt every partially-transparent pixel's decoded elevation.
+ */
+expect fun decodeTerrariumTile(webpBytes: ByteArray): ElevationTile

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/Hillshade.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/Hillshade.kt
@@ -107,20 +107,17 @@ object Hillshade {
      */
     internal fun despike(tile: ElevationTile): ElevationTile {
         val out = tile.elevations.copyOf()
+        // One scratch window per call, refilled per pixel: a fresh array per pixel is ~64k allocations per tile,
+        // on getTile's cache-miss path. Local, not a field — Hillshade is an object and shade() runs concurrently.
+        val neighborhood = FloatArray(NEIGHBORHOOD_SIZE)
         for (y in MARGIN until tile.height - MARGIN) {
             for (x in MARGIN until tile.width - MARGIN) {
-                val neighborhood =
-                    floatArrayOf(
-                        tile.elevationAt(x - 1, y - 1),
-                        tile.elevationAt(x, y - 1),
-                        tile.elevationAt(x + 1, y - 1),
-                        tile.elevationAt(x - 1, y),
-                        tile.elevationAt(x, y),
-                        tile.elevationAt(x + 1, y),
-                        tile.elevationAt(x - 1, y + 1),
-                        tile.elevationAt(x, y + 1),
-                        tile.elevationAt(x + 1, y + 1),
-                    )
+                var n = 0
+                for (dy in -MARGIN..MARGIN) {
+                    for (dx in -MARGIN..MARGIN) {
+                        neighborhood[n++] = tile.elevationAt(x + dx, y + dy)
+                    }
+                }
                 neighborhood.sort()
                 val median = neighborhood[MEDIAN_INDEX]
                 val center = tile.elevationAt(x, y)
@@ -161,5 +158,6 @@ object Hillshade {
     private const val LOCAL_RELIEF_FADE_RANGE = 1.2f
 
     private const val DESPIKE_THRESHOLD_METERS = 2f
+    private const val NEIGHBORHOOD_SIZE = 9
     private const val MEDIAN_INDEX = 4
 }

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/Hillshade.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/Hillshade.kt
@@ -98,11 +98,17 @@ object Hillshade {
      * Reconstructed from iOS's documented behavior rather than a byte-exact port of `HillshadeTileOverlay.swift` (the
      * source wasn't available to copy verbatim); [DESPIKE_THRESHOLD_METERS] is a starting estimate and may need
      * retuning against real Mapterhorn data once this renders somewhere visible.
+     *
+     * Only iterates the interior — the [MARGIN]-px ring is real neighbor-tile elevation data (see this file's own doc
+     * comment on why the padding exists), not despike's to clean up. Despiking it would corrupt exactly the pixels the
+     * padding exists to get right, before [shadeOnePixel] ever reads them as edge-pixel neighbor context. Internal, not
+     * private, so [HillshadeTest][org.meshtastic.feature.map.terrain.HillshadeTest] can assert the margin ring survives
+     * unchanged.
      */
-    private fun despike(tile: ElevationTile): ElevationTile {
+    internal fun despike(tile: ElevationTile): ElevationTile {
         val out = tile.elevations.copyOf()
-        for (y in 0 until tile.height) {
-            for (x in 0 until tile.width) {
+        for (y in MARGIN until tile.height - MARGIN) {
+            for (x in MARGIN until tile.width - MARGIN) {
                 val neighborhood =
                     floatArrayOf(
                         tile.elevationAt(x - 1, y - 1),

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/Hillshade.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/Hillshade.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlin.math.PI
+import kotlin.math.atan
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Horn's-method hillshade, ported from the sibling iOS app's `HillshadeTileOverlay.swift`: shadow-only output (black
+ * RGB, alpha = shadow depth) so it composites correctly over both light and dark basemaps without a separate light-mode
+ * palette, plus the three cleanup passes iOS added against real artifacts in Puget Sound data — despiked water,
+ * sea-surface noise, and flattened-valley noise all showing up as fake terrain.
+ *
+ * [elevations] must be padded by exactly 1px of real neighbor data on every side of the [width]×[height] output area (a
+ * 3×3 kernel needs one ring of context per output pixel) — i.e. an [ElevationTile] of size `(width+2)×(height+2)`.
+ * Getting that padding from adjacent tiles, not just clamping at this tile's own edge, is the caller's job (mirroring
+ * iOS's `TerrainStore.elevationTile(margin:)`); this function only shades.
+ *
+ * Fixed light source (azimuth 315°/NW, altitude 45°) — not configurable, matching iOS: a single consistent light
+ * direction is what makes shading readable across differently-oriented terrain on the same map.
+ */
+object Hillshade {
+
+    /** Shadow alpha per output pixel, `0f` (no shading) to `1f` (full shadow), row-major, [width]×[height]. */
+    fun shade(padded: ElevationTile, width: Int, height: Int, maxShadowAlpha: Float): FloatArray {
+        require(padded.width == width + 2 * MARGIN && padded.height == height + 2 * MARGIN) {
+            "padded tile must be exactly ${MARGIN}px larger than the output on every side: " +
+                "expected ${width + 2 * MARGIN}x${height + 2 * MARGIN}, got ${padded.width}x${padded.height}"
+        }
+
+        val despiked = despike(padded)
+        val shadow = FloatArray(width * height)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                shadow[y * width + x] = shadeOnePixel(despiked, x + MARGIN, y + MARGIN, maxShadowAlpha)
+            }
+        }
+        return shadow
+    }
+
+    private fun shadeOnePixel(padded: ElevationTile, px: Int, py: Int, maxShadowAlpha: Float): Float {
+        // 3x3 Horn window, named to match the standard a..i layout (a=NW ... i=SE, e is the center itself).
+        val a = padded.elevationAt(px - 1, py - 1)
+        val b = padded.elevationAt(px, py - 1)
+        val c = padded.elevationAt(px + 1, py - 1)
+        val d = padded.elevationAt(px - 1, py)
+        val center = padded.elevationAt(px, py)
+        val f = padded.elevationAt(px + 1, py)
+        val g = padded.elevationAt(px - 1, py + 1)
+        val h = padded.elevationAt(px, py + 1)
+        val i = padded.elevationAt(px + 1, py + 1)
+
+        val dzdx = ((c + 2 * f + i) - (a + 2 * d + g)) / (HORN_DENOMINATOR * CELL_SIZE_METERS)
+        val dzdy = ((g + 2 * h + i) - (a + 2 * b + c)) / (HORN_DENOMINATOR * CELL_SIZE_METERS)
+
+        val slope = atan(sqrt(dzdx * dzdx + dzdy * dzdy))
+        val aspect = atan2(dzdy, -dzdx)
+        val illumination =
+            SIN_ALTITUDE * cos(slope) + COS_ALTITUDE * sin(slope) * cos(AZIMUTH_RADIANS - HALF_PI - aspect)
+        var shadow = ((SIN_ALTITUDE - illumination.coerceIn(-1f, 1f)) / SIN_ALTITUDE).coerceIn(0f, 1f)
+
+        // Sea-level fade: zero shading at/below 0.5m, full weight at/above 3m. Kills ~1m-stdev sea-surface
+        // elevation noise the despike pass alone doesn't remove — real terrain rarely sits in that band anyway.
+        shadow *= ((center - SEA_LEVEL_FADE_START) / SEA_LEVEL_FADE_RANGE).coerceIn(0f, 1f)
+
+        // Local-relief fade: water sits within noise of its own local minimum everywhere; real terrain doesn't.
+        // Also flattens valley-bottom noise, which is an acceptable side effect since valley bottoms are flat.
+        val localMin = min(min(min(a, b), min(c, d)), min(min(f, g), min(h, i)))
+        shadow *= ((center - localMin - LOCAL_RELIEF_FADE_START) / LOCAL_RELIEF_FADE_RANGE).coerceIn(0f, 1f)
+
+        return shadow * maxShadowAlpha
+    }
+
+    /**
+     * Median-of-9 despike: replaces an elevation that spikes well above its 3×3 neighborhood's median with that median,
+     * so isolated positive spikes (observed up to ~12m on open water) don't shade as fake terrain while real ridgelines
+     * and edges — which agree with several neighbors, not just their own outlier value — survive.
+     *
+     * Reconstructed from iOS's documented behavior rather than a byte-exact port of `HillshadeTileOverlay.swift` (the
+     * source wasn't available to copy verbatim); [DESPIKE_THRESHOLD_METERS] is a starting estimate and may need
+     * retuning against real Mapterhorn data once this renders somewhere visible.
+     */
+    private fun despike(tile: ElevationTile): ElevationTile {
+        val out = tile.elevations.copyOf()
+        for (y in 0 until tile.height) {
+            for (x in 0 until tile.width) {
+                val neighborhood =
+                    floatArrayOf(
+                        tile.elevationAt(x - 1, y - 1),
+                        tile.elevationAt(x, y - 1),
+                        tile.elevationAt(x + 1, y - 1),
+                        tile.elevationAt(x - 1, y),
+                        tile.elevationAt(x, y),
+                        tile.elevationAt(x + 1, y),
+                        tile.elevationAt(x - 1, y + 1),
+                        tile.elevationAt(x, y + 1),
+                        tile.elevationAt(x + 1, y + 1),
+                    )
+                neighborhood.sort()
+                val median = neighborhood[MEDIAN_INDEX]
+                val center = tile.elevationAt(x, y)
+                if (center - median > DESPIKE_THRESHOLD_METERS) {
+                    out[y * tile.width + x] = median
+                }
+            }
+        }
+        return ElevationTile(tile.width, tile.height, out)
+    }
+
+    /** How far outside the output area [ElevationTile]s passed to [shade] must be padded with real neighbor data. */
+    const val MARGIN = 1
+
+    private const val AZIMUTH_DEGREES = 315.0
+    private const val ALTITUDE_DEGREES = 45.0
+    private val AZIMUTH_RADIANS = (AZIMUTH_DEGREES * PI / 180.0).toFloat()
+    private val ALTITUDE_RADIANS = (ALTITUDE_DEGREES * PI / 180.0).toFloat()
+    private val SIN_ALTITUDE = sin(ALTITUDE_RADIANS)
+    private val COS_ALTITUDE = cos(ALTITUDE_RADIANS)
+
+    // Float, not the bare Double kotlin.math.PI: mixing that into the per-pixel illumination expression below
+    // promotes the whole expression to Double, which is both a needless precision widening on a hot path and
+    // (concretely) a compile error against this function's Float return type.
+    private val HALF_PI = (PI / 2).toFloat()
+
+    private const val HORN_DENOMINATOR = 8f
+
+    // Terrarium tiles are 256px covering one Web Mercator tile edge at the tile's own zoom; the true meters-per-
+    // pixel cell size varies with latitude and zoom, so this is a coarse constant tuned for legible shading
+    // rather than a geodesic distance — matching how iOS's own Horn-method cellSize is a shading parameter, not
+    // a precise ground measurement.
+    private const val CELL_SIZE_METERS = 30f
+
+    private const val SEA_LEVEL_FADE_START = 0.5f
+    private const val SEA_LEVEL_FADE_RANGE = 2.5f
+    private const val LOCAL_RELIEF_FADE_START = 0.3f
+    private const val LOCAL_RELIEF_FADE_RANGE = 1.2f
+
+    private const val DESPIKE_THRESHOLD_METERS = 2f
+    private const val MEDIAN_INDEX = 4
+}

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/MapterhornEndpoints.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/MapterhornEndpoints.kt
@@ -51,4 +51,18 @@ object MapterhornEndpoints {
         val tile = TerrainTileMath.tileAt(REGIONAL_ARCHIVE_ZOOM, centerLat, centerLon)
         return "https://download.mapterhorn.com/${tile.x}-${tile.y}.pmtiles"
     }
+
+    /**
+     * What to show on screen whenever terrain (hillshade or contours) is actively rendering.
+     *
+     * Deliberately generic rather than an enumerated per-source credit: Mapterhorn's data is a mosaic of 100+ regional
+     * datasets under a mix of licenses (CC-BY-4.0, CC0, national open-data licenses, US public domain — see
+     * mapterhorn.com/attribution/, fetched and confirmed during this feature's research, not assumed), with no single
+     * blanket license covering all of it. Computing which specific sources a given downloaded region actually draws
+     * from would be the fully-correct answer, but is real additional engineering; this generic credit plus a link to
+     * Mapterhorn's own attribution page is the honest, low-risk baseline both flavors should ship with now, upgradeable
+     * to a per-region source list later without changing the UI shape that reads it.
+     */
+    const val ATTRIBUTION = "Terrain data © Mapterhorn"
+    const val ATTRIBUTION_URL = "https://mapterhorn.com/attribution/"
 }

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/MapterhornEndpoints.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/MapterhornEndpoints.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+/**
+ * Mapterhorn's two-tier PMTiles layout, ported from the sibling iOS app's `mapterhorn-data-contract.md`: a single
+ * global archive always available at low zoom, plus per-region high-res archives keyed by their own z6 tile coordinate,
+ * present only where source data coverage allows.
+ *
+ * No API key, no documented rate limit (Cloudflare R2-backed, per docs.mapterhorn.com/data-access) — same no-auth,
+ * range-requestable shape as the base layer's Protomaps source.
+ */
+object MapterhornEndpoints {
+
+    const val GLOBAL_PMTILES_URL = "https://download.mapterhorn.com/planet.pmtiles"
+
+    /** Global coverage tops out at this zoom; deeper detail (if any) only exists in a regional archive. */
+    const val GLOBAL_MAX_ZOOM = 12
+
+    /** Regional archives start where global coverage ends. */
+    const val REGIONAL_MIN_ZOOM = 13
+
+    /** Regional archives never go deeper than this, even where source data would allow it. */
+    const val REGIONAL_MAX_ZOOM = 18
+
+    private const val REGIONAL_ARCHIVE_ZOOM = 6
+
+    /**
+     * The regional archive URL for [bounds], or `null` if [bounds] doesn't fit inside one z6 tile — matching iOS's
+     * "global-only terrain is normal, never an error" rule: a region spanning more than one z6 tile just gets no
+     * regional detail, rather than trying to stitch multiple regional archives together.
+     */
+    fun regionalUrlFor(bounds: GeoBounds): String? {
+        if (!TerrainTileMath.fitsInSingleTile(REGIONAL_ARCHIVE_ZOOM, bounds)) return null
+        val centerLat = (bounds.north + bounds.south) / 2
+        val centerLon = (bounds.east + bounds.west) / 2
+        val tile = TerrainTileMath.tileAt(REGIONAL_ARCHIVE_ZOOM, centerLat, centerLon)
+        return "https://download.mapterhorn.com/${tile.x}-${tile.y}.pmtiles"
+    }
+}

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainRegionExtractor.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainRegionExtractor.kt
@@ -49,44 +49,50 @@ class TerrainRegionExtractor(private val store: TerrainTileStore) {
 
     fun download(bounds: GeoBounds, maxZoom: Int): Flow<TerrainDownloadState> = flow {
         val globalZoomRange = 0..minOf(maxZoom, MapterhornEndpoints.GLOBAL_MAX_ZOOM)
-        val globalTiles = globalZoomRange.flatMap { zoom -> TerrainTileMath.tilesAt(zoom, bounds) }
-
         val regionalUrl =
             if (maxZoom > MapterhornEndpoints.GLOBAL_MAX_ZOOM) MapterhornEndpoints.regionalUrlFor(bounds) else null
         val regionalZoomRange =
             MapterhornEndpoints.REGIONAL_MIN_ZOOM..minOf(maxZoom, MapterhornEndpoints.REGIONAL_MAX_ZOOM)
+
+        // Counted cheaply — via TerrainTileMath.tileCountAt's corner arithmetic, O(1) per zoom — before anything is
+        // materialized. A single regional z6 tile at maxZoom 18 is ~16.7M tiles at z18 alone; flatMap-ing a TileIndex
+        // per tile before this check runs would allocate that whole list first and risk OOM on exactly the oversized
+        // requests this limit exists to reject.
+        val globalCount = globalZoomRange.sumOf { zoom -> TerrainTileMath.tileCountAt(zoom, bounds) }
+        val regionalCount =
+            if (regionalUrl != null) {
+                regionalZoomRange.sumOf { zoom -> TerrainTileMath.tileCountAt(zoom, bounds) }
+            } else {
+                0L
+            }
+        val totalTiles = globalCount + regionalCount
+        if (totalTiles > MAX_TILES) {
+            emit(TerrainDownloadState.Failed(TerrainDownloadFailure.TILE_LIMIT_EXCEEDED))
+            return@flow
+        }
+        if (totalTiles == 0L) {
+            emit(TerrainDownloadState.Complete(tileCount = 0, byteSize = 0, hasRegionalDetail = false))
+            return@flow
+        }
+
+        // Only materialized now that the cheap count above has confirmed it's under MAX_TILES.
+        val globalTiles = globalZoomRange.flatMap { zoom -> TerrainTileMath.tilesAt(zoom, bounds) }
         val regionalTiles =
             if (regionalUrl != null) {
                 regionalZoomRange.flatMap { zoom -> TerrainTileMath.tilesAt(zoom, bounds) }
             } else {
                 emptyList()
             }
+        val total = totalTiles.toInt()
 
-        val totalTiles = globalTiles.size + regionalTiles.size
-        if (totalTiles > MAX_TILES) {
-            emit(TerrainDownloadState.Failed(TerrainDownloadFailure.TILE_LIMIT_EXCEEDED))
-            return@flow
-        }
-        if (totalTiles == 0) {
-            emit(TerrainDownloadState.Complete(tileCount = 0, byteSize = 0, hasRegionalDetail = false))
-            return@flow
-        }
-
-        var completed = 0
+        var result = FetchResult(processed = 0, stored = 0)
         try {
-            completed =
-                fetchInto(
-                    MapterhornEndpoints.GLOBAL_PMTILES_URL,
-                    TerrainSource.GLOBAL,
-                    globalTiles,
-                    completed,
-                    totalTiles,
-                ) {
+            result =
+                fetchInto(MapterhornEndpoints.GLOBAL_PMTILES_URL, TerrainSource.GLOBAL, globalTiles, result, total) {
                     emit(it)
                 }
             if (regionalUrl != null) {
-                completed =
-                    fetchInto(regionalUrl, TerrainSource.REGIONAL, regionalTiles, completed, totalTiles) { emit(it) }
+                result = fetchInto(regionalUrl, TerrainSource.REGIONAL, regionalTiles, result, total) { emit(it) }
             }
         } catch (_: Exception) {
             store.deleteAll()
@@ -96,32 +102,45 @@ class TerrainRegionExtractor(private val store: TerrainTileStore) {
 
         emit(
             TerrainDownloadState.Complete(
-                tileCount = completed.toLong(),
+                tileCount = result.stored,
                 byteSize = store.sizeBytes(),
                 hasRegionalDetail = regionalUrl != null,
             ),
         )
     }
 
+    /**
+     * [processed] drives [TerrainDownloadState.InProgress] (every tile the fetch loop reaches, whether or not the
+     * archive actually had it); [stored] drives [TerrainDownloadState.Complete.tileCount] (only tiles [store]'s
+     * writeTile actually persisted). Sparse archive coverage — [TerrainTileFetcher.fetchTile] legitimately returning
+     * `null` for a tile the source archive doesn't have — is documented as normal, not an error, so it must not inflate
+     * the count the UI reports as "downloaded".
+     */
+    private data class FetchResult(val processed: Int, val stored: Long)
+
     private suspend fun fetchInto(
         pmtilesUrl: String,
         source: TerrainSource,
         tiles: List<TileIndex>,
-        startingCompleted: Int,
+        starting: FetchResult,
         totalTiles: Int,
         onProgress: suspend (TerrainDownloadState.InProgress) -> Unit,
-    ): Int {
-        var completed = startingCompleted
+    ): FetchResult {
+        var processed = starting.processed
+        var stored = starting.stored
         TerrainTileFetcher(pmtilesUrl).use { fetcher ->
             for (tile in tiles) {
-                fetcher.fetchTile(tile.zoom, tile.x, tile.y)?.let { bytes -> store.writeTile(source, tile, bytes) }
-                completed++
-                if (completed % PROGRESS_STRIDE == 0 || completed == totalTiles) {
-                    onProgress(TerrainDownloadState.InProgress(completed, totalTiles))
+                fetcher.fetchTile(tile.zoom, tile.x, tile.y)?.let { bytes ->
+                    store.writeTile(source, tile, bytes)
+                    stored++
+                }
+                processed++
+                if (processed % PROGRESS_STRIDE == 0 || processed == totalTiles) {
+                    onProgress(TerrainDownloadState.InProgress(processed, totalTiles))
                 }
             }
         }
-        return completed
+        return FetchResult(processed, stored)
     }
 
     companion object {

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainRegionExtractor.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainRegionExtractor.kt
@@ -45,7 +45,15 @@ enum class TerrainDownloadFailure {
  * lifecycle, "delete the terrain without touching the basemap") — that's the caller's integration concern, same
  * separation as [TerrainTileStore] only knowing about the directory it's handed.
  */
-class TerrainRegionExtractor(private val store: TerrainTileStore) {
+class TerrainRegionExtractor(
+    private val store: TerrainTileStore,
+    private val openArchive: (pmtilesUrl: String) -> TileArchive = ::remoteArchive,
+) {
+
+    /** One open PMTiles archive — [TerrainTileFetcher] in production; a seam so tests can script sparse coverage. */
+    interface TileArchive : AutoCloseable {
+        fun fetchTile(zoom: Int, x: Int, y: Int): ByteArray?
+    }
 
     fun download(bounds: GeoBounds, maxZoom: Int): Flow<TerrainDownloadState> = flow {
         val globalZoomRange = 0..minOf(maxZoom, MapterhornEndpoints.GLOBAL_MAX_ZOOM)
@@ -85,14 +93,16 @@ class TerrainRegionExtractor(private val store: TerrainTileStore) {
             }
         val total = totalTiles.toInt()
 
-        var result = FetchResult(processed = 0, stored = 0)
+        var global = FetchResult(processed = 0, stored = 0)
+        var regional = FetchResult(processed = 0, stored = 0)
         try {
-            result =
-                fetchInto(MapterhornEndpoints.GLOBAL_PMTILES_URL, TerrainSource.GLOBAL, globalTiles, result, total) {
+            global =
+                fetchInto(MapterhornEndpoints.GLOBAL_PMTILES_URL, TerrainSource.GLOBAL, globalTiles, 0, total) {
                     emit(it)
                 }
             if (regionalUrl != null) {
-                result = fetchInto(regionalUrl, TerrainSource.REGIONAL, regionalTiles, result, total) { emit(it) }
+                regional =
+                    fetchInto(regionalUrl, TerrainSource.REGIONAL, regionalTiles, global.processed, total) { emit(it) }
             }
         } catch (_: Exception) {
             store.deleteAll()
@@ -100,11 +110,13 @@ class TerrainRegionExtractor(private val store: TerrainTileStore) {
             return@flow
         }
 
+        // Per tier, not "a regional URL existed": a regional archive with no coverage here stores nothing, and a
+        // renderer trusting the flag would then read an empty REGIONAL dir at z13+ instead of the global tiles.
         emit(
             TerrainDownloadState.Complete(
-                tileCount = result.stored,
+                tileCount = global.stored + regional.stored,
                 byteSize = store.sizeBytes(),
-                hasRegionalDetail = regionalUrl != null,
+                hasRegionalDetail = regional.stored > 0,
             ),
         )
     }
@@ -122,15 +134,15 @@ class TerrainRegionExtractor(private val store: TerrainTileStore) {
         pmtilesUrl: String,
         source: TerrainSource,
         tiles: List<TileIndex>,
-        starting: FetchResult,
+        alreadyProcessed: Int,
         totalTiles: Int,
         onProgress: suspend (TerrainDownloadState.InProgress) -> Unit,
     ): FetchResult {
-        var processed = starting.processed
-        var stored = starting.stored
-        TerrainTileFetcher(pmtilesUrl).use { fetcher ->
+        var processed = alreadyProcessed
+        var stored = 0L
+        openArchive(pmtilesUrl).use { archive ->
             for (tile in tiles) {
-                fetcher.fetchTile(tile.zoom, tile.x, tile.y)?.let { bytes ->
+                archive.fetchTile(tile.zoom, tile.x, tile.y)?.let { bytes ->
                     store.writeTile(source, tile, bytes)
                     stored++
                 }
@@ -147,5 +159,14 @@ class TerrainRegionExtractor(private val store: TerrainTileStore) {
         /** See the base offline layer's own extractor for why this is far below iOS's 600k-tile-scale caps. */
         const val MAX_TILES = 3_000
         private const val PROGRESS_STRIDE = 10
+
+        private fun remoteArchive(pmtilesUrl: String): TileArchive {
+            val fetcher = TerrainTileFetcher(pmtilesUrl)
+            return object : TileArchive {
+                override fun fetchTile(zoom: Int, x: Int, y: Int): ByteArray? = fetcher.fetchTile(zoom, x, y)
+
+                override fun close() = fetcher.close()
+            }
+        }
     }
 }

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainRegionExtractor.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainRegionExtractor.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+sealed interface TerrainDownloadState {
+    data class InProgress(val completed: Int, val total: Int) : TerrainDownloadState
+
+    data class Complete(val tileCount: Long, val byteSize: Long, val hasRegionalDetail: Boolean) : TerrainDownloadState
+
+    data class Failed(val reason: TerrainDownloadFailure) : TerrainDownloadState
+}
+
+enum class TerrainDownloadFailure {
+    /** More tiles than [TerrainRegionExtractor.MAX_TILES] — likely too large an area or too deep a zoom. */
+    TILE_LIMIT_EXCEEDED,
+
+    /** A network or disk failure partway through; nothing partial is kept. */
+    IO_ERROR,
+}
+
+/**
+ * Extracts a region's offline terrain: a global low-res layer (always, up to [MapterhornEndpoints.GLOBAL_MAX_ZOOM])
+ * plus, where [bounds] fits inside a single z6 tile, a regional high-res layer on top — ported from the sibling iOS
+ * app's two-tier `TerrainStore` download behavior. One tile per HTTP request, like the base offline layer's own
+ * extractor; see its README for why that bounds [MAX_TILES] well below iOS's own per-region cap.
+ *
+ * This module owns nothing about how a terrain download relates to a base map region (shared storage budget, region
+ * lifecycle, "delete the terrain without touching the basemap") — that's the caller's integration concern, same
+ * separation as [TerrainTileStore] only knowing about the directory it's handed.
+ */
+class TerrainRegionExtractor(private val store: TerrainTileStore) {
+
+    fun download(bounds: GeoBounds, maxZoom: Int): Flow<TerrainDownloadState> = flow {
+        val globalZoomRange = 0..minOf(maxZoom, MapterhornEndpoints.GLOBAL_MAX_ZOOM)
+        val globalTiles = globalZoomRange.flatMap { zoom -> TerrainTileMath.tilesAt(zoom, bounds) }
+
+        val regionalUrl =
+            if (maxZoom > MapterhornEndpoints.GLOBAL_MAX_ZOOM) MapterhornEndpoints.regionalUrlFor(bounds) else null
+        val regionalZoomRange =
+            MapterhornEndpoints.REGIONAL_MIN_ZOOM..minOf(maxZoom, MapterhornEndpoints.REGIONAL_MAX_ZOOM)
+        val regionalTiles =
+            if (regionalUrl != null) {
+                regionalZoomRange.flatMap { zoom -> TerrainTileMath.tilesAt(zoom, bounds) }
+            } else {
+                emptyList()
+            }
+
+        val totalTiles = globalTiles.size + regionalTiles.size
+        if (totalTiles > MAX_TILES) {
+            emit(TerrainDownloadState.Failed(TerrainDownloadFailure.TILE_LIMIT_EXCEEDED))
+            return@flow
+        }
+        if (totalTiles == 0) {
+            emit(TerrainDownloadState.Complete(tileCount = 0, byteSize = 0, hasRegionalDetail = false))
+            return@flow
+        }
+
+        var completed = 0
+        try {
+            completed =
+                fetchInto(
+                    MapterhornEndpoints.GLOBAL_PMTILES_URL,
+                    TerrainSource.GLOBAL,
+                    globalTiles,
+                    completed,
+                    totalTiles,
+                ) {
+                    emit(it)
+                }
+            if (regionalUrl != null) {
+                completed =
+                    fetchInto(regionalUrl, TerrainSource.REGIONAL, regionalTiles, completed, totalTiles) { emit(it) }
+            }
+        } catch (_: Exception) {
+            store.deleteAll()
+            emit(TerrainDownloadState.Failed(TerrainDownloadFailure.IO_ERROR))
+            return@flow
+        }
+
+        emit(
+            TerrainDownloadState.Complete(
+                tileCount = completed.toLong(),
+                byteSize = store.sizeBytes(),
+                hasRegionalDetail = regionalUrl != null,
+            ),
+        )
+    }
+
+    private suspend fun fetchInto(
+        pmtilesUrl: String,
+        source: TerrainSource,
+        tiles: List<TileIndex>,
+        startingCompleted: Int,
+        totalTiles: Int,
+        onProgress: suspend (TerrainDownloadState.InProgress) -> Unit,
+    ): Int {
+        var completed = startingCompleted
+        TerrainTileFetcher(pmtilesUrl).use { fetcher ->
+            for (tile in tiles) {
+                fetcher.fetchTile(tile.zoom, tile.x, tile.y)?.let { bytes -> store.writeTile(source, tile, bytes) }
+                completed++
+                if (completed % PROGRESS_STRIDE == 0 || completed == totalTiles) {
+                    onProgress(TerrainDownloadState.InProgress(completed, totalTiles))
+                }
+            }
+        }
+        return completed
+    }
+
+    companion object {
+        /** See the base offline layer's own extractor for why this is far below iOS's 600k-tile-scale caps. */
+        const val MAX_TILES = 3_000
+        private const val PROGRESS_STRIDE = 10
+    }
+}

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+/**
+ * Fetches individual tiles from a remote PMTiles archive by range request — never the whole archive, just the bytes of
+ * the tile asked for. Backed by `ch.poole.geo.pmtiles:Reader` (MIT-licensed), the same library the base offline layer
+ * uses for Protomaps; here it's pointed at Mapterhorn's Terrarium elevation archives instead.
+ *
+ * A plain Java library, so its wrapper is duplicated between `androidMain` and `jvmMain` rather than living once in
+ * `commonMain` — see this module's `build.gradle.kts` for why.
+ */
+expect class TerrainTileFetcher(pmtilesUrl: String) : AutoCloseable {
+
+    /** Raw tile bytes (WebP, Terrarium-encoded) at [zoom]/[x]/[y] — google/osm XYZ convention — or `null` if absent. */
+    fun fetchTile(zoom: Int, x: Int, y: Int): ByteArray?
+
+    override fun close()
+}

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMath.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMath.kt
@@ -18,7 +18,9 @@ package org.meshtastic.feature.map.terrain
 
 import kotlin.math.PI
 import kotlin.math.asinh
+import kotlin.math.atan
 import kotlin.math.pow
+import kotlin.math.sinh
 import kotlin.math.tan
 
 /** A geographic bounding box, degrees. */
@@ -26,6 +28,9 @@ data class GeoBounds(val south: Double, val west: Double, val north: Double, val
 
 /** A single XYZ (google/osm-convention, not TMS) slippy-map tile index. */
 data class TileIndex(val zoom: Int, val x: Int, val y: Int)
+
+/** A point in geographic space, degrees — what [TerrainTileMath.lonLatAt] converts a tile-local position into. */
+data class LonLat(val longitude: Double, val latitude: Double)
 
 /**
  * Standard XYZ/slippy-map Web Mercator tile math, self-contained here (rather than reused from either flavor's own copy
@@ -64,6 +69,23 @@ object TerrainTileMath {
         val northwest = tileAt(zoom, bounds.north, bounds.west)
         val southeast = tileAt(zoom, bounds.south, bounds.east)
         return northwest == southeast
+    }
+
+    /**
+     * Inverse of [tileAt]: the geographic point at a fractional position within [tile] — [localX]/[localY] in the
+     * tile's own `[0,1]×[0,1]` unit square, the same convention [ContourPoint] uses. Needed to place contour geometry
+     * (which [ContourGenerator] emits tile-local) on a real map; nothing here needed the inverse before.
+     *
+     * Standard inverse spherical Web Mercator — the mirror of [tileAt]'s own `asinh(tan(...))` forward transform.
+     */
+    fun lonLatAt(tile: TileIndex, localX: Float, localY: Float): LonLat {
+        val n = 2.0.pow(tile.zoom)
+        val x = (tile.x + localX) / n
+        val y = (tile.y + localY) / n
+        val longitude = x * FULL_TURN_DEGREES - FULL_TURN_DEGREES / 2
+        val latitudeRadians = atan(sinh(PI * (1.0 - 2.0 * y)))
+        val latitude = latitudeRadians * HALF_TURN_DEGREES / PI
+        return LonLat(longitude = longitude, latitude = latitude)
     }
 
     private const val HALF_TURN_DEGREES = 180.0

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMath.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMath.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlin.math.PI
+import kotlin.math.asinh
+import kotlin.math.pow
+import kotlin.math.tan
+
+/** A geographic bounding box, degrees. */
+data class GeoBounds(val south: Double, val west: Double, val north: Double, val east: Double)
+
+/** A single XYZ (google/osm-convention, not TMS) slippy-map tile index. */
+data class TileIndex(val zoom: Int, val x: Int, val y: Int)
+
+/**
+ * Standard XYZ/slippy-map Web Mercator tile math, self-contained here (rather than reused from either flavor's own copy
+ * — `feature/map-maplibre`'s `TileEstimate.kt` and the Google flavor's `WebMercatorTileMath` in the sibling
+ * `feat/map-google-pmtiles-offline` branch) so this module has no dependency in either direction on flavor-specific
+ * code — this module is a shared math library, not a consumer of one flavor's app code.
+ */
+object TerrainTileMath {
+
+    private const val MAX_LATITUDE = 85.05112878
+
+    fun tileAt(zoom: Int, latitude: Double, longitude: Double): TileIndex {
+        val n = 2.0.pow(zoom)
+        val clampedLat = latitude.coerceIn(-MAX_LATITUDE, MAX_LATITUDE)
+        val latRad = clampedLat * PI / HALF_TURN_DEGREES
+        val x = (((longitude + FULL_TURN_DEGREES / 2) / FULL_TURN_DEGREES) * n).toInt().coerceIn(0, (n - 1).toInt())
+        val y = (((1.0 - asinh(tan(latRad)) / PI) / 2.0) * n).toInt().coerceIn(0, (n - 1).toInt())
+        return TileIndex(zoom, x, y)
+    }
+
+    /** Every tile in [bounds] at [zoom], inclusive of both corners' own tiles. */
+    fun tilesAt(zoom: Int, bounds: GeoBounds): List<TileIndex> {
+        val northwest = tileAt(zoom, bounds.north, bounds.west)
+        val southeast = tileAt(zoom, bounds.south, bounds.east)
+        val tiles = mutableListOf<TileIndex>()
+        for (x in northwest.x..southeast.x) {
+            for (y in northwest.y..southeast.y) {
+                tiles += TileIndex(zoom, x, y)
+            }
+        }
+        return tiles
+    }
+
+    /** Whether [bounds] fits entirely inside a single tile at [zoom] — used for Mapterhorn's regional-archive gate. */
+    fun fitsInSingleTile(zoom: Int, bounds: GeoBounds): Boolean {
+        val northwest = tileAt(zoom, bounds.north, bounds.west)
+        val southeast = tileAt(zoom, bounds.south, bounds.east)
+        return northwest == southeast
+    }
+
+    private const val HALF_TURN_DEGREES = 180.0
+    private const val FULL_TURN_DEGREES = 360.0
+}

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMath.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMath.kt
@@ -51,17 +51,50 @@ object TerrainTileMath {
         return TileIndex(zoom, x, y)
     }
 
-    /** Every tile in [bounds] at [zoom], inclusive of both corners' own tiles. */
+    /** The largest valid tile-column/row index at [zoom] — `2^zoom - 1`, the same bound [tileAt] clamps into. */
+    private fun maxTileIndex(zoom: Int): Int = (2.0.pow(zoom).toInt() - 1)
+
+    /**
+     * The x-index ranges [tilesAt] must enumerate for [bounds] at [zoom] — normally a single `[west.x, east.x]` range,
+     * but split into two (`[west.x, maxX]` and `[0, east.x]`) when [bounds] crosses the antimeridian (e.g. west=170,
+     * east=-170 — real for Fiji, or Chukotka/Alaska): a plain `IntRange` with `start > end` is empty in Kotlin, which
+     * would otherwise silently enumerate zero tiles for a real, valid region.
+     */
+    private fun xRangesAt(zoom: Int, northwest: TileIndex, southeast: TileIndex): List<IntRange> =
+        if (northwest.x <= southeast.x) {
+            listOf(northwest.x..southeast.x)
+        } else {
+            listOf(northwest.x..maxTileIndex(zoom), 0..southeast.x)
+        }
+
+    /** Every tile in [bounds] at [zoom], inclusive of both corners' own tiles. Antimeridian-aware — see [xRangesAt]. */
     fun tilesAt(zoom: Int, bounds: GeoBounds): List<TileIndex> {
         val northwest = tileAt(zoom, bounds.north, bounds.west)
         val southeast = tileAt(zoom, bounds.south, bounds.east)
         val tiles = mutableListOf<TileIndex>()
-        for (x in northwest.x..southeast.x) {
-            for (y in northwest.y..southeast.y) {
-                tiles += TileIndex(zoom, x, y)
+        for (xRange in xRangesAt(zoom, northwest, southeast)) {
+            for (x in xRange) {
+                for (y in northwest.y..southeast.y) {
+                    tiles += TileIndex(zoom, x, y)
+                }
             }
         }
         return tiles
+    }
+
+    /**
+     * How many tiles [tilesAt] would return for [zoom]/[bounds], computed from the two corner indices rather than by
+     * materializing the list — stays O(1) per zoom regardless of how large the actual count is. Shared by
+     * [TerrainRegionExtractor] (to bound memory before enumerating) and `:feature:map-maplibre`'s own pre-download
+     * estimate shown in the layers sheet.
+     */
+    fun tileCountAt(zoom: Int, bounds: GeoBounds): Long {
+        val northwest = tileAt(zoom, bounds.north, bounds.west)
+        val southeast = tileAt(zoom, bounds.south, bounds.east)
+        val rows = (southeast.y - northwest.y + 1).coerceAtLeast(0)
+        val columns =
+            xRangesAt(zoom, northwest, southeast).sumOf { range -> (range.last - range.first + 1).coerceAtLeast(0) }
+        return columns.toLong() * rows.toLong()
     }
 
     /** Whether [bounds] fits entirely inside a single tile at [zoom] — used for Mapterhorn's regional-archive gate. */

--- a/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileStore.kt
+++ b/feature/map-terrain/src/commonMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileStore.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import okio.FileSystem
+import okio.Path
+
+/**
+ * Raw Terrarium WebP tiles as a plain file hierarchy under [baseDir]: `<baseDir>/<source>/<zoom>/<x>/<y>.webp`.
+ *
+ * Plain files, not a SQLite archive (unlike the base offline layer's Google-only archive): this store also has to work
+ * on Desktop, and Okio's [FileSystem] is genuinely multiplatform where Android's SQLite APIs aren't. One instance is
+ * scoped to one region's own terrain directory — callers own deciding where that directory lives.
+ */
+class TerrainTileStore(private val fileSystem: FileSystem, private val baseDir: Path) {
+
+    fun writeTile(source: TerrainSource, tile: TileIndex, webpBytes: ByteArray) {
+        val path = tilePath(source, tile)
+        path.parent?.let { fileSystem.createDirectories(it) }
+        fileSystem.write(path) { write(webpBytes) }
+    }
+
+    fun readTile(source: TerrainSource, tile: TileIndex): ByteArray? {
+        val path = tilePath(source, tile)
+        if (!fileSystem.exists(path)) return null
+        return fileSystem.read(path) { readByteArray() }
+    }
+
+    fun hasTile(source: TerrainSource, tile: TileIndex): Boolean = fileSystem.exists(tilePath(source, tile))
+
+    /** Total bytes on disk under [baseDir] — both [TerrainSource.GLOBAL] and [TerrainSource.REGIONAL], if present. */
+    fun sizeBytes(): Long {
+        if (!fileSystem.exists(baseDir)) return 0L
+        return fileSystem
+            .listRecursively(baseDir)
+            .filter { fileSystem.metadata(it).isRegularFile }
+            .sumOf { fileSystem.metadata(it).size ?: 0L }
+    }
+
+    /** Deletes every tile this store owns — the whole [baseDir], both sources. */
+    fun deleteAll() {
+        if (fileSystem.exists(baseDir)) fileSystem.deleteRecursively(baseDir)
+    }
+
+    private fun tilePath(source: TerrainSource, tile: TileIndex): Path =
+        baseDir / source.dirName / tile.zoom.toString() / tile.x.toString() / "${tile.y}.webp"
+}
+
+/** Mapterhorn's two-tier archive split: a global low-res layer always present, a regional high-res layer sometimes. */
+enum class TerrainSource(val dirName: String) {
+    GLOBAL("global"),
+    REGIONAL("regional"),
+}

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ContourGeneratorTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ContourGeneratorTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ContourGeneratorTest {
+
+    /** A 5x5 grid where elevation = column × 10 (0,10,20,30,40), constant down every row — a pure east-facing ramp. */
+    private fun eastFacingRamp(): ElevationTile {
+        val row = floatArrayOf(0f, 10f, 20f, 30f, 40f)
+        val elevations = FloatArray(25)
+        for (y in 0 until 5) for (x in 0 until 5) elevations[y * 5 + x] = row[x]
+        return ElevationTile(5, 5, elevations)
+    }
+
+    @Test
+    fun `a contour level below every sample produces no lines`() {
+        assertEquals(emptyList(), ContourGenerator.generate(eastFacingRamp(), levels = listOf(-5f)))
+    }
+
+    @Test
+    fun `zero and negative levels are excluded even when requested`() {
+        // The ramp does cross 0 (its own minimum), but level 0 itself is filtered by the positive-only rule.
+        assertEquals(emptyList(), ContourGenerator.generate(eastFacingRamp(), levels = listOf(0f, -10f)))
+    }
+
+    @Test
+    fun `a level crossing the ramp produces one chained vertical line at the expected x`() {
+        val lines = ContourGenerator.generate(eastFacingRamp(), levels = listOf(20f))
+
+        val line = lines.single()
+        assertEquals(20f, line.elevationMeters)
+        // Column 2 holds elevation 20 — normalized x = 2/4 = 0.5 (4 cells across a 5-sample grid).
+        assertTrue(
+            line.points.all { kotlin.math.abs(it.x - 0.5f) < 1e-4f },
+            "expected every point near x=0.5, got ${line.points}",
+        )
+        // Four row-cells' segments should have chained into one polyline spanning the full grid height.
+        val ys = line.points.map { it.y }.sorted()
+        assertEquals(0f, ys.first(), absoluteTolerance = 1e-4f)
+        assertEquals(1f, ys.last(), absoluteTolerance = 1e-4f)
+    }
+
+    @Test
+    fun `multiple requested levels each produce their own line`() {
+        val lines = ContourGenerator.generate(eastFacingRamp(), levels = listOf(10f, 20f, 30f))
+        assertEquals(setOf(10f, 20f, 30f), lines.map { it.elevationMeters }.toSet())
+    }
+
+    @Test
+    fun `a saddle cell produces two separate segments - not a crossing artifact`() {
+        // 2x2 grid: high corners on one diagonal (TL, BR = 100), low on the other (TR, BL = 0) — the textbook
+        // marching-squares saddle case. A level of 50 should produce two lines, each isolating one high corner,
+        // not a single line that incorrectly connects both diagonal high points through the cell's center.
+        val saddle = ElevationTile(2, 2, floatArrayOf(100f, 0f, 0f, 100f))
+        val lines = ContourGenerator.generate(saddle, levels = listOf(50f))
+        assertEquals(2, lines.size, "expected two disjoint segments from a saddle cell, got $lines")
+    }
+}

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ContourIntervalsTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ContourIntervalsTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ContourIntervalsTest {
+
+    @Test
+    fun `z13-14 metric band matches iOS exactly`() {
+        assertEquals(ContourIntervalBand(50f, 250f), ContourIntervals.forZoom(13, metric = true))
+        assertEquals(ContourIntervalBand(50f, 250f), ContourIntervals.forZoom(14, metric = true))
+    }
+
+    @Test
+    fun `z13-14 imperial band matches iOS's 200ft-1000ft - converted to meters`() {
+        val band = ContourIntervals.forZoom(13, metric = false)
+        assertEquals(200f * 0.3048f, band.minorMeters, absoluteTolerance = 1e-4f)
+        assertEquals(1000f * 0.3048f, band.indexMeters, absoluteTolerance = 1e-4f)
+    }
+
+    @Test
+    fun `every band's index interval is exactly 5x its minor interval`() {
+        for (zoom in listOf(5, 10, 11, 12, 13, 14, 15, 20)) {
+            for (metric in listOf(true, false)) {
+                val band = ContourIntervals.forZoom(zoom, metric)
+                assertEquals(
+                    band.minorMeters * 5f,
+                    band.indexMeters,
+                    absoluteTolerance = 1e-3f,
+                    "zoom=$zoom metric=$metric",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `zoom bands step down at exactly 11 - 13 - and 15`() {
+        assertEquals(500f, ContourIntervals.forZoom(10, metric = true).minorMeters)
+        assertEquals(100f, ContourIntervals.forZoom(11, metric = true).minorMeters)
+        assertEquals(100f, ContourIntervals.forZoom(12, metric = true).minorMeters)
+        assertEquals(50f, ContourIntervals.forZoom(13, metric = true).minorMeters)
+        assertEquals(20f, ContourIntervals.forZoom(15, metric = true).minorMeters)
+        assertEquals(20f, ContourIntervals.forZoom(20, metric = true).minorMeters)
+    }
+
+    @Test
+    fun `levelsForZoom generates every minor multiple up to the elevation ceiling`() {
+        // z15 metric minor = 20m; up to 100m should yield exactly 20,40,60,80,100.
+        val levels = ContourIntervals.levelsForZoom(zoom = 15, metric = true, maxElevationMeters = 100f)
+        assertEquals(listOf(20f, 40f, 60f, 80f, 100f), levels)
+    }
+
+    @Test
+    fun `isIndexLevel is true only on multiples of the index interval`() {
+        // z15 metric: minor 20, index 100 -> 100 and 200 are index levels, 20/40/etc are not.
+        assertTrue(ContourIntervals.isIndexLevel(100f, zoom = 15, metric = true))
+        assertTrue(ContourIntervals.isIndexLevel(200f, zoom = 15, metric = true))
+        assertFalse(ContourIntervals.isIndexLevel(20f, zoom = 15, metric = true))
+        assertFalse(ContourIntervals.isIndexLevel(80f, zoom = 15, metric = true))
+    }
+}

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ElevationTileTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ElevationTileTest.kt
@@ -70,4 +70,12 @@ class ElevationTileTest {
         assertFailsWith<IllegalArgumentException> { ElevationTile(width = 0, height = 2, elevations = floatArrayOf()) }
         assertFailsWith<IllegalArgumentException> { ElevationTile(width = 2, height = 0, elevations = floatArrayOf()) }
     }
+
+    @Test
+    fun `dimensions whose product overflows Int are rejected rather than matching an empty array`() {
+        // 65536 * 65536 wraps to 0 in Int, which would satisfy `size == width * height` for an empty array.
+        assertFailsWith<IllegalArgumentException> {
+            ElevationTile(width = 65536, height = 65536, elevations = floatArrayOf())
+        }
+    }
 }

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ElevationTileTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ElevationTileTest.kt
@@ -62,4 +62,12 @@ class ElevationTileTest {
             ElevationTile(width = 2, height = 2, elevations = floatArrayOf(1f))
         }
     }
+
+    @Test
+    fun `a zero-dimension grid is rejected at construction rather than crashing elevationAt later`() {
+        // width=0 (or height=0) passes the size == width*height check trivially (0 == 0), but would later throw
+        // from elevationAt's coerceIn(0, width - 1) -> coerceIn(0, -1) on first use. Reject it up front instead.
+        assertFailsWith<IllegalArgumentException> { ElevationTile(width = 0, height = 2, elevations = floatArrayOf()) }
+        assertFailsWith<IllegalArgumentException> { ElevationTile(width = 2, height = 0, elevations = floatArrayOf()) }
+    }
 }

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ElevationTileTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/ElevationTileTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ElevationTileTest {
+
+    @Test
+    fun `zero RGB decodes to the Terrarium offset's negative`() {
+        // R=0,G=0,B=0 -> 0 - 32768 = -32768, the encoding's own floor.
+        assertEquals(-32768f, terrariumElevationMeters(red = 0, green = 0, blue = 0))
+    }
+
+    @Test
+    fun `mid-gray-ish RGB decodes to sea level - per the spec's own worked example`() {
+        // Tilezen/Joerd's spec worked example for ~0m: R=128, G=0, B=0 -> 128*256 - 32768 = 0.
+        assertEquals(0f, terrariumElevationMeters(red = 128, green = 0, blue = 0))
+    }
+
+    @Test
+    fun `green and blue channels add sub-256m and sub-1m precision`() {
+        // R=128 (32768 raw), G=10 adds 10m, B=128 adds 0.5m -> 32768+10+0.5-32768 = 10.5
+        assertEquals(10.5f, terrariumElevationMeters(red = 128, green = 10, blue = 128))
+    }
+
+    @Test
+    fun `elevationAt reads row-major with top-left origin`() {
+        val tile = ElevationTile(width = 2, height = 2, elevations = floatArrayOf(1f, 2f, 3f, 4f))
+        assertEquals(1f, tile.elevationAt(0, 0))
+        assertEquals(2f, tile.elevationAt(1, 0))
+        assertEquals(3f, tile.elevationAt(0, 1))
+        assertEquals(4f, tile.elevationAt(1, 1))
+    }
+
+    @Test
+    fun `elevationAt clamps out-of-bounds coordinates to the tile's own edge`() {
+        val tile = ElevationTile(width = 2, height = 2, elevations = floatArrayOf(1f, 2f, 3f, 4f))
+        assertEquals(1f, tile.elevationAt(-5, -5))
+        assertEquals(4f, tile.elevationAt(50, 50))
+    }
+
+    @Test
+    fun `a mismatched elevations array size is rejected at construction`() {
+        assertFailsWith<IllegalArgumentException> {
+            ElevationTile(width = 2, height = 2, elevations = floatArrayOf(1f))
+        }
+    }
+}

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/HillshadeTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/HillshadeTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class HillshadeTest {
+
+    /** A 3x3 padded tile (margin=1 around a single 1x1 output pixel) from a flat row-major 3x3 array. */
+    private fun padded3x3(values: List<Float>): ElevationTile = ElevationTile(3, 3, values.toFloatArray())
+
+    @Test
+    fun `flat terrain casts no shadow - regardless of elevation`() {
+        val flat = padded3x3(List(9) { 100f })
+        val shadow = Hillshade.shade(flat, width = 1, height = 1, maxShadowAlpha = 1f)
+        assertEquals(0f, shadow[0])
+    }
+
+    @Test
+    fun `a slope facing away from the fixed NW light casts a nonzero shadow`() {
+        // Elevation rises to the west (falls to the east) — the light is fixed at azimuth 315 (NW), so this
+        // slope's uphill/lit side faces away from it. A slope rising the other way (east) instead faces toward
+        // the light and is legitimately *brighter* than flat ground (illumination > sinAltitude, clamped to zero
+        // shadow) — that's correct hillshade behavior, not a bug, which is why this test picks the orientation
+        // that should actually be shadowed rather than asserting "any slope shadows."
+        val ramp = padded3x3(listOf(110f, 100f, 90f, 110f, 100f, 90f, 110f, 100f, 90f))
+        val shadow = Hillshade.shade(ramp, width = 1, height = 1, maxShadowAlpha = 1f)
+        assertTrue(shadow[0] > 0f, "expected a nonzero shadow for a slope facing away from the light, got ${shadow[0]}")
+    }
+
+    @Test
+    fun `sea-level fade zeroes shading for a slope entirely under half a meter`() {
+        val shallowRamp = padded3x3(listOf(0.1f, 0.2f, 0.3f, 0.1f, 0.2f, 0.3f, 0.1f, 0.2f, 0.3f))
+        val shadow = Hillshade.shade(shallowRamp, width = 1, height = 1, maxShadowAlpha = 1f)
+        assertEquals(0f, shadow[0])
+    }
+
+    @Test
+    fun `local-relief fade zeroes shading for a pixel barely above its own neighborhood minimum`() {
+        // center 10.1 sits only 0.1m above its 10.0 neighbors — under LOCAL_RELIEF_FADE_START (0.3m) — even
+        // though 10m is nowhere near the sea-level fade's own threshold.
+        val nearFlatAtAltitude = padded3x3(listOf(10f, 10f, 10f, 10f, 10.1f, 10f, 10f, 10f, 10f))
+        val shadow = Hillshade.shade(nearFlatAtAltitude, width = 1, height = 1, maxShadowAlpha = 1f)
+        assertEquals(0f, shadow[0])
+    }
+
+    @Test
+    fun `an isolated single-pixel spike is despiked to its neighborhood's median before shading`() {
+        // The output pixel itself spikes 20m above 8 otherwise-flat neighbors; despike should replace it with
+        // the neighborhood median (the flat value), leaving nothing left to shade.
+        val spike = padded3x3(listOf(50f, 50f, 50f, 50f, 70f, 50f, 50f, 50f, 50f))
+        val shadow = Hillshade.shade(spike, width = 1, height = 1, maxShadowAlpha = 1f)
+        assertEquals(0f, shadow[0])
+    }
+
+    @Test
+    fun `maxShadowAlpha scales the output linearly`() {
+        // Same shadow-facing orientation as the test above — this needs a genuinely nonzero shadow, or "full *
+        // 0.5 == half" would hold trivially at 0 == 0 without exercising the scaling at all.
+        val ramp = padded3x3(listOf(110f, 100f, 90f, 110f, 100f, 90f, 110f, 100f, 90f))
+        val full = Hillshade.shade(ramp, width = 1, height = 1, maxShadowAlpha = 1f)[0]
+        val half = Hillshade.shade(ramp, width = 1, height = 1, maxShadowAlpha = 0.5f)[0]
+        assertTrue(full > 0f, "test setup invariant: expected a nonzero shadow to scale, got $full")
+        assertEquals(full * 0.5f, half, absoluteTolerance = 1e-6f)
+    }
+
+    @Test
+    fun `an incorrectly padded tile is rejected rather than read out of bounds`() {
+        val wrongSize = ElevationTile(2, 2, floatArrayOf(1f, 2f, 3f, 4f))
+        assertFailsWith<IllegalArgumentException> {
+            Hillshade.shade(wrongSize, width = 1, height = 1, maxShadowAlpha = 1f)
+        }
+    }
+}

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/HillshadeTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/HillshadeTest.kt
@@ -88,4 +88,19 @@ class HillshadeTest {
             Hillshade.shade(wrongSize, width = 1, height = 1, maxShadowAlpha = 1f)
         }
     }
+
+    @Test
+    fun `despike leaves the margin ring's original values untouched`() {
+        // 5x5 padded tile (3x3 output + a 1px margin ring): flat at 100 everywhere except the tile's own top-left
+        // margin corner, spiked far above its clamped-at-the-edge neighborhood's median. If despike touched the
+        // margin ring it would flatten that corner back to 100 — it must not, since the margin exists to carry real
+        // neighbor-tile elevation data into edge-pixel shading, not to be cleaned up itself.
+        val values = FloatArray(25) { 100f }
+        values[0] = 1000f
+        val padded = ElevationTile(5, 5, values)
+
+        val despiked = Hillshade.despike(padded)
+
+        assertEquals(1000f, despiked.elevationAt(0, 0))
+    }
 }

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/MapterhornEndpointsTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/MapterhornEndpointsTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MapterhornEndpointsTest {
+
+    @Test
+    fun `a tiny region resolves a regional archive URL`() {
+        val seattle = GeoBounds(south = 47.6, west = -122.4, north = 47.61, east = -122.39)
+        val url = MapterhornEndpoints.regionalUrlFor(seattle)
+        assertEquals(true, url?.startsWith("https://download.mapterhorn.com/"))
+        assertEquals(true, url?.endsWith(".pmtiles"))
+    }
+
+    @Test
+    fun `a region spanning multiple z6 tiles has no regional archive`() {
+        val global = GeoBounds(south = -60.0, west = -170.0, north = 60.0, east = 170.0)
+        assertNull(MapterhornEndpoints.regionalUrlFor(global))
+    }
+}

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainRegionExtractorTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainRegionExtractorTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class TerrainRegionExtractorTest {
+
+    private val store = TerrainTileStore(FakeFileSystem(), "/regions/abc/terrain".toPath())
+
+    /** Small enough to fit one z6 tile, so a regional archive URL resolves for it. */
+    private val seattle = GeoBounds(south = 47.6, west = -122.4, north = 47.61, east = -122.39)
+
+    private val regionalZoom = MapterhornEndpoints.GLOBAL_MAX_ZOOM + 2
+
+    /** Serves a tile for every request when [hasCoverage], and none at all — sparse-archive style — otherwise. */
+    private class FakeArchive(private val hasCoverage: Boolean) : TerrainRegionExtractor.TileArchive {
+        override fun fetchTile(zoom: Int, x: Int, y: Int): ByteArray? = if (hasCoverage) byteArrayOf(1) else null
+
+        override fun close() = Unit
+    }
+
+    private fun extractor(regionalHasCoverage: Boolean) = TerrainRegionExtractor(store) { url ->
+        FakeArchive(hasCoverage = url == MapterhornEndpoints.GLOBAL_PMTILES_URL || regionalHasCoverage)
+    }
+
+    @Test
+    fun `a regional archive that stores nothing does not report regional detail`() = runTest {
+        val result = extractor(regionalHasCoverage = false).download(seattle, regionalZoom).last()
+
+        assertIs<TerrainDownloadState.Complete>(result)
+        assertEquals(false, result.hasRegionalDetail)
+        assertTrue(result.tileCount > 0, "the global tier alone still counts")
+        assertEquals(
+            false,
+            store.hasTile(TerrainSource.REGIONAL, TerrainTileMath.tileAt(regionalZoom, 47.605, -122.395)),
+        )
+    }
+
+    @Test
+    fun `a regional archive that stores tiles reports regional detail`() = runTest {
+        val result = extractor(regionalHasCoverage = true).download(seattle, regionalZoom).last()
+
+        assertIs<TerrainDownloadState.Complete>(result)
+        assertEquals(true, result.hasRegionalDetail)
+        assertTrue(store.hasTile(TerrainSource.REGIONAL, TerrainTileMath.tileAt(regionalZoom, 47.605, -122.395)))
+    }
+}

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMathTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMathTest.kt
@@ -45,6 +45,30 @@ class TerrainTileMathTest {
     }
 
     @Test
+    fun `tilesAt wraps the antimeridian instead of returning zero tiles`() {
+        // Fiji-shaped bounds: west=170, east=-170. northwest.x > southeast.x at any real zoom, which a plain
+        // IntRange(start > end) would silently enumerate as empty.
+        val bounds = GeoBounds(south = -20.0, west = 170.0, north = -16.0, east = -170.0)
+        val tiles = TerrainTileMath.tilesAt(zoom = 6, bounds)
+
+        assertTrue(tiles.isNotEmpty())
+        assertTrue(tiles.contains(TerrainTileMath.tileAt(6, bounds.north, bounds.west)))
+        assertTrue(tiles.contains(TerrainTileMath.tileAt(6, bounds.south, bounds.east)))
+        // The wrap point itself (x=0, the antimeridian) must be covered, not skipped.
+        val y = TerrainTileMath.tileAt(6, bounds.north, bounds.west).y
+        assertTrue(tiles.contains(TileIndex(6, 0, y)))
+    }
+
+    @Test
+    fun `tileCountAt agrees with tilesAt's own size including across the antimeridian`() {
+        val normal = GeoBounds(south = -1.0, west = -1.0, north = 1.0, east = 1.0)
+        assertEquals(TerrainTileMath.tilesAt(4, normal).size.toLong(), TerrainTileMath.tileCountAt(4, normal))
+
+        val wrapping = GeoBounds(south = -20.0, west = 170.0, north = -16.0, east = -170.0)
+        assertEquals(TerrainTileMath.tilesAt(6, wrapping).size.toLong(), TerrainTileMath.tileCountAt(6, wrapping))
+    }
+
+    @Test
     fun `fitsInSingleTile is true for a tiny box and false for a global one`() {
         val tiny = GeoBounds(south = 47.6, west = -122.4, north = 47.61, east = -122.39)
         assertTrue(TerrainTileMath.fitsInSingleTile(zoom = 6, tiny))

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMathTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMathTest.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.feature.map.terrain
 
+import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -50,5 +51,33 @@ class TerrainTileMathTest {
 
         val global = GeoBounds(south = -60.0, west = -170.0, north = 60.0, east = 170.0)
         assertFalse(TerrainTileMath.fitsInSingleTile(zoom = 6, global))
+    }
+
+    @Test
+    fun `lonLatAt at a tile's own corner round-trips through tileAt`() {
+        val zoom = 12
+        val tile = TerrainTileMath.tileAt(zoom, latitude = 47.6, longitude = -122.3)
+
+        // The tile's own top-left corner (localX=0, localY=0) must land back inside that same tile.
+        val corner = TerrainTileMath.lonLatAt(tile, localX = 0f, localY = 0f)
+        assertEquals(tile, TerrainTileMath.tileAt(zoom, corner.latitude, corner.longitude))
+    }
+
+    @Test
+    fun `lonLatAt at the tile center is roughly the tile's own midpoint`() {
+        val zoom = 8
+        val tile = TileIndex(zoom, x = 41, y = 91)
+
+        val center = TerrainTileMath.lonLatAt(tile, localX = 0.5f, localY = 0.5f)
+        assertEquals(tile, TerrainTileMath.tileAt(zoom, center.latitude, center.longitude))
+    }
+
+    @Test
+    fun `lonLatAt zoom 0 spans the whole world`() {
+        val topLeft = TerrainTileMath.lonLatAt(TileIndex(0, 0, 0), localX = 0f, localY = 0f)
+        assertTrue(abs(topLeft.longitude - -180.0) < 1e-6)
+
+        val bottomRight = TerrainTileMath.lonLatAt(TileIndex(0, 0, 0), localX = 1f, localY = 1f)
+        assertTrue(abs(bottomRight.longitude - 180.0) < 1e-6)
     }
 }

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMathTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainTileMathTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TerrainTileMathTest {
+
+    @Test
+    fun `zoom 0 is a single tile covering everywhere`() {
+        assertEquals(TileIndex(0, 0, 0), TerrainTileMath.tileAt(0, latitude = 10.0, longitude = 10.0))
+        assertEquals(TileIndex(0, 0, 0), TerrainTileMath.tileAt(0, latitude = -70.0, longitude = 170.0))
+    }
+
+    @Test
+    fun `zoom 1 splits the world into hemispheric quadrants`() {
+        assertEquals(TileIndex(1, 0, 0), TerrainTileMath.tileAt(1, latitude = 45.0, longitude = -170.0)) // NW
+        assertEquals(TileIndex(1, 1, 1), TerrainTileMath.tileAt(1, latitude = -45.0, longitude = 10.0)) // SE
+    }
+
+    @Test
+    fun `tilesAt covers a bbox's own corners inclusively`() {
+        val bounds = GeoBounds(south = -1.0, west = -1.0, north = 1.0, east = 1.0)
+        val tiles = TerrainTileMath.tilesAt(zoom = 2, bounds)
+        assertTrue(tiles.contains(TerrainTileMath.tileAt(2, bounds.north, bounds.west)))
+        assertTrue(tiles.contains(TerrainTileMath.tileAt(2, bounds.south, bounds.east)))
+    }
+
+    @Test
+    fun `fitsInSingleTile is true for a tiny box and false for a global one`() {
+        val tiny = GeoBounds(south = 47.6, west = -122.4, north = 47.61, east = -122.39)
+        assertTrue(TerrainTileMath.fitsInSingleTile(zoom = 6, tiny))
+
+        val global = GeoBounds(south = -60.0, west = -170.0, north = 60.0, east = 170.0)
+        assertFalse(TerrainTileMath.fitsInSingleTile(zoom = 6, global))
+    }
+}

--- a/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainTileStoreTest.kt
+++ b/feature/map-terrain/src/commonTest/kotlin/org/meshtastic/feature/map/terrain/TerrainTileStoreTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TerrainTileStoreTest {
+
+    private val fileSystem = FakeFileSystem()
+    private val store = TerrainTileStore(fileSystem, "/regions/abc/terrain".toPath())
+
+    @Test
+    fun `a written tile reads back byte-for-byte`() {
+        val tile = TileIndex(zoom = 10, x = 163, y = 353)
+        val bytes = byteArrayOf(1, 2, 3, 4)
+
+        store.writeTile(TerrainSource.GLOBAL, tile, bytes)
+
+        assertTrue(store.hasTile(TerrainSource.GLOBAL, tile))
+        assertEquals(bytes.toList(), store.readTile(TerrainSource.GLOBAL, tile)?.toList())
+    }
+
+    @Test
+    fun `an unwritten tile reads as null not an error`() {
+        assertNull(store.readTile(TerrainSource.GLOBAL, TileIndex(5, 1, 1)))
+        assertEquals(false, store.hasTile(TerrainSource.REGIONAL, TileIndex(5, 1, 1)))
+    }
+
+    @Test
+    fun `global and regional tiles at the same coordinates don't collide`() {
+        val tile = TileIndex(zoom = 14, x = 10, y = 10)
+        store.writeTile(TerrainSource.GLOBAL, tile, byteArrayOf(1))
+        store.writeTile(TerrainSource.REGIONAL, tile, byteArrayOf(2))
+
+        assertEquals(listOf(1.toByte()), store.readTile(TerrainSource.GLOBAL, tile)?.toList())
+        assertEquals(listOf(2.toByte()), store.readTile(TerrainSource.REGIONAL, tile)?.toList())
+    }
+
+    @Test
+    fun `sizeBytes sums every tile written across both sources`() {
+        store.writeTile(TerrainSource.GLOBAL, TileIndex(5, 1, 1), ByteArray(100))
+        store.writeTile(TerrainSource.REGIONAL, TileIndex(14, 2, 2), ByteArray(250))
+        assertEquals(350L, store.sizeBytes())
+    }
+
+    @Test
+    fun `sizeBytes is zero for a store nothing has been written to yet`() {
+        assertEquals(0L, store.sizeBytes())
+    }
+
+    @Test
+    fun `deleteAll removes every tile and leaves the store readable-empty`() {
+        store.writeTile(TerrainSource.GLOBAL, TileIndex(5, 1, 1), byteArrayOf(1))
+        store.deleteAll()
+
+        assertEquals(0L, store.sizeBytes())
+        assertNull(store.readTile(TerrainSource.GLOBAL, TileIndex(5, 1, 1)))
+    }
+
+    @Test
+    fun `deleteAll on a store nothing was ever written to is a harmless no-op`() {
+        store.deleteAll()
+        assertEquals(0L, store.sizeBytes())
+    }
+}

--- a/feature/map-terrain/src/jvmMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.jvm.kt
+++ b/feature/map-terrain/src/jvmMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.jvm.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+
+actual fun decodeTerrariumTile(webpBytes: ByteArray): ElevationTile {
+    val image = Image.makeFromEncoded(webpBytes)
+    val width = image.width
+    val height = image.height
+
+    // ColorAlphaType.UNPREMUL, explicitly: Skia's default read path premultiplies RGB by alpha, which would
+    // corrupt the elevation bits encoded in the RGB channels wherever a tile's alpha isn't fully opaque — the
+    // same concern the Android actual guards against with BitmapFactory.Options.inPremultiplied = false.
+    val bitmap = Bitmap()
+    check(bitmap.allocPixels(ImageInfo(width, height, ColorType.N32, ColorAlphaType.UNPREMUL))) {
+        "Could not allocate a $width×$height bitmap for a decoded Terrarium tile"
+    }
+    check(image.readPixels(bitmap)) { "Could not read pixels from a decoded Terrarium tile" }
+
+    val elevations = FloatArray(width * height)
+    for (y in 0 until height) {
+        for (x in 0 until width) {
+            val color = bitmap.getColor(x, y)
+            val red = (color ushr RED_SHIFT) and COLOR_MASK
+            val green = (color ushr GREEN_SHIFT) and COLOR_MASK
+            val blue = color and COLOR_MASK
+            elevations[y * width + x] = terrariumElevationMeters(red, green, blue)
+        }
+    }
+    return ElevationTile(width, height, elevations)
+}
+
+private const val RED_SHIFT = 16
+private const val GREEN_SHIFT = 8
+private const val COLOR_MASK = 0xFF

--- a/feature/map-terrain/src/jvmMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.jvm.kt
+++ b/feature/map-terrain/src/jvmMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.jvm.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+import ch.poole.geo.pmtiles.Constants
+import ch.poole.geo.pmtiles.HttpUrlConnectionChannel
+import ch.poole.geo.pmtiles.Reader
+import java.net.URL
+import java.util.zip.GZIPInputStream
+
+actual class TerrainTileFetcher actual constructor(pmtilesUrl: String) : AutoCloseable {
+
+    private val reader: Reader = Reader(HttpUrlConnectionChannel(URL(pmtilesUrl)))
+
+    actual fun fetchTile(zoom: Int, x: Int, y: Int): ByteArray? {
+        val raw = reader.getTile(zoom, x, y) ?: return null
+        return if (reader.tileCompression == Constants.COMPRESSION_GZIP) gunzip(raw) else raw
+    }
+
+    actual override fun close() {
+        reader.close()
+    }
+
+    private fun gunzip(bytes: ByteArray): ByteArray = GZIPInputStream(bytes.inputStream()).use { it.readBytes() }
+}

--- a/feature/map-terrain/src/jvmMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.jvm.kt
+++ b/feature/map-terrain/src/jvmMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.jvm.kt
@@ -19,6 +19,8 @@ package org.meshtastic.feature.map.terrain
 import ch.poole.geo.pmtiles.Constants
 import ch.poole.geo.pmtiles.HttpUrlConnectionChannel
 import ch.poole.geo.pmtiles.Reader
+import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.net.URL
 import java.util.zip.GZIPInputStream
 
@@ -35,5 +37,32 @@ actual class TerrainTileFetcher actual constructor(pmtilesUrl: String) : AutoClo
         reader.close()
     }
 
-    private fun gunzip(bytes: ByteArray): ByteArray = GZIPInputStream(bytes.inputStream()).use { it.readBytes() }
+    /**
+     * Bounded, not a bare `GZIPInputStream(...).readBytes()`: `download.mapterhorn.com` is a fixed first-party URL, but
+     * a compromised or MITM'd response is still a real defense-in-depth gap — an unbounded gunzip is a classic zip-bomb
+     * vector. A Terrarium tile decodes to at most 256×256×4 bytes (~256KB); [MAX_DECOMPRESSED_TILE_BYTES] is a generous
+     * multiple of that, not a tight fit.
+     */
+    private fun gunzip(bytes: ByteArray): ByteArray {
+        GZIPInputStream(bytes.inputStream()).use { gzip ->
+            val buffer = ByteArray(GUNZIP_BUFFER_BYTES)
+            val output = ByteArrayOutputStream()
+            var totalRead = 0
+            while (true) {
+                val read = gzip.read(buffer)
+                if (read == -1) break
+                totalRead += read
+                if (totalRead > MAX_DECOMPRESSED_TILE_BYTES) {
+                    throw IOException("Decompressed terrain tile exceeds $MAX_DECOMPRESSED_TILE_BYTES bytes")
+                }
+                output.write(buffer, 0, read)
+            }
+            return output.toByteArray()
+        }
+    }
+
+    private companion object {
+        private const val MAX_DECOMPRESSED_TILE_BYTES = 8 * 1024 * 1024
+        private const val GUNZIP_BUFFER_BYTES = 8192
+    }
 }

--- a/feature/map-terrain/src/nativeMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.native.kt
+++ b/feature/map-terrain/src/nativeMain/kotlin/org/meshtastic/feature/map/terrain/ElevationTile.native.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+/**
+ * Placeholder Kotlin/Native implementation of Terrarium WebP decoding.
+ *
+ * This module explicitly states "No iOS target" (see build.gradle.kts comment), but the KMP library convention plugin
+ * adds iOS targets automatically to all KMP modules. Until those targets are explicitly excluded from the convention
+ * plugin or this module restructured, iOS must be able to compile. This stub throws NotImplementedError if called.
+ */
+actual fun decodeTerrariumTile(webpBytes: ByteArray): ElevationTile = throw NotImplementedError(
+    "Terrarium elevation decoding is not implemented for Kotlin/Native (iOS). " +
+        "This module has no iOS surface; use the Android or JVM implementations instead.",
+)

--- a/feature/map-terrain/src/nativeMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.native.kt
+++ b/feature/map-terrain/src/nativeMain/kotlin/org/meshtastic/feature/map/terrain/TerrainTileFetcher.native.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.map.terrain
+
+/**
+ * Placeholder Kotlin/Native implementation — same reason as [decodeTerrariumTile]'s nativeMain actual: this module has
+ * no iOS surface, but the shared KMP convention plugin adds Kotlin/Native targets to every module regardless.
+ */
+actual class TerrainTileFetcher actual constructor(pmtilesUrl: String) : AutoCloseable {
+
+    actual fun fetchTile(zoom: Int, x: Int, y: Int): ByteArray? = throw NotImplementedError(
+        "Terrain tile fetching is not implemented for Kotlin/Native (iOS). " +
+            "This module has no iOS surface; use the Android or JVM implementations instead.",
+    )
+
+    actual override fun close() = Unit
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -250,6 +250,12 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json-okio = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
+# Reads the PMTiles v3 container format (header + directory tree). MIT-licensed; see
+# https://github.com/simonpoole/pmtiles-reader. Also added independently on feat/map-google-pmtiles-offline
+# (PR #7000, not yet merged) for the base offline layer — identical entry, so whichever branch merges first,
+# the other's rebase sees no real conflict here.
+pmtiles-reader = { module = "ch.poole.geo.pmtiles-reader:Reader", version = "0.3.6" }
 
 # Networking
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
@@ -305,6 +311,7 @@ meshtastic-mqtt-client-transport-ws = { module = "org.meshtastic:mqtt-client-tra
 
 jserialcomm = { module = "com.fazecast:jSerialComm", version.ref = "jserialcomm" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 uri-kmp = { module = "com.eygraber:uri-kmp", version.ref = "uri-kmp" }
 kermit = { module = "co.touchlab:kermit", version = "2.1.0" }
 # Debug-only leak/GC-thrash detector -- see feature/settings/.../debugging/DebugViewModel.kt and

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -112,6 +112,7 @@ include(
     ":feature:connections",
     ":feature:map",
     ":feature:map-maplibre",
+    ":feature:map-terrain",
     ":feature:node",
     ":feature:settings",
     ":feature:discovery",


### PR DESCRIPTION
## Summary

Offline terrain — hillshade + elevation contours — for the MapLibre flavor (F-Droid + Desktop), the sibling piece to #7000's Google-flavor equivalent. Closes the standout Android-vs-iOS map gap: the sibling iOS app ships Mapterhorn-sourced hillshade and contours for its offline regions; Android had zero offline terrain on either flavor before this and #7000.

Wires the shared math core in `:feature:map-terrain` (Terrarium decode, Horn's-method hillshade, marching-squares contour generation, zoom-banded contour intervals — pure `commonMain`, unit-tested independently of either flavor) into this flavor:

- `OfflineTerrainRepository` — tracks a single downloaded region (manifest + tile store under the platform files dir), matching `OfflineMapsSection`'s existing shape and UX.
- Two-tier hillshade via `rememberRasterDemSource` pointed at local `file:///.../terrain/tiles/{tier}/{z}/{x}/{y}.webp` templates — MapLibre does its own Horn's-method shading internally from raw Terrarium tiles, so `Hillshade.shade()` in `:feature:map-terrain` is Google-flavor-only and unused here.
- Contour `LineLayer` via `rememberGeoJsonSource`, decoded from the same downloaded Terrarium tiles, styled through the existing simplestyle (`stroke`/`stroke-width`/`stroke-opacity`) pattern `CustomLayers.kt` already uses for imported overlays.
- Mapterhorn attribution wired into both raster-dem sources' `TileSetOptions` so MapLibre's own `ExpandingAttributionButton` picks it up automatically — the only place either hillshade or contours can carry a credit, since `GeoJsonOptions` (the contour source) has no attribution field of its own.

Full design rationale, including why contours bypass `rememberFeatureSource` for `rememberGeoJsonSource` directly (a stale-cache bug in the wrapper otherwise), is in the relevant files' own doc comments (`TerrainLayers.kt`, `OfflineTerrainRepository.kt`).

Does not touch `androidApp` or the Google flavor. `:feature:map-terrain` is presently duplicated verbatim (module + version-catalog entries) between this branch and #7000's — see that module's own commit history for why that's deliberate, low-conflict-risk duplication pending whichever merges first, not an oversight. One real divergence: `TerrainTileMath.lonLatAt`/`LonLat` exist only here (needed to place contour vertices in real coordinates for `GeoJsonSource`); the Google flavor doesn't need it since it already has its own equivalent conversion in `WebMercatorTileMath`.

## Why draft

**Not visually verified on a real device or desktop build** — no display was available in this development environment. The `file://` + raster-dem combination is architecturally sound (confirmed via direct inspection of `maplibre-native`'s C++ resource-loading source: tile-URL-template substitution in `Resource::tile()` happens before scheme dispatch, so `file://` should behave the same as `mbtiles://`/`https://`) but this is evidence, not an on-device test. Also unverified: MapLibre's behavior when a `file://` source is asked for a tile the store doesn't have on disk (a viewport partially outside the downloaded region, or a zoom between the two tiers) — noted in `TerrainLayers.kt`'s own doc comment.

Marking ready for review once someone can actually look at this on a phone or the desktop app.

## Legal

Mapterhorn: no API key, no documented rate limit (Cloudflare R2-backed). On-screen attribution per above; see `MapterhornEndpoints.ATTRIBUTION`'s own doc comment for why it's a generic credit rather than an enumerated per-source list (100+ regional datasets under a mix of licenses, no single blanket license).

## Test plan
- [x] New unit tests: `TerrainTileMathTest` (the new `lonLatAt` inverse transform), `OfflineTerrainRegionTest`, `OfflineTerrainRepositoryTest`, `TerrainDownloadEstimateTest`, `ContourFeaturesTest` — all passing.
- [x] `./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` — full repo baseline, pass (three transient shared-Gradle-daemon failures on first run, confirmed environmental by serial re-run, not code)
- [x] `./gradlew :core:konsist:testAndroidHostTest` — pass, including the new `:feature:map-terrain` module
- [x] `./gradlew :androidApp:compileFdroidDebugKotlin :desktopApp:compileKotlin` — pass (confirms this doesn't touch the Google flavor)
- [ ] Manual on-device/desktop render check — the main blocker to taking this out of draft; see "Why draft" above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline terrain downloads for map areas, including elevation and hillshade data.
  * Added terrain management controls to view, download, monitor progress, and delete saved regions.
  * Maps now display downloaded terrain shading and contour lines when viewing covered areas.
  * Added support for global terrain data and available regional high-resolution detail.
  * Added localized labels and descriptions for offline terrain features.
* **Bug Fixes**
  * Corrupt terrain tiles no longer prevent other terrain data from rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->