### PR TITLE
fix(network): never send heartbeat nonce 1, the firmware NodeInfo-ping trigger

### DIFF
--- a/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/DataLayerHeartbeatSender.kt
+++ b/core/data/src/commonMain/kotlin/org/meshtastic/core/data/manager/DataLayerHeartbeatSender.kt
@@ -19,6 +19,7 @@ package org.meshtastic.core.data.manager
 import co.touchlab.kermit.Logger
 import kotlinx.atomicfu.atomic
 import org.koin.core.annotation.Single
+import org.meshtastic.core.network.transport.HeartbeatSender
 import org.meshtastic.core.repository.PacketHandler
 import org.meshtastic.proto.Heartbeat
 import org.meshtastic.proto.ToRadio
@@ -27,14 +28,15 @@ import org.meshtastic.proto.ToRadio
  * Centralized heartbeat sender for the data layer.
  *
  * Consolidates heartbeat nonce management into a single monotonically increasing counter, preventing the firmware's
- * per-connection duplicate-write filter (byte-level memcmp) from silently dropping consecutive heartbeats.
+ * per-connection duplicate-write filter (byte-level memcmp) from silently dropping consecutive heartbeats. Starts at
+ * [HeartbeatSender.FIRST_NONCE], past the firmware's NodeInfo-ping trigger.
  *
  * This is distinct from [org.meshtastic.core.network.transport.HeartbeatSender], which operates at the transport layer
  * with raw byte encoding. This class works at the protobuf/data layer through [PacketHandler].
  */
 @Single
 class DataLayerHeartbeatSender(private val packetHandler: PacketHandler) {
-    private val nonce = atomic(0)
+    private val nonce = atomic(HeartbeatSender.FIRST_NONCE)
 
     /**
      * Enqueues a heartbeat with a unique nonce.
@@ -44,7 +46,7 @@ class DataLayerHeartbeatSender(private val packetHandler: PacketHandler) {
     @Suppress("TooGenericExceptionCaught")
     fun sendHeartbeat(tag: String = "handshake") {
         try {
-            val n = nonce.incrementAndGet()
+            val n = nonce.getAndIncrement()
             packetHandler.sendToRadio(ToRadio(heartbeat = Heartbeat(nonce = n)))
             Logger.d { "[$tag] Heartbeat enqueued (nonce=$n)" }
         } catch (e: Exception) {

--- a/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/DataLayerHeartbeatSenderTest.kt
+++ b/core/data/src/commonTest/kotlin/org/meshtastic/core/data/manager/DataLayerHeartbeatSenderTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.data.manager
+
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import org.meshtastic.core.repository.PacketHandler
+import org.meshtastic.proto.ToRadio
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DataLayerHeartbeatSenderTest {
+
+    @Test
+    fun `nonces are strictly increasing and never 1 the firmware NodeInfo-ping trigger`() {
+        val sentPackets = mutableListOf<ToRadio>()
+        val packetHandler = mock<PacketHandler>(MockMode.autofill)
+        every { packetHandler.sendToRadio(any<ToRadio>()) } calls { call -> sentPackets.add(call.arg(0)) }
+        val sender = DataLayerHeartbeatSender(packetHandler)
+
+        repeat(5) { sender.sendHeartbeat("test") }
+
+        val nonces = sentPackets.map { assertNotNull(it.heartbeat).nonce }
+        assertEquals(5, nonces.size)
+        nonces.zipWithNext().forEachIndexed { index, (previous, next) ->
+            assertTrue(next > previous, "nonce at index ${index + 1} ($next) must exceed its predecessor ($previous)")
+        }
+        assertFalse(1 in nonces, "nonce 1 makes the firmware broadcast a NodeInfo ping; got $nonces")
+    }
+}

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/transport/HeartbeatSender.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/transport/HeartbeatSender.kt
@@ -29,7 +29,9 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  *
  * Constructs and sends a `ToRadio(heartbeat = Heartbeat(nonce = ...))` message to keep the firmware's idle timer from
  * expiring. Each call uses a monotonically increasing nonce to prevent the firmware's per-connection duplicate-write
- * filter from silently dropping it.
+ * filter from silently dropping it. Nonce 1 is the firmware's NodeInfo-ping trigger since v2.7.23 (a mesh-wide NodeInfo
+ * broadcast with want_response), so keepalives must never use it: the counter starts at [FIRST_NONCE] and only counts
+ * up.
  *
  * @param sendToRadio callback that reports whether the transport accepted the encoded heartbeat bytes
  * @param afterHeartbeat optional suspend callback invoked after sending (e.g. to schedule a drain)
@@ -56,7 +58,7 @@ private constructor(
     ) : this(sendToRadio, afterHeartbeat, logTag, HeartbeatRejectionLogSink(rejectionLogger))
 
     @OptIn(ExperimentalAtomicApi::class)
-    private val nonce = AtomicInt(0)
+    private val nonce = AtomicInt(FIRST_NONCE)
     private val nonceMutex = Mutex()
 
     private val rejectionLogPolicy = HeartbeatRejectionLogPolicy()
@@ -90,6 +92,11 @@ private constructor(
         if (!accepted) return false
         afterHeartbeat?.invoke()
         return true
+    }
+
+    companion object {
+        /** First heartbeat nonce any sender emits; it sits past 1, the firmware's NodeInfo-ping trigger. */
+        const val FIRST_NONCE = 2
     }
 }
 

