### PR TITLE
perf: cache-window the hot lists, and modernize the nav3 and adaptive wiring

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -59,6 +59,10 @@ kotlin {
             implementation(libs.jetbrains.compose.material3.adaptive.navigation)
             implementation(libs.jetbrains.compose.material3.adaptive.navigation.suite)
             api(libs.jetbrains.navigation3.ui)
+            // Pinned past navigation3-ui's transitive 1.1.1 — the JetBrains mirror never
+            // published 1.1.6's SaveableStateHolder fix. Consumers import
+            // androidx.navigation3.runtime.* (NavKey, NavBackStack) directly from commonMain.
+            api(libs.androidx.navigation3.runtime)
             // navigation3-ui's own POM marks this runtime-scope, so it never reaches any
             // compile classpath transitively — declare it directly. Consumers (e.g.
             // feature:docs) import androidx.navigationevent.compose.* directly.

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/MeshtasticNavDisplay.kt
@@ -20,12 +20,15 @@ import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.VerticalDragHandle
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.PaneExpansionState
+import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldScope
 import androidx.compose.material3.adaptive.layout.rememberPaneExpansionState
 import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
 import androidx.compose.material3.adaptive.navigation3.rememberSupportingPaneSceneStrategy
@@ -47,9 +50,6 @@ import co.touchlab.kermit.Logger
 import org.meshtastic.core.navigation.MultiBackstack
 import org.meshtastic.core.navigation.rumViewName
 import org.meshtastic.core.repository.PlatformAnalytics
-
-/** Duration in milliseconds for the shared crossfade transition between navigation scenes. */
-private const val TRANSITION_DURATION_MS = 350
 
 /**
  * Shared [NavDisplay] wrapper that configures the standard Meshtastic entry decorators, scene strategies, and
@@ -106,34 +106,12 @@ fun MeshtasticNavDisplay(
     val listDetailSceneStrategy =
         rememberListDetailSceneStrategy<NavKey>(
             paneExpansionState = rememberPaneExpansionState(),
-            paneExpansionDragHandle = { state ->
-                val interactionSource = remember { MutableInteractionSource() }
-                VerticalDragHandle(
-                    modifier =
-                    Modifier.paneExpansionDraggable(
-                        state = state,
-                        minTouchTargetSize = 48.dp,
-                        interactionSource = interactionSource,
-                    ),
-                    interactionSource = interactionSource,
-                )
-            },
+            paneExpansionDragHandle = { state -> PaneExpansionDragHandle(state) },
         )
     val supportingPaneSceneStrategy =
         rememberSupportingPaneSceneStrategy<NavKey>(
             paneExpansionState = rememberPaneExpansionState(),
-            paneExpansionDragHandle = { state ->
-                val interactionSource = remember { MutableInteractionSource() }
-                VerticalDragHandle(
-                    modifier =
-                    Modifier.paneExpansionDraggable(
-                        state = state,
-                        minTouchTargetSize = 48.dp,
-                        interactionSource = interactionSource,
-                    ),
-                    interactionSource = interactionSource,
-                )
-            },
+            paneExpansionDragHandle = { state -> PaneExpansionDragHandle(state) },
         )
 
     val saveableDecorator = rememberSaveableStateHolderNavEntryDecorator<NavKey>()
@@ -141,6 +119,9 @@ fun MeshtasticNavDisplay(
 
     val activeDecorators =
         remember(backStack, saveableDecorator, vmStoreDecorator) { listOf(saveableDecorator, vmStoreDecorator) }
+
+    // Fades are alpha, not movement, so they follow the theme's effects spec rather than a spatial one.
+    val fadeSpec = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
 
     SharedTransitionLayout {
         NavDisplay(
@@ -157,12 +138,28 @@ fun MeshtasticNavDisplay(
             // NavDisplay falls back to SinglePaneSceneStrategy automatically when none of these compute a Scene.
             sceneStrategies = listOf(DialogSceneStrategy(), listDetailSceneStrategy, supportingPaneSceneStrategy),
             sharedTransitionScope = this@SharedTransitionLayout,
-            transitionSpec = meshtasticTransitionSpec(),
-            popTransitionSpec = meshtasticTransitionSpec(),
-            predictivePopTransitionSpec = meshtasticPredictivePopTransitionSpec(),
+            transitionSpec = meshtasticTransitionSpec(fadeSpec),
+            popTransitionSpec = meshtasticTransitionSpec(fadeSpec),
+            predictivePopTransitionSpec = meshtasticPredictivePopTransitionSpec(fadeSpec),
             modifier = modifier,
         )
     }
+}
+
+/** Drag handle shared by the list-detail and supporting-pane scene strategies, with a 48.dp touch-target floor. */
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+private fun ThreePaneScaffoldScope.PaneExpansionDragHandle(state: PaneExpansionState) {
+    val interactionSource = remember { MutableInteractionSource() }
+    VerticalDragHandle(
+        modifier =
+        Modifier.paneExpansionDraggable(
+            state = state,
+            minTouchTargetSize = 48.dp,
+            interactionSource = interactionSource,
+        ),
+        interactionSource = interactionSource,
+    )
 }
 
 internal class ScreenViewTracker(private val analytics: PlatformAnalytics) {
@@ -183,19 +180,15 @@ internal class ScreenViewTracker(private val analytics: PlatformAnalytics) {
 }
 
 /** Shared crossfade [ContentTransform] used for both forward and pop navigation. */
-private fun meshtasticTransitionSpec(): AnimatedContentTransitionScope<Scene<NavKey>>.() -> ContentTransform = {
-    ContentTransform(
-        fadeIn(animationSpec = tween(TRANSITION_DURATION_MS)),
-        fadeOut(animationSpec = tween(TRANSITION_DURATION_MS)),
-    )
+private fun meshtasticTransitionSpec(
+    fadeSpec: FiniteAnimationSpec<Float>,
+): AnimatedContentTransitionScope<Scene<NavKey>>.() -> ContentTransform = {
+    ContentTransform(fadeIn(animationSpec = fadeSpec), fadeOut(animationSpec = fadeSpec))
 }
 
 /** Crossfade transition for predictive back gestures (Android 14+). */
-private fun meshtasticPredictivePopTransitionSpec():
-    AnimatedContentTransitionScope<Scene<NavKey>>.(Int) -> ContentTransform =
-    {
-        ContentTransform(
-            fadeIn(animationSpec = tween(TRANSITION_DURATION_MS)),
-            fadeOut(animationSpec = tween(TRANSITION_DURATION_MS)),
-        )
-    }
+private fun meshtasticPredictivePopTransitionSpec(
+    fadeSpec: FiniteAnimationSpec<Float>,
+): AnimatedContentTransitionScope<Scene<NavKey>>.(Int) -> ContentTransform = {
+    ContentTransform(fadeIn(animationSpec = fadeSpec), fadeOut(animationSpec = fadeSpec))
+}

--- a/feature/messaging/detekt-baseline.xml
+++ b/feature/messaging/detekt-baseline.xml
@@ -15,7 +15,7 @@
     <ID>LambdaParameterEventTrailing:QuickChat.kt:onNavigateUp: () -> Unit</ID>
     <ID>ModifierMissing:Contacts.kt:@Suppress("LongMethod", "CyclomaticComplexMethod", "LongParameterList") @Composable fun ContactsScreen</ID>
     <ID>ModifierMissing:DeliveryInfoDialog.kt:@Composable fun DeliveryInfo</ID>
-    <ID>ModifierMissing:Message.kt:@Suppress("LongMethod", "CyclomaticComplexMethod") @Composable fun MessageScreen</ID>
+    <ID>ModifierMissing:Message.kt:@Suppress("LongMethod", "CyclomaticComplexMethod") @OptIn(ExperimentalFoundationApi::class) @Composable fun MessageScreen</ID>
     <ID>ModifierMissing:MessageActionsBottomSheet.kt:@Suppress("LongMethod") @Composable fun MessageActionsContent</ID>
     <ID>ModifierMissing:MessageScreenComponents.kt:@Composable fun ReplySnippet</ID>
     <ID>ModifierMissing:MessageScreenComponents.kt:@OptIn(ExperimentalMaterial3Api::class) @Composable fun ActionModeTopBar</ID>

--- a/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
+++ b/feature/messaging/src/commonMain/kotlin/org/meshtastic/feature/messaging/Message.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.layout.LazyLayoutCacheWindow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -142,6 +143,7 @@ private const val COUNTER_VISIBLE_WITHIN_BYTES = 20
  * @param onNavigateBack Callback to navigate back from this screen.
  */
 @Suppress("LongMethod", "CyclomaticComplexMethod")
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MessageScreen(
     contactKey: String,
@@ -246,7 +248,8 @@ fun MessageScreen(
 
     val inSelectionMode by remember { derivedStateOf { selectedMessageIds.value.isNotEmpty() } }
 
-    val listState = rememberLazyListState()
+    // The message list is reverseLayout; ahead is still the scroll direction, toward older messages.
+    val listState = rememberLazyListState(cacheWindow = LazyLayoutCacheWindow(ahead = 300.dp, behind = 100.dp))
 
     // Track unread messages using lightweight metadata queries
     val hasUnreadMessages by viewModel.hasUnreadMessages.collectAsStateWithLifecycle()

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -17,6 +17,7 @@
 package org.meshtastic.feature.node.list
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
@@ -31,6 +32,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.layout.LazyLayoutCacheWindow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -110,7 +112,7 @@ internal fun canEditStatusMessage(node: Node, ourNode: Node?, connectionState: C
     node.num == ourNode?.num && connectionState == ConnectionState.Connected && node.capabilities.supportsStatusMessage
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun NodeListScreen(
     navigateToNodeDetails: (Int) -> Unit,
@@ -153,7 +155,7 @@ fun NodeListScreen(
     val deviceImageUrls by viewModel.deviceImageUrls.collectAsStateWithLifecycle()
     val ignoredNodeCount = unfilteredNodes.count { it.isIgnored }
 
-    val listState = rememberLazyListState()
+    val listState = rememberLazyListState(cacheWindow = LazyLayoutCacheWindow(ahead = 300.dp, behind = 100.dp))
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(scrollToTopEvents) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,10 @@ glance = "1.2.0"
 lifecycle = "2.11.0"
 jetbrains-lifecycle = "2.11.0"
 navigation3 = "1.1.1"
+# navigation3-runtime is AndroidX's own KMP artifact (androidx.navigation3:navigation3-runtime),
+# separate from the JetBrains navigation3-ui mirror above — the mirror never published past 1.1.1,
+# so this ref moves independently and is deliberately ahead.
+navigation3-runtime = "1.1.7"
 navigationevent = "1.1.0"
 paging = "3.5.1"
 room = "3.0.2"
@@ -150,6 +154,7 @@ jetbrains-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecyc
 jetbrains-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "jetbrains-lifecycle" }
 jetbrains-lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "jetbrains-lifecycle" }
 jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3-runtime" }
 jetbrains-navigationevent-compose = { module = "org.jetbrains.androidx.navigationevent:navigationevent-compose", version.ref = "navigationevent" }
 androidx-paging-common = { module = "androidx.paging:paging-common", version.ref = "paging" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }


### PR DESCRIPTION
The node list and the conversation list are the two lists users scroll fast through, and both were running on Compose's default single-item prefetch. Foundation 1.12.0 ships a stable distance-based cache window that we were not using in any of the app's 37 LazyColumns. This PR adopts it on those two, and picks up two adjacent bits of debt found while verifying it.

## 🌟 New Features

- Node list and conversation list now build their `LazyListState` with `LazyLayoutCacheWindow(ahead = 300.dp, behind = 100.dp)`. Ahead and behind are deliberately asymmetric because forward scrolling dominates. The conversation list is `reverseLayout`, where ahead still means the scroll direction.

## 🧹 Chores

- `androidx.navigation3:navigation3-runtime` now has its own catalog ref, pinned to 1.1.7.

  Navigation 3 reaches us as two artifacts from two publishers. `navigation3-ui` comes from the JetBrains mirror; `navigation3-runtime` is published by AndroidX itself as full KMP and was only ever arriving transitively, which pinned it to whatever the ui declared. The mirror never published 1.1.2 through 1.1.7, so the runtime could not move at all without its own ref. 1.1.7 is stable and carries 1.1.6's fix for the duplicate `SaveableStateHolder` key crash on rapid back navigation.

## 🛠️ Refactoring & Architecture

- `MeshtasticNavDisplay` carried two character-identical pane-expansion drag-handle lambdas. Extracted to one `ThreePaneScaffoldScope` extension. The receiver matters: `paneExpansionDraggable` is a member of that scope, so a plain top-level composable does not compile.
- Navigation scene transitions were a hardcoded `tween(350ms)` while the rest of the app runs on `MotionScheme.expressive()`. They now read `MaterialTheme.motionScheme.defaultEffectsSpec<Float>()`. An effects spec rather than a spatial one, because fades are alpha and not movement. This follows the pattern `NodeCardGlow` already uses.

## Testing Performed

- `spotlessCheck detekt assembleFdroidDebug` green.
- `:core:ui:allTests`, `:feature:node:allTests`, `:feature:messaging:allTests` green.
- The `cacheWindow` overload of `rememberLazyListState` and the `LazyLayoutCacheWindow` factory are both `@ExperimentalFoundationApi` in the 1.12.0 bytecode, so the opt-ins are required rather than decorative. `DpLazyLayoutCacheWindow` is not public, so the top-level factory is the supported entry point.
- The `ModifierMissing` detekt baseline entry for `MessageScreen` is re-signed. Baseline IDs match on literal annotation text, so inserting `@OptIn` between `@Suppress` and `@Composable` silently breaks the match.

No UI-visible change beyond transition timing now following the theme, so no screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved scrolling performance in messaging and node lists by preloading nearby content and retaining recently viewed items.
* **Navigation**
  * Updated navigation pane drag handles for a more consistent interaction.
  * Navigation transitions now follow the app’s Material theme animations, including forward, back, and predictive-back actions.
* **UI Polish**
  * Navigation animation timing is now adaptive to the active theme rather than fixed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->