### PR TITLE
fix(firmware): move firmware artifact fetching onto the R2 hosts

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/repository/FirmwareReleaseRepositoryImpl.kt
@@ -60,7 +60,7 @@ open class FirmwareReleaseRepositoryImpl(
     private val releaseRefresher =
         SingleFlightRefresher(dispatchers.io, "FirmwareReleaseRepository") { fetchAndPersistReleases() }
 
-    /** Nightly lives on meshtastic.github.io, not in the API's release list, so it refreshes on its own flight. */
+    /** Nightly lives on its own host, not in the API's release list, so it refreshes on its own flight. */
     private val nightlyRefresher =
         SingleFlightRefresher(dispatchers.io, "FirmwareReleaseRepository.nightly") { fetchAndPersistNightly() }
 
@@ -113,7 +113,7 @@ open class FirmwareReleaseRepositoryImpl(
         shouldFetch = { cached ->
             cached == null || localDataSource.getLatestRelease(releaseType)?.isStale() != false
         },
-        // Nightly lives on meshtastic.github.io, not in the API's release list, so it refreshes on its own
+        // Nightly lives on its own host, not in the API's release list, so it refreshes on its own
         // path — regular (locked) users never hit the nightly URL because only unlocked UI collects that flow.
         fetch = {
             if (releaseType == FirmwareReleaseType.NIGHTLY) {

--- a/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/FirmwareReleaseEntity.kt
+++ b/core/database/src/commonMain/kotlin/org/meshtastic/core/database/entity/FirmwareReleaseEntity.kt
@@ -74,7 +74,7 @@ enum class FirmwareReleaseType {
     STABLE,
     ALPHA,
 
-    /** Nightly preview from meshtastic.github.io's `firmware-nightly/` folder; gated behind the modules unlock. */
+    /** Nightly preview from the nightly host's root; gated behind the modules unlock. */
     NIGHTLY,
     LOCAL,
 }

--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/NetworkFirmwareRelease.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/NetworkFirmwareRelease.kt
@@ -42,9 +42,9 @@ data class Releases(
 @Serializable data class NetworkFirmwareReleases(@SerialName("releases") val releases: Releases = Releases())
 
 /**
- * The nightly-preview pointer published to `firmware-nightly/index.json` on meshtastic.github.io. Unlike the release
- * channels above it is not served by api.meshtastic.org, and only [version] is guaranteed present — [id] and [title]
- * are derived when absent, matching the web flasher's parsing.
+ * The nightly-preview pointer published to `index.json` at the root of the nightly host. Unlike the release channels
+ * above it is not served by api.meshtastic.org, and only [version] is guaranteed present — [id] and [title] are derived
+ * when absent, matching the web flasher's parsing.
  */
 @Serializable
 data class NetworkFirmwareNightly(
@@ -56,7 +56,7 @@ data class NetworkFirmwareNightly(
 
 /**
  * Normalizes the nightly pointer into the common release shape, or null when the pointer carries no usable version.
- * Nightly artifacts are served per-file from the fixed `firmware-nightly/` folder, so there is no release zip.
+ * Nightly artifacts are served per-file from the nightly host's root, so there is no release zip.
  */
 fun NetworkFirmwareNightly.asFirmwareRelease(): NetworkFirmwareRelease? {
     val resolvedId = id?.takeIf { it.isNotBlank() } ?: version.takeIf { it.isNotBlank() }?.let { "v$it" }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/FirmwareReleaseRemoteDataSource.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/FirmwareReleaseRemoteDataSource.kt
@@ -35,7 +35,7 @@ class FirmwareReleaseRemoteDataSource(
     suspend fun getFirmwareReleaseManifest(manifestUrl: String): FirmwareReleaseManifest =
         withContext(dispatchers.io) { apiService.getFirmwareReleaseManifest(manifestUrl) }
 
-    /** The nightly preview pointer from meshtastic.github.io, or null when no nightly is published. */
+    /** The nightly preview pointer from the nightly host, or null when no nightly is published. */
     suspend fun getNightlyFirmware(): NetworkFirmwareNightly? =
         withContext(dispatchers.io) { apiService.getNightlyFirmware() }
 }

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
@@ -46,6 +46,16 @@ object HttpClientDefaults {
      * reached from a browser at all (meshtastic/api#134).
      */
     const val API_BASE_URL = "https://apiv2.meshtastic.org/"
+
+    /**
+     * Base URL for the nightly firmware channel. Absolute, and not routed through [API_BASE_URL] — the nightly build is
+     * published outside the API, flat at this host's root: `index.json` alongside every per-target artifact.
+     *
+     * Replaces the `firmware-nightly/` folder on meshtastic.github.io, which can lag behind this host. The version
+     * pointer and the artifacts must both be read from this host: the two publishers sit on different firmware commits,
+     * so a version taken from one resolves artifact filenames that do not exist on the other.
+     */
+    const val NIGHTLY_BASE_URL = "https://nightly.meshtastic.org"
 }
 
 /**

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/HttpClientDefaults.kt
@@ -51,11 +51,21 @@ object HttpClientDefaults {
      * Base URL for the nightly firmware channel. Absolute, and not routed through [API_BASE_URL] — the nightly build is
      * published outside the API, flat at this host's root: `index.json` alongside every per-target artifact.
      *
-     * Replaces the `firmware-nightly/` folder on meshtastic.github.io, which can lag behind this host. The version
-     * pointer and the artifacts must both be read from this host: the two publishers sit on different firmware commits,
-     * so a version taken from one resolves artifact filenames that do not exist on the other.
+     * The version pointer and the artifacts must both be read from this host. Nightly and [RELEASE_BASE_URL] are
+     * separate buckets tracking different firmware commits, so a version taken from one resolves artifact filenames
+     * that do not exist on the other.
      */
     const val NIGHTLY_BASE_URL = "https://nightly.meshtastic.org"
+
+    /**
+     * Base URL for the stable and alpha firmware channels, one directory per version at the root:
+     * `<version>/firmware-<target>-<version>.<ext>`.
+     *
+     * Artifacts are immutable once published — the version is part of every filename — so this host's long edge TTL is
+     * safe to cache against. Versions older than the published window are absent here, exactly as they are upstream;
+     * those fall back to the release zip named by the API's `zip_url`, which is a GitHub release asset and unaffected.
+     */
+    const val RELEASE_BASE_URL = "https://release.meshtastic.org"
 }
 
 /**

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/service/ApiService.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/service/ApiService.kt
@@ -32,13 +32,17 @@ import org.meshtastic.core.model.NetworkDeviceHardware
 import org.meshtastic.core.model.NetworkDeviceLinksResponse
 import org.meshtastic.core.model.NetworkFirmwareNightly
 import org.meshtastic.core.model.NetworkFirmwareReleases
+import org.meshtastic.core.network.HttpClientDefaults
 
 /**
- * Pointer to the nightly preview build published by CI to meshtastic.github.io. Served from GitHub Pages raw content
- * (not api.meshtastic.org) as `text/plain`, so it is parsed manually rather than via content negotiation.
+ * Pointer to the nightly preview build published by CI, served at the root of [HttpClientDefaults.NIGHTLY_BASE_URL]
+ * rather than by api.meshtastic.org.
+ *
+ * Decoded manually rather than via content negotiation so that a 404 — nothing currently published — can be told apart
+ * from a transport failure. The not-found body is the host's HTML error page, which content negotiation would reject
+ * before the status could be inspected.
  */
-private const val NIGHTLY_INDEX_URL =
-    "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/firmware-nightly/index.json"
+private const val NIGHTLY_INDEX_URL = "${HttpClientDefaults.NIGHTLY_BASE_URL}/index.json"
 
 private val firmwareJson = Json {
     isLenient = true
@@ -67,7 +71,7 @@ interface ApiService {
     suspend fun getFirmwareReleaseManifest(manifestUrl: String): FirmwareReleaseManifest
 
     /**
-     * Fetches the nightly preview build pointer from meshtastic.github.io. Returns null when no nightly is currently
+     * Fetches the nightly preview build pointer from the nightly host. Returns null when no nightly is currently
      * published (HTTP 404); throws on transport or server errors so callers can distinguish "gone" from "unreachable".
      */
     suspend fun getNightlyFirmware(): NetworkFirmwareNightly?

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/service/ApiServiceTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/service/ApiServiceTest.kt
@@ -19,9 +19,11 @@ package org.meshtastic.core.network.service
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.test.runTest
@@ -30,8 +32,45 @@ import org.meshtastic.core.model.FirmwareTarget
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 class ApiServiceTest {
+    @Test
+    fun `nightly pointer is fetched from the nightly host root`() = runTest {
+        var requested: String? = null
+        val engine = MockEngine { request ->
+            requested = request.url.toString()
+            respond(
+                content = """{"version":"2.8.1.0becda3","id":"v2.8.1.0becda3","commit":"0becda3"}""",
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = HttpClient(engine)
+
+        try {
+            val nightly = ApiServiceImpl(client).getNightlyFirmware()
+
+            assertEquals("https://nightly.meshtastic.org/index.json", requested)
+            assertEquals("2.8.1.0becda3", nightly?.version)
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `nightly pointer returns null when nothing is published`() = runTest {
+        // The host answers an unpublished nightly with its own HTML error page, so the status — not the body —
+        // is what distinguishes "gone" from "unreachable".
+        val engine = MockEngine { respondError(HttpStatusCode.NotFound, "<!doctype html><title>Not Found</title>") }
+        val client = HttpClient(engine)
+
+        try {
+            assertNull(ApiServiceImpl(client).getNightlyFirmware())
+        } finally {
+            client.close()
+        }
+    }
+
     @Test
     fun `service decodes release manifest served as octet stream`() = runTest {
         val manifestUrl = "https://downloads.example/firmware/manifest.json"

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/FirmwareReleaseRepository.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/FirmwareReleaseRepository.kt
@@ -27,8 +27,8 @@ interface FirmwareReleaseRepository {
     val alphaRelease: Flow<FirmwareRelease?>
 
     /**
-     * A flow that provides the current NIGHTLY preview build, or null when none is published. Sourced from
-     * meshtastic.github.io rather than the API server, and surfaced only behind the hidden-features unlock.
+     * A flow that provides the current NIGHTLY preview build, or null when none is published. Sourced from the nightly
+     * host rather than the API server, and surfaced only behind the hidden-features unlock.
      */
     val nightlyRelease: Flow<FirmwareRelease?>
 

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareManifest.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareManifest.kt
@@ -35,8 +35,7 @@ import kotlinx.serialization.Serializable
  *
  * Example URL:
  * ```
- * https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master/
- *   firmware-2.7.17/firmware-t-deck-2.7.17.mt.json
+ * https://release.meshtastic.org/2.7.17/firmware-t-deck-2.7.17.mt.json
  * ```
  */
 @Serializable internal data class FirmwareManifest(val files: List<FirmwareManifestFile> = emptyList())

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareRetriever.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareRetriever.kt
@@ -28,9 +28,6 @@ import org.meshtastic.feature.firmware.ota.FirmwareHashUtil
 
 private val KNOWN_ARCHS = setOf("esp32-s3", "esp32-c3", "esp32-c6", "nrf52840", "rp2040", "stm32", "esp32")
 
-/** Host serving the versioned `firmware-<version>/` artifact folders. The nightly channel is published elsewhere. */
-private const val FIRMWARE_BASE_URL = "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master"
-
 /** Radix for the hex flash addresses in maintenance-image diagnostics. */
 private const val HEX_RADIX = 16
 
@@ -333,19 +330,19 @@ open class FirmwareRetriever(private val fileHandler: FirmwareFileHandler) {
     }
 
     /**
-     * Base URL holding this release's artifacts. Nightly builds sit flat at the root of the nightly host (mirroring the
-     * web flasher); stable and alpha use the versioned folder on meshtastic.github.io, which that host does not serve.
+     * Base URL holding this release's artifacts. Nightly builds sit flat at the root of the nightly host; stable and
+     * alpha use a per-version directory on the release host. Structurally the same split as the web flasher's
+     * `getFirmwareBaseUrl`.
      *
-     * A nightly must resolve against the same host its version pointer came from — the nightly host and
-     * meshtastic.github.io publish different firmware commits, so a filename built from the other host's version does
-     * not exist.
+     * A release must resolve against the host its version came from. The two buckets track different firmware commits,
+     * so a filename built from the other host's version does not exist.
      */
     private val FirmwareRelease.artifactBaseUrl: String
         get() =
             if (releaseType == FirmwareReleaseType.NIGHTLY) {
                 HttpClientDefaults.NIGHTLY_BASE_URL
             } else {
-                "$FIRMWARE_BASE_URL/firmware-${id.removePrefix("v")}"
+                "${HttpClientDefaults.RELEASE_BASE_URL}/${id.removePrefix("v")}"
             }
 
     private fun resolveZipUrl(url: String, targetArch: String): String {

--- a/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareRetriever.kt
+++ b/feature/firmware/src/commonMain/kotlin/org/meshtastic/feature/firmware/FirmwareRetriever.kt
@@ -23,10 +23,12 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.database.entity.FirmwareRelease
 import org.meshtastic.core.database.entity.FirmwareReleaseType
 import org.meshtastic.core.model.DeviceHardware
+import org.meshtastic.core.network.HttpClientDefaults
 import org.meshtastic.feature.firmware.ota.FirmwareHashUtil
 
 private val KNOWN_ARCHS = setOf("esp32-s3", "esp32-c3", "esp32-c6", "nrf52840", "rp2040", "stm32", "esp32")
 
+/** Host serving the versioned `firmware-<version>/` artifact folders. The nightly channel is published elsewhere. */
 private const val FIRMWARE_BASE_URL = "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master"
 
 /** Radix for the hex flash addresses in maintenance-image diagnostics. */
@@ -225,7 +227,7 @@ open class FirmwareRetriever(private val fileHandler: FirmwareFileHandler) {
         hardware: DeviceHardware,
         onProgress: (Float) -> Unit,
     ): FirmwareArtifact? {
-        val manifestUrl = "$FIRMWARE_BASE_URL/${release.artifactFolder}/firmware-$target-$version.mt.json"
+        val manifestUrl = "${release.artifactBaseUrl}/firmware-$target-$version.mt.json"
 
         val text = fileHandler.fetchText(manifestUrl)
         if (text == null) {
@@ -299,7 +301,7 @@ open class FirmwareRetriever(private val fileHandler: FirmwareFileHandler) {
         val version = release.id.removePrefix("v")
         val target = hardware.platformioTarget.ifEmpty { hardware.hwModelSlug }
         val filename = preferredFilename ?: "firmware-$target-$version$fileSuffix"
-        val directUrl = "$FIRMWARE_BASE_URL/${release.artifactFolder}/$filename"
+        val directUrl = "${release.artifactBaseUrl}/$filename"
 
         if (fileHandler.checkUrlExists(directUrl)) {
             try {
@@ -331,12 +333,20 @@ open class FirmwareRetriever(private val fileHandler: FirmwareFileHandler) {
     }
 
     /**
-     * The meshtastic.github.io folder holding this release's artifacts. Nightly builds live in the fixed
-     * `firmware-nightly/` folder (mirroring the web flasher); everything else uses the versioned folder.
+     * Base URL holding this release's artifacts. Nightly builds sit flat at the root of the nightly host (mirroring the
+     * web flasher); stable and alpha use the versioned folder on meshtastic.github.io, which that host does not serve.
+     *
+     * A nightly must resolve against the same host its version pointer came from — the nightly host and
+     * meshtastic.github.io publish different firmware commits, so a filename built from the other host's version does
+     * not exist.
      */
-    private val FirmwareRelease.artifactFolder: String
+    private val FirmwareRelease.artifactBaseUrl: String
         get() =
-            if (releaseType == FirmwareReleaseType.NIGHTLY) "firmware-nightly" else "firmware-${id.removePrefix("v")}"
+            if (releaseType == FirmwareReleaseType.NIGHTLY) {
+                HttpClientDefaults.NIGHTLY_BASE_URL
+            } else {
+                "$FIRMWARE_BASE_URL/firmware-${id.removePrefix("v")}"
+            }
 
     private fun resolveZipUrl(url: String, targetArch: String): String {
         for (arch in KNOWN_ARCHS) {

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonFirmwareRetrieverTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonFirmwareRetrieverTest.kt
@@ -41,10 +41,14 @@ import kotlin.test.assertTrue
 abstract class CommonFirmwareRetrieverTest {
 
     protected companion object {
-        const val BASE_URL = "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master"
+        /** Stable and alpha artifacts: one directory per version at this host's root. */
+        const val RELEASE_BASE_URL = "https://release.meshtastic.org"
 
-        /** Nightly artifacts are served flat at this host's root, not from a folder under [BASE_URL]. */
+        /** Nightly artifacts are served flat at this host's root, in its own bucket. */
         const val NIGHTLY_BASE_URL = "https://nightly.meshtastic.org"
+
+        /** The retired host. No channel may resolve against it any more. */
+        const val RETIRED_BASE_URL = "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master"
 
         val TEST_RELEASE = FirmwareRelease(id = "v2.7.17", zipUrl = "https://example.com/esp32-s3.zip")
 
@@ -84,10 +88,10 @@ abstract class CommonFirmwareRetrieverTest {
         val retriever = FirmwareRetriever(handler)
 
         // Manifest is available
-        handler.textResponses["$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.mt.json"] = MANIFEST_JSON
+        handler.textResponses["$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.mt.json"] = MANIFEST_JSON
 
         // Direct download of the manifest-resolved filename succeeds
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.bin")
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -105,9 +109,9 @@ abstract class CommonFirmwareRetrieverTest {
         val name = "firmware-heltec-v3-2.7.17-app0.bin"
         val payload = ByteArray(2048) { it.toByte() }
         val md5 = FirmwareHashUtil.calculateMd5Hex(payload)
-        handler.textResponses["$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.mt.json"] =
+        handler.textResponses["$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.mt.json"] =
             """{"files":[{"name":"$name","part_name":"app0","md5":"$md5","bytes":${payload.size}}]}"""
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/$name")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/$name")
         handler.fileBytes[name] = payload
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
@@ -123,12 +127,12 @@ abstract class CommonFirmwareRetrieverTest {
 
         val name = "firmware-heltec-v3-2.7.17-app0.bin"
         // Size matches (4) so md5 is computed; the manifest md5 is wrong, so the artifact must be rejected.
-        handler.textResponses["$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.mt.json"] =
+        handler.textResponses["$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.mt.json"] =
             """{"files":[{"name":"$name","part_name":"app0","md5":"deadbeef","bytes":4}]}"""
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/$name")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/$name")
         handler.fileBytes[name] = byteArrayOf(0x01, 0x02, 0x03, 0x04)
         // Heuristic fallback the rejection should land on.
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.bin")
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -143,11 +147,11 @@ abstract class CommonFirmwareRetrieverTest {
 
         val name = "firmware-heltec-v3-2.7.17-app0.bin"
         // Blank md5 → only size is checked; the declared size disagrees with the download, so it must be rejected.
-        handler.textResponses["$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.mt.json"] =
+        handler.textResponses["$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.mt.json"] =
             """{"files":[{"name":"$name","part_name":"app0","md5":"","bytes":9999}]}"""
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/$name")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/$name")
         handler.fileBytes[name] = ByteArray(10)
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.bin")
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -162,7 +166,7 @@ abstract class CommonFirmwareRetrieverTest {
 
         // No manifest
         // Current naming direct download succeeds
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.bin")
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -176,7 +180,7 @@ abstract class CommonFirmwareRetrieverTest {
         val retriever = FirmwareRetriever(handler)
 
         // No manifest, no plain .bin; only the bare app `-update.bin` is published.
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17-update.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17-update.bin")
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -192,8 +196,8 @@ abstract class CommonFirmwareRetrieverTest {
         // No manifest. Both files exist: on pre-2.7.17 releases the plain `.bin` is a *merged* bootloader+app image
         // (which esp_ota_end rejects when flashed to app0), while `-update.bin` is the bare app image. Confirmed on
         // hardware with 2.7.15: the merged image failed `OTA End`, the -update.bin app image is the OTA-able one.
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.bin")
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17-update.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17-update.bin")
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -260,10 +264,10 @@ abstract class CommonFirmwareRetrieverTest {
         val retriever = FirmwareRetriever(handler)
 
         // Malformed manifest
-        handler.textResponses["$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.mt.json"] = "{ not valid json }"
+        handler.textResponses["$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.mt.json"] = "{ not valid json }"
 
         // Current naming succeeds
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.bin")
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -277,11 +281,11 @@ abstract class CommonFirmwareRetrieverTest {
         val retriever = FirmwareRetriever(handler)
 
         // Manifest with no app0 entry
-        handler.textResponses["$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.mt.json"] =
+        handler.textResponses["$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.mt.json"] =
             """{"files": [{"name": "bootloader.bin", "md5": "abc", "bytes": 1024, "part_name": "bootloader"}]}"""
 
         // Current naming succeeds
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.bin")
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -294,7 +298,7 @@ abstract class CommonFirmwareRetrieverTest {
         val handler = FakeFirmwareFileHandler()
         val retriever = FirmwareRetriever(handler)
 
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.bin")
 
         retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -315,7 +319,7 @@ abstract class CommonFirmwareRetrieverTest {
         val handler = FakeFirmwareFileHandler()
         val retriever = FirmwareRetriever(handler)
 
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-heltec-v3-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-heltec-v3-2.7.17.bin")
 
         retriever.retrieveEsp32Firmware(TEST_RELEASE, TEST_HARDWARE) {}
 
@@ -332,7 +336,7 @@ abstract class CommonFirmwareRetrieverTest {
         val retriever = FirmwareRetriever(handler)
         val hardware = TEST_HARDWARE.copy(platformioTarget = "", hwModelSlug = "CUSTOM_BOARD")
 
-        handler.existingUrls.add("$BASE_URL/firmware-2.7.17/firmware-CUSTOM_BOARD-2.7.17.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.7.17/firmware-CUSTOM_BOARD-2.7.17.bin")
 
         val result = retriever.retrieveEsp32Firmware(TEST_RELEASE, hardware) {}
 
@@ -356,9 +360,12 @@ abstract class CommonFirmwareRetrieverTest {
 
         val result = retriever.retrieveEsp32Firmware(nightly, TEST_HARDWARE) {}
 
-        assertNotNull(result, "Nightly should resolve from the nightly host, not a folder under $BASE_URL")
+        assertNotNull(result, "Nightly should resolve from the nightly host, not the release host")
         assertEquals("firmware-heltec-v3-2.8.0.f52e2ea.bin", result.fileName)
-        assertTrue(handler.checkedUrls.none { BASE_URL in it }, "meshtastic.github.io must not be used for nightly")
+        assertTrue(
+            handler.checkedUrls.none { RELEASE_BASE_URL in it || RETIRED_BASE_URL in it },
+            "nightly must resolve only against the nightly host",
+        )
         assertTrue(
             "$NIGHTLY_BASE_URL/firmware-heltec-v3-2.8.0.f52e2ea.mt.json" in handler.fetchedTextUrls,
             "manifest must be fetched from the nightly host root",
@@ -394,20 +401,25 @@ abstract class CommonFirmwareRetrieverTest {
     }
 
     @Test
-    fun `stable release keeps using the versioned folder on meshtastic github io`() = runTest {
+    fun `stable release resolves from a per-version directory on the release host`() = runTest {
         val handler = FakeFirmwareFileHandler()
         val retriever = FirmwareRetriever(handler)
         val stable = FirmwareRelease(id = "v2.8.0", zipUrl = "", releaseType = FirmwareReleaseType.STABLE)
 
-        handler.existingUrls.add("$BASE_URL/firmware-2.8.0/firmware-heltec-v3-2.8.0.bin")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.8.0/firmware-heltec-v3-2.8.0.bin")
 
         val result = retriever.retrieveEsp32Firmware(stable, TEST_HARDWARE) {}
 
-        assertNotNull(result, "stable must resolve from the versioned folder")
+        assertNotNull(result, "stable must resolve from the release host's per-version directory")
+        assertTrue(
+            handler.checkedUrls.any { it == "$RELEASE_BASE_URL/2.8.0/firmware-heltec-v3-2.8.0.bin" },
+            "stable must be looked up at <release host>/<version>/, got ${handler.checkedUrls}",
+        )
         assertTrue(
             handler.checkedUrls.none { NIGHTLY_BASE_URL in it },
-            "the nightly host serves no versioned folders, so stable must never be looked up there",
+            "the nightly host is a separate bucket, so stable must never be looked up there",
         )
+        assertTrue(handler.checkedUrls.none { RETIRED_BASE_URL in it }, "the retired host must not be used")
     }
 
     // -----------------------------------------------------------------------
@@ -421,7 +433,7 @@ abstract class CommonFirmwareRetrieverTest {
         val hardware = DeviceHardware(hwModelSlug = "RAK4631", platformioTarget = "rak4631", architecture = "nrf52840")
         val release = FirmwareRelease(id = "v2.5.0", zipUrl = "https://example.com/nrf52.zip")
 
-        handler.existingUrls.add("$BASE_URL/firmware-2.5.0/firmware-rak4631-2.5.0-ota.zip")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.5.0/firmware-rak4631-2.5.0-ota.zip")
 
         val result = retriever.retrieveOtaFirmware(release, hardware) {}
 
@@ -441,7 +453,7 @@ abstract class CommonFirmwareRetrieverTest {
             )
         val release = FirmwareRelease(id = "v2.5.0", zipUrl = "https://example.com/nrf52.zip")
 
-        handler.existingUrls.add("$BASE_URL/firmware-2.5.0/firmware-rak4631_nomadstar_meteor_pro-2.5.0-ota.zip")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.5.0/firmware-rak4631_nomadstar_meteor_pro-2.5.0-ota.zip")
 
         val result = retriever.retrieveOtaFirmware(release, hardware) {}
 
@@ -460,7 +472,7 @@ abstract class CommonFirmwareRetrieverTest {
         val hardware = DeviceHardware(hwModelSlug = "RPI_PICO", platformioTarget = "pico", architecture = "rp2040")
         val release = FirmwareRelease(id = "v2.5.0", zipUrl = "https://example.com/rp2040.zip")
 
-        handler.existingUrls.add("$BASE_URL/firmware-2.5.0/firmware-pico-2.5.0.uf2")
+        handler.existingUrls.add("$RELEASE_BASE_URL/2.5.0/firmware-pico-2.5.0.uf2")
 
         val result = retriever.retrieveUsbFirmware(release, hardware) {}
 

--- a/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonFirmwareRetrieverTest.kt
+++ b/feature/firmware/src/commonTest/kotlin/org/meshtastic/feature/firmware/CommonFirmwareRetrieverTest.kt
@@ -43,6 +43,9 @@ abstract class CommonFirmwareRetrieverTest {
     protected companion object {
         const val BASE_URL = "https://raw.githubusercontent.com/meshtastic/meshtastic.github.io/master"
 
+        /** Nightly artifacts are served flat at this host's root, not from a folder under [BASE_URL]. */
+        const val NIGHTLY_BASE_URL = "https://nightly.meshtastic.org"
+
         val TEST_RELEASE = FirmwareRelease(id = "v2.7.17", zipUrl = "https://example.com/esp32-s3.zip")
 
         val TEST_HARDWARE =
@@ -338,38 +341,38 @@ abstract class CommonFirmwareRetrieverTest {
     }
 
     // -----------------------------------------------------------------------
-    // Nightly channel (fixed firmware-nightly/ folder, no release zip)
+    // Nightly channel (flat at the nightly host root, no release zip)
     // -----------------------------------------------------------------------
 
     @Test
-    fun `nightly release resolves from the fixed firmware-nightly folder`() = runTest {
+    fun `nightly release resolves from the nightly host root`() = runTest {
         val handler = FakeFirmwareFileHandler()
         val retriever = FirmwareRetriever(handler)
         val nightly = FirmwareRelease(id = "v2.8.0.f52e2ea", zipUrl = "", releaseType = FirmwareReleaseType.NIGHTLY)
 
-        handler.textResponses["$BASE_URL/firmware-nightly/firmware-heltec-v3-2.8.0.f52e2ea.mt.json"] =
+        handler.textResponses["$NIGHTLY_BASE_URL/firmware-heltec-v3-2.8.0.f52e2ea.mt.json"] =
             """{"files":[{"name":"firmware-heltec-v3-2.8.0.f52e2ea.bin","md5":"","bytes":0,"part_name":"app0"}]}"""
-        handler.existingUrls.add("$BASE_URL/firmware-nightly/firmware-heltec-v3-2.8.0.f52e2ea.bin")
+        handler.existingUrls.add("$NIGHTLY_BASE_URL/firmware-heltec-v3-2.8.0.f52e2ea.bin")
 
         val result = retriever.retrieveEsp32Firmware(nightly, TEST_HARDWARE) {}
 
-        assertNotNull(result, "Nightly should resolve from firmware-nightly/, not firmware-<version>/")
+        assertNotNull(result, "Nightly should resolve from the nightly host, not a folder under $BASE_URL")
         assertEquals("firmware-heltec-v3-2.8.0.f52e2ea.bin", result.fileName)
-        assertTrue(handler.checkedUrls.none { "firmware-2.8.0.f52e2ea/" in it }, "versioned folder must not be used")
+        assertTrue(handler.checkedUrls.none { BASE_URL in it }, "meshtastic.github.io must not be used for nightly")
         assertTrue(
-            "$BASE_URL/firmware-nightly/firmware-heltec-v3-2.8.0.f52e2ea.mt.json" in handler.fetchedTextUrls,
-            "manifest must be fetched from firmware-nightly/",
+            "$NIGHTLY_BASE_URL/firmware-heltec-v3-2.8.0.f52e2ea.mt.json" in handler.fetchedTextUrls,
+            "manifest must be fetched from the nightly host root",
         )
     }
 
     @Test
-    fun `nightly ota zip resolves from the fixed firmware-nightly folder`() = runTest {
+    fun `nightly ota zip resolves from the nightly host root`() = runTest {
         val handler = FakeFirmwareFileHandler()
         val retriever = FirmwareRetriever(handler)
         val hardware = DeviceHardware(hwModelSlug = "RAK4631", platformioTarget = "rak4631", architecture = "nrf52840")
         val nightly = FirmwareRelease(id = "v2.8.0.f52e2ea", zipUrl = "", releaseType = FirmwareReleaseType.NIGHTLY)
 
-        handler.existingUrls.add("$BASE_URL/firmware-nightly/firmware-rak4631-2.8.0.f52e2ea-ota.zip")
+        handler.existingUrls.add("$NIGHTLY_BASE_URL/firmware-rak4631-2.8.0.f52e2ea-ota.zip")
 
         val result = retriever.retrieveOtaFirmware(nightly, hardware) {}
 
@@ -388,6 +391,23 @@ abstract class CommonFirmwareRetrieverTest {
 
         assertNull(result)
         assertTrue(handler.downloadedUrls.isEmpty(), "no zip download may be attempted when zipUrl is blank")
+    }
+
+    @Test
+    fun `stable release keeps using the versioned folder on meshtastic github io`() = runTest {
+        val handler = FakeFirmwareFileHandler()
+        val retriever = FirmwareRetriever(handler)
+        val stable = FirmwareRelease(id = "v2.8.0", zipUrl = "", releaseType = FirmwareReleaseType.STABLE)
+
+        handler.existingUrls.add("$BASE_URL/firmware-2.8.0/firmware-heltec-v3-2.8.0.bin")
+
+        val result = retriever.retrieveEsp32Firmware(stable, TEST_HARDWARE) {}
+
+        assertNotNull(result, "stable must resolve from the versioned folder")
+        assertTrue(
+            handler.checkedUrls.none { NIGHTLY_BASE_URL in it },
+            "the nightly host serves no versioned folders, so stable must never be looked up there",
+        )
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Meshtastic firmware artifacts are served from Cloudflare R2 hosts, but the app was still fetching all of them from `raw.githubusercontent.com/meshtastic/meshtastic.github.io/master`. This moves both the nightly channel and the release channels onto the R2 hosts, which is what `web-flasher` already does (`utils/firmwareUrl.ts`: `NIGHTLY_BASE`, `RELEASE_BASE`, `getFirmwareBaseUrl`).

Two commits, so the nightly fix stays independently revertable.

### 🐛 Bug Fixes

**Nightly channel was serving a stale build.** The `firmware-nightly/` folder on `meshtastic.github.io` last published 2026-09-06, while `nightly.meshtastic.org` was current as of 2026-09-08. The in-app nightly channel was therefore two days behind. Both the version pointer (`index.json`) and the artifacts now come from `nightly.meshtastic.org`, which serves them flat at its root.

The pointer and the artifacts have to come from the same host: the nightly and release buckets track different firmware commits, so reading a version from one and building artifact filenames against the other resolves files that do not exist.

### 🛠️ Refactoring & Architecture

**Stable and alpha moved to `release.meshtastic.org`**, one directory per version at the root (`<version>/firmware-<target>-<version>.<ext>`) instead of the versioned `firmware-<version>/` folder on github.io.

- `HttpClientDefaults.NIGHTLY_BASE_URL` and `HttpClientDefaults.RELEASE_BASE_URL` give every firmware host one home, and the nightly index URL derives from the former.
- `FirmwareRelease.artifactFolder` (a path fragment) became `FirmwareRelease.artifactBaseUrl` (a full base URL), so a channel can resolve against a different *host* rather than a different folder on one host. Structurally the same split as the flasher's `getFirmwareBaseUrl`.
- `FIRMWARE_BASE_URL` is deleted. No firmware artifact is fetched from `raw.githubusercontent.com` any more.

### 🧹 Chores

- Refresh the KDoc naming `meshtastic.github.io` as a firmware source across `core:model`, `core:network`, `core:data`, `core:database`, `core:repository` and `feature:firmware`.

### Verification

Checked against the live hosts before writing the change, not inferred:

- **Byte-identical.** `firmware-heltec-v3-2.7.26.54e0d8d.bin` is sha256-identical on `release.meshtastic.org` and github.io (2109248 bytes both).
- **Coverage is identical, version for version.** I probed all 25 versions the API currently offers (2 stable, 23 alpha). Only the newest few are present, and the same ones on both hosts; every older version 404s on *both*. So this changes nothing about which versions resolve directly, and the older ones keep falling back to the release zip from the API's `zip_url` (a GitHub release asset, untouched here).
- `HEAD` and range requests work on both new hosts, which `FirmwareFileHandler.checkUrlExists` depends on.
- All four artifact types resolve on the release host: `.bin`, `.uf2`, `-ota.zip`, `.mt.json`.
- Content types: artifacts are `application/octet-stream` on both hosts; `index.json` and `.mt.json` are `application/json` and `-ota.zip` is `application/zip` on the nightly host, where `.uf2` carries no `content-type` at all. Nothing in the download path branches on content type, but it does rule out relying on content negotiation for artifacts.

Two cache notes for reviewers, both infrastructure rather than code:

- The release host sends `cache-control: public, max-age=86400, s-maxage=2592000` against github.io's `max-age=300`. Safe to cache long, because the version is part of every artifact filename, so a published artifact is immutable.
- The nightly host sends `max-age=14400` (4 h) against the app's 1 h `CACHE_EXPIRATION_TIME_MS`, so a freshly published nightly can take up to 4 h to surface.

### Out of scope

Not touched, and deliberately so: the release-zip fallback and `resolveZipUrl` (GitHub release assets, a different host that is not moving), the pinned maintenance/factory-erase images (absolute URLs from the API's `maintenanceUf2` manifest, still digest-verified before any write), and event firmware (an absolute `zip_url` from the API, no path construction).

### Testing Performed

Added:

- `ApiServiceTest.nightly pointer is fetched from the nightly host root` pins the exact index URL.
- `ApiServiceTest.nightly pointer returns null when nothing is published` covers the 404 path, where the body is the host's HTML error page, so the status is what distinguishes "gone" from "unreachable".
- `CommonFirmwareRetrieverTest.stable release resolves from a per-version directory on the release host` asserts the exact per-version URL and guards that neither the nightly host nor the retired host is used.

Updated the existing nightly cases and rewrote the 25 artifact URLs in `CommonFirmwareRetrieverTest` onto the release host. The nightly case now also asserts it never reaches the release host.

Baseline run locally on the final tree, green:

```
./gradlew spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile
```

All 31 `FirmwareRetrieverTest` cases pass. Locally that exercised the `jvm` variant of `CommonFirmwareRetrieverTest`; the `androidHostTest` subclass is covered by CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Firmware Updates**
  - Firmware manifests and downloads now use dedicated release and nightly hosts.
  - Stable and alpha firmware files are organized by version.
  - Nightly firmware is served from the nightly host’s root location.
  - Firmware retrieval now supports the appropriate host and path for each release type.
  - Unavailable nightly releases are handled distinctly from unreachable services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->