### PR TITLE
fix(settings): fetch Mesh Beacon config from remote-admin nodes

### DIFF
--- a/feature/settings/settings-validation.md
+++ b/feature/settings/settings-validation.md
@@ -379,10 +379,12 @@ configuration settings screen. Constraints are sourced from two layers:
 
 ### Mesh Beacon (`ModuleConfig.MeshBeaconConfig`)
 
-Gated behind the `supportsMeshBeacon` capability. There is no `AdminMessage.ModuleConfigType`
-value for this module, so the editor reads from the connect-time config sync (no per-module
-refresh) and writes via `AdminMessage.setModuleConfig`. Flag edits are read-modify-write so
-`FLAG_LEGACY_SPLIT` and any unknown bits survive.
+Gated behind the `supportsMeshBeacon` capability. The editor reads via
+`AdminMessage.getModuleConfigRequest(MESHBEACON_CONFIG)` plus the LoRa config and channel 0
+(the region gate and the offer-channel picker need both on a remote node) and writes via
+`AdminMessage.setModuleConfig`. Flag edits are read-modify-write so `FLAG_LEGACY_SPLIT` and any
+unknown bits survive. Over remote admin only the primary channel is read, so the picker offers
+the primary only there.
 
 | Field | Type | Validation | Notes |
 |-------|------|------------|-------|

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/ModuleRoute.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/navigation/ModuleRoute.kt
@@ -61,9 +61,6 @@ enum class ModuleRoute(
     val type: Int = 0,
     val isSupported: (Capabilities) -> Boolean = { true },
     val isApplicable: (Config.DeviceConfig.Role?) -> Boolean = { true },
-    // False when the firmware has no ModuleConfigType to request this module per-request; the editor then relies on the
-    // connect-time config sync instead of a get (MeshBeacon: MeshBeaconConfig is in ModuleConfig but not in the enum).
-    val refreshable: Boolean = true,
     val hasReadFanOut: Boolean = false,
 ) {
     MQTT(Res.string.mqtt, SettingsRoute.MQTT, Res.drawable.ic_cloud, AdminMessage.ModuleConfigType.MQTT_CONFIG.value),
@@ -150,14 +147,15 @@ enum class ModuleRoute(
         isApplicable = { it == Config.DeviceConfig.Role.TAK || it == Config.DeviceConfig.Role.TAK_TRACKER },
     ),
 
-    // MeshBeaconConfig has no AdminMessage.ModuleConfigType value upstream — the editor reads from the connect-time
-    // config sync, so refreshable=false (no per-module get is issued). Gated to firmware that ships the beacon module.
+    // Reads the module config plus the LoRa config and the primary channel, which the editor's region gate and
+    // channel picker need on a remote node whose connect-time snapshot is empty.
     MESH_BEACON(
         Res.string.mesh_beacon,
         SettingsRoute.MeshBeacon,
         Res.drawable.ic_perm_scan_wifi,
+        AdminMessage.ModuleConfigType.MESHBEACON_CONFIG.value,
         isSupported = { it.supportsMeshBeacon },
-        refreshable = false,
+        hasReadFanOut = true,
     ),
     ;
 

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModel.kt
@@ -621,6 +621,7 @@ open class RadioConfigViewModel(
                         paxcounter = config.paxcounter ?: state.moduleConfig.paxcounter,
                         statusmessage = config.statusmessage ?: state.moduleConfig.statusmessage,
                         tak = config.tak ?: state.moduleConfig.tak,
+                        mesh_beacon = config.mesh_beacon ?: state.moduleConfig.mesh_beacon,
                     ),
                 )
             }
