### PR TITLE
fix(desktop): use standard SPDX license identifier for RPM packaging

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -251,7 +251,7 @@ compose.desktop {
                 menuGroup = "Network"
                 debMaintainer = "developers@meshtastic.org"
                 appCategory = "Network"
-                rpmLicenseType = "GPLv3+"
+                rpmLicenseType = "GPL-3.0-or-later"
             }
 
             // Define target formats based on the current host OS to avoid configuration errors


### PR DESCRIPTION
### Summary

Updates the Linux RPM packaging configuration in `desktopApp/build.gradle.kts` to use the standard SPDX license identifier `GPL-3.0-or-later` instead of the legacy `GPLv3+`.

### Background & Root Cause

When installing the Meshtastic Desktop `.rpm` on Fedora (or other modern Linux distributions using GNOME Software / PackageKit / libdnf), graphical package installers inspect the RPM header's `License` tag to determine the application's license and whether it is Free/Open Source software.

Previously, `rpmLicenseType` was configured as `"GPLv3+"`. While `GPLv3+` was the historical identifier under Fedora's legacy Callaway licensing system, modern Linux package tooling and AppStream evaluate license expressions strictly against the [SPDX License List](https://spdx.org/licenses/).

Because `GPLv3+` is not a valid modern SPDX identifier:
1. `libappstream` (`as_spdx_license_tokenize` / `as_license_is_free_license`) fails to recognize it as an approved Free/Open Source license.
2. GNOME Software treats the package as having an unrecognized/special license, prompting the user with:
   > *"This app does not specify what license it is developed under, and may be proprietary... You may or may not be able to contribute to this app."*
   and grouping the license under the fallback category "Other".

Setting `rpmLicenseType = "GPL-3.0-or-later"` resolves this warning and aligns the RPM package header with:
- The project's existing AppStream metadata in [`desktopApp/packaging/linux/org.meshtastic.MeshtasticDesktop.metainfo.xml`](desktopApp/packaging/linux/org.meshtastic.MeshtasticDesktop.metainfo.xml) (`<project_license>GPL-3.0-or-later</project_license>`)
- [Fedora Packaging Guidelines: Licensing](https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/)
- [Fedora Allowed Licenses](https://docs.fedoraproject.org/en-US/legal/allowed-licenses/)
- [SPDX Specification for GPL-3.0-or-later](https://spdx.org/licenses/GPL-3.0-or-later.html)

### Changes

- 🐛 **Bug Fixes**
  - Changed `rpmLicenseType` in `desktopApp/build.gradle.kts` from `"GPLv3+"` to `"GPL-3.0-or-later"`.

### Testing Performed

- Verified `./gradlew :desktopApp:spotlessCheck` passes cleanly.
- Confirmed license identifier syntax against SPDX specs and AppStream license database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux RPM package license classification to use the SPDX-standard GPL-3.0-or-later identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->