### PR TITLE
refactor(prefs): keep each surface's filters in one state object

### DIFF
--- a/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/map/MapPrefsImpl.kt
+++ b/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/map/MapPrefsImpl.kt
@@ -16,6 +16,8 @@
  */
 package org.meshtastic.core.prefs.map
 
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -34,6 +36,7 @@ import org.koin.core.annotation.Single
 import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.prefs.di.MapDataStore
 import org.meshtastic.core.repository.MapCameraPosition
+import org.meshtastic.core.repository.MapFilterPrefs
 import org.meshtastic.core.repository.MapPrefs
 
 @Single
@@ -50,83 +53,44 @@ class MapPrefsImpl(private val dataStore: MapDataStore, dispatchers: CoroutineDi
 
     override suspend fun awaitMapStyle(): Int = dataStore.data.map { it[KEY_MAP_STYLE_PREF] ?: 0 }.first()
 
-    override val showOnlyFavorites: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_SHOW_ONLY_FAVORITES_PREF] ?: false }.stateIn(scope, SharingStarted.Eagerly, false)
+    override val mapFilters: StateFlow<MapFilterPrefs> =
+        dataStore.data.map { it.toMapFilterPrefs() }.stateIn(scope, SharingStarted.Eagerly, MapFilterPrefs())
 
-    override fun setShowOnlyFavorites(show: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_SHOW_ONLY_FAVORITES_PREF] = show } }
+    override fun updateMapFilters(transform: (MapFilterPrefs) -> MapFilterPrefs) {
+        // Read-modify-write inside edit{}, which is transactional — the same lost-update guard updateHiddenLayerUrls
+        // uses. Writing every key rather than the changed one keeps this a single pure transform.
+        scope.launch { dataStore.edit { it.writeMapFilterPrefs(transform(it.toMapFilterPrefs())) } }
     }
 
-    override val showWaypointsOnMap: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_SHOW_WAYPOINTS_PREF] ?: true }.stateIn(scope, SharingStarted.Eagerly, true)
-
-    override fun setShowWaypointsOnMap(show: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_SHOW_WAYPOINTS_PREF] = show } }
+    private fun Preferences.toMapFilterPrefs(): MapFilterPrefs {
+        val defaults = MapFilterPrefs()
+        return MapFilterPrefs(
+            onlyFavorites = this[KEY_SHOW_ONLY_FAVORITES_PREF] ?: defaults.onlyFavorites,
+            showWaypoints = this[KEY_SHOW_WAYPOINTS_PREF] ?: defaults.showWaypoints,
+            showPrecisionCircle = this[KEY_SHOW_PRECISION_CIRCLE_PREF] ?: defaults.showPrecisionCircle,
+            onlyOnline = this[KEY_ONLY_ONLINE_PREF] ?: defaults.onlyOnline,
+            onlyDirect = this[KEY_ONLY_DIRECT_PREF] ?: defaults.onlyDirect,
+            excludeMqtt = this[KEY_EXCLUDE_MQTT_PREF] ?: defaults.excludeMqtt,
+            showIgnored = this[KEY_SHOW_IGNORED_PREF] ?: defaults.showIgnored,
+            includeUnknown = this[KEY_INCLUDE_UNKNOWN_PREF] ?: defaults.includeUnknown,
+            lastHeardSeconds = this[KEY_LAST_HEARD_FILTER_PREF] ?: defaults.lastHeardSeconds,
+            lastHeardTrackSeconds = this[KEY_LAST_HEARD_TRACK_FILTER_PREF] ?: defaults.lastHeardTrackSeconds,
+            excludedRoles = this[KEY_EXCLUDED_ROLES_PREF] ?: defaults.excludedRoles,
+        )
     }
 
-    override val showPrecisionCircleOnMap: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_SHOW_PRECISION_CIRCLE_PREF] ?: true }.stateIn(scope, SharingStarted.Eagerly, true)
-
-    override fun setShowPrecisionCircleOnMap(show: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_SHOW_PRECISION_CIRCLE_PREF] = show } }
-    }
-
-    override val lastHeardFilter: StateFlow<Long> =
-        dataStore.data.map { it[KEY_LAST_HEARD_FILTER_PREF] ?: 0L }.stateIn(scope, SharingStarted.Eagerly, 0L)
-
-    override fun setLastHeardFilter(seconds: Long) {
-        scope.launch { dataStore.edit { it[KEY_LAST_HEARD_FILTER_PREF] = seconds } }
-    }
-
-    override val lastHeardTrackFilter: StateFlow<Long> =
-        dataStore.data.map { it[KEY_LAST_HEARD_TRACK_FILTER_PREF] ?: 0L }.stateIn(scope, SharingStarted.Eagerly, 0L)
-
-    override fun setLastHeardTrackFilter(seconds: Long) {
-        scope.launch { dataStore.edit { it[KEY_LAST_HEARD_TRACK_FILTER_PREF] = seconds } }
-    }
-
-    override val onlyOnlineOnMap: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_ONLY_ONLINE_PREF] ?: false }.stateIn(scope, SharingStarted.Eagerly, false)
-
-    override fun setOnlyOnlineOnMap(only: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_ONLY_ONLINE_PREF] = only } }
-    }
-
-    override val onlyDirectOnMap: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_ONLY_DIRECT_PREF] ?: false }.stateIn(scope, SharingStarted.Eagerly, false)
-
-    override fun setOnlyDirectOnMap(only: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_ONLY_DIRECT_PREF] = only } }
-    }
-
-    override val excludeMqttOnMap: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_EXCLUDE_MQTT_PREF] ?: false }.stateIn(scope, SharingStarted.Eagerly, false)
-
-    override fun setExcludeMqttOnMap(exclude: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_EXCLUDE_MQTT_PREF] = exclude } }
-    }
-
-    override val showIgnoredOnMap: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_SHOW_IGNORED_PREF] ?: false }.stateIn(scope, SharingStarted.Eagerly, false)
-
-    override fun setShowIgnoredOnMap(show: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_SHOW_IGNORED_PREF] = show } }
-    }
-
-    override val includeUnknownOnMap: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_INCLUDE_UNKNOWN_PREF] ?: true }.stateIn(scope, SharingStarted.Eagerly, true)
-
-    override fun setIncludeUnknownOnMap(include: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_INCLUDE_UNKNOWN_PREF] = include } }
-    }
-
-    override val excludedMapRoles: StateFlow<Set<String>> =
-        dataStore.data
-            .map { it[KEY_EXCLUDED_ROLES_PREF] ?: emptySet() }
-            .stateIn(scope, SharingStarted.Eagerly, emptySet())
-
-    override fun setExcludedMapRoles(roles: Set<String>) {
-        scope.launch { dataStore.edit { it[KEY_EXCLUDED_ROLES_PREF] = roles } }
+    private fun MutablePreferences.writeMapFilterPrefs(prefs: MapFilterPrefs) {
+        this[KEY_SHOW_ONLY_FAVORITES_PREF] = prefs.onlyFavorites
+        this[KEY_SHOW_WAYPOINTS_PREF] = prefs.showWaypoints
+        this[KEY_SHOW_PRECISION_CIRCLE_PREF] = prefs.showPrecisionCircle
+        this[KEY_ONLY_ONLINE_PREF] = prefs.onlyOnline
+        this[KEY_ONLY_DIRECT_PREF] = prefs.onlyDirect
+        this[KEY_EXCLUDE_MQTT_PREF] = prefs.excludeMqtt
+        this[KEY_SHOW_IGNORED_PREF] = prefs.showIgnored
+        this[KEY_INCLUDE_UNKNOWN_PREF] = prefs.includeUnknown
+        this[KEY_LAST_HEARD_FILTER_PREF] = prefs.lastHeardSeconds
+        this[KEY_LAST_HEARD_TRACK_FILTER_PREF] = prefs.lastHeardTrackSeconds
+        this[KEY_EXCLUDED_ROLES_PREF] = prefs.excludedRoles
     }
 
     override val hiddenLayerUrls: StateFlow<Set<String>> =

--- a/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/ui/UiPrefsImpl.kt
+++ b/core/prefs/src/commonMain/kotlin/org/meshtastic/core/prefs/ui/UiPrefsImpl.kt
@@ -16,6 +16,7 @@
  */
 package org.meshtastic.core.prefs.ui
 
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -35,6 +36,7 @@ import org.meshtastic.core.di.CoroutineDispatchers
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.prefs.cachedFlow
 import org.meshtastic.core.prefs.di.UiDataStore
+import org.meshtastic.core.repository.NodeFilterPrefs
 import org.meshtastic.core.repository.UiPrefs
 
 @Single
@@ -83,53 +85,13 @@ class UiPrefsImpl(private val dataStore: UiDataStore, dispatchers: CoroutineDisp
     }
 
     // Defaults on so nodes heard before their NodeInfo arrives stay visible and messageable (design#16).
-    override val includeUnknown: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_INCLUDE_UNKNOWN] ?: true }.stateIn(scope, SharingStarted.Lazily, true)
+    override val nodeFilters: StateFlow<NodeFilterPrefs> =
+        dataStore.data.map { it.toNodeFilterPrefs() }.stateIn(scope, SharingStarted.Lazily, NodeFilterPrefs())
 
