### PR TITLE
docs: catch the user guide up to September and tag every code fence

### DIFF
--- a/docs/en/developer/adding-a-feature-module.md
+++ b/docs/en/developer/adding-a-feature-module.md
@@ -16,7 +16,7 @@ Step-by-step guide for creating a new KMP feature module in the Meshtastic proje
 
 ## Create the Module Directory
 
-```bash
+```shell
 mkdir -p feature/my-feature/src/{commonMain,commonTest,androidMain,jvmMain,iosMain}/kotlin/org/meshtastic/feature/myfeature
 ```
 

--- a/docs/en/developer/architecture.md
+++ b/docs/en/developer/architecture.md
@@ -2,7 +2,7 @@
 title: Architecture
 parent: Developer Guide
 nav_order: 1
-last_updated: 2026-08-29
+last_updated: 2026-09-11
 description: How the Android and Desktop apps split into androidApp/desktopApp, feature modules, and core modules, and how radio control and navigation are layered across them.
 aliases:
   - layers
@@ -17,7 +17,7 @@ The Meshtastic Android and Desktop apps follow a modular Kotlin Multiplatform (K
 
 ## Layer Overview
 
-```
+```text
 ┌─────────────────────────────────────────────┐
 │          androidApp / desktopApp            │  Platform entry points
 ├─────────────────────────────────────────────┤
@@ -105,7 +105,7 @@ Protobuf models come from the external `org.meshtastic:protobufs` Maven artifact
 
 Each module uses the standard KMP source set hierarchy:
 
-```
+```text
 src/
 ├── commonMain/     ← Shared code (all platforms)
 ├── commonTest/     ← Shared tests

--- a/docs/en/developer/codebase.md
+++ b/docs/en/developer/codebase.md
@@ -2,7 +2,7 @@
 title: Codebase
 parent: Developer Guide
 nav_order: 2
-last_updated: 2026-08-29
+last_updated: 2026-09-11
 description: Repository layout, package namespacing, and the Gradle build system — convention plugins, build variants, and key tasks.
 aliases:
   - repository-layout
@@ -16,7 +16,7 @@ Repository layout, namespacing conventions, and build system overview.
 
 ## Repository Structure
 
-```
+```text
 Meshtastic-Android/
 ├── androidApp/                 # Android application module
 │   ├── src/main/           # Shared Android code
@@ -75,7 +75,7 @@ Meshtastic-Android/
 ## Namespacing Convention
 
 All Kotlin packages follow the pattern:
-```
+```text
 org.meshtastic.{layer}.{module}.{subpackage}
 ```
 
@@ -123,7 +123,7 @@ block rather than assuming a plugin does or does not exist.
 
 ### Key Gradle Tasks
 
-```bash
+```shell
 # Compile check across all KMP targets
 ./gradlew kmpSmokeCompile
 

--- a/docs/en/developer/contributing.md
+++ b/docs/en/developer/contributing.md
@@ -2,7 +2,7 @@
 title: Contributing
 parent: Developer Guide
 nav_order: 8
-last_updated: 2026-09-10
+last_updated: 2026-09-11
 description: Branch naming, commit style, PR workflow, and the verification gates a change must pass before merge.
 aliases:
   - contributing
@@ -48,7 +48,7 @@ Examples:
 ## Commit Messages
 
 Follow conventional commit style:
-```
+```text
 feat(docs): add in-app documentation browser
 fix(ble): handle reconnection timeout
 refactor(navigation): migrate to typed routes
@@ -76,7 +76,7 @@ Before submitting:
 - **Line length:** 120 characters maximum
 
 Run formatting:
-```bash
+```shell
 ./gradlew spotlessApply
 ```
 
@@ -91,12 +91,12 @@ Run formatting:
 ## Verification
 
 Full pre-merge verification:
-```bash
+```shell
 ./gradlew spotlessCheck detekt kmpSmokeCompile test allTests
 ```
 
 For docs-specific changes, also run:
-```bash
+```shell
 ./gradlew generateDocsBundle validateDocsBundle
 ```
 

--- a/docs/en/developer/navigation-and-deep-links.md
+++ b/docs/en/developer/navigation-and-deep-links.md
@@ -2,7 +2,7 @@
 title: Navigation & Deep Links
 parent: Developer Guide
 nav_order: 4
-last_updated: 2026-08-29
+last_updated: 2026-09-11
 description: How typed Navigation 3 routes and DeepLinkRouter work together, the supported deep link URIs, and how to add a new one.
 aliases:
   - deeplinks
@@ -144,6 +144,6 @@ These are called from the settings navigation composition.
 ## Testing
 
 Deep link routing is tested in:
-```
+```text
 core/navigation/src/commonTest/kotlin/org/meshtastic/core/navigation/DeepLinkRouterTest.kt
 ```

--- a/docs/en/developer/testing.md
+++ b/docs/en/developer/testing.md
@@ -2,7 +2,7 @@
 title: Testing
 parent: Developer Guide
 nav_order: 7
-last_updated: 2026-08-29
+last_updated: 2026-09-11
 description: Testing strategy for the Meshtastic KMP project — test categories, screenshot pipeline, baseline profiles, and CI integration.
 aliases:
   - tests
@@ -20,7 +20,7 @@ Testing strategy and practices for the Meshtastic KMP project.
 
 Shared tests that run on all platforms:
 
-```bash
+```shell
 ./gradlew allTests
 ```
 
@@ -33,7 +33,7 @@ Shared tests that run on all platforms:
 
 Android-specific tests that run on JVM:
 
-```bash
+```shell
 ./gradlew test
 ```
 
@@ -62,7 +62,7 @@ Uses Android Gradle Plugin's native (layoutlib) screenshot testing framework, sp
 - **`:screenshot-tests`** — the **visual-regression gate**. CI runs `validateDebugScreenshotTest` on it; reframing one of these baselines is a real diff to review. Holds atomic, dual-purpose components.
 - **`:docs-screenshots`** — **generate-only**, *not* validated in CI. Holds doc-framed compositions whose framing is tuned for the docs site, so reframing a doc image never churns the regression gate.
 
-```bash
+```shell
 ./gradlew :screenshot-tests:updateDebugScreenshotTest    # record regression goldens
 ./gradlew :screenshot-tests:validateDebugScreenshotTest  # compare against goldens (CI gate)
 ./gradlew :docs-screenshots:updateDebugScreenshotTest    # record doc-framed composition images
