### PR TITLE
refactor(map): retire the maps-utils workarounds its 5.1 fixes made stale

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -298,10 +298,8 @@ dependencies {
     googleImplementation(libs.maps.compose)
     googleImplementation(libs.maps.compose.utils)
     googleImplementation(libs.maps.compose.widgets)
-    // Direct declaration raises the transitive android-maps-utils 5.0.0 (via maps-utils-ktx 6.2.0)
-    // to 5.1.1, whose KmlParser is built against the xmlutil 1.0.x compat API the app actually ships
-    // — 5.0.0's is compiled against 0.91.x's removed policyBuilder(), so every KML/KMZ map import
-    // crashed with NoSuchMethodError. Drop when maps-compose's chain requires >= 5.1.1 on its own.
+    // The app draws imported layers through this data layer itself, so it is declared rather than inherited.
+    // The version is a plain floor over maps-utils-ktx 6.2.0's transitive 5.0.0 — see gradle/libs.versions.toml.
     googleImplementation(libs.android.maps.utils)
     // maps-compose-widgets requests androidx.compose.material:material version-less (expects a BOM
     // we exclude). Name it with a version so the version is published in the app's graph metadata.

--- a/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
+++ b/androidApp/src/google/kotlin/org/meshtastic/app/map/MapView.kt
@@ -102,7 +102,6 @@ import com.google.maps.android.data.renderer.mapview.MapViewRenderer
 import com.google.maps.android.data.renderer.model.DataLayer
 import com.google.maps.android.data.renderer.model.Feature
 import com.google.maps.android.data.renderer.model.Geometry
-import com.google.maps.android.data.renderer.model.LineString
 import com.google.maps.android.data.renderer.model.LineStyle
 import com.google.maps.android.data.renderer.model.MultiGeometry
 import com.google.maps.android.data.renderer.model.PointGeometry
@@ -1553,9 +1552,9 @@ private fun parseMapLayer(layerType: LayerType, stream: InputStream): DataLayer?
  * A parsed custom overlay (KML/KMZ/GeoJSON) plus the machinery to draw it on the map.
  *
  * Each [show] creates a fresh single-use [MapViewRenderer] and [hide] tears it down with [MapViewRenderer.clear].
- * Renderers are deliberately not reused: clear() cancels their icon-loading scope for good, and per-feature removal
- * ([MapViewRenderer.removeFeature]) silently no-ops for MultiGeometry features (the renderer keys rendered map objects
- * by internal per-geometry copies), so clear() is the only teardown that reliably takes everything off the map.
+ * Renderers are deliberately not reused: clear() cancels their icon-loading scope for good, so a hidden layer holds
+ * nothing live and every re-show starts with a working one. Reuse would buy nothing — an opacity change or a refresh
+ * rebuilds this object outright, leaving the visibility toggle as the only re-show path.
  */
 private class RenderedMapLayer(
     private val map: GmsGoogleMap,
@@ -1633,11 +1632,13 @@ private fun RenderedMapLayer.safeHide() {
 /**
  * Apply simplestyle-spec (https://github.com/mapbox/simplestyle-spec) properties to a parsed GeoJSON layer.
  *
- * The maps-utils GeoJSON mapper reads `fill`/`stroke`/`stroke-width`/`fill-opacity`/`stroke-opacity` itself, but misses
- * several things this app relies on for Meshtastic Site Planner coverage exports: the legacy `color` fallback,
- * `rgb()`/`rgba()` colors, a default fill opacity so stacked contour bands read as a gradient, and polygon styling for
- * MultiPolygon features (the mapper styles any multi-geometry as a line). Rebuild each feature's style from its
- * properties so the coverage draws in its dBm colors instead of the default black outline.
+ * The maps-utils GeoJSON mapper reads `fill`/`stroke`/`stroke-width`/`fill-opacity`/`stroke-opacity` itself, but
+ * attaches no style at all to a feature carrying none of those keys — which is every Meshtastic Site Planner coverage
+ * export that predates them, and leaves the opacity slider nothing to fade. So each feature's style is resolved here,
+ * adding what the mapper does not cover: the legacy `color` fallback, `rgb()`/`rgba()` colors, `stroke-opacity` on
+ * lines, a default fill opacity so stacked contour bands read as a gradient, and the imported `icon-url` it has no
+ * marker styling for. Geometry is classified the way the mapper classifies it, except that a point without an
+ * `icon-url` is left alone — the mapper styles no point at all, and there is nothing of ours to add.
  */
 internal fun DataLayer.applySimpleStyleSpec(): DataLayer = copy(features = features.map { it.applySimpleStyleSpec() })
 
@@ -1651,6 +1652,13 @@ internal fun Feature.applySimpleStyleSpec(): Feature {
         }
     val strokeWidth = stringProperty("stroke-width")?.toFloatOrNull() ?: DEFAULT_GEOJSON_STROKE_WIDTH
     return when {
+        // A KML icon reaches us as the `icon-url` the converter writes; the mapper reads no icon property at all, and
+        // sorts a MultiPoint into the line branch below, so without this the map loses the icons it has always drawn.
+        geometry.isPointLike() ->
+            stringProperty(ICON_URL_PROPERTY)?.let(::sanitizeImportedIconUrl)?.let {
+                copy(style = PointStyle(iconUrl = it))
+            } ?: this
+
         geometry.isPolygonal() ->
             copy(
                 style =
@@ -1661,16 +1669,7 @@ internal fun Feature.applySimpleStyleSpec(): Feature {
                 ),
             )
 
-        geometry.isLinear() -> copy(style = LineStyle(color = stroke ?: AndroidColor.BLACK, width = strokeWidth))
-
-        // A KML icon reaches us as the `icon-url` the converter writes; maps-utils' GeoJSON mapper reads no icon
-        // property at all, so without this the Google map would silently lose the icons it has always drawn.
-        geometry.isPointLike() ->
-            stringProperty(ICON_URL_PROPERTY)?.let(::sanitizeImportedIconUrl)?.let {
-                copy(style = PointStyle(iconUrl = it))
-            } ?: this
-
-        else -> this // Mixed geometry collections keep the mapper's style.
+        else -> copy(style = LineStyle(color = stroke ?: AndroidColor.BLACK, width = strokeWidth))
     }
 }
 
@@ -1715,13 +1714,9 @@ private fun Int.scaleAlpha(opacity: Float): Int = AndroidColor.argb(
 private fun Geometry.isPointLike(): Boolean = this is PointGeometry ||
     (this is MultiGeometry && geometries.isNotEmpty() && geometries.all { it is PointGeometry })
 
-/** Polygon or MultiPolygon (a multi-geometry whose members are all polygons). */
+/** Polygon or MultiPolygon — recursive, so a nested collection is classified the way the mapper classifies it. */
 private fun Geometry.isPolygonal(): Boolean =
-    this is ModelPolygon || (this is MultiGeometry && geometries.isNotEmpty() && geometries.all { it is ModelPolygon })
-
-/** LineString or MultiLineString (a multi-geometry whose members are all line strings). */
-private fun Geometry.isLinear(): Boolean =
-    this is LineString || (this is MultiGeometry && geometries.isNotEmpty() && geometries.all { it is LineString })
+    this is ModelPolygon || (this is MultiGeometry && geometries.isNotEmpty() && geometries.all { it.isPolygonal() })
 
 private fun Feature.stringProperty(key: String): String? = properties[key] as? String
 

--- a/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/ApplySimpleStyleSpecTest.kt
+++ b/androidApp/src/testGoogle/kotlin/org/meshtastic/app/map/ApplySimpleStyleSpecTest.kt
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.app.map
+
+import com.google.maps.android.data.parser.geojson.GeoJsonParser
+import com.google.maps.android.data.renderer.mapper.toLayer
+import com.google.maps.android.data.renderer.model.Feature
+import com.google.maps.android.data.renderer.model.LineStyle
+import com.google.maps.android.data.renderer.model.PointStyle
+import com.google.maps.android.data.renderer.model.PolygonStyle
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import android.graphics.Color as AndroidColor
+
+/**
+ * What the app's own styling pass adds on top of the maps-utils GeoJSON mapper.
+ *
+ * The mapper attaches no style at all unless a feature carries one of its own simplestyle keys, so everything below is
+ * a case where leaning on it alone would silently change how an import draws.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ApplySimpleStyleSpecTest {
+
+    private fun featureFrom(geoJson: String): Feature =
+        assertNotNull(GeoJsonParser().parse(geoJson.byteInputStream())?.toLayer()?.applySimpleStyleSpec())
+            .features
+            .single()
+
+    private fun polygon(properties: String) = featureFrom(
+        """
+        {"type":"FeatureCollection","features":[{"type":"Feature",
+          "properties":{$properties},
+          "geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}}]}
+        """
+            .trimIndent(),
+    )
+
+    private fun lineString(properties: String) = featureFrom(
+        """
+        {"type":"FeatureCollection","features":[{"type":"Feature",
+          "properties":{$properties},
+          "geometry":{"type":"LineString","coordinates":[[0,0],[1,1]]}}]}
+        """
+            .trimIndent(),
+    )
+
+    private val Feature.polygonStyle: PolygonStyle
+        get() = assertNotNull(style as? PolygonStyle, "expected a PolygonStyle, got $style")
+
+    private val Feature.lineStyle: LineStyle
+        get() = assertNotNull(style as? LineStyle, "expected a LineStyle, got $style")
+
+    // region Site Planner's legacy `color` key — the mapper reads only `fill`/`stroke`.
+
+    @Test
+    fun `a polygon falls back to the legacy color property for both fill and stroke`() {
+        val style = polygon(""""color":"#00ff00"""").polygonStyle
+
+        assertEquals(0x00, AndroidColor.red(style.fillColor))
+        assertEquals(0xFF, AndroidColor.green(style.fillColor))
+        assertEquals(0xFF00FF00.toInt(), style.strokeColor)
+    }
+
+    @Test
+    fun `a line falls back to the legacy color property`() {
+        assertEquals(0xFF00FF00.toInt(), lineString(""""color":"#00ff00"""").lineStyle.color)
+    }
+
+    // endregion
+
+    // region rgb()/rgba() — the mapper's parser rejects functional notation and drops the style entirely.
+
+    @Test
+    fun `rgb colors are parsed`() {
+        val fill = polygon(""""color":"rgb(255, 128, 0)"""").polygonStyle.fillColor
+
+        assertEquals(255, AndroidColor.red(fill))
+        assertEquals(128, AndroidColor.green(fill))
+        assertEquals(0, AndroidColor.blue(fill))
+    }
+
+    @Test
+    fun `an rgba alpha survives when no fill-opacity is given`() {
+        // The colour's own alpha wins over the default; 0.35 would give 89.
+        assertEquals(128, AndroidColor.alpha(polygon(""""fill":"rgba(255, 0, 0, 0.5)"""").polygonStyle.fillColor))
+    }
+
+    // endregion
+
+    // region The default fill opacity that makes stacked coverage bands read as a gradient.
+
+    @Test
+    fun `an opaque fill with no fill-opacity gets the default gradient opacity`() {
+        assertEquals(89, AndroidColor.alpha(polygon(""""fill":"#ff0000"""").polygonStyle.fillColor))
+    }
+
+    @Test
+    fun `an explicit numeric fill-opacity wins over the default`() {
+        // Site Planner writes fill-opacity as a JSON number, not a string; the parser stringifies it on the way in.
+        val style = polygon(""""fill":"#ff0000","fill-opacity":0.8""").polygonStyle
+
+        assertEquals(204, AndroidColor.alpha(style.fillColor))
+    }
+
+    // endregion
+
+    // region stroke-opacity on lines — the mapper applies it to polygons only, and the KML converter emits it on
+    // every styled line.
+
+    @Test
+    fun `stroke-opacity fades a line`() {
+        val style = lineString(""""stroke":"#ff0000","stroke-opacity":"0.5"""").lineStyle
+
+        assertEquals(128, AndroidColor.alpha(style.color))
+        assertEquals(0xFF, AndroidColor.red(style.color))
+    }
+
+    // endregion
+
+    // region Defaults: the mapper's are 1px strokes and no style at all for a bare geometry.
+
+    @Test
+    fun `imported lines and polygons default to a 2px stroke`() {
+        assertEquals(2f, lineString(""""stroke":"#ff0000"""").lineStyle.width)
+        assertEquals(2f, polygon(""""fill":"#ff0000"""").polygonStyle.strokeWidth)
+    }
+
+    @Test
+    fun `a feature carrying no style properties still gets a style`() {
+        // Without one, the Maps SDK's own defaults draw the shape and the opacity slider cannot fade it.
+        val style = polygon("").polygonStyle
+
+        assertEquals(AndroidColor.TRANSPARENT, style.fillColor)
+        assertEquals(AndroidColor.BLACK, style.strokeColor)
+        assertEquals(2f, style.strokeWidth)
+    }
+
+    @Test
+    fun `an unparseable color falls back to the defaults rather than throwing`() {
+        val style = polygon(""""fill":"not-a-color"""").polygonStyle
+
+        assertEquals(AndroidColor.TRANSPARENT, style.fillColor)
+        assertEquals(AndroidColor.BLACK, style.strokeColor)
+    }
+
+    // endregion
+
+    // region Geometry classification.
+
+    @Test
+    fun `a MultiPolygon is styled as a polygon, not a line`() {
+        val style =
+            featureFrom(
+                """
+                    {"type":"FeatureCollection","features":[{"type":"Feature",
+                      "properties":{"fill":"#ff0000","stroke":"#0000ff"},
+                      "geometry":{"type":"MultiPolygon","coordinates":[[[[0,0],[1,0],[1,1],[0,0]]]]}}]}
+                    """
+                    .trimIndent(),
+            )
+                .polygonStyle
+
+        assertEquals(89, AndroidColor.alpha(style.fillColor))
+    }
+
+    @Test
+    fun `a MultiLineString is styled as a line`() {
+        val style =
+            featureFrom(
+                """
+                    {"type":"FeatureCollection","features":[{"type":"Feature",
+                      "properties":{"stroke":"#ff0000"},
+                      "geometry":{"type":"MultiLineString","coordinates":[[[0,0],[1,1]]]}}]}
+                    """
+                    .trimIndent(),
+            )
+                .lineStyle
+
+        assertEquals(0xFFFF0000.toInt(), style.color)
+    }
+
+    @Test
+    fun `a MultiPoint keeps its icon instead of being styled as a line`() {
+        // The mapper routes any non-polygonal multi-geometry into its line branch, which would lose the icon.
+        val feature =
+            featureFrom(
+                """
+                {"type":"FeatureCollection","features":[{"type":"Feature",
+                  "properties":{"icon-url":"files/tower.png","stroke":"#ff0000"},
+                  "geometry":{"type":"MultiPoint","coordinates":[[0,0],[1,1]]}}]}
+                """
+                    .trimIndent(),
+            )
+
+        assertEquals("files/tower.png", assertNotNull(feature.style as? PointStyle).iconUrl)
+    }
+
+    @Test
+    fun `a mixed geometry collection is styled as a line`() {
+        // Same rule the mapper uses — anything not wholly polygonal is a line — so the app's extras and the opacity
+        // slider reach it too.
+        val style =
+            featureFrom(
+                """
+                    {"type":"FeatureCollection","features":[{"type":"Feature",
+                      "properties":{"stroke":"#ff0000","stroke-opacity":"0.5"},
+                      "geometry":{"type":"GeometryCollection","geometries":[
+                        {"type":"Point","coordinates":[0,0]},
+                        {"type":"LineString","coordinates":[[0,0],[1,1]]}]}}]}
+                    """
+                    .trimIndent(),
+            )
+                .lineStyle
+
+        assertEquals(128, AndroidColor.alpha(style.color))
+        assertEquals(2f, style.width)
+    }
+
+    @Test
+    fun `an unstyled mixed geometry collection draws like every other unstyled line`() {
+        // The mapper leaves this one styleless, which drew it at the Maps SDK's own 10px default and put it out of
+        // the opacity slider's reach. It now matches a bare LineString.
+        val style =
+            featureFrom(
+                """
+                    {"type":"FeatureCollection","features":[{"type":"Feature",
+                      "properties":{},
+                      "geometry":{"type":"GeometryCollection","geometries":[
+                        {"type":"Point","coordinates":[0,0]},
+                        {"type":"LineString","coordinates":[[0,0],[1,1]]}]}}]}
+                    """
+                    .trimIndent(),
+            )
+                .lineStyle
+
+        assertEquals(AndroidColor.BLACK, style.color)
+        assertEquals(2f, style.width)
+    }
+
+    @Test
+    fun `a collection nesting a MultiPolygon is styled as a polygon`() {
+        // Classification recurses, so a collection whose members are all polygonal takes the polygon branch and picks
+        // up the legacy `color` fallback and the default fill opacity, the same as a bare Polygon.
+        val style =
+            featureFrom(
+                """
+                    {"type":"FeatureCollection","features":[{"type":"Feature",
+                      "properties":{"color":"#ff0000"},
+                      "geometry":{"type":"GeometryCollection","geometries":[
+                        {"type":"MultiPolygon","coordinates":[[[[0,0],[1,0],[1,1],[0,0]]]]}]}}]}
+                    """
+                    .trimIndent(),
+            )
+                .polygonStyle
+
+        assertEquals(89, AndroidColor.alpha(style.fillColor))
+        assertEquals(0xFF, AndroidColor.red(style.fillColor))
+        assertEquals(0xFFFF0000.toInt(), style.strokeColor)
+    }
+
+    // endregion
+}


### PR DESCRIPTION
android-maps-utils 5.1.0 fixed both data-layer bugs #6304 worked around and we already pin 5.2.0, so this drops only what the fixes actually retired - `isLinear()`, and the two doc claims that are no longer true.

Everything else stays and is now pinned by `ApplySimpleStyleSpecTest`, which was written first and was green against the unchanged code: the legacy `color` fallback, `rgb()`/`rgba()` parsing, the 0.35 default fill opacity, plus `stroke-opacity` on lines and the 2f stroke width, neither of which the issue lists and both of which the mapper would have silently changed.

Behaviour change worth calling out - a GeometryCollection now draws like the equivalent bare geometry. Unstyled and mixed, that takes it off the Maps SDK 10px polyline default onto the 2px every other unstyled line already used, and into the opacity slider's reach.

The overlay device pass (Site Planner GeoJSON, KMZ with icons, visibility toggle per layer type) is not covered here and still needs running by hand.

fixes #6306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved styling for imported GeoJSON and KML map layers.
  - Point and multi-point features with custom icons now display correctly.
  - Nested multi-geometries and geometry collections are classified and styled more consistently.
  - Line and mixed geometry features now receive appropriate line styling.
  - Improved handling of colors, opacity, invalid color values, and default styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->