### PR TITLE
chore: device link disclosure

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -399,6 +399,7 @@ device_db_cache_limit
 device_db_cache_limit_summary
 device_gps
 device_links
+device_links_affiliate_disclosure
 device_links_i_want_one
 device_links_open_in_browser
 device_metrics_label_value

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -429,6 +429,7 @@
     <string name="device_db_cache_limit_summary">Max device databases to keep on this phone</string>
     <string name="device_gps">Device GPS</string>
     <string name="device_links">Device Links</string>
+    <string name="device_links_affiliate_disclosure">Product links may be affiliate links — purchases may earn Meshtastic a commission.</string>
     <string name="device_links_i_want_one">I want one</string>
     <string name="device_links_open_in_browser">Open in browser</string>
     <string name="device_metrics_label_value">%1$s: %2$s</string>

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -167,6 +167,8 @@ When a node's hardware is recognized, the detail view shows a collapsible **"I w
 
 A full, browsable directory of every link is also available at **Settings → Device Links**. The item is hidden while you have Settings open for a remote node.
 
+Some of these are affiliate links. Both places say so above the links: product links may be affiliate links, and purchases may earn Meshtastic a commission.
+
 ## When No Nodes Appear
 
 The list stays empty until your radio hears another node.

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/DeviceLinksSection.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/DeviceLinksSection.kt
@@ -51,6 +51,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.model.DeviceLink
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.collapsed
+import org.meshtastic.core.resources.device_links_affiliate_disclosure
 import org.meshtastic.core.resources.device_links_i_want_one
 import org.meshtastic.core.resources.device_links_open_in_browser
 import org.meshtastic.core.resources.expanded
@@ -99,6 +100,13 @@ fun DeviceLinksSection(links: List<DeviceLink>, modifier: Modifier = Modifier) {
                 )
             }
             if (expanded) {
+                // The disclosure sits above the links it covers.
+                Text(
+                    text = stringResource(Res.string.device_links_affiliate_disclosure),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
+                )
                 links.forEach { DeviceLinkRow(it) }
             }
         }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/DeviceLinkDirectoryScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/DeviceLinkDirectoryScreen.kt
@@ -17,18 +17,23 @@
 package org.meshtastic.feature.settings
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.jetbrains.compose.resources.stringResource
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.device_links
+import org.meshtastic.core.resources.device_links_affiliate_disclosure
 import org.meshtastic.core.ui.component.ListItem
 import org.meshtastic.core.ui.component.MainAppBar
 import org.meshtastic.core.ui.icon.Language
@@ -59,6 +64,17 @@ fun DeviceLinkDirectoryScreen(
         },
     ) { paddingValues ->
         LazyColumn(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+            if (links.isNotEmpty()) {
+                // The disclosure sits above the links it covers.
+                item {
+                    Text(
+                        text = stringResource(Res.string.device_links_affiliate_disclosure),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+                    )
+                }
+            }
             items(links, key = { it.shortCode }) { link ->
                 ListItem(
                     text = link.description ?: link.shortCode,


### PR DESCRIPTION
Product links in the app route through msh.to and carry Meshtastic referral
parameters. This states that where the links appear.

Wording is taken from web-flasher
[#415](https://github.com/meshtastic/web-flasher/pull/415) so the line reads the
same on every client.

## 🌟 New Features

- **"I want one" section** (`feature:node`) — the disclosure sits above the first
  link, shown once the section is expanded.
- **Settings → Device Links** (`feature:settings`) — the same line as the first
  row of the directory, shown when there are links.
- New string `device_links_affiliate_disclosure`. English only; Crowdin picks up
  the rest.

## 🧹 Chores

- `docs/en/user/nodes.md` — the "Device Links" section describes both surfaces,
  so it mentions this too.

## Notes

- Checked 2026-09-08: the msh.to redirects for RAK, Rokland and AliExpress carry
  referral or partner parameters. The Amazon redirects carry none.
- The line is placed above the links rather than below them so it is read first.

## Testing Performed

No tests added; the change is a static string on two composables and neither has
an existing golden.

- `spotlessApply spotlessCheck detekt assembleDebug kmpSmokeCompile` — green.
- `python3 scripts/sort-strings.py` run after adding the string; index regenerated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added affiliate-link disclosures above device and imported link lists when displayed.
  * Clarified in documentation that purchases through product links may earn Meshtastic a commission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->