@@ -77,7 +77,7 @@ The `:baselineprofile` module (#5735) generates a [Baseline Profile](https://dev
 
 The Macrobenchmark generator (`BaselineProfileGenerator`) and the before/after benchmark (`StartupBenchmark`) live in `baselineprofile/src/main/kotlin/org/meshtastic/baselineprofile/`. Both run on a device/emulator:
 
-```bash
+```shell
 ./gradlew :androidApp:generateGoogleReleaseBaselineProfile   # Generate the profile (commit the output)
 ./gradlew :androidApp:benchmarkGoogleReleaseBaselineProfile  # Quantify the cold-start win
 ```
@@ -90,7 +90,7 @@ Extending the journey past cold start needs a fake transport or a connected radi
 
 ## Test Organization
 
-```
+```text
 feature/my-feature/src/
 ├── commonTest/kotlin/org/meshtastic/feature/myfeature/
 │   ├── MyBusinessLogicTest.kt
@@ -119,7 +119,7 @@ feature/my-feature/src/
 
 ## Running Tests
 
-```bash
+```shell
 # All KMP tests
 ./gradlew allTests
 

--- a/docs/en/user.md
+++ b/docs/en/user.md
@@ -19,7 +19,7 @@ Keep the last 5–8 entries and archive older ones by removing them.
 
 **September 2026** — [Nodes](user/nodes) — Nodes on firmware 2.8 show signed and verified identity icons in place of the PKI lock, and **Signed only** and **Encrypted only** filters join the node list and the map.
 
-**September 2026** — [Map & Waypoints](user/map-and-waypoints) — Offline terrain (hillshade and contours) downloads alongside offline regions on both Google Play and F-Droid.
+**September 2026** — [Map & Waypoints](user/map-and-waypoints) — Offline terrain (hillshade and contours) can be downloaded on Google Play, F-Droid, and Desktop.
 
 **August 2026** — [Local Mesh Discovery](user/discovery) — Mesh Beacon advertises the region and preset your radio actually uses, requires a region and a standard modem preset before it will broadcast, and hides invitations to channels your radio already has.
 

--- a/docs/en/user.md
+++ b/docs/en/user.md
@@ -17,6 +17,10 @@ Documentation for using the Meshtastic Android and Desktop app.
 Keep the last 5–8 entries and archive older ones by removing them.
 -->
 
+**September 2026** — [Nodes](user/nodes) — Nodes on firmware 2.8 show signed and verified identity icons in place of the PKI lock, and **Signed only** and **Encrypted only** filters join the node list and the map.
+
+**September 2026** — [Map & Waypoints](user/map-and-waypoints) — Offline terrain (hillshade and contours) downloads alongside offline regions on both Google Play and F-Droid.
+
 **August 2026** — [Local Mesh Discovery](user/discovery) — Mesh Beacon advertises the region and preset your radio actually uses, requires a region and a standard modem preset before it will broadcast, and hides invitations to channels your radio already has.
 
 **August 2026** — [Map & Waypoints](user/map-and-waypoints) — Filter the map by node role and by how a node was heard, from a new filter sheet.
@@ -28,10 +32,6 @@ Keep the last 5–8 entries and archive older ones by removing them.
 **August 2026** — [Settings — Radio & User](user/settings-radio-user) — The status message moved into the User Profile, beside Long Name and Short Name; its separate module screen is gone.
 
 **August 2026** — [Messages & Channels](user/messages-and-channels) — Swipe a message right to reply, double-tap it to react, and day separators group the thread.
-
-**August 2026** — [Messages & Channels](user/messages-and-channels) — The conversation list keeps per-contact drafts and adds pinning, mark-unread, and swipe-to-mute/delete, and a conversation can be opened as a floating bubble.
-
-**August 2026** — [Units & Locale](user/units-and-locale) — New page. Units now follow your device region and OS locale, with a Units setting to override them, and all number formatting goes through ICU.
 
 <!-- WHATS_NEW_END -->
 

--- a/docs/en/user/desktop.md
+++ b/docs/en/user/desktop.md
@@ -2,7 +2,7 @@
 title: Desktop App
 parent: User Guide
 nav_order: 14
-last_updated: 2026-08-30
+last_updated: 2026-09-11
 description: Install and use the Meshtastic Desktop app on Linux, macOS, and Windows — connections, feature parity, and keyboard shortcuts.
 aliases:
   - desktop
@@ -122,7 +122,7 @@ Individual doc pages render with full formatting:
 
 ## Building from Source
 
-```bash
+```shell
 git clone https://github.com/meshtastic/Meshtastic-Android.git
 cd Meshtastic-Android
 ./gradlew :desktopApp:run

--- a/docs/en/user/desktop.md
+++ b/docs/en/user/desktop.md
@@ -62,7 +62,7 @@ Bluetooth Low Energy is supported on desktop via the [Kable](https://github.com/
 |---------|---------|---------|-------|
 | Messaging | ✓ | ✓ | Full parity |
 | Node List | ✓ | ✓ | Full parity |
-| Map | ✓ | ✓ | Interactive MapLibre map, with base map and overlay pickers and custom tile sources. No offline downloads or local `.mbtiles` archives |
+| Map | ✓ | ✓ | Interactive MapLibre map, with base map and overlay pickers and custom tile sources. Offline terrain (hillshade and contours) can be downloaded; offline base-map packs and local `.mbtiles` archives cannot |
 | Map layers (`.kml`/`.kmz`/GeoJSON) | ✓ | ✓ | Same layer store and sheet as Android; imported files draw on the desktop map |
 | Site Planner | ✓ | ✓* | *Opens in your browser on desktop; the estimate is not drawn on the desktop map |
 | Settings | ✓ | ✓ | Full parity |
@@ -134,7 +134,7 @@ Requirements:
 
 ## Known Limitations
 
-- Offline tile downloads and local `.mbtiles` archives are not available on desktop.
+- Offline base-map downloads and local `.mbtiles` archives are not available on desktop. Offline terrain is — see [Map & Waypoints](map-and-waypoints).
 - `.kml`/`.kmz`/GeoJSON layer import works — see
   [Map & Waypoints](map-and-waypoints#map-layers). Site Planner opens in your browser
   rather than in the app; to bring its coverage estimate onto the map, click the transmitter pin

--- a/docs/en/user/discovery.md
+++ b/docs/en/user/discovery.md
@@ -2,7 +2,7 @@
 title: Local Mesh Discovery
 parent: User Guide
 nav_order: 12
-last_updated: 2026-08-30
+last_updated: 2026-09-11
 description: Explore your mesh network — the Local Mesh Discovery scanner, traceroute paths, neighbor maps, and node discovery tools.
 aliases:
   - discovery
@@ -97,7 +97,7 @@ Mesh Beacon lets nodes invite others to join their mesh. A beaconing node period
 Configure it under **Settings → Module configuration → Mesh Beacon**. The entry appears only on radios running firmware 2.8.0 or newer. A read-only **Region** row at the top of the screen shows the region the beacon advertises: that region, and the preset, are always the ones the radio itself uses, so a beacon cannot invite anyone onto settings your radio is not running.
 
 - **Listen for beacons** — receive invitations broadcast by other nodes.
-- **Broadcast a beacon** — periodically advertise this mesh to nearby nodes, with an optional **Beacon message** of up to 100 bytes, a **Broadcast interval** picked from fixed intervals between 1 hour and 72 hours, and an **Offered channel** chosen from your radio's own channels. The offered channel is required, and defaults to your primary channel.
+- **Broadcast a beacon** — periodically advertise this mesh to nearby nodes, with an optional **Beacon message** of up to 100 bytes, a **Broadcast interval** picked from fixed intervals between 1 hour and 72 hours, and an **Offered channel** chosen from your radio's own channels. The offered channel is required, and defaults to your primary channel. Over remote admin the picker offers the primary channel only.
 - **Broadcast targets** — optional extra destinations beyond the offered channel. **Add target** appends a row; each row picks a **Channel** and a **Transmit preset**, and **Remove target** deletes it. With no targets, the beacon goes out on the offered channel alone.
 
 Two conditions block beacon setup:

--- a/docs/en/user/help-and-docs.md
+++ b/docs/en/user/help-and-docs.md
@@ -2,7 +2,7 @@
 title: Help & In-App Docs
 parent: User Guide
 nav_order: 21
-last_updated: 2026-08-30
+last_updated: 2026-09-11
 description: Browse this documentation inside the app, search it, and ask Chirpy — the on-device AI assistant — questions about Meshtastic.
 aliases:
   - help
@@ -23,7 +23,7 @@ The docs browser lists every user-guide page. Tap a page to read it; images and 
 
 ### Search
 
-The search box sits at the top of the docs browser. Type in it to filter pages by title and keywords — results update as you type, and the **Clear search** button (✕) empties the box.
+Tap the search field at the top of the docs browser to open a full-screen search view. Type to filter pages by title and keywords — results update as you type, under the same field. The back arrow, or the keyboard's search action, closes the view. The field hides while you scroll down the page list and comes back when you scroll up.
 
 ![Searching the in-app documentation](../../assets/screenshots/docs-browser_search.png)
 

--- a/docs/en/user/map-and-waypoints.md
+++ b/docs/en/user/map-and-waypoints.md
@@ -170,7 +170,8 @@ On **Google Play**, the layers sheet's **Offline Manager** section downloads its
 — water, roads and administrative boundaries extracted from the public Protomaps basemap dataset, drawn
 directly as map shapes rather than raster tiles. Frame the area you want, tap **Start Download**, and once
 it finishes flip **Show on map** to draw it (it's off by default so it never surprises you by covering up the
-live map). You can still import a pre-made `.mbtiles` archive here too, as before. **Desktop** has neither.
+live map). You can still import a pre-made `.mbtiles` archive here too, as before. **Desktop** has neither, though
+the offline terrain described next does work there.
 
 ### Offline terrain
 
@@ -195,8 +196,8 @@ An **Offline** pill appears over the map whenever the device has no network conn
 builds, if you've imported a local `.mbtiles` archive, the map switches to it automatically the moment the
 network drops — no toggle to remember — and switches back once you're reconnected, as long as you haven't
 picked a different base map yourself in between. On **F-Droid**, a downloaded offline area keeps rendering on
-its own; the pill is purely informational there. **Desktop** has no offline downloads at all yet, so the pill
-is informational there too.
+its own; the pill is purely informational there. **Desktop** downloads offline terrain but no base-map
+packs, so the pill is informational there too.
 
 ## Related Topics
 

--- a/docs/en/user/map-and-waypoints.md
+++ b/docs/en/user/map-and-waypoints.md
@@ -43,7 +43,7 @@ The floating toolbar provides quick access to the compass, the map type and laye
 
 ### Filtering the Map
 
-Tap the filter button in the floating toolbar to open **Filter map**. **Display** controls what is drawn: **Only Favorites**, **Show Waypoints**, **Show Precision Circles**, and a slider that hides nodes not heard from recently. **Node roles** is a chip per device role, plus **All** to show every role; a selected chip means that role is shown. **Nodes** narrows the set further with **Hide offline nodes**, **Only show direct nodes**, **Exclude MQTT**, **Show ignored nodes**, **Include unknown**, **Signed only**, and **Encrypted only**. The last two follow the same rules as the node list's [security indicators](nodes).
+Tap the filter button in the floating toolbar to open **Filter map**. **Display** controls what is drawn: **Only Favorites**, **Show Waypoints**, **Show Precision Circles**, and a slider that hides nodes not heard from recently. **Node roles** is a chip per device role, plus **All** to show every role; a selected chip means that role is shown. **Nodes** narrows the set further with **Hide offline nodes**, **Only show direct nodes**, **Signed only**, **Encrypted only**, **Exclude MQTT**, **Show ignored nodes**, and **Include unknown** — the same rules as the node list's [filter toggles](nodes).
 
 A dot on the filter button means at least one filter is hiding something — check it before concluding the mesh is quiet. Turning **Show Waypoints** off hides every waypoint, including your own. **Show ignored nodes** adds them to the map rather than showing only them — unlike the node list's **Only show ignored Nodes**.
 
@@ -144,8 +144,9 @@ picker, all three offer the same raster base maps:
 Overlays can be toggled on top of any base map, from the layers sheet:
 
 - **Weather radar** — NOAA NEXRAD reflectivity (US coverage)
-- **Hillshade** — terrain relief. Useful for understanding why a link fails, since LoRa range is
-  limited by terrain
+- **Hillshade** — terrain relief from an online tile source, on **F-Droid** and **Desktop** only; Google
+  Play draws hillshade from downloaded offline terrain instead. Useful for understanding why a link
+  fails, since LoRa range is limited by terrain
 
 ### Adding your own tile source
 
@@ -178,17 +179,10 @@ the offline terrain described next does work there.
 Hillshade and elevation contours can be downloaded for offline use as well, so a downloaded area still
 shows why a link fails when there is no network. The terrain data comes from Mapterhorn and is credited on
 the map. On **Google Play**, each downloaded region in the **Offline Manager** list has a **Download Terrain**
-button and a **Contours** switch; terrain attaches to that region and shares its storage limit, and an area
+button and **Hillshade** and **Contours** switches; terrain attaches to that region and shares its storage limit, and an area
 too large for terrain asks you to zoom in or pick a smaller region. On **F-Droid** and **Desktop**, the
 layers sheet has an **Offline Terrain** section of its own: frame the area, tap **Start Download**, and the
 hillshade and contours draw from the downloaded tiles from then on.
-
-### When the map cannot load
-
-The F-Droid build for 32-bit phones ships without the map renderer, because the MapLibre engine is not
-published for that processor. On such a phone the map tab reads **Map unavailable on this device** and
-explains that everything else works normally. There is no setting to change; the rest of the app is
-unaffected.
 
 ### Going offline
 

--- a/docs/en/user/map-and-waypoints.md
+++ b/docs/en/user/map-and-waypoints.md
@@ -2,7 +2,7 @@
 title: Map & Waypoints
 parent: User Guide
 nav_order: 6
-last_updated: 2026-09-01
+last_updated: 2026-09-11
 description: View node positions on the map, create and share waypoints, manage map layers and Site Planner, and control position sharing and privacy.
 aliases:
   - map
@@ -43,7 +43,7 @@ The floating toolbar provides quick access to the compass, the map type and laye
 
 ### Filtering the Map
 
-Tap the filter button in the floating toolbar to open **Filter map**. **Display** controls what is drawn: **Only Favorites**, **Show Waypoints**, **Show Precision Circles**, and a slider that hides nodes not heard from recently. **Node roles** is a chip per device role, plus **All** to show every role; a selected chip means that role is shown. **Nodes** narrows the set further with **Hide offline nodes**, **Only show direct nodes**, **Exclude MQTT**, **Show ignored nodes**, and **Include unknown**.
+Tap the filter button in the floating toolbar to open **Filter map**. **Display** controls what is drawn: **Only Favorites**, **Show Waypoints**, **Show Precision Circles**, and a slider that hides nodes not heard from recently. **Node roles** is a chip per device role, plus **All** to show every role; a selected chip means that role is shown. **Nodes** narrows the set further with **Hide offline nodes**, **Only show direct nodes**, **Exclude MQTT**, **Show ignored nodes**, **Include unknown**, **Signed only**, and **Encrypted only**. The last two follow the same rules as the node list's [security indicators](nodes).
 
 A dot on the filter button means at least one filter is hiding something — check it before concluding the mesh is quiet. Turning **Show Waypoints** off hides every waypoint, including your own. **Show ignored nodes** adds them to the map rather than showing only them — unlike the node list's **Only show ignored Nodes**.
 
@@ -144,8 +144,8 @@ picker, all three offer the same raster base maps:
 Overlays can be toggled on top of any base map, from the layers sheet:
 
 - **Weather radar** — NOAA NEXRAD reflectivity (US coverage)
-- **Hillshade** — terrain relief, on **F-Droid** and **Desktop** only. Useful for understanding why a
-  link fails, since LoRa range is limited by terrain
+- **Hillshade** — terrain relief. Useful for understanding why a link fails, since LoRa range is
+  limited by terrain
 
 ### Adding your own tile source
 
@@ -153,7 +153,7 @@ Any XYZ tile endpoint can be added as a base map, on every flavor and on desktop
 Tile Sources** at the foot of the base map picker and paste a URL template using `{z}`, `{x}` and `{y}`
 — plus `{s}` if the provider uses rotating subdomains. A national mapping service, for example:
 
-```
+```text
 https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.pixelkarte-farbe/default/current/3857/{z}/{x}/{y}.jpeg
 ```
 
@@ -171,6 +171,23 @@ On **Google Play**, the layers sheet's **Offline Manager** section downloads its
 directly as map shapes rather than raster tiles. Frame the area you want, tap **Start Download**, and once
 it finishes flip **Show on map** to draw it (it's off by default so it never surprises you by covering up the
 live map). You can still import a pre-made `.mbtiles` archive here too, as before. **Desktop** has neither.
+
+### Offline terrain
+
+Hillshade and elevation contours can be downloaded for offline use as well, so a downloaded area still
+shows why a link fails when there is no network. The terrain data comes from Mapterhorn and is credited on
+the map. On **Google Play**, each downloaded region in the **Offline Manager** list has a **Download Terrain**
+button and a **Contours** switch; terrain attaches to that region and shares its storage limit, and an area
+too large for terrain asks you to zoom in or pick a smaller region. On **F-Droid** and **Desktop**, the
+layers sheet has an **Offline Terrain** section of its own: frame the area, tap **Start Download**, and the
+hillshade and contours draw from the downloaded tiles from then on.
+
+### When the map cannot load
+
+The F-Droid build for 32-bit phones ships without the map renderer, because the MapLibre engine is not
+published for that processor. On such a phone the map tab reads **Map unavailable on this device** and
+explains that everything else works normally. There is no setting to change; the rest of the app is
+unaffected.
 
 ### Going offline
 

--- a/docs/en/user/mqtt.md
+++ b/docs/en/user/mqtt.md
@@ -2,7 +2,7 @@
 title: MQTT
 parent: User Guide
 nav_order: 11
-last_updated: 2026-08-30
+last_updated: 2026-09-11
 description: Bridge your mesh to the internet — MQTT broker setup, encryption layers, and map reporting.
 aliases:
   - mqtt
@@ -24,7 +24,7 @@ The MQTT module connects your node to an MQTT broker, allowing:
 
 ## How It Works
 
-```
+```text
 [Your Node] → Radio → [Gateway Node with Wi-Fi] → MQTT Broker → [Remote Gateway] → Radio → [Remote Node]
 ```
 

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -75,17 +75,17 @@ Most users should keep the default **Client** role. Consider a different role wh
 
 ### Security indicators
 
-Each node carries one security icon beside its name, in the node list and on its detail screen. Tap the icon to read what it means, and choose **Show All Meanings** in that dialog for the full legend.
+Each node carries one security icon beside its name in the node list. Tap it to read what it means, and choose **Show All Meanings** in that dialog for the full legend. The detail screen shows the same state in words, as a **Security** row that opens the same dialog.
 
 | Icon | Meaning | Shown for |
 |------|---------|-----------|
 | Person with a shield check (green) | **Verified contact** — you verified this node's key in person by exchanging contact QR codes, so its identity is confirmed. The strongest trust the list shows | Any firmware version |
-| Mesh icon with a shield check (green) | **Signed node** — your node verified this node's signed broadcasts with its identity key, so its identity is consistent over time, but you have not verified it in person | Firmware 2.8 or newer, and any node whose signature your node has verified |
+| Nodes icon with a shield check (green) | **Signed node** — your node verified this node's signed broadcasts with its identity key, so its identity is consistent over time, but you have not verified it in person | Firmware 2.8 or newer, and any node whose signature your node has verified |
 | 🔒 Closed lock | A public key is on file and matches, so direct messages to this node are encrypted | Firmware before 2.8, or no reported version |
 | 🔓 Open lock | No public key has been received for this node, so it cannot be direct messaged — use **Request User Info** on the node detail page to ask for one | Firmware before 2.8, or no reported version |
 | ⚠️ Mismatch | **Public key mismatch** — a different key arrived for this node after one was stored. Investigate before trusting | Any firmware version |
 
-Every node on firmware 2.8 or newer signs its broadcasts, so on that firmware the signed state is the baseline and the locks are not shown. The **Security** row on the detail screen states the same result in words.
+Every node on firmware 2.8 or newer signs its broadcasts, so on that firmware the signed state is the baseline and the locks are not shown.
 
 Direct messages always use public-key encryption, so your node needs the other node's public key before it can send one. It refuses the send rather than falling back to channel encryption. Keys arrive inside node info, which is why an open lock usually clears itself once that node is heard from properly.
 
@@ -131,7 +131,7 @@ Type in the search field to filter nodes by name or short name. The filter updat
 | **Include unknown** | Show nodes that haven't sent user info yet. **On by default**, so a node heard before its info arrives stays visible; these carry a badge marking them incomplete, and cannot be direct messaged until their user info brings a public key |
 | **Exclude infrastructure** | Hide infrastructure-role nodes (Router, Router Late, Client Base, and legacy Repeater nodes) and any node that cannot be messaged, whatever its role |
 | **Exclude MQTT** | Hide nodes heard only via MQTT internet bridge |
-| **Signed only** | Show only nodes whose signed broadcasts your node has verified — the signed and verified states in the security legend |
+| **Signed only** | Show only nodes whose signed broadcasts your node has actually heard and verified. Stricter than the icon: a node on 2.8 shows as signed by its firmware version before any signed broadcast arrives, and a contact verified in person on older firmware is not signed at all |
 | **Encrypted only** | Show only nodes with a matching public key on file, so every node left can be direct messaged. A node with a key mismatch is excluded |
 | **Only show ignored Nodes** | Replace the list with the nodes you have ignored. Every other node is hidden while this is on, and a banner appears at the top of the list to take you back |
 

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -73,19 +73,23 @@ Most users should keep the default **Client** role. Consider a different role wh
 
 > 💡 **Tip:** The mesh works best when most nodes are **Client** or **Router**. Too many Client Mute nodes reduce mesh resilience; too many Routers in a dense area can cause congestion. A good rule of thumb: one Router per 5–10 Clients in your area.
 
-### Encryption Indicators
+### Security indicators
 
-Nodes display encryption status icons next to their name:
+Each node carries one security icon beside its name, in the node list and on its detail screen. Tap the icon to read what it means, and choose **Show All Meanings** in that dialog for the full legend.
 
-| Icon | Meaning |
-|------|---------|
-| 🔒 Locked | Communication uses PKI (public key infrastructure) — end-to-end encrypted with verified identity |
-| 🔓 Unlocked | No public key has been received for this node, so it cannot be direct messaged — use **Request User Info** on the node detail page to ask for one |
-| ⚠️ Mismatch | Public key mismatch — the node's key has changed since last seen (investigate before trusting) |
+| Icon | Meaning | Shown for |
+|------|---------|-----------|
+| Person with a shield check (green) | **Verified contact** — you verified this node's key in person by exchanging contact QR codes, so its identity is confirmed. The strongest trust the list shows | Any firmware version |
+| Mesh icon with a shield check (green) | **Signed node** — your node verified this node's signed broadcasts with its identity key, so its identity is consistent over time, but you have not verified it in person | Firmware 2.8 or newer, and any node whose signature your node has verified |
+| 🔒 Closed lock | A public key is on file and matches, so direct messages to this node are encrypted | Firmware before 2.8, or no reported version |
+| 🔓 Open lock | No public key has been received for this node, so it cannot be direct messaged — use **Request User Info** on the node detail page to ask for one | Firmware before 2.8, or no reported version |
+| ⚠️ Mismatch | **Public key mismatch** — a different key arrived for this node after one was stored. Investigate before trusting | Any firmware version |
 
-> 💡 **Tip:** Direct messages always use PKI, so the radio needs the other node's public key before it can send one. It refuses the send rather than falling back to channel encryption. Keys arrive inside node info, which is why an open lock usually clears itself once that node is heard from properly. If you see a key mismatch warning, the node may have been reset or compromised.
+Every node on firmware 2.8 or newer signs its broadcasts, so on that firmware the signed state is the baseline and the locks are not shown. The **Security** row on the detail screen states the same result in words.
 
-To clear a mismatch, first confirm through another trusted channel that the key change was intentional — a factory reset causes one. Then touch & hold the node, choose **Remove**, and let the two radios exchange keys again the next time yours hears it.
+Direct messages always use public-key encryption, so your node needs the other node's public key before it can send one. It refuses the send rather than falling back to channel encryption. Keys arrive inside node info, which is why an open lock usually clears itself once that node is heard from properly.
+
+A mismatch never replaces the key you already hold. The app keeps the first key it recorded and refuses the new one, as the firmware does, so a stray or hostile node info cannot silently break encrypted messaging to a contact. To clear a mismatch, first confirm through another trusted channel that the key change was intentional — a factory reset causes one. Then touch & hold the node, choose **Remove**, and let the two nodes exchange keys again the next time yours hears it.
 
 ## Quick Actions
 
@@ -108,6 +112,8 @@ radio is connected and running firmware 2.8 or newer — see
 
 On a node's detail screen, tap **Share Contact** to produce a link and a QR code for that node. From the same dialog, **Share link** opens the Android share sheet (on desktop it copies the link instead), **Write to NFC tag** saves it to a writable NFC tag, and **Copy** puts it on the clipboard. While that dialog is open and in front of you, the phone also offers the same link to any NFC reader, so someone can take the contact by tapping their phone against yours with no tag involved.
 
+Sharing your own contact this way marks it as verified in person, so whoever imports it sees the **Verified contact** icon rather than the signed one. Relaying someone else's contact passes on only what your app had already recorded about them.
+
 To add someone else's contact, use the import button on the node list and choose **Scan Shared Contact QR Code**, **Scan Shared Contact NFC**, or **Input Shared Contact URL**. The app asks you to confirm with **Import Shared Contact?**, and warns you when the contact is one you already have.
 
 ## Filtering & Sorting
@@ -125,6 +131,8 @@ Type in the search field to filter nodes by name or short name. The filter updat
 | **Include unknown** | Show nodes that haven't sent user info yet. **On by default**, so a node heard before its info arrives stays visible; these carry a badge marking them incomplete, and cannot be direct messaged until their user info brings a public key |
 | **Exclude infrastructure** | Hide infrastructure-role nodes (Router, Router Late, Client Base, and legacy Repeater nodes) and any node that cannot be messaged, whatever its role |
 | **Exclude MQTT** | Hide nodes heard only via MQTT internet bridge |
+| **Signed only** | Show only nodes whose signed broadcasts your node has verified — the signed and verified states in the security legend |
+| **Encrypted only** | Show only nodes with a matching public key on file, so every node left can be direct messaged. A node with a key mismatch is excluded |
 | **Only show ignored Nodes** | Replace the list with the nodes you have ignored. Every other node is hidden while this is on, and a banner appears at the top of the list to take you back |
 
 ### Sort Options

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -80,7 +80,7 @@ Each node carries one security icon beside its name in the node list. Tap it to 
 | Icon | Meaning | Shown for |
 |------|---------|-----------|
 | Person with a shield check (green) | **Verified contact** — you verified this node's key in person by exchanging contact QR codes, so its identity is confirmed. The strongest trust the list shows | Any firmware version |
-| Nodes icon with a shield check (green) | **Signed node** — your node verified this node's signed broadcasts with its identity key, so its identity is consistent over time, but you have not verified it in person | Firmware 2.8 or newer, and any node whose signature your node has verified |
+| Nodes icon with a shield check (green) | **Signed node** — this node signs its broadcasts with its identity key, so its identity is consistent over time, but you have not verified it in person. On firmware 2.8 the icon appears from the version alone, before any signed broadcast has been heard | Firmware 2.8 or newer, and any node whose signed broadcast your node has verified |
 | 🔒 Closed lock | A public key is on file and matches, so direct messages to this node are encrypted | Firmware before 2.8, or no reported version |
 | 🔓 Open lock | No public key has been received for this node, so it cannot be direct messaged — use **Request User Info** on the node detail page to ask for one | Firmware before 2.8, or no reported version |
 | ⚠️ Mismatch | **Public key mismatch** — a different key arrived for this node after one was stored. Investigate before trusting | Any firmware version |

--- a/docs/en/user/nodes.md
+++ b/docs/en/user/nodes.md
@@ -79,7 +79,7 @@ Each node carries one security icon beside its name in the node list. Tap it to 
 
 | Icon | Meaning | Shown for |
 |------|---------|-----------|
-| Person with a shield check (green) | **Verified contact** — you verified this node's key in person by exchanging contact QR codes, so its identity is confirmed. The strongest trust the list shows | Any firmware version |
+| Person with a shield check (green) | **Verified contact** — you verified this node's key in person by exchanging contact QR codes, so its identity is confirmed. The strongest trust the list shows. Your own connected node carries it too | Any firmware version |
 | Nodes icon with a shield check (green) | **Signed node** — this node signs its broadcasts with its identity key, so its identity is consistent over time, but you have not verified it in person. On firmware 2.8 the icon appears from the version alone, before any signed broadcast has been heard | Firmware 2.8 or newer, and any node whose signed broadcast your node has verified |
 | 🔒 Closed lock | A public key is on file and matches, so direct messages to this node are encrypted | Firmware before 2.8, or no reported version |
 | 🔓 Open lock | No public key has been received for this node, so it cannot be direct messaged — use **Request User Info** on the node detail page to ask for one | Firmware before 2.8, or no reported version |
@@ -132,7 +132,7 @@ Type in the search field to filter nodes by name or short name. The filter updat
 | **Exclude infrastructure** | Hide infrastructure-role nodes (Router, Router Late, Client Base, and legacy Repeater nodes) and any node that cannot be messaged, whatever its role |
 | **Exclude MQTT** | Hide nodes heard only via MQTT internet bridge |
 | **Signed only** | Show only nodes whose signed broadcasts your node has actually heard and verified. Stricter than the icon: a node on 2.8 shows as signed by its firmware version before any signed broadcast arrives, and a contact verified in person on older firmware is not signed at all |
-| **Encrypted only** | Show only nodes with a matching public key on file, so every node left can be direct messaged. A node with a key mismatch is excluded |
+| **Encrypted only** | Show nodes with a matching public key on file, the key an encrypted direct message needs. A node with a key mismatch is excluded |
 | **Only show ignored Nodes** | Replace the list with the nodes you have ignored. Every other node is hidden while this is on, and a banner appears at the top of the list to take you back |
 
 ### Sort Options

--- a/docs/en/user/settings-radio-user.md
+++ b/docs/en/user/settings-radio-user.md
@@ -83,7 +83,7 @@ On **Settings → LoRa**.
 | Transmit Power | Transmission power (dBm); 0 = max allowed for region | 0 (region max) |
 | Frequency Override | Overrides the computed operating frequency outright (MHz). It does not offset the calculated value — leave at 0 unless you know you need a specific frequency | 0 (use calculated) |
 | Use Preset | On by default. Turn it off to set Spread Factor, Coding Rate and Bandwidth by hand instead of taking them from the modem preset | On |
-| Spread Factor | Manual mode only: 5–12. Higher spreads further but slower. Spread factors 5 and 6 need a second-generation LoRa chip (SX126x, LR11xx, SX128x); on SX127x hardware the firmware clamps them to 7 | From preset |
+| Spread Factor | Manual mode only: 5–12. Higher spreads further but slower. Spread factors 5 and 6 are only available on second-generation LoRa chips (SX126x, LR11xx, SX128x) | From preset |
 | Coding Rate | Manual mode only: 5–8. More redundancy costs airtime | From preset |
 | Bandwidth | Manual mode only: the channel bandwidth in kHz, typed in directly. On the 2.4 GHz region the app offers a list of the bandwidths your radio supports instead, and a stored value that is not on that list shows as *Unsupported* and blocks saving until you pick a supported one | From preset |
 | Frequency Slot | Which slot within the region's band to use. 0 derives it from the primary channel name | 0 (automatic) |

--- a/docs/en/user/settings-radio-user.md
+++ b/docs/en/user/settings-radio-user.md
@@ -2,7 +2,7 @@
 title: Settings — Radio & User
 parent: User Guide
 nav_order: 7
-last_updated: 2026-09-09
+last_updated: 2026-09-11
 description: Configure your radio hardware, LoRa presets, user profile, position sharing, power management, and security.
 aliases:
   - settings
@@ -51,7 +51,7 @@ The footer appears as soon as you change something. **Discard** throws the chang
 The status message is saved with the same **Save**, but it never reboots the node — and, like the
 rest of this screen, it can be edited on a remote node you administer. For your own radio there is a
 shortcut while it is connected: touch & hold your node in the [node list](nodes.md) and choose
-**Update status**. Older firmware and a disconnected radio have no shortcut — the field above is
+**Update status**. Older firmware and a disconnected node have no shortcut — the field itself is
 still the way in.
 
 ## Configuration
@@ -77,13 +77,13 @@ On **Settings → LoRa**.
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| Region | Regulatory region for frequency bands. You must set this before transmitting | Unset (must configure) |
+| Region | Regulatory region for frequency bands. You must set this before transmitting. On firmware 2.8 or newer, the first region set also creates the node's identity key and gives it a new node number | Unset (must configure) |
 | Presets | Speed/range tradeoff | LongFast |
 | Number of Hops | Maximum retransmit hops | 3 |
 | Transmit Power | Transmission power (dBm); 0 = max allowed for region | 0 (region max) |
 | Frequency Override | Overrides the computed operating frequency outright (MHz). It does not offset the calculated value — leave at 0 unless you know you need a specific frequency | 0 (use calculated) |
 | Use Preset | On by default. Turn it off to set Spread Factor, Coding Rate and Bandwidth by hand instead of taking them from the modem preset | On |
-| Spread Factor | Manual mode only: 7–12. Higher spreads further but slower | From preset |
+| Spread Factor | Manual mode only: 5–12. Higher spreads further but slower. Spread factors 5 and 6 need a second-generation LoRa chip (SX126x, LR11xx, SX128x); on SX127x hardware the firmware clamps them to 7 | From preset |
 | Coding Rate | Manual mode only: 5–8. More redundancy costs airtime | From preset |
 | Bandwidth | Manual mode only: the channel bandwidth in kHz, typed in directly. On the 2.4 GHz region the app offers a list of the bandwidths your radio supports instead, and a stored value that is not on that list shows as *Unsupported* and blocks saving until you pick a supported one | From preset |
 | Frequency Slot | Which slot within the region's band to use. 0 derives it from the primary channel name | 0 (automatic) |

--- a/docs/en/user/settings-radio-user.md
+++ b/docs/en/user/settings-radio-user.md
@@ -83,7 +83,7 @@ On **Settings → LoRa**.
 | Transmit Power | Transmission power (dBm); 0 = max allowed for region | 0 (region max) |
 | Frequency Override | Overrides the computed operating frequency outright (MHz). It does not offset the calculated value — leave at 0 unless you know you need a specific frequency | 0 (use calculated) |
 | Use Preset | On by default. Turn it off to set Spread Factor, Coding Rate and Bandwidth by hand instead of taking them from the modem preset | On |
-| Spread Factor | Manual mode only: 5–12. Higher spreads further but slower. Spread factors 5 and 6 are only available on second-generation LoRa chips (SX126x, LR11xx, SX128x) | From preset |
+| Spread Factor | Manual mode only: 5–12. Higher spreads further but slower. On SX127x (RF95) radios the firmware does not accept 5 or 6 and uses 11 instead | From preset |
 | Coding Rate | Manual mode only: 5–8. More redundancy costs airtime | From preset |
 | Bandwidth | Manual mode only: the channel bandwidth in kHz, typed in directly. On the 2.4 GHz region the app offers a list of the bandwidths your radio supports instead, and a stored value that is not on that list shows as *Unsupported* and blocks saving until you pick a supported one | From preset |
 | Frequency Slot | Which slot within the region's band to use. 0 derives it from the primary channel name | 0 (automatic) |

--- a/docs/en/user/tak.md
+++ b/docs/en/user/tak.md
@@ -2,7 +2,7 @@
 title: TAK Integration
 parent: User Guide
 nav_order: 10
-last_updated: 2026-08-30
+last_updated: 2026-09-11
 description: Interoperate with ATAK and WinTAK — CoT position sharing, TAK roles, and plugin setup.
 aliases:
   - tak
@@ -35,7 +35,7 @@ The TAK module allows Meshtastic nodes to:
 > ⚠️ **Warning:** The old **Meshtastic ATAK Plugin** is no longer part of this path and cannot
 > work. It bridged through the cross-process AIDL API, which was removed in app 2.8.0; the mesh
 > service is now in-process only. Do not install it. Interop today runs over the app's own local
-> TAK server plus the Mesh to CoT Converter, both described below, with stock ATAK/iTAK/WinTAK.
+> TAK server plus the Mesh to CoT Converter, both described in the following sections, with stock ATAK/iTAK/WinTAK.
 
 ### Configuration
 

--- a/docs/en/user/translate.md
+++ b/docs/en/user/translate.md
@@ -2,7 +2,7 @@
 title: Translate the App
 parent: User Guide
 nav_order: 17
-last_updated: 2026-08-30
+last_updated: 2026-09-11
 description: How the app and its documentation are translated via Crowdin, and guidelines for contributing translations.
 aliases:
   - translate
@@ -45,7 +45,7 @@ If your language is not yet listed on Crowdin:
 
 The Android app uses **Compose Multiplatform resources** for all user-visible strings:
 
-```
+```text
 core/resources/src/commonMain/composeResources/
 ├── values/              ← English (default)
 │   └── strings.xml
@@ -58,7 +58,7 @@ core/resources/src/commonMain/composeResources/
 
 In-app documentation follows a similar pattern under `docs/`:
 
-```
+```text
 docs/
 ├── en/user/             ← English source (default)
 │   ├── onboarding.md


### PR DESCRIPTION
Docs sweep against what merged since the 2026-08-30 audit (#6968), plus the mechanical half of the Section 11.16 quick checks from the design standards this repo's guide now defers to (#7125). Every claim below was checked against the code and the string resources, not the PR bodies.

## 🧹 Chores

**Content brought current**

- **Nodes** — the *Encryption Indicators* section is now *Security indicators*: the five states `NodeSecurityIndicator` decides (verified contact, signed node, closed lock, open lock, mismatch), which firmware each shows for, the **Show All Meanings** legend, and the **Security** row on the detail screen (#7117). A mismatch keeps the stored key and refuses the new one (#7118), and sharing your own contact marks it verified at the far end. **Signed only** and **Encrypted only** join the filter table, with the predicates the code actually uses (verified signature; matching key on file, mismatch excluded).
- **Map & Waypoints** — **Signed only** / **Encrypted only** in the filter sheet, in the sheet's order (#7117). New *Offline terrain* section covering both flavors and desktop: **Download Terrain** + **Hillshade** / **Contours** switches per region on Google Play (#7000), the **Offline Terrain** section on MapLibre (#7012), which is deliberately not gated on `offlineMapsSupported`, so the two "Desktop has no offline downloads" sentences on the page were corrected too. The online **Hillshade** overlay stays F-Droid/Desktop: `MapViewModel.availableOverlays` filters out DEM-encoded sources on Google, which gets hillshade from offline terrain only.
- **Settings — Radio & User** — Spread Factor is 5–12 (#7119); on RF95/SX127x the firmware's `clampSpreadFactor` returns `LORA_SF_DEFAULT` (11) for 5 and 6. The first region set on 2.8 creates the identity key and renumbers the node (#7021).
- **Help & Docs** — search is the M3 full-screen bar: expands on tap, back arrow / IME search collapses, hides on scroll (#7098).
- **Local Mesh Discovery** — over remote admin the offered-channel picker offers the primary channel only (#7077).
- **What's New** — two September entries; the two oldest August entries dropped to stay within the 5–8 the template asks for.

**Section 11.16 mechanical pass**

- Every code fence declares a language (11 untagged → `text`), and every command block is `shell` rather than `bash` (11 fences).
- Two textual *above*/*below* pointers reworded (LANG-9); the remaining hits are spatial or literal (noise floor, card above the list).
- The security tip in Nodes folded into body text, so the *Node List* H2 is down to one admonition (11.11).
- Headings re-cased to sentence case only in the sections rewritten, per the fix-as-you-touch rule in `documentation-style.md`. *radio* → *node* in the rewritten prose only.

## Corrected after an adversarial pass over every claim

- The 32-bit F-Droid **Map unavailable on this device** section was dropped: `scripts/lib/abi-parity.sh` records the gap as closed since maplibre-compose 0.16.0 (the catalog pin), so no shipped ABI reaches that screen.
- `Signed only` reads the raw `signsPackets` flag, not the version-gated indicator, so the filter row says so instead of equating it with the badge.
- The security icon is list-only; node detail has the **Security** row.
- CodeRabbit round 1: `desktop.md` still denied all offline downloads, now says terrain yes and base-map packs no; the **Signed node** row says the icon is a version fact before it is a heard one.

## Not in this PR (audit findings)

- **Admonition density (11.11):** *Settings — Radio & User* › Configuration holds 8 callouts, *Settings — Module Configuration* › Module Configuration holds 6, and nine more H2 sections carry 2–3. Demoting them to body text is a per-page rewrite.
- **Screenshots vs 11.9:** 48 image references, all PNG, no dark variants. The sync script already has `--convert-webp`, so the site-weight half is a sync flag; the dark-variant half needs the in-app renderer (`ComposeResourceImageTransformer`) to learn theme switching before the guide can ask for it. IMG-1 and 11.9 disagree today, which 11.1 says they should not — needs a third *In transition* bullet or a design-repo carve-out.
- `docs-browser_search.png` shows the old inline search field; the prose no longer depends on it, but it wants a recapture.
- **Hide unheard nodes** (#7055) is left undocumented: `supportsHeardOnCurrentLora` is gated to `UNRELEASED` and firmware #11811 is still open. The toggle renders in the filter menu today and is inert until then.
- Fix-as-you-touch backlog: 223 of 394 headings are still Title Case; *radio* still appears 268 times across the user pages.

## Testing Performed

- `node scripts/validate-doc-links.js docs/en`, `check-doc-coverage.js .`, `check-doc-aliases.js .`, `check-doc-freshness.js` — all pass.
- `./gradlew generateDocsBundle validateDocsBundle` — pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on offline terrain downloads, map filtering, security indicators, node identity verification, and radio configuration.
  * Clarified desktop offline-map limitations, platform-specific hillshade behavior, and remote-admin beacon channel selection.
  * Documented the full-screen search experience and updated related user guidance.
  * Refreshed the documentation changelog with entries for node security indicators and offline terrain.
  * Standardized code examples, formatting labels, and page update dates across developer and user documentation.
  * Removed older changelog entries covering conversation-list features and Units & Locale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->