### PR TITLE
build: fix the inert Kotlin compile daemon heap property

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -12,10 +12,12 @@
 org.gradle.daemon=false
 
 # ── Memory ────────────────────────────────────────────────────────────
-# Standard GitHub runners have 7 GB RAM. Keep Gradle + Kotlin daemon
-# within budget (4g Gradle + 2g Kotlin daemon + 1g OS/tooling headroom).
+# Public-repo ubuntu-24.04 runners have 16 GB RAM. Keep Gradle + Kotlin daemon
+# within budget (4g Gradle + 6g Kotlin daemon, leaving room for lint and K/N).
+# Only kotlin.daemon.jvmargs is read from a properties file; kotlin.daemon.jvm.options
+# is a system property. Unset, the daemon inherits org.gradle.jvmargs' 4g and OOMs.
 org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
-kotlin.daemon.jvm.options=-Xmx2g -XX:+UseParallelGC
+kotlin.daemon.jvmargs=-Xmx6g -XX:+UseG1GC
 
 # ── Parallelism ───────────────────────────────────────────────────────
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 # Lint analysis runs in its own worker, so neither org.gradle.jvmargs nor
-# kotlin.daemon.jvm.options applies to it. The default heap OOMs on a cold analysis.
+# kotlin.daemon.jvmargs applies to it. The default heap OOMs on a cold analysis.
 android.experimental.lint.heapSize=3G
 
 # --- Compose ---
@@ -13,7 +13,9 @@ enableComposeCompilerReports=false
 
 # --- Kotlin ---
 kotlin.code.style=official
-kotlin.daemon.jvm.options=-Xmx4g -XX\:+UseG1GC -XX\:SoftRefLRUPolicyMSPerMB=1 -XX\:ReservedCodeCacheSize=320m -XX\:+HeapDumpOnOutOfMemoryError
+# Only kotlin.daemon.jvmargs is read from here; kotlin.daemon.jvm.options is a system
+# property. Unset, the daemon inherits org.gradle.jvmargs' 8g and over-commits CI runners.
+kotlin.daemon.jvmargs=-Xmx6g -XX\:+UseG1GC -XX\:SoftRefLRUPolicyMSPerMB=1 -XX\:ReservedCodeCacheSize=320m -XX\:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.useFallback=false
 # The Kotlin/Native compiler runs in its own JVM, governed by neither of the heaps
 # above. Its 3g default OOMs compiling every module for iOS from a cold cache.


### PR DESCRIPTION
The Kotlin compile daemon has never used the heap settings this repo declares for it, and on a 16 GB CI runner that is now costing us builds: `:androidApp:compileGoogleDebugKotlin` dies with `GC overhead limit exceeded` once Koin `compileSafety` validates the whole graph from a cold cache.

`kotlin.daemon.jvm.options` is a **system** property. KGP reads the Gradle property `kotlin.daemon.jvmargs` (`PropertiesProvider.getKotlinDaemonJvmArgs()`), which is also the one its own OOM message tells you to set. So the line in `gradle.properties` was inert, and with `jvmargs` unset the daemon silently inherits `org.gradle.jvmargs` instead.

Verified on a live `KotlinCompileDaemon`:

```
-Xmx8g -XX:MaxMetaspaceSize=2g -XX:ReservedCodeCacheSize=512m
-XX:+UseCodeCacheFlushing -XX:+UseParallelGC
```

That is `org.gradle.jvmargs`, not the intended 4g/G1.

`.github/ci-gradle.properties` is copied over `~/.gradle/gradle.properties`, which outranks the project file, and carried the same inert line. So on CI the daemon inherits **4g**, below what the task needs. Both files are fixed here.

Renaming the property alone would have cut the daemon's real heap from 8g to 4g, so the value moves to 6g at the same time.

### 🐛 Bug Fixes
- Rename `kotlin.daemon.jvm.options` to `kotlin.daemon.jvmargs` in both `gradle.properties` and `.github/ci-gradle.properties`, so the setting is actually applied.
- Set the daemon to `-Xmx6g`, replacing the 4g it inherits on CI and the 8g it inherits locally.
- Correct the stale 7 GB runner budget comment; public-repo `ubuntu-24.04` has 16 GB.

### 🧹 Chores
- Correct the `android.experimental.lint.heapSize` comment, which named the inert property.

### Testing Performed
No test changes; this only affects build JVM configuration.

- `spotlessCheck`, `detekt`, `assembleDebug` all pass locally, with zero `OutOfMemoryError` or `GC overhead limit exceeded` in any build log.
- Confirmed the property is read: requesting a heap larger than any running daemon forces a fork, and the new daemon came up with the exact flags from this line. KGP reuses any daemon whose heap already satisfies the request, which is why a smaller value appears to do nothing.
- Sized from measurement, not guesswork. With GC logging on that task, peak heap is **4.95 GB before GC / 4.34 GB after, with no full GCs**, so 6g holds it with headroom while leaving the runner room for the Gradle daemon.

### Note
This is expected to unblock #7117, but I have not confirmed that on CI yet. The runner-contention reasoning is inferred from the heap arithmetic rather than measured on the runner itself.
