### PR TITLE
fix(messaging): keep the composer IME session stable while the node list changes

### DIFF
--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -55,6 +55,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -717,16 +718,20 @@ private fun remapBoundary(
  * Displays `@!<hex>` tokens as `@FriendlyName` and applies live inline-markdown styling (bold/italic/strikethrough/
  * code) while typing. Both are presentation-only via [OutputTransformation]: the stored buffer keeps the hex wire form
  * and the raw markdown delimiters, so the bytes sent are unchanged.
+ *
+ * [candidatesById] is read on every transform, so the caller can hand the field one long-lived instance and still feed
+ * it the latest node names. A fresh instance while the field is focused restarts the IME session, which on Android
+ * hides and re-shows the keyboard.
  */
 @OptIn(ExperimentalFoundationApi::class)
-private fun mentionOutputTransformation(candidatesById: Map<String, MentionCandidate>) = OutputTransformation {
+private fun mentionOutputTransformation(candidatesById: () -> Map<String, MentionCandidate>) = OutputTransformation {
     val source = toString()
     // Fast path: plain text with no mention tokens or markdown delimiters — skip all scanning.
     val hasMention = source.indexOf('@') >= 0
     val needsStyle = hasMention || source.any { it in LIVE_STYLE_DELIMITER_SET }
     if (!needsStyle) return@OutputTransformation
 
-    val plan = mentionOutputPlan(source, candidatesById)
+    val plan = mentionOutputPlan(source, candidatesById())
     for (replacement in plan.replacements.asReversed()) {
         replace(replacement.range.first, replacement.range.last + 1, replacement.text)
     }
@@ -749,14 +754,15 @@ private fun mentionOutputTransformation(candidatesById: Map<String, MentionCandi
  * @param isEnabled Whether the input field should be enabled.
  * @param textFieldState The [TextFieldState] managing the input's text.
  * @param mentionCandidates Identity-stable node-id → mention entry. Only changes when a node's id or display name
- *   changes — telemetry-only updates leave this map structurally identical, preventing recomposition churn.
+ *   changes — telemetry-only updates leave this map structurally identical, preventing recomposition churn. A change is
+ *   fed to the field's [OutputTransformation] through a state holder, never by replacing the transformation.
  * @param modifier The modifier for this composable.
  * @param maxByteSize The maximum allowed size of the message in bytes.
  * @param onSendMessage Callback invoked when the send button is pressed or send IME action is triggered.
  */
 @Suppress("LongMethod", "CyclomaticComplexMethod") // Due to multiple parts of the OutlinedTextField
 @Composable
-private fun MessageInput(
+internal fun MessageInput(
     isEnabled: Boolean,
     isHomoglyphEncodingEnabled: Boolean,
     textFieldState: TextFieldState,
@@ -783,7 +789,10 @@ private fun MessageInput(
     val isOverLimit = currentByteLength > maxByteSize
     val canSend = !isOverLimit && currentText.isNotEmpty() && isEnabled
 
-    val mentionOutput = remember(mentionCandidates) { mentionOutputTransformation(mentionCandidates) }
+    // One transformation for the field's whole life: a new instance replaces the transformed state and restarts the
+    // IME session, so the latest candidates are read through this holder instead.
+    val candidates = rememberUpdatedState(mentionCandidates)
+    val mentionOutput = remember { mentionOutputTransformation { candidates.value } }
     val mentionQuery by
         remember(textFieldState) {
             derivedStateOf { currentMentionQuery(textFieldState.text.toString(), textFieldState.selection) }

--- a/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageInputImeSessionTest.kt
+++ b/feature/messaging/src/commonTest/kotlin/org/meshtastic/feature/messaging/MessageInputImeSessionTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.feature.messaging
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.InterceptPlatformTextInput
+import androidx.compose.ui.platform.PlatformTextInputInterceptor
+import androidx.compose.ui.platform.PlatformTextInputMethodRequest
+import androidx.compose.ui.platform.PlatformTextInputSession
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.coroutines.awaitCancellation
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The composer's mention [androidx.compose.foundation.text.input.OutputTransformation] reads the node list. Handing the
+ * text field a new transformation instance while it is focused restarts its IME session, which Android turns into a
+ * keyboard hide/show (#6950). This pins that a node rename reaches the rendered mention without a restart.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+class MessageInputImeSessionTest {
+
+    private fun candidates(longName: String): ImmutableMap<String, MentionCandidate> =
+        persistentMapOf(NODE_ID to MentionCandidate(id = NODE_ID, longName = longName, shortName = "ALP"))
+
+    @Test
+    fun renamingAMentionedNodeWhileFocusedKeepsTheImeSessionAndRendersTheNewName() = runComposeUiTest {
+        var sessionsStarted = 0
+        val interceptor =
+            object : PlatformTextInputInterceptor {
+                override suspend fun interceptStartInputMethod(
+                    request: PlatformTextInputMethodRequest,
+                    nextHandler: PlatformTextInputSession,
+                ): Nothing {
+                    sessionsStarted++
+                    awaitCancellation()
+                }
+            }
+        var mentionCandidates by mutableStateOf(candidates(OLD_NAME))
+        val textFieldState = TextFieldState("hi @$NODE_ID ")
+
+        setContent {
+            MaterialTheme {
+                InterceptPlatformTextInput(interceptor) {
+                    MessageInput(
+                        isEnabled = true,
+                        isHomoglyphEncodingEnabled = false,
+                        textFieldState = textFieldState,
+                        mentionCandidates = mentionCandidates,
+                        onSendMessage = {},
+                    )
+                }
+            }
+        }
+
+        val field = onNode(hasSetTextAction())
+        field.requestFocus()
+        waitForIdle()
+        field.assertIsFocused()
+        field.assertTextContains("@$OLD_NAME", substring = true)
+        // The interceptor sits on the path the decorator node uses, so the first session proves the counter sees it.
+        assertEquals(1, sessionsStarted, "focusing the composer should open exactly one IME session")
+
+        mentionCandidates = candidates(NEW_NAME)
+        waitForIdle()
+
+        field.assertIsFocused()
+        field.assertTextContains("@$NEW_NAME", substring = true)
+        field.assert(!hasText("@$OLD_NAME", substring = true))
+        assertEquals(1, sessionsStarted, "a node rename must not restart the IME session of a focused composer")
+    }
+
+    private companion object {
+        const val NODE_ID = "!a1b2c3d4"
+        const val OLD_NAME = "Alpha Node"
+        const val NEW_NAME = "Alpha Renamed"
+    }
+}


### PR DESCRIPTION
The composer's mention `OutputTransformation` was rebuilt whenever a node's name or id changed. `BasicTextField` keys its transformed state on that instance, so the decorator node restarted the IME session on every rebuild, and on Android a restart lands as a keyboard hide followed by a show. Busy channels and 2.8 firmware churn the node table constantly, so the keyboard dropped and came back while typing.

Fixes #6950

### 🐛 Bug Fixes
- `MessageInput` keeps one `OutputTransformation` for the field's life and reads the latest mention candidates through a `rememberUpdatedState` holder, so renames still render without touching the IME session

### Testing Performed
- `MessageInputImeSessionTest.renamingAMentionedNodeWhileFocusedKeepsTheImeSessionAndRendersTheNewName` (new): renames a mentioned node while the field is focused, asserts the transformation instance is unchanged and the new name renders; fails on the old `remember(mentionCandidates)` code

Baseline green (`spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`). Not reproduced on hardware here; the second reporter's "only on 2.8 over BLE" is not explained by this change, though every IME-restart path found goes through this transformation identity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated mention suggestions without restarting the keyboard input session.
  * Ensured renamed mention candidates are reflected immediately while removing outdated display text.

* **Tests**
  * Added coverage verifying mention updates preserve the active keyboard session and display the latest candidate information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->