### PR TITLE
fix(test): stop androidApp unit tests opening the app database

### DIFF
--- a/.github/workflows/reusable-check.yml
+++ b/.github/workflows/reusable-check.yml
@@ -329,6 +329,20 @@ jobs:
           ./gradlew ${{ matrix.shard.tasks }} $kover_tasks -Pci=true --continue \
             "-Dscan.value.CI shard=${{ matrix.shard.name }}"
 
+      # A test fork that dies in native code (exit 134) names no test, and the JVM's crash report is the
+      # only thing that does -- it carries the crashing thread's Java frames. Without this the same
+      # ejection has to be diagnosed twice.
+      - name: Upload JVM crash reports (${{ matrix.shard.name }})
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: jvm-crash-${{ matrix.shard.name }}
+          path: |
+            **/hs_err_pid*.log
+            **/replay_pid*.log
+          if-no-files-found: ignore
+          retention-days: 7
+
       # Flags are tagged by logical module group (core/feature/app/desktop), matching
       # codecov.yml's flags/component_management — NOT by shard name. Shards are a CI
       # load-balancing detail; which shard happens to run a module must not change

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MeshUtilApplication.kt
@@ -22,7 +22,6 @@ import android.appwidget.AppWidgetProviderInfo
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.annotation.VisibleForTesting
 import androidx.collection.intSetOf
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.work.Configuration
@@ -103,6 +102,16 @@ open class MeshUtilApplication :
             workManagerFactory()
         }
 
+        startBackgroundInit()
+    }
+
+    /**
+     * Launches the best-effort init that does not have to finish before the first Activity: log cleanup, the
+     * previous-exit report, the widget preview, the active database, and discovery-scan recovery. Open so a test can
+     * boot the real Application without any of it — chiefly the database, whose connection is what makes an
+     * un-terminated Application unsafe.
+     */
+    protected open fun startBackgroundInit() {
         // Schedule periodic MeshLog cleanup. Off-main: WorkManager uses on-demand init here
         // (the startup provider is removed), so getInstance() opens WorkManager's Room DB.
         applicationScope.launch { scheduleMeshLogCleanup() }
@@ -171,12 +180,11 @@ open class MeshUtilApplication :
     }
 
     /**
-     * Stops the background init launched by [onCreate]. Robolectric never calls [onTerminate], so a unit test that
-     * boots this Application must call this itself — otherwise those jobs outlive the test on real
-     * [Dispatchers.Default] threads and their failures surface against whichever test is running next.
+     * Stops the background init launched by [startBackgroundInit]. Cancellation is not a join: work already inside an
+     * uninterruptible native call (a database open) runs on past this, which is why [onTerminate] still has to close
+     * the database afterwards.
      */
-    @VisibleForTesting
-    fun cancelBackgroundInit() {
+    private fun cancelBackgroundInit() {
         applicationScope.cancel()
     }
 

--- a/androidApp/src/test/kotlin/org/meshtastic/app/CoilImageLoaderLifecycleTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/CoilImageLoaderLifecycleTest.kt
@@ -29,14 +29,11 @@ import kotlin.test.Test
 import kotlin.test.assertSame
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = MeshUtilApplication::class, sdk = [34])
+@Config(application = ImageLoaderOnlyApplication::class, sdk = [34])
 class CoilImageLoaderLifecycleTest {
     @After
     @OptIn(DelicateCoilApi::class)
     fun tearDown() {
-        // Booting the real Application starts background init on Dispatchers.Default; leaving it running
-        // leaks failures into later tests in this JVM (Robolectric never calls onTerminate).
-        ApplicationProvider.getApplicationContext<MeshUtilApplication>().cancelBackgroundInit()
         SingletonImageLoader.reset()
     }
 
@@ -47,4 +44,12 @@ class CoilImageLoaderLifecycleTest {
 
         assertSame(configuredImageLoader, SingletonImageLoader.get(application))
     }
+}
+
+/**
+ * Boots the production Application with its background init suppressed: what this asserts is the Koin/Coil wiring, and
+ * the real [MeshUtilApplication.startBackgroundInit] opens a database whose connection can outlive the test.
+ */
+private class ImageLoaderOnlyApplication : MeshUtilApplication() {
+    override fun startBackgroundInit() = Unit
 }

--- a/androidApp/src/test/kotlin/org/meshtastic/app/ShareMessageDeepLinkTest.kt
+++ b/androidApp/src/test/kotlin/org/meshtastic/app/ShareMessageDeepLinkTest.kt
@@ -18,8 +18,6 @@ package org.meshtastic.app
 
 import android.app.PendingIntent
 import android.content.Intent
-import androidx.test.core.app.ApplicationProvider
-import org.junit.After
 import org.junit.runner.RunWith
 import org.meshtastic.core.common.util.CommonUri
 import org.meshtastic.core.navigation.ContactsRoute
