### PR TITLE
feat(firmware): factory erase through the OTAFIX bootloader when the drive advertises it

### DIFF
--- a/.github/workflows/scheduled-updates.yml
+++ b/.github/workflows/scheduled-updates.yml
@@ -221,11 +221,13 @@ jobs:
             # a degraded response (missing erase set or empty board map) must never
             # replace the bundled seed.
             board_count=$(jq -r 'if (.otafixByBoardId | type) == "object" then (.otafixByBoardId | length) else 0 end' "$temp_uf2_file" 2>/dev/null || echo 0)
-            has_erase=$(jq -r 'if (.erase | type) == "object" then 1 else 0 end' "$temp_uf2_file" 2>/dev/null || echo 0)
+            # .erase.nrf52Bootloader is required too: the bundled seed carries it, and a manifest without it
+            # would silently drop the bootloader-driven erase path from every offline install.
+            has_erase=$(jq -r 'if (.erase | type) == "object" and (.erase.nrf52Bootloader | type) == "object" then 1 else 0 end' "$temp_uf2_file" 2>/dev/null || echo 0)
             if [ "$board_count" -eq 0 ] || [ "$has_erase" -ne 1 ]; then
-              echo "::warning::Maintenance UF2 API response is missing the erase set or board map. Skipping to protect the bundled seed."
+              echo "::warning::Maintenance UF2 API response is missing the erase set (incl. erase.nrf52Bootloader) or board map. Skipping to protect the bundled seed."
               echo "status=error" >> "$GITHUB_OUTPUT"
-              echo "detail=degraded maintenance UF2 manifest (no erase set or empty board map)" >> "$GITHUB_OUTPUT"
+              echo "detail=degraded maintenance UF2 manifest (no erase set, no erase.nrf52Bootloader, or empty board map)" >> "$GITHUB_OUTPUT"
             elif [ ! -f "$uf2_file_path" ] || ! jq --sort-keys . "$temp_uf2_file" | diff -q - <(jq --sort-keys . "$uf2_file_path"); then
               echo "Changes detected in maintenance UF2 manifest or local file missing. Updating $uf2_file_path."
               jq . "$temp_uf2_file" > "$uf2_file_path"

--- a/androidApp/src/main/assets/maintenance_uf2.json
+++ b/androidApp/src/main/assets/maintenance_uf2.json
@@ -15,6 +15,11 @@
         "expectedFirstTargetAddress": 159744
       }
     },
