### PR TITLE
feat(node): add an update-status shortcut to the local node menu

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -1938,6 +1938,7 @@ unset
 up_down_select_input_enabled
 update_interval
 update_interval_seconds
+update_status
 updated
 uplink_enabled
 uplink_feature_description

--- a/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/Routes.kt
+++ b/core/navigation/src/commonMain/kotlin/org/meshtastic/core/navigation/Routes.kt
@@ -106,6 +106,9 @@ sealed interface SettingsRoute : Route {
 
     @Serializable data object User : SettingsRoute
 
+    /** The user screen opened straight to its status message field — the local node's edit shortcut. */
+    @Serializable data object UserStatusMessage : SettingsRoute
+
     @Serializable data object ChannelConfig : SettingsRoute
 
     @Serializable data object Device : SettingsRoute

--- a/core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/NavigationConfigTest.kt
+++ b/core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/NavigationConfigTest.kt
@@ -74,6 +74,7 @@ class NavigationConfigTest {
             SettingsRoute.ModuleConfiguration,
             SettingsRoute.Administration,
             SettingsRoute.User,
+            SettingsRoute.UserStatusMessage,
             SettingsRoute.ChannelConfig,
             SettingsRoute.Device,
             SettingsRoute.Position,

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1995,6 +1995,7 @@
     <string name="up_down_select_input_enabled">Up/Down/Select input enabled</string>
     <string name="update_interval">GPS Polling Interval</string>
     <string name="update_interval_seconds">Update interval (seconds)</string>
+    <string name="update_status">Update status</string>
     <string name="updated">Updated</string>
     <string name="uplink_enabled">MQTT Uplink Enabled</string>
     <string name="uplink_feature_description">Messages from the mesh will be sent to the public internet through any node's configured gateway.</string>

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/EditTextPreference.kt
@@ -33,7 +33,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -213,6 +215,8 @@ fun EditTextPreference(
     // does, instead of only while the field has focus.
     counterVisibleWithinBytes: Int? = null,
     onFocusChanged: (FocusState) -> Unit = {},
+    // [modifier] lands on the wrapping column, so a caller that needs the text field itself focused passes one here.
+    focusRequester: FocusRequester? = null,
     trailingIcon: (@Composable () -> Unit)? = null,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     multiline: Boolean = false,
@@ -222,10 +226,12 @@ fun EditTextPreference(
     Column(modifier = modifier.fillMaxWidth().padding(8.dp)) {
         OutlinedTextField(
             modifier =
-            Modifier.fillMaxWidth().onFocusEvent {
-                isFocused = it.isFocused
-                onFocusChanged(it)
-            },
+            Modifier.fillMaxWidth()
+                .then(focusRequester?.let { Modifier.focusRequester(it) } ?: Modifier)
+                .onFocusEvent {
+                    isFocused = it.isFocused
+                    onFocusChanged(it)
+                },
             value = value,
             singleLine = !multiline,
             maxLines = if (multiline) 5 else 1,

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/EditTextPreferenceFocusTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/EditTextPreferenceFocusTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.component
+
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.meshtastic.core.ui.theme.AppTheme
+import kotlin.test.Test
+
+private const val FIELD_TAG = "focus_target"
+
+@Composable
+private fun FocusableField(focusRequester: FocusRequester?) {
+    EditTextPreference(
+        title = "Status Message",
+        value = "",
+        enabled = true,
+        isError = false,
+        keyboardOptions = KeyboardOptions.Default,
+        keyboardActions = KeyboardActions.Default,
+        onValueChanged = {},
+        modifier = Modifier.testTag(FIELD_TAG),
+        focusRequester = focusRequester,
+    )
+}
+
+/**
+ * [EditTextPreference] applies the caller's modifier to its wrapping column, so a caller that wants the text field
+ * itself focused has to be handed a route to it.
+ */
+@OptIn(ExperimentalTestApi::class)
+class EditTextPreferenceFocusTest {
+
+    @Test
+    fun `a focus requester focuses the text field rather than its wrapping column`() = runComposeUiTest {
+        setContent {
+            AppTheme {
+                val requester = remember { FocusRequester() }
+                FocusableField(requester)
+                LaunchedEffect(Unit) { requester.requestFocus() }
+            }
+        }
+
+        onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag(FIELD_TAG))).assertIsFocused()
+    }
+
+    @Test
+    fun `a field with no focus requester is left alone`() = runComposeUiTest {
+        setContent { AppTheme { FocusableField(focusRequester = null) } }
+
+        onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag(FIELD_TAG))).assertIsNotFocused()
+    }
+}

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -2,7 +2,7 @@
 title: Nodes
 parent: User Guide
 nav_order: 4
-last_updated: 2026-08-30
+last_updated: 2026-09-04
 description: Browse, filter, and sort mesh nodes — view details, signal quality, roles, and quick actions.
 aliases:
   - node-list
@@ -98,6 +98,11 @@ From the node list, you can:
   - Trace route
   - Ignore/unignore
   - Remove
+
+Touch & hold **your own node** instead and you get one action, **Update status**, which opens the
+User settings screen with the cursor already in the Status Message field. It only appears while the
+radio is connected and running firmware 2.8 or newer — see
+[Settings — Radio & User](settings-radio-user.md) for the field itself.
 
 ## Sharing a Contact
 

--- a/docs/en/user/settings-radio-user.md
+++ b/docs/en/user/settings-radio-user.md
@@ -2,7 +2,7 @@
 title: Settings — Radio & User
 parent: User Guide
 nav_order: 7
-last_updated: 2026-08-30
+last_updated: 2026-09-04
 description: Configure your radio hardware, LoRa presets, user profile, position sharing, power management, and security.
 aliases:
   - settings
@@ -49,7 +49,10 @@ On **Settings → User**.
 The footer appears as soon as you change something. **Discard** throws the change away, and the other button writes it to the radio: it reads **Save & restart** on the screens the firmware applies with a reboot — Position, Network, Bluetooth, Security, and most module screens — and **Save** everywhere else.
 
 The status message is saved with the same **Save**, but it never reboots the node — and, like the
-rest of this screen, it can be edited on a remote node you administer.
+rest of this screen, it can be edited on a remote node you administer. For your own radio there is a
+shortcut while it is connected: touch & hold your node in the [node list](nodes.md) and choose
+**Update status**. Older firmware and a disconnected radio have no shortcut — the field above is
+still the way in.
 
 ## Configuration
 

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeContextMenu.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeContextMenu.kt
@@ -41,12 +41,14 @@ import org.meshtastic.core.resources.remove_favorite
 import org.meshtastic.core.resources.remove_ignored
 import org.meshtastic.core.resources.trace_route
 import org.meshtastic.core.resources.unmute
+import org.meshtastic.core.resources.update_status
 import org.meshtastic.core.ui.icon.DeleteNode
 import org.meshtastic.core.ui.icon.DoDisturb
 import org.meshtastic.core.ui.icon.Favorite
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Message
 import org.meshtastic.core.ui.icon.NotFavorite
+import org.meshtastic.core.ui.icon.Notes
 import org.meshtastic.core.ui.icon.Route
 import org.meshtastic.core.ui.icon.VolumeOff
 import org.meshtastic.core.ui.icon.VolumeUp
@@ -81,6 +83,23 @@ fun NodeContextMenu(
         DropdownMenuGroup(shapes = MenuDefaults.groupShapes()) {
             IgnoreMenuItem(node, onIgnore, onDismiss)
             RemoveMenuItem(node, onRemove, onDismiss)
+        }
+    }
+}
+
+/** A menu of its own: favoriting, muting, messaging or removing yourself is meaningless (design#115). */
+@Composable
+fun LocalNodeContextMenu(expanded: Boolean, onUpdateStatus: () -> Unit, onDismiss: () -> Unit) {
+    DropdownMenu(expanded = expanded, onDismissRequest = onDismiss) {
+        DropdownMenuGroup(shapes = MenuDefaults.groupShapes()) {
+            DropdownMenuItem(
+                onClick = {
+                    onUpdateStatus()
+                    onDismiss()
+                },
+                leadingIcon = { Icon(imageVector = MeshtasticIcons.Notes, contentDescription = null) },
+                text = { Text(text = stringResource(Res.string.update_status)) },
+            )
         }
     }
 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeListDensity
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.channel_invalid
@@ -83,11 +84,19 @@ import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.NoDevice
 import org.meshtastic.core.ui.icon.Nodes
 import org.meshtastic.core.ui.util.parseDeepLinkOrInvalid
+import org.meshtastic.feature.node.component.LocalNodeContextMenu
 import org.meshtastic.feature.node.component.NodeContextMenu
 import org.meshtastic.feature.node.component.NodeCountSummary
 import org.meshtastic.feature.node.component.NodeFilterTextField
 import org.meshtastic.feature.node.component.NodeHopHistogramSheet
 import org.meshtastic.feature.node.component.NodeListHelp
+
+/**
+ * design#115: status message editing is offered on the connected local node only, and only where the firmware has the
+ * module — absent, never disabled, everywhere else.
+ */
+internal fun canEditStatusMessage(node: Node, ourNode: Node?, connectionState: ConnectionState): Boolean =
+    node.num == ourNode?.num && connectionState == ConnectionState.Connected && node.capabilities.supportsStatusMessage
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -101,6 +110,7 @@ fun NodeListScreen(
     activeNodeId: Int? = null,
     onHandleDeepLink: (org.meshtastic.core.common.util.CommonUri, onInvalid: () -> Unit) -> Unit = { _, _ -> },
     onNavigateToConnections: () -> Unit = {},
+    onEditStatusMessage: () -> Unit = {},
 ) {
     val showToast = org.meshtastic.core.ui.util.rememberShowToastResource()
     val scope = rememberCoroutineScope()
@@ -257,8 +267,12 @@ fun NodeListScreen(
                     var expanded by remember { mutableStateOf(false) }
 
                     Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
+                        val isThisNode = node.num == ourNode?.num
+                        val canEditStatus = canEditStatusMessage(node, ourNode, connectionState)
+                        // Our own node only earns a long press while it has something to offer, or it opens an
+                        // empty menu.
                         val longClick =
-                            if (node.num != ourNode?.num) {
+                            if (!isThisNode || canEditStatus) {
                                 { expanded = true }
                             } else {
                                 null
@@ -305,8 +319,13 @@ fun NodeListScreen(
                                     deviceImageUrl = deviceImageUrls[node.user.hw_model.value],
                                 )
                         }
-                        val isThisNode = remember(node) { ourNode?.num == node.num }
-                        if (!isThisNode) {
+                        if (canEditStatus) {
+                            LocalNodeContextMenu(
+                                expanded = expanded,
+                                onUpdateStatus = onEditStatusMessage,
+                                onDismiss = { expanded = false },
+                            )
+                        } else if (!isThisNode) {
                             NodeContextMenu(
                                 expanded = expanded,
                                 node = node,

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/navigation/AdaptiveNodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/navigation/AdaptiveNodeListScreen.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.Flow
 import org.koin.compose.viewmodel.koinViewModel
 import org.meshtastic.core.navigation.ContactsRoute
 import org.meshtastic.core.navigation.NodesRoute
+import org.meshtastic.core.navigation.SettingsRoute
 import org.meshtastic.core.ui.component.ScrollToTopEvent
 import org.meshtastic.feature.node.list.NodeListScreen
 import org.meshtastic.feature.node.list.NodeListViewModel
@@ -44,5 +45,7 @@ fun AdaptiveNodeListScreen(
         activeNodeId = null,
         onHandleDeepLink = onHandleDeepLink,
         onNavigateToConnections = onNavigateToConnections,
+        // A bare radio-config route on this tab's stack resolves to the local session, the same as Connections -> LoRa.
+        onEditStatusMessage = { backStack.add(SettingsRoute.UserStatusMessage) },
     )
 }

--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/list/StatusMessageActionGateTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/list/StatusMessageActionGateTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.list
+
+import org.meshtastic.core.model.ConnectionState
+import org.meshtastic.core.model.Node
+import org.meshtastic.proto.DeviceMetadata
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * design#115: the status-message edit action belongs to the connected local node on firmware that has the module, and
+ * is absent — never disabled — everywhere else.
+ */
+class StatusMessageActionGateTest {
+
+    private fun node(num: Int, firmware: String?) =
+        Node(num = num, metadata = firmware?.let { DeviceMetadata(firmware_version = it) })
+
+    private val ourNode = node(num = 1, firmware = "2.8.0")
+
+    @Test
+    fun `the local node offers the action while connected on 2 8 firmware`() {
+        assertTrue(canEditStatusMessage(ourNode, ourNode, ConnectionState.Connected))
+    }
+
+    @Test
+    fun `another node never offers the action`() {
+        val other = node(num = 2, firmware = "2.8.0")
+
+        assertFalse(canEditStatusMessage(other, ourNode, ConnectionState.Connected))
+    }
+
+    @Test
+    fun `older firmware does not offer the action`() {
+        val old = node(num = 1, firmware = "2.7.21")
+
+        assertFalse(canEditStatusMessage(old, old, ConnectionState.Connected))
+    }
+
+    @Test
+    fun `firmware metadata we have not read yet does not offer the action`() {
+        val unknown = node(num = 1, firmware = null)
+
+        assertFalse(canEditStatusMessage(unknown, unknown, ConnectionState.Connected))
+    }
+
+    @Test
+    fun `a disconnected radio does not offer the action`() {
+        assertFalse(canEditStatusMessage(ourNode, ourNode, ConnectionState.Disconnected))
+    }
+
+    @Test
+    fun `a node list with no local node offers the action nowhere`() {
+        assertFalse(canEditStatusMessage(ourNode, null, ConnectionState.Connected))
+    }
+}

--- a/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/component/LocalNodeContextMenuTest.kt
+++ b/feature/node/src/jvmTest/kotlin/org/meshtastic/feature/node/component/LocalNodeContextMenuTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.node.component
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.getString
+import org.meshtastic.core.resources.update_status
+import org.meshtastic.core.ui.theme.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** The local node's own context menu: one entry, the fast path to its status message. */
+@OptIn(ExperimentalTestApi::class)
+class LocalNodeContextMenuTest {
+
+    @Test
+    fun `the update status entry opens the editor and closes the menu`() = runComposeUiTest {
+        var updates = 0
+        var dismissals = 0
+        setContent {
+            AppTheme {
+                LocalNodeContextMenu(expanded = true, onUpdateStatus = { updates++ }, onDismiss = { dismissals++ })
+            }
+        }
+
+        onNodeWithText(getString(Res.string.update_status)).performClick()
+
+        assertEquals(1, updates)
+        assertTrue(dismissals >= 1)
+    }
+
+    @Test
+    fun `a collapsed menu shows nothing`() = runComposeUiTest {
+        setContent { AppTheme { LocalNodeContextMenu(expanded = false, onUpdateStatus = {}, onDismiss = {}) } }
+
+        onNodeWithText(getString(Res.string.update_status)).assertDoesNotExist()
+    }
+}

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigation.kt
@@ -240,6 +240,7 @@ internal fun settingsRadioConfigSession(backStack: List<NavKey>): SettingsRadioC
 }
 
 private fun NavKey.usesRadioConfigSettingsSession(): Boolean = this is SettingsRoute.Settings ||
+    this == SettingsRoute.UserStatusMessage ||
     this == SettingsRoute.DeviceConfiguration ||
     this == SettingsRoute.ModuleConfiguration ||
     this == SettingsRoute.Administration ||
@@ -300,6 +301,19 @@ fun EntryProviderScope<NavKey>.settingsGraph(
     entry<SettingsRoute.CleanNodeDb> {
         val viewModel: CleanNodeDatabaseViewModel = koinViewModel()
         CleanNodeDatabaseScreen(viewModel = viewModel, onBack = dropUnlessResumed { backStack.removeLastOrNull() })
+    }
+
+    // The local node's context-menu shortcut: the same user screen and the same read fan-out, opened on its field.
+    configComposable(
+        SettingsRoute.UserStatusMessage::class,
+        ConfigRoute.USER,
+        radioConfigViewModelProvider,
+    ) { viewModel ->
+        UserConfigScreen(
+            viewModel,
+            onBack = dropUnlessResumed { backStack.removeLastOrNull() },
+            focusStatusMessage = true,
+        )
     }
 
     ConfigRoute.entries.forEach { routeInfo ->

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/UserConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/UserConfigItemList.kt
@@ -25,12 +25,15 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
@@ -73,13 +76,16 @@ private const val STATUS_MESSAGE_MAX_BYTES = 80 // status_message max_size:80
 // The byte counter appears this close to the limit, matching the message composer.
 private const val STATUS_MESSAGE_COUNTER_WITHIN_BYTES = 20
 
+// The field is subcomposed by a LazyColumn, so its node can attach a frame after the request.
+private const val FOCUS_REQUEST_ATTEMPTS = 3
+
 internal const val USER_LONG_NAME_TEST_TAG = "user_long_name"
 internal const val HAM_LONG_NAME_TEST_TAG = "ham_long_name"
 internal const val USER_SHORT_NAME_TEST_TAG = "user_short_name"
 internal const val USER_STATUS_MESSAGE_TEST_TAG = "user_status_message"
 
 @Composable
-fun UserConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
+fun UserConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit, focusStatusMessage: Boolean = false) {
     val state by viewModel.radioConfigState.collectAsStateWithLifecycle()
     val destNode by viewModel.destNode.collectAsStateWithLifecycle()
     val userConfig = state.userConfig
@@ -95,6 +101,13 @@ fun UserConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
             statusMessagePrefill(state.moduleConfig.statusmessage, destNode?.nodeStatus)
         }
     var statusMessageInput by rememberSaveable(statusMessage) { mutableStateOf(statusMessage) }
+
+    val statusFocus =
+        rememberStatusMessageFocus(
+            requested = focusStatusMessage,
+            supported = capabilities.supportsStatusMessage,
+            connected = state.connected,
+        )
     // The field is absent without the capability, so the input can only differ from the saved value when shown.
     val statusMessageDirty = statusMessageInput != statusMessage
 
@@ -137,6 +150,7 @@ fun UserConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
                     StatusMessageField(
                         value = statusMessageInput,
                         enabled = state.connected,
+                        focus = statusFocus,
                         onValueChange = { statusMessageInput = it },
                     )
                 }
@@ -185,6 +199,28 @@ fun UserConfigScreen(viewModel: RadioConfigViewModel, onBack: () -> Unit) {
 }
 
 /**
+ * The field only exists once metadata reports the capability, so [pending] waits for that rather than for the first
+ * frame. It stays true until focus actually lands, and false forever after, so a failed request is retried while a
+ * later config read cannot steal focus back.
+ */
+internal class StatusMessageFocus(val requester: FocusRequester, val pending: Boolean, val onLanded: () -> Unit)
+
+@Composable
+internal fun rememberStatusMessageFocus(
+    requested: Boolean,
+    supported: Boolean,
+    connected: Boolean,
+): StatusMessageFocus {
+    val requester = remember { FocusRequester() }
+    var landed by rememberSaveable { mutableStateOf(false) }
+    return StatusMessageFocus(
+        requester = requester,
+        pending = requested && supported && connected && !landed,
+        onLanded = { landed = true },
+    )
+}
+
+/**
  * The status to edit: the configured value, falling back to the node's broadcast status only while no config has been
  * read, so the operator edits the live value rather than a blank. A config that is present and empty is a status
  * cleared on purpose, and must not be repopulated from a stale broadcast.
@@ -202,8 +238,25 @@ private fun RadioConfigViewModel.save(user: User, userDirty: Boolean, statusMess
 
 /** The node's own status message: a short free-text line other nodes display beside it. */
 @Composable
-private fun StatusMessageField(value: String, enabled: Boolean, onValueChange: (String) -> Unit) {
+internal fun StatusMessageField(
+    value: String,
+    enabled: Boolean,
+    focus: StatusMessageFocus,
+    onValueChange: (String) -> Unit,
+) {
     val focusManager = LocalFocusManager.current
+    var focused by remember { mutableStateOf(false) }
+
+    // Requested from inside the field so its node exists; a request that still lands early fails silently, hence the
+    // frame retry.
+    LaunchedEffect(focus.pending) {
+        if (!focus.pending) return@LaunchedEffect
+        repeat(FOCUS_REQUEST_ATTEMPTS) {
+            focus.requester.requestFocus()
+            if (focused) return@LaunchedEffect
+            withFrameNanos {}
+        }
+    }
 
     EditTextPreference(
         title = stringResource(Res.string.status_message),
@@ -216,6 +269,11 @@ private fun StatusMessageField(value: String, enabled: Boolean, onValueChange: (
         keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Text, imeAction = ImeAction.Done),
         keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
         modifier = Modifier.testTag(USER_STATUS_MESSAGE_TEST_TAG),
+        focusRequester = focus.requester,
+        onFocusChanged = {
+            focused = it.isFocused
+            if (it.isFocused) focus.onLanded()
+        },
         onValueChanged = onValueChange,
         trailingIcon = {
             if (value.isNotEmpty()) {

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigationTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/navigation/SettingsNavigationTest.kt
@@ -61,6 +61,13 @@ class SettingsNavigationTest {
     }
 
     @Test
+    fun `the local node status message shortcut keeps a local session active`() {
+        val stack = listOf<NavKey>(NodesRoute.Nodes, SettingsRoute.UserStatusMessage)
+
+        assertEquals(SettingsRadioConfigSession.Local, settingsRadioConfigSession(stack))
+    }
+
+    @Test
     fun `non radio settings route outside settings tab stays inactive`() {
         val stack = listOf<NavKey>(NodesRoute.Nodes, SettingsRoute.FilterSettings)
 

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/StatusMessageFocusTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/component/StatusMessageFocusTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.settings.radio.component
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.meshtastic.core.ui.component.EditTextPreference
+import org.meshtastic.core.ui.theme.AppTheme
+import kotlin.test.Test
+
+private const val OTHER_FIELD_TAG = "other_field"
+
+/**
+ * The node list's shortcut opens this screen on the status message field. The field is gated on an async capability
+ * read, so it composes after the first frame — and the operator must keep focus once they move off it.
+ *
+ * The container is a [LazyColumn] because the real screen's is: its items are subcomposed at measure time, so a request
+ * issued from the enclosing scope reaches an unattached node and fails silently. A plain Column does not reproduce
+ * that.
+ */
+@OptIn(ExperimentalTestApi::class)
+class StatusMessageFocusTest {
+
+    /** The real field, in the real container, beside a plain one, over hoisted state the test drives. */
+    private fun ComposeUiTest.showFields(
+        requested: Boolean,
+        supported: MutableState<Boolean>,
+        connected: MutableState<Boolean>,
+    ) {
+        setContent {
+            AppTheme {
+                val focus =
+                    rememberStatusMessageFocus(
+                        requested = requested,
+                        supported = supported.value,
+                        connected = connected.value,
+                    )
+                LazyColumn {
+                    item {
+                        EditTextPreference(
+                            title = "Other",
+                            value = "",
+                            enabled = true,
+                            isError = false,
+                            keyboardOptions = KeyboardOptions.Default,
+                            keyboardActions = KeyboardActions.Default,
+                            onValueChanged = {},
+                            modifier = Modifier.testTag(OTHER_FIELD_TAG),
+                        )
+                        if (supported.value) {
+                            StatusMessageField(value = "", enabled = connected.value, focus = focus, onValueChange = {})
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /** The text field itself: [EditTextPreference] tags its wrapping column, which carries no text actions. */
+    private fun ComposeUiTest.field(tag: String): SemanticsNodeInteraction =
+        onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag(tag)))
+
+    @Test
+    fun `the field is focused once the capability read lands`() = runComposeUiTest {
+        val supported = mutableStateOf(false)
+        showFields(requested = true, supported = supported, connected = mutableStateOf(true))
+
+        supported.value = true
+        waitForIdle()
+
+        field(USER_STATUS_MESSAGE_TEST_TAG).assertIsFocused()
+    }
+
+    @Test
+    fun `the field is focused when the capability is known from the first frame`() = runComposeUiTest {
+        showFields(requested = true, supported = mutableStateOf(true), connected = mutableStateOf(true))
+
+        field(USER_STATUS_MESSAGE_TEST_TAG).assertIsFocused()
+    }
+
+    @Test
+    fun `arriving without the shortcut leaves the field alone`() = runComposeUiTest {
+        showFields(requested = false, supported = mutableStateOf(true), connected = mutableStateOf(true))
+
+        field(USER_STATUS_MESSAGE_TEST_TAG).assertIsNotFocused()
+    }
+
+    @Test
+    fun `focus is not stolen back after the operator moves on`() = runComposeUiTest {
+        val connected = mutableStateOf(true)
+        showFields(requested = true, supported = mutableStateOf(true), connected = connected)
+
+        field(OTHER_FIELD_TAG).performClick()
+        // A connection flap re-runs the request; the one-shot latch has to hold.
+        connected.value = false
+        waitForIdle()
+        connected.value = true
+        waitForIdle()
+
+        field(USER_STATUS_MESSAGE_TEST_TAG).assertIsNotFocused()
+        field(OTHER_FIELD_TAG).assertIsFocused()
+    }
+}


### PR DESCRIPTION
Touch & hold the connected node and the one entry, Update status, opens the User config screen with the status message field already focused. Absent - never disabled - off the local node, while disconnected, or below firmware 2.8. The local node had no context menu at all before this, so it gets one whose sole entry is the shortcut.

The focus request is issued from inside the field rather than the screen around it. The field is subcomposed by a LazyColumn, so a request from the enclosing scope reaches a node that has not attached yet, and a failed request is a `println` and a `false` - no throw, nothing to retry from. The latch closes on focus actually landing, for the same reason. `StatusMessageFocusTest` composes the real field in a real LazyColumn because a plain Column does not reproduce any of that.

Deliberately narrower than #6932: this navigates to the existing inline field instead of the popup editor design#115 proposes, and removes nothing. Status message editing stays reachable for remote-administered nodes - see the unresolved objection on the issue.

No screenshots, no device on hand today.

refs #6932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Update status** action for the connected local node when running firmware 2.8 or newer.
  * Opens User settings directly with the Status Message field focused for immediate editing.
  * Existing actions remain available for other nodes.

* **Documentation**
  * Documented the new Update status shortcut in node and user settings guides.

* **Tests**
  * Added coverage for availability rules, navigation, menu behavior, and status-field focus handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->