@@ -36,13 +34,6 @@ import kotlin.test.assertNull
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class ShareMessageDeepLinkTest {
-
-    @After
-    fun tearDown() {
-        // No `application =` override, so Robolectric boots the manifest's real MeshUtilApplication and its
-        // background init; stop it here or its failures land on whichever test runs next in this JVM.
-        ApplicationProvider.getApplicationContext<MeshUtilApplication>().cancelBackgroundInit()
-    }
 
     @Test
     fun `shared text round trips through the deep link query`() {

--- a/androidApp/src/test/resources/robolectric.properties
+++ b/androidApp/src/test/resources/robolectric.properties
@@ -1,6 +1,11 @@
-# Legacy SQLite keeps Robolectric's native SQLite off androidApp's unit-test path. The native
+# Robolectric boots the manifest's Application, and the production one opens a Room3 database on
+# BundledSQLiteDriver. Its close runs at test teardown but gives up after a bounded drain if the open is still
+# in flight, leaving the connection live while Robolectric deletes the temp data dir under it -- a SIGSEGV in
+# the sqlite JNI that kills the whole test fork. Booting the real Application is therefore opt-in per test.
+application=android.app.Application
+# Legacy SQLite keeps Robolectric's own native SQLite off androidApp's unit-test path. The native
 # implementation segfaults the whole test fork if its nativeruntime temp dir is torn down while a
 # background database open is still in flight, which fails the task outright (retry cannot help).
-# No androidApp unit test asserts database behaviour -- :core:database owns that and stays native.
+# It says nothing about the bundled driver above -- that never goes through android.database.sqlite.
 sdk=34
 sqliteMode=LEGACY


### PR DESCRIPTION
androidApp unit tests keep taking the whole test fork down with a native SIGSEGV, which ejects whatever PR is in the merge queue with no failing test named. #7020 was ejected twice on 2026-09-08 and #7005 hit the same thing on 2026-09-03. In every case the PR's own run of that shard had passed.

Robolectric boots the manifest's `MeshUtilApplication` for any test that does not override it. Its background init opens the app's Room3 database on `BundledSQLiteDriver`, and `onTerminate` cannot reliably close it: `DatabaseManager.close()` bound-waits `WRITER_DRAIN_TIMEOUT_MS` (5s) for the in-flight open, then deliberately retains the pools for a later close retry that a test never makes. Robolectric destroys that test's temp data dir out from under the live connection, and the next test in the fork dies in the sqlite JNI (`walIndexTryHdr`, `sqlite3VdbeHalt`, `sqlite3ExprDeleteNN`), exit 134.

Four androidApp test classes were booting the production Application. Three of them (`KmlToGoogleLayerTest`, `MapLayerOpacityTest`, `KmlImportTest`) only wanted `android.graphics` and had no teardown at all.

### 🐛 Bug Fixes

- `robolectric.properties`: default the unit-test Application to `android.app.Application`, so booting the production one is opt-in per test.
- `MeshUtilApplication`: move the `onCreate` background launches into `protected open fun startBackgroundInit()`. `CoilImageLoaderLifecycleTest` now boots a subclass that no-ops it, so it still asserts the real Koin/Coil wiring without opening a database. `GoogleMeshUtilApplication` still launches its own AppFunctions sync after `super.onCreate()`; that test pins `MeshUtilApplication::class` so it never runs there.
- `ShareMessageDeepLinkTest` no longer needs its `cancelBackgroundInit` teardown.
- `cancelBackgroundInit` is private again and its doc no longer claims Robolectric skips `onTerminate`. It does call it, from `AndroidTestEnvironment.tearDownApplication`.

### 🧹 Chores

- Upload `hs_err_pid*.log` from the test shards on failure. Both ejecting runs produced no artifacts at all, so the JVM crash report, the only thing that names the crashing thread, was gone.

### Testing Performed

- `:androidApp:testGoogleDebugUnitTest` and `:androidApp:testFdroidDebugUnitTest` with `--rerun`: green. No `androidx_sqliteJni`, `BundledSQLiteDriver` or `MeshtasticDatabase` reference is left in either task's results. The only database traffic remaining is WorkManager's own Room 2.x through `androidx.sqlite.db.framework`, which is the shadowed framework path `sqliteMode=LEGACY` already covers.
- Full baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests`.

No behaviour change in the app. `startBackgroundInit()` runs from the same point in `onCreate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android test stability by preventing database-related native crashes during Robolectric teardown.
  - Added collection of JVM crash reports when Android test shards fail, making failures easier to investigate.

- **Refactor**
  - Improved control over application background initialization, including isolated test setup that avoids unnecessary startup work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->