### PR TITLE
fix(mqtt): downgrade unparseable-payload decode logs from error to warn

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/WireExtensions.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/util/WireExtensions.kt
@@ -26,7 +26,9 @@ import okio.ByteString.Companion.toByteString
 fun <T : Message<T, *>> ProtoAdapter<T>.decodeOrNull(bytes: ByteString?, logger: Logger? = null): T? {
     if (bytes == null) return null
     return runCatching { decode(bytes) }
-        .onFailure { exception -> logger?.e(exception) { "Failed to decode proto message" } }
+        // Warn, not error: this helper's contract is "return null instead of throwing", so a failure
+        // here is expected for callers decoding payloads of uncertain provenance, not by itself a defect.
+        .onFailure { exception -> logger?.w(exception) { "Failed to decode proto message" } }
         .getOrNull()
 }
 
@@ -36,7 +38,7 @@ fun <T : Message<T, *>> ProtoAdapter<T>.decodeOrNull(bytes: ByteString?, logger:
  * Convenience overload for ByteArray inputs, automatically converting to ByteString.
  *
  * @param bytes The ByteArray to decode, or null
- * @param logger Optional logger for error reporting
+ * @param logger Optional logger for warn-level failure reporting
  * @return The decoded message, or null if bytes is null or decoding fails
  */
 fun <T : Message<T, *>> ProtoAdapter<T>.decodeOrNull(bytes: ByteArray?, logger: Logger? = null): T? {

--- a/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/WireExtensionsTest.kt
+++ b/core/model/src/commonTest/kotlin/org/meshtastic/core/model/util/WireExtensionsTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.model.util
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.loggerConfigInit
+import org.meshtastic.proto.Position
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class WireExtensionsTest {
+
+    private class CapturingWriter : LogWriter() {
+        val severities = mutableListOf<Severity>()
+
+        override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+            severities += severity
+        }
+    }
+
+    private val writer = CapturingWriter()
+    private val logger = Logger(loggerConfigInit(writer), tag = "Test")
+
+    // Garbage bytes that are not a valid encoding of any message: decoding must fail, not merely
+    // produce an empty/default Position.
+    private val garbage = byteArrayOf(0x0f, 0x00, 0x05)
+
+    @Test
+    fun `a decode failure logs at WARN not ERROR`() {
+        val result = Position.ADAPTER.decodeOrNull(garbage, logger)
+
+        assertNull(result)
+        assertEquals(listOf(Severity.Warn), writer.severities)
+    }
+
+    @Test
+    fun `the ByteArray overload delegates the same WARN behavior`() {
+        val result = Position.ADAPTER.decodeOrNull(bytes = garbage, logger = logger)
+
+        assertNull(result)
+        assertEquals(listOf(Severity.Warn), writer.severities)
+    }
+
+    @Test
+    fun `no logger means no log line only null`() {
+        val result = Position.ADAPTER.decodeOrNull(garbage)
+
+        assertNull(result)
+        assertEquals(emptyList(), writer.severities)
+    }
+
+    @Test
+    fun `null bytes short-circuit without touching the logger`() {
+        val result = Position.ADAPTER.decodeOrNull(bytes = null as ByteArray?, logger = logger)
+
+        assertNull(result)
+        assertEquals(emptyList(), writer.severities)
+    }
+}

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/repository/MQTTRepositoryImpl.kt
@@ -304,11 +304,13 @@ class MQTTRepositoryImpl(
                 json.decodeFromString<MqttJsonPayload>(jsonStr)
                 trySend(MqttClientProxyMessage(topic = topic, text = jsonStr, retained = msg.retain))
             } catch (e: JsonDecodingException) {
-                Logger.e(e) { "Failed to parse MQTT JSON: ${e.shortMessage} (path: ${e.path})" }
+                // Warn, not error: a non-conforming payload recurs for as long as a busy public broker
+                // stays subscribed, not an app defect worth a non-fatal per message.
+                Logger.w(e) { "Failed to parse MQTT JSON: ${e.shortMessage} (path: ${e.path})" }
             } catch (e: SerializationException) {
-                Logger.e(e) { "Failed to parse MQTT JSON: ${e.message}" }
+                Logger.w(e) { "Failed to parse MQTT JSON: ${e.message}" }
             } catch (e: IllegalArgumentException) {
-                Logger.e(e) { "Failed to parse MQTT JSON: ${e.message}" }
+                Logger.w(e) { "Failed to parse MQTT JSON: ${e.message}" }
             }
         } else {
             // Drop provably-undeliverable downlink packets before spending BLE bandwidth on
@@ -557,7 +559,7 @@ private const val PKI_CHANNEL_ID = "PKI"
  */
 internal fun isUndeliverableDownlink(payload: ByteArray, myId: String?): Boolean {
     // Decode without a logger: this is fail-open and, on a public broker, may see arbitrary bytes on the binary
-    // topic. Passing Logger would emit an error log per unparseable downlink — expensive noise for an expected case.
+    // topic. Passing Logger would emit a warn log per unparseable downlink — expensive noise for an expected case.
     val envelope = ServiceEnvelope.ADAPTER.decodeOrNull(payload) ?: return false // fail open on garbage
     // Guards — never drop: PKI-channel traffic (accepted without decryption) or our own echoed-back
     // packets (used as implicit ACKs).


### PR DESCRIPTION
## Problem

Two sites log at error level for every inbound message they cannot parse, with no rate limit: MQTT JSON payload parsing in `MQTTRepositoryImpl.processMessage`, and the shared `decodeOrNull` proto-decode helper in `WireExtensions.kt`. Together they are the large majority of the app's non-fatal error volume in Datadog RUM (`@error.message:*MQTT*`, `@error.message:*"decode proto"*`) — concentrated on a small number of devices reporting thousands of times each, because a client subscribed to a busy public-broker feed reports continuously for as long as it stays subscribed.

Both are expected outcomes, not app defects: `decodeOrNull`'s whole contract is "return null instead of throwing" for payloads of uncertain provenance (mesh/MQTT traffic), and a non-conforming JSON payload on a public broker topic recurs indefinitely, not a bug in this app.

Fixes #7035

## 🐛 Bug Fixes

- `WireExtensions.decodeOrNull` now logs a decode failure at `Warn` instead of `Error`.
- `MQTTRepositoryImpl.processMessage`'s three JSON-parse catch blocks now log at `Warn` instead of `Error`.
- Both sinks (`GooglePlatformAnalytics`'s `CrashlyticsLogWriter`/`DatadogLogWriter`) already gate reporting on severity, so this removes these from Crashlytics non-fatals and Datadog RUM errors while keeping the log line for local triage. `Firebase.crashlytics.log(...)` still buffers the line as a breadcrumb regardless of severity — this only stops the non-fatal report, not the breadcrumb.

Out of scope, per the issue: the underlying `payload` String-vs-object schema mismatch, and the separately-flagged handshake-stall / malformed-database-image volume.

## Testing

- New `core/model/src/commonTest/.../WireExtensionsTest.kt`: asserts `decodeOrNull` logs at `Warn` (not `Error`) on both the `ByteString` and `ByteArray` overloads, and that no logger/null bytes touch the logger at all.
- `:core:model:allTests` and `:core:network:allTests` — 902 tests, 0 failures.
- `spotlessApply spotlessCheck detekt kmpSmokeCompile` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expected data-decoding and message-parsing failures are now reported as warnings instead of errors.
  * Invalid or incomplete data continues to be handled safely without disrupting normal operation.
  * Optional logging remains quiet when no logger is provided, reducing unnecessary diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->