--- a/core/network/src/commonMain/kotlin/org/meshtastic/core/network/transport/TcpTransport.kt
+++ b/core/network/src/commonMain/kotlin/org/meshtastic/core/network/transport/TcpTransport.kt
@@ -146,7 +146,7 @@ class TcpTransport(
 
     @Volatile private var timeoutEvents: Int = 0
 
-    private val heartbeatNonce = atomic(0)
+    private val heartbeatNonce = atomic(HeartbeatSender.FIRST_NONCE)
 
     /** Whether the transport is currently connected. */
     val isConnected: Boolean
@@ -182,7 +182,10 @@ class TcpTransport(
         bytesSent += payload.size
     }
 
-    /** Send a heartbeat packet with a monotonically-increasing nonce to keep the connection alive. */
+    /**
+     * Send a heartbeat packet with a monotonically-increasing nonce to keep the connection alive. Starts at
+     * [HeartbeatSender.FIRST_NONCE], past the firmware's NodeInfo-ping trigger.
+     */
     suspend fun sendHeartbeat() {
         val nonce = heartbeatNonce.getAndIncrement()
         val heartbeat = ToRadio(heartbeat = org.meshtastic.proto.Heartbeat(nonce = nonce))

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/transport/HeartbeatSenderTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/transport/HeartbeatSenderTest.kt
@@ -56,7 +56,7 @@ class HeartbeatSenderTest {
 
         val message = ToRadio.ADAPTER.decode(sentPackets.single())
         val heartbeat = assertNotNull(message.heartbeat)
-        assertEquals(0, heartbeat.nonce)
+        assertEquals(HeartbeatSender.FIRST_NONCE, heartbeat.nonce)
         assertNull(message.packet)
     }
 
@@ -77,7 +77,7 @@ class HeartbeatSenderTest {
         accept = true
         assertTrue(sender.sendHeartbeat())
         assertEquals(1, afterHeartbeatCalls)
-        assertHeartbeats(sentPackets, 0)
+        assertHeartbeats(sentPackets, 2)
     }
 
     @Test
@@ -119,15 +119,15 @@ class HeartbeatSenderTest {
         val job = launchFiniteHeartbeatLoop(sender = sender, interval = interval, repeatCount = 3)
 
         runCurrent()
-        assertHeartbeats(sentPackets, 0)
+        assertHeartbeats(sentPackets, 2)
 
         advanceTimeBy(interval.inWholeMilliseconds)
         runCurrent()
-        assertHeartbeats(sentPackets, 0, 1)
+        assertHeartbeats(sentPackets, 2, 3)
 
         advanceTimeBy(interval.inWholeMilliseconds)
         runCurrent()
-        assertHeartbeats(sentPackets, 0, 1, 2)
+        assertHeartbeats(sentPackets, 2, 3, 4)
 
         job.cancel()
     }
@@ -142,13 +142,13 @@ class HeartbeatSenderTest {
         runCurrent()
         advanceTimeBy(interval.inWholeMilliseconds)
         runCurrent()
-        assertHeartbeats(sentPackets, 0, 1)
+        assertHeartbeats(sentPackets, 2, 3)
 
         job.cancel()
         advanceTimeBy(interval.inWholeMilliseconds * 5)
         runCurrent()
 
-        assertHeartbeats(sentPackets, 0, 1)
+        assertHeartbeats(sentPackets, 2, 3)
     }
 
     @Test
@@ -160,7 +160,7 @@ class HeartbeatSenderTest {
         runCurrent()
 
         assertEquals(0L, testScheduler.currentTime)
-        assertHeartbeats(sentPackets, 0, 1, 2)
+        assertHeartbeats(sentPackets, 2, 3, 4)
     }
 
     @Test
@@ -181,7 +181,22 @@ class HeartbeatSenderTest {
         runCurrent()
         secondJob.cancel()
 
-        assertHeartbeats(sentPackets, 0, 1, 2, 3)
+        assertHeartbeats(sentPackets, 2, 3, 4, 5)
+    }
+
+    @Test
+    fun `nonces are strictly increasing and never 1 the firmware NodeInfo-ping trigger`() = runTest {
+        val sentPackets = mutableListOf<ByteArray>()
+        val sender = HeartbeatSender(sendToRadio = { sentPackets.add(it) })
+
+        repeat(5) { assertTrue(sender.sendHeartbeat()) }
+
+        val nonces = sentPackets.map { assertNotNull(ToRadio.ADAPTER.decode(it).heartbeat).nonce }
+        assertEquals(5, nonces.size)
+        nonces.zipWithNext().forEachIndexed { index, (previous, next) ->
+            assertTrue(next > previous, "nonce at index ${index + 1} ($next) must exceed its predecessor ($previous)")
+        }
+        assertFalse(1 in nonces, "nonce 1 makes the firmware broadcast a NodeInfo ping; got $nonces")
     }
 
     private fun TestScope.launchRepeatingHeartbeatLoop(sender: HeartbeatSender, interval: Duration): Job =

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/transport/TcpTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/transport/TcpTransportTest.kt
@@ -40,9 +40,12 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import org.meshtastic.core.di.CoroutineDispatchers
+import org.meshtastic.proto.ToRadio
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -134,6 +137,51 @@ class TcpTransportTest {
         }
     }
 
+    @Test
+    fun `heartbeat nonces are strictly increasing and never 1 the firmware NodeInfo-ping trigger`() = runTest {
+        withContext(Dispatchers.Default) {
+            val server = TestTcpServer.start()
+            val connected = CompletableDeferred<Unit>()
+            val transport =
+                TcpTransport(
+                    dispatchers = testDispatchers(),
+                    scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+                    listener =
+                    object : TcpTransport.Listener {
+                        override fun onConnected() {
+                            connected.complete(Unit)
+                        }
+
+                        override fun onDisconnected() = Unit
+
+                        override fun onPacketReceived(bytes: ByteArray) = Unit
+                    },
+                )
+
+            try {
+                transport.start("$LOCALHOST:${server.port}")
+                val conn = withTimeout(5_000) { server.awaitConnection() }
+                withTimeout(5_000) { connected.await() }
+                conn.drain(StreamFrameCodec.WAKE_BYTES.size)
+
+                repeat(3) { transport.sendHeartbeat() }
+
+                val nonces =
+                    List(3) {
+                        val frame = withTimeout(5_000) { conn.readFramed() }
+                        assertNotNull(ToRadio.ADAPTER.decode(frame).heartbeat, "frame $it is not a heartbeat").nonce
+                    }
+                nonces.zipWithNext().forEachIndexed { index, (previous, next) ->
+                    assertTrue(next > previous, "nonce at index ${index + 1} ($next) must exceed ($previous)")
+                }
+                assertFalse(1 in nonces, "nonce 1 makes the firmware broadcast a NodeInfo ping; got $nonces")
+            } finally {
+                transport.stop()
+                server.close()
+            }
+        }
+    }
+
     private fun testDispatchers() =
         CoroutineDispatchers(io = Dispatchers.Default, main = Dispatchers.Default, default = Dispatchers.Default)
 
@@ -178,6 +226,19 @@ class TcpTransportTest {
     ) {
         /** Reads and discards exactly [count] bytes. */
         suspend fun drain(count: Int) {
+            readExactly(count)
+        }
+
+        /** Reads one Meshtastic stream frame and returns its payload. */
+        suspend fun readFramed(): ByteArray {
+            val header = readExactly(StreamFrameCodec.HEADER_SIZE)
+            assertEquals(StreamFrameCodec.START1, header[0])
+            assertEquals(StreamFrameCodec.START2, header[1])
+            val length = ((header[2].toInt() and 0xff) shl 8) or (header[3].toInt() and 0xff)
+            return readExactly(length)
+        }
+
+        private suspend fun readExactly(count: Int): ByteArray {
             val buf = ByteArray(count)
             var off = 0
             while (off < count) {
@@ -186,6 +247,8 @@ class TcpTransportTest {
                 if (n == -1) break
                 off += n
             }
+            assertEquals(count, off, "peer closed before $count bytes arrived")
+            return buf
         }
 
         /** Writes a Meshtastic stream frame: [START1][START2][len MSB][len LSB][payload]. */

--- a/core/network/src/commonTest/kotlin/org/meshtastic/core/network/transport/TcpTransportTest.kt
+++ b/core/network/src/commonTest/kotlin/org/meshtastic/core/network/transport/TcpTransportTest.kt
@@ -142,10 +142,11 @@ class TcpTransportTest {
         withContext(Dispatchers.Default) {
             val server = TestTcpServer.start()
             val connected = CompletableDeferred<Unit>()
+            val transportScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
             val transport =
                 TcpTransport(
                     dispatchers = testDispatchers(),
-                    scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+                    scope = transportScope,
                     listener =
                     object : TcpTransport.Listener {
                         override fun onConnected() {
@@ -177,6 +178,7 @@ class TcpTransportTest {
                 assertFalse(1 in nonces, "nonce 1 makes the firmware broadcast a NodeInfo ping; got $nonces")
             } finally {
                 transport.stop()
+                transportScope.cancel()
                 server.close()
             }
         }


### PR DESCRIPTION
Since firmware v2.7.23 (meshtastic/firmware#10194) a `ToRadio.heartbeat` with nonce 1 is a "nodeinfo ping": the radio broadcasts its NodeInfo to the mesh with want_response. Our keepalive counters started at 0, so the second 30 s keepalive after every BLE, serial or TCP connect hit 1 and triggered a mesh-wide NodeInfo burst, and the data-layer sender's first pre-handshake heartbeat was 1 too.

### 🐛 Bug Fixes
- `HeartbeatSender`, `TcpTransport` and `DataLayerHeartbeatSender` start at `HeartbeatSender.FIRST_NONCE` (2) and only count up. The nonce exists only to defeat the firmware's duplicate-write memcmp filter, so any strictly increasing sequence past 1 is equivalent.

### Testing Performed
- `HeartbeatSenderTest`: nonces strictly increase and never hit 1 across five sends; first-heartbeat expectations moved to `FIRST_NONCE`
- `DataLayerHeartbeatSenderTest` (new): first heartbeat is never 1
- `TcpTransportTest`: three heartbeats decoded off the loopback socket, none with nonce 1

Baseline green (`spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Heartbeat nonce generation now starts at 2 and increases consistently.
  - Prevents heartbeat traffic from using nonce 1, which could trigger an unintended firmware NodeInfo broadcast.
  - Applies consistently across supported heartbeat transport paths, including TCP connections.
  - Improves heartbeat reliability by avoiding unnecessary NodeInfo traffic.

- **Documentation**
  - Updated heartbeat behavior documentation to clarify the starting nonce and its relationship to firmware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->