@@ -835,13 +836,6 @@ open class RadioConfigViewModel(
     private fun setResponseStateLoading(route: Enum<*>, showOverlay: Boolean) {
         val destNum = destNum ?: destNode.value?.num ?: return
 
-        // A module without a per-module get (no ModuleConfigType, e.g. MeshBeacon) reads from the connect-time config
-        // sync — just select the route and render, skipping the loading/request round-trip that would never complete.
-        if (route is ModuleRoute && !route.refreshable) {
-            _radioConfigState.update { it.copy(route = route.name, responseState = ResponseState.Empty) }
-            return
-        }
-
         _radioConfigState.update {
             it.copy(route = route.name, responseState = ResponseState.Loading(showOverlay = showOverlay))
         }
@@ -926,6 +920,21 @@ open class RadioConfigViewModel(
             safeLaunch(tag = "getRingtone") {
                 radioConfigUseCase.getRingtone(destNum, onRequestId = ::registerReadRequestId)
             }
+        }
+        if (route == ModuleRoute.MESH_BEACON) {
+            // The beacon editor gates on the radio's LoRa region and offers its channels, neither of which a remote
+            // session has until read. Firmware without the module never answers the module get, so skip it there.
+            safeLaunch(tag = "getChannel0ForMeshBeacon") {
+                radioConfigUseCase.getChannel(destNum, 0, onRequestId = ::registerReadRequestId)
+            }
+            safeLaunch(tag = "getLoraConfigForMeshBeacon") {
+                radioConfigUseCase.getConfig(
+                    destNum,
+                    AdminMessage.ConfigType.LORA_CONFIG.value,
+                    onRequestId = ::registerReadRequestId,
+                )
+            }
+            if (!Capabilities(radioConfigState.value.metadata?.firmware_version).supportsMeshBeacon) return
         }
         safeLaunch(tag = "getModuleConfig") {
             radioConfigUseCase.getModuleConfig(destNum, route.type, onRequestId = ::registerReadRequestId)
@@ -1344,6 +1353,7 @@ open class RadioConfigViewModel(
                             paxcounter = response.paxcounter ?: state.moduleConfig.paxcounter,
                             statusmessage = response.statusmessage ?: state.moduleConfig.statusmessage,
                             tak = response.tak ?: state.moduleConfig.tak,
+                            mesh_beacon = response.mesh_beacon ?: state.moduleConfig.mesh_beacon,
                         ),
                     )
                 }

--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MeshBeaconConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/MeshBeaconConfigItemList.kt
@@ -90,9 +90,9 @@ private fun Int.withFlag(flag: Int, on: Boolean): Int = if (on) this or flag els
 private fun Int.hasFlag(flag: Int): Boolean = (this and flag) != 0
 
 /**
- * Editor for `ModuleConfig.MeshBeaconConfig` (design#140, Android issue #6931). Reads from the connect-time config sync
- * (there is no `ModuleConfigType` beacon value to request per-module) and writes via `AdminMessage.setModuleConfig`.
- * Flag edits are read-modify-write so unknown bits survive.
+ * Editor for `ModuleConfig.MeshBeaconConfig` (design#140, Android issue #6931). Reads via
+ * `AdminMessage.getModuleConfigRequest(MESHBEACON_CONFIG)` and writes via `AdminMessage.setModuleConfig`. Flag edits
+ * are read-modify-write so unknown bits survive.
  *
  * The region and offered/transmit preset are never user-chosen here: the radio's own LoRa region and configured preset
  * are always stamped in on save (`stampBeaconConfigForSave`), so the beacon can never transmit region or preset

--- a/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/org/meshtastic/feature/settings/radio/RadioConfigViewModelTest.kt
@@ -94,6 +94,8 @@ import org.meshtastic.proto.LoRaRegionPresetMap
 import org.meshtastic.proto.LocalConfig
 import org.meshtastic.proto.LocalModuleConfig
 import org.meshtastic.proto.MeshPacket
+import org.meshtastic.proto.ModuleConfig
+import org.meshtastic.proto.ModuleConfig.MeshBeaconConfig
 import org.meshtastic.proto.PortNum
 import org.meshtastic.proto.Routing
 import org.meshtastic.proto.User
@@ -118,7 +120,7 @@ class RadioConfigViewModelTest {
             ConfigRoute.entries.filter(ConfigRoute::hasReadFanOut).toSet(),
         )
         assertEquals(
-            setOf(ModuleRoute.CANNED_MESSAGE, ModuleRoute.EXT_NOTIFICATION),
+            setOf(ModuleRoute.CANNED_MESSAGE, ModuleRoute.EXT_NOTIFICATION, ModuleRoute.MESH_BEACON),
             ModuleRoute.entries.filter(ModuleRoute::hasReadFanOut).toSet(),
         )
     }
@@ -147,6 +149,153 @@ class RadioConfigViewModelTest {
         advanceUntilIdle()
 
         verifySuspend(exactly(0)) { radioConfigUseCase.getModuleConfig(any(), any(), any()) }
+    }
+
+    @Test
+    fun `MESH_BEACON route on a remote node reads the beacon module config plus LoRa config and channel 0`() = runTest {
+        val localNode = Node(num = 100, user = User(id = "!100"))
+        val remoteNode =
+            Node(num = 456, user = User(id = "!456"), metadata = DeviceMetadata(firmware_version = "2.8.0"))
+        nodeRepository.setNodes(listOf(localNode, remoteNode))
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 100))
+        viewModel = createViewModel(destNum = 456)
+
+        viewModel.setResponseStateLoading(ModuleRoute.MESH_BEACON)
+        advanceUntilIdle()
+
+        // Pins ModuleRoute.MESH_BEACON.type: the default (0) would fetch MQTT_CONFIG instead.
+        verifySuspend {
+            radioConfigUseCase.getModuleConfig(456, AdminMessage.ModuleConfigType.MESHBEACON_CONFIG.value, any())
+        }
+        verifySuspend(exactly(0)) {
+            radioConfigUseCase.getModuleConfig(456, AdminMessage.ModuleConfigType.MQTT_CONFIG.value, any())
+        }
+        // Pins the loadModuleRoute fan-out that fills the editor's region gate and channel picker.
+        verifySuspend { radioConfigUseCase.getChannel(456, 0, any()) }
+        verifySuspend { radioConfigUseCase.getConfig(456, AdminMessage.ConfigType.LORA_CONFIG.value, any()) }
+    }
+
+    @Test
+    fun `MESH_BEACON route skips the module get on firmware without the module but still reads LoRa and channel 0`() =
+        runTest {
+            val localNode = Node(num = 100, user = User(id = "!100"))
+            val remoteNode =
+                Node(num = 456, user = User(id = "!456"), metadata = DeviceMetadata(firmware_version = "2.7.21"))
+            nodeRepository.setNodes(listOf(localNode, remoteNode))
+            nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 100))
+            viewModel = createViewModel(destNum = 456)
+
+            viewModel.setResponseStateLoading(ModuleRoute.MESH_BEACON)
+            advanceUntilIdle()
+
+            // Pins the supportsMeshBeacon gate: firmware without the module never answers, so no get is issued. The
+            // module list already hides the route on such firmware; this keeps the view model safe if reached directly.
+            verifySuspend(exactly(0)) { radioConfigUseCase.getModuleConfig(any(), any(), any()) }
+            verifySuspend { radioConfigUseCase.getChannel(456, 0, any()) }
+            verifySuspend { radioConfigUseCase.getConfig(456, AdminMessage.ConfigType.LORA_CONFIG.value, any()) }
+        }
+
+    @Test
+    fun `MESH_BEACON remote read completes only after all three responses land`() = runTest {
+        val localNode = Node(num = 100, user = User(id = "!100"))
+        val remoteNode =
+            Node(num = 456, user = User(id = "!456"), metadata = DeviceMetadata(firmware_version = "2.8.0"))
+        val packetFlow = MutableSharedFlow<MeshPacket>()
+        val beacon =
+            MeshBeaconConfig(broadcast_offer_region = Config.LoRaConfig.RegionCode.US, broadcast_message = "join us")
+        every { serviceRepository.meshPacketFlow } returns packetFlow
+        everySuspend { radioConfigUseCase.getChannel(any(), any(), any()) } calls
+            {
+                it.args.onRequestIdArg()(41)
+                41
+            }
+        everySuspend { radioConfigUseCase.getConfig(any(), any(), any()) } calls
+            {
+                it.args.onRequestIdArg()(42)
+                42
+            }
+        everySuspend { radioConfigUseCase.getModuleConfig(any(), any(), any()) } calls
+            {
+                it.args.onRequestIdArg()(43)
+                43
+            }
+        every { processRadioResponseUseCase(any(), 456, any()) } calls
+            {
+                val requestId = (it.args[0] as MeshPacket).decoded?.request_id
+
+                @Suppress("UNCHECKED_CAST")
+                val pendingRequestIds = it.args[2] as Set<Int>
+                when (requestId?.takeIf { id -> id in pendingRequestIds }) {
+                    41 ->
+                        RadioResponseResult.ChannelResponse(
+                            Channel(
+                                index = 0,
+                                role = Channel.Role.PRIMARY,
+                                settings = ChannelSettings(name = "LongFast"),
+                            ),
+                        )
+
+                    42 ->
+                        RadioResponseResult.ConfigResponse(
+                            Config(lora = Config.LoRaConfig(region = Config.LoRaConfig.RegionCode.US)),
+                        )
+
+                    43 -> RadioResponseResult.ModuleConfigResponse(ModuleConfig(mesh_beacon = beacon))
+
+                    else -> null
+                }
+            }
+        nodeRepository.setNodes(listOf(localNode, remoteNode))
+        nodeRepository.setMyNodeInfo(myNodeInfo(myNodeNum = 100))
+        viewModel = createViewModel(destNum = 456)
+
+        viewModel.setResponseStateLoading(ModuleRoute.MESH_BEACON)
+        runCurrent()
+        assertEquals(3, (viewModel.radioConfigState.value.responseState as ResponseState.Loading).total)
+
+        packetFlow.emit(MeshPacket(decoded = Data(request_id = 41)))
+        packetFlow.emit(MeshPacket(decoded = Data(request_id = 42)))
+        runCurrent()
+        assertTrue(
+            viewModel.radioConfigState.value.responseState is ResponseState.Loading,
+            "two of three responses must not complete the read",
+        )
+        assertEquals(3, (viewModel.radioConfigState.value.responseState as ResponseState.Loading).total)
+
+        packetFlow.emit(MeshPacket(decoded = Data(request_id = 43)))
+        runCurrent()
+
+        assertEquals(ResponseState.Empty, viewModel.radioConfigState.value.responseState)
+        assertEquals(beacon, viewModel.radioConfigState.value.moduleConfig.mesh_beacon)
+        assertEquals(Config.LoRaConfig.RegionCode.US, viewModel.radioConfigState.value.radioConfig.lora?.region)
+        // Pins the getChannel(0) half of the fan-out: the primary channel is what the offer picker renders.
+        assertEquals(listOf("LongFast"), viewModel.radioConfigState.value.channelList.map { it.name })
+    }
+
+    @Test
+    fun `ModuleConfigResponse carrying mesh_beacon is merged and survives a later response without it`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        val packetFlow = MutableSharedFlow<MeshPacket>()
+        every { serviceRepository.meshPacketFlow } returns packetFlow
+        viewModel = createViewModel()
+
+        val beacon =
+            MeshBeaconConfig(broadcast_offer_region = Config.LoRaConfig.RegionCode.EU_868, broadcast_message = "hi")
+        every { processRadioResponseUseCase(any(), 123, any()) } returns
+            RadioResponseResult.ModuleConfigResponse(ModuleConfig(mesh_beacon = beacon))
+        packetFlow.emit(MeshPacket())
+        // Pins the mesh_beacon merge line: without it the reply is dropped and the editor renders defaults.
+        assertEquals(beacon, viewModel.radioConfigState.value.moduleConfig.mesh_beacon)
+
+        every { processRadioResponseUseCase(any(), 123, any()) } returns
+            RadioResponseResult.ModuleConfigResponse(
+                ModuleConfig(telemetry = ModuleConfig.TelemetryConfig(device_update_interval = 300)),
+            )
+        packetFlow.emit(MeshPacket())
+        // Pins the `?: state.moduleConfig.mesh_beacon` fallback: a reply for another module keeps the beacon config.
+        assertEquals(beacon, viewModel.radioConfigState.value.moduleConfig.mesh_beacon)
+        assertEquals(300, viewModel.radioConfigState.value.moduleConfig.telemetry?.device_update_interval)
     }
 
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -1281,6 +1430,20 @@ class RadioConfigViewModelTest {
 
         verifySuspend { radioConfigUseCase.setModuleConfig(123, config, any()) }
         assertEquals(true, viewModel.radioConfigState.value.moduleConfig.mqtt?.enabled)
+    }
+
+    @Test
+    fun `setModuleConfig merges mesh_beacon into state before the radio answers`() = runTest {
+        val node = Node(num = 123, user = User(id = "!123"))
+        nodeRepository.setNodes(listOf(node))
+        viewModel = createViewModel()
+        val beacon = MeshBeaconConfig(broadcast_message = "join us")
+        everySuspend { radioConfigUseCase.setModuleConfig(any(), any(), any()) } returns 42
+
+        viewModel.setModuleConfig(ModuleConfig(mesh_beacon = beacon))
+
+        // Pins the optimistic mesh_beacon merge: a second save in the same session reads this, not the radio's reply.
+        assertEquals(beacon, viewModel.radioConfigState.value.moduleConfig.mesh_beacon)
     }
 
     @Test


### PR DESCRIPTION
Over remote admin the Mesh Beacon editor asked for a region and then rendered everything off. `MESH_BEACON` was marked `refreshable = false` on the premise that no `ModuleConfigType` existed for it, so no get was ever sent, and the `ModuleConfigResponse` merge dropped `mesh_beacon` anyway. `MESHBEACON_CONFIG` is in the pinned protos and 2.8 firmware answers it.

Fixes #7060

### 🐛 Bug Fixes
- `ModuleRoute.MESH_BEACON` requests `MESHBEACON_CONFIG`; the `refreshable` flag and its early return are gone (nothing else used it)
- `loadModuleRoute` also reads the LoRa config and the primary channel for this route, which the editor's region gate and offer picker need on a remote node, gated on `supportsMeshBeacon` so firmware without the module does not sit on a get it will never answer
- `mesh_beacon` is carried through both `ModuleConfigResponse` merges (read and optimistic save)

### 🧹 Chores
- `settings-validation.md` and the editor KDoc describe the real read path. Over remote admin the picker offers the primary channel only.

### Testing Performed
`RadioConfigViewModelTest`, each pins one production line:
- `MESH_BEACON route on a remote node reads the beacon module config plus LoRa config and channel 0`
- `MESH_BEACON route skips the module get on firmware without the module but still reads LoRa and channel 0`
- `MESH_BEACON remote read completes only after all three responses land` (also pins the loading total and the channel merge)
- `ModuleConfigResponse carrying mesh_beacon is merged and survives a later response without it`
- `setModuleConfig merges mesh_beacon into state before the radio answers`

Baseline green (`spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`). Not verified on hardware yet: on the bench the remote module list hides Mesh Beacon until the app has the remote node's metadata, which is a separate gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mesh Beacon settings now load through the standard settings flow, providing more reliable configuration updates.
  * The editor now loads the required region, radio, and channel information before displaying available options.
  * Remote administration now limits the offer-channel picker to the primary channel when applicable.
  * Mesh Beacon changes appear immediately in the settings view while updates are being processed.
  * Settings remain synchronized as configuration responses arrive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->