### PR TITLE
fix(lora): correct preset SNR floors and signal colors

### DIFF
--- a/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ChannelOption.kt
+++ b/core/model/src/commonMain/kotlin/org/meshtastic/core/model/ChannelOption.kt
@@ -460,39 +460,52 @@ enum class RegionInfo(
 enum class ChannelOption(
     val modemPreset: ModemPreset,
     val bandwidth: Float,
-    val snrLimit: Float,
+    val spreadingFactor: Int,
     val minFirmware: DeviceVersion? = null,
 ) {
     // Grouped by range and speed for better readability.
-    // snrLimit = demodulation floor for the preset's spreading factor (see [ModemPreset.snrLimit]).
+    // Preset parameters mirror firmware's modemPresetToParams (src/mesh/MeshRadio.h).
     // minFirmware = first firmware release whose preset table has the entry ([Capabilities.supportsPreset]);
     // older firmware silently falls back to LONG_FAST when sent an unknown preset.
-    VERY_LONG_SLOW(ModemPreset.VERY_LONG_SLOW, 0.0625f, snrLimit = -20f), // SF12
-    LONG_TURBO(ModemPreset.LONG_TURBO, 0.500f, snrLimit = -12.5f), // SF9
-    LONG_FAST(ModemPreset.LONG_FAST, 0.250f, snrLimit = -17.5f), // SF11
-    LONG_MODERATE(ModemPreset.LONG_MODERATE, 0.125f, snrLimit = -17.5f), // SF11
 
-    // SF12: physically -20 dB. NB: Meshtastic-Apple's snrLimit() returns -7.5 here, which is the SF7 value
-    // and an apparent bug — see meshtastic/Meshtastic-Android#5446.
-    LONG_SLOW(ModemPreset.LONG_SLOW, 0.125f, snrLimit = -20f), // SF12
-    MEDIUM_FAST(ModemPreset.MEDIUM_FAST, 0.250f, snrLimit = -12.5f), // SF9
-    MEDIUM_SLOW(ModemPreset.MEDIUM_SLOW, 0.250f, snrLimit = -15f), // SF10
-    MEDIUM_TURBO(ModemPreset.MEDIUM_TURBO, 0.500f, snrLimit = -12.5f, minFirmware = FIRMWARE_2_8), // SF9
-    SHORT_FAST(ModemPreset.SHORT_FAST, 0.250f, snrLimit = -7.5f), // SF7
-    SHORT_SLOW(ModemPreset.SHORT_SLOW, 0.250f, snrLimit = -10f), // SF8
-    SHORT_TURBO(ModemPreset.SHORT_TURBO, 0.500f, snrLimit = -7.5f), // SF7
-    LITE_FAST(ModemPreset.LITE_FAST, 0.125f, snrLimit = -12.5f, minFirmware = FIRMWARE_2_8),
-    LITE_SLOW(ModemPreset.LITE_SLOW, 0.125f, snrLimit = -15f, minFirmware = FIRMWARE_2_8),
-    NARROW_FAST(ModemPreset.NARROW_FAST, 0.0625f, snrLimit = -10f, minFirmware = FIRMWARE_2_8),
-    NARROW_SLOW(ModemPreset.NARROW_SLOW, 0.0625f, snrLimit = -12.5f, minFirmware = FIRMWARE_2_8),
+    // Historical parameters for firmware predating the removal of VERY_LONG_SLOW.
+    VERY_LONG_SLOW(ModemPreset.VERY_LONG_SLOW, 0.0625f, spreadingFactor = 12),
+    LONG_TURBO(ModemPreset.LONG_TURBO, 0.500f, spreadingFactor = 11),
+    LONG_FAST(ModemPreset.LONG_FAST, 0.250f, spreadingFactor = 11),
+    LONG_MODERATE(ModemPreset.LONG_MODERATE, 0.125f, spreadingFactor = 11),
+    LONG_SLOW(ModemPreset.LONG_SLOW, 0.125f, spreadingFactor = 12),
+    MEDIUM_FAST(ModemPreset.MEDIUM_FAST, 0.250f, spreadingFactor = 9),
+    MEDIUM_SLOW(ModemPreset.MEDIUM_SLOW, 0.250f, spreadingFactor = 10),
+    MEDIUM_TURBO(ModemPreset.MEDIUM_TURBO, 0.500f, spreadingFactor = 9, minFirmware = FIRMWARE_2_8),
+    SHORT_FAST(ModemPreset.SHORT_FAST, 0.250f, spreadingFactor = 7),
+    SHORT_SLOW(ModemPreset.SHORT_SLOW, 0.250f, spreadingFactor = 8),
+    SHORT_TURBO(ModemPreset.SHORT_TURBO, 0.500f, spreadingFactor = 7),
+    LITE_FAST(ModemPreset.LITE_FAST, 0.125f, spreadingFactor = 9, minFirmware = FIRMWARE_2_8),
+    LITE_SLOW(ModemPreset.LITE_SLOW, 0.125f, spreadingFactor = 10, minFirmware = FIRMWARE_2_8),
+    NARROW_FAST(ModemPreset.NARROW_FAST, 0.0625f, spreadingFactor = 7, minFirmware = FIRMWARE_2_8),
+    NARROW_SLOW(ModemPreset.NARROW_SLOW, 0.0625f, spreadingFactor = 8, minFirmware = FIRMWARE_2_8),
 
     // 15.625 kHz LoRa bandwidth (firmware modemPresetToParams; the proto's "20kHz" is the
     // padded channel spacing, not the modem bandwidth used for numChannels/radioFreq math).
-    TINY_FAST(ModemPreset.TINY_FAST, 0.015625f, snrLimit = -7.5f, minFirmware = FIRMWARE_2_8), // SF7
-    TINY_SLOW(ModemPreset.TINY_SLOW, 0.015625f, snrLimit = -10f, minFirmware = FIRMWARE_2_8), // SF8
+    TINY_FAST(ModemPreset.TINY_FAST, 0.015625f, spreadingFactor = 7, minFirmware = FIRMWARE_2_8),
+    TINY_SLOW(ModemPreset.TINY_SLOW, 0.015625f, spreadingFactor = 8, minFirmware = FIRMWARE_2_8),
     ;
 
+    // Semtech demodulation floor: -7.5 dB at SF7, improving 2.5 dB per SF step.
+    // Bandwidth changes sensitivity in dBm, not this SNR threshold.
+    val snrLimit: Float
+        get() = SNR_FLOOR_SF7_DB - SNR_FLOOR_PER_SF_DB * (spreadingFactor - MIN_SPREADING_FACTOR)
+
     companion object {
+        /** SF7's demodulation floor, the anchor for [snrLimit]. */
+        private const val SNR_FLOOR_SF7_DB = -7.5f
+
+        /** Each spreading-factor step doubles the symbol length, buying 2.5 dB of demodulation floor. */
+        private const val SNR_FLOOR_PER_SF_DB = 2.5f
+
+        /** The lowest spreading factor any Meshtastic preset uses, and the anchor [SNR_FLOOR_SF7_DB] describes. */
+        private const val MIN_SPREADING_FACTOR = 7
+
         /** The default channel option for new configurations. */
         val DEFAULT = LONG_FAST
 

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicator.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicator.kt
@@ -60,13 +60,10 @@ import org.meshtastic.core.ui.theme.StatusColors.StatusYellow
 import org.meshtastic.core.ui.util.LocalModemPreset
 import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
 
-// Fixed-threshold SNR colors retained for contexts without an active preset (e.g. traceroute hop coloring in
-// AnnotatedStrings). Per-node signal quality uses preset-relative thresholds instead — see [determineSignalQuality].
-const val SNR_GOOD_THRESHOLD = -7f
-const val SNR_FAIR_THRESHOLD = -15f
-
+// RSSI display bands match Apple's getRssiColor; quality needs SNR and a preset instead.
 const val RSSI_GOOD_THRESHOLD = -115
-const val RSSI_FAIR_THRESHOLD = -126
+const val RSSI_FAIR_THRESHOLD = -120
+const val RSSI_BAD_THRESHOLD = -126
 
 // SNR offsets (dB) below a preset's demodulation floor that delimit the quality bands, matching Meshtastic-Apple's
 // getSnrColor(): within 5.5 dB below the limit is FAIR, within 7.5 dB is BAD, further down is NONE.
@@ -139,12 +136,11 @@ fun Snr(snr: Float?, modifier: Modifier = Modifier, modemPreset: ModemPreset? = 
 fun Rssi(rssi: Int?, modifier: Modifier = Modifier, label: String = stringResource(Res.string.rssi)) {
     if (rssi == null) return
     val color: Color =
-        if (rssi > RSSI_GOOD_THRESHOLD) {
-            Quality.GOOD.color.invoke()
-        } else if (rssi > RSSI_FAIR_THRESHOLD) {
-            Quality.FAIR.color.invoke()
-        } else {
-            Quality.BAD.color.invoke()
+        when {
+            rssi > RSSI_GOOD_THRESHOLD -> Quality.GOOD.color.invoke()
+            rssi > RSSI_FAIR_THRESHOLD -> Quality.FAIR.color.invoke()
+            rssi > RSSI_BAD_THRESHOLD -> Quality.BAD.color.invoke()
+            else -> Quality.NONE.color.invoke()
         }
     Text(
         modifier = modifier,
@@ -165,6 +161,8 @@ fun Rssi(rssi: Int?, modifier: Modifier = Modifier, label: String = stringResour
  * a noisy channel is still a bad link. With either missing, the rating is SNR-only, unchanged from #5446.
  *
  * A null/unknown [modemPreset] falls back to the LongFast default limit.
+ *
+ * Without a noise floor, fixed RSSI thresholds cannot account for the preset's bandwidth, so rating stays SNR-only.
  */
 fun determineSignalQuality(snr: Float, modemPreset: ModemPreset?, rssi: Int? = null, noiseFloor: Int? = null): Quality {
     val limit = modemPreset.snrLimit

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/TracerouteAlertHandler.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/TracerouteAlertHandler.kt
@@ -38,7 +38,9 @@ import org.meshtastic.core.resources.traceroute
 import org.meshtastic.core.resources.view_on_map
 import org.meshtastic.core.ui.theme.StatusColors.StatusGreen
 import org.meshtastic.core.ui.theme.StatusColors.StatusOrange
+import org.meshtastic.core.ui.theme.StatusColors.StatusRed
 import org.meshtastic.core.ui.theme.StatusColors.StatusYellow
+import org.meshtastic.core.ui.util.LocalModemPreset
 import org.meshtastic.core.ui.util.annotateTraceroute
 import org.meshtastic.core.ui.util.toMessageRes
 import org.meshtastic.core.ui.viewmodel.UIViewModel
@@ -71,6 +73,8 @@ fun TracerouteAlertHandler(
                                 statusGreen = colorScheme.StatusGreen,
                                 statusYellow = colorScheme.StatusYellow,
                                 statusOrange = colorScheme.StatusOrange,
+                                statusRed = colorScheme.StatusRed,
+                                modemPreset = LocalModemPreset.current,
                             ),
                         )
                     }

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/AnnotatedStrings.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/AnnotatedStrings.kt
@@ -22,8 +22,9 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
-import org.meshtastic.core.ui.component.SNR_FAIR_THRESHOLD
-import org.meshtastic.core.ui.component.SNR_GOOD_THRESHOLD
+import org.meshtastic.core.ui.component.Quality
+import org.meshtastic.core.ui.component.determineSignalQuality
+import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
 
 /**
  * Converts a raw traceroute string into an [AnnotatedString] with SNR values highlighted according to their quality.
@@ -33,6 +34,8 @@ fun annotateTraceroute(
     statusGreen: Color,
     statusYellow: Color,
     statusOrange: Color,
+    statusRed: Color,
+    modemPreset: ModemPreset?,
 ): AnnotatedString {
     if (inString == null) return buildAnnotatedString { append("") }
 
@@ -47,11 +50,7 @@ fun annotateTraceroute(
 
                 if (snrValue != null) {
                     val snrColor =
-                        when {
-                            snrValue >= SNR_GOOD_THRESHOLD -> statusGreen
-                            snrValue >= SNR_FAIR_THRESHOLD -> statusYellow
-                            else -> statusOrange
-                        }
+                        snrTierColor(snrValue, modemPreset, statusGreen, statusYellow, statusOrange, statusRed)
                     withStyle(style = SpanStyle(color = snrColor, fontWeight = FontWeight.Bold)) { append(line) }
                 } else {
                     append(line)
@@ -71,6 +70,8 @@ fun annotateNeighborInfo(
     statusGreen: Color,
     statusYellow: Color,
     statusOrange: Color,
+    statusRed: Color,
+    modemPreset: ModemPreset?,
 ): AnnotatedString {
     if (inString == null) return buildAnnotatedString { append("") }
 
@@ -85,11 +86,7 @@ fun annotateNeighborInfo(
 
                 if (snrValue != null) {
                     val snrColor =
-                        when {
-                            snrValue >= SNR_GOOD_THRESHOLD -> statusGreen
-                            snrValue >= SNR_FAIR_THRESHOLD -> statusYellow
-                            else -> statusOrange
-                        }
+                        snrTierColor(snrValue, modemPreset, statusGreen, statusYellow, statusOrange, statusRed)
                     val snrPrefix = "(SNR: "
                     append(line.substring(0, line.indexOf(snrPrefix) + snrPrefix.length))
                     withStyle(style = SpanStyle(color = snrColor, fontWeight = FontWeight.Bold)) { append("$snrValue") }
@@ -102,4 +99,18 @@ fun annotateNeighborInfo(
             }
         }
     }
+}
+
+private fun snrTierColor(
+    snr: Float,
+    modemPreset: ModemPreset?,
+    statusGreen: Color,
+    statusYellow: Color,
+    statusOrange: Color,
+    statusRed: Color,
+): Color = when (determineSignalQuality(snr, modemPreset)) {
+    Quality.GOOD -> statusGreen
+    Quality.FAIR -> statusYellow
+    Quality.BAD -> statusOrange
+    Quality.NONE -> statusRed
 }

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicatorTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/component/LoraSignalIndicatorTest.kt
@@ -28,21 +28,64 @@ import kotlin.test.assertEquals
  */
 class LoraSignalIndicatorTest {
 
+    // Firmware spreading factors (MeshRadio.h) paired with literal Semtech demodulation floors.
+    // Keep expected values independent of the production formula.
+    private val expectedFloors =
+        mapOf(
+            ModemPreset.SHORT_TURBO to (7 to -7.5f),
+            ModemPreset.SHORT_FAST to (7 to -7.5f),
+            ModemPreset.SHORT_SLOW to (8 to -10f),
+            ModemPreset.MEDIUM_FAST to (9 to -12.5f),
+            ModemPreset.MEDIUM_SLOW to (10 to -15f),
+            ModemPreset.MEDIUM_TURBO to (9 to -12.5f),
+            ModemPreset.LONG_TURBO to (11 to -17.5f),
+            ModemPreset.LONG_FAST to (11 to -17.5f),
+            ModemPreset.LONG_MODERATE to (11 to -17.5f),
+            ModemPreset.LONG_SLOW to (12 to -20f),
+            ModemPreset.VERY_LONG_SLOW to (12 to -20f),
+            ModemPreset.LITE_FAST to (9 to -12.5f),
+            ModemPreset.LITE_SLOW to (10 to -15f),
+            ModemPreset.NARROW_FAST to (7 to -7.5f),
+            ModemPreset.NARROW_SLOW to (8 to -10f),
+            ModemPreset.TINY_FAST to (7 to -7.5f),
+            ModemPreset.TINY_SLOW to (8 to -10f),
+        )
+
     @Test
-    fun `snrLimit follows spreading-factor demod floor per preset`() {
-        assertEquals(-7.5f, ModemPreset.SHORT_FAST.snrLimit) // SF7
-        assertEquals(-7.5f, ModemPreset.SHORT_TURBO.snrLimit) // SF7
-        assertEquals(-10f, ModemPreset.SHORT_SLOW.snrLimit) // SF8
-        assertEquals(-12.5f, ModemPreset.MEDIUM_FAST.snrLimit) // SF9
-        assertEquals(-15f, ModemPreset.MEDIUM_SLOW.snrLimit) // SF10
-        assertEquals(-17.5f, ModemPreset.LONG_FAST.snrLimit) // SF11
-        assertEquals(-17.5f, ModemPreset.LONG_MODERATE.snrLimit) // SF11
+    fun `every preset's snrLimit is its spreading factor's demod floor`() {
+        expectedFloors.forEach { (preset, expected) ->
+            val (sf, floor) = expected
+            assertEquals(floor, preset.snrLimit, "$preset (SF$sf)")
+        }
+    }
+
+    @Test
+    fun `presets sharing a spreading factor share a floor regardless of bandwidth`() {
+        // Bandwidth changes sensitivity in dBm, not the demodulation SNR floor.
+        assertEquals(ModemPreset.LONG_FAST.snrLimit, ModemPreset.LONG_TURBO.snrLimit)
+        assertEquals(ModemPreset.MEDIUM_FAST.snrLimit, ModemPreset.MEDIUM_TURBO.snrLimit)
+        assertEquals(ModemPreset.SHORT_FAST.snrLimit, ModemPreset.SHORT_TURBO.snrLimit)
+        assertEquals(ModemPreset.SHORT_FAST.snrLimit, ModemPreset.TINY_FAST.snrLimit)
+    }
+
+    @Test
+    fun `every ModemPreset is covered by the firmware spreading-factor table`() {
+        // A preset added to the proto without a row above would otherwise be rated against LongFast's floor silently.
+        val uncovered =
+            ModemPreset.entries
+                .filter { it.name != "UNSET" && it.name != "UNRECOGNIZED" }
+                .filter { it !in expectedFloors }
+        assertEquals(emptyList(), uncovered, "presets missing from expectedFloors")
+    }
+
+    @Test
+    fun `LongTurbo is rated at its SF11 floor rather than SF9`() {
+        assertEquals(-17.5f, ModemPreset.LONG_TURBO.snrLimit)
+        assertEquals(Quality.GOOD, determineSignalQuality(snr = -15f, modemPreset = ModemPreset.LONG_TURBO))
     }
 
     @Test
     fun `LONG_SLOW uses physically-correct SF12 floor`() {
-        // Meshtastic-Apple's snrLimit() returns -7.5 here (the SF7 value, an apparent bug). The correct SF12
-        // demodulation floor is -20 dB — see #5446.
         assertEquals(-20f, ModemPreset.LONG_SLOW.snrLimit)
         assertEquals(-20f, ModemPreset.VERY_LONG_SLOW.snrLimit)
     }

--- a/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/AnnotatedStringsTest.kt
+++ b/core/ui/src/commonTest/kotlin/org/meshtastic/core/ui/util/AnnotatedStringsTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.ui.util
+
+import androidx.compose.ui.graphics.Color
+import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AnnotatedStringsTest {
+    @Test
+    fun `traceroute colors the same SNR differently for different presets`() {
+        val text = "Node A\n⇊ -15.0 dB\nNode B"
+        val longTurbo =
+            annotateTraceroute(text, Color.Green, Color.Yellow, Color.Magenta, Color.Red, ModemPreset.LONG_TURBO)
+        val shortFast =
+            annotateTraceroute(text, Color.Green, Color.Yellow, Color.Magenta, Color.Red, ModemPreset.SHORT_FAST)
+
+        assertEquals(text, longTurbo.text)
+        assertEquals(Color.Green, longTurbo.spanStyles.single().item.color)
+        assertEquals(Color.Magenta, shortFast.spanStyles.single().item.color)
+    }
+
+    @Test
+    fun `neighbor info uses the preset and the lowest quality band`() {
+        val text = "• Node B (SNR: -15.0)"
+        val longTurbo =
+            annotateNeighborInfo(text, Color.Green, Color.Yellow, Color.Magenta, Color.Red, ModemPreset.LONG_TURBO)
+        val shortFast =
+            annotateNeighborInfo(text, Color.Green, Color.Yellow, Color.Magenta, Color.Red, ModemPreset.SHORT_FAST)
+        val belowFloor =
+            annotateNeighborInfo(
+                "• Node B (SNR: -30.0)",
+                Color.Green,
+                Color.Yellow,
+                Color.Magenta,
+                Color.Red,
+                ModemPreset.LONG_FAST,
+            )
+
+        assertEquals(text, longTurbo.text)
+        assertEquals(Color.Green, longTurbo.spanStyles.single().item.color)
+        assertEquals(Color.Magenta, shortFast.spanStyles.single().item.color)
+        assertEquals(Color.Red, belowFloor.spanStyles.single().item.color)
+    }
+
+    @Test
+    fun `unknown traceroute SNR remains unstyled while zero is a measurement`() {
+        val unknown = annotateTraceroute("⇊ ? dB", Color.Green, Color.Yellow, Color.Magenta, Color.Red, null)
+        val zero = annotateTraceroute("⇊ 0.0 dB", Color.Green, Color.Yellow, Color.Magenta, Color.Red, null)
+
+        assertEquals("⇊ ? dB", unknown.text)
+        assertTrue(unknown.spanStyles.isEmpty())
+        assertEquals(Color.Green, zero.spanStyles.single().item.color)
+    }
+}

--- a/docs/en/user/node-metrics.md
+++ b/docs/en/user/node-metrics.md
@@ -2,7 +2,7 @@
 title: Node Metrics
 parent: User Guide
 nav_order: 5
-last_updated: 2026-08-30
+last_updated: 2026-09-09
 description: Telemetry dashboards for each mesh node — device health, environment sensors, air quality, signal quality, power, traceroute, and position history.
 aliases:
   - metrics
@@ -114,7 +114,7 @@ Radio signal quality information:
 
 ### Signal Quality Reference
 
-Signal quality is rated from **SNR relative to the active LoRa modem preset's demodulation floor**, not from fixed thresholds — a given SNR means different things on different presets (e.g. −15 dB is fine on LongSlow but unusable on ShortFast). RSSI is shown but is not part of the rating. In the table, *limit* is the preset's SNR limit.
+Signal quality is rated from **SNR relative to the active LoRa modem preset's demodulation floor**, not from fixed thresholds — a given SNR means different things on different presets (e.g. −15 dB is fine on LongSlow but unusable on ShortFast). When RSSI and a noise-floor reading are both available, the app also rates their difference against the preset limit and uses the worse rating. Otherwise, RSSI is display-only. In the table, *limit* is the preset's SNR limit.
 
 | Quality | Criteria |
 |---------|----------|

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -2,7 +2,7 @@
 title: Nodes
 parent: User Guide
 nav_order: 4
-last_updated: 2026-09-04
+last_updated: 2026-09-09
 description: Browse, filter, and sort mesh nodes — view details, signal quality, roles, and quick actions.
 aliases:
   - node-list
@@ -146,6 +146,8 @@ Tap the hop-histogram icon in the node list's app bar to open a bar chart of how
 ## Node Detail
 
 Tapping a node opens the detail view with comprehensive information. See [Node Metrics](node-metrics) for full details on metrics and telemetry.
+
+Signal quality is rated against your modem preset. The same SNR can be good on a long-range preset and poor on a faster one. Traceroute and neighbor-info SNR colors use that preset too. RSSI text has its own strength colors; it affects the quality rating only when a noise-floor reading is also available.
 
 The Details card carries the node's short name, role, IDs, last heard time, hops away, uptime, and its SNR and RSSI:
 

--- a/docs/en/user/settings-radio-user.md
+++ b/docs/en/user/settings-radio-user.md
@@ -2,7 +2,7 @@
 title: Settings — Radio & User
 parent: User Guide
 nav_order: 7
-last_updated: 2026-09-04
+last_updated: 2026-09-09
 description: Configure your radio hardware, LoRa presets, user profile, position sharing, power management, and security.
 aliases:
   - settings
@@ -111,13 +111,13 @@ The Lite, Narrow, Medium Turbo, and Tiny presets need firmware 2.8 or newer — 
 | Short Slow | ~5 km | 6.25 kbps | −10 dB | Suburban short-range; moderate building density |
 | Medium Fast | ~5 km | 3.52 kbps | −12.5 dB | Suburban areas; moderate building density |
 | Medium Slow | ~8 km | 1.95 kbps | −15 dB | Suburban/rural; moderate range with slower speed |
-| Long Turbo | ~10 km | 1.34 kbps | −12.5 dB | Similar range to Long Fast but with 500 kHz bandwidth; faster throughput |
+| Long Turbo | ~10 km | 1.34 kbps | −17.5 dB | Similar range to Long Fast but with 500 kHz bandwidth; faster throughput |
 | Long Fast | ~10 km | 1.1 kbps | −17.5 dB | **General use (default)** — balanced range and speed |
 | Long Moderate | ~20 km | 0.34 kbps | −17.5 dB | Rural with some terrain; occasional use |
 | Lite Fast | ~5 km | 1.76 kbps | −12.5 dB | EU 866 MHz SRD band (125 kHz BW); comparable to Medium Fast |
 | Lite Slow | ~10 km | 0.98 kbps | −15 dB | EU 866 MHz SRD band (125 kHz BW); comparable to Long Fast |
-| Narrow Fast | ~5 km | 2.28 kbps | −10 dB | EU 868 MHz band (62.5 kHz BW); avoids interference with other devices |
-| Narrow Slow | ~10 km | 1.30 kbps | −12.5 dB | EU 868 MHz band (62.5 kHz BW); comparable to Long Fast |
+| Narrow Fast | ~5 km | 2.28 kbps | −7.5 dB | EU 868 MHz band (62.5 kHz BW); avoids interference with other devices |
+| Narrow Slow | ~10 km | 1.30 kbps | −10 dB | EU 868 MHz band (62.5 kHz BW); comparable to Long Fast |
 | Medium Turbo | ~5 km | 7.0 kbps | −12.5 dB | Like Medium Fast but with 500 kHz bandwidth; not legal in every region. Needs firmware 2.8 or newer |
 | Tiny Fast | ~10 km | 0.68 kbps | −7.5 dB | Amateur bands that cap occupied bandwidth; these presets use 15.6 kHz. Needs firmware 2.8 or newer, an SX126x or SX127x radio, and a TCXO of ±5 ppm or better |
 | Tiny Slow | ~20 km | 0.33 kbps | −10 dB | Same band restrictions as Tiny Fast, longer range. Same firmware, radio, and TCXO requirements |

--- a/docs/en/user/signal-meter.md
+++ b/docs/en/user/signal-meter.md
@@ -2,7 +2,7 @@
 title: How the Meshtastic Signal Meter Works
 parent: User Guide
 nav_order: 15
-last_updated: 2026-08-30
+last_updated: 2026-09-09
 description: How the signal meter rates quality from SNR relative to the LoRa modem preset — spread spectrum, presets, and what the bars really mean.
 aliases:
   - signal
@@ -32,7 +32,7 @@ Each modem preset has an SNR limit: the lowest SNR at which that preset can stil
 
 ## Rating Signal Quality
 
-The app rates signal quality (None, Bad, Fair, or Good) from SNR alone, measured against the active preset's SNR limit. It does not factor in RSSI: without knowing the local noise floor, RSSI alone cannot say whether a signal is decodable. RSSI is still available — on the node detail screen and in the metrics charts.
+The app rates signal quality (None, Bad, Fair, or Good) from SNR relative to the active preset's SNR limit. When RSSI and a noise-floor reading are both available, it also rates the difference between them against that limit and uses the worse rating. Otherwise, it uses SNR alone.
 
 Because the rating is relative to the preset, the same SNR rates differently on different presets. An SNR of −16 dB rates Good on Long Fast (SNR limit −17.5 dB) but None on Short Fast (SNR limit −7.5 dB). Let `limit` be the active preset's SNR limit:
 
@@ -45,7 +45,7 @@ Because the rating is relative to the preset, the same SNR rates differently on 
 
 The icon never goes blank, so count the bars carefully: a single bar means None, not a weak but usable link, and Good is a solid wedge rather than a set of bars. A gray three-bar icon labeled Unknown is a different state again — the packet carried no SNR measurement at all, which is not the same as measuring one and finding it too weak.
 
-> ℹ️ **Note:** Traceroute hop colors use fixed thresholds (−7 dB / −15 dB); the per-node signal meter uses the preset-relative rating instead.
+> ℹ️ **Note:** Traceroute and neighbor-info SNR colors use the active preset's limits too. RSSI text has separate strength colors: green above −115 dBm, yellow above −120 dBm, orange above −126 dBm, and red at or below −126 dBm.
 
 ## Diagnosing Local Interference
 

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/SitePlannerLaunch.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/SitePlannerLaunch.kt
@@ -62,13 +62,26 @@ private fun dbmToWatts(dbm: Int): Double? = if (dbm <= 0) null else 10.0.pow((db
 @Suppress("MagicNumber")
 private fun sensitivityDbmFor(preset: ModemPreset?): Double = when (preset) {
     ModemPreset.SHORT_TURBO -> -126.0
+
     ModemPreset.SHORT_FAST -> -129.0
+
     ModemPreset.SHORT_SLOW -> -131.5
+
     ModemPreset.MEDIUM_FAST -> -134.0
+
     ModemPreset.MEDIUM_SLOW -> -136.5
+
+    // 500 kHz at SF11: the same spreading factor as LONG_FAST, but 3 dB more thermal noise in the wider passband —
+    // the 150 vs 153 dB link budgets in the radio-settings docs table.
+    ModemPreset.LONG_TURBO -> -136.0
+
     ModemPreset.LONG_FAST -> -139.0
+
     ModemPreset.LONG_MODERATE -> -142.0
+
     ModemPreset.LONG_SLOW -> -144.5
+
     ModemPreset.VERY_LONG_SLOW -> -147.5
+
     else -> SitePlannerParams.DEFAULT_RX_SENSITIVITY_DBM
 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/NeighborInfoLog.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/NeighborInfoLog.kt
@@ -50,7 +50,9 @@ import org.meshtastic.core.ui.icon.PersonOff
 import org.meshtastic.core.ui.icon.Refresh
 import org.meshtastic.core.ui.theme.StatusColors.StatusGreen
 import org.meshtastic.core.ui.theme.StatusColors.StatusOrange
+import org.meshtastic.core.ui.theme.StatusColors.StatusRed
 import org.meshtastic.core.ui.theme.StatusColors.StatusYellow
+import org.meshtastic.core.ui.util.LocalModemPreset
 import org.meshtastic.core.ui.util.annotateNeighborInfo
 import org.meshtastic.feature.node.component.CooldownIconButton
 
@@ -65,6 +67,8 @@ fun NeighborInfoLogScreen(modifier: Modifier = Modifier, viewModel: MetricsViewM
     val statusGreen = MaterialTheme.colorScheme.StatusGreen
     val statusYellow = MaterialTheme.colorScheme.StatusYellow
     val statusOrange = MaterialTheme.colorScheme.StatusOrange
+    val statusRed = MaterialTheme.colorScheme.StatusRed
+    val modemPreset = LocalModemPreset.current
 
     Scaffold(
         topBar = {
@@ -131,6 +135,8 @@ fun NeighborInfoLogScreen(modifier: Modifier = Modifier, viewModel: MetricsViewM
                                             statusGreen = statusGreen,
                                             statusYellow = statusYellow,
                                             statusOrange = statusOrange,
+                                            statusRed = statusRed,
+                                            modemPreset = modemPreset,
                                         )
                                     viewModel.showLogDetail(Res.string.neighbor_info, message)
                                 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TracerouteLog.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/metrics/TracerouteLog.kt
@@ -83,9 +83,12 @@ import org.meshtastic.core.ui.icon.Route
 import org.meshtastic.core.ui.theme.GraphColors
 import org.meshtastic.core.ui.theme.StatusColors.StatusGreen
 import org.meshtastic.core.ui.theme.StatusColors.StatusOrange
+import org.meshtastic.core.ui.theme.StatusColors.StatusRed
 import org.meshtastic.core.ui.theme.StatusColors.StatusYellow
+import org.meshtastic.core.ui.util.LocalModemPreset
 import org.meshtastic.core.ui.util.annotateTraceroute
 import org.meshtastic.feature.node.component.CooldownIconButton
+import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
 import org.meshtastic.proto.RouteDiscovery
 
 /**
@@ -112,6 +115,8 @@ fun TracerouteLogScreen(
     val statusGreen = MaterialTheme.colorScheme.StatusGreen
     val statusYellow = MaterialTheme.colorScheme.StatusYellow
     val statusOrange = MaterialTheme.colorScheme.StatusOrange
+    val statusRed = MaterialTheme.colorScheme.StatusRed
+    val modemPreset = LocalModemPreset.current
 
     val headerTowardsStr = stringResource(Res.string.traceroute_route_towards_dest)
     val headerBackStr = stringResource(Res.string.traceroute_route_back_to_us)
@@ -182,6 +187,8 @@ fun TracerouteLogScreen(
                                 statusGreen = statusGreen,
                                 statusYellow = statusYellow,
                                 statusOrange = statusOrange,
+                                statusRed = statusRed,
+                                modemPreset = modemPreset,
                                 onViewOnMap = onViewOnMap,
                             )
                         },
@@ -320,6 +327,8 @@ private fun showTracerouteDetail(
     statusGreen: Color,
     statusYellow: Color,
     statusOrange: Color,
+    statusRed: Color,
+    modemPreset: ModemPreset?,
     onViewOnMap: (requestId: Int, responseLogUuid: String) -> Unit,
 ) {
     val result = point.result ?: return
@@ -338,6 +347,8 @@ private fun showTracerouteDetail(
                     statusGreen = statusGreen,
                     statusYellow = statusYellow,
                     statusOrange = statusOrange,
+                    statusRed = statusRed,
+                    modemPreset = modemPreset,
                 )
             val durationText = formatString(durationTemplate, NumberFormatter.format(seconds, 1))
             buildAnnotatedString {


### PR DESCRIPTION
LongTurbo links were rated against an SF9 SNR floor even though firmware uses SF11. NarrowFast and NarrowSlow also had incorrect floors, and traceroute colors ignored the selected preset.

### 🐛 Bug Fixes

- Derive SNR floors from firmware spreading factors and apply preset-relative colors to traceroutes and neighbor info.
- Use four RSSI text-color bands and add LongTurbo receiver sensitivity to the site planner.
- Correct the signal-meter documentation and preset table.

### Testing Performed

- Regression tests cover every preset floor, bandwidth independence, and preset-relative traceroute/neighbor colors, including unknown and zero SNR.
- Passed `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` on Linux. Apple test execution is skipped on this host.
- All four docs checks pass. Local CodeRabbit review: no findings.
- Screenshot validation passed with `-Dorg.gradle.isolated-projects=false --no-configuration-cache` (CI also disables Isolated Projects for this task). No golden changes.

Constitution check: all seven principles evaluated; shared logic stays in commonMain, no new dependencies or privacy-sensitive data, and user docs are updated.

<!--
If you have screenshots or recordings to display your change, please include them!

You can use this template for displaying a single screenshot:
<img src="" width="300"/>

or a video recording:
<video src="" width="300"></video>

And if you want to display the state before and after a change, you can use this table template:

| Before | After |
|------|-----|
| <img src="" width="300"/> | <img src="" width="300"/> |
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Signal quality ratings now account for the active modem preset and use separate quality bands for weak RSSI.
  - Traceroute and neighbor information displays now apply preset-relative SNR colors, including a red lowest-quality state.
  - Long Turbo radio settings now reflect updated sensitivity and signal thresholds.

- **Bug Fixes**
  - Corrected SNR limits for Long Turbo, Narrow Fast, and Narrow Slow presets.

- **Documentation**
  - Updated signal-meter, node, radio-settings, and node-metrics guidance to reflect the revised rating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->