### PR TITLE
fix(settings): allow all available spread factors

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
+++ b/feature/settings/src/commonMain/kotlin/org/meshtastic/feature/settings/radio/component/LoRaConfigItemList.kt
@@ -76,7 +76,7 @@ import org.meshtastic.proto.Config
 import org.meshtastic.proto.Config.LoRaConfig.ModemPreset
 import org.meshtastic.proto.Config.LoRaConfig.RegionCode
 
-private val SPREAD_FACTOR_RANGE = 7..12
+private val SPREAD_FACTOR_RANGE = 5..12
 private val CODING_RATE_RANGE = 5..8
 
 /**


### PR DESCRIPTION
### Motivation

#5477 added input validation to the manual modem fields and pinned spread_factor to 7..12.

This change limits users for setting up custom presets.

Spread factors 5 and 6 are valid values on the 2nd-gen LoRa chips Meshtastic supports (SX126x, LR11xx, SX128x) — only 1st-gen chips (SX127x/RF95) are limited to SF7–SF12.
The firmware already handles this correctly: it accepts SF5/6 and automatically clamps the value if hardware can't use it.
https://github.com/meshtastic/firmware/pull/10160

### Changes

• SPREAD_FACTOR_RANGE to 5–12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded the valid spread factor range in the manual modem settings editor to support values from 5 through 12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->