+    "nrf52Bootloader": {
+      "fileName": "meshtastic_factory_erase.uf2",
+      "sha256": "6ef3146505c40079ee9e7e692448e40a793dad636f55d1545063299d28908f0d",
+      "expectedFamilyId": 1296388936
+    },
     "rp2040": {
       "fileName": "pico_erase.uf2",
       "sha256": "08aa7d561e8b8bf2f9b061b3506fb4d8f135e832efe0f3ae978241db2da0c853"

--- a/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/MaintenanceUf2RepositoryImplTest.kt
+++ b/core/data/src/jvmTest/kotlin/org/meshtastic/core/data/repository/MaintenanceUf2RepositoryImplTest.kt
@@ -92,10 +92,18 @@ class MaintenanceUf2RepositoryImplTest {
     private fun manifestWithBoard(boardId: String, slug: String = "wiscore_rak4631_board") =
         MaintenanceUf2Manifest(otafixByBoardId = mapOf(boardId to OtafixAssetEntry(slug, "1".repeat(64))))
 
+    private val bootloaderErase =
+        EraseImageEntry(
+            fileName = "meshtastic_factory_erase.uf2",
+            sha256 = "3".repeat(64),
+            expectedFamilyId = 0x4D455348L,
+        )
+
     private fun manifestWithErase(softDevice: String) = MaintenanceUf2Manifest(
         erase =
         MaintenanceUf2EraseSet(
             nrf52 = mapOf(softDevice to EraseImageEntry(fileName = "nrf_erase.uf2", sha256 = "2".repeat(64))),
+            nrf52Bootloader = bootloaderErase,
             rp2040 = pico,
         ),
     )
@@ -161,6 +169,21 @@ class MaintenanceUf2RepositoryImplTest {
         val snapshot = repository.getSnapshot()
 
         assertEquals(listOf("7.3.0"), snapshot.erase?.nrf52?.keys?.toList())
+        assertEquals(
+            bootloaderErase,
+            snapshot.erase?.nrf52Bootloader,
+            "the bootloader erase entry round-trips the cache",
+        )
+    }
+
+    @Test
+    fun aManifestWithoutTheBootloaderEraseEntryStillDecodes() = runBlocking {
+        // Every manifest published before the entry existed, and every cache row written from one.
+        api.response =
+            manifestWithErase("7.3.0").copy(erase = manifestWithErase("7.3.0").erase?.copy(nrf52Bootloader = null))
+        repository.reconcile()
+
+        assertEquals(null, repository.getSnapshot().erase?.nrf52Bootloader)
     }
 
     @Test

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/MaintenanceUf2Manifest.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/MaintenanceUf2Manifest.kt
@@ -44,14 +44,29 @@ data class MaintenanceUf2Manifest(
 data class MaintenanceUf2EraseSet(
     /** Keyed by [SoftDeviceVariant.fromWire]'s own input strings, e.g. "6.1.1" / "7.3.0". */
     @SerialName("nrf52") val nrf52: Map<String, EraseImageEntry> = emptyMap(),
+    /**
+     * The board-agnostic bootloader-driven erase image (OTAFIX `tools/meshtastic_factory_erase.uf2`): a single UF2
+     * block the bootloader itself consumes when its `INFO_UF2.TXT` advertises `Factory-Erase: UF2 family <id>`. Absent
+     * from manifests that predate it, and ignored by bootloaders that do not advertise it — so it is only ever
+     * preferred over [nrf52], never a replacement for it.
+     */
+    @SerialName("nrf52Bootloader") val nrf52Bootloader: EraseImageEntry? = null,
     @SerialName("rp2040") val rp2040: EraseImageEntry,
 )
 
+/**
+ * @property expectedFirstTargetAddress The flash address the image's first block writes to, for images whose address
+ *   carries a safety invariant (the SoftDevice-specific nRF erase sketches). Null otherwise.
+ * @property expectedFamilyId The UF2 family ID the image's block must declare (flag `0x2000` set, u32 at offset 28) —
+ *   the bootloader-driven erase image's contract, checked against the bytes instead of an address, because that image's
+ *   `targetAddr` is 0 by design. Null for every other image.
+ */
 @Serializable
 data class EraseImageEntry(
     @SerialName("fileName") val fileName: String,
     @SerialName("sha256") val sha256: String,
     @SerialName("expectedFirstTargetAddress") val expectedFirstTargetAddress: Long? = null,
+    @SerialName("expectedFamilyId") val expectedFamilyId: Long? = null,
 )
 
 /**

--- a/docs/en/user/firmware.md
+++ b/docs/en/user/firmware.md
@@ -2,7 +2,7 @@
 title: Firmware Updates
 parent: User Guide
 nav_order: 13
-last_updated: 2026-08-30
+last_updated: 2026-09-06
 description: Update your radio firmware over Bluetooth or USB — OTA process, version channels, pre-flight checks, and recovery.
 aliases:
   - firmware
@@ -74,7 +74,16 @@ Select a firmware version before either one: the app hides both until a release 
 
 Both a USB erase and a bootloader upgrade write two files in turn, so you are asked to select the device's update drive twice: once for the erase or bootloader image, then again for the firmware.
 
-The app reads `INFO_UF2.TXT` from the drive you select to confirm it really is the device's update drive and to identify the board before writing anything. If it can't confirm which Bluetooth stack your device uses, it refuses to erase and points you at the [Web Flasher](https://flasher.meshtastic.org) instead. In the Web Flasher, choosing the wrong Bluetooth stack can leave the radio recoverable only with a hardware programmer.
+The app reads `INFO_UF2.TXT` from the drive you select to confirm it really is the device's update drive and to identify the board before writing anything.
+
+On nRF52 the app must already know which Bluetooth stack your device uses before it starts, because it can't read the bootloader until the device has rebooted. If it can't confirm the stack, it refuses to erase and points you at the [Web Flasher](https://flasher.meshtastic.org) instead. In the Web Flasher, choosing the wrong Bluetooth stack can leave the radio recoverable only with a hardware programmer.
+
+Once the drive is readable, how an nRF52 device is erased depends on its bootloader:
+
+- **Newer bootloaders erase themselves.** A bootloader that advertises factory-erase support in `INFO_UF2.TXT` (newer OTAFIX bootloaders) takes a single, board-agnostic erase file. The bootloader wipes your settings, channels, keys and the stored node list itself, leaves the installed firmware in place, and comes back as an update drive a second or two later for the firmware file. There is no Bluetooth-stack choice to get wrong on this path.
+- **Older bootloaders need a Bluetooth-stack-specific erase.** On these the app writes a small erase program matched to your device's Bluetooth stack, then starts it over the serial port. If the drive reports a different stack than expected, the app refuses rather than guessing.
+
+The app picks the path from what the drive reports; you don't choose it.
 
 ### Other Flashing Options
 

--- a/feature/firmware/README.md
+++ b/feature/firmware/README.md
@@ -77,11 +77,16 @@ sequenceDiagram
 ```
 
 #### 4. USB Maintenance: Factory Erase & OTAFIX Bootloader Upgrade
-An nRF52/RP2040 device can also run a **factory erase** (wipes the internal filesystem, useful for a device stuck in a bad state or carrying stale event-firmware state) or, on boards OTAFIX ships a bootloader for, a **bootloader self-update**. The erase is reached through the update screen's "Erase device during update" opt-in (default off) rather than a standalone action, so a wipe always ends with the selected release installed; over BLE/WiFi the same opt-in instead sends an admin factory reset once the update is verified. Both USB flows are two-pass sequences: the maintenance image (erase or OTAFIX) is written first, which reboots the device back into a bare bootloader; the release firmware is then written as the second, ordinary UF2 pass.
+An nRF52/RP2040 device can also run a **factory erase** (wipes the internal filesystem, useful for a device stuck in a bad state or carrying stale event-firmware state) or, on boards OTAFIX ships a bootloader for, a **bootloader self-update**. The erase is reached through the update screen's "Erase device during update" opt-in (default off) rather than a standalone action, so a wipe always ends with the selected release installed; over BLE/WiFi the same opt-in instead sends an admin factory reset once the update is verified. Both USB flows are two-pass sequences: the maintenance image (erase or OTAFIX) is written first, after which the device re-enters its bootloader (bare of any application after the SoftDevice erase sketch or an OTAFIX self-update, application intact after a bootloader-driven erase); the release firmware is then written as the second, ordinary UF2 pass.
 
-Two runtime facts make the maintenance image itself safety-critical, not just another UF2 write:
+There are two nRF52 erase paths, chosen from what the mounted volume reports — never by the user:
 
-- **The nRF52 erase image is SoftDevice-version-specific.** Writing the S140 6.1.1 image to a 7.3.0 device (or vice versa) corrupts the SoftDevice with no on-device recovery. `MaintenanceUf2.kt` treats the mounted volume's own `INFO_UF2.TXT` `SoftDevice:` line as authoritative over the bundled hardware-catalog hint — the two must agree, or the app refuses rather than guessing (`EraseImageResolution.Conflict`).
+- **Bootloader-driven erase** (`erase.nrf52Bootloader`, OTAFIX PR #41 onwards). A bootloader that advertises `Factory-Erase: UF2 family 0x4D455348` in `INFO_UF2.TXT` consumes a single 512-byte, board-agnostic UF2 block (`meshtastic_factory_erase.uf2`) as a command: it erases its whole App Data reservation (LittleFS config/keys/bonds plus the firmware's node-DB ring) and leaves MBR, SoftDevice, bootloader *and application* untouched, then detaches ~500 ms later and returns as a UF2 drive in 1–2 s. `bootloaderEraseUf2For()` resolves it only when the advertised family equals the manifest entry's `expectedFamilyId`; its integrity contract is the family ID in the block header (`uf2FamilyId()`, flag `0x2000` + u32 at offset 28) rather than a target address, because its `targetAddr` is 0. **No CDC unblock** follows it — the only port present afterwards is the bootloader's own.
+- **SoftDevice-specific erase sketch** (`erase.nrf52`, every earlier bootloader — those silently ignore the block above). Unchanged, and still the fallback whenever the `Factory-Erase:` line is absent or names another family.
+
+Two runtime facts make the sketch path safety-critical, not just another UF2 write:
+
+- **The nRF52 erase sketch is SoftDevice-version-specific.** Writing the S140 6.1.1 image to a 7.3.0 device (or vice versa) corrupts the SoftDevice with no on-device recovery. `MaintenanceUf2.kt` treats the mounted volume's own `INFO_UF2.TXT` `SoftDevice:` line as authoritative over the bundled hardware-catalog hint — the two must agree, or the app refuses rather than guessing (`EraseImageResolution.Conflict`). The sketch also blocks in `while (!Serial)` until a host asserts DTR, which is what `UsbPassWriter`'s CDC unblock step is for (`MaintenanceUf2.requiresCdcUnblock`).
 - **OTAFIX bootloaders are resolved by `Board-ID`, not by build target or USB VID/PID** — both of the latter collide across multiple boards. `otafixUf2ForBoardId()` looks up the exact bootloader image for the `Board-ID:` line the volume reports; the Meshtastic build-target name is only ever used to decide whether to *offer* the action in the UI.
 
 ```mermaid
@@ -92,10 +97,11 @@ sequenceDiagram
 
     App->>Radio: rebootToDfu()
     Radio->>Radio: Mounts as UF2 bootloader drive
-    App->>USB: Read INFO_UF2.TXT (Board-ID, SoftDevice)
-    App->>App: Resolve erase/OTAFIX image, verify digest + target address
+    App->>USB: Read INFO_UF2.TXT (Board-ID, SoftDevice, Factory-Erase)
+    App->>App: Resolve erase/OTAFIX image, verify digest + target address / family ID
     App->>USB: Write maintenance image
-    USB->>USB: Auto-flash & reboot to bare bootloader
+    USB->>USB: Consume image & re-enter bootloader
+    App->>Radio: CDC unblock (SoftDevice erase sketch only)
     App->>App: Prompt User to Save release firmware
     App->>USB: Write firmware.uf2 (pass 2)
     USB->>USB: Auto-Flash & Reboot
@@ -117,7 +123,8 @@ A `FirmwareMaintenanceLock` (`:core:common`) is held for the duration of the seq
 - `SecureDfuTransport.kt`: BLE transport layer for Secure DFU using Kable (control/data point characteristics, PRN flow control).
 - `DfuZipParser.kt`: Parses Nordic DFU ZIP archives (manifest, init packet, firmware binary).
 - `UsbUpdateHandler.kt`: Handles USB/UF2 firmware updates across platforms.
-- `MaintenanceUf2.kt`: Pinned erase/OTAFIX image tables, `INFO_UF2.TXT` parsing (Board-ID, SoftDevice), and the drive-vs-map SoftDevice resolution used to pick a safe erase image.
+- `MaintenanceUf2.kt`: Pinned erase/OTAFIX image resolution, `INFO_UF2.TXT` parsing (Board-ID, SoftDevice, Factory-Erase family), the drive-vs-map SoftDevice resolution used to pick a safe erase sketch, and the bootloader-driven erase resolver that pre-empts it.
+- `Uf2Header.kt`: UF2 block-header readers (first target address, family ID) that `FirmwareRetriever` checks a downloaded maintenance image against before it can be written.
 - `UsbMaintenance.kt`: Pure gating (`usbMaintenanceGate`) and volume-inspection/image-choice types for the factory-erase and bootloader-upgrade actions.
 - `UsbUpdateSupport.kt`: Sequences a maintenance pass (download → reboot to DFU → vet volume → write → confirm landed) and drives the two-pass state machine.
 

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareFileHandler.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareFileHandler.kt
@@ -75,8 +75,8 @@ interface FirmwareFileHandler {
      * bootloader drive rather than internal storage.
      *
      * Used to reject the Downloads mistake *before* writing, which matters only once a write is destructive: in a
-     * multi-pass maintenance sequence a mis-saved pass leaves the device with no application, and nothing else in the
-     * flow can tell a landed write from a lost one. The plain single-pass update path deliberately does not consult
+     * multi-pass maintenance sequence a mis-saved pass can leave the device with no application, and nothing else in
+     * the flow can tell a landed write from a lost one. The plain single-pass update path deliberately does not consult
      * this — its worst case is "nothing happened, replug".
      */
     suspend fun isRemovableDestination(destinationUri: CommonUri): Boolean

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareRetriever.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareRetriever.kt
@@ -83,11 +83,12 @@ open class FirmwareRetriever(private val fileHandler: FirmwareFileHandler) {
      * Download a pinned maintenance image (factory erase, bootloader upgrade) and verify it before returning.
      *
      * The module's only absolute-URL entry point. Unlike release artifacts, these images have no versioned upstream —
-     * `nrf52_factory_erase` has cut no releases — so the URL is commit/tag-pinned and the content is the real contract.
+     * the erase images are commit-pinned, not released — so the URL is commit/tag-pinned and the content is the real
+     * contract.
      *
-     * A digest or address mismatch is **terminal**: the file is deleted and `null` is returned with no fallback. The
-     * release-zip fallback the other retrievers use would be actively wrong here, because the payload is destructive
-     * and "some other file with the right name" is precisely the failure being guarded against.
+     * A digest, address or family-ID mismatch is **terminal**: the file is deleted and `null` is returned with no
+     * fallback. The release-zip fallback the other retrievers use would be actively wrong here, because the payload is
+     * destructive and "some other file with the right name" is precisely the failure being guarded against.
      *
      * @return The verified [FirmwareArtifact], or `null` when the download failed or verification did not pass.
      */
@@ -124,6 +125,21 @@ open class FirmwareRetriever(private val fileHandler: FirmwareFileHandler) {
                 Logger.e {
                     "Maintenance image ${asset.fileName} targets ${actualAddress?.toString(HEX_RADIX)}, " +
                         "expected ${expectedAddress.toString(HEX_RADIX)} — refusing to write"
+                }
+                fileHandler.deleteFile(artifact)
+                return null
+            }
+        }
+
+        val expectedFamily = asset.expectedFamilyId
+        if (expectedFamily != null) {
+            val actualFamily = uf2FamilyId(bytes)
+            if (actualFamily != expectedFamily) {
+                // The bootloader-driven erase image is a single block the bootloader recognises by family ID; its
+                // targetAddr is 0, so this is the row-authoring check that replaces the address check above.
+                Logger.e {
+                    "Maintenance image ${asset.fileName} declares family ${actualFamily?.toString(HEX_RADIX)}, " +
+                        "expected ${expectedFamily.toString(HEX_RADIX)} — refusing to write"
                 }
                 fileHandler.deleteFile(artifact)
                 return null

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUpdateViewModel.kt
@@ -695,9 +695,9 @@ class FirmwareUpdateViewModel(
     /**
      * Re-offers the same pass with an explanation, or fails outright when nothing destructive has happened yet.
      *
-     * Once an erase or bootloader image has been written the device has no application, so dropping the user on an
-     * error screen is the worst available outcome — the flow keeps offering the pass until it succeeds or they leave
-     * deliberately.
+     * Once an erase or bootloader image has been written the device may have no application (a bootloader-driven erase
+     * keeps it, the SoftDevice sketch and OTAFIX do not), so dropping the user on an error screen is the worst
+     * available outcome — the flow keeps offering the pass until it succeeds or they leave deliberately.
      */
     private fun reofferOrFail(pass: UsbFileSavePass, message: UiText) {
         if (destructiveWriteDone) {

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUsbManager.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareUsbManager.kt
@@ -45,9 +45,10 @@ interface FirmwareUsbManager {
      * Opens the port that appeared since [excluding] was captured and holds DTR asserted, so firmware waiting on a host
      * will run.
      *
-     * The nRF52 factory-erase image blocks in `while (!Serial)` before `InternalFS.format()`, and `Serial` only becomes
-     * truthy once DTR is asserted — without this the erase never starts. A failure here is therefore safe: the image is
-     * written but has destroyed nothing.
+     * The SoftDevice-specific nRF52 erase sketch blocks in `while (!Serial)` before `InternalFS.format()`, and `Serial`
+     * only becomes truthy once DTR is asserted — without this the erase never starts. A failure here is therefore safe:
+     * the image is written but has destroyed nothing. Never called after the bootloader-driven erase image: the only
+     * port present then is the bootloader's own (see `MaintenanceUf2.requiresCdcUnblock`).
      *
      * @return true when a port was claimed and DTR held.
      */

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/MaintenanceUf2.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/MaintenanceUf2.kt
@@ -31,16 +31,26 @@ import org.meshtastic.core.network.HttpClientDefaults
  * this class is the download-time gate against a corrupted transfer, independent of how the manifest naming this image
  * was itself fetched.
  *
- * @property expectedFirstTargetAddress For nRF erase images, the flash address the UF2's first block writes to. Checked
- *   against the resolved [SoftDeviceVariant] before the image is offered, because a swapped URL/digest row is the one
- *   authoring mistake a digest alone cannot catch — and the mistake that corrupts a SoftDevice. Null when the image's
- *   address carries no such invariant (RP2040, bootloader self-updates).
+ * @property expectedFirstTargetAddress For the SoftDevice-specific nRF erase sketches, the flash address the UF2's
+ *   first block writes to. Checked against the resolved [SoftDeviceVariant] before the image is offered, because a
+ *   swapped URL/digest row is the one authoring mistake a digest alone cannot catch — and the mistake that corrupts a
+ *   SoftDevice. Null when the image's address carries no such invariant (RP2040, bootloader self-updates, and the
+ *   bootloader-driven erase image, whose `targetAddr` is 0 by design).
+ * @property expectedFamilyId For the bootloader-driven erase image, the UF2 family ID its block must declare. That
+ *   image is a single block the bootloader consumes itself, so its integrity contract is the family ID rather than an
+ *   address. Null for every other image.
+ * @property requiresCdcUnblock True only for the SoftDevice-specific nRF erase sketches, which block in `while
+ *   (!Serial)` before formatting and need a host to assert DTR. False for images the bootloader consumes itself (RP2040
+ *   `pico_erase`, OTAFIX self-updates, and the bootloader-driven erase image): opening a CDC port after one of those
+ *   latches onto the bootloader's own port and stalls the flow for nothing.
  */
 internal data class MaintenanceUf2(
     val url: String,
     val fileName: String,
     val sha256: String,
     val expectedFirstTargetAddress: Long? = null,
+    val expectedFamilyId: Long? = null,
+    val requiresCdcUnblock: Boolean = false,
 ) {
     init {
         // downloadFile interpolates fileName straight into a temp path. The mapping boundary already refuses unsafe
@@ -68,15 +78,34 @@ private val SAFE_UF2_FILE_NAME = Regex("""[A-Za-z0-9._-]+\.uf2""")
  * `null` when the row names an unsafe file: a refusal of that image, never a crash. One malformed row must not take
  * down the whole firmware screen.
  */
-private fun EraseImageEntry.toMaintenanceUf2OrNull(): MaintenanceUf2? {
+private fun EraseImageEntry.toMaintenanceUf2OrNull(requiresCdcUnblock: Boolean = false): MaintenanceUf2? {
     if (!SAFE_UF2_FILE_NAME.matches(fileName)) return null
     return MaintenanceUf2(
         url = "${HttpClientDefaults.API_BASE_URL}resource/maintenanceUf2/asset/$fileName",
         fileName = fileName,
         sha256 = sha256,
         expectedFirstTargetAddress = expectedFirstTargetAddress,
+        expectedFamilyId = expectedFamilyId,
+        requiresCdcUnblock = requiresCdcUnblock,
     )
 }
+
+/**
+ * The bootloader-driven erase image from [MaintenanceUf2EraseSet.nrf52Bootloader], when the volume's advertised
+ * `Factory-Erase:` family ([volumeFamily]) equals the entry's `expectedFamilyId`; `null` otherwise.
+ *
+ * Both sides must be present and equal: a bootloader that advertises no family silently ignores the file (every
+ * bootloader shipped before OTAFIX PR #41), and an entry with no expected family cannot be verified against the bytes,
+ * so neither may resolve here — the caller falls through to the SoftDevice-specific sketch path unchanged.
+ */
+internal fun bootloaderEraseUf2For(manifest: MaintenanceUf2Manifest, volumeFamily: Long?): MaintenanceUf2? =
+    manifest.erase
+        ?.nrf52Bootloader
+        ?.takeIf { it.expectedFamilyId != null && it.expectedFamilyId == volumeFamily }
+        // targetAddr is 0 in this image by design, so the first-target-address invariant does not apply — the family
+        // ID is the contract the retriever checks instead. Force it null so an authored address can never reject it.
+        ?.copy(expectedFirstTargetAddress = null)
+        ?.toMaintenanceUf2OrNull()
 
 /**
  * OTAFIX bootloader self-update images stay hosted on `Adafruit_nRF52_Bootloader_OTAFIX`'s own GitHub releases — only
@@ -113,7 +142,12 @@ internal fun eraseUf2For(manifest: MaintenanceUf2Manifest, hardware: DeviceHardw
     val erase = manifest.erase ?: return null
     return when {
         hardware.isRp2040Arc -> erase.rp2040.toMaintenanceUf2OrNull()
-        hardware.isNrf52Arc -> hardware.softDeviceVariant?.let { erase.nrf52[it.wireValue]?.toMaintenanceUf2OrNull() }
+
+        hardware.isNrf52Arc ->
+            hardware.softDeviceVariant?.let {
+                erase.nrf52[it.wireValue]?.toMaintenanceUf2OrNull(requiresCdcUnblock = true)
+            }
+
         else -> null
     }
 }
@@ -177,13 +211,34 @@ internal fun parseUf2SoftDevice(infoUf2Text: String): SoftDeviceVariant? {
 }
 
 /**
+ * Extracts the UF2 family ID a bootloader advertises for its own factory erase, from its `INFO_UF2.TXT`.
+ *
+ * OTAFIX (PR #41 onwards) appends `Factory-Erase: UF2 family 0x4D455348` when it will consume a single-block UF2 of
+ * that family as an erase command. Parsed like its siblings — by line prefix, case-insensitively, tolerating leading
+ * whitespace — taking the last `0x`-prefixed token. Returns `null` when the line is absent (every earlier bootloader)
+ * or carries no parseable hex token; a *different* family parses fine and is refused by [bootloaderEraseUf2For].
+ */
+@Suppress("ReturnCount") // guard clauses; an unparseable line must yield null rather than a guess
+internal fun parseUf2FactoryEraseFamily(infoUf2Text: String): Long? {
+    val value =
+        infoUf2Text
+            .lineSequence()
+            .firstOrNull { it.trimStart().startsWith(UF2_FACTORY_ERASE_PREFIX, ignoreCase = true) }
+            ?.substringAfter(':') ?: return null
+    val token =
+        value.split(' ').lastOrNull { it.startsWith(HEX_PREFIX, ignoreCase = true) }?.drop(HEX_PREFIX.length)
+            ?: return null
+    return token.toLongOrNull(HEX_RADIX)
+}
+
+/**
  * Which erase image [variant] needs, from [manifest]. `null` when [manifest] carries no `erase` set at all (never
  * fetched/seeded — fail closed), when this specific variant's row is missing from `erase.nrf52` (a malformed or partial
  * manifest), or when that row names an unsafe file — never a guess at a substitute image.
  */
 internal fun eraseUf2ForVariant(manifest: MaintenanceUf2Manifest, variant: SoftDeviceVariant): MaintenanceUf2? {
     val erase = manifest.erase ?: return null
-    return erase.nrf52[variant.wireValue]?.toMaintenanceUf2OrNull()
+    return erase.nrf52[variant.wireValue]?.toMaintenanceUf2OrNull(requiresCdcUnblock = true)
 }
 
 /** Outcome of reconciling the SoftDevice the drive reports against the manifest's pre-flight hint. */
@@ -237,40 +292,11 @@ private const val UF2_BOARD_ID_PREFIX = "Board-ID:"
 
 private const val UF2_SOFTDEVICE_PREFIX = "SoftDevice:"
 
+private const val UF2_FACTORY_ERASE_PREFIX = "Factory-Erase:"
+
+private const val HEX_PREFIX = "0x"
+
+private const val HEX_RADIX = 16
+
 /** All Meshtastic nRF52840 boards run the S140 SoftDevice; anything else is out of scope and refuses. */
 private const val SUPPORTED_SOFTDEVICE_ID = "S140"
-
-/** UF2 block size, per the UF2 specification. */
-internal const val UF2_BLOCK_BYTES = 512
-
-/** Byte offset of `targetAddr` within a UF2 block header. */
-internal const val UF2_TARGET_ADDR_OFFSET = 12
-
-private const val UF2_MAGIC_START0 = 0x0A324655
-
-/** Bytes in a little-endian 32-bit field, and the mask/shift used to reassemble one. */
-private const val UINT32_BYTES = 4
-
-private const val BITS_PER_BYTE = 8
-
-private const val BYTE_MASK = 0xFFL
-
-/**
- * Reads the target flash address of the first UF2 block in [bytes], or `null` when the payload is not a UF2 image.
- *
- * Used to cross-check a pinned erase image against the resolved SoftDevice variant before it is written.
- */
-@Suppress("ReturnCount") // guard clauses over a binary header
-internal fun uf2FirstTargetAddress(bytes: ByteArray): Long? {
-    if (bytes.size < UF2_BLOCK_BYTES) return null
-    if (readLittleEndianUInt32(bytes, 0) != UF2_MAGIC_START0.toLong()) return null
-    return readLittleEndianUInt32(bytes, UF2_TARGET_ADDR_OFFSET)
-}
-
-private fun readLittleEndianUInt32(bytes: ByteArray, offset: Int): Long {
-    var value = 0L
-    for (i in UINT32_BYTES - 1 downTo 0) {
-        value = (value shl BITS_PER_BYTE) or (bytes[offset + i].toLong() and BYTE_MASK)
-    }
-    return value
-}

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/Uf2Header.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/Uf2Header.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.firmware
+
+/*
+ * UF2 block-header readers used to cross-check a downloaded maintenance image against the manifest row that named it
+ * (see `FirmwareRetriever.retrieveMaintenanceUf2`). Kept apart from the manifest resolvers in `MaintenanceUf2.kt`,
+ * which they know nothing about: these only read bytes.
+ */
+
+/** UF2 block size, per the UF2 specification. */
+internal const val UF2_BLOCK_BYTES = 512
+
+/** Byte offset of `targetAddr` within a UF2 block header. */
+internal const val UF2_TARGET_ADDR_OFFSET = 12
+
+/** Byte offset of `flags` within a UF2 block header. */
+internal const val UF2_FLAGS_OFFSET = 8
+
+/** Byte offset of `fileSize`/`familyID` within a UF2 block header — the family ID when [UF2_FLAG_FAMILY_ID] is set. */
+internal const val UF2_FAMILY_ID_OFFSET = 28
+
+/** UF2 `flags` bit meaning "the word at offset 28 is a family ID, not a file size". */
+internal const val UF2_FLAG_FAMILY_ID = 0x2000L
+
+private const val UF2_MAGIC_START0 = 0x0A324655
+
+/** Bytes in a little-endian 32-bit field, and the mask/shift used to reassemble one. */
+private const val UINT32_BYTES = 4
+
+private const val BITS_PER_BYTE = 8
+
+private const val BYTE_MASK = 0xFFL
+
+/**
+ * Reads the target flash address of the first UF2 block in [bytes], or `null` when the payload is not a UF2 image.
+ *
+ * Used to cross-check a pinned erase image against the resolved SoftDevice variant before it is written.
+ */
+@Suppress("ReturnCount") // guard clauses over a binary header
+internal fun uf2FirstTargetAddress(bytes: ByteArray): Long? {
+    if (bytes.size < UF2_BLOCK_BYTES) return null
+    if (readLittleEndianUInt32(bytes, 0) != UF2_MAGIC_START0.toLong()) return null
+    return readLittleEndianUInt32(bytes, UF2_TARGET_ADDR_OFFSET)
+}
+
+/**
+ * Reads the UF2 family ID declared by the first block in [bytes], or `null` when the payload is not a UF2 image or its
+ * block declares no family (flag `0x2000` clear — offset 28 is then a file size, not an identity).
+ *
+ * The bootloader-driven erase image's integrity contract: paired with the digest, this proves the pinned row names the
+ * single-block command the bootloader recognises, where a first-target-address check would reject it (`targetAddr` is
+ * 0).
+ */
+@Suppress("ReturnCount") // guard clauses over a binary header
+internal fun uf2FamilyId(bytes: ByteArray): Long? {
+    if (bytes.size < UF2_BLOCK_BYTES) return null
+    if (readLittleEndianUInt32(bytes, 0) != UF2_MAGIC_START0.toLong()) return null
+    if (readLittleEndianUInt32(bytes, UF2_FLAGS_OFFSET) and UF2_FLAG_FAMILY_ID == 0L) return null
+    return readLittleEndianUInt32(bytes, UF2_FAMILY_ID_OFFSET)
+}
+
+private fun readLittleEndianUInt32(bytes: ByteArray, offset: Int): Long {
+    var value = 0L
+    for (i in UINT32_BYTES - 1 downTo 0) {
+        value = (value shl BITS_PER_BYTE) or (bytes[offset + i].toLong() and BYTE_MASK)
+    }
+    return value
+}

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/UsbMaintenance.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/UsbMaintenance.kt
@@ -53,8 +53,11 @@ enum class UsbFileSaveStep {
     ;
 
     /**
-     * True when writing this image destroys the device's application, making the *next* pass mandatory rather than
-     * optional. Drives back-navigation gating and the "no abort edge" retry behaviour.
+     * True when writing this image may leave the device without a usable application, making the *next* pass mandatory
+     * rather than optional. Drives back-navigation gating and the "no abort edge" retry behaviour.
+     *
+     * Deliberately conservative: a bootloader-driven factory erase leaves the application installed, but the user opted
+     * into erase-then-reinstall, and the sequence cannot know which erase path it will take until the drive is read.
      */
     val isDestructive: Boolean
         get() = this != Firmware
@@ -200,8 +203,15 @@ internal fun usbMaintenanceGate(
  * @property boardId The `Board-ID:` line — unique per board, and stable across bootloader vintages.
  * @property softDevice The installed SoftDevice, when the bootloader reports one. `null` on RP2040 (no SoftDevice
  *   exists) and on bootloaders predating the `uf2_init` that appends the line.
+ * @property factoryEraseFamily The UF2 family ID the bootloader will consume as a factory-erase command (its
+ *   `Factory-Erase:` line), when it advertises one. `null` on every bootloader shipped before OTAFIX PR #41 — those
+ *   silently ignore the file, so `null` means "use the SoftDevice-specific sketch", never "refuse".
  */
-internal data class MaintenanceVolume(val boardId: String, val softDevice: SoftDeviceVariant?)
+internal data class MaintenanceVolume(
+    val boardId: String,
+    val softDevice: SoftDeviceVariant?,
+    val factoryEraseFamily: Long? = null,
+)
 
 /** Outcome of vetting a user-picked volume before anything is written to it. */
 internal sealed interface VolumeInspection {
@@ -228,7 +238,13 @@ internal suspend fun inspectMaintenanceVolume(treeUri: CommonUri, fileHandler: F
             ?: return VolumeInspection.Rejected(UsbMaintenanceRefusal.NotABootloaderVolume)
     val boardId = parseUf2BoardId(info) ?: return VolumeInspection.Rejected(UsbMaintenanceRefusal.NotABootloaderVolume)
 
-    return VolumeInspection.Accepted(MaintenanceVolume(boardId = boardId, softDevice = parseUf2SoftDevice(info)))
+    return VolumeInspection.Accepted(
+        MaintenanceVolume(
+            boardId = boardId,
+            softDevice = parseUf2SoftDevice(info),
+            factoryEraseFamily = parseUf2FactoryEraseFamily(info),
+        ),
+    )
 }
 
 /** Which image to write, or why not. */
@@ -244,6 +260,10 @@ internal sealed interface MaintenanceImageChoice {
  * Total over both requests and every refusal, with no default image on any path. Called only after
  * [inspectMaintenanceVolume] accepts, and always before anything is written — so a refusal here costs the user a
  * message, never a half-flashed device.
+ *
+ * On nRF52 the bootloader-driven erase image wins whenever the volume advertises the family the manifest expects
+ * ([bootloaderEraseUf2For]): one board-agnostic file, no SoftDevice to reconcile, and the application survives. Any
+ * other volume takes the SoftDevice-specific sketch path exactly as before, refusals included.
  */
 internal fun chooseMaintenanceImage(
     manifest: MaintenanceUf2Manifest,
@@ -253,15 +273,18 @@ internal fun chooseMaintenanceImage(
 ): MaintenanceImageChoice = when (request) {
     UsbMaintenanceRequest.FactoryErase ->
         if (hardware.isNrf52Arc) {
-            when (val resolution = resolveNrfEraseImage(manifest, hardware.softDeviceVariant, volume.softDevice)) {
-                is EraseImageResolution.Resolved -> MaintenanceImageChoice.Resolved(resolution.asset)
+            bootloaderEraseUf2For(manifest, volume.factoryEraseFamily)?.let { MaintenanceImageChoice.Resolved(it) }
+                ?: when (
+                    val resolution = resolveNrfEraseImage(manifest, hardware.softDeviceVariant, volume.softDevice)
+                ) {
+                    is EraseImageResolution.Resolved -> MaintenanceImageChoice.Resolved(resolution.asset)
 
-                is EraseImageResolution.Conflict ->
-                    MaintenanceImageChoice.Refused(UsbMaintenanceRefusal.SoftDeviceConflict)
+                    is EraseImageResolution.Conflict ->
+                        MaintenanceImageChoice.Refused(UsbMaintenanceRefusal.SoftDeviceConflict)
 
-                EraseImageResolution.Unresolved ->
-                    MaintenanceImageChoice.Refused(UsbMaintenanceRefusal.UnknownSoftDevice)
-            }
+                    EraseImageResolution.Unresolved ->
+                        MaintenanceImageChoice.Refused(UsbMaintenanceRefusal.UnknownSoftDevice)
+                }
         } else {
             // RP2040: pico_erase is board-agnostic and there is no SoftDevice to reconcile, so an unresolved image
             // means the manifest lacks usable data rather than the architecture lacking a UF2 erase path.

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/UsbUpdateSupport.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/UsbUpdateSupport.kt
@@ -49,16 +49,15 @@ private const val PERCENT_MAX = 100
 internal sealed interface UsbFileSavePass {
     val step: UsbFileSaveStep
 
-    /** Image identity is decided from the mounted volume; nothing has been downloaded yet. */
-    data class FromVolume(
-        override val step: UsbFileSaveStep,
-        val request: UsbMaintenanceRequest,
-        /**
-         * True for the nRF factory-erase image, which blocks on `while (!Serial)` before formatting and needs a host to
-         * assert DTR before it will run.
-         */
-        val requiresCdcUnblock: Boolean,
-    ) : UsbFileSavePass
+    /**
+     * Image identity is decided from the mounted volume; nothing has been downloaded yet.
+     *
+     * Whether the written image then needs a CDC unblock is decided with the image
+     * ([MaintenanceUf2.requiresCdcUnblock]) rather than here: the same erase request resolves to the SoftDevice sketch
+     * (which blocks on `while (!Serial)`) or to the bootloader-driven erase image (which must *not* have its port
+     * opened) depending on what the drive reports.
+     */
+    data class FromVolume(override val step: UsbFileSaveStep, val request: UsbMaintenanceRequest) : UsbFileSavePass
 
     /** Already downloaded and verified. */
     data class Prepared(override val step: UsbFileSaveStep, val artifact: FirmwareArtifact, val fileName: String) :
@@ -134,13 +133,7 @@ internal suspend fun performUsbMaintenance(
 
     val passes =
         listOf(
-            UsbFileSavePass.FromVolume(
-                step = maintenanceStep,
-                request = request,
-                // Only the nRF erase image blocks waiting for a CDC host; pico_erase runs on its own, and a bootloader
-                // self-update is consumed by the bootloader itself.
-                requiresCdcUnblock = request == UsbMaintenanceRequest.FactoryErase && hardware.isNrf52Arc,
-            ),
+            UsbFileSavePass.FromVolume(step = maintenanceStep, request = request),
             UsbFileSavePass.Prepared(
                 step = UsbFileSaveStep.Firmware,
                 artifact = firmware,
@@ -212,11 +205,12 @@ internal class UsbPassWriter(
                 is VolumeInspection.Accepted -> inspection.volume
             }
 
-        val artifact =
-            when (val resolved = resolveImage(pass, hardware, volume, updateState)) {
-                is ImageResolution.Failed -> return resolved.result
-                is ImageResolution.Ready -> resolved.artifact
+        val resolved =
+            when (val resolution = resolveImage(pass, hardware, volume, updateState)) {
+                is ImageResolution.Failed -> return resolution.result
+                is ImageResolution.Ready -> resolution
             }
+        val artifact = resolved.artifact
 
         val fileName = artifact.fileName ?: return UsbPassResult.CopyFailed
         updateState(FirmwareUpdateState.Processing(ProgressState(UiText.Resource(Res.string.firmware_update_copying))))
@@ -248,9 +242,12 @@ internal class UsbPassWriter(
             }
         }
 
-        if (pass is UsbFileSavePass.FromVolume && pass.requiresCdcUnblock) {
+        // Only the SoftDevice erase sketch waits for a host. The bootloader-driven erase image, pico_erase and OTAFIX
+        // self-updates are consumed by the bootloader itself, and the only CDC port after those is the bootloader's
+        // own — opening it would latch onto the wrong port and stall for nothing.
+        if (resolved.requiresCdcUnblock) {
             if (!unblockCdc(CDC_UNBLOCK_WAIT_MS, CDC_DTR_HOLD_MS)) {
-                // The erase image blocks before InternalFS.format(), so a failed unblock has destroyed nothing.
+                // The erase sketch blocks before InternalFS.format(), so a failed unblock has destroyed nothing.
                 return UsbPassResult.CdcUnblockFailed
             }
         }
@@ -260,7 +257,8 @@ internal class UsbPassWriter(
 
     /** Either the image to write, or the result to return instead. */
     private sealed interface ImageResolution {
-        data class Ready(val artifact: FirmwareArtifact) : ImageResolution
+        /** @property requiresCdcUnblock Carried from [MaintenanceUf2.requiresCdcUnblock]; always false for firmware. */
+        data class Ready(val artifact: FirmwareArtifact, val requiresCdcUnblock: Boolean = false) : ImageResolution
 
         data class Failed(val result: UsbPassResult) : ImageResolution
     }
@@ -298,8 +296,9 @@ internal class UsbPassWriter(
                                 ),
                             )
                         }
-                    artifact?.let { ImageResolution.Ready(it) }
-                        ?: ImageResolution.Failed(UsbPassResult.ImageDownloadFailed)
+                    artifact?.let {
+                        ImageResolution.Ready(it, requiresCdcUnblock = choice.asset.requiresCdcUnblock)
+                    } ?: ImageResolution.Failed(UsbPassResult.ImageDownloadFailed)
                 }
             }
     }

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonFirmwareRetrieverTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonFirmwareRetrieverTest.kt
@@ -532,6 +532,112 @@ abstract class CommonFirmwareRetrieverTest {
         assertNotNull(retriever.retrieveMaintenanceUf2(asset) {}, "No expected address means no address check")
     }
 
+    // ── Bootloader-driven erase image (family-ID contract) ───────────────────
+
+    /** The family OTAFIX consumes as a factory-erase command: 0x4D455348, "MESH". */
+    private val meshFamily = 0x4D455348L
+
+    /**
+     * Rebuilds `tools/meshtastic_factory_erase.uf2` byte for byte from its published header: one 512-byte block,
+     * family-ID flag set, targetAddr 0, 256 zero payload bytes. Parameterised only where a test needs a wrong value.
+     */
+    private fun factoryEraseBlock(flags: Long = UF2_FLAG_FAMILY_ID, familyId: Long = meshFamily): ByteArray {
+        val block = ByteArray(UF2_BLOCK_BYTES)
+        fun putLe32(offset: Int, value: Long) {
+            for (i in 0 until 4) {
+                block[offset + i] = ((value shr (8 * i)) and 0xFF).toByte()
+            }
+        }
+        putLe32(0, 0x0A324655L) // magicStart0
+        putLe32(4, 0x9E5D5157L) // magicStart1
+        putLe32(UF2_FLAGS_OFFSET, flags)
+        putLe32(UF2_TARGET_ADDR_OFFSET, 0L)
+        putLe32(16, 256L) // payloadSize
+        putLe32(20, 0L) // blockNo
+        putLe32(24, 1L) // numBlocks
+        putLe32(UF2_FAMILY_ID_OFFSET, familyId)
+        putLe32(508, 0x0AB16F30L) // magicEnd
+        return block
+    }
+
+    private fun bootloaderEraseAsset(payload: ByteArray, expectedFamily: Long?) = MaintenanceUf2(
+        url = "https://example.com/uf2/meshtastic_factory_erase.uf2",
+        fileName = "meshtastic_factory_erase.uf2",
+        sha256 = FirmwareHashUtil.bytesToHex(FirmwareHashUtil.calculateSha256Bytes(payload)),
+        expectedFamilyId = expectedFamily,
+    )
+
+    @Test
+    fun `the bootloader erase image rebuilt from its contract matches the shipped digest and family`() {
+        // Pins the reader to the bytes that actually ship (OTAFIX c8ccd1d7 tools/meshtastic_factory_erase.uf2), not
+        // just to a synthetic block: the digest is the manifest's, so a header drift here would show up as a mismatch.
+        val block = factoryEraseBlock()
+
+        assertEquals(
+            "6ef3146505c40079ee9e7e692448e40a793dad636f55d1545063299d28908f0d",
+            FirmwareHashUtil.bytesToHex(FirmwareHashUtil.calculateSha256Bytes(block)),
+        )
+        assertEquals(meshFamily, uf2FamilyId(block))
+        assertEquals(0L, uf2FirstTargetAddress(block), "targetAddr is 0 — the address check would reject this file")
+    }
+
+    @Test
+    fun `bootloader erase image with matching digest and family id is returned`() = runTest {
+        val handler = FakeFirmwareFileHandler()
+        val retriever = FirmwareRetriever(handler)
+        val payload = factoryEraseBlock()
+        val asset = bootloaderEraseAsset(payload, expectedFamily = meshFamily)
+        handler.existingUrls.add(asset.url)
+        handler.fileBytes[asset.fileName] = payload
+
+        val result = retriever.retrieveMaintenanceUf2(asset) {}
+
+        assertNotNull(result, "A verified bootloader erase image should be returned")
+        assertTrue(handler.deletedFiles.isEmpty(), "A verified image must not be deleted")
+    }
+
+    @Test
+    fun `bootloader erase image with the wrong family id is rejected even when the digest matches`() = runTest {
+        // A row pointing at some other single-block UF2: intact, digest-correct, and not the command the bootloader
+        // recognises. It would be written and then silently ignored by the device.
+        val handler = FakeFirmwareFileHandler()
+        val retriever = FirmwareRetriever(handler)
+        val payload = factoryEraseBlock(familyId = 0xADA52840L)
+        val asset = bootloaderEraseAsset(payload, expectedFamily = meshFamily)
+        handler.existingUrls.add(asset.url)
+        handler.fileBytes[asset.fileName] = payload
+
+        val result = retriever.retrieveMaintenanceUf2(asset) {}
+
+        assertNull(result, "A family-ID mismatch must not yield an artifact")
+        assertEquals(1, handler.deletedFiles.size, "The rejected download must be deleted")
+    }
+
+    @Test
+    fun `bootloader erase image without the family flag is rejected when a family is expected`() = runTest {
+        val handler = FakeFirmwareFileHandler()
+        val retriever = FirmwareRetriever(handler)
+        val payload = factoryEraseBlock(flags = 0L)
+        val asset = bootloaderEraseAsset(payload, expectedFamily = meshFamily)
+        handler.existingUrls.add(asset.url)
+        handler.fileBytes[asset.fileName] = payload
+
+        assertNull(retriever.retrieveMaintenanceUf2(asset) {}, "Offset 28 is a file size without the flag")
+        assertEquals(1, handler.deletedFiles.size)
+    }
+
+    @Test
+    fun `bootloader erase image skips the family check when the asset declares no expected family`() = runTest {
+        val handler = FakeFirmwareFileHandler()
+        val retriever = FirmwareRetriever(handler)
+        val payload = factoryEraseBlock(familyId = 0xADA52840L)
+        val asset = bootloaderEraseAsset(payload, expectedFamily = null)
+        handler.existingUrls.add(asset.url)
+        handler.fileBytes[asset.fileName] = payload
+
+        assertNotNull(retriever.retrieveMaintenanceUf2(asset) {}, "No expected family means no family check")
+    }
+
     // -----------------------------------------------------------------------
     // Test infrastructure
     // -----------------------------------------------------------------------

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonMaintenanceVolumeTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonMaintenanceVolumeTest.kt
@@ -57,6 +57,11 @@ abstract class CommonMaintenanceVolumeTest {
                         "expectedFirstTargetAddress": 159744
                       }
                     },
+                    "nrf52Bootloader": {
+                      "fileName": "meshtastic_factory_erase.uf2",
+                      "sha256": "6ef3146505c40079ee9e7e692448e40a793dad636f55d1545063299d28908f0d",
+                      "expectedFamilyId": 1296388936
+                    },
                     "rp2040": {
                       "fileName": "pico_erase.uf2",
                       "sha256": "08aa7d561e8b8bf2f9b061b3506fb4d8f135e832efe0f3ae978241db2da0c853"
@@ -157,6 +162,12 @@ abstract class CommonMaintenanceVolumeTest {
 
     /** RP2040 BOOTSEL volumes expose an INFO_UF2.TXT too, with no SoftDevice line. */
     private val picoInfo = "UF2 Bootloader v3.0\r\nModel: Raspberry Pi RP2\r\nBoard-ID: RPI-RP2\r\n"
+
+    /** The family OTAFIX (PR #41 onwards) advertises and consumes as a factory-erase command. */
+    private val meshFamily = 0x4D455348L
+
+    /** [rakInfo] as an OTAFIX bootloader with bootloader-driven erase emits it — the SoftDevice line is still there. */
+    private val rakOtafixEraseInfo = rakInfo + "Factory-Erase: UF2 family 0x4D455348\r\n"
 
     private class FakeVolume(private val removable: Boolean = true, private val info: String? = null) :
         NoopFirmwareFileHandler() {
@@ -316,5 +327,122 @@ abstract class CommonMaintenanceVolumeTest {
             )
 
         assertEquals(UsbMaintenanceRefusal.UnknownBoardId, assertIs<MaintenanceImageChoice.Refused>(choice).reason)
+    }
+
+    // ── Bootloader-driven factory erase ──────────────────────────────────────
+
+    @Test
+    fun `a volume advertising a factory erase family reports it alongside its softdevice`() = runTest {
+        val accepted =
+            assertIs<VolumeInspection.Accepted>(
+                inspectMaintenanceVolume(treeUri, FakeVolume(info = rakOtafixEraseInfo)),
+            )
+
+        assertEquals(meshFamily, accepted.volume.factoryEraseFamily)
+        assertEquals(SoftDeviceVariant.S140_6_1_1, accepted.volume.softDevice, "The SoftDevice line is still read")
+    }
+
+    @Test
+    fun `a volume without the factory erase line reports no family`() = runTest {
+        val accepted =
+            assertIs<VolumeInspection.Accepted>(inspectMaintenanceVolume(treeUri, FakeVolume(info = rakInfo)))
+
+        assertEquals(null, accepted.volume.factoryEraseFamily)
+    }
+
+    @Test
+    fun `erase prefers the bootloader image when the volume advertises the manifest family`() {
+        val choice =
+            chooseMaintenanceImage(
+                testManifest,
+                UsbMaintenanceRequest.FactoryErase,
+                nrf(SoftDeviceVariant.S140_6_1_1),
+                MaintenanceVolume("WisBlock-RAK4631-Board", SoftDeviceVariant.S140_6_1_1, meshFamily),
+            )
+
+        val asset = assertIs<MaintenanceImageChoice.Resolved>(choice).asset
+        assertEquals("meshtastic_factory_erase.uf2", asset.fileName)
+        assertEquals(false, asset.requiresCdcUnblock, "The bootloader consumes the block; do not open its CDC port")
+    }
+
+    @Test
+    fun `erase uses the bootloader image even when no softdevice can be resolved`() {
+        // The bootloader knows its own flash layout, so there is no SoftDevice choice to get wrong.
+        val choice =
+            chooseMaintenanceImage(
+                testManifest,
+                UsbMaintenanceRequest.FactoryErase,
+                nrf(variant = null),
+                MaintenanceVolume("SomeBoard", softDevice = null, factoryEraseFamily = meshFamily),
+            )
+
+        assertEquals("meshtastic_factory_erase.uf2", assertIs<MaintenanceImageChoice.Resolved>(choice).asset.fileName)
+    }
+
+    @Test
+    fun `erase uses the bootloader image over a softdevice conflict`() {
+        // The conflict refusal exists to protect the SoftDevice from the wrong sketch; the bootloader image touches
+        // neither SoftDevice nor application, so the disagreement is moot on this path.
+        val choice =
+            chooseMaintenanceImage(
+                testManifest,
+                UsbMaintenanceRequest.FactoryErase,
+                nrf(SoftDeviceVariant.S140_6_1_1),
+                MaintenanceVolume("WisBlock-RAK4631-Board", SoftDeviceVariant.S140_7_3_0, meshFamily),
+            )
+
+        assertEquals("meshtastic_factory_erase.uf2", assertIs<MaintenanceImageChoice.Resolved>(choice).asset.fileName)
+    }
+
+    @Test
+    fun `erase falls back to the softdevice sketch when the volume advertises a different family`() {
+        val choice =
+            chooseMaintenanceImage(
+                testManifest,
+                UsbMaintenanceRequest.FactoryErase,
+                nrf(SoftDeviceVariant.S140_6_1_1),
+                MaintenanceVolume("WisBlock-RAK4631-Board", SoftDeviceVariant.S140_6_1_1, 0xDEADBEEFL),
+            )
+
+        val asset = assertIs<MaintenanceImageChoice.Resolved>(choice).asset
+        assertEquals("nrf_erase2.uf2", asset.fileName)
+        assertTrue(asset.requiresCdcUnblock, "The sketch still waits for a host")
+    }
+
+    @Test
+    fun `erase falls back to every existing refusal when the volume advertises no family`() {
+        val conflict =
+            chooseMaintenanceImage(
+                testManifest,
+                UsbMaintenanceRequest.FactoryErase,
+                nrf(SoftDeviceVariant.S140_6_1_1),
+                MaintenanceVolume("WisBlock-RAK4631-Board", SoftDeviceVariant.S140_7_3_0, factoryEraseFamily = null),
+            )
+        assertEquals(
+            UsbMaintenanceRefusal.SoftDeviceConflict,
+            assertIs<MaintenanceImageChoice.Refused>(conflict).reason,
+        )
+
+        val unknown =
+            chooseMaintenanceImage(
+                testManifest,
+                UsbMaintenanceRequest.FactoryErase,
+                nrf(variant = null),
+                MaintenanceVolume("SomeBoard", softDevice = null, factoryEraseFamily = null),
+            )
+        assertEquals(UsbMaintenanceRefusal.UnknownSoftDevice, assertIs<MaintenanceImageChoice.Refused>(unknown).reason)
+    }
+
+    @Test
+    fun `erase on rp2040 ignores a factory erase family`() {
+        val choice =
+            chooseMaintenanceImage(
+                testManifest,
+                UsbMaintenanceRequest.FactoryErase,
+                rp2040(),
+                MaintenanceVolume("RPI-RP2", softDevice = null, factoryEraseFamily = meshFamily),
+            )
+
+        assertEquals("pico_erase.uf2", assertIs<MaintenanceImageChoice.Resolved>(choice).asset.fileName)
     }
 }

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonUsbPassWriterTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonUsbPassWriterTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.firmware
+
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.meshtastic.core.common.util.CommonUri
+import org.meshtastic.core.model.DeviceHardware
+import org.meshtastic.core.model.MaintenanceUf2Manifest
+import org.meshtastic.core.model.SoftDeviceVariant
+import org.meshtastic.core.repository.MaintenanceUf2Repository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the one decision [UsbPassWriter] makes after the image is chosen: whether to open a CDC port and assert DTR.
+ *
+ * That decision used to be fixed before the drive was read ("nRF52 factory erase ⇒ unblock"). It now follows the
+ * resolved image, because the same request writes the SoftDevice erase sketch (which waits for a host) on one
+ * bootloader and the bootloader-driven erase block (after which the only port is the bootloader's own) on another.
+ *
+ * Abstract because it builds [CommonUri]; the concrete `jvmTest` subclass supplies the runner.
+ */
+abstract class CommonUsbPassWriterTest {
+
+    private val manifest =
+        Json { ignoreUnknownKeys = true }
+            .decodeFromString<MaintenanceUf2Manifest>(
+                """
+                {
+                  "manifestVersion": 1,
+                  "otafixReleaseTag": "0.9.2-OTAFIX2.3-BP1.5",
+                  "otafixBase": "https://example.invalid/otafix",
+                  "erase": {
+                    "nrf52": {
+                      "6.1.1": { "fileName": "nrf_erase2.uf2", "sha256": "00", "expectedFirstTargetAddress": 155648 }
+                    },
+                    "nrf52Bootloader": {
+                      "fileName": "meshtastic_factory_erase.uf2",
+                      "sha256": "00",
+                      "expectedFamilyId": 1296388936
+                    },
+                    "rp2040": { "fileName": "pico_erase.uf2", "sha256": "00" }
+                  },
+                  "otafixByBoardId": {
+                    "WisBlock-RAK4631-Board": { "otafixBoardSlug": "wiscore_rak4631_board", "sha256": "00" }
+                  },
+                  "otafixSupportedTargets": ["rak4631"]
+                }
+                """
+                    .trimIndent(),
+            )
+
+    private val treeUri = CommonUri.parse("content://com.android.externalstorage.documents/tree/1234-5678%3A")
+
+    private val rak =
+        DeviceHardware(
+            hwModelSlug = "RAK4631",
+            platformioTarget = "rak4631",
+            architecture = "nrf52840",
+            softDeviceVariant = SoftDeviceVariant.S140_6_1_1,
+        )
+
+    private val sketchInfo = "UF2 Bootloader 0.4.3\r\nBoard-ID: WisBlock-RAK4631-Board\r\nSoftDevice: S140 6.1.1\r\n"
+
+    private val bootloaderEraseInfo = sketchInfo + "Factory-Erase: UF2 family 0x4D455348\r\n"
+
+    /** A volume that accepts every write: the copy lands and the device detaches, so only the CDC decision varies. */
+    private class WritableVolume(private val info: String) : NoopFirmwareFileHandler() {
+        override suspend fun isRemovableDestination(destinationUri: CommonUri): Boolean = true
+
+        override suspend fun readSiblingText(treeUri: CommonUri, fileName: String): String? = info
+
+        override suspend fun createDocumentInTree(treeUri: CommonUri, fileName: String, mimeType: String): CommonUri =
+            CommonUri.parse("content://com.android.externalstorage.documents/document/1234-5678%3A$fileName")
+
+        override suspend fun copyToUri(source: FirmwareArtifact, destinationUri: CommonUri): Long =
+            UF2_BLOCK_BYTES.toLong()
+    }
+
+    private class FixedManifest(private val manifest: MaintenanceUf2Manifest) : MaintenanceUf2Repository {
+        override suspend fun getSnapshot(): MaintenanceUf2Manifest = manifest
+
+        override suspend fun reconcile() = Unit
+    }
+
+    private inner class Harness(info: String) {
+        val unblockCalls = mutableListOf<Pair<Long, Long>>()
+        var unblockResult = true
+        val written = mutableListOf<String>()
+
+        val writer =
+            UsbPassWriter(
+                fileHandler = WritableVolume(info),
+                maintenanceUf2Repository = FixedManifest(manifest),
+                retrieveMaintenanceUf2 = { asset, _ ->
+                    written += asset.fileName
+                    FirmwareArtifact(uri = CommonUri.parse("file:///tmp/${asset.fileName}"), fileName = asset.fileName)
+                },
+                awaitDeviceDetach = { true },
+                unblockCdc = { wait, hold ->
+                    unblockCalls += wait to hold
+                    unblockResult
+                },
+            )
+    }
+
+    private fun harness(info: String) = Harness(info)
+
+    private val erasePass = UsbFileSavePass.FromVolume(UsbFileSaveStep.FactoryErase, UsbMaintenanceRequest.FactoryErase)
+
+    @Test
+    fun `the softdevice erase sketch is unblocked over cdc after it is written`() = runTest {
+        val h = harness(sketchInfo)
+
+        val result = h.writer.write(erasePass, treeUri, rak) {}
+
+        assertEquals(UsbPassResult.Written, result)
+        assertEquals(listOf("nrf_erase2.uf2"), h.written)
+        assertEquals(1, h.unblockCalls.size, "The sketch blocks on while(!Serial) until DTR is asserted")
+    }
+
+    @Test
+    fun `the bootloader erase image never has its cdc port opened`() = runTest {
+        // After the bootloader consumes the block the only CDC port present is the bootloader's own; opening it would
+        // latch onto the wrong port and hold the flow for the whole unblock timeout for nothing.
+        val h = harness(bootloaderEraseInfo)
+
+        val result = h.writer.write(erasePass, treeUri, rak) {}
+
+        assertEquals(UsbPassResult.Written, result)
+        assertEquals(listOf("meshtastic_factory_erase.uf2"), h.written)
+        assertTrue(h.unblockCalls.isEmpty(), "No CDC unblock after the bootloader-driven erase image")
+    }
+
+    @Test
+    fun `a failed cdc unblock is only reported for the sketch`() = runTest {
+        val sketch = harness(sketchInfo).apply { unblockResult = false }
+        assertEquals(UsbPassResult.CdcUnblockFailed, sketch.writer.write(erasePass, treeUri, rak) {})
+
+        val bootloader = harness(bootloaderEraseInfo).apply { unblockResult = false }
+        assertEquals(UsbPassResult.Written, bootloader.writer.write(erasePass, treeUri, rak) {})
+        assertTrue(bootloader.unblockCalls.isEmpty())
+    }
+
+    @Test
+    fun `a bootloader self-update never has its cdc port opened`() = runTest {
+        val h = harness(sketchInfo)
+        val pass =
+            UsbFileSavePass.FromVolume(UsbFileSaveStep.BootloaderUpgrade, UsbMaintenanceRequest.BootloaderUpgrade)
+
+        assertEquals(UsbPassResult.Written, h.writer.write(pass, treeUri, rak) {})
+        assertTrue(h.unblockCalls.isEmpty())
+    }
+}

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/UsbMaintenanceGateTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/UsbMaintenanceGateTest.kt
@@ -65,6 +65,11 @@ class UsbMaintenanceGateTest {
                         "expectedFirstTargetAddress": 159744
                       }
                     },
+                    "nrf52Bootloader": {
+                      "fileName": "meshtastic_factory_erase.uf2",
+                      "sha256": "6ef3146505c40079ee9e7e692448e40a793dad636f55d1545063299d28908f0d",
+                      "expectedFamilyId": 1296388936
+                    },
                     "rp2040": {
                       "fileName": "pico_erase.uf2",
                       "sha256": "08aa7d561e8b8bf2f9b061b3506fb4d8f135e832efe0f3ae978241db2da0c853"
@@ -720,5 +725,147 @@ class UsbMaintenanceGateTest {
     fun `non-uf2 payloads yield no target address`() {
         assertNull(uf2FirstTargetAddress(ByteArray(UF2_BLOCK_BYTES)), "Zeroed bytes carry no UF2 magic")
         assertNull(uf2FirstTargetAddress(ByteArray(16)), "A short payload cannot hold a UF2 block")
+    }
+
+    // ── Bootloader-driven factory erase (OTAFIX PR #41) ──────────────────────
+
+    /** The family OTAFIX advertises and consumes: 0x4D455348, "MESH" little-endian. */
+    private val meshFamily = 0x4D455348L
+
+    private val rakOtafixEraseInfo =
+        "UF2 Bootloader 0.9.2-OTAFIX2.3-BP1.6\r\nModel: WisBlock RAK4631 Board\r\n" +
+            "Board-ID: WisBlock-RAK4631-Board\r\nDate: Sep  6 2026\r\nSoftDevice: S140 7.3.0\r\n" +
+            "Factory-Erase: UF2 family 0x4D455348\r\n"
+
+    @Test
+    fun `the manifest decodes the bootloader erase entry with its family id`() {
+        val entry = assertNotNull(testManifest.erase?.nrf52Bootloader, "the shipped manifest carries the entry")
+
+        assertEquals("meshtastic_factory_erase.uf2", entry.fileName)
+        assertEquals(meshFamily, entry.expectedFamilyId, "1296388936 decimal in the manifest is 0x4D455348")
+        assertNull(entry.expectedFirstTargetAddress, "targetAddr is 0 by design; no address invariant is authored")
+    }
+
+    @Test
+    fun `factory erase family is parsed from the bootloader's own line`() {
+        assertEquals(meshFamily, parseUf2FactoryEraseFamily(rakOtafixEraseInfo))
+        assertEquals(meshFamily, parseUf2FactoryEraseFamily("Factory-Erase: UF2 family 0x4D455348"), "no CRLF")
+    }
+
+    @Test
+    fun `factory erase family parsing tolerates case and leading whitespace like its siblings`() {
+        assertEquals(meshFamily, parseUf2FactoryEraseFamily("  factory-erase: uf2 family 0X4d455348\r\n"))
+    }
+
+    @Test
+    fun `factory erase family takes the last hex token on the line`() {
+        assertEquals(0xDEADBEEFL, parseUf2FactoryEraseFamily("Factory-Erase: UF2 family 0x1234 0xDEADBEEF\r\n"))
+    }
+
+    @Test
+    fun `a different factory erase family still parses so the resolver can refuse it`() {
+        assertEquals(0xDEADBEEFL, parseUf2FactoryEraseFamily("Factory-Erase: UF2 family 0xDEADBEEF\r\n"))
+    }
+
+    @Test
+    fun `an absent or malformed factory erase line yields no family`() {
+        assertNull(parseUf2FactoryEraseFamily(rak4631OtafixInfo), "Every bootloader before PR #41 omits the line")
+        assertNull(parseUf2FactoryEraseFamily("Factory-Erase: UF2 family\r\n"), "No token at all")
+        assertNull(parseUf2FactoryEraseFamily("Factory-Erase: UF2 family 4D455348\r\n"), "Not 0x-prefixed")
+        assertNull(parseUf2FactoryEraseFamily("Factory-Erase: UF2 family 0xZZZZ\r\n"), "Not hex")
+        assertNull(parseUf2FactoryEraseFamily("Factory-Erase: 0x\r\n"), "Prefix with nothing after it")
+        assertNull(parseUf2FactoryEraseFamily(""), "Empty payload")
+    }
+
+    @Test
+    fun `bootloader erase image resolves when the volume advertises the manifest family`() {
+        val asset = assertNotNull(bootloaderEraseUf2For(testManifest, meshFamily))
+
+        assertEquals("meshtastic_factory_erase.uf2", asset.fileName)
+        assertEquals(meshFamily, asset.expectedFamilyId)
+        assertNull(asset.expectedFirstTargetAddress, "The address check would reject a targetAddr of 0")
+        assertFalse(asset.requiresCdcUnblock, "The bootloader consumes the block itself; there is no sketch to unblock")
+        assertTrue(asset.url.endsWith("resource/maintenanceUf2/asset/meshtastic_factory_erase.uf2"))
+    }
+
+    @Test
+    fun `bootloader erase image refuses a volume advertising another family or none`() {
+        assertNull(bootloaderEraseUf2For(testManifest, 0xDEADBEEFL), "Wrong family must fall through to the sketch")
+        assertNull(bootloaderEraseUf2For(testManifest, null), "No line means the bootloader ignores the file")
+    }
+
+    @Test
+    fun `bootloader erase image refuses when the manifest cannot vouch for a family`() {
+        val withoutEntry = testManifest.copy(erase = testManifest.erase?.copy(nrf52Bootloader = null))
+        assertNull(bootloaderEraseUf2For(withoutEntry, meshFamily), "Older manifests carry no entry")
+
+        val unverifiable =
+            testManifest.copy(
+                erase =
+                testManifest.erase?.copy(
+                    nrf52Bootloader = testManifest.erase?.nrf52Bootloader?.copy(expectedFamilyId = null),
+                ),
+            )
+        assertNull(bootloaderEraseUf2For(unverifiable, meshFamily), "No expected family means no byte-level check")
+        assertNull(bootloaderEraseUf2For(MaintenanceUf2Manifest(), meshFamily), "No erase set at all")
+    }
+
+    @Test
+    fun `an unsafe bootloader erase filename refuses the image instead of throwing`() {
+        val unsafe =
+            testManifest.copy(
+                erase =
+                testManifest.erase?.copy(
+                    nrf52Bootloader = testManifest.erase?.nrf52Bootloader?.copy(fileName = "../erase.uf2"),
+                ),
+            )
+
+        assertNull(bootloaderEraseUf2For(unsafe, meshFamily))
+    }
+
+    @Test
+    fun `only the softdevice erase sketches need a cdc unblock`() {
+        assertTrue(assertNotNull(eraseUf2For(testManifest, nrf())).requiresCdcUnblock)
+        assertTrue(assertNotNull(eraseUf2ForVariant(testManifest, SoftDeviceVariant.S140_7_3_0)).requiresCdcUnblock)
+        assertFalse(assertNotNull(eraseUf2For(testManifest, rp2040())).requiresCdcUnblock, "pico_erase runs on its own")
+        assertFalse(
+            assertNotNull(otafixUf2ForBoardId(testManifest, "WisBlock-RAK4631-Board")).requiresCdcUnblock,
+            "A bootloader self-update is consumed by the bootloader",
+        )
+    }
+
+    // ── UF2 family ID header parsing ─────────────────────────────────────────
+
+    private fun uf2Block(flags: Long, familyId: Long): ByteArray {
+        val block = ByteArray(UF2_BLOCK_BYTES)
+        fun putLe32(offset: Int, value: Long) {
+            for (i in 0 until 4) block[offset + i] = ((value shr (8 * i)) and 0xFF).toByte()
+        }
+        putLe32(0, 0x0A324655L)
+        putLe32(UF2_FLAGS_OFFSET, flags)
+        putLe32(UF2_FAMILY_ID_OFFSET, familyId)
+        return block
+    }
+
+    @Test
+    fun `uf2 family id is read from the first block when the family flag is set`() {
+        assertEquals(meshFamily, uf2FamilyId(uf2Block(flags = UF2_FLAG_FAMILY_ID, familyId = meshFamily)))
+        assertEquals(
+            meshFamily,
+            uf2FamilyId(uf2Block(flags = UF2_FLAG_FAMILY_ID or 0x1L, familyId = meshFamily)),
+            "Other flag bits do not matter",
+        )
+    }
+
+    @Test
+    fun `uf2 family id is absent when the family flag is clear`() {
+        // Without 0x2000 the word at offset 28 is a file size, and reading it as an identity would be a false match.
+        assertNull(uf2FamilyId(uf2Block(flags = 0L, familyId = meshFamily)))
+    }
+
+    @Test
+    fun `non-uf2 payloads yield no family id`() {
+        assertNull(uf2FamilyId(ByteArray(UF2_BLOCK_BYTES)), "Zeroed bytes carry no UF2 magic")
+        assertNull(uf2FamilyId(ByteArray(32)), "A short payload cannot hold a UF2 block")
     }
 }

--- a/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/UsbPassWriterTest.kt
+++ b/feature/firmware/src/jvmTest/kotlin/org/meshtastic/feature/firmware/UsbPassWriterTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.firmware
+
+/**
+ * JVM runner for [CommonUsbPassWriterTest].
+ *
+ * The base class is abstract because it builds `CommonUri`. Without a concrete subclass it would contribute zero tests
+ * silently — see [MaintenanceVolumeTest].
+ */
+class UsbPassWriterTest : CommonUsbPassWriterTest()


### PR DESCRIPTION
Consumer side of meshtastic/Adafruit_nRF52_Bootloader_OTAFIX#41 (merged, not in a release yet). Draft until the api PR (meshtastic/api, "Serve the OTAFIX bootloader factory-erase image") is deployed.

## What changed

- `MaintenanceVolume` gains `factoryEraseFamily`, parsed from a new `Factory-Erase:` line in `INFO_UF2.TXT` (same prefix tolerance as `Board-ID:` / `SoftDevice:`). `chooseMaintenanceImage` prefers the manifest's new `erase.nrf52Bootloader` image when the advertised family matches `expectedFamilyId`; otherwise the SoftDevice-specific path is exactly what it was, Conflict and Unresolved included.
- `FirmwareRetriever` checks the UF2 family ID (offset 28, flag `0x2000`) for that image instead of the first-target-address, which is 0 for it. Mismatch deletes the download and refuses, like the address case.
- `requiresCdcUnblock` is no longer fixed pre-flight; it follows the resolved image. The bootloader image must not open the CDC port - that is the bootloader's own port now, not the old sketch's `while(!Serial)`.
- Manifest model: `EraseImageEntry.expectedFamilyId`, `MaintenanceUf2EraseSet.nrf52Bootloader` (nullable, `ignoreUnknownKeys` everywhere). Seed asset and both verbatim test manifests carry the entry. `scheduled-updates.yml`'s guard now also requires `.erase.nrf52Bootloader`, so the seed cannot be overwritten by a production manifest that lacks it.
- `uf2FirstTargetAddress` moved unchanged into `Uf2Header.kt` beside the new `uf2FamilyId` (detekt TooManyFunctions).
- Docs: `docs/en/user/firmware.md` (both nRF52 paths), `feature/firmware/README.md` §4 and diagram.

## What the user sees

On a supporting bootloader: erase during update writes one 512-byte file, the drive detaches about half a second later and returns in UF2 mode, the second pass writes firmware as before. The installed firmware stays and boots factory-fresh if they unplug instead. On any other bootloader nothing changes.

## Merge order

api must be deployed first. Until then the scheduled seed refresh skips with a warning (by design) and the bundled seed keeps the entry.

## Verified

- `spotlessApply spotlessCheck detekt` clean; `:feature:firmware:allTests`, `:core:model:allTests`, `:core:data:allTests`, `:androidApp:testFdroidDebugUnitTest --tests "*SoftDeviceQuirkCoverageTest*"`, `kmpSmokeCompile` pass. New tests: parser, header reader, resolver, `UsbPassWriter` CDC decision, retriever family check, repository round-trip; the shipped file is rebuilt byte-for-byte in a test and asserted against the manifest sha256.
- Doc checks (`validate-doc-links`, `check-doc-coverage`, `check-doc-aliases`) pass.
- Not run on a phone: no bench radio with a phone attached today. The OTAFIX side was verified on a RAK4631 in #41.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - USB maintenance now prefers bootloader-driven factory erase on compatible nRF52 devices.
  - Automatically detects the device’s advertised erase family and selects the appropriate image.
  - Validates erase images against their expected family ID before installation.
  - Retains the existing SoftDevice erase path as a fallback when needed.

- **Bug Fixes**
  - Prevents incompatible or incomplete maintenance manifests and UF2 images from being accepted.

- **Documentation**
  - Updated firmware and USB maintenance guidance with the new erase paths and device-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->