### PR TITLE
chore(coderabbit): review pushes incrementally again

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,10 +13,10 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    # Review once when the PR goes ready, then on demand via `@coderabbitai review`.
-    # Re-reviewing every push turned 6-commit PRs into 8 review rounds, because each
-    # fix commit reopened a full pass. Batch the fixes, push, then ask for one re-review.
-    auto_incremental_review: false
+    # Review each push incrementally. With this off, a push got no review at all and the
+    # only way to re-review was `@coderabbitai full review`, which re-reads the whole diff
+    # and surfaces new findings on unchanged lines every round.
+    auto_incremental_review: true
     ignore_usernames:
       - renovate
       - renovate[bot]


### PR DESCRIPTION
With `auto_incremental_review: false` (#6504), a push to an open PR gets no review at all. The only way to get one is `@coderabbitai full review`, which re-reads the entire diff and surfaces new Minor findings on lines that never changed. On #7134, two fix rounds of two one-line docs edits each produced two fresh threads apiece that way.

## 🧹 Chores

- `auto_incremental_review: true`, so CodeRabbit reviews the delta of each push and nobody has to type a command. Comment updated to say why.