### PR TITLE
fix(firmware): source the nightly channel from nightly.meshtastic.org

### DIFF
--- a/androidApp/src/main/kotlin/org/meshtastic/app/di/NetworkModule.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/di/NetworkModule.kt
@@ -39,9 +39,13 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.request.url
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import okhttp3.Cache
+import okhttp3.ConnectionPool
+import okhttp3.Dispatcher
 import okio.Path.Companion.toOkioPath
 import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
@@ -51,10 +55,15 @@ import org.meshtastic.core.network.KermitHttpLogger
 import org.meshtastic.core.network.configureDefaultRetry
 import org.meshtastic.core.network.service.ApiService
 import org.meshtastic.core.network.service.ApiServiceImpl
+import java.util.concurrent.TimeUnit
 
 private const val DISK_CACHE_PERCENT = 0.02
 private const val MEMORY_CACHE_PERCENT = 0.25
 private const val MEMORY_CACHE_BACKGROUND_PERCENT = 0.1
+private const val HTTP_CACHE_SIZE_BYTES = 10L * 1024L * 1024L // 10 MiB
+private const val MAX_IDLE_CONNECTIONS = 8
+private const val KEEP_ALIVE_DURATION_MINUTES = 2L
+private const val MAX_REQUESTS_PER_HOST = 10
 
 @Module
 class NetworkModule {
@@ -107,18 +116,39 @@ class NetworkModule {
      */
     @Single
     fun provideHttpClient(
+        application: Context,
         json: Json,
         buildConfigProvider: BuildConfigProvider,
         networkInstrumentation: OkHttpNetworkInstrumentation,
     ): HttpClient = HttpClient(engineFactory = OkHttp) {
         engine {
+            config {
+                cache(
+                    Cache(directory = application.cacheDir.resolve("http_cache"), maxSize = HTTP_CACHE_SIZE_BYTES),
+                )
+                fastFallback(true)
+                connectionPool(
+                    ConnectionPool(
+                        maxIdleConnections = MAX_IDLE_CONNECTIONS,
+                        keepAliveDuration = KEEP_ALIVE_DURATION_MINUTES,
+                        timeUnit = TimeUnit.MINUTES,
+                    ),
+                )
+                dispatcher(Dispatcher().apply { maxRequestsPerHost = MAX_REQUESTS_PER_HOST })
+            }
             // Flavor-provided analytics hooks: google supplies Datadog's interceptor + event listener so RUM
             // captures per-request network timing; fdroid supplies OkHttpNetworkInstrumentation.NONE (no-op).
             networkInstrumentation.interceptors.forEach { addInterceptor(it) }
             networkInstrumentation.eventListenerFactory?.let { factory -> config { eventListenerFactory(factory) } }
         }
         install(plugin = ContentNegotiation) { json(json) }
-        install(DefaultRequest) { url(HttpClientDefaults.API_BASE_URL) }
+        install(DefaultRequest) {
+            url(HttpClientDefaults.API_BASE_URL)
+            header(
+                HttpHeaders.UserAgent,
+                "Meshtastic-Android/${buildConfigProvider.versionName} (${buildConfigProvider.applicationId})",
+            )
+        }
         install(plugin = HttpTimeout) {
             requestTimeoutMillis = HttpClientDefaults.REQUEST_TIMEOUT_MS
             connectTimeoutMillis = HttpClientDefaults.TIMEOUT_MS

--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
@@ -60,7 +60,7 @@ open class FirmwareReleaseRepositoryImpl(
     private val releaseRefresher =
         SingleFlightRefresher(dispatchers.io, "FirmwareReleaseRepository") { fetchAndPersistReleases() }
 
-    /** Nightly lives on meshtastic.github.io, not in the API's release list, so it refreshes on its own flight. */
+    /** Nightly lives on its own host, not in the API's release list, so it refreshes on its own flight. */
     private val nightlyRefresher =
         SingleFlightRefresher(dispatchers.io, "FirmwareReleaseRepository.nightly") { fetchAndPersistNightly() }
 
@@ -113,7 +113,7 @@ open class FirmwareReleaseRepositoryImpl(
         shouldFetch = { cached ->
             cached == null || localDataSource.getLatestRelease(releaseType)?.isStale() != false
         },
-        // Nightly lives on meshtastic.github.io, not in the API's release list, so it refreshes on its own
+        // Nightly lives on its own host, not in the API's release list, so it refreshes on its own
         // path — regular (locked) users never hit the nightly URL because only unlocked UI collects that flow.
         fetch = {
             if (releaseType == FirmwareReleaseType.NIGHTLY) {

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/FirmwareReleaseEntity.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/FirmwareReleaseEntity.kt
@@ -74,7 +74,7 @@ enum class FirmwareReleaseType {
     STABLE,
     ALPHA,
 
-    /** Nightly preview from meshtastic.github.io's `firmware-nightly/` folder; gated behind the modules unlock. */
+    /** Nightly preview from the nightly host's root; gated behind the modules unlock. */
     NIGHTLY,
     LOCAL,
 }

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/NetworkFirmwareRelease.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/NetworkFirmwareRelease.kt
@@ -42,9 +42,9 @@ data class Releases(
 @Serializable data class NetworkFirmwareReleases(@SerialName("releases") val releases: Releases = Releases())
 
 /**
- * The nightly-preview pointer published to `firmware-nightly/index.json` on meshtastic.github.io. Unlike the release
- * channels above it is not served by api.meshtastic.org, and only [version] is guaranteed present — [id] and [title]
- * are derived when absent, matching the web flasher's parsing.
+ * The nightly-preview pointer published to `index.json` at the root of the nightly host. Unlike the release channels
+ * above it is not served by api.meshtastic.org, and only [version] is guaranteed present — [id] and [title] are derived
+ * when absent, matching the web flasher's parsing.
  */
 @Serializable
 data class NetworkFirmwareNightly(
@@ -56,7 +56,7 @@ data class NetworkFirmwareNightly(
 
 /**
  * Normalizes the nightly pointer into the common release shape, or null when the pointer carries no usable version.
- * Nightly artifacts are served per-file from the fixed `firmware-nightly/` folder, so there is no release zip.
+ * Nightly artifacts are served per-file from the nightly host's root, so there is no release zip.
  */
 fun NetworkFirmwareNightly.asFirmwareRelease(): NetworkFirmwareRelease? {
     val resolvedId = id?.takeIf { it.isNotBlank() } ?: version.takeIf { it.isNotBlank() }?.let { "v$it" }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/FirmwareReleaseRemoteDataSource.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/FirmwareReleaseRemoteDataSource.kt
@@ -35,7 +35,7 @@ class FirmwareReleaseRemoteDataSource(
     suspend fun getFirmwareReleaseManifest(manifestUrl: String): FirmwareReleaseManifest =
         withContext(dispatchers.io) { apiService.getFirmwareReleaseManifest(manifestUrl) }
 
-    /** The nightly preview pointer from meshtastic.github.io, or null when no nightly is published. */
+    /** The nightly preview pointer from the nightly host, or null when no nightly is published. */
     suspend fun getNightlyFirmware(): NetworkFirmwareNightly? =
         withContext(dispatchers.io) { apiService.getNightlyFirmware() }
 }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
@@ -46,6 +46,16 @@ object HttpClientDefaults {
      * reached from a browser at all (meshtastic/api#134).
      */
     const val API_BASE_URL = "https://apiv2.meshtastic.org/"
+
+    /**
+     * Base URL for the nightly firmware channel. Absolute, and not routed through [API_BASE_URL] — the nightly build is
+     * published outside the API, flat at this host's root: `index.json` alongside every per-target artifact.
+     *
+     * Replaces the `firmware-nightly/` folder on meshtastic.github.io, which stopped tracking the newest build. The
+     * version pointer and the artifacts must both be read from this host: the two publishers sit on different firmware
+     * commits, so a version taken from one resolves artifact filenames that do not exist on the other.
+     */
+    const val NIGHTLY_BASE_URL = "https://nightly.meshtastic.org"
 }
 
 /**

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/service/ApiService.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/service/ApiService.kt
@@ -32,13 +32,17 @@ import org.meshtastic.core.model.NetworkDeviceHardware
 import org.meshtastic.core.model.NetworkDeviceLinksResponse
 import org.meshtastic.core.model.NetworkFirmwareNightly
 import org.meshtastic.core.model.NetworkFirmwareReleases
+import org.meshtastic.core.network.HttpClientDefaults
 
 /**
- * Pointer to the nightly preview build published by CI to meshtastic.github.io. Served from GitHub Pages raw content
- * (not api.meshtastic.org) as `text/plain`, so it is parsed manually rather than via content negotiation.
+ * Pointer to the nightly preview build published by CI, served at the root of [HttpClientDefaults.NIGHTLY_BASE_URL]
+ * rather than by api.meshtastic.org.
+ *
+ * Decoded manually rather than via content negotiation so that a 404 — nothing currently published — can be told apart
+ * from a transport failure. The not-found body is the host's HTML error page, which content negotiation would reject
+ * before the status could be inspected.
  */
-private const val NIGHTLY_INDEX_URL =
-    "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/firmware-nightly/index.json"
+private const val NIGHTLY_INDEX_URL = "${HttpClientDefaults.NIGHTLY_BASE_URL}/index.json"
 
 private val firmwareJson = Json {
     isLenient = true
@@ -67,7 +71,7 @@ interface ApiService {
     suspend fun getFirmwareReleaseManifest(manifestUrl: String): FirmwareReleaseManifest
 
     /**
-     * Fetches the nightly preview build pointer from meshtastic.github.io. Returns null when no nightly is currently
+     * Fetches the nightly preview build pointer from the nightly host. Returns null when no nightly is currently
      * published (HTTP 404); throws on transport or server errors so callers can distinguish "gone" from "unreachable".
      */
     suspend fun getNightlyFirmware(): NetworkFirmwareNightly?

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/service/ApiServiceTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/service/ApiServiceTest.kt
@@ -19,9 +19,11 @@ package org.meshtastic.core.network.service
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.test.runTest
@@ -30,8 +32,45 @@ import org.meshtastic.core.model.FirmwareTarget
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 class ApiServiceTest {
+    @Test
+    fun `nightly pointer is fetched from the nightly host root`() = runTest {
+        var requested: String? = null
+        val engine = MockEngine { request ->
+            requested = request.url.toString()
+            respond(
+                content = """{"version":"2.8.1.0becda3","id":"v2.8.1.0becda3","commit":"0becda3"}""",
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = HttpClient(engine)
+
+        try {
+            val nightly = ApiServiceImpl(client).getNightlyFirmware()
+
+            assertEquals("https://nightly.meshtastic.org/index.json", requested)
+            assertEquals("2.8.1.0becda3", nightly?.version)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `nightly pointer returns null when nothing is published`() = runTest {
+        // The host answers an unpublished nightly with its own HTML error page, so the status — not the body —
+        // is what distinguishes "gone" from "unreachable".
+        val engine = MockEngine { respondError(HttpStatusCode.NotFound, "<!doctype html><title>Not Found</title>") }
+        val client = HttpClient(engine)
+
+        try {
+            assertNull(ApiServiceImpl(client).getNightlyFirmware())
+        } finally {
+            client.close()
+        }
+    }
+
     @Test
     fun `service decodes release manifest served as octet stream`() = runTest {
         val manifestUrl = "https://downloads.example/firmware/manifest.json"

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/FirmwareReleaseRepository.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/FirmwareReleaseRepository.kt
@@ -27,8 +27,8 @@ interface FirmwareReleaseRepository {
     val alphaRelease: Flow<FirmwareRelease?>
 
     /**
-     * A flow that provides the current NIGHTLY preview build, or null when none is published. Sourced from
-     * meshtastic.github.io rather than the API server, and surfaced only behind the hidden-features unlock.
+     * A flow that provides the current NIGHTLY preview build, or null when none is published. Sourced from the nightly
+     * host rather than the API server, and surfaced only behind the hidden-features unlock.
      */
     val nightlyRelease: Flow<FirmwareRelease?>
 

--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/di/DesktopKoinModule.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/di/DesktopKoinModule.kt
@@ -29,7 +29,8 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.request.url
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import org.koin.dsl.module
@@ -241,8 +242,15 @@ private fun desktopPlatformStubsModule() = module {
     // Ktor HttpClient for JVM/Desktop (equivalent of CoreNetworkAndroidModule on Android)
     single<HttpClient> {
         HttpClient(Java) {
+            engine {
+                protocolVersion = java.net.http.HttpClient.Version.HTTP_2
+                config { followRedirects(java.net.http.HttpClient.Redirect.NORMAL) }
+            }
             install(ContentNegotiation) { json(get<Json>()) }
-            install(DefaultRequest) { url(HttpClientDefaults.API_BASE_URL) }
+            install(DefaultRequest) {
+                url(HttpClientDefaults.API_BASE_URL)
+                header(HttpHeaders.UserAgent, "Meshtastic-Desktop/${DesktopBuildConfig.VERSION_NAME}")
+            }
             install(HttpTimeout) {
                 requestTimeoutMillis = HttpClientDefaults.REQUEST_TIMEOUT_MS
                 connectTimeoutMillis = HttpClientDefaults.TIMEOUT_MS

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareRetriever.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareRetriever.kt
@@ -23,10 +23,12 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.FirmwareReleaseType
 import org.meshtastic.core.model.DeviceHardware
+import org.meshtastic.core.network.HttpClientDefaults
 import org.meshtastic.feature.firmware.ota.FirmwareHashUtil
 
 private val KNOWN_ARCHS = setOf("esp32-s3", "esp32-c3", "esp32-c6", "nrf52840", "rp2040", "stm32", "esp32")
 
+/** Host serving the versioned `firmware-<version>/` artifact folders. The nightly channel is published elsewhere. */
 private const val FIRMWARE_BASE_URL = "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master"
 
 /** Radix for the hex flash addresses in maintenance-image diagnostics. */
@@ -209,7 +211,7 @@ open class FirmwareRetriever(private val fileHandler: FirmwareFileHandler) {
         hardware: DeviceHardware,
         onProgress: (Float) -> Unit,
     ): FirmwareArtifact? {
-        val manifestUrl = "$FIRMWARE_BASE_URL/${release.artifactFolder}/firmware-$target-$version.mt.json"
+        val manifestUrl = "${release.artifactBaseUrl}/firmware-$target-$version.mt.json"
 
         val text = fileHandler.fetchText(manifestUrl)
         if (text == null) {
@@ -283,7 +285,7 @@ open class FirmwareRetriever(private val fileHandler: FirmwareFileHandler) {
         val version = release.id.removePrefix("v")
         val target = hardware.platformioTarget.ifEmpty { hardware.hwModelSlug }
         val filename = preferredFilename ?: "firmware-$target-$version$fileSuffix"
-        val directUrl = "$FIRMWARE_BASE_URL/${release.artifactFolder}/$filename"
+        val directUrl = "${release.artifactBaseUrl}/$filename"
 
         if (fileHandler.checkUrlExists(directUrl)) {
             try {
@@ -315,12 +317,20 @@ open class FirmwareRetriever(private val fileHandler: FirmwareFileHandler) {
     }
 
     /**
-     * The meshtastic.github.io folder holding this release's artifacts. Nightly builds live in the fixed
-     * `firmware-nightly/` folder (mirroring the web flasher); everything else uses the versioned folder.
+     * Base URL holding this release's artifacts. Nightly builds sit flat at the root of the nightly host (mirroring the
+     * web flasher); stable and alpha use the versioned folder on meshtastic.github.io, which that host does not serve.
+     *
+     * A nightly must resolve against the same host its version pointer came from — the nightly host and
+     * meshtastic.github.io publish different firmware commits, so a filename built from the other host's version does
+     * not exist.
      */
-    private val FirmwareRelease.artifactFolder: String
+    private val FirmwareRelease.artifactBaseUrl: String
         get() =
-            if (releaseType == FirmwareReleaseType.NIGHTLY) "firmware-nightly" else "firmware-${id.removePrefix("v")}"
+            if (releaseType == FirmwareReleaseType.NIGHTLY) {
+                HttpClientDefaults.NIGHTLY_BASE_URL
+            } else {
+                "$FIRMWARE_BASE_URL/firmware-${id.removePrefix("v")}"
+            }
 
     private fun resolveZipUrl(url: String, targetArch: String): String {
         for (arch in KNOWN_ARCHS) {

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonFirmwareRetrieverTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonFirmwareRetrieverTest.kt
@@ -43,6 +43,9 @@ abstract class CommonFirmwareRetrieverTest {
     protected companion object {
         const val BASE_URL = "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master"
 
+        /** Nightly artifacts are served flat at this host's root, not from a folder under [BASE_URL]. */
+        const val NIGHTLY_BASE_URL = "https://nightly.meshtastic.org"
+
         val TEST_RELEASE = FirmwareRelease(id = "v2.7.17", zipUrl = "https://example.com/esp32-s3.zip")
 
         val TEST_HARDWARE =
@@ -338,38 +341,38 @@ abstract class CommonFirmwareRetrieverTest {
     }
 
     // -----------------------------------------------------------------------
-    // Nightly channel (fixed firmware-nightly/ folder, no release zip)
+    // Nightly channel (flat at the nightly host root, no release zip)
     // -----------------------------------------------------------------------
 
     @Test
-    fun `nightly release resolves from the fixed firmware-nightly folder`() = runTest {
+    fun `nightly release resolves from the nightly host root`() = runTest {
         val handler = FakeFirmwareFileHandler()
         val retriever = FirmwareRetriever(handler)
         val nightly = FirmwareRelease(id = "v2.8.0.f52e2ea", zipUrl = "", releaseType = FirmwareReleaseType.NIGHTLY)
 
-        handler.textResponses["$BASE_URL/firmware-nightly/firmware-heltec-v3-2.8.0.f52e2ea.mt.json"] =
+        handler.textResponses["$NIGHTLY_BASE_URL/firmware-heltec-v3-2.8.0.f52e2ea.mt.json"] =
             """{"files":[{"name":"firmware-heltec-v3-2.8.0.f52e2ea.bin","md5":"","bytes":0,"part_name":"app0"}]}"""
-        handler.existingUrls.add("$BASE_URL/firmware-nightly/firmware-heltec-v3-2.8.0.f52e2ea.bin")
+        handler.existingUrls.add("$NIGHTLY_BASE_URL/firmware-heltec-v3-2.8.0.f52e2ea.bin")
 
         val result = retriever.retrieveEsp32Firmware(nightly, TEST_HARDWARE) {}
 
-        assertNotNull(result, "Nightly should resolve from firmware-nightly/, not firmware-<version>/")
+        assertNotNull(result, "Nightly should resolve from the nightly host, not a folder under $BASE_URL")
         assertEquals("firmware-heltec-v3-2.8.0.f52e2ea.bin", result.fileName)
-        assertTrue(handler.checkedUrls.none { "firmware-2.8.0.f52e2ea/" in it }, "versioned folder must not be used")
+        assertTrue(handler.checkedUrls.none { BASE_URL in it }, "meshtastic.github.io must not be used for nightly")
         assertTrue(
-            "$BASE_URL/firmware-nightly/firmware-heltec-v3-2.8.0.f52e2ea.mt.json" in handler.fetchedTextUrls,
-            "manifest must be fetched from firmware-nightly/",
+            "$NIGHTLY_BASE_URL/firmware-heltec-v3-2.8.0.f52e2ea.mt.json" in handler.fetchedTextUrls,
+            "manifest must be fetched from the nightly host root",
         )
     }
 
     @Test
-    fun `nightly ota zip resolves from the fixed firmware-nightly folder`() = runTest {
+    fun `nightly ota zip resolves from the nightly host root`() = runTest {
         val handler = FakeFirmwareFileHandler()
         val retriever = FirmwareRetriever(handler)
         val hardware = DeviceHardware(hwModelSlug = "RAK4631", platformioTarget = "rak4631", architecture = "nrf52840")
         val nightly = FirmwareRelease(id = "v2.8.0.f52e2ea", zipUrl = "", releaseType = FirmwareReleaseType.NIGHTLY)
 
-        handler.existingUrls.add("$BASE_URL/firmware-nightly/firmware-rak4631-2.8.0.f52e2ea-ota.zip")
+        handler.existingUrls.add("$NIGHTLY_BASE_URL/firmware-rak4631-2.8.0.f52e2ea-ota.zip")
 
         val result = retriever.retrieveOtaFirmware(nightly, hardware) {}
 
@@ -388,6 +391,23 @@ abstract class CommonFirmwareRetrieverTest {
 
         assertNull(result)
         assertTrue(handler.downloadedUrls.isEmpty(), "no zip download may be attempted when zipUrl is blank")
+    }
+
+    @Test
+    fun `stable release keeps using the versioned folder on meshtastic github io`() = runTest {
+        val handler = FakeFirmwareFileHandler()
+        val retriever = FirmwareRetriever(handler)
+        val stable = FirmwareRelease(id = "v2.8.0", zipUrl = "", releaseType = FirmwareReleaseType.STABLE)
+
+        handler.existingUrls.add("$BASE_URL/firmware-2.8.0/firmware-heltec-v3-2.8.0.bin")
+
+        val result = retriever.retrieveEsp32Firmware(stable, TEST_HARDWARE) {}
+
+        assertNotNull(result, "stable must resolve from the versioned folder")
+        assertTrue(
+            handler.checkedUrls.none { NIGHTLY_BASE_URL in it },
+            "the nightly host serves no versioned folders, so stable must never be looked up there",
+        )
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
The nightly firmware channel read its version pointer and its artifacts from the `firmware-nightly/` folder on `meshtastic.github.io`. That folder last published on 2026-09-06, while `nightly.meshtastic.org` is current as of 2026-09-08, so the in-app nightly channel was serving a build two days behind. `web-flasher` already treats `nightly.meshtastic.org` as the nightly source (`utils/firmwareUrl.ts`, `NIGHTLY_BASE`), so this brings Android onto the same host.

The two publishers sit on different firmware commits, so the pointer and the artifacts have to come from the same host. Reading the version from one and building artifact filenames against the other resolves files that do not exist.

### 🐛 Bug Fixes

- Point the nightly version pointer at `https://nightly.meshtastic.org/index.json` instead of the `raw.githubusercontent.com` copy of `firmware-nightly/index.json`.
- Point nightly artifact downloads (`.bin`, `.uf2`, `-ota.zip`, `.mt.json`) at the same host, which serves them flat at its root.

### 🛠️ Refactoring & Architecture

- Add `HttpClientDefaults.NIGHTLY_BASE_URL` so the hostname has one home, and derive the nightly index URL from it.
- Replace `FirmwareRelease.artifactFolder` (a path fragment) with `FirmwareRelease.artifactBaseUrl` (a full base URL), so the nightly channel can resolve against a different host rather than a different folder on the same one. This mirrors `web-flasher`'s `getFirmwareBaseUrl`.

### 🧹 Chores

- Refresh the KDoc that named `meshtastic.github.io` as the nightly source across `core:model`, `core:network`, `core:data`, `core:database` and `core:repository`.

### Scope

Stable and alpha are unchanged. They keep resolving against the versioned `firmware-<version>/` folders on `meshtastic.github.io`; the nightly host is flat and serves no versioned folders (`nightly.meshtastic.org/firmware-2.8.0/` returns 404).

### Verification

Checked against the live hosts before writing the change:

- `nightly.meshtastic.org` serves `index.json` plus every per-target artifact at its root, as `application/json` / `application/octet-stream`.
- `HEAD` and range requests both work there, which `FirmwareFileHandler.checkUrlExists` depends on.
- The nightly index 404s before the first nightly of a series is published, which is the existing "no nightly" path and is preserved.

One infrastructure note for reviewers: the new host sets a Cloudflare edge `cache-control: max-age=14400`, against the app's 1 hour `CACHE_EXPIRATION_TIME_MS`. A freshly published nightly can therefore take up to 4 hours to surface. That is unchanged in behaviour from a stale upstream folder and is not addressed here.

### Testing Performed

Added:

- `ApiServiceTest.nightly pointer is fetched from the nightly host root` pins the exact index URL.
- `ApiServiceTest.nightly pointer returns null when nothing is published` covers the 404 path, where the body is the host's HTML error page and the status is what distinguishes "gone" from "unreachable".
- `CommonFirmwareRetrieverTest.stable release keeps using the versioned folder on meshtastic github io` is a regression guard that stable is never looked up on the nightly host.

Updated the three existing nightly cases in `CommonFirmwareRetrieverTest` to the new base URL.

Baseline run locally, all green:

```
./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile
```

Locally that exercised the `jvm` variant of `CommonFirmwareRetrieverTest`; the `androidHostTest` subclass is covered by CI.

### Follow-up, not in this PR

`web-flasher` also serves stable and alpha from `release.meshtastic.org/<version>/` (R2-backed) rather than `raw.githubusercontent.com`. I confirmed that host serves the current stable's artifacts, so moving the release channels off `raw.githubusercontent.com` is available as a separate change.
