### PR TITLE
feat(nfc): share a contact or channel by tapping phones, no tag needed

### DIFF
--- a/.skills/compose-ui/strings-index.txt
+++ b/.skills/compose-ui/strings-index.txt
@@ -533,6 +533,9 @@ doc_keywords_telemetry
 doc_keywords_translate
 doc_keywords_units
 doc_keywords_widget
+doc_loading
+doc_no_documentation
+doc_no_results
 doc_search_placeholder
 doc_section_developer
 doc_section_user
@@ -1713,6 +1716,7 @@ set_your_region
 settings
 ### SHARE ###
 share
+share_by_tap_subtext
 share_channels_qr
 share_connected_node
 share_contact

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -93,6 +93,10 @@
         android:name="android.hardware.nfc"
         android:required="false" />
 
+    <uses-feature
+        android:name="android.hardware.nfc.hce"
+        android:required="false" />
+
     <!-- for USB serial access -->
     <uses-feature
         android:name="android.hardware.usb.host"
@@ -179,6 +183,24 @@
         <meta-data
             android:name="google_analytics_default_allow_analytics_storage"
             android:value="false" />
+
+        <!--
+             Presents the armed share URL as an NFC Forum Type 4 Tag, so another phone can take a
+             contact or channel by tapping this one. Serves nothing unless a share dialog has armed
+             it. BIND_NFC_SERVICE is the system-only permission that makes exported="true" safe.
+        -->
+        <service
+            android:name="org.meshtastic.core.nfc.MeshtasticHostApduService"
+            android:exported="true"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/nfc_apduservice" />
+        </service>
 
         <!-- In-app mesh foreground service -->
         <service

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
@@ -19,6 +19,7 @@ package org.meshtastic.app
 import android.app.PendingIntent
 import android.app.TaskStackBuilder
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Color
 import android.hardware.usb.UsbManager
 import android.net.Uri
@@ -59,6 +60,7 @@ import org.meshtastic.app.ui.MainScreen
 import org.meshtastic.core.barcode.rememberBarcodeScanner
 import org.meshtastic.core.navigation.DEEP_LINK_BASE_URI
 import org.meshtastic.core.network.repository.UsbRepository
+import org.meshtastic.core.nfc.NfcEmulatorEffect
 import org.meshtastic.core.nfc.NfcScannerEffect
 import org.meshtastic.core.nfc.NfcWriterEffect
 import org.meshtastic.core.resources.Res
@@ -81,6 +83,8 @@ import org.meshtastic.core.ui.util.LocalEventBranding
 import org.meshtastic.core.ui.util.LocalInlineMapProvider
 import org.meshtastic.core.ui.util.LocalMapMainScreenProvider
 import org.meshtastic.core.ui.util.LocalMapViewProvider
+import org.meshtastic.core.ui.util.LocalNfcEmulationSupported
+import org.meshtastic.core.ui.util.LocalNfcEmulatorProvider
 import org.meshtastic.core.ui.util.LocalNfcScannerProvider
 import org.meshtastic.core.ui.util.LocalNfcScannerSupported
 import org.meshtastic.core.ui.util.LocalNfcWriterProvider
