### PR TITLE
feat(node): overflow the time frame selector instead of crushing it

### DIFF
--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TimeFrameSelector.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TimeFrameSelector.kt
@@ -17,14 +17,26 @@
 package org.meshtastic.feature.node.metrics
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.ButtonGroup
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedToggleButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import org.jetbrains.compose.resources.stringResource
+import org.meshtastic.core.resources.Res
+import org.meshtastic.core.resources.overflow_menu
+import org.meshtastic.core.ui.icon.Check
+import org.meshtastic.core.ui.icon.MeshtasticIcons
+import org.meshtastic.core.ui.icon.More
 import org.meshtastic.feature.node.model.TimeFrame
 
 @Suppress("LambdaParameterEventTrailing")
@@ -37,14 +49,53 @@ fun TimeFrameSelector(
 ) {
     if (availableTimeFrames.size <= 1) return
 
-    SingleChoiceSegmentedButtonRow(modifier = modifier.fillMaxWidth()) {
-        availableTimeFrames.forEachIndexed { index, timeFrame ->
-            val text = stringResource(timeFrame.strRes)
-            SegmentedButton(
-                shape = SegmentedButtonDefaults.itemShape(index, availableTimeFrames.size),
-                onClick = { onTimeFrameSelected(timeFrame) },
-                selected = timeFrame == selectedTimeFrame,
-                label = { Text(text = text, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+    // Items that don't fit collapse into overflowIndicator's menu instead of squeezing every label.
+    ButtonGroup(
+        overflowIndicator = { menuState ->
+            IconButton(onClick = { if (menuState.isShowing) menuState.dismiss() else menuState.show() }) {
+                Icon(imageVector = MeshtasticIcons.More, contentDescription = stringResource(Res.string.overflow_menu))
+            }
+        },
+        modifier = modifier.fillMaxWidth().selectableGroup(),
+    ) {
+        availableTimeFrames.forEach { timeFrame ->
+            val isSelected = timeFrame == selectedTimeFrame
+            customItem(
+                buttonGroupContent = {
+                    // ToggleButton hardcodes Role.Checkbox; override it so the group still
+                    // reads as single-choice radio semantics to a screen reader.
+                    OutlinedToggleButton(
+                        checked = isSelected,
+                        onCheckedChange = { onTimeFrameSelected(timeFrame) },
+                        modifier =
+                        Modifier.semantics {
+                            role = Role.RadioButton
+                            selected = isSelected
+                        },
+                    ) {
+                        Text(text = stringResource(timeFrame.strRes), maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                },
+                menuContent = { menuState ->
+                    DropdownMenuItem(
+                        text = { Text(text = stringResource(timeFrame.strRes)) },
+                        onClick = {
+                            onTimeFrameSelected(timeFrame)
+                            menuState.dismiss()
+                        },
+                        trailingIcon =
+                        if (isSelected) {
+                            { Icon(imageVector = MeshtasticIcons.Check, contentDescription = null) }
+                        } else {
+                            null
+                        },
+                        modifier =
+                        Modifier.semantics {
+                            role = Role.RadioButton
+                            selected = isSelected
+                        },
+                    )
+                },
             )
         }
     }


### PR DESCRIPTION
`TimeFrameSelector` renders `availableTimeFrames`, which is variable length. `SingleChoiceSegmentedButtonRow` divides the row evenly however many entries there are, so on a narrow screen every label ellipsises at once rather than the list adapting. M3's `ButtonGroup` collapses whatever does not fit into a menu, which is the actual fix.

## 🌟 New Features

- Time frames that do not fit now collapse behind an overflow icon button and stay selectable from its dropdown, each showing a check when it is the current selection. Reuses the existing `overflow_menu` string and `MeshtasticIcons.More` / `.Check`, so no new resources.

## 🛠️ Refactoring & Architecture

- `SingleChoiceSegmentedButtonRow` / `SegmentedButton` replaced with `ButtonGroup` + `OutlinedToggleButton` via `ButtonGroupScope.customItem`, which is what lets one item supply both its inline button and its overflow-menu row.

## Accessibility

Worth calling out, because it was the hard part. `ToggleButton` hardcodes `Role.Checkbox` internally and exposes no parameter to change it, and `ButtonGroupScope.toggleableItem` gives you no `Modifier` to reach it either. A caller-supplied `Modifier.semantics {}` does win over the internal role, so each item sets `role = Role.RadioButton` and its `selected` state explicitly, the row keeps `selectableGroup()`, and the overflow-menu items carry the same semantics. Net effect is that the screen reader contract matches what `SegmentedButton` gave before.

## Visual change

Equal-width segments spanning the row become intrinsic-width pills at `ButtonGroupDefaults` spacing. That is inherent to the API rather than a styling choice here. If the connected-segment look should be kept, that is `Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween)` plus per-item connected shapes, and can be a follow-up.

`TransportSelector` is deliberately untouched. Its three segments are fixed and never overflow, and it has a screenshot golden that would need re-baselining for a purely cosmetic change with no functional gain.

## Testing Performed

- `spotlessCheck detekt assembleFdroidDebug` green.
- `:feature:node:allTests` green.
- No screenshot goldens cover this composable, so none needed regenerating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the time frame selector with a more flexible button layout.
  - Time frames that do not fit are now available through an overflow menu.
  - Added visible selection indicators in the overflow menu.
  - Improved screen reader support for time frame selection controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->