### PR TITLE
ci: fail when an ABI split ships fewer native libraries than its siblings

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -301,6 +301,8 @@ jobs:
       # scanner would have skipped its own test.
       - name: Self-test verify-rb Step 6
         run: ./scripts/verify-rb-selftest.sh
+      - name: Self-test verify-abi-parity
+        run: ./scripts/verify-abi-parity-selftest.sh
       - name: Validate store listing metadata lengths
         run: python3 scripts/check-metadata-length.py
       # Compose Multiplatform does not strip Android-style \" / \' escapes, so a

--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -552,6 +552,12 @@ jobs:
         # survives a pin-back below 9.7 without editing this line.
         run: ./gradlew androidApp:assembleFdroidDebug androidApp:assembleGoogleDebug -Pci=true --parallel --configuration-cache -Dorg.gradle.isolated-projects=false --continue
 
+      # A dependency published for only some of our ABIs builds and installs cleanly and then
+      # crashes with UnsatisfiedLinkError on the others (#7001). Compare the splits here, where
+      # they are already built for every PR.
+      - name: Verify native library ABI parity
+        run: ./scripts/verify-abi-parity.sh
+
       - name: Upload debug artifact
         if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/scripts/lib/abi-parity.sh
+++ b/scripts/lib/abi-parity.sh
@@ -1,0 +1,65 @@
+# shellcheck shell=bash
+# Checks that every ABI split of a flavor ships the same set of native libraries.
+# Sourced by verify-abi-parity.sh; exercised directly by verify-abi-parity-selftest.sh.
+#
+# A dependency published for only some of our ABIs installs cleanly on the others and dies
+# with UnsatisfiedLinkError the first time it is touched — nothing at build time says a word.
+# That is #7001: maplibre-native-ffi 0.202608.3 ships arm64-v8a and x86_64 only, so the
+# F-Droid armeabi-v7a split had no map engine and the map tab crashed the app.
+
+# Gaps we know about and have decided to ship. One per line: <flavor> <abi> <lib>.
+# An entry is checked both ways — the lib must be absent from that split, and the check
+# fails once it turns up, so an entry cannot outlive its reason: the dependency bump that
+# closes the gap goes red until the line is deleted with it.
+#
+# fdroid armeabi-v7a: no 32-bit ARM build of MapLibre exists yet. Upstream merged it on
+# 2026-08-24 (maplibre-native-ffi #658/#659/#660); the release carrying it, and the
+# maplibre-compose bump onto it, are what remove these two lines. Until then the app shows
+# a message instead of a map on those devices (#7005).
+ABI_PARITY_KNOWN_GAPS="
+fdroid armeabi-v7a libjniMaplibreNativeC.so
+fdroid armeabi-v7a libmaplibre-native-c.so
+"
+
+# apk_libs <apk> <abi> — basenames of the libs under lib/<abi>/ in the APK, one per line.
+apk_libs() {
+  unzip -Z1 "$1" "lib/$2/*.so" 2>/dev/null | sed 's|.*/||' | sort -u
+}
+
+# check_abi_parity <flavor> <abi>=<apk> [<abi>=<apk> ...]
+# Sets ABI_PARITY_MISSING and ABI_PARITY_STALE (space-prefixed "<abi>/<lib>" entries) and
+# ABI_PARITY_KNOWN, the number of known-gap lines that held.
+#
+# The reference set is the union across splits: a lib present in any ABI is one the app
+# expects to load, so every other ABI needs it too unless a known-gap line says otherwise.
+check_abi_parity() {
+  local flavor=$1 spec abi apk lib union="" libs
+  shift
+  ABI_PARITY_MISSING=""
+  ABI_PARITY_STALE=""
+  ABI_PARITY_KNOWN=0
+
+  for spec in "$@"; do
+    union="$union
+$(apk_libs "${spec#*=}" "${spec%%=*}")"
+  done
+  union=$(printf '%s\n' "$union" | sed '/^$/d' | sort -u)
+
+  for spec in "$@"; do
+    abi=${spec%%=*}
+    apk=${spec#*=}
+    libs=$(apk_libs "$apk" "$abi")
+    while IFS= read -r lib; do
+      [ -n "$lib" ] || continue
+      if printf '%s\n' "$ABI_PARITY_KNOWN_GAPS" | grep -qxF "$flavor $abi $lib"; then
+        if printf '%s\n' "$libs" | grep -qxF "$lib"; then
+          ABI_PARITY_STALE="${ABI_PARITY_STALE} ${abi}/${lib}"
+        else
+          ABI_PARITY_KNOWN=$((ABI_PARITY_KNOWN + 1))
+        fi
+      elif ! printf '%s\n' "$libs" | grep -qxF "$lib"; then
+        ABI_PARITY_MISSING="${ABI_PARITY_MISSING} ${abi}/${lib}"
+      fi
+    done <<< "$union"
+  done
+}

--- a/scripts/verify-abi-parity-selftest.sh
+++ b/scripts/verify-abi-parity-selftest.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Self-test for scripts/lib/abi-parity.sh — the classifier behind verify-abi-parity.sh.
+#
+# The real check only sees whatever the current dependencies happen to ship, so the two
+# failure modes it exists for — a lib missing from one ABI, and a known-gap line that has
+# outlived its reason — would otherwise go unexercised until they bit. Fixture APKs are
+# plain zips: unzip only reads the entry names, so the libs are one-byte files.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+# shellcheck source=scripts/lib/abi-parity.sh
+. scripts/lib/abi-parity.sh
+# The cases below overwrite the allowlist; keep the checked-in one for the last check.
+CHECKED_IN_KNOWN_GAPS=$ABI_PARITY_KNOWN_GAPS
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAILURES=0
+
+# apk <name> <abi> <lib>... — builds $WORKDIR/<name>.apk with those libs under lib/<abi>/.
+apk() {
+  local name=$1 abi=$2 lib dir="$WORKDIR/$1-src"
+  shift 2
+  mkdir -p "$dir/lib/$abi"
+  for lib in "$@"; do printf 'x' > "$dir/lib/$abi/$lib"; done
+  (cd "$dir" && zip -q -r "$WORKDIR/$name.apk" lib)
+}
+
+# expect <label> <var> <want>
+expect() {
+  local label=$1 var=$2 want=$3 got
+  got=$(eval "printf '%s' \"\$$var\"")
+  if [ "$got" = "$want" ]; then
+    echo "✅ $label"
+  else
+    echo "❌ $label: $var='$got', expected '$want'"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# 1. Matching splits: nothing to report.
+apk even-v7a armeabi-v7a liba.so libb.so
+apk even-v8a arm64-v8a liba.so libb.so
+check_abi_parity testflavor "armeabi-v7a=$WORKDIR/even-v7a.apk" "arm64-v8a=$WORKDIR/even-v8a.apk"
+expect "matching splits report nothing" ABI_PARITY_MISSING ""
+expect "matching splits have no stale entries" ABI_PARITY_STALE ""
+expect "matching splits count no known gaps" ABI_PARITY_KNOWN 0
+
+# 2. A lib only one ABI ships, with no known-gap line for it.
+apk gap-v7a armeabi-v7a liba.so
+apk gap-v8a arm64-v8a liba.so libengine.so
+check_abi_parity testflavor "armeabi-v7a=$WORKDIR/gap-v7a.apk" "arm64-v8a=$WORKDIR/gap-v8a.apk"
+expect "unlisted gap is reported as missing" ABI_PARITY_MISSING " armeabi-v7a/libengine.so"
+expect "unlisted gap is not stale" ABI_PARITY_STALE ""
+
+# 3. The same gap, recorded. Direction matters: the gap is on v7a, so listing it under v8a
+#    must not excuse it.
+ABI_PARITY_KNOWN_GAPS="
+testflavor armeabi-v7a libengine.so
+"
+check_abi_parity testflavor "armeabi-v7a=$WORKDIR/gap-v7a.apk" "arm64-v8a=$WORKDIR/gap-v8a.apk"
+expect "recorded gap is excused" ABI_PARITY_MISSING ""
+expect "recorded gap is counted" ABI_PARITY_KNOWN 1
+ABI_PARITY_KNOWN_GAPS="
+testflavor arm64-v8a libengine.so
+"
+check_abi_parity testflavor "armeabi-v7a=$WORKDIR/gap-v7a.apk" "arm64-v8a=$WORKDIR/gap-v8a.apk"
+expect "gap recorded against the wrong abi still fails" ABI_PARITY_MISSING " armeabi-v7a/libengine.so"
+expect "wrong-abi entry is flagged stale, since v8a has the lib" ABI_PARITY_STALE " arm64-v8a/libengine.so"
+
+# 4. A known-gap line for another flavor does not excuse this one.
+ABI_PARITY_KNOWN_GAPS="
+otherflavor armeabi-v7a libengine.so
+"
+check_abi_parity testflavor "armeabi-v7a=$WORKDIR/gap-v7a.apk" "arm64-v8a=$WORKDIR/gap-v8a.apk"
+expect "other flavor's entry does not excuse this flavor" ABI_PARITY_MISSING " armeabi-v7a/libengine.so"
+
+# 5. The gap closes upstream but the line stays: must fail so the line gets deleted.
+ABI_PARITY_KNOWN_GAPS="
+testflavor armeabi-v7a liba.so
+"
+check_abi_parity testflavor "armeabi-v7a=$WORKDIR/even-v7a.apk" "arm64-v8a=$WORKDIR/even-v8a.apk"
+expect "closed gap with a leftover line is stale" ABI_PARITY_STALE " armeabi-v7a/liba.so"
+expect "closed gap reports nothing missing" ABI_PARITY_MISSING ""
+expect "stale line is not counted as a held gap" ABI_PARITY_KNOWN 0
+
+# 6. The entries actually checked in must name real ABIs and real lib names.
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  case "$line" in
+    fdroid\ armeabi-v7a\ lib*.so|fdroid\ arm64-v8a\ lib*.so|google\ armeabi-v7a\ lib*.so|google\ arm64-v8a\ lib*.so)
+      echo "✅ known-gap line is well-formed: $line" ;;
+    *)
+      echo "❌ known-gap line is malformed: '$line'"; FAILURES=$((FAILURES + 1)) ;;
+  esac
+done <<< "$CHECKED_IN_KNOWN_GAPS"
+
+echo
+if [ "$FAILURES" -gt 0 ]; then
+  echo "❌ $FAILURES check(s) failed"
+  exit 1
+fi
+echo "✅ abi-parity self-test passed"