@@ -224,6 +228,9 @@ class MainActivity : AppCompatActivity() {
             LocalNfcWriterProvider provides { url, onResult, onDisabled -> NfcWriterEffect(url, onResult, onDisabled) },
             LocalBarcodeScannerSupported provides true,
             LocalNfcScannerSupported provides true,
+            LocalNfcEmulatorProvider provides { url -> NfcEmulatorEffect(url) },
+            LocalNfcEmulationSupported provides
+                packageManager.hasSystemFeature(PackageManager.FEATURE_NFC_HOST_CARD_EMULATION),
             LocalAnalyticsIntroProvider provides { AnalyticsIntro() },
             LocalMapViewProvider provides getMapViewProvider(),
             LocalSitePlannerAvailable provides true,

--- a/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
+++ b/androidApp/src/main/kotlin/org/meshtastic/app/MainActivity.kt
@@ -42,7 +42,9 @@ import androidx.compose.runtime.remember
 import androidx.core.content.IntentCompat
 import androidx.core.net.toUri
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.currentStateAsState
 import androidx.lifecycle.lifecycleScope
 import co.touchlab.kermit.Logger
 import com.eygraber.uri.toKmpUri
@@ -228,7 +230,15 @@ class MainActivity : AppCompatActivity() {
             LocalNfcWriterProvider provides { url, onResult, onDisabled -> NfcWriterEffect(url, onResult, onDisabled) },
             LocalBarcodeScannerSupported provides true,
             LocalNfcScannerSupported provides true,
-            LocalNfcEmulatorProvider provides { url -> NfcEmulatorEffect(url) },
+            // Arm card emulation only while the app is actually in the foreground. A share dialog left open behind a
+            // home-press stays composed, and a channel URL carries the channel PSK. This reads the activity's own
+            // lifecycle, not LocalLifecycleOwner: the effect is composed inside a Dialog, whose own lifecycle stays
+            // RESUMED when the activity is backgrounded.
+            LocalNfcEmulatorProvider provides
+                { url ->
+                    val lifecycleState by lifecycle.currentStateAsState()
+                    if (lifecycleState.isAtLeast(Lifecycle.State.RESUMED)) NfcEmulatorEffect(url)
+                },
             LocalNfcEmulationSupported provides
                 packageManager.hasSystemFeature(PackageManager.FEATURE_NFC_HOST_CARD_EMULATION),
             LocalAnalyticsIntroProvider provides { AnalyticsIntro() },

--- a/androidApp/src/main/res/xml/nfc_apduservice.xml
+++ b/androidApp/src/main/res/xml/nfc_apduservice.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2025 Meshtastic LLC
+  ~ Copyright (c) 2026 Meshtastic LLC
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -15,8 +15,14 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
-<resources>
-    <string name="app_name">Meshtastic</string>
-    <string name="app_description">Off-grid mesh networking for secure, long-range communications via LoRa radio.</string>
-    <string name="nfc_tag_emulation_service">Meshtastic contact and channel sharing</string>
-</resources>
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/nfc_tag_emulation_service"
+    android:requireDeviceUnlock="true">
+
+    <!-- The NFC Forum NDEF Tag Application. Readers select this AID to read any Type 4 tag. -->
+    <aid-group
+        android:category="other"
+        android:description="@string/nfc_tag_emulation_service">
+        <aid-filter android:name="D2760000850101" />
+    </aid-group>
+</host-apdu-service>

--- a/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/MeshtasticHostApduService.kt
+++ b/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/MeshtasticHostApduService.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.nfc
+
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+import co.touchlab.kermit.Logger
+
+/**
+ * Presents the armed share URL as an NFC Forum Type 4 Tag, so a reader - another phone, a Flipper, any NDEF reader -
+ * can take a contact or channel by tapping this phone, with no physical tag.
+ *
+ * Read-only by construction: the capability container advertises no write access and no write command is answered.
+ * Serves nothing unless [NfcTagEmulation] is armed, so an idle phone presents no tag at all.
+ *
+ * Implements only what a Type 4 read needs: SELECT application, SELECT file, READ BINARY.
+ */
+class MeshtasticHostApduService : HostApduService() {
+
+    private var selectedFile = FILE_NONE
+
+    override fun processCommandApdu(commandApdu: ByteArray?, extras: Bundle?): ByteArray {
+        val ndef = NfcTagEmulation.armedNdefMessage()
+        // Unarmed, every command is refused, so a reader sees no tag rather than an empty one.
+        return if (commandApdu == null || ndef == null) SW_FILE_NOT_FOUND else dispatch(commandApdu, ndef)
+    }
+
+    override fun onDeactivated(reason: Int) {
+        // The next reader starts unselected; without this a second tap could read whatever file
+        // the previous one left selected.
+        selectedFile = FILE_NONE
+    }
+
+    private fun dispatch(apdu: ByteArray, ndef: ByteArray): ByteArray = when {
+        apdu.contentEquals(SELECT_APPLICATION) -> {
+            selectedFile = FILE_NONE
+            SW_OK
+        }
+
+        isSelectFile(apdu) -> selectFile(apdu)
+
+        isReadBinary(apdu) -> readBinary(apdu, ndef)
+
+        else -> SW_INS_NOT_SUPPORTED
+    }
+
+    private fun isSelectFile(apdu: ByteArray) = apdu.size == SELECT_FILE_LENGTH &&
+        apdu[OFFSET_CLA] == CLA_ISO &&
+        apdu[OFFSET_INS] == INS_SELECT &&
+        apdu[OFFSET_P1] == SELECT_BY_FILE_ID &&
+        apdu[OFFSET_P2] == SELECT_FIRST_OCCURRENCE
+
+    private fun isReadBinary(apdu: ByteArray) =
+        apdu.size >= READ_BINARY_LENGTH && apdu[OFFSET_CLA] == CLA_ISO && apdu[OFFSET_INS] == INS_READ_BINARY
+
+    private fun selectFile(apdu: ByteArray): ByteArray {
+        val fileId = twoByteValue(apdu, SELECT_FILE_ID_OFFSET)
+        return if (fileId == FILE_CAPABILITY_CONTAINER || fileId == FILE_NDEF) {
+            selectedFile = fileId
+            SW_OK
+        } else {
+            Logger.w { "Reader selected unknown file 0x${fileId.toString(HEX_RADIX)}" }
+            SW_FILE_NOT_FOUND
+        }
+    }
+
+    private fun readBinary(apdu: ByteArray, ndef: ByteArray): ByteArray {
+        val content =
+            when (selectedFile) {
+                FILE_CAPABILITY_CONTAINER -> CAPABILITY_CONTAINER
+                FILE_NDEF -> ndefFile(ndef)
+                else -> null
+            }
+        val offset = twoByteValue(apdu, OFFSET_P1)
+        // Le == 0 means "as much as you can", which for a short APDU is 256 bytes.
+        val requested = (apdu[OFFSET_LE].toInt() and BYTE_MASK).let { if (it == 0) MAX_SHORT_LE else it }
+
+        return when {
+            content == null -> SW_FILE_NOT_FOUND
+            offset > content.size -> SW_WRONG_PARAMETERS
+            else -> content.copyOfRange(offset, minOf(offset + requested, content.size)) + SW_OK
+        }
+    }
+
+    /**
+     * The NDEF file as a reader sees it: a two-byte big-endian length, then the message. A message too large for what
+     * [CAPABILITY_CONTAINER] advertises is served as empty rather than truncated, since a truncated NDEF message is
+     * worse than none.
+     */
+    private fun ndefFile(ndef: ByteArray): ByteArray {
+        val body =
+            if (ndef.size > MAX_NDEF_FILE_SIZE - NLEN_SIZE) {
+                Logger.w { "Armed NDEF message too large to emulate: ${ndef.size} bytes" }
+                ByteArray(0)
+            } else {
+                ndef
+            }
+        val nlen = byteArrayOf((body.size shr BITS_PER_BYTE and BYTE_MASK).toByte(), (body.size and BYTE_MASK).toByte())
+        return nlen + body
+    }
+
+    private fun twoByteValue(apdu: ByteArray, offset: Int): Int =
+        (apdu[offset].toInt() and BYTE_MASK shl BITS_PER_BYTE) or (apdu[offset + 1].toInt() and BYTE_MASK)
+
+    private companion object {
+        fun hex(spaced: String): ByteArray =
+            spaced.filterNot(Char::isWhitespace).chunked(2).map { it.toInt(HEX_RADIX).toByte() }.toByteArray()
+
+        val SW_OK = hex("90 00")
+        val SW_FILE_NOT_FOUND = hex("6A 82")
+        val SW_WRONG_PARAMETERS = hex("6B 00")
+        val SW_INS_NOT_SUPPORTED = hex("6D 00")
+
+        /** SELECT (by name) of the NFC Forum NDEF Tag Application, AID D2760000850101. */
+        val SELECT_APPLICATION = hex("00 A4 04 00 07 D2 76 00 00 85 01 01 00")
+
+        /**
+         * CCLEN 000F, mapping version 2.0, MLe 00FF, MLc 0034, then the NDEF File Control TLV: type 04, length 06, file
+         * id E104, max size 0400, read access free, write access none. MLe is the largest response a reader may ask for
+         * in one READ BINARY; 255 keeps a share URL to a single exchange.
+         */
+        val CAPABILITY_CONTAINER = hex("000F 20 00FF 0034 04 06 E104 0400 00 FF")
+
+        const val CLA_ISO: Byte = 0x00
+        const val INS_SELECT: Byte = 0xA4.toByte()
+        const val INS_READ_BINARY: Byte = 0xB0.toByte()
+        const val SELECT_BY_FILE_ID: Byte = 0x00
+        const val SELECT_FIRST_OCCURRENCE: Byte = 0x0C
+
+        const val OFFSET_CLA = 0
+        const val OFFSET_INS = 1
+        const val OFFSET_P1 = 2
+        const val OFFSET_P2 = 3
+        const val OFFSET_LE = 4
+        const val SELECT_FILE_ID_OFFSET = 5
+
+        const val SELECT_FILE_LENGTH = 7
+        const val READ_BINARY_LENGTH = 5
+
+        const val FILE_NONE = -1
+        const val FILE_CAPABILITY_CONTAINER = 0xE103
+        const val FILE_NDEF = 0xE104
+
+        const val MAX_NDEF_FILE_SIZE = 1024
+        const val NLEN_SIZE = 2
+        const val MAX_SHORT_LE = 256
+
+        const val BYTE_MASK = 0xFF
+        const val BITS_PER_BYTE = 8
+        const val HEX_RADIX = 16
+    }
+}

--- a/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/NfcTagEmulation.kt
+++ b/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/NfcTagEmulation.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.meshtastic.core.nfc
+
+import android.nfc.NdefMessage
+import android.nfc.NdefRecord
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+
+/**
+ * The share URL this phone is currently offering to NFC readers, as an encoded NDEF message.
+ *
+ * Card emulation is served by the system, in a service this app does not own the lifetime of, so the armed payload
+ * lives here rather than in the service. Nothing is offered unless a share surface has armed it: a reader that taps an
+ * unarmed phone gets no tag at all. Channel URLs carry channel PSKs, so "armed only while the share dialog is open" is
+ * the privacy boundary, the same exposure as the QR code being on screen.
+ */
+object NfcTagEmulation {
+
+    @Volatile private var armed: ByteArray? = null
+
+    /** The encoded NDEF message to serve, or null when nothing is armed. */
+    fun armedNdefMessage(): ByteArray? = armed
+
+    fun arm(url: String) {
+        armed = NdefMessage(NdefRecord.createUri(url)).toByteArray()
+    }
+
+    fun disarm() {
+        armed = null
+    }
+}
+
+/**
+ * Offers [url] to NFC readers for as long as this stays composed. Mirrors [NfcWriterEffect]: keep it composed while the
+ * share surface is open, dispose to stop offering it.
+ */
+@Composable
+fun NfcEmulatorEffect(url: String) {
+    DisposableEffect(url) {
+        NfcTagEmulation.arm(url)
+        onDispose { NfcTagEmulation.disarm() }
+    }
+}

--- a/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/NfcTagEmulation.kt
+++ b/core/nfc/src/androidMain/kotlin/org/meshtastic/core/nfc/NfcTagEmulation.kt
@@ -46,8 +46,11 @@ object NfcTagEmulation {
 }
 
 /**
- * Offers [url] to NFC readers for as long as this stays composed. Mirrors [NfcWriterEffect]: keep it composed while the
- * share surface is open, dispose to stop offering it.
+ * Offers [url] to NFC readers for as long as this effect stays composed.
+ *
+ * The effect does not police the foreground itself. Callers compose it only while the share surface is actually on
+ * screen and resumed; `MainActivity` holds that gate, because a dialog left open behind a home-press stays composed and
+ * arming through that would offer a channel PSK to any reader while the phone sits in a pocket.
  */
 @Composable
 fun NfcEmulatorEffect(url: String) {

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1767,6 +1767,7 @@
     <string name="settings">settings</string>
     <!-- SHARE -->
     <string name="share">Share</string>
+    <string name="share_by_tap_subtext">While this is open, another phone can take this by tapping yours. No tag needed.</string>
     <string name="share_channels_qr">Share Channels QR Code</string>
     <string name="share_connected_node">Share Connected Node</string>
     <string name="share_contact">Share Contact</string>

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/QrDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/component/QrDialog.kt
@@ -50,6 +50,7 @@ import org.meshtastic.core.resources.cancel
 import org.meshtastic.core.resources.copy
 import org.meshtastic.core.resources.okay
 import org.meshtastic.core.resources.qr_code
+import org.meshtastic.core.resources.share_by_tap_subtext
 import org.meshtastic.core.resources.write_nfc
 import org.meshtastic.core.resources.write_nfc_failed
 import org.meshtastic.core.resources.write_nfc_subtext
@@ -59,6 +60,8 @@ import org.meshtastic.core.ui.icon.Copy
 import org.meshtastic.core.ui.icon.MeshtasticIcons
 import org.meshtastic.core.ui.icon.Nfc
 import org.meshtastic.core.ui.theme.SemanticColors
+import org.meshtastic.core.ui.util.LocalNfcEmulationSupported
+import org.meshtastic.core.ui.util.LocalNfcEmulatorProvider
 import org.meshtastic.core.ui.util.LocalNfcScannerSupported
 import org.meshtastic.core.ui.util.LocalNfcWriterProvider
 import org.meshtastic.core.ui.util.SetScreenBrightness
@@ -77,11 +80,20 @@ fun QrDialog(title: String, uriString: String, onDismiss: () -> Unit) {
 
     val nfcSupported = LocalNfcScannerSupported.current
     val nfcWriter = LocalNfcWriterProvider.current
+    val hceSupported = LocalNfcEmulationSupported.current
+    val nfcEmulator = LocalNfcEmulatorProvider.current
     var isWritingNfc by rememberSaveable { mutableStateOf(false) }
     var showNfcDisabled by rememberSaveable { mutableStateOf(false) }
     var writeSucceeded by rememberSaveable { mutableStateOf<Boolean?>(null) }
 
     SetScreenBrightness(1f)
+
+    // Offer the same URL to readers for as long as this dialog is up. The exposure matches the
+    // QR already on screen, and arming ends with the dialog. An armed write takes the radio into
+    // reader mode, which suspends card emulation, so the two never contend.
+    if (hceSupported) {
+        nfcEmulator(uriString)
+    }
 
     if (isWritingNfc) {
         nfcWriter(
@@ -161,6 +173,15 @@ fun QrDialog(title: String, uriString: String, onDismiss: () -> Unit) {
                     ) {
                         Icon(imageVector = MeshtasticIcons.Copy, contentDescription = stringResource(Res.string.copy))
                     }
+                }
+
+                if (hceSupported) {
+                    Text(
+                        text = stringResource(Res.string.share_by_tap_subtext),
+                        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
 
                 if (nfcSupported) {

--- a/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/LocalNfcScannerProvider.kt
+++ b/core/ui/src/commonMain/kotlin/org/meshtastic/core/ui/util/LocalNfcScannerProvider.kt
@@ -28,3 +28,11 @@ val LocalNfcWriterProvider =
     compositionLocalOf<@Composable (url: String, onResult: (Boolean) -> Unit, onNfcDisabled: () -> Unit) -> Unit> {
         { _, _, _ -> }
     }
+
+/** Offers a share URL to NFC readers for as long as the composable stays composed. */
+@Suppress("CompositionLocalAllowlist")
+val LocalNfcEmulatorProvider = compositionLocalOf<@Composable (url: String) -> Unit> { {} }
+
+/** True where the platform can emulate an NFC tag (Android host card emulation). */
+@Suppress("CompositionLocalAllowlist")
+val LocalNfcEmulationSupported = compositionLocalOf { false }

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -2,7 +2,7 @@
 title: Nodes
 parent: User Guide
 nav_order: 4
-last_updated: 2026-09-09
+last_updated: 2026-09-10
 description: Browse, filter, and sort mesh nodes — view details, signal quality, roles, and quick actions.
 aliases:
   - node-list
@@ -106,7 +106,7 @@ radio is connected and running firmware 2.8 or newer — see
 
 ## Sharing a Contact
 
-On a node's detail screen, tap **Share Contact** to produce a link and a QR code for that node. From the same dialog, **Write to NFC tag** saves the link to a writable NFC tag that anyone can tap to open.
+On a node's detail screen, tap **Share Contact** to produce a link and a QR code for that node. From the same dialog, **Write to NFC tag** saves the link to a writable NFC tag that anyone can tap to open. While that dialog is open the phone also offers the same link to any NFC reader, so someone can take the contact by tapping their phone against yours with no tag involved.
 
 To add someone else's contact, use the import button on the node list and choose **Scan Shared Contact QR Code**, **Scan Shared Contact NFC**, or **Input Shared Contact URL**. The app asks you to confirm with **Import Shared Contact?**, and warns you when the contact is one you already have.
 


### PR DESCRIPTION
The share dialog could write a contact or channel to a physical tag but could not be one. Anyone without a blank tag in their pocket was back to scanning a QR code. This adds host card emulation, so while the share dialog is open the phone answers as an NFC Forum Type 4 Tag serving the same URL the QR encodes, and another phone can take the contact or channel by tapping.

### 🌟 New Features

- `MeshtasticHostApduService`, a Type 4 Tag implementation covering SELECT application, SELECT file, and READ BINARY over the NFC Forum AID `D2760000850101`.
- `NfcTagEmulation` holds the armed payload, and `NfcEmulatorEffect` arms it for as long as it stays composed. `MainActivity` composes it only while the app is RESUMED, so the foreground gate sits with the platform wiring rather than in `core:nfc`. `QrDialog` serves both contact and channel sharing, so both get this from one call site.
- `LocalNfcEmulationSupported` / `LocalNfcEmulatorProvider` follow the existing NFC capability contract. `MainActivity` gates on `FEATURE_NFC_HOST_CARD_EMULATION`, so the affordance is absent on hardware without HCE.

### 🧹 Chores

- One new string, `share_by_tap_subtext`, explaining what the open dialog is doing in plain language.
- `docs/en/user/nodes.md` updated, `last_updated` bumped.
- `.skills/compose-ui/strings-index.txt` regenerated by `scripts/sort-strings.py`. It also picks up `doc_loading`, `doc_no_documentation` and `doc_no_results`, which had drifted out of the index before this branch.

## Security and privacy

Read-only by construction. The capability container advertises no write access and no write command is answered.

Nothing is served unless a share surface has armed it: unarmed, every command including SELECT AID is answered `6A82`, so an idle phone presents no tag rather than an empty one. Channel URLs carry channel PSKs, and the exposure is deliberately the same as the QR code being on screen.

Arming is gated on RESUME, not on composition alone. A dialog left open behind a home-press stays composed, and the first version of this branch went on serving the PSK from a pocket, which is not what the dialog copy promises. `requireDeviceUnlock` covered the lock screen but not backgrounded-and-unlocked. Caught in review by CodeRabbit.

The gate lives in `MainActivity`, in the `LocalNfcEmulatorProvider` lambda. It was briefly a `LifecycleResumeEffect` inside `core:nfc`, which meant adding `lifecycle-runtime-compose` to that module. Moving it up to the provider puts the policy next to the rest of the NFC wiring, keeps `QrDialog` unaware of lifecycle, and leaves this branch touching no build script at all. `core:nfc` keeps serving whatever payload it is handed.

I first moved it to fix the `lint-check` timeout on this PR, and said so here. That was wrong and I am correcting it: removing the dependency did not fix the job. The cause is repo-wide, not this diff. `lint-check` has a 30-minute cap and `kmpSmokeCompile` recompiles every module for iOS and JVM; PR runs read the remote Gradle cache but never write it, so any change to a low-level module recompiles cold, and the runner's JVM ceilings (`-Xmx8g` Gradle plus `-Xmx4g` Kotlin daemon on a 16 GB box) leave no headroom when both peak together. It dies as `OutOfMemoryError: GC overhead limit exceeded` in Kotlin FIR resolution, landing as either a failure or a cancel at the cap.

Three unrelated branches hit it on 2026-09-10: `feat/node-security-indicators` failed at 24m45s (OOM in `:androidApp:lintAnalyzeGoogleDebug`), `chore/koin-compile-safety` cancelled at 30m16s, and this branch cancelled twice at 30m19s then failed at 27m36s (OOM in `:feature:node:compileKotlinIosSimulatorArm64`). The refactor is still the right shape, but it does not unblock this PR and I should not have claimed it would.

The reader side needed no change. An armed write puts the radio into reader mode, which suspends card emulation, so writing and emulating never contend.

MLe is advertised as 255 rather than the 59 a minimal tag may claim. A channel set is 218 bytes of NDEF, measured off a tag this app wrote, so 59 would cost a compliant reader four exchanges for one share URL.

Android only. iOS has no third-party tag emulation.

## Testing Performed

Bench: Pixel 6a (Android 17) emulating, Flipper Zero and a Pixel 9 Pro (Android 17) reading.

**AID registration accepted.** `dumpsys nfc` lists the service as `*DEFAULT*` owner:

```
ApduService: ComponentInfo{...core.nfc.MeshtasticHostApduService}, description: Meshtastic
contact and channel sharing, Static AID Groups: Category: other, AIDs:D2760000850101
```

**Full Type 4 read from an independent reader** (Flipper `nfc apdu -p 4a`):

```
Tx: 00 A4 04 00 07 D2 76 00 00 85 01 01 00   Rx: 90 00
Tx: 00 A4 00 0C 02 E1 03                     Rx: 90 00
Tx: 00 B0 00 00 0F                           Rx: 00 0F 20 00 FF 00 34 04 06 E1 04 04 00 00 FF 90 00
Tx: 00 A4 00 0C 02 E1 04                     Rx: 90 00
Tx: 00 B0 00 00 02                           Rx: 00 53 90 00
Tx: 00 B0 00 02 60                           Rx: D1 01 4F 55 04 6D 65 73 68 74 ... 90 00
```

The decoded URI record is byte-equal to the URL displayed in the dialog.

**Unarmed gate.** Same probe with the dialog closed returns `6A 82` to every command, SELECT AID included.

The backgrounded case (dialog open, app sent to the background) is not yet bench-verified against the lifecycle fix; it is the same probe and will be added here once run.

**Phone to phone.** The Pixel 9 Pro's own NFC stack reads it:

```
NfcDispatcher: dispatchTag: TAG: Tech [IsoDep, NfcA, Ndef]
  message: NdefMessage [NdefRecord tnf=1 type=55 payload=046D6573687461737469632E6F72672F762F23...]
```

`Ndef` in the tech list means Android walked the whole Type 4 mapping itself and produced a parsed message, not just a card detection. Decoded payload is again byte-equal to the URL on screen.

Not covered: channel sharing over emulation was not run separately. It is the same `QrDialog` and the same effect, differing only in payload length, but the channel screen needs a connected radio and this was not exercised.

Baseline: `spotlessApply spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile` all pass.

## Screenshots

<!--
Share dialog with the new subtext. Drag the PNG in here.
<img src="" width="300"/>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added NFC “tap to share” support for contacts and channels on compatible Android devices.
  - Share dialogs now explain when content can be received by tapping another phone, without requiring a physical NFC tag.
  - Added user-facing messages for documentation loading and empty results.

- **Documentation**
  - Updated contact-sharing guidance to include sharing directly with nearby NFC readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


