### PR TITLE
fix(nfc): write to tags that have never been NDEF-formatted

### DIFF
--- a/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/NfcScanner.kt
+++ b/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/NfcScanner.kt
@@ -23,6 +23,8 @@ import android.nfc.NdefRecord
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.tech.Ndef
+import android.nfc.tech.NdefFormatable
+import android.nfc.tech.TagTechnology
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -104,42 +106,66 @@ fun NfcWriterEffect(url: String, onResult: (Boolean) -> Unit, onNfcDisabled: (()
 }
 
 private fun writeNdefUrl(tag: Tag, url: String): Boolean {
-    val ndef = Ndef.get(tag)
-    if (ndef == null) {
-        Logger.w { "Tag does not support NDEF" }
-        return false
-    }
     val message = NdefMessage(NdefRecord.createUri(url))
-    return try {
-        ndef.connect()
-        when {
-            !ndef.isWritable -> {
-                Logger.w { "NDEF tag is read-only" }
-                false
-            }
+    val ndef = Ndef.get(tag)
+    // A tag that has never been NDEF-formatted exposes NdefFormatable and no Ndef: blank
+    // Ultralight/Classic, or an NTAG whose capability container was zeroed. format() writes both.
+    val formatable = if (ndef == null) NdefFormatable.get(tag) else null
 
-            ndef.maxSize < message.byteArrayLength -> {
-                Logger.w { "NDEF tag too small: ${ndef.maxSize} < ${message.byteArrayLength}" }
-                false
-            }
+    return when {
+        ndef != null -> writeToNdef(ndef, message)
 
-            else -> {
-                ndef.writeNdefMessage(message)
-                true
-            }
+        formatable != null -> formatAndWrite(formatable, message)
+
+        else -> {
+            Logger.w { "Tag supports neither NDEF nor NDEF formatting" }
+            false
         }
+    }
+}
+
+private fun writeToNdef(ndef: Ndef, message: NdefMessage): Boolean = withTag(ndef) {
+    when {
+        !ndef.isWritable -> {
+            Logger.w { "NDEF tag is read-only" }
+            false
+        }
+
+        ndef.maxSize < message.byteArrayLength -> {
+            Logger.w { "NDEF tag too small: ${ndef.maxSize} < ${message.byteArrayLength}" }
+            false
+        }
+
+        else -> {
+            ndef.writeNdefMessage(message)
+            true
+        }
+    }
+}
+
+private fun formatAndWrite(formatable: NdefFormatable, message: NdefMessage): Boolean = withTag(formatable) {
+    // format() lays down the capability container and the NDEF message in one pass; a tag too
+    // small for the message fails here as IOException, so there is no maxSize to check first.
+    formatable.format(message)
+    Logger.i { "Formatted unformatted tag and wrote NDEF" }
+    true
+}
+
+/** Connects [tech], runs [block], and always closes. Reports every failure mode as `false`. */
+private inline fun withTag(tech: TagTechnology, block: () -> Boolean): Boolean = try {
+    tech.connect()
+    block()
+} catch (e: IOException) {
+    Logger.w(e) { "Error writing NDEF tag" }
+    false
+} catch (e: FormatException) {
+    Logger.w(e) { "Malformed NDEF message" }
+    false
+} finally {
+    try {
+        tech.close()
     } catch (e: IOException) {
-        Logger.w(e) { "Error writing NDEF tag" }
-        false
-    } catch (e: FormatException) {
-        Logger.w(e) { "Malformed NDEF message" }
-        false
-    } finally {
-        try {
-            ndef.close()
-        } catch (e: IOException) {
-            Logger.w(e) { "Error closing NDEF" }
-        }
+        Logger.w(e) { "Error closing NDEF" }
     }
 }
 

--- a/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/NfcScanner.kt
+++ b/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/NfcScanner.kt
@@ -161,33 +161,38 @@ private inline fun withTag(tech: TagTechnology, block: () -> Boolean): Boolean =
 } catch (e: FormatException) {
     Logger.w(e) { "Malformed NDEF message" }
     false
+} catch (e: SecurityException) {
+    // The framework invalidates a Tag handle once the tag leaves the field, and every call here
+    // then throws this rather than IOException. Letting it escape strands the caller's armed-write
+    // UI with no result, so it reports as an ordinary write failure.
+    Logger.w(e) { "Tag went out of range before the write completed" }
+    false
 } finally {
-    try {
-        tech.close()
-    } catch (e: IOException) {
-        Logger.w(e) { "Error closing NDEF" }
-    }
+    closeQuietly(tech)
 }
 
 private fun handleNfcTag(tag: Tag, onResult: (String?) -> Unit) {
     val ndef = Ndef.get(tag) ?: return
     try {
         ndef.connect()
-        val ndefMessage = ndef.ndefMessage ?: return
-        for (record in ndefMessage.records) {
-            val payload = record.toUri()?.toString()
-            if (payload != null) {
-                onResult(payload)
-                break
-            }
-        }
+        ndef.ndefMessage?.records?.firstNotNullOfOrNull { it.toUri()?.toString() }?.let(onResult)
     } catch (e: IOException) {
         Logger.w(e) { "Error reading NDEF tag" }
+    } catch (e: SecurityException) {
+        // Runs on a binder thread, so an escaping exception takes the process with it.
+        Logger.w(e) { "Tag went out of range before the read completed" }
     } finally {
-        try {
-            ndef.close()
-        } catch (e: IOException) {
-            Logger.w(e) { "Error closing NDEF" }
-        }
+        closeQuietly(ndef)
+    }
+}
+
+/** Closes [tech], swallowing the failures a stale tag handle produces. */
+private fun closeQuietly(tech: TagTechnology) {
+    try {
+        tech.close()
+    } catch (e: IOException) {
+        Logger.w(e) { "Error closing NDEF" }
+    } catch (e: SecurityException) {
+        Logger.w(e) { "Tag already gone when closing NDEF" }
     }
 }


### PR DESCRIPTION
Writing a share link to a blank NFC tag failed, and the error told the user to go and find the exact kind of tag that had just failed.

`Ndef.get(tag)` returns null for a tag with no valid capability container, so `writeNdefUrl` gave up immediately and the dialog reported *"Couldn't write to tag. Use a writable, empty NFC tag and hold it steady."* Blank Ultralight and Classic tags land here, as does any NTAG whose CC has been zeroed. Android already tells us these are writable: it puts `NdefFormatable` in the tech list and reports `is formattable=1`.

### 🐛 Bug Fixes

- Fall back to `NdefFormatable.format()` when `Ndef.get()` returns null. `format()` lays down the capability container and the first message in one pass, so a never-formatted tag now takes a share link.
- The format path logs its own line, so the two cases are distinguishable in a bug report rather than both surfacing as one generic failure.

### 🛠️ Refactoring & Architecture

- `writeNdefUrl` splits into `writeToNdef` and `formatAndWrite` over a shared `withTag` helper that connects, runs, and always closes. Previously the connect/close bracket was inline and would have had to be duplicated for the second technology.

## Testing Performed

Bench: Pixel 6a (Android 17), Flipper Zero emulating an NTAG216.

Reproduced against a tag with the CC zeroed. Android reports:

```
NfcDispatcher: dispatchTag: TAG: Tech [NfcA, MifareUltralight, NdefFormatable]
libnfc_nci: nativeNfcTag_doIsNdefFormatable: is formattable=1
libnfc_nci: RW_T2tLocateTlv: Invalid NDEF Magic Number!, CC[0]=0x00, CC[1]=0x00, CC[3]=0x00
```

No `Ndef` in the tech list, and 2.8.2 shows the misleading failure message above.

Control, same rig with a valid CC: writes fine, dialog reports "Written to tag". So the emulated tag does accept writes.

With this change the new path is reached, confirmed by stack trace:

```
java.io.IOException
  at android.nfc.tech.NdefFormatable.format(NdefFormatable.java:136)
  at org.meshtastic.core.nfc.NfcScannerKt.formatAndWrite(NfcScanner.kt:140)
  at org.meshtastic.core.nfc.NfcScannerKt.writeNdefUrl(NfcScanner.kt:113)
```

**`format()` succeeding is not bench-verified, and reviewers should know that.** It fails against this rig with `NFA_FORMAT_CPLT_EVT: status=0x3` 10 ms after `nativeNfcTag_doNdefFormat: enter`, with no write traffic on the wire, which is the stack refusing at its own precondition rather than a rejected write. With the CC zeroed the stack sizes the tag at `max_size = 46`, the static-memory fallback, instead of the 868 it reports when the CC is present, so it never identified the emulated chip. The likely cause is the Flipper's emulation not answering `GET_VERSION`; that specific cause is unproven. Confirming the success path needs a physical blank NTAG or Ultralight, which the bench does not currently have.

Baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` all pass.

No user-facing docs change. `docs/en/user/nodes.md` describes writing to "a writable NFC tag" and does not document the limitation being removed, so it stays accurate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - NFC URL writing now supports previously unformatted NFC tags by formatting them automatically before writing.

- **Bug Fixes**
  - Improved NFC tag connection cleanup and error handling to prevent failures from leaving tag connections open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->