### PR TITLE
chore(deps): migrate to maplibre-compose 0.16.0

### DIFF
--- a/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
+++ b/desktopApp/src/main/kotlin/org/meshtastic/desktop/Main.kt
@@ -73,8 +73,8 @@ import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
-import org.maplibre.compose.desktop.ProvideMapHost
-import org.maplibre.compose.desktop.rememberAwtComposeMapHost
+import org.maplibre.compose.desktop.ProvideMapPresentationHost
+import org.maplibre.compose.desktop.rememberAwtComposeMapPresentationHost
 import org.meshtastic.core.common.BuildConfigProvider
 import org.meshtastic.core.common.log.InMemoryLogBuffer
 import org.meshtastic.core.common.util.CommonUri
@@ -410,7 +410,7 @@ private fun ApplicationScope.MeshtasticWindow(
 
         CoilImageLoaderSetup()
         // Each window hands MapLibre its own GPU context; the map composites into Compose from there.
-        ProvideMapHost(host = rememberAwtComposeMapHost(window)) {
+        ProvideMapPresentationHost(host = rememberAwtComposeMapPresentationHost(window)) {
             CompositionLocalProvider(
                 LocalEventBranding provides eventEdition,
                 LocalMapViewProvider provides desktopMapViewProvider(),

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/CameraPersistence.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/CameraPersistence.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.feature.map.maplibre
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,42 +27,54 @@ import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import org.koin.compose.koinInject
-import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.map.MapState
 import org.maplibre.spatialk.geojson.Position
 import org.meshtastic.core.repository.MapCameraPosition
 import org.meshtastic.core.repository.MapPrefs
 
 /**
- * Restores the map to wherever the user left it, and keeps that saved.
+ * Reads back the camera the user left the map on.
  *
  * The OSMdroid map did this and the Google flavor still does; the MapLibre map lost it in the cutover even though
- * `MapPrefs.setCameraPosition` and its stored value survived untouched. Returns null until the stored position has been
- * read, then whether there was one — the caller needs that to decide between the remembered view and framing the mesh,
- * and must not do either while the answer is unknown.
+ * `MapPrefs.setCameraPosition` and its stored value survived untouched.
+ *
+ * The stored position is handed to `rememberMapState` as its initial camera rather than written to the map afterwards,
+ * which is what maplibre-compose 0.16.0 made possible — a map created at the remembered position opens there instead of
+ * opening on a default and then moving.
+ *
+ * Pair with [SaveCameraPosition], which is what keeps the value up to date.
  */
 @Composable
-internal fun rememberRestoredCamera(cameraState: CameraState): Boolean? {
+internal fun rememberRestoredCamera(): RestoredCamera? {
     val mapPrefs: MapPrefs = koinInject()
-    var restored by remember { mutableStateOf<Boolean?>(null) }
+    var restored by remember { mutableStateOf<RestoredCamera?>(null) }
 
     LaunchedEffect(Unit) {
         val saved = mapPrefs.awaitCameraPosition()
-        if (saved != null) {
-            cameraState.position =
-                cameraState.position.copy(
-                    target = Position(longitude = saved.longitude, latitude = saved.latitude),
-                    zoom = saved.zoom,
-                )
-        }
-        restored = saved != null
+        restored =
+            RestoredCamera(
+                saved?.let {
+                    CameraPosition(target = Position(longitude = it.longitude, latitude = it.latitude), zoom = it.zoom)
+                },
+            )
     }
 
-    LaunchedEffect(restored) {
-        // Saving only starts once the restore has been attempted, and only while the camera is settled. Writing
-        // before that would overwrite the remembered view with wherever the map happened to open.
-        if (restored == null) return@LaunchedEffect
+    return restored
+}
 
-        snapshotFlow { cameraState.position.takeUnless { cameraState.isCameraMoving } }
+/**
+ * Keeps the stored camera position in step with [mapState].
+ *
+ * Only writes while the camera is settled: saving mid-gesture would store every frame of a pan, and the value that
+ * matters is the one the user stopped on.
+ */
+@Composable
+internal fun SaveCameraPosition(mapState: MapState) {
+    val mapPrefs: MapPrefs = koinInject()
+
+    LaunchedEffect(mapState) {
+        snapshotFlow { mapState.cameraPosition.takeUnless { mapState.isCameraMoving } }
             .filterNotNull()
             .distinctUntilChanged()
             .collect { position ->
@@ -74,6 +87,12 @@ internal fun rememberRestoredCamera(cameraState: CameraState): Boolean? {
                 )
             }
     }
-
-    return restored
 }
+
+/**
+ * Where the user left the map, once that is known.
+ *
+ * [position] is null when there was nothing stored, which is the caller's cue to frame the mesh instead. The whole
+ * value is null while the answer is still being read, and the caller must do neither until it arrives.
+ */
+@Immutable internal class RestoredCamera(val position: CameraPosition?)

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MapCamera.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MapCamera.kt
@@ -16,7 +16,7 @@
  */
 package org.meshtastic.feature.map.maplibre
 
-import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.map.MapState
 
 /**
  * Steps the camera zoom by [delta], clamped to [range].
@@ -25,9 +25,9 @@ import org.maplibre.compose.camera.CameraState
  * wants buttons has to do this itself, and the clamp matters: pushing past a source's maximum zoom leaves the renderer
  * with no tiles to draw.
  */
-internal suspend fun CameraState.zoomBy(delta: Double, range: ClosedFloatingPointRange<Float>) {
-    val target = (position.zoom + delta).coerceIn(range.start.toDouble(), range.endInclusive.toDouble())
-    if (target != position.zoom) animateTo(position.copy(zoom = target))
+internal suspend fun MapState.zoomBy(delta: Double, range: ClosedFloatingPointRange<Float>) {
+    val target = (cameraPosition.zoom + delta).coerceIn(range.start.toDouble(), range.endInclusive.toDouble())
+    if (target != cameraPosition.zoom) animateCameraPosition(cameraPosition.copy(zoom = target))
 }
 
 /** One zoom level per button press, which is what both predecessors' zoom controls did. */

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MapLibreMapViewProvider.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MapLibreMapViewProvider.kt
@@ -36,15 +36,15 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
-import org.maplibre.compose.camera.CameraState
-import org.maplibre.compose.camera.rememberCameraState
+import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.location.BearingUpdate
 import org.maplibre.compose.location.LocationPermission
 import org.maplibre.compose.location.LocationState
+import org.maplibre.compose.location.rememberDefaultHeadingProvider
 import org.maplibre.compose.location.rememberDefaultLocationProvider
-import org.maplibre.compose.location.rememberDefaultOrientationProvider
 import org.maplibre.compose.location.rememberLocationState
 import org.maplibre.compose.location.rememberSystemSettingsLauncher
+import org.maplibre.compose.map.MapState
 import org.meshtastic.core.ui.util.KeepScreenOn
 import org.meshtastic.core.ui.util.MapViewProvider
 import org.meshtastic.feature.map.SharedMapViewModel
@@ -136,14 +136,29 @@ class MapLibreMapViewProvider(
         if (!LocalMapLibreRuntimeProbe.current()) return MapEngineUnavailable(modifier)
 
         val viewModel: SharedMapViewModel = koinViewModel()
-        // Null for the one frame before the basemap preference has loaded from disk; see rememberBasemapSelection.
-        val basemaps = rememberBasemapSelection(customBasemaps()) ?: return
+        // Both are null for the one frame before their stored value has been read from disk: the basemap preference
+        // (see rememberBasemapSelection) and the remembered camera (see rememberRestoredCamera). The map must not
+        // open on a default and then jump, nor frame the mesh over a view the user chose.
+        val basemaps = rememberBasemapSelection(customBasemaps())
+        val restored = rememberRestoredCamera()
+        if (basemaps == null || restored == null) return
 
-        val cameraState = rememberCameraState()
-        val location = rememberLocationControls(cameraState)
-
+        val location = rememberLocationControls()
         val waypoints = rememberWaypointEditing()
         val screen = rememberMapScreenState(waypointId = waypointId, sitePlannerNodeNum = sitePlannerNodeNum)
+
+        val mapState =
+            rememberMapScreenMapState(
+                basemap = basemaps.current,
+                restored = restored,
+                screen = screen,
+                waypoints = waypoints,
+                location = location,
+                customLayers = customLayers(),
+                navigateToNodeDetails = navigateToNodeDetails,
+            )
+
+        SaveCameraPosition(mapState)
 
         // Following the user means the screen is the thing being watched — the Google flavor holds it awake for the
         // same reason, and a map that sleeps mid-walk is the one complaint a location-follow feature always draws.
@@ -151,33 +166,21 @@ class MapLibreMapViewProvider(
 
         Box(modifier = modifier.fillMaxSize()) {
             MeshMap(
-                viewModel = viewModel,
-                navigateToNodeDetails = navigateToNodeDetails,
+                mapState = mapState,
                 modifier = Modifier.fillMaxSize(),
                 basemap = basemaps.current,
-                overlays = screen.overlays,
-                layerOpacity = koinInject<LayerOpacityStore>().opacity.collectAsState().value,
-                customLayers = customLayers(),
-                cameraState = cameraState,
-                locationState = location.state,
-                followLocation = location.following,
-                bearingUpdate = location.bearingUpdate,
-                frameOnNodes = rememberRestoredCamera(cameraState) == false,
-                onWaypointClick = { screen.infoWaypointId = it },
-                onClusterMembers = { screen.clusterMembers = it },
                 onMapLongClick = waypoints.onLongPress,
                 onMapClick = waypoints.onMapTap,
-                boxCorner = waypoints.firstCorner,
             )
 
-            MapZoom(cameraState = cameraState, basemap = basemaps.current)
+            MapZoom(mapState = mapState, basemap = basemaps.current)
 
             OfflineIndicator(viewModel)
 
             MapToolbar(
                 basemaps = basemaps,
                 location = location,
-                cameraState = cameraState,
+                mapState = mapState,
                 overlays = screen.overlays,
                 onOverlaysChange = { screen.overlays = it },
                 basemapMenuExtra = basemapMenuExtra,
@@ -191,12 +194,12 @@ class MapLibreMapViewProvider(
             SitePlannerSlot(
                 open = screen.plannerOpen,
                 nodeNum = sitePlannerNodeNum,
-                cameraState = cameraState,
+                mapState = mapState,
                 planner = sitePlanner,
                 onDismiss = { screen.plannerOpen = false },
             )
 
-            BoxAuthoringSlot(editing = waypoints, cameraState = cameraState)
+            BoxAuthoringSlot(editing = waypoints, mapState = mapState)
 
             WaypointDialogs(
                 viewModel = viewModel,
@@ -207,6 +210,37 @@ class MapLibreMapViewProvider(
             )
         }
     }
+}
+
+/** The mesh map's state, wired to everything this screen feeds into it. */
+@Composable
+private fun rememberMapScreenMapState(
+    basemap: Basemap,
+    restored: RestoredCamera,
+    screen: MapScreenState,
+    waypoints: WaypointEditing,
+    location: LocationControls,
+    customLayers: List<CustomLayer>,
+    navigateToNodeDetails: (Int) -> Unit,
+): MapState {
+    val viewModel: SharedMapViewModel = koinViewModel()
+    return rememberMeshMapState(
+        viewModel = viewModel,
+        navigateToNodeDetails = navigateToNodeDetails,
+        basemap = basemap,
+        initialCameraPosition = restored.position ?: CameraPosition(),
+        overlays = screen.overlays,
+        layerOpacity = koinInject<LayerOpacityStore>().opacity.collectAsState().value,
+        customLayers = customLayers,
+        onClusterMembers = { screen.clusterMembers = it },
+        onWaypointClick = { screen.infoWaypointId = it },
+        boxCorner = waypoints.firstCorner,
+        locationState = location.state,
+        followLocation = location.following,
+        bearingUpdate = location.bearingUpdate,
+        // Only when there was nothing stored: a remembered view is the user's own and is not yanked away.
+        frameOnNodes = restored.position == null,
+    )
 }
 
 /** The "you're offline" pill, top-start so it never collides with the toolbar's top-center controls. */
@@ -248,12 +282,12 @@ private fun rememberMapScreenState(waypointId: Int?, sitePlannerNodeNum: Int?): 
  * dialogs — clear of the zoom pair and the attribution row that share that edge.
  */
 @Composable
-private fun BoxScope.BoxAuthoringSlot(editing: WaypointEditing, cameraState: CameraState) {
+private fun BoxScope.BoxAuthoringSlot(editing: WaypointEditing, mapState: MapState) {
     if (editing.boxDraft == null) return
 
     BoxAuthoringBar(
         onCancel = editing.onCancelBox,
-        onUseVisibleRegion = { cameraState.viewport?.visibleBoundingBox?.let(editing.onUseVisibleRegion) },
+        onUseVisibleRegion = { mapState.viewport?.visibleBounds?.toBoundingBox()?.let(editing.onUseVisibleRegion) },
         modifier =
         Modifier.align(Alignment.BottomCenter)
             .padding(start = AUTHORING_BAR_SIDE.dp, end = AUTHORING_BAR_SIDE.dp, bottom = AUTHORING_BAR_BOTTOM.dp),
@@ -295,7 +329,7 @@ private fun ClusterMembersSlot(members: List<ClusterMember>, onPick: (Int) -> Un
 private fun SitePlannerSlot(
     open: Boolean,
     nodeNum: Int?,
-    cameraState: CameraState,
+    mapState: MapState,
     planner: (@Composable (SitePlannerSession) -> Unit)?,
     onDismiss: () -> Unit,
 ) {
@@ -306,8 +340,10 @@ private fun SitePlannerSlot(
     planner(
         SitePlannerSession(
             nodeNum = nodeNum,
-            mapCenter = { cameraState.position.target },
-            moveTo = { target -> scope.launch { cameraState.animateTo(cameraState.position.copy(target = target)) } },
+            mapCenter = { mapState.cameraPosition.target },
+            moveTo = { target ->
+                scope.launch { mapState.animateCameraPosition(mapState.cameraPosition.copy(target = target)) }
+            },
             onDismiss = onDismiss,
         ),
     )
@@ -326,7 +362,7 @@ private fun SitePlannerSlot(
 private fun BoxScope.MapToolbar(
     basemaps: BasemapSelection,
     location: LocationControls,
-    cameraState: CameraState,
+    mapState: MapState,
     overlays: List<MapOverlay>,
     onOverlaysChange: (List<MapOverlay>) -> Unit,
     basemapMenuExtra: @Composable () -> Unit,
@@ -344,9 +380,18 @@ private fun BoxScope.MapToolbar(
         modifier = Modifier.align(Alignment.TopCenter).padding(top = TOOLBAR_INSET.dp),
         onToggleFilterMenu = { filterMenuExpanded = !filterMenuExpanded },
         filtersActive = filterState.isNarrowing,
-        bearing = cameraState.position.bearing.toFloat(),
+        bearing = mapState.cameraPosition.bearing.toFloat(),
         followPhoneBearing = location.followingBearing,
-        onCompassClick = location.onCompassClick,
+        // Matches the Google flavor: while following, the compass toggles heading-lock; otherwise it straightens
+        // the map back to north. Assembled here because it needs both the controls and the map state, and the
+        // controls are built before the state exists.
+        onCompassClick = {
+            if (location.following) {
+                location.onToggleBearingLock()
+            } else {
+                scope.launch { mapState.animateCameraPosition(mapState.cameraPosition.copy(bearing = 0.0)) }
+            }
+        },
         filterDropdownContent = {
             if (filterMenuExpanded) {
                 MapFilterSheet(
@@ -364,9 +409,9 @@ private fun BoxScope.MapToolbar(
                 offlineTarget =
                 OfflineMapTarget(
                     styleUrl = (basemaps.current as? Basemap.Vector)?.styleUri,
-                    bounds = { cameraState.viewport?.visibleBoundingBox },
-                    zoom = { cameraState.position.zoom },
-                    showRegion = { box -> scope.launch { cameraState.animateTo(boundingBox = box) } },
+                    bounds = { mapState.viewport?.visibleBounds?.toBoundingBox() },
+                    zoom = { mapState.cameraPosition.zoom },
+                    showRegion = { box -> scope.launch { mapState.animateCameraToBounds(box) } },
                 ),
                 offlineMapsSupported = offlineMapsSupported,
                 extra = layersSheetExtra,
@@ -385,10 +430,10 @@ private class LocationControls(
     val following: Boolean,
     val followingBearing: Boolean,
     val onToggleFollow: () -> Unit,
-    val onCompassClick: () -> Unit,
+    val onToggleBearingLock: () -> Unit,
 ) {
     val bearingUpdate: BearingUpdate
-        get() = if (followingBearing) BearingUpdate.TRACK_ORIENTATION else BearingUpdate.IGNORE
+        get() = if (followingBearing) BearingUpdate.TRACK_HEADING else BearingUpdate.IGNORE
 }
 
 /**
@@ -399,9 +444,7 @@ private class LocationControls(
  * fused location lives behind the separate `location-runtime-gms` artifact and must never enter an F-Droid build.
  */
 @Composable
-private fun rememberLocationControls(cameraState: CameraState): LocationControls {
-    val scope = rememberCoroutineScope()
-
+private fun rememberLocationControls(): LocationControls {
     var following by remember { mutableStateOf(false) }
     var followingBearing by remember { mutableStateOf(false) }
     var enableAfterPermission by remember { mutableStateOf(false) }
@@ -410,7 +453,7 @@ private fun rememberLocationControls(cameraState: CameraState): LocationControls
         rememberLocationState(
             enabled = following,
             provider = rememberDefaultLocationProvider(),
-            orientationProvider = rememberDefaultOrientationProvider(),
+            headingProvider = rememberDefaultHeadingProvider(),
         )
     val settingsLauncher = rememberSystemSettingsLauncher()
 
@@ -446,15 +489,9 @@ private fun rememberLocationControls(cameraState: CameraState): LocationControls
                 }
             }
         },
-        // Matches the Google flavor: while following, the compass toggles heading-lock; otherwise it straightens the
-        // map back to north.
-        onCompassClick = {
-            if (following) {
-                followingBearing = !followingBearing
-            } else {
-                scope.launch { cameraState.animateTo(cameraState.position.copy(bearing = 0.0)) }
-            }
-        },
+        // Only the heading-lock half lives here; straightening the map to north needs the map state, which does
+        // not exist yet at this point — see MapToolbar.
+        onToggleBearingLock = { followingBearing = !followingBearing },
     )
 }
 

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MapLibreRuntime.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MapLibreRuntime.kt
@@ -22,9 +22,13 @@ import androidx.compose.runtime.staticCompositionLocalOf
  * Whether MapLibre's native rendering engine can actually load on this device.
  *
  * MapLibre Compose reaches its C++ engine through a JNI shim, and an app can be built for an architecture that shim was
- * never published for. maplibre-native-ffi 0.202608.3 ships arm64-v8a and x86_64 only, so an armeabi-v7a build carries
- * no engine and the first frame of a map dies with `UnsatisfiedLinkError` — see #7001. A missing renderer is not worth
- * a crash when every other screen still works, so the map screens ask first and say so instead.
+ * never published for. maplibre-native-ffi 0.202608.3 shipped arm64-v8a and x86_64 only, so an armeabi-v7a build
+ * carried no engine and the first frame of a map died with `UnsatisfiedLinkError` — see #7001 and #7005. A missing
+ * renderer is not worth a crash when every other screen still works, so the map screens ask first and say so instead.
+ *
+ * maplibre-compose 0.16.0 closed that gap: its FFI ships armeabi-v7a too, so every ABI the app builds now carries an
+ * engine and this answers `true` everywhere. The probe stays as the cheap defence it always was — it is one lazy
+ * `System.loadLibrary` and it fails soft — but nothing is expected to reach the unavailable path any more.
  *
  * Off Android there is no such gap, and the actuals there answer `true` unconditionally.
  */

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MeshMap.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/MeshMap.kt
@@ -22,28 +22,38 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
-import org.maplibre.compose.camera.CameraState
-import org.maplibre.compose.camera.rememberCameraState
+import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.expressions.dsl.const
+import org.maplibre.compose.interaction.ClickResult
+import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.location.BearingUpdate
 import org.maplibre.compose.location.LocationPuck
 import org.maplibre.compose.location.LocationState
 import org.maplibre.compose.location.LocationTrackingEffect
-import org.maplibre.compose.location.mostAccurateBearing
 import org.maplibre.compose.location.updateCamera
+import org.maplibre.compose.map.CameraConstraints
+import org.maplibre.compose.map.LocalMapState
+import org.maplibre.compose.map.LocalViewport
+import org.maplibre.compose.map.MapState
 import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.rememberMapState
 import org.maplibre.compose.material3.LocationPuckDefaults
-import org.maplibre.compose.util.ClickResult
+import org.maplibre.compose.overlay.include
 import org.maplibre.compose.util.MaplibreComposable
+import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.Point
@@ -72,35 +82,37 @@ import org.meshtastic.feature.map.maplibre.style.zoomRange
 import kotlin.math.floor
 
 /**
- * The mesh map, rendered by MapLibre.
+ * Everything the mesh map draws, as one [MapState].
+ *
+ * Since maplibre-compose 0.16.0 the base style and the sources and layers over it belong to the state rather than to a
+ * trailing block on `MaplibreMap`, so this is where the mesh data is read and turned into layers. [MeshMap] presents
+ * the result. The state is returned because the caller also needs it: the toolbar reads the bearing off it, the zoom
+ * buttons move it, and the Site Planner asks it where the map is pointed.
+ *
+ * The camera effects stay out of the style block, even though that is where upstream puts `LocationTrackingEffect`. The
+ * library hosts style content in a subcomposition keyed on the loaded style and disposes it on every base-style switch,
+ * so a `remember` in there does not survive the user changing basemap.
  *
  * Shared by the F-Droid Android flavor and the desktop app — the two differ only in what they hand in, not in what gets
  * drawn.
  */
 @Composable
-fun MeshMap(
+@Suppress("LongParameterList")
+fun rememberMeshMapState(
     viewModel: BaseMapViewModel,
     navigateToNodeDetails: (Int) -> Unit,
-    modifier: Modifier = Modifier,
     basemap: Basemap = Basemaps.default,
+    /** Where the map opens. [rememberRestoredCamera] supplies the position the user left it on. */
+    initialCameraPosition: CameraPosition = CameraPosition(),
     overlays: List<MapOverlay> = emptyList(),
     layerOpacity: Map<String, Float> = emptyMap(),
     customLayers: List<CustomLayer> = emptyList(),
-    onWaypointClick: (Int) -> Unit = {},
     /** Called with the nodes of a tapped cluster that cannot be zoomed apart any further. */
     onClusterMembers: (List<ClusterMember>) -> Unit = {},
-    /** Called with the pressed position on a long press, which is how a new waypoint gets placed. */
-    onMapLongClick: (Position) -> Unit = {},
-    /** Called with the tapped position. Used to collect the two corners of a waypoint's geofence bounding box. */
-    onMapClick: (Position) -> Unit = {},
+    onWaypointClick: (Int) -> Unit = {},
     /** The first corner of a box being authored, drawn so the tap reads as registered. */
     boxCorner: Position? = null,
-    /**
-     * Hoisted so the host can read the bearing for a compass and steer the camera itself. Defaults to a map-owned state
-     * for callers that only want the map to frame itself.
-     */
-    cameraState: CameraState = rememberCameraState(),
-    /** Location and orientation state to draw a puck for and optionally follow. Null disables both. */
+    /** Location and heading state to draw a puck for and optionally follow. Null disables both. */
     locationState: LocationState? = null,
     /**
      * Whether the user has asked to be followed. Gates both the camera and the puck, so switching tracking off leaves
@@ -114,10 +126,7 @@ fun MeshMap(
      * user's own view is not yanked away from them.
      */
     frameOnNodes: Boolean = true,
-) {
-    // No engine on this device means composing a map is the UnsatisfiedLinkError crash in #7001.
-    if (!LocalMapLibreRuntimeProbe.current()) return MapEngineUnavailable(modifier)
-
+): MapState {
     val nodes by viewModel.nodesWithPosition.collectAsStateWithLifecycle()
     val waypoints by viewModel.waypoints.collectAsStateWithLifecycle()
     val filterState by viewModel.mapFilterStateFlow.collectAsStateWithLifecycle()
@@ -125,70 +134,118 @@ fun MeshMap(
     val displayUnits by viewModel.displayUnits.collectAsStateWithLifecycle()
 
     val scope = rememberCoroutineScope()
-    // This body recomposes on every camera frame (it reads the viewport below); the mesh-wide filter should not.
+    // The style block recomposes on every camera frame (it reads the viewport below); the mesh-wide filter should not.
     // `nowSeconds` is deliberately not a key: a packet arriving already changes the node list.
     val visibleNodes =
         remember(nodes, filterState, myNodeInfo) {
             MapNodePolicy.visibleNodes(nodes, filterState, nowSeconds, myNodeInfo?.myNodeNum)
         }
 
-    FrameOnce(enabled = frameOnNodes, nodes = visibleNodes, cameraState = cameraState)
+    val mapState =
+        rememberMapState(baseStyle = basemap.toBaseStyle(), initialCameraPosition = initialCameraPosition) {
+            val state = checkNotNull(LocalMapState.current)
+            // The viewport local, rather than the state's own property: it is what the library scopes viewport
+            // recomposition to, and these reads are the whole reason this block runs per frame.
+            val viewportBounds = LocalViewport.current?.visibleBounds?.toBoundingBox()
+
+            if (basemap is Basemap.Raster) {
+                RasterBasemapLayer(basemap)
+            }
+            MapOverlayLayers(overlays, layerOpacity)
+            TerrainLayers(
+                viewportBounds = viewportBounds,
+                zoom = state.cameraPosition.zoom,
+                displayUnits = displayUnits,
+            )
+            CustomLayers(customLayers, layerOpacity)
+
+            if (filterState.showWaypoints) {
+                WaypointLayers(waypoints = waypoints.values, onWaypointClick = onWaypointClick)
+            }
+
+            MeshMapNodeLayers(
+                visibleNodes = visibleNodes,
+                mapState = state,
+                viewportBounds = viewportBounds,
+                filterState = filterState,
+                myNodeNum = myNodeInfo?.myNodeNum,
+                navigateToNodeDetails = navigateToNodeDetails,
+                onClusterMembers = onClusterMembers,
+                scope = scope,
+            )
+
+            // Declared last so the user's own position and an in-progress box corner draw above the mesh.
+            UserLocationPuck(locationState = locationState, visible = followLocation)
+            BoxCornerMarker(boxCorner)
+        }
+
+    // Both effects stay out here, in this composition rather than the style block's. The library hosts the style
+    // content in a subcomposition keyed on the loaded style and disposes it on every base-style switch, so a
+    // `remember` in there is lost whenever the user changes basemap — which would reset FrameOnce's latch and
+    // re-frame the mesh over wherever they had panned to.
+    FrameOnce(enabled = frameOnNodes, nodes = visibleNodes, mapState = mapState)
 
     // Follows position whenever tracking is on; touches bearing only when the caller asks for it, so a user who
     // has rotated the map is not straightened out behind their back.
     FollowUserLocation(
         locationState = locationState,
-        cameraState = cameraState,
+        mapState = mapState,
         followLocation = followLocation,
         bearingUpdate = bearingUpdate,
     )
 
+    return mapState
+}
+
+/**
+ * The mesh map, rendered by MapLibre.
+ *
+ * Presents [mapState] and nothing else; what gets drawn is declared by [rememberMeshMapState].
+ *
+ * [basemap] must be the same one that state was built with: it supplies the zoom range the camera is held to, and a
+ * different value here would clamp the camera to a range the loaded style cannot serve.
+ */
+@Composable
+fun MeshMap(
+    mapState: MapState,
+    modifier: Modifier = Modifier,
+    basemap: Basemap = Basemaps.default,
+    /** Called with the pressed position on a long press, which is how a new waypoint gets placed. */
+    onMapLongClick: (Position) -> Unit = {},
+    /** Called with the tapped position. Used to collect the two corners of a waypoint's geofence bounding box. */
+    onMapClick: (Position) -> Unit = {},
+) {
+    // No engine on this device means presenting a map is the UnsatisfiedLinkError crash in #7001. Guarded here and
+    // not at the state, which is pure Kotlin: the native library is loaded by the map *view*.
+    if (!LocalMapLibreRuntimeProbe.current()) return MapEngineUnavailable(modifier)
+
+    val zoomRange = basemap.zoomRange()
     MaplibreMap(
-        baseStyle = basemap.toBaseStyle(),
-        cameraState = cameraState,
         modifier = modifier,
+        state = mapState,
         // Honour what the source can actually serve, as the OSMdroid map did.
-        zoomRange = basemap.zoomRange(),
-        onMapLongClick = { position, _ ->
-            onMapLongClick(position)
-            ClickResult.Consume
+        cameraConstraints =
+        CameraConstraints(minZoom = zoomRange.start.toDouble(), maxZoom = zoomRange.endInclusive.toDouble()),
+        interactions =
+        MapInteractions {
+            callbacks {
+                longClick {
+                    onEvent { event ->
+                        event.position?.let(onMapLongClick)
+                        ClickResult.Consume
+                    }
+                }
+                // Pass, not Consume: a tap has to keep reaching the layers underneath or nothing is selectable.
+                click {
+                    onEvent { event ->
+                        event.position?.let(onMapClick)
+                        ClickResult.Pass
+                    }
+                }
+            }
         },
-        // Pass, not Consume: a tap has to keep reaching the layers underneath or nothing on the map is selectable.
-        onMapClick = { position, _ ->
-            onMapClick(position)
-            ClickResult.Pass
-        },
-        overlay = MeshMapOrnaments,
-    ) {
-        if (basemap is Basemap.Raster) {
-            RasterBasemapLayer(basemap)
-        }
-        MapOverlayLayers(overlays, layerOpacity)
-        TerrainLayers(
-            viewportBounds = cameraState.viewport?.visibleBoundingBox,
-            zoom = cameraState.position.zoom,
-            displayUnits = displayUnits,
-        )
-        CustomLayers(customLayers, layerOpacity)
-
-        if (filterState.showWaypoints) {
-            WaypointLayers(waypoints = waypoints.values, onWaypointClick = onWaypointClick)
-        }
-
-        MeshMapNodeLayers(
-            visibleNodes = visibleNodes,
-            cameraState = cameraState,
-            filterState = filterState,
-            myNodeNum = myNodeInfo?.myNodeNum,
-            navigateToNodeDetails = navigateToNodeDetails,
-            onClusterMembers = onClusterMembers,
-            scope = scope,
-        )
-
-        // Declared last so the user's own position and an in-progress box corner draw above the mesh.
-        UserLocationPuck(locationState = locationState, cameraState = cameraState, visible = followLocation)
-        BoxCornerMarker(boxCorner)
-    }
+        overlay = { include(MeshMapOrnaments) },
+    )
 }
 
 /** The node chips, clusters and precision circles — split out of [MeshMap] itself only to keep that function short. */
@@ -196,7 +253,8 @@ fun MeshMap(
 @MaplibreComposable
 private fun MeshMapNodeLayers(
     visibleNodes: List<Node>,
-    cameraState: CameraState,
+    mapState: MapState,
+    viewportBounds: BoundingBox?,
     filterState: BaseMapViewModel.MapFilterState,
     myNodeNum: Int?,
     navigateToNodeDetails: (Int) -> Unit,
@@ -207,20 +265,20 @@ private fun MeshMapNodeLayers(
         nodes = visibleNodes,
         // Padded so a modest pan keeps the same nodes in view, and the chips are not redrawn for every frame of a
         // drag. Without a viewport at all — the first composition — every node is a candidate, as before.
-        visibleBounds = cameraState.viewport?.visibleBoundingBox?.padded(CHIP_VIEW_PADDING),
+        visibleBounds = viewportBounds?.padded(CHIP_VIEW_PADDING),
         // Floored: clustering indexes per whole zoom level, so the set only changes when the level does — and a
         // pinch does not recompute it for every fractional step in between.
-        zoom = floor(cameraState.position.zoom).toInt(),
+        zoom = floor(mapState.cameraPosition.zoom).toInt(),
         myNodeNum = myNodeNum,
         showPrecisionCircles = filterState.showPrecisionCircle,
         onNodeClick = navigateToNodeDetails,
         onClusterMembers = onClusterMembers,
         onClusterZoom = { centre, expansionZoom ->
             scope.launch {
-                val current = cameraState.position
+                val current = mapState.cameraPosition
                 // A cluster that cannot report an expansion zoom answers with a sentinel (0 on
                 // Android and desktop, -1 on iOS), so clamp — never zoom out on a tap.
-                cameraState.animateTo(current.copy(target = centre, zoom = maxOf(expansionZoom, current.zoom)))
+                mapState.animateCameraPosition(current.copy(target = centre, zoom = maxOf(expansionZoom, current.zoom)))
             }
         },
     )
@@ -233,20 +291,26 @@ private fun MeshMapNodeLayers(
  * mesh that is still filling in that would be continuous.
  */
 @Composable
-private fun FrameOnce(enabled: Boolean, nodes: List<Node>, cameraState: CameraState) {
+private fun FrameOnce(enabled: Boolean, nodes: List<Node>, mapState: MapState) {
     if (!enabled) return
 
     var hasFramed by remember { mutableStateOf(false) }
-    val hasViewport = cameraState.viewport != null
+    val hasViewport = mapState.viewport != null
+    // The node list is read through a snapshot rather than keyed on, so an arriving packet cannot cancel this.
+    // Keying on it meant the effect restarted mid-fit: `fitCameraToBounds` suspends, and whether the latch was
+    // set before the call (fit lost, latch kept, mesh never framed) or after it (latch lost to a user pan, so a
+    // later packet re-frames over them) one of the two failure modes was always reachable. Nothing here restarts
+    // on node changes now, so the latch and the fit cannot come apart.
+    val currentNodes by rememberUpdatedState(nodes)
     // An effect, not composition-body work: a launch from composition fires even if the composition is
-    // abandoned, while its state write is rolled back — a camera jump with no framing recorded. The viewport
-    // gate is FitBoundsOnceVisible's: fitting before the map reports a viewport lands on a default.
-    LaunchedEffect(nodes, hasViewport) {
+    // abandoned, while its state write is rolled back — a camera jump with no framing recorded. Fitting before
+    // the map reports a viewport silently lands on a default, hence the gate.
+    LaunchedEffect(hasViewport) {
         if (hasFramed || !hasViewport) return@LaunchedEffect
-        nodesBoundingBox(nodes)?.let { box ->
-            hasFramed = true
-            cameraState.jumpTo(boundingBox = box)
-        }
+        // Waits for the first node set that has anything to frame; a mesh still filling in reports none.
+        val box = snapshotFlow { nodesBoundingBox(currentNodes) }.filterNotNull().first()
+        hasFramed = true
+        mapState.fitCameraToBounds(box)
     }
 }
 
@@ -254,7 +318,7 @@ private fun FrameOnce(enabled: Boolean, nodes: List<Node>, cameraState: CameraSt
 @Composable
 private fun FollowUserLocation(
     locationState: LocationState?,
-    cameraState: CameraState,
+    mapState: MapState,
     followLocation: Boolean,
     bearingUpdate: BearingUpdate,
 ) {
@@ -265,23 +329,18 @@ private fun FollowUserLocation(
         enabled = followLocation,
         trackBearing = bearingUpdate != BearingUpdate.IGNORE,
     ) {
-        updateCamera(camera = cameraState, updateBearing = bearingUpdate)
+        updateCamera(mapState = mapState, updateBearing = bearingUpdate)
     }
 }
 
 /** The user's position, accuracy and heading. Drawn only while tracking, so switching it off leaves no stale dot. */
 @Composable
 @MaplibreComposable
-private fun UserLocationPuck(locationState: LocationState?, cameraState: CameraState, visible: Boolean) {
+private fun UserLocationPuck(locationState: LocationState?, visible: Boolean) {
     if (locationState == null || !visible) return
 
-    LocationPuck(
-        idPrefix = "user-location",
-        location = locationState.location,
-        cameraState = cameraState,
-        bearing = locationState.mostAccurateBearing(),
-        colors = LocationPuckDefaults.colors(),
-    )
+    // The state overload, which resolves the latest measurement and its most accurate bearing itself.
+    LocationPuck(idPrefix = "user-location", locationState = locationState, colors = LocationPuckDefaults.colors())
 }
 
 /**

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/NodeTrackMap.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/NodeTrackMap.kt
@@ -32,7 +32,6 @@ import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.koin.compose.viewmodel.koinViewModel
-import org.maplibre.compose.camera.rememberCameraState
 import org.maplibre.compose.expressions.dsl.asNumber
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.feature
@@ -40,10 +39,10 @@ import org.maplibre.compose.expressions.dsl.interpolate
 import org.maplibre.compose.expressions.dsl.linear
 import org.maplibre.compose.expressions.value.LineCap
 import org.maplibre.compose.expressions.value.LineJoin
+import org.maplibre.compose.interaction.ClickResult
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.layers.LineLayer
 import org.maplibre.compose.sources.GeoJsonOptions
-import org.maplibre.compose.util.ClickResult
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.LineString
@@ -99,7 +98,6 @@ fun MapLibreNodeTrackMap(
     // runs from the start of the line, the fade runs from index 0, and the chip goes on the last point. The view model
     // hands these over newest-first for its list, so an unsorted track drew the whole thing backwards.
     val allPoints = remember(positions) { positions.mapNotNull { it.toTrackPoint() }.sortedBy { it.second } }
-    val cameraState = rememberCameraState()
 
     // The basemap is a shared preference, so a track opens on whatever the main map is set to. The OSMdroid track map
     // resolved the same preference; hardcoding the default meant picking Dark on the main map and getting Liberty here.
@@ -115,22 +113,14 @@ fun MapLibreNodeTrackMap(
     val trackFilter = filterState.lastHeardTrackFilter
     val points = remember(allPoints, trackFilter) { allPoints.olderThanCutoffRemoved(trackFilter) }
 
-    // Frame the whole track, not just its midpoint: a fixed zoom on the centre cropped long tracks at both ends. Keyed
-    // on the *unfiltered* track, so tightening the age filter does not yank the camera around under the user.
-    FitBoundsOnceVisible(cameraState = cameraState, key = allPoints) {
-        positionsBoundingBox(allPoints.map { it.first })
-    }
-
     if (allPoints.isEmpty()) return
 
     // The colour the rest of the app draws this node in. The track used to be a flat blue, which said nothing about
     // whose track it was — the Google flavor fades the node's own colour along it, and so does this now.
     val trackColor = node?.let { Color(it.colors.second) } ?: MapColors.Slate
 
-    // The map and its toolbar stay up even when the filter empties the track — otherwise the control that emptied it
-    // disappears along with the points, leaving no way back.
-    Box(modifier = modifier) {
-        SecondaryMapSurface(basemaps = basemaps, cameraState = cameraState) {
+    val mapState =
+        rememberSecondaryMapState(basemaps) {
             // A LineString needs two coordinates; a filter tight enough to leave one point would otherwise throw.
             if (points.size > 1) TrackLineLayer(points = points, color = trackColor)
             if (points.isNotEmpty()) {
@@ -143,8 +133,17 @@ fun MapLibreNodeTrackMap(
                 if (node != null) NewestPositionChip(node = node, newest = points.last())
             }
         }
+
+    // Frame the whole track, not just its midpoint: a fixed zoom on the centre cropped long tracks at both ends. Keyed
+    // on the *unfiltered* track, so tightening the age filter does not yank the camera around under the user.
+    FitBoundsOnceVisible(mapState = mapState, key = allPoints) { positionsBoundingBox(allPoints.map { it.first }) }
+
+    // The map and its toolbar stay up even when the filter empties the track — otherwise the control that emptied it
+    // disappears along with the points, leaving no way back.
+    Box(modifier = modifier) {
+        SecondaryMapSurface(mapState = mapState, basemaps = basemaps)
         SecondaryMapChrome(
-            cameraState = cameraState,
+            mapState = mapState,
             basemaps = basemaps,
             filterMenu = { expanded, onDismissRequest ->
                 NodeTrackFilterMenu(

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/SecondaryMapScaffold.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/SecondaryMapScaffold.kt
@@ -27,9 +27,13 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import org.maplibre.compose.camera.CameraState
-import org.maplibre.compose.map.MapOptions
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.interaction.MapInteractions
+import org.maplibre.compose.map.CameraConstraints
+import org.maplibre.compose.map.MapState
+import org.maplibre.compose.map.MapUiOptions
 import org.maplibre.compose.map.MaplibreMap
+import org.maplibre.compose.map.rememberMapState
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.meshtastic.feature.map.component.MapEngineUnavailable
 import org.meshtastic.feature.map.maplibre.component.BasemapSelection
@@ -41,41 +45,66 @@ import org.meshtastic.feature.map.maplibre.style.toBaseStyle
 import org.meshtastic.feature.map.maplibre.style.zoomRange
 
 /**
- * The map surface the maps outside the main one all draw on.
+ * The map state the maps outside the main one all share.
  *
  * They differ in what they draw and which controls they carry, but not in how the map itself is set up: the chosen
  * basemap supplies both the style and the zoom range it can actually serve, and a raster basemap needs a layer of its
  * own over the empty style. Repeating that in four places is how three of them ended up with slightly different
  * versions of it.
  *
+ * Since maplibre-compose 0.16.0 the style content is declared here, on the state, rather than in a trailing block on
+ * `MaplibreMap` — the state owns the base style and the sources and layers over it, and the composable only presents
+ * it. The state is returned so the caller can drive the camera and hang its chrome off the same one.
+ *
  * [content] is a plain `@Composable`, matching the layer composables it will hold — `NodeLayers` and
- * `RasterBasemapLayer` are declared that way and compose inside `MaplibreMap` without the applier annotation. Spelling
- * `@MaplibreComposable` here is what spotless and detekt disagree about formatting.
+ * `RasterBasemapLayer` are declared that way and compose inside the style block without the applier annotation.
+ * Spelling `@MaplibreComposable` here is what spotless and detekt disagree about formatting.
  *
  * The raster underlay is composed **before** [content] and must stay that way: layers stack in composition order, so a
  * basemap added afterwards paints over the mesh data instead of sitting under it.
  */
 @Composable
-internal fun SecondaryMapSurface(
+internal fun rememberSecondaryMapState(
     basemaps: BasemapSelection,
-    cameraState: CameraState,
-    modifier: Modifier = Modifier.fillMaxSize(),
-    options: MapOptions = SecondaryMapOptions,
+    initialCameraPosition: CameraPosition = CameraPosition(),
     content: @Composable () -> Unit,
-) {
-    // Same guard as MeshMap: the secondary maps compose MaplibreMap directly, so they crash the same way.
-    if (!LocalMapLibreRuntimeProbe.current()) return MapEngineUnavailable(modifier)
-
-    MaplibreMap(
-        baseStyle = basemaps.current.toBaseStyle(),
-        cameraState = cameraState,
-        modifier = modifier,
-        options = options,
-        zoomRange = basemaps.current.zoomRange(),
-    ) {
+): MapState =
+    rememberMapState(baseStyle = basemaps.current.toBaseStyle(), initialCameraPosition = initialCameraPosition) {
         (basemaps.current as? Basemap.Raster)?.let { RasterBasemapLayer(it) }
         content()
     }
+
+/**
+ * The map surface the maps outside the main one all draw on.
+ *
+ * Presents [mapState] and nothing else: what gets drawn is declared by [rememberSecondaryMapState], which the caller
+ * holds so it can also frame the camera and place the chrome.
+ *
+ * [basemaps] must be the same selection that state was built with: it supplies the zoom range the camera is held to,
+ * and a different value here would clamp the camera to a range the loaded style cannot serve.
+ */
+@Composable
+internal fun SecondaryMapSurface(
+    mapState: MapState,
+    basemaps: BasemapSelection,
+    modifier: Modifier = Modifier.fillMaxSize(),
+    interactions: MapInteractions = SecondaryMapInteractions,
+    uiOptions: MapUiOptions = MapUiOptions.Standard,
+) {
+    // Same guard as MeshMap, and in the same place: the state is pure Kotlin, the map view is what loads the
+    // native library. The style content is never composed without a presentation, so it stops here too.
+    if (!LocalMapLibreRuntimeProbe.current()) return MapEngineUnavailable(modifier)
+
+    val zoomRange = basemaps.current.zoomRange()
+    MaplibreMap(
+        modifier = modifier,
+        state = mapState,
+        // Honour what the source can actually serve, as the OSMdroid map did.
+        cameraConstraints =
+        CameraConstraints(minZoom = zoomRange.start.toDouble(), maxZoom = zoomRange.endInclusive.toDouble()),
+        interactions = interactions,
+        uiOptions = uiOptions,
+    )
 }
 
 /**
@@ -87,13 +116,13 @@ internal fun SecondaryMapSurface(
  */
 @Composable
 internal fun BoxScope.SecondaryMapChrome(
-    cameraState: CameraState,
+    mapState: MapState,
     basemaps: BasemapSelection,
     filterMenu: (@Composable (expanded: Boolean, onDismissRequest: () -> Unit) -> Unit)? = null,
 ) {
-    MapZoom(cameraState = cameraState, basemap = basemaps.current)
+    MapZoom(mapState = mapState, basemap = basemaps.current)
     SecondaryMapControls(
-        cameraState = cameraState,
+        mapState = mapState,
         basemaps = basemaps,
         modifier = Modifier.align(Alignment.TopCenter).padding(top = TOOLBAR_INSET.dp),
         filterMenu = filterMenu,
@@ -103,27 +132,29 @@ internal fun BoxScope.SecondaryMapChrome(
 /**
  * Frames [bounds] once the map can report a viewport.
  *
- * Fitting a bounding box needs a viewport size, and on first composition there is none — the fit silently lands on a
- * default instead, which is what made these maps open zoomed past the very thing they exist to show. Null bounds is a
- * no-op, which covers having nothing to frame yet.
+ * Fitting before the map reports a viewport silently lands on a default instead, and that is what made these maps open
+ * zoomed past the very thing they exist to show. Null bounds is a no-op, which covers having nothing to frame yet.
  *
  * [key] is what re-frames the camera, and it is deliberately the caller's choice rather than the bounds themselves:
  * each map has its own answer for when the user would want the camera moved under them.
  */
 @Composable
 internal fun FitBoundsOnceVisible(
-    cameraState: CameraState,
+    mapState: MapState,
     key: Any?,
     padding: PaddingValues = SecondaryMapFitPadding,
     bounds: () -> BoundingBox?,
 ) {
-    val hasViewport = cameraState.viewport != null
     // The effect restarts on [key], not on `bounds`, so it must read the current lambda rather than the one captured
     // when it last restarted — otherwise a recomposition that passes new bounds keeps framing the old ones.
     val currentBounds by rememberUpdatedState(bounds)
+    // Gated on the viewport rather than letting `fitCameraToBounds` wait for one inside the effect. Both reach the
+    // same camera, but waiting inside leaves the call cancellable for the whole time the map has yet to render,
+    // and it is cancelled by user input as well as by [key]: a fit lost that way is not retried until [key]
+    // changes again, which for these maps may be never.
+    val hasViewport = mapState.viewport != null
     LaunchedEffect(key, hasViewport) {
-        if (hasViewport) {
-            currentBounds()?.let { cameraState.jumpTo(boundingBox = it, padding = padding) }
-        }
+        if (!hasViewport) return@LaunchedEffect
+        currentBounds()?.let { mapState.fitCameraToBounds(it, padding = padding) }
     }
 }

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/SecondaryMaps.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/SecondaryMaps.kt
@@ -41,16 +41,15 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.jetbrains.compose.resources.stringResource
 import org.maplibre.compose.camera.CameraPosition
-import org.maplibre.compose.camera.rememberCameraState
 import org.maplibre.compose.expressions.dsl.asBoolean
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.feature
 import org.maplibre.compose.expressions.dsl.not
 import org.maplibre.compose.expressions.value.LineCap
+import org.maplibre.compose.interaction.ClickResult
+import org.maplibre.compose.interaction.MapInteractions
 import org.maplibre.compose.layers.LineLayer
-import org.maplibre.compose.map.GestureOptions
-import org.maplibre.compose.map.MapOptions
-import org.maplibre.compose.util.ClickResult
+import org.maplibre.compose.map.MapUiOptions
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Feature
 import org.maplibre.spatialk.geojson.FeatureCollection
@@ -103,13 +102,21 @@ fun MapLibreInlineMap(
     // Null for the one frame before the basemap preference has loaded from disk; see rememberBasemapSelection.
     val basemaps = rememberBasemapSelection(customBasemaps()) ?: return
     val target = GeoPosition(longitude = node.longitude, latitude = node.latitude)
-    val cameraState = rememberCameraState(CameraPosition(target = target, zoom = INLINE_ZOOM))
+    val mapState =
+        rememberSecondaryMapState(basemaps, CameraPosition(target = target, zoom = INLINE_ZOOM)) {
+            val source = rememberFeatureSource(node) { nodesToFeatureCollection(listOf(node)) }
+
+            // The node-detail sheet is where a degraded position matters most — it is the screen a user opens to ask
+            // how precisely this node is placed. The Google mini-map draws the circle; this one left it out.
+            NodePrecisionLayer(id = "inline-precision", nodes = listOf(node))
+            NodeChipLayer(id = "inline-node", source = source, nodes = listOf(node))
+        }
 
     // Follows the node as fresh positions arrive, as the Google mini-map does. Guarded on the current target so the
-    // first composition — which rememberCameraState has already centred — does not animate to where the camera is.
+    // first composition does not animate to where the camera already is.
     LaunchedEffect(target) {
-        if (cameraState.position.target != target) {
-            cameraState.animateTo(cameraState.position.copy(target = target))
+        if (mapState.cameraPosition.target != target) {
+            mapState.animateCameraPosition(mapState.cameraPosition.copy(target = target))
         }
     }
 
@@ -121,16 +128,9 @@ fun MapLibreInlineMap(
     // The same control every other map uses, at the same size. A shrunken variant was tried and looked out of place
     // against the rest of the map chrome for the ~25% of height it saved.
     Box(modifier = modifier) {
-        SecondaryMapSurface(basemaps = basemaps, cameraState = cameraState, options = InlineMapOptions) {
-            val source = rememberFeatureSource(node) { nodesToFeatureCollection(listOf(node)) }
+        SecondaryMapSurface(mapState = mapState, basemaps = basemaps, uiOptions = InlineMapUiOptions)
 
-            // The node-detail sheet is where a degraded position matters most — it is the screen a user opens to ask
-            // how precisely this node is placed. The Google mini-map draws the circle; this one left it out.
-            NodePrecisionLayer(id = "inline-precision", nodes = listOf(node))
-            NodeChipLayer(id = "inline-node", source = source, nodes = listOf(node))
-        }
-
-        MapZoom(cameraState = cameraState, basemap = basemaps.current)
+        MapZoom(mapState = mapState, basemap = basemaps.current)
     }
 }
 
@@ -149,21 +149,23 @@ fun MapLibreTracerouteMap(
     modifier: Modifier = Modifier,
     customBasemaps: @Composable () -> List<Basemap.Raster> = { customRasterBasemaps() },
 ) {
-    val cameraState = rememberCameraState()
     // Null for the one frame before the basemap preference has loaded from disk; see rememberBasemapSelection.
     val basemaps = rememberBasemapSelection(customBasemaps()) ?: return
     val hops = (forwardRoute + returnRoute).distinct().mapNotNull { nodeLookup[it] }
 
-    // Keyed on the hops: the route is what this map exists to frame, so a different route should re-frame it. The
-    // padding is what keeps the outermost hops clear of the toolbar and the legend.
-    FitBoundsOnceVisible(cameraState = cameraState, key = hops) { nodesBoundingBox(hops) }
-
-    Box(modifier = modifier) {
-        SecondaryMapSurface(basemaps = basemaps, cameraState = cameraState) {
+    val mapState =
+        rememberSecondaryMapState(basemaps) {
             TracerouteLayers(forwardRoute = forwardRoute, returnRoute = returnRoute, nodeLookup = nodeLookup)
             TracerouteHopLayers(hops)
         }
-        SecondaryMapChrome(cameraState = cameraState, basemaps = basemaps)
+
+    // Keyed on the hops: the route is what this map exists to frame, so a different route should re-frame it. The
+    // padding is what keeps the outermost hops clear of the toolbar and the legend.
+    FitBoundsOnceVisible(mapState = mapState, key = hops) { nodesBoundingBox(hops) }
+
+    Box(modifier = modifier) {
+        SecondaryMapSurface(mapState = mapState, basemaps = basemaps)
+        SecondaryMapChrome(mapState = mapState, basemaps = basemaps)
     }
 }
 
@@ -189,7 +191,6 @@ fun MapLibreDiscoveryMap(
     customBasemaps: @Composable () -> List<Basemap.Raster> = { customRasterBasemaps() },
 ) {
     val scanner = GeoPosition(longitude = userLongitude, latitude = userLatitude)
-    val cameraState = rememberCameraState(CameraPosition(target = scanner, zoom = DETAIL_ZOOM))
     // Null for the one frame before the basemap preference has loaded from disk; see rememberBasemapSelection.
     val basemaps = rememberBasemapSelection(customBasemaps()) ?: return
     // The node itself, not its index. The feature carries an index into `located`, which is only meaningful for
@@ -203,18 +204,21 @@ fun MapLibreDiscoveryMap(
     // list to agree on.
     val located = remember(nodes) { nodes.filter { it.latitude != 0.0 || it.longitude != 0.0 } }
 
-    // Frame the scanner together with everything it heard, which is the OSMdroid map's behaviour and the only view
-    // that answers the question this map is opened to answer. Opening at a fixed zoom on the scanner put every
-    // discovered node off screen. Keyed on the located nodes, so a scan that hears another one re-frames to include it.
-    FitBoundsOnceVisible(cameraState = cameraState, key = located) { discoveryBoundingBox(scanner, located) }
-
-    Box(modifier = modifier) {
-        SecondaryMapSurface(basemaps = basemaps, cameraState = cameraState) {
+    val mapState =
+        rememberSecondaryMapState(basemaps, CameraPosition(target = scanner, zoom = DETAIL_ZOOM)) {
             DiscoveryTopologyLayer(scanner = scanner, nodes = located)
             DiscoveredNodeLayers(nodes = located, onNodeClick = { selectedNode = located.getOrNull(it) })
             ScannerLayer(scanner = scanner, label = stringResource(Res.string.you))
         }
-        SecondaryMapChrome(cameraState = cameraState, basemaps = basemaps)
+
+    // Frame the scanner together with everything it heard, which is the OSMdroid map's behaviour and the only view
+    // that answers the question this map is opened to answer. Opening at a fixed zoom on the scanner put every
+    // discovered node off screen. Keyed on the located nodes, so a scan that hears another one re-frames to include it.
+    FitBoundsOnceVisible(mapState = mapState, key = located) { discoveryBoundingBox(scanner, located) }
+
+    Box(modifier = modifier) {
+        SecondaryMapSurface(mapState = mapState, basemaps = basemaps)
+        SecondaryMapChrome(mapState = mapState, basemaps = basemaps)
 
         // The signal figures the Google map shows in a marker snippet. A MapLibre marker is a layer feature and has no
         // snippet, so the tapped node's numbers go at the foot of the map.
@@ -385,9 +389,12 @@ private fun ScannerLayer(scanner: GeoPosition, label: String) {
  * two-finger drag pitches the map with nothing on screen to put it back. The Google flavor makes the same call with
  * `tiltGesturesEnabled = isMainMode`, and the OSMdroid map never had tilt at all. Rotation stays, which is what Google
  * does too.
+ *
+ * Says that directly now: 0.16.0 replaced the per-gesture flags with camera capabilities, and the old
+ * `isDragRotateTiltEnabled = false` had bundled rotation in with tilt, so a mouse drag could not rotate these maps
+ * either despite the intent above. It can now.
  */
-internal val SecondaryMapOptions =
-    MapOptions(gestureOptions = GestureOptions(isDragRotateTiltEnabled = false, isTwoFingerTiltEnabled = false))
+internal val SecondaryMapInteractions = MapInteractions { camera { tilt { enabled = false } } }
 
 /**
  * Gestures off entirely, for the mini-map embedded in the node detail sheet.
@@ -396,25 +403,26 @@ internal val SecondaryMapOptions =
  * one the column is also trying to read. The Google flavor resolves it the same way, turning off scroll, zoom, rotate
  * and tilt in its own `InlineMap` and leaving the zoom buttons as the only way in. Keyboard pan and zoom stay: they
  * cost the column nothing and are the desktop's route to the same thing.
+ *
+ * The gesture families are switched off one by one rather than with `MapUiOptions.None`, which would also take the keys
+ * and the feature taps this map still wants. Momentum needs no separate mention: the gestures that could carry it are
+ * gone.
  */
-internal val InlineMapOptions =
-    MapOptions(
-        gestureOptions =
-        GestureOptions(
-            isDragPanEnabled = false,
-            isDragRotateTiltEnabled = false,
-            isPinchZoomEnabled = false,
-            isTwoFingerRotateEnabled = false,
-            isTwoFingerTiltEnabled = false,
-            isTwoFingerTapZoomEnabled = false,
-            isScrollZoomEnabled = false,
-            isDoubleClickZoomEnabled = false,
-            isQuickZoomEnabled = false,
-            isFlingEnabled = false,
-            isPinchZoomVelocityEnabled = false,
-            isRotateVelocityEnabled = false,
-        ),
-    )
+internal val InlineMapUiOptions = MapUiOptions {
+    bindings {
+        drag { enabled = false }
+        transform {
+            pan { enabled = false }
+            zoom { enabled = false }
+            rotate { enabled = false }
+            tilt { enabled = false }
+        }
+        scroll { enabled = false }
+        doubleTap { enabled = false }
+        twoFingerTap { enabled = false }
+        tapDrag { enabled = false }
+    }
+}
 
 /** Keeps a floating toolbar clear of the top edge, matching the main map's own inset. */
 internal const val TOOLBAR_INSET = 8

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/MapOrnaments.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/MapOrnaments.kt
@@ -16,14 +16,10 @@
  */
 package org.meshtastic.feature.map.maplibre.component
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import org.maplibre.compose.overlay.DisappearingScaleBar
-import org.maplibre.compose.overlay.ExpandingAttributionButton
-import org.maplibre.compose.overlay.MaplibreLogo
+import org.maplibre.compose.overlay.include
 import org.maplibre.compose.overlay.MapOverlay as MaplibreOverlay
 
 /**
@@ -41,20 +37,11 @@ import org.maplibre.compose.overlay.MapOverlay as MaplibreOverlay
  */
 internal val MeshMapOrnaments: MaplibreOverlay = MaplibreOverlay {
     DisappearingScaleBar(
-        metersPerDp = cameraState.viewport?.metersPerDpAtTarget ?: 0.0,
-        zoom = cameraState.position.zoom,
+        metersPerDp = mapState.viewport?.metersPerDpAtTarget ?: 0.0,
+        zoom = mapState.cameraPosition.zoom,
         modifier = Modifier.align(Alignment.TopStart),
     )
 
-    // Read before entering the Row, whose scope shadows this one.
-    val camera = cameraState
-    val style = styleState
-    Row(
-        modifier = Modifier.align(Alignment.BottomStart).fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        MaplibreLogo()
-        ExpandingAttributionButton(cameraState = camera, styleState = style)
-    }
+    // The logo and the attribution button, in the places `MapOverlay.Default` puts them.
+    include(MaplibreOverlay.AttributionOnly)
 }

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/OfflineMapTarget.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/OfflineMapTarget.kt
@@ -34,16 +34,17 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
+import org.maplibre.compose.map.DefaultMapRuntime
 import org.maplibre.compose.offline.DownloadProgress
 import org.maplibre.compose.offline.DownloadStatus
 import org.maplibre.compose.offline.OfflineManager
 import org.maplibre.compose.offline.OfflinePack
 import org.maplibre.compose.offline.OfflinePackDefinition
-import org.maplibre.compose.offline.rememberOfflineManager
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.meshtastic.core.common.util.NumberFormatter
 import org.meshtastic.core.common.util.ioDispatcher
@@ -86,9 +87,13 @@ internal class OfflineMapTarget(
  */
 @Composable
 internal fun OfflineMapsSection(target: OfflineMapTarget, onShowRegion: (BoundingBox) -> Unit) {
-    val manager = rememberOfflineManager()
+    // 0.16.0 moved the manager onto the runtime; `rememberOfflineManager()` is gone. The default runtime is
+    // the one every map here uses, so its packs are the ones the user sees on the map.
+    val manager = DefaultMapRuntime.instance.offlineManager
     val scope = rememberCoroutineScope()
     val packs = manager.packs
+    // A pack definition now carries the pixel ratio it was downloaded at, so the tiles match this display.
+    val pixelRatio = LocalDensity.current.density
 
     val range = target.zoomRange()
     val estimate = target.bounds()?.tileCount(range.first, range.last) ?: 0L
@@ -106,7 +111,7 @@ internal fun OfflineMapsSection(target: OfflineMapTarget, onShowRegion: (Boundin
         DownloadEstimateLines(estimate = estimate, range = range)
 
         Button(
-            onClick = { scope.launch { manager.downloadVisibleArea(target) } },
+            onClick = { scope.launch { manager.downloadVisibleArea(target, pixelRatio) } },
             enabled = target.styleUrl != null && estimate > 0L,
             modifier = Modifier.padding(vertical = 8.dp),
         ) {
@@ -244,7 +249,7 @@ private fun OfflinePackRow(
  * Creates the pack only. A created pack is paused, and stays that way until the user presses play on its row —
  * [OfflineManager.resume] is deliberately not called here, so a download never starts itself.
  */
-private suspend fun OfflineManager.downloadVisibleArea(target: OfflineMapTarget): Boolean {
+private suspend fun OfflineManager.downloadVisibleArea(target: OfflineMapTarget, pixelRatio: Float): Boolean {
     val styleUrl = target.styleUrl
     val bounds = target.bounds()
     if (styleUrl == null || bounds == null) return false
@@ -256,6 +261,7 @@ private suspend fun OfflineManager.downloadVisibleArea(target: OfflineMapTarget)
             OfflinePackDefinition.TilePyramid(
                 styleUrl = styleUrl,
                 bounds = bounds,
+                pixelRatio = pixelRatio,
                 minZoom = range.first,
                 maxZoom = range.last,
             ),

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/SecondaryMapControls.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/SecondaryMapControls.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import kotlinx.coroutines.launch
-import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.map.MapState
 import org.meshtastic.feature.map.component.MapControlsOverlay
 
 /**
@@ -39,7 +39,7 @@ import org.meshtastic.feature.map.component.MapControlsOverlay
  */
 @Composable
 internal fun SecondaryMapControls(
-    cameraState: CameraState,
+    mapState: MapState,
     basemaps: BasemapSelection,
     modifier: Modifier = Modifier,
     filterMenu: (@Composable (expanded: Boolean, onDismissRequest: () -> Unit) -> Unit)? = null,
@@ -51,8 +51,10 @@ internal fun SecondaryMapControls(
         modifier = modifier,
         onToggleFilterMenu = filterMenu?.let { { filterMenuExpanded = !filterMenuExpanded } },
         filterDropdownContent = { filterMenu?.invoke(filterMenuExpanded) { filterMenuExpanded = false } },
-        bearing = cameraState.position.bearing.toFloat(),
-        onCompassClick = { scope.launch { cameraState.animateTo(cameraState.position.copy(bearing = 0.0)) } },
+        bearing = mapState.cameraPosition.bearing.toFloat(),
+        onCompassClick = {
+            scope.launch { mapState.animateCameraPosition(mapState.cameraPosition.copy(bearing = 0.0)) }
+        },
         mapTypeContent = { BasemapButton(selection = basemaps) },
         onToggleLocationTracking = null,
     )

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/ZoomControls.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/component/ZoomControls.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-import org.maplibre.compose.camera.CameraState
+import org.maplibre.compose.map.MapState
 import org.meshtastic.feature.map.component.MapZoomControls
 import org.meshtastic.feature.map.maplibre.ZOOM_STEP
 import org.meshtastic.feature.map.maplibre.style.Basemap
@@ -51,13 +51,13 @@ private const val ZOOM_BOTTOM_INSET = 56
  * showing — see [MeshMapOrnaments].
  */
 @Composable
-internal fun BoxScope.MapZoom(cameraState: CameraState, basemap: Basemap) {
+internal fun BoxScope.MapZoom(mapState: MapState, basemap: Basemap) {
     val scope = rememberCoroutineScope()
     val zoomRange = basemap.zoomRange()
 
     MapZoomControls(
-        onZoomIn = { scope.launch { cameraState.zoomBy(ZOOM_STEP, zoomRange) } },
-        onZoomOut = { scope.launch { cameraState.zoomBy(-ZOOM_STEP, zoomRange) } },
+        onZoomIn = { scope.launch { mapState.zoomBy(ZOOM_STEP, zoomRange) } },
+        onZoomOut = { scope.launch { mapState.zoomBy(-ZOOM_STEP, zoomRange) } },
         modifier = Modifier.align(Alignment.BottomEnd).padding(end = ZOOM_INSET.dp, bottom = ZOOM_BOTTOM_INSET.dp),
     )
 }

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/BasemapLayers.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/BasemapLayers.kt
@@ -23,8 +23,8 @@ import org.maplibre.compose.layers.HillshadeLayer
 import org.maplibre.compose.layers.RasterLayer
 import org.maplibre.compose.sources.RasterDemEncoding
 import org.maplibre.compose.sources.TileSetOptions
-import org.maplibre.compose.sources.rememberRasterDemSource
-import org.maplibre.compose.sources.rememberRasterSource
+import org.maplibre.compose.sources.rememberRasterDemTileSource
+import org.maplibre.compose.sources.rememberRasterTileSource
 import org.meshtastic.feature.map.layers.opacityOf
 import org.meshtastic.feature.map.maplibre.style.Basemap
 import org.meshtastic.feature.map.maplibre.style.MapOverlay
@@ -42,7 +42,7 @@ internal fun RasterTileSpec.toTileSetOptions(): TileSetOptions =
  */
 @Composable
 internal fun RasterBasemapLayer(basemap: Basemap.Raster) {
-    val source = rememberRasterSource(tiles = basemap.spec.tiles, options = basemap.spec.toTileSetOptions())
+    val source = rememberRasterTileSource(tiles = basemap.spec.tiles, options = basemap.spec.toTileSetOptions())
     RasterLayer(id = "basemap-${basemap.id}", source = source)
 }
 
@@ -60,7 +60,8 @@ internal fun MapOverlayLayers(overlays: List<MapOverlay>, opacity: Map<String, F
             is MapOverlay.Hillshade -> HillshadeOverlayLayer(overlay, layerOpacity)
 
             is MapOverlay.Raster -> {
-                val source = rememberRasterSource(tiles = overlay.spec.tiles, options = overlay.spec.toTileSetOptions())
+                val source =
+                    rememberRasterTileSource(tiles = overlay.spec.tiles, options = overlay.spec.toTileSetOptions())
                 RasterLayer(id = "overlay-${overlay.id}", source = source, opacity = const(layerOpacity))
             }
         }
@@ -77,7 +78,7 @@ internal fun MapOverlayLayers(overlays: List<MapOverlay>, opacity: Map<String, F
 @Composable
 private fun HillshadeOverlayLayer(overlay: MapOverlay.Hillshade, opacity: Float) {
     val source =
-        rememberRasterDemSource(
+        rememberRasterDemTileSource(
             tiles = overlay.spec.tiles,
             options = overlay.spec.toTileSetOptions(),
             // Not the default. MapLibre assumes Mapbox Terrain-RGB; every keyless public DEM is

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/CustomLayers.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/CustomLayers.kt
@@ -94,10 +94,14 @@ private fun ImportedLayer(layer: CustomLayer, opacity: Float) {
     // top — a ground overlay is a basemap-like backdrop, not a marker.
     layer.groundOverlays.forEachIndexed { index, overlay -> GroundOverlayLayer(layer.id, index, overlay, opacity) }
 
-    val fill = coalesce(feature["fill"].asString(), feature["color"].asString())
-    val stroke = coalesce(feature["stroke"].asString(), feature["color"].asString())
+    // The untyped property goes into coalesce and the conversion happens on the result: since 0.16.0 an
+    // assertion *inside* coalesce aborts on a null input rather than falling through to the next value, so
+    // asserting first would make a feature with no "fill" skip "color" too.
+    val fill = coalesce(feature["fill"], feature["color"])
+    val stroke = coalesce(feature["stroke"], feature["color"])
     val strokeColor = stroke.convertToColor(const(CustomLayerBlue))
-    val strokeWidth = coalesce(feature["stroke-width"].asNumber(), const(DEFAULT_STROKE_WIDTH)).dp
+    // One key, so the assertion's own fallback does the job coalesce used to.
+    val strokeWidth = feature["stroke-width"].asNumber(const(DEFAULT_STROKE_WIDTH)).dp
 
     // One source, three layers, each filtered to the geometry it can actually draw. Unfiltered, the fill layer
     // painted a LineString's vertices as a solid wedge and the circle layer put a dot on every polygon corner —
@@ -109,7 +113,7 @@ private fun ImportedLayer(layer: CustomLayer, opacity: Float) {
         color = fill.convertToColor(const(CustomLayerBlue)),
         // The layer's own opacity scales whatever the feature asked for, rather than replacing it: an import that
         // styles some features translucent stays relatively translucent as the whole layer fades.
-        opacity = coalesce(feature["fill-opacity"].asNumber(), const(DEFAULT_FILL_OPACITY)) * const(opacity),
+        opacity = feature["fill-opacity"].asNumber(const(DEFAULT_FILL_OPACITY)) * const(opacity),
     )
     LineLayer(
         id = "custom-${layer.id}-line",
@@ -124,7 +128,7 @@ private fun ImportedLayer(layer: CustomLayer, opacity: Float) {
             GeometryType.MultiPolygon,
         ),
         color = strokeColor,
-        opacity = coalesce(feature["stroke-opacity"].asNumber(), const(1f)) * const(opacity),
+        opacity = feature["stroke-opacity"].asNumber(const(1f)) * const(opacity),
         width = strokeWidth,
     )
     CircleLayer(
@@ -150,7 +154,7 @@ private fun ImportedLayer(layer: CustomLayer, opacity: Float) {
             filter = iconIsOneOf(icons.keys),
             iconImage =
             switch(
-                input = coalesce(feature[ICON_URL_PROPERTY].asString(), const("")),
+                input = feature[ICON_URL_PROPERTY].asString(const("")),
                 *icons.map { (url, painter) -> case(url, image(painter, ICON_SIZE)) }.toTypedArray(),
                 // Unreachable given the filter, and required: `switch` has no way to say "draw nothing".
                 fallback = image(icons.values.first(), ICON_SIZE),

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/NodeChipLayer.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/NodeChipLayer.kt
@@ -52,14 +52,13 @@ import org.maplibre.compose.expressions.dsl.condition
 import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.feature
 import org.maplibre.compose.expressions.dsl.image
-import org.maplibre.compose.expressions.dsl.nil
 import org.maplibre.compose.expressions.dsl.switch
 import org.maplibre.compose.expressions.value.BooleanValue
 import org.maplibre.compose.expressions.value.FloatValue
+import org.maplibre.compose.interaction.ClickResult
+import org.maplibre.compose.layers.FeaturesClickHandler
 import org.maplibre.compose.layers.SymbolLayer
-import org.maplibre.compose.sources.Source
-import org.maplibre.compose.util.ClickResult
-import org.maplibre.compose.util.FeaturesClickHandler
+import org.maplibre.compose.sources.VectorSource
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Person
@@ -95,10 +94,10 @@ import org.meshtastic.feature.map.maplibre.geojson.toNodeChip
 @Composable
 internal fun NodeChipLayer(
     id: String,
-    source: Source,
+    source: VectorSource,
     nodes: List<Node>,
     onNodeClick: ((Int) -> Unit)? = null,
-    chipFilter: Expression<BooleanValue> = nil(),
+    chipFilter: Expression<BooleanValue>? = null,
 ) = MapChipLayer(
     id = id,
     source = source,
@@ -156,9 +155,9 @@ private fun chipSortKey(): Expression<FloatValue> = switch(
 @Composable
 internal fun MapChipLayer(
     id: String,
-    source: Source,
+    source: VectorSource,
     chips: List<MapChipKey>,
-    filter: Expression<BooleanValue> = nil(),
+    filter: Expression<BooleanValue>? = null,
     onClick: FeaturesClickHandler? = null,
 ) {
     val distinct = remember(chips) { chips.distinct().take(MAX_CHIP_IMAGES) }

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/NodeLayers.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/NodeLayers.kt
@@ -31,11 +31,12 @@ import org.maplibre.compose.expressions.dsl.convertToColor
 import org.maplibre.compose.expressions.dsl.feature
 import org.maplibre.compose.expressions.dsl.not
 import org.maplibre.compose.expressions.dsl.step
+import org.maplibre.compose.interaction.ClickResult
 import org.maplibre.compose.layers.CircleLayer
 import org.maplibre.compose.layers.FillLayer
 import org.maplibre.compose.layers.SymbolLayer
+import org.maplibre.compose.map.LocalMapState
 import org.maplibre.compose.sources.GeoJsonOptions
-import org.maplibre.compose.util.ClickResult
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.Point
 import org.maplibre.spatialk.geojson.Position
@@ -135,6 +136,10 @@ internal fun NodeLayers(
     // no longer block the caller), and onClick is not a suspending callback.
     val clusterScope = rememberCoroutineScope()
 
+    // 0.16.0 moved the cluster queries off the source and onto its style handle. Read the state here, in
+    // composition, and resolve the handle at click time — see the comment at the query itself.
+    val mapState = checkNotNull(LocalMapState.current)
+
     val nodeSource =
         rememberFeatureSource(
             nodes,
@@ -173,12 +178,16 @@ internal fun NodeLayers(
                     val centre = (clusterFeature.geometry as? Point)?.coordinates
                     if (centre != null) {
                         clusterScope.launch {
+                            // A handle belongs to the style generation it was read from, so it is resolved per
+                            // click rather than remembered: switching basemap replaces the style and any handle
+                            // held across that switch is stale. Null while no style is loaded.
+                            val handle = mapState.style.sources[nodeSource] ?: return@launch
                             // A cluster that can still be broken apart is worth zooming into. One that cannot is
                             // nodes sitting on the same spot, so zooming would do nothing — list them instead.
-                            val expansionZoom = nodeSource.getClusterExpansionZoom(clusterFeature)
+                            val expansionZoom = handle.getClusterExpansionZoom(clusterFeature)
                             if (expansionZoom <= NO_EXPANSION_ZOOM) {
                                 onClusterMembers(
-                                    nodeSource
+                                    handle
                                         .getClusterLeaves(clusterFeature, CLUSTER_LEAF_LIMIT, CLUSTER_LEAF_OFFSET)
                                         .toClusterMembers(),
                                 )

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/NodePulseLayer.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/NodePulseLayer.kt
@@ -32,7 +32,7 @@ import org.maplibre.compose.expressions.dsl.feature
 import org.maplibre.compose.expressions.dsl.gt
 import org.maplibre.compose.expressions.dsl.not
 import org.maplibre.compose.layers.CircleLayer
-import org.maplibre.compose.sources.Source
+import org.maplibre.compose.sources.VectorSource
 import org.meshtastic.core.common.util.nowSeconds
 import org.meshtastic.core.model.Node
 import org.meshtastic.feature.map.RECENTLY_HEARD_SECONDS
@@ -56,7 +56,7 @@ import org.meshtastic.feature.map.maplibre.style.MapColors
  * between packets is invisible.
  */
 @Composable
-internal fun NodePulseLayer(nodes: List<Node>, source: Source) {
+internal fun NodePulseLayer(nodes: List<Node>, source: VectorSource) {
     val heardJustNow = remember(nodes) { nodes.heardJustNow(nowSeconds) }
     // Frozen with the membership so the filter cannot drift out from under a pulse already running.
     val cutoff = remember(heardJustNow) { (nowSeconds - RECENTLY_HEARD_SECONDS).toInt() }

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/TerrainLayers.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/TerrainLayers.kt
@@ -37,7 +37,7 @@ import org.maplibre.compose.sources.GeoJsonData
 import org.maplibre.compose.sources.RasterDemEncoding
 import org.maplibre.compose.sources.TileSetOptions
 import org.maplibre.compose.sources.rememberGeoJsonSource
-import org.maplibre.compose.sources.rememberRasterDemSource
+import org.maplibre.compose.sources.rememberRasterDemTileSource
 import org.maplibre.spatialk.geojson.BoundingBox
 import org.maplibre.spatialk.geojson.FeatureCollection
 import org.maplibre.spatialk.geojson.LineString
@@ -104,9 +104,9 @@ private const val MAPTERHORN_ATTRIBUTION_HTML =
 
 /**
  * The two hillshade tiers, as two [HillshadeLayer]s over two `file://` raster-dem sources (see
- * [org.maplibre.compose.sources.rememberRasterDemSource]) — see this feature's PR description for why MapLibre's own
- * internal Horn's-method shading means no decoded elevation grid or [org.meshtastic.feature.map.terrain.Hillshade] call
- * is needed here at all, unlike the contours below.
+ * [org.maplibre.compose.sources.rememberRasterDemTileSource]) — see this feature's PR description for why MapLibre's
+ * own internal Horn's-method shading means no decoded elevation grid or [org.meshtastic.feature.map.terrain.Hillshade]
+ * call is needed here at all, unlike the contours below.
  *
  * A style layer's own `minZoom`/`maxZoom` (exclusive on the max, per the style spec) is how the two tiers hand off: the
  * global layer stops at [MapterhornEndpoints.REGIONAL_MIN_ZOOM] once regional detail exists, and the regional layer
@@ -118,7 +118,7 @@ private const val MAPTERHORN_ATTRIBUTION_HTML =
 private fun HillshadeTiers(repository: OfflineTerrainRepository, region: OfflineTerrainRegion) {
     val globalMaxZoom = minOf(region.maxZoom, MapterhornEndpoints.GLOBAL_MAX_ZOOM)
     val globalSource =
-        rememberRasterDemSource(
+        rememberRasterDemTileSource(
             tiles = listOf(repository.tileUrlTemplate(TerrainSource.GLOBAL)),
             options =
             TileSetOptions(minZoom = 0, maxZoom = globalMaxZoom, attributionHtml = MAPTERHORN_ATTRIBUTION_HTML),
@@ -137,7 +137,7 @@ private fun HillshadeTiers(repository: OfflineTerrainRepository, region: Offline
 
         val regionalMaxZoom = minOf(region.maxZoom, MapterhornEndpoints.REGIONAL_MAX_ZOOM)
         val regionalSource =
-            rememberRasterDemSource(
+            rememberRasterDemTileSource(
                 tiles = listOf(repository.tileUrlTemplate(TerrainSource.REGIONAL)),
                 options =
                 TileSetOptions(

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/WaypointLayers.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/layers/WaypointLayers.kt
@@ -37,10 +37,11 @@ import org.maplibre.compose.expressions.dsl.const
 import org.maplibre.compose.expressions.dsl.eq
 import org.maplibre.compose.expressions.dsl.feature
 import org.maplibre.compose.expressions.dsl.image
+import org.maplibre.compose.expressions.dsl.textOffset
+import org.maplibre.compose.interaction.ClickResult
 import org.maplibre.compose.layers.FillLayer
 import org.maplibre.compose.layers.LineLayer
 import org.maplibre.compose.layers.SymbolLayer
-import org.maplibre.compose.util.ClickResult
 import org.meshtastic.core.model.DataPacket
 import org.meshtastic.feature.map.maplibre.geojson.WaypointFeatureKeys
 import org.meshtastic.feature.map.maplibre.geojson.geofencesToFeatureCollection
@@ -100,7 +101,7 @@ internal fun WaypointLayers(waypoints: Collection<DataPacket>, onWaypointClick: 
         textColor = const(Color.White),
         textHaloColor = const(Color.Black),
         textHaloWidth = const(1.dp),
-        textOffset = org.maplibre.compose.expressions.dsl.offset(0f.em, WAYPOINT_LABEL_OFFSET_EM.em),
+        textOffset = textOffset(0f.em, WAYPOINT_LABEL_OFFSET_EM.em),
     )
 }
 

--- a/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
+++ b/feature/map-maplibre/src/commonMain/kotlin/org/meshtastic/feature/map/maplibre/terrain/OfflineTerrainRepository.kt
@@ -177,8 +177,9 @@ class OfflineTerrainRepository(private val fileSystem: FileSystem, private val b
     }
 
     /**
-     * The `file://` URL template [rememberRasterDemSource][org.maplibre.compose.sources.rememberRasterDemSource]
-     * (hillshade) can use to reach [source]'s downloaded tiles directly, matching [TerrainTileStore]'s own
+     * The `file://` URL template
+     * [rememberRasterDemTileSource][org.maplibre.compose.sources.rememberRasterDemTileSource] (hillshade) can use to
+     * reach [source]'s downloaded tiles directly, matching [TerrainTileStore]'s own
      * `<baseDir>/<source>/<zoom>/<x>/<y>.webp` layout.
      *
      * `baseDir` is always an absolute path (see [terrainStorageDirectory]'s platform actuals), so this yields a
@@ -188,7 +189,7 @@ class OfflineTerrainRepository(private val fileSystem: FileSystem, private val b
      * The directory portion is percent-encoded before interpolation — a Desktop/JVM user-data path can legitimately
      * contain characters reserved in a URL (a space in a Windows/macOS username is the common case, `#`/`%` less so but
      * just as real) — while the trailing `{z}/{x}/{y}` placeholders are appended afterwards, literally, so
-     * [rememberRasterDemSource]'s own substitution still sees them unescaped.
+     * [rememberRasterDemTileSource]'s own substitution still sees them unescaped.
      */
     fun tileUrlTemplate(source: TerrainSource): String {
         val encodedDir = (baseDir / TILES_DIR_NAME / source.dirName).toString().percentEncodeUrlReserved()

--- a/feature/map-maplibre/src/jvmTest/kotlin/org/meshtastic/feature/map/maplibre/MapLibreRuntimeTest.kt
+++ b/feature/map-maplibre/src/jvmTest/kotlin/org/meshtastic/feature/map/maplibre/MapLibreRuntimeTest.kt
@@ -17,25 +17,26 @@
 package org.meshtastic.feature.map.maplibre
 
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.v2.runComposeUiTest
-import org.maplibre.compose.camera.rememberCameraState
 import org.meshtastic.core.resources.Res
 import org.meshtastic.core.resources.getString
 import org.meshtastic.core.resources.map_engine_unavailable
-import org.meshtastic.feature.map.maplibre.component.BasemapSelection
-import org.meshtastic.feature.map.maplibre.style.Basemaps
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
  * The crash in #7001 is a missing native library, and a missing library is an `UnsatisfiedLinkError` — an `Error`, not
- * an `Exception`. The probe has to survive exactly that, and the map surfaces have to stop before composing MapLibre
- * when it says no.
+ * an `Exception`. The probe has to survive exactly that, and the map screen has to stop before reaching MapLibre when
+ * it says no.
+ *
+ * The guard is the first statement of [MapLibreMapViewProvider.MapView], and this test leans on that: nothing else in
+ * this module's Koin graph is available here, so anything composed past the guard would fail with a Koin error rather
+ * than the notice. A guard that drifts later in the function fails this test rather than passing it quietly.
  */
 @OptIn(ExperimentalTestApi::class)
 class MapLibreRuntimeTest {
@@ -51,19 +52,18 @@ class MapLibreRuntimeTest {
     }
 
     @Test
-    fun `the secondary map surface composes the fallback and never its content`() = runComposeUiTest {
-        var contentCompositions = 0
+    fun `the map screen composes the fallback and nothing else`() = runComposeUiTest {
         setContent {
             CompositionLocalProvider(LocalMapLibreRuntimeProbe provides { false }) {
-                SecondaryMapSurface(
-                    basemaps = BasemapSelection(Basemaps.default, emptyList(), emptyList()) {},
-                    cameraState = rememberCameraState(),
-                ) {
-                    contentCompositions++
-                }
+                MapLibreMapViewProvider()
+                    .MapView(
+                        modifier = Modifier,
+                        navigateToNodeDetails = {},
+                        waypointId = null,
+                        sitePlannerNodeNum = null,
+                    )
             }
         }
         onNodeWithText(getString(Res.string.map_engine_unavailable)).assertIsDisplayed()
-        assertEquals(0, contentCompositions, "map content must not be composed without an engine to draw it")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ jetbrains-adaptive = "1.3.0-beta02"
 # 2.8.0–2.8.1). KML is now read by the app's own xmlutil-based converter and that parser is unused, so
 # the pairing — and the canary test that guarded it — is gone. The floor stays as a plain minimum.
 android-maps-utils = "5.2.0"
-maplibre-compose = "0.15.0"
+maplibre-compose = "0.16.0"
 maps-compose = "8.6.0"
 
 # ML Kit

--- a/scripts/lib/abi-parity.sh
+++ b/scripts/lib/abi-parity.sh
@@ -12,13 +12,11 @@
 # fails once it turns up, so an entry cannot outlive its reason: the dependency bump that
 # closes the gap goes red until the line is deleted with it.
 #
-# fdroid armeabi-v7a: no 32-bit ARM build of MapLibre exists yet. Upstream merged it on
-# 2026-08-24 (maplibre-native-ffi #658/#659/#660); the release carrying it, and the
-# maplibre-compose bump onto it, are what remove these two lines. Until then the app shows
-# a message instead of a map on those devices (#7005).
+# Empty since maplibre-compose 0.16.0, whose maplibre-native FFI ships armeabi-v7a: that
+# closed the only gap this list ever held (fdroid armeabi-v7a libjniMaplibreNativeC.so and
+# libmaplibre-native-c.so, #7005), and the check went red until the lines came out with the
+# bump, which is what it is for.
 ABI_PARITY_KNOWN_GAPS="
-fdroid armeabi-v7a libjniMaplibreNativeC.so
-fdroid armeabi-v7a libmaplibre-native-c.so
 "
 
 # apk_libs <apk> <abi> — basenames of the libs under lib/<abi>/ in the APK, one per line.

--- a/scripts/verify-abi-parity-selftest.sh
+++ b/scripts/verify-abi-parity-selftest.sh
@@ -130,12 +130,16 @@ wrapper "matching splits pass, universal ignored" even 0 "google: all splits shi
 tree gap google debug armeabi-v7a=liba.so arm64-v8a=liba.so,libengine.so
 wrapper "unrecorded gap fails with the lib named" gap 1 "armeabi-v7a/libengine.so"
 
+# The two cases that used to live here drove the wrapper through the *checked-in* allowlist:
+# one asserted the recorded fdroid gap was excused and counted, the other that the gap
+# closing failed until the lines went. maplibre-compose 0.16.0 closed that gap and the lines
+# are gone, so neither case has anything real to drive and both would now assert the
+# opposite of what the script does. Cases 3 and 5 cover excused and stale entries against
+# the classifier directly, with allowlists they set themselves, so only the end-to-end
+# variants are lost. This keeps the `*/release` glob those cases also happened to exercise.
 MAPLIBRE="libjniMaplibreNativeC.so,libmaplibre-native-c.so"
-tree known fdroid release armeabi-v7a=liba.so "arm64-v8a=liba.so,$MAPLIBRE"
-wrapper "the recorded fdroid gap passes and is counted" known 0 "fdroid: splits match apart from 2 recorded known gap(s)"
-
-tree stale fdroid release "armeabi-v7a=liba.so,$MAPLIBRE" "arm64-v8a=liba.so,$MAPLIBRE"
-wrapper "the recorded gap closing fails until the lines go" stale 1 "known-gap entries whose library is now present"
+tree rel fdroid release "armeabi-v7a=liba.so,$MAPLIBRE" "arm64-v8a=liba.so,$MAPLIBRE"
+wrapper "release splits are scanned, not just debug" rel 0 "fdroid: all splits ship the same native libraries"
 
 tree single google debug arm64-v8a=liba.so
 wrapper "a lone split is nothing to compare, so no APKs were checked" single 1 "no split APKs found"


### PR DESCRIPTION
maplibre-compose 0.16.0 is a breaking release and `:feature:map-maplibre` did not compile against it: 212 errors across 18 of the 20 commonMain files that import the library. Renovate opened #7086 for the version bump on its own, which cannot merge. This supersedes it.

Fixes #7001

0.16.0 also ships an `armeabi-v7a` maplibre-native FFI, which closes the gap that kept the map off 32-bit ARM F-Droid builds. #7005 mitigated that crash by showing a message instead of a map; this restores the map itself.

0.16.0 moves the base style and the sources and layers over it onto `MapState`, replaces the per-gesture options with camera capabilities plus a binding table, moves cluster and feature-state queries onto style handles, and splits location into separate location and heading models.

## 🛠️ Refactoring & Architecture

- `MeshMap` and `SecondaryMapSurface` each split into a state builder that declares the style content and a surface that presents it, because the content now belongs to the state. `MeshMap`'s only caller was `MapLibreMapViewProvider`, and `MapLibreNodeTrackMap`'s public signature is unchanged.
- Camera persistence feeds `initialCameraPosition` instead of writing the camera after the map exists, which is what 0.16.0 made possible. The map opens on the remembered view rather than opening on a default and moving to it.
- `FrameOnce` and `FollowUserLocation` stay in the outer composition rather than the style block. The library hosts style content in a subcomposition keyed on the loaded style and disposes it on every base-style switch, so a latch in there would reset when the user changed basemap and re-frame the mesh over wherever they had panned to.
- The #7001 no-engine guard stays at the surface. A `MapState` is pure Kotlin, and it is the map view that loads the native library.

## 🐛 Bug Fixes

- The map works again on 32-bit ARM F-Droid builds (#7001). `armeabi-v7a` now ships `libjniMaplibreNativeC.so` and `libmaplibre-native-c.so`, so the engine probe finds an engine on every ABI the app builds. The two `ABI_PARITY_KNOWN_GAPS` entries in `scripts/lib/abi-parity.sh` are deleted with the bump, which is exactly what `verify-abi-parity.sh` demands once the libraries turn up: it failed this PR until they came out. The probe stays as a cheap soft-failing defence, but its KDoc no longer claims the gap is open.
- `CustomLayers` was wrong under the new expression semantics, not only uncompilable. An assertion inside `coalesce` now aborts on a null input instead of falling through to the next value, so `coalesce(feature["fill"].asString(), feature["color"].asString())` would have skipped the `color` fallback. It passes the untyped property in and converts the result instead.

## 🧹 Chores

`org.maplibre.compose` 0.15.0 to 0.16.0, with the API moves it requires:

| 0.15.0 | 0.16.0 |
| --- | --- |
| `rememberCameraState` / `CameraState` / `styleState` | `rememberMapState` / `MapState` |
| `position` / `animateTo` / `jumpTo` | `cameraPosition` / `animateCameraPosition` / `setCameraPosition` / `fitCameraToBounds` |
| `viewport.visibleBoundingBox` | `viewport.visibleBounds.toBoundingBox()` |
| `MapOptions` / `GestureOptions` | `cameraConstraints` + `MapInteractions` / `MapUiOptions` |
| `onMapClick` / `onMapLongClick` params | `MapInteractions.callbacks` |
| source cluster queries | the `mapState.style.sources[source]` handle |
| `rememberOfflineManager()` | `DefaultMapRuntime.instance.offlineManager`, and `OfflinePackDefinition` now requires `pixelRatio` |
| `rememberRasterSource` / `rememberRasterDemSource` | `rememberRasterTileSource` / `rememberRasterDemTileSource` |
| `Orientation*` / `TRACK_ORIENTATION` | `Heading*` / `TRACK_HEADING` |
| `ClickResult` in `.util` | `.interaction`, and `FeaturesClickHandler` to `.layers` |
| `offset(em, em)` | `textOffset(em, em)` |
| `ProvideMapHost` (desktopApp) | `ProvideMapPresentationHost` |

## Testing Performed

- Full baseline green: `spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`, plus `:desktopApp:compileKotlin` because `kmpSmokeCompile` does not cover `:desktopApp` and that is where the desktop host rename landed. `:feature:map-maplibre:jvmTest` and `:detekt` were also force-rerun so they executed rather than reporting up to date.
- `verify-abi-parity-selftest.sh` loses the two cases that drove the wrapper through the checked-in allowlist. With the allowlist empty they have nothing real to drive, and both would assert the opposite of what the script now does: one wanted exit 0 from an excused gap, the other exit 1 from a stale entry. Cases 3 and 5 already cover excused and stale entries against the classifier with allowlists they set themselves, so only the end-to-end variants are lost; a release-directory case keeps the `*/release` glob those two also happened to exercise. All 19 cases pass, plus `verify-rb-selftest.sh`.
- `./scripts/verify-abi-parity.sh` run against the locally assembled splits: both flavors pass, and `unzip -Z1` on `androidApp-fdroid-armeabi-v7a-debug.apk` confirms both maplibre libraries are present. `shellcheck -x` clean across `scripts/` (the form CI uses).
- `MapLibreRuntimeTest` rewritten. Its old case asserted that the secondary surface shows the fallback and never composes its content. That cannot run in `jvmTest` any more: building a `MapState` needs a live `MapRuntime`, and a Gradle test worker can supply neither the cache path (0.16.0 derives it from the process main class, and upstream excludes Gradle and JUnit frames) nor the native library. It now covers the guard at `MapLibreMapViewProvider.MapView`, where it is the first statement. None of the module's Koin graph is available in that test, so anything composed past the guard fails with a Koin error instead of showing the notice. Confirmed it discriminates by flipping the probe to `true` and watching it fail.

## Not covered by tests

No test exercises a real map, on the old code or the new, because `MapState` creation needs the native runtime. Worth a look on a device:

- camera restore opens on the remembered view with no jump
- `MapOrnaments`: the logo and attribution move from a full-width `SpaceBetween` row to corner alignment, matching `MapOverlay.AttributionOnly`. Check they clear `TrackPointCard` and `DiscoveryNodeCard`, which sit above a hand-tuned `ORNAMENT_CLEARANCE`.
- basemap switching, cluster tap to expand, and offline pack creation

## Behaviour changes worth naming

- Secondary maps can now be rotated by mouse drag. Their KDoc always said rotation stays and only tilt is off; the old `isDragRotateTiltEnabled` flag had bundled the two together.
- The desktop ambient tile cache path now derives from the process main class (`org.meshtastic.desktop`). 0.15.0 had no such inference, so an existing desktop user's cache is orphaned once.

Pre-existing and deliberately left alone: `SaveCameraPosition` starts collecting before the map attaches, so a first-ever open persists the default camera before `FrameOnce` can fit the mesh. If the app dies in that window, the next launch treats it as a remembered view and never frames the mesh. `MapPrefsImpl` guards neither side. The old code did the same, so it is not a regression here, but it deserves its own issue.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated map rendering and controls for improved compatibility and smoother camera interactions.
  - Camera positions are now restored and saved more reliably across map sessions.
  - Offline map downloads now better match the device display for improved visual quality.
  - Map attribution and compass controls have been refreshed.

- **Bug Fixes**
  - Improved handling of map styling values and fallback behavior.
  - Updated cluster, waypoint, and node interactions for more reliable map responses.
  - Improved support for map rendering across supported device architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->