### PR TITLE
build: give the K/N compiler and lint worker enough heap for a cold CI build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 # --- Android build features ---
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+# Lint analysis runs in its own worker, so neither org.gradle.jvmargs nor
+# kotlin.daemon.jvm.options applies to it. The default heap OOMs on a cold analysis.
+android.experimental.lint.heapSize=3G
 
 # --- Compose ---
 android.experimental.enableScreenshotTest=true
@@ -12,6 +15,9 @@ enableComposeCompilerReports=false
 kotlin.code.style=official
 kotlin.daemon.jvm.options=-Xmx4g -XX\:+UseG1GC -XX\:SoftRefLRUPolicyMSPerMB=1 -XX\:ReservedCodeCacheSize=320m -XX\:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallback=false
+# The Kotlin/Native compiler runs in its own JVM, governed by neither of the heaps
+# above. Its 3g default OOMs compiling every module for iOS from a cold cache.
+kotlin.native.jvmArgs=-Xmx5g -XX\:+UseG1GC -XX\:+HeapDumpOnOutOfMemoryError
 
 # --- KSP ---
 # (incremental processing is default-on in KSP2; only the non-default flag is declared)


### PR DESCRIPTION
`lint-check` has been failing on PRs in two shapes that look unrelated and are not: `OutOfMemoryError: GC overhead limit exceeded`, or a cancel at the 30-minute timeout when it grinds instead of dying. Same cost, two exits.

Three branches hit it on 2026-09-10 alone:

| branch | lint-check | time |
|---|---|---|
| feat/node-security-indicators | failure, OOM in `:androidApp:lintAnalyzeGoogleDebug` | 24m45s |
| chore/koin-compile-safety | cancelled | 30m16s |
| feat/nfc-hce-share (#7124) | one pass, then cancelled x2, failure, failure, cancelled | 18m46s then 20-30m |

## What is actually running out of memory

`GC overhead limit exceeded` is one JVM hitting its own `-Xmx`, not the box running out of RAM. The two tasks that die take their heap from neither of the settings we already tune:

- `:feature:*:compileKotlinIosSimulatorArm64` dies in Kotlin FIR resolution. Kotlin/Native forks its own compiler JVM, governed by `kotlin.native.jvmArgs`, which we do not set. Its default is `-Xmx3g`.
- `:androidApp:lintAnalyzeGoogleDebug` dies in the Kotlin Analysis API, in AGP's lint worker, which has its own heap.

`org.gradle.jvmargs=-Xmx8g` governs neither. That is why this looks like flake: nothing we had configured was the constraint.

## Why it bites PRs and not main

Remote build cache writes are gated to `push` and `merge_group` (`MeshtasticDevelocitySettingsPlugin.kt:69`), and the Actions-side Gradle home cache is read-only unless the ref is `main` (`reusable-check.yml:50`). A PR warms neither layer, so any change to a low-level module recompiles the world. `kmpSmokeCompile` then builds every module for `iosSimulatorArm64` and `jvm` on a 3g compiler heap inside a 30-minute cap. `main` passes because it writes both caches.

## The change

Two lines in `gradle.properties`:

- `kotlin.native.jvmArgs=-Xmx5g ...` (was the 3g default)
- `android.experimental.lint.heapSize=3G`

Neither number is tuned. They are raised past where it was observed failing, nothing more. `org.gradle.jvmargs` is deliberately untouched: the Gradle daemon never OOMed, and lowering it would not hand heap to a process that does not draw from it.

`-Xmx` is a ceiling, not a reservation, so this does not commit the 16 GB runner to 8+5+3.

## Testing Performed

Local baseline on this branch passes: `spotlessCheck detekt assembleDebug test allTests kmpSmokeCompile androidApp:lintFdroidDebug`.

AGP parses the lint property rather than ignoring it, confirmed by its own warning:

```
WARNING: The option setting 'android.experimental.lint.heapSize=3G' is experimental.
```

Both property names were read out of the shipped jars rather than from memory: `kotlin.native.jvmArgs` from kotlin-gradle-plugin 2.4.20, `android.experimental.lint.heapSize` from AGP 9.4.0, where it is a `StringOption` and so takes a JVM size string.

**What this PR cannot prove.** A local machine does not reproduce the runner, and this PR's own `lint-check` will run against a small diff, which is the cheap case. The real test is whether #7124 goes green once this lands. If it does not, the next levers are `android.experimental.lint.reservedMemoryPerTask`, capping CI worker parallelism, or raising `timeout-minutes` — though that last one fixes no OOM.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build stability for lint analysis and Kotlin/Native compilation, particularly during clean or cold builds.
  - Reduced the likelihood of build failures caused by insufficient memory during these processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->