-    override fun setIncludeUnknown(value: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_INCLUDE_UNKNOWN] = value } }
-    }
-
-    override val excludeInfrastructure: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_EXCLUDE_INFRASTRUCTURE] ?: false }.stateIn(scope, SharingStarted.Lazily, false)
-
-    override fun setExcludeInfrastructure(value: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_EXCLUDE_INFRASTRUCTURE] = value } }
-    }
-
-    override val onlyOnline: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_ONLY_ONLINE] ?: false }.stateIn(scope, SharingStarted.Lazily, false)
-
-    override fun setOnlyOnline(value: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_ONLY_ONLINE] = value } }
-    }
-
-    override val onlyDirect: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_ONLY_DIRECT] ?: false }.stateIn(scope, SharingStarted.Lazily, false)
-
-    override fun setOnlyDirect(value: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_ONLY_DIRECT] = value } }
-    }
-
-    override val showIgnored: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_SHOW_IGNORED] ?: false }.stateIn(scope, SharingStarted.Lazily, false)
-
-    override fun setShowIgnored(value: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_SHOW_IGNORED] = value } }
-    }
-
-    override val excludeMqtt: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_EXCLUDE_MQTT] ?: false }.stateIn(scope, SharingStarted.Lazily, false)
-
-    override fun setExcludeMqtt(value: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_EXCLUDE_MQTT] = value } }
-    }
-
-    override val excludeUnheard: StateFlow<Boolean> =
-        dataStore.data.map { it[KEY_EXCLUDE_UNHEARD] ?: false }.stateIn(scope, SharingStarted.Lazily, false)
-
-    override fun setExcludeUnheard(value: Boolean) {
-        scope.launch { dataStore.edit { it[KEY_EXCLUDE_UNHEARD] = value } }
+    override fun updateNodeFilters(transform: (NodeFilterPrefs) -> NodeFilterPrefs) {
+        // Read-modify-write inside edit{}, which is transactional — the same lost-update guard updateHiddenLayerUrls
+        // uses. Writing every key rather than the changed one keeps this a single pure transform.
+        scope.launch { dataStore.edit { it.writeNodeFilterPrefs(transform(it.toNodeFilterPrefs())) } }
     }
 
     override val hasShownNotPairedWarning: StateFlow<Boolean> =
@@ -316,6 +278,26 @@ class UiPrefsImpl(private val dataStore: UiDataStore, dispatchers: CoroutineDisp
 
     override fun setShouldShowTelemetry(value: Boolean) {
         scope.launch { dataStore.edit { it[NodeListLayoutPreferences.KEY_SHOW_TELEMETRY] = value } }
+    }
+
+    private fun Preferences.toNodeFilterPrefs() = NodeFilterPrefs(
+        includeUnknown = this[KEY_INCLUDE_UNKNOWN] ?: NodeFilterPrefs().includeUnknown,
+        excludeInfrastructure = this[KEY_EXCLUDE_INFRASTRUCTURE] ?: false,
+        onlyOnline = this[KEY_ONLY_ONLINE] ?: false,
+        onlyDirect = this[KEY_ONLY_DIRECT] ?: false,
+        showIgnored = this[KEY_SHOW_IGNORED] ?: false,
+        excludeMqtt = this[KEY_EXCLUDE_MQTT] ?: false,
+        excludeUnheard = this[KEY_EXCLUDE_UNHEARD] ?: false,
+    )
+
+    private fun MutablePreferences.writeNodeFilterPrefs(prefs: NodeFilterPrefs) {
+        this[KEY_INCLUDE_UNKNOWN] = prefs.includeUnknown
+        this[KEY_EXCLUDE_INFRASTRUCTURE] = prefs.excludeInfrastructure
+        this[KEY_ONLY_ONLINE] = prefs.onlyOnline
+        this[KEY_ONLY_DIRECT] = prefs.onlyDirect
+        this[KEY_SHOW_IGNORED] = prefs.showIgnored
+        this[KEY_EXCLUDE_MQTT] = prefs.excludeMqtt
+        this[KEY_EXCLUDE_UNHEARD] = prefs.excludeUnheard
     }
 
     companion object {

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AppPreferences.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/AppPreferences.kt
@@ -105,34 +105,16 @@ interface UiPrefs {
 
     fun setNodeSort(value: Int)
 
-    val includeUnknown: StateFlow<Boolean>
+    /**
+     * Every node-list filter, as one value.
+     *
+     * One flow rather than one per toggle: the store already holds them together, and splitting them apart only to
+     * recombine them downstream costs a `combine` argument per filter — a cap the typed overloads hit at five.
+     */
+    val nodeFilters: StateFlow<NodeFilterPrefs>
 
-    fun setIncludeUnknown(value: Boolean)
-
-    val excludeInfrastructure: StateFlow<Boolean>
-
-    fun setExcludeInfrastructure(value: Boolean)
-
-    val onlyOnline: StateFlow<Boolean>
-
-    fun setOnlyOnline(value: Boolean)
-
-    val onlyDirect: StateFlow<Boolean>
-
-    fun setOnlyDirect(value: Boolean)
-
-    val showIgnored: StateFlow<Boolean>
-
-    fun setShowIgnored(value: Boolean)
-
-    val excludeMqtt: StateFlow<Boolean>
-
-    /** Hide nodes not heard since the radio's current LoRa config took effect. */
-    val excludeUnheard: StateFlow<Boolean>
-
-    fun setExcludeMqtt(value: Boolean)
-
-    fun setExcludeUnheard(value: Boolean)
+    /** Applies [transform] to the stored filters. Read-modify-write happens inside the store's own transaction. */
+    fun updateNodeFilters(transform: (NodeFilterPrefs) -> NodeFilterPrefs)
 
     val hasShownNotPairedWarning: StateFlow<Boolean>
 
@@ -280,60 +262,14 @@ interface MapPrefs {
      */
     suspend fun awaitMapStyle(): Int
 
-    val showOnlyFavorites: StateFlow<Boolean>
-
-    fun setShowOnlyFavorites(show: Boolean)
-
-    val showWaypointsOnMap: StateFlow<Boolean>
-
-    fun setShowWaypointsOnMap(show: Boolean)
-
-    val showPrecisionCircleOnMap: StateFlow<Boolean>
-
-    fun setShowPrecisionCircleOnMap(show: Boolean)
-
-    val lastHeardFilter: StateFlow<Long>
-
-    fun setLastHeardFilter(seconds: Long)
-
-    val lastHeardTrackFilter: StateFlow<Long>
-
-    fun setLastHeardTrackFilter(seconds: Long)
-
     /**
-     * Node filters shared with the node list's vocabulary, persisted separately: a user filtering the map to routers
-     * has not asked for the same of their contact list.
+     * Every map filter, as one value — the same shape, and for the same reason, as [UiPrefs.nodeFilters]. The map keeps
+     * its own copy of the node-list vocabulary: filtering the map to routers is not a statement about the contact list.
      */
-    val onlyOnlineOnMap: StateFlow<Boolean>
+    val mapFilters: StateFlow<MapFilterPrefs>
 
-    fun setOnlyOnlineOnMap(only: Boolean)
-
-    val onlyDirectOnMap: StateFlow<Boolean>
-
-    fun setOnlyDirectOnMap(only: Boolean)
-
-    val excludeMqttOnMap: StateFlow<Boolean>
-
-    fun setExcludeMqttOnMap(exclude: Boolean)
-
-    val showIgnoredOnMap: StateFlow<Boolean>
-
-    fun setShowIgnoredOnMap(show: Boolean)
-
-    val includeUnknownOnMap: StateFlow<Boolean>
-
-    fun setIncludeUnknownOnMap(include: Boolean)
-
-    /**
-     * Names of the device roles the user has switched off on the map.
-     *
-     * Excluded rather than included, and by name rather than ordinal: an included set would make nodes reporting a role
-     * added by future firmware invisible with no way to discover why, and `ROUTER_CLIENT = 3` is already a deprecated
-     * slot.
-     */
-    val excludedMapRoles: StateFlow<Set<String>>
-
-    fun setExcludedMapRoles(roles: Set<String>)
+    /** Applies [transform] to the stored filters. Read-modify-write happens inside the store's own transaction. */
+    fun updateMapFilters(transform: (MapFilterPrefs) -> MapFilterPrefs)
 
     /** URIs of imported map layers the user has toggled off; a layer is visible unless its URI is in this set. */
     val hiddenLayerUrls: StateFlow<Set<String>>

--- a/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeFilterPrefs.kt
+++ b/core/repository/src/commonMain/kotlin/org/meshtastic/core/repository/NodeFilterPrefs.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.repository
+
+/**
+ * The stored node-list filters, as one value.
+ *
+ * The defaults here are what a fresh install reads back, so they are the app's real defaults, not an "unset"
+ * placeholder. Adding a filter is one property here plus one key in the store.
+ */
+data class NodeFilterPrefs(
+    /** Show nodes whose user info has not arrived yet. On by default: hiding them looks like packet loss. */
+    val includeUnknown: Boolean = true,
+    /** Hide routers, repeaters and other nodes that are infrastructure rather than people. */
+    val excludeInfrastructure: Boolean = false,
+    val onlyOnline: Boolean = false,
+    /** Show only nodes heard with no intervening hop. */
+    val onlyDirect: Boolean = false,
+    val showIgnored: Boolean = false,
+    val excludeMqtt: Boolean = false,
+    /** Hide nodes not heard since the radio's current LoRa config took effect. */
+    val excludeUnheard: Boolean = false,
+)
+
+/**
+ * The stored map filters, as one value. The map keeps its own copy of the node-list vocabulary on purpose: filtering
+ * the map to routers is not a statement about the contact list.
+ */
+data class MapFilterPrefs(
+    val onlyFavorites: Boolean = false,
+    val showWaypoints: Boolean = true,
+    val showPrecisionCircle: Boolean = true,
+    val onlyOnline: Boolean = false,
+    val onlyDirect: Boolean = false,
+    val excludeMqtt: Boolean = false,
+    val showIgnored: Boolean = false,
+    val includeUnknown: Boolean = true,
+    /** Seconds; `0` means no last-heard limit. */
+    val lastHeardSeconds: Long = 0,
+    /** Seconds; `0` means no limit on how far back a node's track is drawn. */
+    val lastHeardTrackSeconds: Long = 0,
+    /**
+     * Names of the device roles switched off.
+     *
+     * Excluded rather than included, and by name rather than ordinal: an included set would make nodes reporting a role
+     * added by future firmware invisible with no way to discover why, and `ROUTER_CLIENT = 3` is already a deprecated
+     * slot.
+     */
+    val excludedRoles: Set<String> = emptySet(),
+)

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeAppPreferences.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeAppPreferences.kt
@@ -18,6 +18,7 @@ package org.meshtastic.core.testing
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import org.meshtastic.core.model.DeviceType
 import org.meshtastic.core.repository.AnalyticsPrefs
 import org.meshtastic.core.repository.AppFunctionsPrefs
@@ -115,7 +116,9 @@ class FakeUiPrefs : UiPrefs {
     override val nodeFilters = MutableStateFlow(NodeFilterPrefs())
 
     override fun updateNodeFilters(transform: (NodeFilterPrefs) -> NodeFilterPrefs) {
-        nodeFilters.value = transform(nodeFilters.value)
+        // update, not read-then-assign: the real one is transactional, and a fake that loses a concurrent write
+        // would pass tests the production path fails.
+        nodeFilters.update(transform)
     }
 
     override val hasShownNotPairedWarning = MutableStateFlow(false)
@@ -251,7 +254,7 @@ class FakeMapPrefs : MapPrefs {
     override val mapFilters = MutableStateFlow(MapFilterPrefs())
 
     override fun updateMapFilters(transform: (MapFilterPrefs) -> MapFilterPrefs) {
-        mapFilters.value = transform(mapFilters.value)
+        mapFilters.update(transform)
     }
 
     override val hiddenLayerUrls = MutableStateFlow<Set<String>>(emptySet())

--- a/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeAppPreferences.kt
+++ b/core/testing/src/commonMain/kotlin/org/meshtastic/core/testing/FakeAppPreferences.kt
@@ -27,9 +27,11 @@ import org.meshtastic.core.repository.FilterPrefs
 import org.meshtastic.core.repository.HomoglyphPrefs
 import org.meshtastic.core.repository.MapCameraPosition
 import org.meshtastic.core.repository.MapConsentPrefs
+import org.meshtastic.core.repository.MapFilterPrefs
 import org.meshtastic.core.repository.MapPrefs
 import org.meshtastic.core.repository.MapTileProviderPrefs
 import org.meshtastic.core.repository.MeshPrefs
+import org.meshtastic.core.repository.NodeFilterPrefs
 import org.meshtastic.core.repository.RadioPrefs
 import org.meshtastic.core.repository.UiPrefs
 
@@ -110,46 +112,10 @@ class FakeUiPrefs : UiPrefs {
         nodeSort.value = value
     }
 
-    override val includeUnknown = MutableStateFlow(true)
+    override val nodeFilters = MutableStateFlow(NodeFilterPrefs())
 
-    override fun setIncludeUnknown(value: Boolean) {
-        includeUnknown.value = value
-    }
-
-    override val excludeInfrastructure = MutableStateFlow(false)
-
-    override fun setExcludeInfrastructure(value: Boolean) {
-        excludeInfrastructure.value = value
-    }
-
-    override val onlyOnline = MutableStateFlow(false)
-
-    override fun setOnlyOnline(value: Boolean) {
-        onlyOnline.value = value
-    }
-
-    override val onlyDirect = MutableStateFlow(false)
-
-    override fun setOnlyDirect(value: Boolean) {
-        onlyDirect.value = value
-    }
-
-    override val showIgnored = MutableStateFlow(false)
-
-    override fun setShowIgnored(value: Boolean) {
-        showIgnored.value = value
-    }
-
-    override val excludeMqtt = MutableStateFlow(false)
-
-    override fun setExcludeMqtt(value: Boolean) {
-        excludeMqtt.value = value
-    }
-
-    override val excludeUnheard = MutableStateFlow(false)
-
-    override fun setExcludeUnheard(value: Boolean) {
-        excludeUnheard.value = value
+    override fun updateNodeFilters(transform: (NodeFilterPrefs) -> NodeFilterPrefs) {
+        nodeFilters.value = transform(nodeFilters.value)
     }
 
     override val hasShownNotPairedWarning = MutableStateFlow(false)
@@ -282,70 +248,10 @@ class FakeMapPrefs : MapPrefs {
 
     override suspend fun awaitMapStyle(): Int = mapStyle.value
 
-    override val showOnlyFavorites = MutableStateFlow(false)
+    override val mapFilters = MutableStateFlow(MapFilterPrefs())
 
-    override fun setShowOnlyFavorites(show: Boolean) {
-        showOnlyFavorites.value = show
-    }
-
-    override val showWaypointsOnMap = MutableStateFlow(true)
-
-    override fun setShowWaypointsOnMap(show: Boolean) {
-        showWaypointsOnMap.value = show
-    }
-
-    override val showPrecisionCircleOnMap = MutableStateFlow(true)
-
-    override fun setShowPrecisionCircleOnMap(show: Boolean) {
-        showPrecisionCircleOnMap.value = show
-    }
-
-    override val lastHeardFilter = MutableStateFlow(0L)
-
-    override fun setLastHeardFilter(seconds: Long) {
-        lastHeardFilter.value = seconds
-    }
-
-    override val lastHeardTrackFilter = MutableStateFlow(0L)
-
-    override fun setLastHeardTrackFilter(seconds: Long) {
-        lastHeardTrackFilter.value = seconds
-    }
-
-    override val onlyOnlineOnMap = MutableStateFlow(false)
-
-    override fun setOnlyOnlineOnMap(only: Boolean) {
-        onlyOnlineOnMap.value = only
-    }
-
-    override val onlyDirectOnMap = MutableStateFlow(false)
-
-    override fun setOnlyDirectOnMap(only: Boolean) {
-        onlyDirectOnMap.value = only
-    }
-
-    override val excludeMqttOnMap = MutableStateFlow(false)
-
-    override fun setExcludeMqttOnMap(exclude: Boolean) {
-        excludeMqttOnMap.value = exclude
-    }
-
-    override val showIgnoredOnMap = MutableStateFlow(false)
-
-    override fun setShowIgnoredOnMap(show: Boolean) {
-        showIgnoredOnMap.value = show
-    }
-
-    override val includeUnknownOnMap = MutableStateFlow(true)
-
-    override fun setIncludeUnknownOnMap(include: Boolean) {
-        includeUnknownOnMap.value = include
-    }
-
-    override val excludedMapRoles = MutableStateFlow<Set<String>>(emptySet())
-
-    override fun setExcludedMapRoles(roles: Set<String>) {
-        excludedMapRoles.value = roles
+    override fun updateMapFilters(transform: (MapFilterPrefs) -> MapFilterPrefs) {
+        mapFilters.value = transform(mapFilters.value)
     }
 
     override val hiddenLayerUrls = MutableStateFlow<Set<String>>(emptySet())

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/BaseMapViewModel.kt
@@ -17,7 +17,6 @@
 package org.meshtastic.feature.map
 
 import androidx.lifecycle.ViewModel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -35,6 +34,7 @@ import org.meshtastic.core.model.TracerouteOverlay
 import org.meshtastic.core.model.geofence.activeWaypointPackets
 import org.meshtastic.core.model.isFromLocal
 import org.meshtastic.core.network.repository.NetworkRepository
+import org.meshtastic.core.repository.MapFilterPrefs
 import org.meshtastic.core.repository.MapPrefs
 import org.meshtastic.core.repository.NodeRepository
 import org.meshtastic.core.repository.NotificationPrefs
@@ -129,40 +129,27 @@ open class BaseMapViewModel(
     /** True if the waypoint with [id] was created by this device (vs. received from another node over the mesh). */
     fun isMyWaypoint(id: Int): Boolean = waypoints.value[id]?.isFromLocal(myNodeNum) == true
 
-    // Every filter reads its persisted flow directly rather than snapshotting `.value` into a mirror at
-    // construction. MapPrefsImpl's flows start eagerly but load from DataStore asynchronously, so a view model built
+    // Every filter reads the persisted flow directly rather than snapshotting `.value` into a mirror at
+    // construction. MapPrefsImpl's flow starts eagerly but loads from DataStore asynchronously, so a view model built
     // before that first read kept the defaults forever — nothing wrote the persisted values back into a mirror.
-    val showOnlyFavoritesOnMap: StateFlow<Boolean> = mapPrefs.showOnlyFavorites
+    private val storedFilters: StateFlow<MapFilterPrefs> = mapPrefs.mapFilters
 
-    fun toggleOnlyFavorites() = mapPrefs.setShowOnlyFavorites(!showOnlyFavoritesOnMap.value)
+    fun toggleOnlyFavorites() = mapPrefs.updateMapFilters { it.copy(onlyFavorites = !it.onlyFavorites) }
 
-    val showWaypointsOnMap: StateFlow<Boolean> = mapPrefs.showWaypointsOnMap
+    fun toggleShowWaypointsOnMap() = mapPrefs.updateMapFilters { it.copy(showWaypoints = !it.showWaypoints) }
 
-    fun toggleShowWaypointsOnMap() = mapPrefs.setShowWaypointsOnMap(!showWaypointsOnMap.value)
+    fun toggleShowPrecisionCircleOnMap() =
+        mapPrefs.updateMapFilters { it.copy(showPrecisionCircle = !it.showPrecisionCircle) }
 
-    val showPrecisionCircleOnMap: StateFlow<Boolean> = mapPrefs.showPrecisionCircleOnMap
+    fun toggleOnlyOnline() = mapPrefs.updateMapFilters { it.copy(onlyOnline = !it.onlyOnline) }
 
-    fun toggleShowPrecisionCircleOnMap() = mapPrefs.setShowPrecisionCircleOnMap(!showPrecisionCircleOnMap.value)
+    fun toggleOnlyDirect() = mapPrefs.updateMapFilters { it.copy(onlyDirect = !it.onlyDirect) }
 
-    val onlyOnlineOnMap: StateFlow<Boolean> = mapPrefs.onlyOnlineOnMap
+    fun toggleExcludeMqtt() = mapPrefs.updateMapFilters { it.copy(excludeMqtt = !it.excludeMqtt) }
 
-    fun toggleOnlyOnline() = mapPrefs.setOnlyOnlineOnMap(!onlyOnlineOnMap.value)
+    fun toggleShowIgnored() = mapPrefs.updateMapFilters { it.copy(showIgnored = !it.showIgnored) }
 
-    val onlyDirectOnMap: StateFlow<Boolean> = mapPrefs.onlyDirectOnMap
-
-    fun toggleOnlyDirect() = mapPrefs.setOnlyDirectOnMap(!onlyDirectOnMap.value)
-
-    val excludeMqttOnMap: StateFlow<Boolean> = mapPrefs.excludeMqttOnMap
-
-    fun toggleExcludeMqtt() = mapPrefs.setExcludeMqttOnMap(!excludeMqttOnMap.value)
-
-    val showIgnoredOnMap: StateFlow<Boolean> = mapPrefs.showIgnoredOnMap
-
-    fun toggleShowIgnored() = mapPrefs.setShowIgnoredOnMap(!showIgnoredOnMap.value)
-
-    val includeUnknownOnMap: StateFlow<Boolean> = mapPrefs.includeUnknownOnMap
-
-    fun toggleIncludeUnknown() = mapPrefs.setIncludeUnknownOnMap(!includeUnknownOnMap.value)
+    fun toggleIncludeUnknown() = mapPrefs.updateMapFilters { it.copy(includeUnknown = !it.includeUnknown) }
 
     /**
      * The nodes the map draws from.
@@ -171,40 +158,32 @@ open class BaseMapViewModel(
      * right default for the pickers that read it, but it left the map's own show-ignored filter with nothing to add
      * back. [MapNodePolicy] still decides; this only stops the discard happening before it is asked.
      *
-     * Declared here rather than beside [nodes] because it reads [showIgnoredOnMap], and a property initialiser cannot
-     * see one declared below it.
+     * Declared here rather than beside [nodes] because it reads [storedFilters], and a property initialiser cannot see
+     * one declared below it.
      */
     val nodesWithPosition: StateFlow<List<Node>> =
-        combine(nodeRepository.getNodes(), showIgnoredOnMap) { all, showIgnored ->
-            all.filter { node -> node.validPosition != null && (showIgnored || !node.isIgnored) }
+        combine(nodeRepository.getNodes(), storedFilters) { all, filters ->
+            all.filter { node -> node.validPosition != null && (filters.showIgnored || !node.isIgnored) }
         }
             .stateInWhileSubscribed(initialValue = emptyList())
 
-    val excludedMapRoles: StateFlow<Set<Config.DeviceConfig.Role>> =
-        mapPrefs.excludedMapRoles
-            .map(::decodeExcludedRoles)
-            .stateInWhileSubscribed(decodeExcludedRoles(mapPrefs.excludedMapRoles.value))
-
-    fun toggleRoleExcluded(role: Config.DeviceConfig.Role) {
-        val newValue = excludedMapRoles.value.let { if (role in it) it - role else it + role }
-        mapPrefs.setExcludedMapRoles(newValue.mapTo(mutableSetOf()) { it.name })
+    /**
+     * Toggles by name rather than through [decodeExcludedRoles], which drops names the current protobufs do not define.
+     * Decoding and re-encoding here would discard a role excluded by a newer build on every toggle.
+     */
+    fun toggleRoleExcluded(role: Config.DeviceConfig.Role) = mapPrefs.updateMapFilters { prefs ->
+        val excluded = prefs.excludedRoles
+        val next = if (role.name in excluded) excluded - role.name else excluded + role.name
+        prefs.copy(excludedRoles = next)
     }
 
-    fun clearExcludedRoles() = mapPrefs.setExcludedMapRoles(emptySet())
+    fun clearExcludedRoles() = mapPrefs.updateMapFilters { it.copy(excludedRoles = emptySet()) }
 
-    val lastHeardFilter: StateFlow<LastHeardFilter> =
-        mapPrefs.lastHeardFilter
-            .map(LastHeardFilter::fromSeconds)
-            .stateInWhileSubscribed(LastHeardFilter.fromSeconds(mapPrefs.lastHeardFilter.value))
+    fun setLastHeardFilter(filter: LastHeardFilter) =
+        mapPrefs.updateMapFilters { it.copy(lastHeardSeconds = filter.seconds) }
 
-    fun setLastHeardFilter(filter: LastHeardFilter) = mapPrefs.setLastHeardFilter(filter.seconds)
-
-    val lastHeardTrackFilter: StateFlow<LastHeardFilter> =
-        mapPrefs.lastHeardTrackFilter
-            .map(LastHeardFilter::fromSeconds)
-            .stateInWhileSubscribed(LastHeardFilter.fromSeconds(mapPrefs.lastHeardTrackFilter.value))
-
-    fun setLastHeardTrackFilter(filter: LastHeardFilter) = mapPrefs.setLastHeardTrackFilter(filter.seconds)
+    fun setLastHeardTrackFilter(filter: LastHeardFilter) =
+        mapPrefs.updateMapFilters { it.copy(lastHeardTrackSeconds = filter.seconds) }
 
     open fun getUser(userId: String?) =
         nodeRepository.getUser(userId ?: org.meshtastic.core.model.NodeAddress.ID_BROADCAST)
@@ -259,62 +238,22 @@ open class BaseMapViewModel(
                     lastHeardFilter != LastHeardFilter.Any
     }
 
-    // Two intermediate combines rather than one: `combine` tops out at five flows, and there are eleven.
-    private val displayFilters: Flow<MapFilterState> =
-        combine(
-            showOnlyFavoritesOnMap,
-            showWaypointsOnMap,
-            showPrecisionCircleOnMap,
-            lastHeardFilter,
-            lastHeardTrackFilter,
-        ) { favoritesOnly, showWaypoints, showPrecisionCircle, lastHeardFilter, lastHeardTrackFilter ->
-            MapFilterState(favoritesOnly, showWaypoints, showPrecisionCircle, lastHeardFilter, lastHeardTrackFilter)
-        }
-
-    private val nodeFilters: Flow<NodeFilters> =
-        combine(excludedMapRoles, onlyOnlineOnMap, onlyDirectOnMap, excludeMqttOnMap, showIgnoredOnMap, ::NodeFilters)
-
+    // One flow, one map: the store hands every filter back as a single value, so there is nothing to recombine.
     val mapFilterStateFlow: StateFlow<MapFilterState> =
-        combine(displayFilters, nodeFilters, includeUnknownOnMap) { display, nodes, includeUnknown ->
-            display.with(nodes, includeUnknown)
-        }
-            .stateInWhileSubscribed(
-                initialValue =
-                MapFilterState(
-                    showOnlyFavoritesOnMap.value,
-                    showWaypointsOnMap.value,
-                    showPrecisionCircleOnMap.value,
-                    lastHeardFilter.value,
-                    lastHeardTrackFilter.value,
-                )
-                    .with(
-                        NodeFilters(
-                            excludedMapRoles.value,
-                            onlyOnlineOnMap.value,
-                            onlyDirectOnMap.value,
-                            excludeMqttOnMap.value,
-                            showIgnoredOnMap.value,
-                        ),
-                        includeUnknownOnMap.value,
-                    ),
-            )
+        storedFilters.map(::toFilterState).stateInWhileSubscribed(toFilterState(storedFilters.value))
 
-    /** The five node-level toggles, boxed so they fit one `combine`. */
-    private data class NodeFilters(
-        val excludedRoles: Set<Config.DeviceConfig.Role>,
-        val onlyOnline: Boolean,
-        val onlyDirect: Boolean,
-        val excludeMqtt: Boolean,
-        val showIgnored: Boolean,
-    )
-
-    private fun MapFilterState.with(nodes: NodeFilters, includeUnknown: Boolean) = copy(
-        excludedRoles = nodes.excludedRoles,
-        onlyOnline = nodes.onlyOnline,
-        onlyDirect = nodes.onlyDirect,
-        excludeMqtt = nodes.excludeMqtt,
-        showIgnored = nodes.showIgnored,
-        includeUnknown = includeUnknown,
+    private fun toFilterState(prefs: MapFilterPrefs) = MapFilterState(
+        onlyFavorites = prefs.onlyFavorites,
+        showWaypoints = prefs.showWaypoints,
+        showPrecisionCircle = prefs.showPrecisionCircle,
+        lastHeardFilter = LastHeardFilter.fromSeconds(prefs.lastHeardSeconds),
+        lastHeardTrackFilter = LastHeardFilter.fromSeconds(prefs.lastHeardTrackSeconds),
+        excludedRoles = decodeExcludedRoles(prefs.excludedRoles),
+        onlyOnline = prefs.onlyOnline,
+        onlyDirect = prefs.onlyDirect,
+        excludeMqtt = prefs.excludeMqtt,
+        showIgnored = prefs.showIgnored,
+        includeUnknown = prefs.includeUnknown,
     )
 }
 

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/MapNodePolicy.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/MapNodePolicy.kt
@@ -79,14 +79,25 @@ object MapNodePolicy {
      */
     private fun Node.passesFilters(filterState: BaseMapViewModel.MapFilterState, nowSeconds: Long): Boolean {
         val secondsSinceHeard = nowSeconds - lastHeard
-        val cutoff = filterState.lastHeardFilter.seconds
-        return (!filterState.onlyFavorites || isFavorite) &&
+        return passesIdentityFilters(filterState) && passesReachabilityFilters(filterState, secondsSinceHeard)
+    }
+
+    /** Who the node is: favourited, ignored, its role, and whether its name has arrived yet. */
+    private fun Node.passesIdentityFilters(filterState: BaseMapViewModel.MapFilterState): Boolean =
+        (!filterState.onlyFavorites || isFavorite) &&
             (!isIgnored || filterState.showIgnored) &&
             user.role !in filterState.excludedRoles &&
-            (!filterState.onlyOnline || secondsSinceHeard <= ONLINE_WINDOW_SECONDS) &&
+            (filterState.includeUnknown || user.short_name.isNotEmpty())
+
+    /** How the node is reachable: online, hop count, bearer, and how recently it was heard. */
+    private fun Node.passesReachabilityFilters(
+        filterState: BaseMapViewModel.MapFilterState,
+        secondsSinceHeard: Long,
+    ): Boolean {
+        val cutoff = filterState.lastHeardFilter.seconds
+        return (!filterState.onlyOnline || secondsSinceHeard <= ONLINE_WINDOW_SECONDS) &&
             (!filterState.onlyDirect || hopsAway == 0) &&
             (!filterState.excludeMqtt || !viaMqtt) &&
-            (filterState.includeUnknown || user.short_name.isNotEmpty()) &&
             (cutoff == LastHeardFilter.Any.seconds || secondsSinceHeard <= cutoff)
     }
 }

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/MapFilterActions.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/MapFilterActions.kt
@@ -46,9 +46,9 @@ class MapFilterActions(
 /**
  * The standard wiring from a view model to [MapFilterSheet].
  *
- * Both flavours build the identical bag of method references, and eleven of them written out twice is eleven chances
- * for the two maps to drift apart again — which is exactly what [org.meshtastic.feature.map.MapNodePolicy] exists to
- * prevent on the rules side.
+ * Both flavours build the identical bag of method references, and writing them out twice is that many chances for the
+ * two maps to drift apart again — which is exactly what [org.meshtastic.feature.map.MapNodePolicy] exists to prevent on
+ * the rules side.
  */
 fun BaseMapViewModel.mapFilterActions(): MapFilterActions = MapFilterActions(
     onToggleOnlyFavorites = ::toggleOnlyFavorites,

--- a/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/MapFilterSheet.kt
+++ b/feature/map/src/commonMain/kotlin/org/meshtastic/feature/map/component/MapFilterSheet.kt
@@ -135,8 +135,8 @@ internal fun MapFilterSheetContent(filterState: BaseMapViewModel.MapFilterState,
 }
 
 /**
- * The node-level filters, in the node list's own words — four of these five labels are its string resources, so a user
- * who has met them there does not have to learn them twice.
+ * The node-level filters, in the node list's own words — all but one of these labels are its string resources, so a
+ * user who has met them there does not have to learn them twice.
  */
 @Composable
 private fun NodeFilterToggles(filterState: BaseMapViewModel.MapFilterState, actions: MapFilterActions) = Column {
@@ -155,8 +155,8 @@ private fun NodeFilterToggles(filterState: BaseMapViewModel.MapFilterState, acti
         checked = filterState.excludeMqtt,
         onToggle = actions.onToggleExcludeMqtt,
     )
-    // The fifth is ours: the list's `node_filter_show_ignored` reads "Only show ignored Nodes", which is what the
-    // list does and the opposite of what this does.
+    // The one exception is ours: the list's `node_filter_show_ignored` reads "Only show ignored Nodes", which is what
+    // the list does and the opposite of what this does.
     FilterToggle(
         label = stringResource(Res.string.map_filter_show_ignored),
         checked = filterState.showIgnored,

--- a/feature/map/src/commonTest/kotlin/org/meshtastic/feature/map/BaseMapViewModelTest.kt
+++ b/feature/map/src/commonTest/kotlin/org/meshtastic/feature/map/BaseMapViewModelTest.kt
@@ -17,8 +17,10 @@
 package org.meshtastic.feature.map
 
 import app.cash.turbine.test
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -34,6 +36,7 @@ import org.meshtastic.core.model.DataPacket
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeAddress
 import org.meshtastic.core.network.repository.NetworkRepository
+import org.meshtastic.core.repository.MapFilterPrefs
 import org.meshtastic.core.repository.MapPrefs
 import org.meshtastic.core.repository.PacketRepository
 import org.meshtastic.core.testing.FakeLocaleUnitsProvider
@@ -42,6 +45,7 @@ import org.meshtastic.core.testing.FakeNotificationPrefs
 import org.meshtastic.core.testing.FakeRadioConfigRepository
 import org.meshtastic.core.testing.FakeRadioController
 import org.meshtastic.core.testing.TestDataFactory
+import org.meshtastic.proto.Config
 import org.meshtastic.proto.Position
 import org.meshtastic.proto.Waypoint
 import kotlin.test.AfterTest
@@ -60,7 +64,7 @@ class BaseMapViewModelTest {
     private lateinit var radioConfigRepository: FakeRadioConfigRepository
     private lateinit var waypointPacketsFlow: MutableStateFlow<List<DataPacket>>
     private val mapPrefs: MapPrefs = mock()
-    private val showIgnored = MutableStateFlow(false)
+    private val storedFilters = MutableStateFlow(MapFilterPrefs())
     private val packetRepository: PacketRepository = mock()
     private val localeUnitsProvider = FakeLocaleUnitsProvider()
     private val networkRepository: NetworkRepository = mock()
@@ -73,17 +77,12 @@ class BaseMapViewModelTest {
         radioConfigRepository = FakeRadioConfigRepository()
         radioController.setConnectionState(ConnectionState.Disconnected)
 
-        every { mapPrefs.showOnlyFavorites } returns MutableStateFlow(false)
-        every { mapPrefs.showWaypointsOnMap } returns MutableStateFlow(false)
-        every { mapPrefs.showPrecisionCircleOnMap } returns MutableStateFlow(false)
-        every { mapPrefs.lastHeardFilter } returns MutableStateFlow(0L)
-        every { mapPrefs.lastHeardTrackFilter } returns MutableStateFlow(0L)
-        every { mapPrefs.onlyOnlineOnMap } returns MutableStateFlow(false)
-        every { mapPrefs.onlyDirectOnMap } returns MutableStateFlow(false)
-        every { mapPrefs.excludeMqttOnMap } returns MutableStateFlow(false)
-        every { mapPrefs.showIgnoredOnMap } returns showIgnored
-        every { mapPrefs.includeUnknownOnMap } returns MutableStateFlow(true)
-        every { mapPrefs.excludedMapRoles } returns MutableStateFlow(emptySet())
+        storedFilters.value = MapFilterPrefs(showWaypoints = false, showPrecisionCircle = false)
+        every { mapPrefs.mapFilters } returns storedFilters
+        every { mapPrefs.updateMapFilters(any()) } calls
+            { (transform: (MapFilterPrefs) -> MapFilterPrefs) ->
+                storedFilters.value = transform(storedFilters.value)
+            }
 
         waypointPacketsFlow = MutableStateFlow(emptyList())
         every { packetRepository.getWaypoints() } returns waypointPacketsFlow
@@ -158,7 +157,7 @@ class BaseMapViewModelTest {
         // Set on the prefs flow, after the view model was built: that is the DataStore-arrives-late case, which
         // used to be lost because the view model snapshotted `.value` into a mirror nothing updated.
         nodeRepository.setNodes(listOf(positioned(1), positioned(2, isIgnored = true)))
-        showIgnored.value = true
+        storedFilters.value = storedFilters.value.copy(showIgnored = true)
 
         viewModel.nodesWithPosition.test {
             assertEquals(listOf(1, 2), awaitItem().map { it.num }.sorted())
@@ -261,6 +260,21 @@ class BaseMapViewModelTest {
             )
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `toggling a role keeps role names this build does not know`() {
+        // decodeExcludedRoles drops names the current protobufs do not define, so decoding and re-encoding on every
+        // toggle would silently discard a role a newer build excluded.
+        storedFilters.value = storedFilters.value.copy(excludedRoles = setOf("ROLE_FROM_A_NEWER_BUILD"))
+
+        viewModel.toggleRoleExcluded(Config.DeviceConfig.Role.ROUTER)
+
+        assertEquals(setOf("ROLE_FROM_A_NEWER_BUILD", "ROUTER"), storedFilters.value.excludedRoles)
+
+        viewModel.toggleRoleExcluded(Config.DeviceConfig.Role.ROUTER)
+
+        assertEquals(setOf("ROLE_FROM_A_NEWER_BUILD"), storedFilters.value.excludedRoles)
     }
 
     private fun waypointPacket(id: Int, expire: Int): DataPacket = DataPacket(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeFilterTextField.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/component/NodeFilterTextField.kt
@@ -79,29 +79,14 @@ import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Search
 import org.meshtastic.core.ui.icon.Sort
 
-@Suppress("LongParameterList")
 @Composable
 fun NodeFilterTextField(
-    modifier: Modifier = Modifier,
     filterText: String,
     onTextChange: (String) -> Unit,
     currentSortOption: NodeSortOption,
     onSortSelect: (NodeSortOption) -> Unit,
-    includeUnknown: Boolean,
-    onToggleIncludeUnknown: () -> Unit,
-    excludeInfrastructure: Boolean,
-    onToggleExcludeInfrastructure: () -> Unit,
-    onlyOnline: Boolean,
-    onToggleOnlyOnline: () -> Unit,
-    onlyDirect: Boolean,
-    onToggleOnlyDirect: () -> Unit,
-    showIgnored: Boolean,
-    onToggleShowIgnored: () -> Unit,
-    ignoredNodeCount: Int,
-    excludeUnheard: Boolean,
-    onToggleExcludeUnheard: () -> Unit,
-    excludeMqtt: Boolean,
-    onToggleExcludeMqtt: () -> Unit,
+    toggles: NodeFilterToggles,
+    modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.background(MaterialTheme.colorScheme.background)) {
         Row {
@@ -111,32 +96,15 @@ fun NodeFilterTextField(
                 modifier = Modifier.align(Alignment.CenterVertically),
                 currentSortOption = currentSortOption,
                 onSortSelect = onSortSelect,
-                toggles =
-                NodeFilterToggles(
-                    includeUnknown = includeUnknown,
-                    onToggleIncludeUnknown = onToggleIncludeUnknown,
-                    excludeInfrastructure = excludeInfrastructure,
-                    onToggleExcludeInfrastructure = onToggleExcludeInfrastructure,
-                    onlyOnline = onlyOnline,
-                    onToggleOnlyOnline = onToggleOnlyOnline,
-                    onlyDirect = onlyDirect,
-                    onToggleOnlyDirect = onToggleOnlyDirect,
-                    showIgnored = showIgnored,
-                    onToggleShowIgnored = onToggleShowIgnored,
-                    ignoredNodeCount = ignoredNodeCount,
-                    excludeMqtt = excludeMqtt,
-                    onToggleExcludeMqtt = onToggleExcludeMqtt,
-                    excludeUnheard = excludeUnheard,
-                    onToggleExcludeUnheard = onToggleExcludeUnheard,
-                ),
+                toggles = toggles,
             )
         }
-        if (showIgnored) {
+        if (toggles.showIgnored) {
             Box(
                 modifier =
                 Modifier.fillMaxWidth()
                     .background(MaterialTheme.colorScheme.surfaceDim)
-                    .clickable { onToggleShowIgnored() }
+                    .clickable { toggles.onToggleShowIgnored() }
                     .padding(vertical = 16.dp, horizontal = 24.dp),
             ) {
                 Text(

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeFilterPreferences.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeFilterPreferences.kt
@@ -24,13 +24,8 @@ import org.meshtastic.core.repository.UiPrefs
 @Single
 @Suppress("TooManyFunctions")
 open class NodeFilterPreferences constructor(private val uiPrefs: UiPrefs) {
-    open val includeUnknown = uiPrefs.includeUnknown
-    open val excludeInfrastructure = uiPrefs.excludeInfrastructure
-    open val onlyOnline = uiPrefs.onlyOnline
-    open val onlyDirect = uiPrefs.onlyDirect
-    open val showIgnored = uiPrefs.showIgnored
-    open val excludeMqtt = uiPrefs.excludeMqtt
-    open val excludeUnheard = uiPrefs.excludeUnheard
+    /** Every node-list filter as one value; see [org.meshtastic.core.repository.NodeFilterPrefs]. */
+    open val filters = uiPrefs.nodeFilters
 
     // Node list layout preferences
     open val nodeListDensity = uiPrefs.nodeListDensity
@@ -92,30 +87,30 @@ open class NodeFilterPreferences constructor(private val uiPrefs: UiPrefs) {
     }
 
     open fun toggleIncludeUnknown() {
-        uiPrefs.setIncludeUnknown(!includeUnknown.value)
+        uiPrefs.updateNodeFilters { it.copy(includeUnknown = !it.includeUnknown) }
     }
 
     open fun toggleExcludeInfrastructure() {
-        uiPrefs.setExcludeInfrastructure(!excludeInfrastructure.value)
+        uiPrefs.updateNodeFilters { it.copy(excludeInfrastructure = !it.excludeInfrastructure) }
     }
 
     open fun toggleOnlyOnline() {
-        uiPrefs.setOnlyOnline(!onlyOnline.value)
+        uiPrefs.updateNodeFilters { it.copy(onlyOnline = !it.onlyOnline) }
     }
 
     open fun toggleOnlyDirect() {
-        uiPrefs.setOnlyDirect(!onlyDirect.value)
+        uiPrefs.updateNodeFilters { it.copy(onlyDirect = !it.onlyDirect) }
     }
 
     open fun toggleShowIgnored() {
-        uiPrefs.setShowIgnored(!showIgnored.value)
+        uiPrefs.updateNodeFilters { it.copy(showIgnored = !it.showIgnored) }
     }
 
     open fun toggleExcludeMqtt() {
-        uiPrefs.setExcludeMqtt(!excludeMqtt.value)
+        uiPrefs.updateNodeFilters { it.copy(excludeMqtt = !it.excludeMqtt) }
     }
 
     open fun toggleExcludeUnheard() {
-        uiPrefs.setExcludeUnheard(!excludeUnheard.value)
+        uiPrefs.updateNodeFilters { it.copy(excludeUnheard = !it.excludeUnheard) }
     }
 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListScreen.kt
@@ -101,6 +101,7 @@ import org.meshtastic.feature.node.component.LocalNodeContextMenu
 import org.meshtastic.feature.node.component.NodeContextMenu
 import org.meshtastic.feature.node.component.NodeCountSummary
 import org.meshtastic.feature.node.component.NodeFilterTextField
+import org.meshtastic.feature.node.component.NodeFilterToggles
 import org.meshtastic.feature.node.component.NodeHopHistogramSheet
 import org.meshtastic.feature.node.component.NodeListHelp
 
@@ -269,29 +270,31 @@ fun NodeListScreen(
                             onRemoveAll = { unheardNodes.forEach(viewModel::removeNode) },
                             modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
                         )
+                        val filterPrefs = viewModel.nodeFilterPreferences
                         NodeFilterTextField(
-                            modifier = Modifier.fillMaxWidth(),
                             filterText = state.filter.filterText,
                             onTextChange = { viewModel.nodeFilterText = it },
                             currentSortOption = state.sort,
                             onSortSelect = viewModel::setSortOption,
-                            includeUnknown = state.filter.includeUnknown,
-                            onToggleIncludeUnknown = { viewModel.nodeFilterPreferences.toggleIncludeUnknown() },
-                            excludeInfrastructure = state.filter.excludeInfrastructure,
-                            onToggleExcludeInfrastructure = {
-                                viewModel.nodeFilterPreferences.toggleExcludeInfrastructure()
-                            },
-                            onlyOnline = state.filter.onlyOnline,
-                            onToggleOnlyOnline = { viewModel.nodeFilterPreferences.toggleOnlyOnline() },
-                            onlyDirect = state.filter.onlyDirect,
-                            onToggleOnlyDirect = { viewModel.nodeFilterPreferences.toggleOnlyDirect() },
-                            showIgnored = state.filter.showIgnored,
-                            onToggleShowIgnored = { viewModel.nodeFilterPreferences.toggleShowIgnored() },
-                            ignoredNodeCount = ignoredNodeCount,
-                            excludeMqtt = state.filter.excludeMqtt,
-                            onToggleExcludeMqtt = { viewModel.nodeFilterPreferences.toggleExcludeMqtt() },
-                            excludeUnheard = state.filter.excludeUnheard,
-                            onToggleExcludeUnheard = { viewModel.nodeFilterPreferences.toggleExcludeUnheard() },
+                            modifier = Modifier.fillMaxWidth(),
+                            toggles =
+                            NodeFilterToggles(
+                                includeUnknown = state.filter.includeUnknown,
+                                onToggleIncludeUnknown = filterPrefs::toggleIncludeUnknown,
+                                excludeInfrastructure = state.filter.excludeInfrastructure,
+                                onToggleExcludeInfrastructure = filterPrefs::toggleExcludeInfrastructure,
+                                onlyOnline = state.filter.onlyOnline,
+                                onToggleOnlyOnline = filterPrefs::toggleOnlyOnline,
+                                onlyDirect = state.filter.onlyDirect,
+                                onToggleOnlyDirect = filterPrefs::toggleOnlyDirect,
+                                showIgnored = state.filter.showIgnored,
+                                onToggleShowIgnored = filterPrefs::toggleShowIgnored,
+                                ignoredNodeCount = ignoredNodeCount,
+                                excludeUnheard = state.filter.excludeUnheard,
+                                onToggleExcludeUnheard = filterPrefs::toggleExcludeUnheard,
+                                excludeMqtt = state.filter.excludeMqtt,
+                                onToggleExcludeMqtt = filterPrefs::toggleExcludeMqtt,
+                            ),
                         )
                     }
                 }

--- a/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
+++ b/feature/node/src/commonMain/kotlin/org/meshtastic/feature/node/list/NodeListViewModel.kt
@@ -101,23 +101,6 @@ class NodeListViewModel(
 
     private val _nodeFilterText = savedStateHandle.getStateFlow(KEY_FILTER_TEXT, "")
 
-    private val filterToggles =
-        combine(
-            nodeFilterPreferences.includeUnknown,
-            nodeFilterPreferences.excludeInfrastructure,
-            nodeFilterPreferences.onlyOnline,
-            nodeFilterPreferences.onlyDirect,
-            nodeFilterPreferences.showIgnored,
-        ) { includeUnknown, excludeInfrastructure, onlyOnline, onlyDirect, showIgnored ->
-            NodeFilterToggles(
-                includeUnknown = includeUnknown,
-                excludeInfrastructure = excludeInfrastructure,
-                onlyOnline = onlyOnline,
-                onlyDirect = onlyDirect,
-                showIgnored = showIgnored,
-            )
-        }
-
     /**
      * The unheard filter may only narrow the list once the firmware has proven it reports the field AND the handshake's
      * NodeInfo install has completed. Between setFirmwareVersion flipping the capability and that install landing,
@@ -129,23 +112,18 @@ class NodeListViewModel(
             reportsHeard && dbReady
         }
 
+    // Three flows regardless of how many filters exist: the store hands back all of them as one value.
     private val nodeFilter: Flow<NodeFilterState> =
-        combine(
-            _nodeFilterText,
-            filterToggles,
-            nodeFilterPreferences.excludeMqtt,
-            nodeFilterPreferences.excludeUnheard,
-            unheardFilterAllowed,
-        ) { filterText, filterToggles, excludeMqtt, excludeUnheard, unheardAllowed ->
+        combine(_nodeFilterText, nodeFilterPreferences.filters, unheardFilterAllowed) { text, prefs, unheardAllowed ->
             NodeFilterState(
-                filterText = filterText,
-                includeUnknown = filterToggles.includeUnknown,
-                excludeInfrastructure = filterToggles.excludeInfrastructure,
-                onlyOnline = filterToggles.onlyOnline,
-                onlyDirect = filterToggles.onlyDirect,
-                showIgnored = filterToggles.showIgnored,
-                excludeMqtt = excludeMqtt,
-                excludeUnheard = excludeUnheard && unheardAllowed,
+                filterText = text,
+                includeUnknown = prefs.includeUnknown,
+                excludeInfrastructure = prefs.excludeInfrastructure,
+                onlyOnline = prefs.onlyOnline,
+                onlyDirect = prefs.onlyDirect,
+                showIgnored = prefs.showIgnored,
+                excludeMqtt = prefs.excludeMqtt,
+                excludeUnheard = prefs.excludeUnheard && unheardAllowed,
             )
         }
 
@@ -290,11 +268,3 @@ data class NodeFilterState(
                 excludeMqtt ||
                 excludeUnheard
 }
-
-data class NodeFilterToggles(
-    val includeUnknown: Boolean = true,
-    val excludeInfrastructure: Boolean = false,
-    val onlyOnline: Boolean = false,
-    val onlyDirect: Boolean = false,
-    val showIgnored: Boolean = false,
-)

--- a/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/list/NodeListViewModelTest.kt
+++ b/feature/node/src/commonTest/kotlin/org/meshtastic/feature/node/list/NodeListViewModelTest.kt
@@ -31,6 +31,7 @@ import org.meshtastic.core.model.ConnectionState
 import org.meshtastic.core.model.Node
 import org.meshtastic.core.model.NodeSortOption
 import org.meshtastic.core.repository.ConnectionStateProvider
+import org.meshtastic.core.repository.NodeFilterPrefs
 import org.meshtastic.core.repository.NodeManager
 import org.meshtastic.core.repository.RadioConfigRepository
 import org.meshtastic.core.testing.FakeDeviceHardwareRepository
@@ -73,13 +74,7 @@ class NodeListViewModelTest {
         every { connectionStateProvider.connectionState } returns MutableStateFlow(ConnectionState.Disconnected)
 
         every { nodeFilterPreferences.nodeSortOption } returns MutableStateFlow(NodeSortOption.LAST_HEARD)
-        every { nodeFilterPreferences.includeUnknown } returns MutableStateFlow(true)
-        every { nodeFilterPreferences.excludeInfrastructure } returns MutableStateFlow(false)
-        every { nodeFilterPreferences.onlyOnline } returns MutableStateFlow(false)
-        every { nodeFilterPreferences.onlyDirect } returns MutableStateFlow(false)
-        every { nodeFilterPreferences.showIgnored } returns MutableStateFlow(false)
-        every { nodeFilterPreferences.excludeMqtt } returns MutableStateFlow(false)
-        every { nodeFilterPreferences.excludeUnheard } returns MutableStateFlow(false)
+        every { nodeFilterPreferences.filters } returns MutableStateFlow(NodeFilterPrefs())
         every { nodeManager.reportsHeardOnCurrentLora } returns MutableStateFlow(true)
         every { nodeManager.isNodeDbReady } returns MutableStateFlow(true)
 


### PR DESCRIPTION
`UiPrefs` exposed nine separate node filter flows and `MapPrefs` thirteen map ones, so every reader had to recombine them downstream. The typed `combine` overloads cap at five, which the map had already outgrown: it carried two intermediate combines, a `NodeFilters` box that existed only "so they fit one combine", and a hand duplicated initial value.

The store already holds these together. They are now handed back together.

No behaviour change. This is groundwork for adding filters in #7117, where a new one costs one property and one key instead of touching seven files.

## 🛠️ Refactoring & Architecture

- `nodeFilters: StateFlow<NodeFilterPrefs>` and `mapFilters: StateFlow<MapFilterPrefs>` replace the per toggle flows. Writes go through `updateNodeFilters` / `updateMapFilters`, applying a pure transform inside DataStore's own transaction, which is the lost update guard `updateHiddenLayerUrls` already used.
- Node list `combine` drops from five flows plus a nested combine to three. The map drops from eleven flows and two intermediate combines to a single `map`, and loses both the `NodeFilters` box and the duplicated initial value.
- `NodeFilterTextField` took twenty parameters and now takes the `NodeFilterToggles` it was already constructing internally. That retires three detekt baseline entries (`ComposableParamOrder`, `LambdaParameterEventTrailing`, `ParameterNaming`) rather than adding to them.

## 🐛 Bug Fixes

- `toggleRoleExcluded` decoded the stored role names into enum values, toggled, then re-encoded. `decodeExcludedRoles` deliberately drops names the current protobufs do not define, so every role toggle silently discarded any role excluded by a newer build, which is the exact data loss the "names rather than ordinals" comment exists to prevent. It now toggles by name on the stored set. Pre-existing, but the refactor is what puts the string set in hand.

## Testing Performed

- `BaseMapViewModelTest`: new `toggling a role keeps role names this build does not know` excludes an unknown role name, toggles ROUTER on and off, and asserts the unknown name survives both. The `updateMapFilters` mock now applies the transform so toggles are observable. Eleven `every { }` stubs collapse to one.
- `NodeListViewModelTest`: seven per toggle stubs collapse to one `nodeFilters` stub.
- `MapNodePolicyTest`, `MapFilterSheetTest`, `GetFilteredNodesUseCaseTest` updated for the new shapes.
- Baseline green: `spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Consolidated node-list and map filtering preferences into unified filter settings.
  - Preserved existing filtering behavior for favorites, visibility, connectivity, ignored nodes, MQTT, unheard nodes, and role exclusions.
  - Map role exclusions continue to preserve names not recognized by current device definitions.

- **Bug Fixes**
  - Improved consistency when updating multiple filter settings by applying changes atomically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->