--- a/scripts/verify-abi-parity.sh
+++ b/scripts/verify-abi-parity.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Fails when an ABI split ships fewer native libraries than its siblings (see #7001).
+# Run from repo root after assembling the split APKs (CI: android-check); takes the
+# outputs directory as an optional argument, default androidApp/build/outputs/apk.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+# shellcheck source=scripts/lib/abi-parity.sh
+. scripts/lib/abi-parity.sh
+
+OUT=${1:-androidApp/build/outputs/apk}
+FAILURES=0
+CHECKED=0
+
+for dir in "$OUT"/*/debug "$OUT"/*/release; do
+  [ -d "$dir" ] || continue
+  flavor=$(basename "$(dirname "$dir")")
+  specs=()
+  for apk in "$dir"/androidApp-"$flavor"-*-*.apk; do
+    [ -f "$apk" ] || continue
+    abi=$(basename "$apk" | sed -E "s/^androidApp-$flavor-(.*)-(debug|release)\.apk$/\1/")
+    [ "$abi" = universal ] && continue
+    specs+=("$abi=$apk")
+  done
+  # One split means splits are disabled for this build; there is nothing to compare.
+  [ "${#specs[@]}" -ge 2 ] || continue
+
+  check_abi_parity "$flavor" "${specs[@]}"
+  CHECKED=$((CHECKED + 1))
+  flavor_ok=1
+  if [ -n "$ABI_PARITY_MISSING" ]; then
+    echo "::error::$flavor: native libraries missing from a split:$ABI_PARITY_MISSING"
+    echo "  Every ABI in abiFilters must ship every library, or the app installs and then crashes"
+    echo "  with UnsatisfiedLinkError on that ABI. Fix the dependency, drop the ABI, or record a"
+    echo "  known gap in scripts/lib/abi-parity.sh with the reason and what removes it."
+    FAILURES=$((FAILURES + 1)); flavor_ok=0
+  fi
+  if [ -n "$ABI_PARITY_STALE" ]; then
+    echo "::error::$flavor: known-gap entries whose library is now present:$ABI_PARITY_STALE"
+    echo "  The gap has closed. Delete those lines from ABI_PARITY_KNOWN_GAPS in"
+    echo "  scripts/lib/abi-parity.sh in this same change."
+    FAILURES=$((FAILURES + 1)); flavor_ok=0
+  fi
+  if [ "$flavor_ok" -eq 1 ]; then
+    if [ "$ABI_PARITY_KNOWN" -gt 0 ]; then
+      echo "✅ $flavor: splits match apart from $ABI_PARITY_KNOWN recorded known gap(s)"
+    else
+      echo "✅ $flavor: all splits ship the same native libraries"
+    fi
+  fi
+done
+
+if [ "$CHECKED" -eq 0 ]; then
+  echo "::error::no split APKs found under $OUT — assemble with ABI splits enabled first"
+  exit 1
+fi
+exit "$FAILURES"


### PR DESCRIPTION
## Why

A dependency published for only some of our ABIs builds and installs cleanly on the rest, then dies with `UnsatisfiedLinkError` the first time it is touched — and nothing at build time says a word. That is #7001: `maplibre-native-ffi 0.202608.3` ships arm64-v8a and x86_64 only, so the F-Droid `armeabi-v7a` split had no map engine and opening the map took the app down. The two shipped `v2.8.2-closed.1` splits were 32.5 MB and 18.2 MB and CI was green.

Stacked on #7005, which makes the crash a message. This makes the gap visible, and makes closing it verified.

Relates to #7001.

## 🧹 Chores

- `scripts/lib/abi-parity.sh` — the classifier. The reference set is the union of native libs across a flavor's split APKs; every split must carry all of it unless a known-gap line says otherwise.
- `scripts/verify-abi-parity.sh` — runs in `android-check` right after the debug assemble, where every PR already builds the splits. Fails on a missing lib with the three ways out (fix the dependency, drop the ABI, record a known gap with its reason).
- `scripts/verify-abi-parity-selftest.sh` — fixture self-test in `lint-check`, mirroring `verify-rb-selftest.sh`. The real check only ever sees what the current dependencies happen to ship, so both failure modes would otherwise go unexercised until they bit.

## The part that matters for review: known gaps are checked both ways

The two lines recorded now are the MapLibre gap on `fdroid/armeabi-v7a`. An entry must be **absent** from its split — and the check **fails once the library turns up**, so an entry cannot outlive its reason.

That closes the hole in the obvious alternative. Renovate tracks the 8 `org.maplibre.compose` artifacts in the catalog and will bump `maplibre-compose` when a release with the 32-bit build lands (upstream merged it 2026-08-24: maplibre-native-ffi [#658](https://github.com/maplibre/maplibre-native-ffi/pull/658), [#659](https://github.com/maplibre/maplibre-native-ffi/pull/659), [#660](https://github.com/maplibre/maplibre-native-ffi/pull/660); no release yet). Without this, that bump lands green and nothing marks #7001 closed. With it, the bump PR goes red with *"the gap has closed, delete those lines"*, and deleting them is the proof the v7a APK really has an engine.

## Why not the snapshot pin (#7003)

Closed in favour of this. Verified against it directly:

- The rolling `0.1.0-SNAPSHOT` was **re-published overnight** — yesterday's bytes were `20260825.201433-1`, today's are `20260902.064417-1`. Same version string, different engine.
- Pinning a timestamped snapshot instead does not work either: the timestamps are **per artifact** (`-android` is `064417-1`, `-runtime-opengl-android` is `064601-1`), and Central's snapshot retention is **90 days**, so a merged pin would 404 for any rebuild of that tag after late November.
- `rb-check` would not have caught any of that: it assembles the APK once and never compares two builds.

## Testing Performed

Run against three real APK sets, not just fixtures:

| input | result |
| --- | --- |
| shipped `v2.8.2-closed.1` fdroid splits + google splits | ✅ google clean; ✅ fdroid "splits match apart from 2 recorded known gap(s)" |
| the #7003 snapshot build, where v7a **has** the engine | ❌ "known-gap entries whose library is now present" — the self-healing signal, exit 1 |
| shipped splits with the two lines deleted | ❌ "native libraries missing from a split: armeabi-v7a/libjniMaplibreNativeC.so armeabi-v7a/libmaplibre-native-c.so", exit 1 |

- Self-test: 15 checks green, including the wrong-ABI and wrong-flavor entries that must *not* excuse a gap.
- `shellcheck -x` over `scripts/` (the lint-check invocation) clean; `actionlint` on both workflows clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
