### PR TITLE
docs(nodes): unknown nodes stay visible but are not messageable

### DIFF
--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -122,7 +122,7 @@ Type in the search field to filter nodes by name or short name. The filter updat
 |--------|-------------|
 | **Hide offline nodes** | Show only nodes heard within the last 2 hours |
 | **Only show direct nodes** | Show only nodes your radio heard directly, with no relay in between |
-| **Include unknown** | Show nodes that haven't sent user info yet. **On by default**, so a node heard before its info arrives stays visible and messageable; these carry a badge marking them incomplete |
+| **Include unknown** | Show nodes that haven't sent user info yet. **On by default**, so a node heard before its info arrives stays visible; these carry a badge marking them incomplete, and cannot be direct messaged until their user info brings a public key |
 | **Exclude infrastructure** | Hide infrastructure-role nodes (Router, Router Late, Client Base, and legacy Repeater nodes) and any node that cannot be messaged, whatever its role |
 | **Exclude MQTT** | Hide nodes heard only via MQTT internet bridge |
 | **Only show ignored Nodes** | Replace the list with the nodes you have ignored. Every other node is hidden while this is on, and a banner appears at the top of the list to take you back |


### PR DESCRIPTION
Follow-up to #7050, which could not carry this line because it was already in the merge queue when CodeRabbit raised it.

#7050 stopped offering a direct message to a node we hold no public key for, but the **Include unknown** filter row still told the reader such a node "stays visible and messageable". It stays visible; it cannot be direct messaged until its user info brings a key.

## 🧹 Chores

- `docs/en/user/nodes.md` — reword the **Include unknown** filter description to match the shipped behaviour.

## Testing Performed

- `spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` green. The file is bundled into compose resources by `syncDocsToComposeResources`, so it is built, not just linted. No screenshot goldens dirtied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the “Include unknown” filter guidance to clarify that nodes without user information remain visible but cannot be directly messaged until a public key is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->